### PR TITLE
Move the router to use generated clientsets

### DIFF
--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -15,7 +15,9 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	projectinternalclientset "github.com/openshift/origin/pkg/project/generated/internalclientset"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	routeinternalclientset "github.com/openshift/origin/pkg/route/generated/internalclientset"
 	"github.com/openshift/origin/pkg/router/controller"
 	f5plugin "github.com/openshift/origin/pkg/router/f5"
 )
@@ -214,16 +216,24 @@ func (o *F5RouterOptions) Run() error {
 		return err
 	}
 
-	oc, kc, err := o.Config.Clients()
+	_, kc, err := o.Config.Clients()
+	if err != nil {
+		return err
+	}
+	routeclient, err := routeinternalclientset.NewForConfig(o.Config.OpenShiftConfig())
+	if err != nil {
+		return err
+	}
+	projectclient, err := projectinternalclientset.NewForConfig(o.Config.OpenShiftConfig())
 	if err != nil {
 		return err
 	}
 
-	statusPlugin := controller.NewStatusAdmitter(f5Plugin, oc, o.RouterName, "")
+	statusPlugin := controller.NewStatusAdmitter(f5Plugin, routeclient, o.RouterName, "")
 	uniqueHostPlugin := controller.NewUniqueHost(statusPlugin, o.RouteSelectionFunc(), o.RouterSelection.DisableNamespaceOwnershipCheck, statusPlugin)
 	plugin := controller.NewHostAdmitter(uniqueHostPlugin, o.F5RouteAdmitterFunc(), false, o.RouterSelection.DisableNamespaceOwnershipCheck, statusPlugin)
 
-	factory := o.RouterSelection.NewFactory(oc, kc)
+	factory := o.RouterSelection.NewFactory(routeclient, projectclient.Projects(), kc)
 	watchNodes := (len(o.InternalAddress) != 0 && len(o.VxlanGateway) != 0)
 	controller := factory.Create(plugin, watchNodes, o.EnableIngress)
 	controller.Run()

--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -15,10 +15,11 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
-	oclient "github.com/openshift/origin/pkg/client"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
+	projectclient "github.com/openshift/origin/pkg/project/generated/internalclientset/typed/project/internalversion"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset/typed/route/internalversion"
 	"github.com/openshift/origin/pkg/router/controller"
 	controllerfactory "github.com/openshift/origin/pkg/router/controller/factory"
 )
@@ -220,8 +221,8 @@ func (o *RouterSelection) Complete() error {
 }
 
 // NewFactory initializes a factory that will watch the requested routes
-func (o *RouterSelection) NewFactory(oc oclient.Interface, kc kclientset.Interface) *controllerfactory.RouterControllerFactory {
-	factory := controllerfactory.NewDefaultRouterControllerFactory(oc, kc)
+func (o *RouterSelection) NewFactory(routeclient routeclient.RoutesGetter, projectclient projectclient.ProjectResourceInterface, kc kclientset.Interface) *controllerfactory.RouterControllerFactory {
+	factory := controllerfactory.NewDefaultRouterControllerFactory(routeclient, kc)
 	factory.Labels = o.Labels
 	factory.Fields = o.Fields
 	factory.Namespace = o.Namespace
@@ -232,7 +233,7 @@ func (o *RouterSelection) NewFactory(oc oclient.Interface, kc kclientset.Interfa
 		factory.Namespaces = namespaceNames{kc.Core().Namespaces(), o.NamespaceLabels}
 	case o.ProjectLabels != nil:
 		glog.Infof("Router is only using routes in projects matching %s", o.ProjectLabels)
-		factory.Namespaces = projectNames{oc.Projects(), o.ProjectLabels}
+		factory.Namespaces = projectNames{projectclient, o.ProjectLabels}
 	case len(factory.Namespace) > 0:
 		glog.Infof("Router is only using resources in namespace %s", factory.Namespace)
 	default:
@@ -243,7 +244,7 @@ func (o *RouterSelection) NewFactory(oc oclient.Interface, kc kclientset.Interfa
 
 // projectNames returns the names of projects matching the label selector
 type projectNames struct {
-	client   oclient.ProjectInterface
+	client   projectclient.ProjectResourceInterface
 	selector labels.Selector
 }
 

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -19,9 +19,9 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	kextensionsclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	oscache "github.com/openshift/origin/pkg/client/cache"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	osclient "github.com/openshift/origin/pkg/route/generated/internalclientset/typed/route/internalversion"
 	"github.com/openshift/origin/pkg/router"
 	routercontroller "github.com/openshift/origin/pkg/router/controller"
 )
@@ -31,7 +31,7 @@ import (
 // If Namespace is empty, it means "all namespaces".
 type RouterControllerFactory struct {
 	KClient        kcoreclient.EndpointsGetter
-	OSClient       osclient.RoutesNamespacer
+	OSClient       osclient.RoutesGetter
 	IngressClient  kextensionsclient.IngressesGetter
 	SecretClient   kcoreclient.SecretsGetter
 	NodeClient     kcoreclient.NodesGetter
@@ -43,7 +43,7 @@ type RouterControllerFactory struct {
 }
 
 // NewDefaultRouterControllerFactory initializes a default router controller factory.
-func NewDefaultRouterControllerFactory(oc osclient.RoutesNamespacer, kc kclientset.Interface) *RouterControllerFactory {
+func NewDefaultRouterControllerFactory(oc osclient.RoutesGetter, kc kclientset.Interface) *RouterControllerFactory {
 	return &RouterControllerFactory{
 		KClient:        kc.Core(),
 		OSClient:       oc,
@@ -321,7 +321,7 @@ func hostIndexFunc(obj interface{}) ([]string, error) {
 // routeLW is a ListWatcher for routes that can be filtered to a label, field, or
 // namespace.
 type routeLW struct {
-	client    osclient.RoutesNamespacer
+	client    osclient.RoutesGetter
 	label     labels.Selector
 	field     fields.Selector
 	namespace string

--- a/pkg/router/controller/host_admitter_test.go
+++ b/pkg/router/controller/host_admitter_test.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	"github.com/openshift/origin/pkg/route/generated/internalclientset/fake"
 )
 
 const (
@@ -772,7 +772,7 @@ func TestStatusWildcardPolicyNoOp(t *testing.T) {
 	now := nowFn()
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake()
+	c := fake.NewSimpleClientset()
 	recorder := rejectionRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, true, false, recorder)
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{
@@ -810,7 +810,7 @@ func TestStatusWildcardPolicyNotAllowedNoOp(t *testing.T) {
 	now := nowFn()
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake()
+	c := fake.NewSimpleClientset()
 	recorder := rejectionRecorder{rejections: make(map[string]string)}
 	admitter := NewHostAdmitter(p, wildcardAdmitter, false, false, recorder)
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/client"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	client "github.com/openshift/origin/pkg/route/generated/internalclientset/typed/route/internalversion"
 	"github.com/openshift/origin/pkg/router"
 )
 
@@ -27,7 +27,7 @@ type RejectionRecorder interface {
 // StatusAdmitter ensures routes added to the plugin have status set.
 type StatusAdmitter struct {
 	plugin                  router.Plugin
-	client                  client.RoutesNamespacer
+	client                  client.RoutesGetter
 	routerName              string
 	routerCanonicalHostname string
 
@@ -39,7 +39,7 @@ type StatusAdmitter struct {
 // route has a status field set that matches this router. The admitter manages
 // an LRU of recently seen conflicting updates to handle when two router processes
 // with differing configurations are writing updates at the same time.
-func NewStatusAdmitter(plugin router.Plugin, client client.RoutesNamespacer, name, hostName string) *StatusAdmitter {
+func NewStatusAdmitter(plugin router.Plugin, client client.RoutesGetter, name, hostName string) *StatusAdmitter {
 	expected, _ := lru.New(1024)
 	return &StatusAdmitter{
 		plugin:                  plugin,
@@ -227,7 +227,7 @@ func (a *StatusAdmitter) recordIngressTouch(route *routeapi.Route, touch *metav1
 // admitRoute returns true if the route has already been accepted to this router, or
 // updates the route to contain an accepted condition. Returns an error if the route could
 // not be admitted due to a failure, or false if the route can't be admitted at this time.
-func (a *StatusAdmitter) admitRoute(oc client.RoutesNamespacer, route *routeapi.Route, name, hostName string) (bool, error) {
+func (a *StatusAdmitter) admitRoute(oc client.RoutesGetter, route *routeapi.Route, name, hostName string) (bool, error) {
 	ingress, updated := findOrCreateIngress(route, name, hostName)
 
 	// keep lastTouch around

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -15,8 +15,8 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	"github.com/openshift/origin/pkg/route/generated/internalclientset/fake"
 )
 
 type fakePlugin struct {
@@ -48,8 +48,8 @@ func TestStatusNoOp(t *testing.T) {
 	now := nowFn()
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake()
-	admitter := NewStatusAdmitter(p, c, "test", "a.b.c.d")
+	c := fake.NewSimpleClientset()
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "a.b.c.d")
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -78,7 +78,7 @@ func TestStatusNoOp(t *testing.T) {
 	}
 }
 
-func checkResult(t *testing.T, err error, c *testclient.Fake, admitter *StatusAdmitter, targetHost string, targetObjTime metav1.Time, targetCachedTime *time.Time, ingressInd int, actionInd int) *routeapi.Route {
+func checkResult(t *testing.T, err error, c *fake.Clientset, admitter *StatusAdmitter, targetHost string, targetObjTime metav1.Time, targetCachedTime *time.Time, ingressInd int, actionInd int) *routeapi.Route {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,8 +116,8 @@ func TestStatusResetsHost(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -146,14 +146,14 @@ func TestStatusAdmitsRouteOnForbidden(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
 	c.PrependReactor("update", "routes", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetSubresource() != "status" {
 			return false, nil, nil
 		}
 		return true, nil, errors.NewForbidden(kapi.Resource("Route"), "route1", nil)
 	})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -181,14 +181,14 @@ func TestStatusBackoffOnConflict(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
 	c.PrependReactor("update", "routes", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetSubresource() != "status" {
 			return false, nil, nil
 		}
 		return true, nil, errors.NewConflict(kapi.Resource("Route"), "route1", nil)
 	})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	err := admitter.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -215,8 +215,8 @@ func TestStatusRecordRejection(t *testing.T) {
 	now := nowFn()
 	nowFn = func() metav1.Time { return now }
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	admitter.RecordRouteRejection(&routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -247,8 +247,8 @@ func TestStatusRecordRejectionNoChange(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	admitter.RecordRouteRejection(&routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -284,8 +284,8 @@ func TestStatusRecordRejectionWithStatus(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	admitter.RecordRouteRejection(&routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -331,8 +331,8 @@ func TestStatusRecordRejectionOnHostUpdateOnly(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	admitter.RecordRouteRejection(&routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -380,14 +380,14 @@ func TestStatusRecordRejectionConflict(t *testing.T) {
 	nowFn = func() metav1.Time { return now }
 	touched := metav1.Time{Time: now.Add(-time.Minute)}
 	p := &fakePlugin{}
-	c := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	c := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
 	c.PrependReactor("update", "routes", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetSubresource() != "status" {
 			return false, nil, nil
 		}
 		return true, nil, errors.NewConflict(kapi.Resource("Route"), "route1", nil)
 	})
-	admitter := NewStatusAdmitter(p, c, "test", "")
+	admitter := NewStatusAdmitter(p, c.Route(), "test", "")
 	admitter.RecordRouteRejection(&routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -434,8 +434,8 @@ func TestStatusFightBetweenReplicas(t *testing.T) {
 	// the initial pre-population
 	now1 := metav1.Now()
 	nowFn = func() metav1.Time { return now1 }
-	c1 := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter1 := NewStatusAdmitter(p, c1, "test", "")
+	c1 := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter1 := NewStatusAdmitter(p, c1.Route(), "test", "")
 	err := admitter1.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route1.test.local"},
@@ -447,8 +447,8 @@ func TestStatusFightBetweenReplicas(t *testing.T) {
 	// the new deployment's replica
 	now2 := metav1.Time{Time: now1.Time.Add(time.Minute)}
 	nowFn = func() metav1.Time { return now2 }
-	c2 := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
-	admitter2 := NewStatusAdmitter(p, c2, "test", "")
+	c2 := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	admitter2 := NewStatusAdmitter(p, c2.Route(), "test", "")
 	outObj1.Spec.Host = "route1.test-new.local"
 	err = admitter2.HandleRoute(watch.Added, outObj1)
 
@@ -477,7 +477,7 @@ func TestStatusFightBetweenRouters(t *testing.T) {
 	now1 := metav1.Now()
 	nowFn = func() metav1.Time { return now1 }
 	touched1 := metav1.Time{Time: now1.Add(-time.Minute)}
-	c1 := testclient.NewSimpleFake(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
+	c1 := fake.NewSimpleClientset(&routeapi.Route{ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")}})
 	returnConflict := true
 	c1.PrependReactor("update", "routes", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetSubresource() != "status" {
@@ -489,7 +489,7 @@ func TestStatusFightBetweenRouters(t *testing.T) {
 		}
 		return false, nil, nil
 	})
-	admitter1 := NewStatusAdmitter(p, c1, "test2", "")
+	admitter1 := NewStatusAdmitter(p, c1.Route(), "test2", "")
 	err := admitter1.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route2.test-new.local"},
@@ -527,7 +527,7 @@ func TestStatusFightBetweenRouters(t *testing.T) {
 	now2 := metav1.Now()
 	nowFn = func() metav1.Time { return now2 }
 	touched2 := metav1.Time{Time: now2.Add(-time.Minute)}
-	//c2 := testclient.NewSimpleFake(&routeapi.Route{})
+	//c2 := fake.NewSimpleClientset(&routeapi.Route{})
 	err = admitter1.HandleRoute(watch.Added, &routeapi.Route{
 		ObjectMeta: metav1.ObjectMeta{Name: "route1", Namespace: "default", UID: types.UID("uid1")},
 		Spec:       routeapi.RouteSpec{Host: "route2.test-new.local"},
@@ -564,7 +564,7 @@ func TestStatusFightBetweenRouters(t *testing.T) {
 
 func makePass(t *testing.T, host string, admitter *StatusAdmitter, srcObj *routeapi.Route, expectUpdate bool, conflict bool) *routeapi.Route {
 	// initialize a new client
-	c := testclient.NewSimpleFake(srcObj)
+	c := fake.NewSimpleClientset(srcObj)
 	if conflict {
 		c.PrependReactor("update", "routes", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 			if action.GetSubresource() != "status" {
@@ -574,7 +574,7 @@ func makePass(t *testing.T, host string, admitter *StatusAdmitter, srcObj *route
 		})
 	}
 
-	admitter.client = c
+	admitter.client = c.Route()
 
 	inputObjRaw, err := kapi.Scheme.DeepCopy(srcObj)
 	if err != nil {

--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -40,6 +40,7 @@ func Listen(listenAddr string, username, password string, checks ...healthz.Heal
 			Addr:    listenAddr,
 			Handler: mux,
 		}
+		glog.Infof("Router health and metrics port listening at %s", listenAddr)
 		glog.Fatal(server.ListenAndServe())
 	}()
 

--- a/test/integration/router/router_http_server.go
+++ b/test/integration/router/router_http_server.go
@@ -2,14 +2,20 @@ package router
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/websocket"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/discovery"
+	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/cmd/util"
 )
@@ -198,7 +204,13 @@ func (s *TestHttpService) handleNodeWatch(w http.ResponseWriter, r *http.Request
 // handleRouteWatch handles calls to /osapi/v1beta1/watch/routes and uses the route channel to simulate watch events
 func (s *TestHttpService) handleRouteWatch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	io.WriteString(w, <-s.RouteChannel)
+	routeJSON := <-s.RouteChannel
+	// TODO: avoids a more extensive rewrite, future should send an event and the http service
+	// should have two codecs
+	if strings.HasPrefix(r.URL.Path, "/apis/route.openshift.io/v1") {
+		routeJSON = rewriteEventAPIVersion(routeJSON, "v1", "route.openshift.io/v1")
+	}
+	io.WriteString(w, routeJSON)
 }
 
 // handleRouteList handles calls to /osapi/v1beta1/routes and always returns empty data
@@ -313,6 +325,9 @@ func (s *TestHttpService) startMaster() error {
 		masterServer.HandleFunc(fmt.Sprintf("/oapi/%s/routes", version), s.handleRouteList)
 		masterServer.HandleFunc(fmt.Sprintf("/oapi/%s/namespaces/", version), s.handleRouteCalls)
 		masterServer.HandleFunc(fmt.Sprintf("/oapi/%s/watch/routes", version), s.handleRouteWatch)
+		masterServer.HandleFunc(fmt.Sprintf("/apis/route.openshift.io/%s/routes", version), s.handleRouteList)
+		masterServer.HandleFunc(fmt.Sprintf("/apis/route.openshift.io/%s/namespaces/", version), s.handleRouteCalls)
+		masterServer.HandleFunc(fmt.Sprintf("/apis/route.openshift.io/%s/watch/routes", version), s.handleRouteWatch)
 		masterServer.HandleFunc(fmt.Sprintf("/api/%s/nodes", version), s.handleNodeList)
 		masterServer.HandleFunc(fmt.Sprintf("/api/%s/watch/nodes", version), s.handleNodeWatch)
 		masterServer.HandleFunc(fmt.Sprintf("/api/%s/services", version), s.handleSvcList)
@@ -323,11 +338,36 @@ func (s *TestHttpService) startMaster() error {
 	masterServer.HandleFunc("/apis/extensions/v1beta1/ingresses", s.handleIngressList)
 	masterServer.HandleFunc("/apis/extensions/v1beta1/watch/ingresses", s.handleIngressWatch)
 
+	h := discovery.NewRootAPIsHandler(discovery.DefaultAddresses{DefaultAddress: s.MasterHttpAddr}, kapi.Codecs)
+	h.AddGroup(metav1.APIGroup{
+		Name:     "route.openshift.io",
+		Versions: []metav1.GroupVersionForDiscovery{{GroupVersion: "route.openshift.io/v1", Version: "v1"}},
+	})
+	masterServer.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		glog.Infof("%s %s", req.Method, req.URL)
+		switch req.URL.Path {
+		case "/":
+			data, _ := json.Marshal(rootAPI{Paths: []string{"/oapi", "/oapi/v1", "/apis", "/apis/route.openshift.io", "/apis/route.openshift.io/v1"}})
+			w.WriteHeader(200)
+			w.Write(data)
+			return
+		case "/apis":
+			h.ServeHTTP(w, req)
+			return
+		}
+		glog.Infof("%s %s 404", req.Method, req.URL)
+		w.WriteHeader(404)
+	})
+
 	if err := s.startServing(s.MasterHttpAddr, http.Handler(masterServer)); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+type rootAPI struct {
+	Paths []string `json:"paths"`
 }
 
 func (s *TestHttpService) startPod() error {
@@ -420,4 +460,21 @@ func (s *TestHttpService) startServingTLS(addr string, cert []byte, key []byte, 
 	}()
 
 	return nil
+}
+
+func rewriteEventAPIVersion(s string, fromVersion, toVersion string) string {
+	m := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		panic(err)
+	}
+	obj := m["object"].(map[string]interface{})
+	if obj["apiVersion"].(string) != fromVersion {
+		panic(obj["apiVersion"])
+	}
+	obj["apiVersion"] = toVersion
+	data, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }


### PR DESCRIPTION
Ensures it's using the new API and can get new behavior.

@knobunc  this preps us having the new router get different results from the old router for destination CA cert and should be a no-op for 3.6 clusters (you can't use 3.6 router without a 3.6 cluster)

[severity:blocker]