### PR TITLE
Add a diagnostic that runs extended validation on routes

### DIFF
--- a/pkg/cmd/admin/diagnostics/cluster.go
+++ b/pkg/cmd/admin/diagnostics/cluster.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -30,6 +31,7 @@ var (
 		clustdiags.MasterNodeName,
 		clustdiags.MetricsApiProxyName,
 		clustdiags.NodeDefinitionsName,
+		clustdiags.RouteCertificateValidationName,
 		clustdiags.ServiceExternalIPsName,
 	)
 )
@@ -47,10 +49,13 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 		kclusterClient kclientset.Interface
 	)
 
-	clusterClient, kclusterClient, found, serverUrl, err := o.findClusterClients(rawConfig)
+	config, clusterClient, kclusterClient, found, serverUrl, err := o.findClusterClients(rawConfig)
 	if !found {
 		o.Logger.Notice("CED1002", "Could not configure a client with cluster-admin permissions for the current server, so cluster diagnostics will be skipped")
 		return nil, true, err
+	}
+	if err != nil {
+		return nil, false, err
 	}
 
 	diagnostics := []types.Diagnostic{}
@@ -75,6 +80,8 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 			d = &clustdiags.MetricsApiProxy{KubeClient: kclusterClient}
 		case clustdiags.ServiceExternalIPsName:
 			d = &clustdiags.ServiceExternalIPs{MasterConfigFile: o.MasterConfigLocation, KclusterClient: kclusterClient}
+		case clustdiags.RouteCertificateValidationName:
+			d = &clustdiags.RouteCertificateValidation{OsClient: clusterClient, RESTConfig: config}
 		default:
 			return nil, false, fmt.Errorf("unknown diagnostic: %v", diagnosticName)
 		}
@@ -84,51 +91,56 @@ func (o DiagnosticsOptions) buildClusterDiagnostics(rawConfig *clientcmdapi.Conf
 }
 
 // attempts to find which context in the config might be a cluster-admin for the server in the current context.
-func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (*client.Client, kclientset.Interface, bool, string, error) {
+func (o DiagnosticsOptions) findClusterClients(rawConfig *clientcmdapi.Config) (*rest.Config, *client.Client, kclientset.Interface, bool, string, error) {
 	if o.ClientClusterContext != "" { // user has specified cluster context to use
 		if context, exists := rawConfig.Contexts[o.ClientClusterContext]; exists {
 			configErr := fmt.Errorf("Specified '%s' as cluster-admin context, but it was not found in your client configuration.", o.ClientClusterContext)
 			o.Logger.Error("CED1003", configErr.Error())
-			return nil, nil, false, "", configErr
-		} else if os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, o.ClientClusterContext, context); found {
-			return os, kube, true, serverUrl, err
+			return nil, nil, nil, false, "", configErr
+		} else if config, os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, o.ClientClusterContext, context); found {
+			return config, os, kube, true, serverUrl, err
 		} else {
-			return nil, nil, false, "", err
+			return nil, nil, nil, false, "", err
 		}
 	}
 	currentContext, exists := rawConfig.Contexts[rawConfig.CurrentContext]
 	if !exists { // config specified cluster admin context that doesn't exist; complain and quit
 		configErr := fmt.Errorf("Current context '%s' not found in client configuration; will not attempt cluster diagnostics.", rawConfig.CurrentContext)
 		o.Logger.Error("CED1004", configErr.Error())
-		return nil, nil, false, "", configErr
+		return nil, nil, nil, false, "", configErr
 	}
 	// check if current context is already cluster admin
-	if os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, rawConfig.CurrentContext, currentContext); found {
-		return os, kube, true, serverUrl, err
+	if config, os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, rawConfig.CurrentContext, currentContext); found {
+		return config, os, kube, true, serverUrl, err
 	}
 	// otherwise, for convenience, search for a context with the same server but with the system:admin user
 	for name, context := range rawConfig.Contexts {
 		if context.Cluster == currentContext.Cluster && name != rawConfig.CurrentContext && strings.HasPrefix(context.AuthInfo, "system:admin/") {
-			if os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, name, context); found {
-				return os, kube, true, serverUrl, err
+			if config, os, kube, found, serverUrl, err := o.makeClusterClients(rawConfig, name, context); found {
+				return config, os, kube, true, serverUrl, err
 			} else {
-				return nil, nil, false, "", err // don't try more than one such context, they'll probably fail the same
+				return nil, nil, nil, false, "", err // don't try more than one such context, they'll probably fail the same
 			}
 		}
 	}
-	return nil, nil, false, "", nil
+	return nil, nil, nil, false, "", nil
 }
 
 // makes the client from the specified context and determines whether it is a cluster-admin.
-func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (*client.Client, kclientset.Interface, bool, string, error) {
+func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, contextName string, context *clientcmdapi.Context) (*rest.Config, *client.Client, kclientset.Interface, bool, string, error) {
 	overrides := &clientcmd.ConfigOverrides{Context: *context}
 	clientConfig := clientcmd.NewDefaultClientConfig(*rawConfig, overrides)
 	serverUrl := rawConfig.Clusters[context.Cluster].Server
 	factory := osclientcmd.NewFactory(clientConfig)
+	config, err := factory.ClientConfig()
+	if err != nil {
+		o.Logger.Debug("CED1006", fmt.Sprintf("Error creating client for context '%s':\n%v", contextName, err))
+		return nil, nil, nil, false, "", nil
+	}
 	o.Logger.Debug("CED1005", fmt.Sprintf("Checking if context is cluster-admin: '%s'", contextName))
 	if osClient, kubeClient, err := factory.Clients(); err != nil {
 		o.Logger.Debug("CED1006", fmt.Sprintf("Error creating client for context '%s':\n%v", contextName, err))
-		return nil, nil, false, "", nil
+		return nil, nil, nil, false, "", nil
 	} else {
 		subjectAccessReview := authorizationapi.SubjectAccessReview{Action: authorizationapi.Action{
 			// if you can do everything, you're the cluster admin.
@@ -139,16 +151,16 @@ func (o DiagnosticsOptions) makeClusterClients(rawConfig *clientcmdapi.Config, c
 		if resp, err := osClient.SubjectAccessReviews().Create(&subjectAccessReview); err != nil {
 			if regexp.MustCompile(`User "[\w:]+" cannot create \w+ at the cluster scope`).MatchString(err.Error()) {
 				o.Logger.Debug("CED1007", fmt.Sprintf("Context '%s' does not have cluster-admin access:\n%v", contextName, err))
-				return nil, nil, false, "", nil
+				return nil, nil, nil, false, "", nil
 			} else {
 				o.Logger.Error("CED1008", fmt.Sprintf("Unknown error testing cluster-admin access for context '%s':\n%v", contextName, err))
-				return nil, nil, false, "", err
+				return nil, nil, nil, false, "", err
 			}
 		} else if resp.Allowed {
 			o.Logger.Info("CED1009", fmt.Sprintf("Using context for cluster-admin access: '%s'", contextName))
-			return osClient, kubeClient, true, serverUrl, nil
+			return config, osClient, kubeClient, true, serverUrl, nil
 		}
 	}
 	o.Logger.Debug("CED1010", fmt.Sprintf("Context does not have cluster-admin access: '%s'", contextName))
-	return nil, nil, false, "", nil
+	return nil, nil, nil, false, "", nil
 }

--- a/pkg/diagnostics/cluster/route_validation.go
+++ b/pkg/diagnostics/cluster/route_validation.go
@@ -1,0 +1,109 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/rest"
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/diagnostics/types"
+	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+	"github.com/openshift/origin/pkg/route/apis/route/validation"
+	clientset "github.com/openshift/origin/pkg/route/generated/internalclientset"
+)
+
+// RouteCertificateValidation is a Diagnostic to check that there is a working router.
+type RouteCertificateValidation struct {
+	OsClient   *client.Client
+	RESTConfig *rest.Config
+}
+
+const (
+	RouteCertificateValidationName = "RouteCertificateValidation"
+
+	clGetRoutesFailed = `
+Client error while retrieving all routes. Client retrieved records
+before, so this is likely to be a transient error. Try running
+diagnostics again. If this message persists, there may be a permissions
+problem with getting records. The error was:
+
+(%[1]T) %[1]v`
+)
+
+func (d *RouteCertificateValidation) Name() string {
+	return "RouteCertificateValidation"
+}
+
+func (d *RouteCertificateValidation) Description() string {
+	return "Check all route certificates for certificates that might be rejected by extended validation."
+}
+
+func (d *RouteCertificateValidation) CanRun() (bool, error) {
+	if d.RESTConfig == nil || d.OsClient == nil {
+		return false, errors.New("must have OpenShift client configuration")
+	}
+	can, err := userCan(d.OsClient, authorizationapi.Action{
+		Namespace: metav1.NamespaceAll,
+		Verb:      "get",
+		Group:     routeapi.GroupName,
+		Resource:  "routes",
+	})
+	if err != nil {
+		return false, types.DiagnosticError{ID: "DRouCert2010", LogMessage: fmt.Sprintf(clientAccessError, err), Cause: err}
+	} else if !can {
+		return false, types.DiagnosticError{ID: "DRouCert2011", LogMessage: "Client does not have cluster-admin access", Cause: err}
+	}
+	return true, nil
+}
+
+func (d *RouteCertificateValidation) Check() types.DiagnosticResult {
+	r := types.NewDiagnosticResult(RouteCertificateValidationName)
+
+	client, err := clientset.NewForConfig(d.RESTConfig)
+	if err != nil {
+		r.Error("DRouCert2012", err, fmt.Sprintf(clientAccessError, err))
+		return r
+	}
+
+	routes, err := client.Route().Routes(metav1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		r.Error("DRouCert2013", err, fmt.Sprintf(clGetRoutesFailed, err))
+		return r
+	}
+
+	for _, route := range routes.Items {
+		copied, err := kapi.Scheme.Copy(&route)
+		if err != nil {
+			r.Error("DRouCert2003", err, fmt.Errorf("unable to copy route: %v", err).Error())
+			return r
+		}
+		original := copied.(*routeapi.Route)
+
+		errs := validation.ExtendedValidateRoute(&route)
+
+		if len(errs) == 0 {
+			if !kapi.Semantic.DeepEqual(original, &route) {
+				err := fmt.Errorf("Route was normalized when extended validation was run (route/%s -n %s).\nPlease verify that this route certificate contains no invalid data.\n", route.Name, route.Namespace)
+				r.Warn("DRouCert2004", nil, err.Error())
+			}
+			continue
+		}
+		err = fmt.Errorf("Route failed extended validation (route/%s -n %s):\n%s", route.Name, route.Namespace, flattenErrors(errs))
+		r.Error("DRouCert2005", nil, err.Error())
+	}
+	return r
+}
+
+func flattenErrors(errs field.ErrorList) string {
+	var out []string
+	for i := range errs {
+		out = append(out, fmt.Sprintf("* %s", errs[i].Error()))
+	}
+	return strings.Join(out, "\n")
+}


### PR DESCRIPTION
In 3.6 route extended validation has become more aggressive. This
diagnostic makes it easy for an admin to test how many routes on the
cluster would fail extended validation by running it on all routes.

    $ oadm diagnostics RouteCertificateValidation

will report all failing routes.

[test] @knobunc @liggitt