### PR TITLE
Build junitreport with hack/build-go.sh, based on tools/junitreport/README.md.

### DIFF
--- a/hack/test-tools.sh
+++ b/hack/test-tools.sh
@@ -6,6 +6,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::test::junit::declare_suite_start 'tools'
 
+os::util::ensure::built_binary_exists 'junitreport'
 os::cmd::expect_success 'tools/junitreport/test/integration.sh'
 
 echo "test-tools: ok"

--- a/tools/junitreport/test/integration.sh
+++ b/tools/junitreport/test/integration.sh
@@ -14,9 +14,6 @@ diff_args='-ydb --suppress-common-lines'
 TMPDIR="/tmp/junitreport/test/integration"
 mkdir -p "${TMPDIR}"
 
-echo "[INFO] Building junitreport binary for testing..."
-go build .
-
 for suite in test/*/; do
 	suite_name=$( basename ${suite} )
 	echo "[INFO] Testing suite ${suite_name}..."
@@ -28,24 +25,24 @@ for suite in test/*/; do
 	for test in ${suite}/testdata/*.txt; do
 		test_name=$( basename ${test} '.txt' )
 
-		cat "${test}" | ./junitreport -type "${suite_name}" -suites flat > "${WORKINGDIR}/${test_name}_flat.xml"
+		cat "${test}" | junitreport -type "${suite_name}" -suites flat > "${WORKINGDIR}/${test_name}_flat.xml"
 		if ! diff ${diff_args} "${suite}/reports/${test_name}_flat.xml" "${WORKINGDIR}/${test_name}_flat.xml"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for flat suite builder."
 			exit 1
 		fi
 
-		cat "${test}" | ./junitreport -type "${suite_name}" -suites nested > "${WORKINGDIR}/${test_name}_nested.xml"
+		cat "${test}" | junitreport -type "${suite_name}" -suites nested > "${WORKINGDIR}/${test_name}_nested.xml"
 		if ! diff ${diff_args} "${suite}/reports/${test_name}_nested.xml" "${WORKINGDIR}/${test_name}_nested.xml"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for nested suite builder."
 			exit 1
 		fi
 
-		cat "${WORKINGDIR}/${test_name}_flat.xml" | ./junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
+		cat "${WORKINGDIR}/${test_name}_flat.xml" | junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
 		if ! diff ${diff_args} "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize flat XML."
 		fi
 
-		cat "${WORKINGDIR}/${test_name}_nested.xml" | ./junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
+		cat "${WORKINGDIR}/${test_name}_nested.xml" | junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
 		if ! diff ${diff_args} "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize nested XML."
 		fi
@@ -56,25 +53,25 @@ done
 
 echo "[INFO] Testing restricted roots with nested suites..."
 # test some cases with nested suites and given roots
-cat "test/gotest/testdata/1.txt" | ./junitreport -type gotest -suites nested -roots package/name > "${TMPDIR}/gotest/1_nested_restricted.xml"
+cat "test/gotest/testdata/1.txt" | junitreport -type gotest -suites nested -roots package/name > "${TMPDIR}/gotest/1_nested_restricted.xml"
 if ! diff ${diff_args} "test/gotest/reports/1_nested_restricted.xml" "${TMPDIR}/gotest/1_nested_restricted.xml"; then
 	echo "[FAIL] Test '1' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name'."
 	exit 1
 fi
 
-cat "test/oscmd/testdata/1.txt" | ./junitreport -type oscmd -suites nested -roots package/name > "${TMPDIR}/oscmd/1_nested_restricted.xml"
+cat "test/oscmd/testdata/1.txt" | junitreport -type oscmd -suites nested -roots package/name > "${TMPDIR}/oscmd/1_nested_restricted.xml"
 if ! diff ${diff_args} "test/oscmd/reports/1_nested_restricted.xml" "${TMPDIR}/oscmd/1_nested_restricted.xml"; then
 	echo "[FAIL] Test '1' in suite 'oscmd' failed for nested suite builder with restricted roots: 'package/name'."
 	exit 1
 fi
 
-cat "test/gotest/testdata/9.txt" | ./junitreport -type gotest -suites nested -roots package/name,package/other > "${TMPDIR}/gotest/9_nested_restricted.xml"
+cat "test/gotest/testdata/9.txt" | junitreport -type gotest -suites nested -roots package/name,package/other > "${TMPDIR}/gotest/9_nested_restricted.xml"
 if ! diff ${diff_args} "test/gotest/reports/9_nested_restricted.xml" "${TMPDIR}/gotest/9_nested_restricted.xml"; then
 	echo "[FAIL] Test '9' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name,package/other'."
 	exit 1
 fi
 
-cat "test/oscmd/testdata/4.txt" | ./junitreport -type oscmd -suites nested -roots package/name,package/other > "${TMPDIR}/oscmd/4_nested_restricted.xml"
+cat "test/oscmd/testdata/4.txt" | junitreport -type oscmd -suites nested -roots package/name,package/other > "${TMPDIR}/oscmd/4_nested_restricted.xml"
 if ! diff ${diff_args} "test/oscmd/reports/4_nested_restricted.xml" "${TMPDIR}/oscmd/4_nested_restricted.xml"; then
 	echo "[FAIL] Test '4' in suite 'oscmd' failed for nested suite builder with restricted roots: 'package/name,package/other'."
 	exit 1


### PR DESCRIPTION
Addressing
```
$ make test
hack/test-tools.sh
FAILURE after 0.050s: hack/test-tools.sh:9: executing 'tools/junitreport/test/integration.sh' expecting success: the command returned the wrong error code
Standard output from the command:
[INFO] Building junitreport binary for testing...

Standard error from the command:
junitreport.go:10:2: cannot find package "github.com/openshift/origin/tools/junitreport/pkg/cmd" in any of:
        /usr/lib/golang/src/github.com/openshift/origin/tools/junitreport/pkg/cmd (from $GOROOT)
        ($GOPATH not set)
[ERROR] PID 28008: hack/lib/cmd.sh:241: `return "${return_code}"` exited with status 1.
[INFO]          Stack Trace:
[INFO]            1: hack/lib/cmd.sh:241: `return "${return_code}"`
[INFO]            2: hack/test-tools.sh:9: os::cmd::expect_success
[INFO]   Exiting with code 1.
Makefile:198: recipe for target 'test-tools' failed
make: *** [test-tools] Error 1
```