### PR TITLE
Allow project admins to create/edit/delete NetworkPolicies

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -322,7 +322,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs", "scheduledjobs", "cronjobs").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
-					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback").RuleOrDie(),
+					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback", "networkpolicies").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				authorizationapi.NewRule(readWrite...).Groups(appsGroup).Resources("statefulsets", "deployments", "deployments/scale", "deployments/status").RuleOrDie(),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -677,6 +677,7 @@ items:
     - deployments/scale
     - horizontalpodautoscalers
     - jobs
+    - networkpolicies
     - replicasets
     - replicasets/scale
     - replicationcontrollers/scale


### PR DESCRIPTION
This is how it's supposed to work.

Some customers have argued that they don't actually want this behavior, but as far as we've been able to tell, that has always been based on the mistaken belief that this would allow project admins to give themselves access to *other* projects. But anyway, we can adjust the permissions for 3.7 if really necessary. This is definitely the right default behavior for 3.6.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1461208
https://trello.com/c/CBQ3Rc00

@knobunc 