### PR TITLE
Preserve backwards compatibilty for old routes for destination CA

### DIFF
--- a/pkg/cmd/server/origin/legacy.go
+++ b/pkg/cmd/server/origin/legacy.go
@@ -7,6 +7,8 @@ import (
 
 	buildconfigetcd "github.com/openshift/origin/pkg/build/registry/buildconfig/etcd"
 	deploymentconfigetcd "github.com/openshift/origin/pkg/deploy/registry/deployconfig/etcd"
+	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
+	routeetcd "github.com/openshift/origin/pkg/route/registry/route/etcd"
 )
 
 var (
@@ -204,6 +206,11 @@ func LegacyStorage(storage map[schema.GroupVersion]map[string]rest.Storage) map[
 					store := *restStorage.Store
 					restStorage.DeleteStrategy = orphanByDefault(store.DeleteStrategy)
 					legacyStorage[resource] = &deploymentconfigetcd.REST{Store: &store}
+				case "routes":
+					restStorage := s.(*routeetcd.REST)
+					store := *restStorage.Store
+					store.Decorator = routeregistry.DecorateLegacyRouteWithEmptyDestinationCACertificates
+					legacyStorage[resource] = &routeetcd.REST{Store: &store}
 
 				default:
 					legacyStorage[resource] = s

--- a/test/cmd/routes.sh
+++ b/test/cmd/routes.sh
@@ -32,6 +32,12 @@ os::cmd::expect_success 'oc delete routes foo'
 os::cmd::expect_success_and_text 'oc create route edge --service foo --port=8080' 'created'
 os::cmd::expect_success_and_text 'oc create route edge --service bar --port=9090' 'created'
 
+# verify that reencrypt routes with no destination CA return the stub PEM block on the old API
+project="$(oc project -q)"
+os::cmd::expect_success_and_text     'oc create route reencrypt --service baz --port=9090' 'created'
+os::cmd::expect_success_and_text     'oc get --raw /oapi/v1/namespaces/${project}/routes/baz' 'This is an empty PEM file'
+os::cmd::expect_success_and_not_text 'oc get --raw /apis/route.openshift.io/v1/namespaces/${project}/routes/baz' 'This is an empty PEM file'
+
 os::cmd::expect_success_and_text 'oc set route-backends foo' 'routes/foo'
 os::cmd::expect_success_and_text 'oc set route-backends foo' 'Service'
 os::cmd::expect_success_and_text 'oc set route-backends foo' '100'


### PR DESCRIPTION
OpenShift 3.6 allows destinationCACertificates on the new
route.openshift.io group for reencrypt routes to be empty. To preserve
backwards compatibility for the existing route API, set a simple "no-op"
PEM into the returned REST response, and strip it if a client round trips
it. A v1 client that tries to send an empty destinationCACertificate will
be allowed to do so, but will get back a response that includes the empty
PEM file.

I still need to add a set of tests

[test] @knobunc