### PR TITLE
proxy: honor BindAddress for the iptables proxy

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node.go
+++ b/pkg/cmd/server/kubernetes/node/node.go
@@ -362,6 +362,9 @@ func (c *NodeConfig) RunProxy() {
 	switch c.ProxyConfig.Mode {
 	case componentconfig.ProxyModeIPTables:
 		glog.V(0).Info("Using iptables Proxier.")
+		if bindAddr.Equal(net.IPv4zero) {
+			bindAddr = getNodeIP(c.Client, hostname)
+		}
 		if c.ProxyConfig.IPTablesMasqueradeBit == nil {
 			// IPTablesMasqueradeBit must be specified or defaulted.
 			glog.Fatalf("Unable to read IPTablesMasqueradeBit from config")
@@ -376,7 +379,7 @@ func (c *NodeConfig) RunProxy() {
 			int(*c.ProxyConfig.IPTablesMasqueradeBit),
 			c.ProxyConfig.ClusterCIDR,
 			hostname,
-			getNodeIP(c.Client, hostname),
+			bindAddr,
 			recorder,
 		)
 		if err != nil {


### PR DESCRIPTION
A loose port of https://github.com/kubernetes/kubernetes/pull/46678

If the configuration specifies a BindAddress, we should probably
honor it.  If the configuration doesn't, and there is no default
route with which to autodetect the node address, then the user
really needs to tell the proxy what address to use via BindAddress.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1462428

@openshift/networking @knobunc 