### PR TITLE
UPSTREAM: 47822: Separate serviceaccount and secret storage config

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -742,14 +742,26 @@ func newServiceAccountTokenGetter(options configapi.MasterConfig) (serviceaccoun
 		return nil, err
 	}
 
-	storageConfig, err := kubeStorageFactory.NewConfig(kapi.Resource("serviceaccounts"))
+	storageConfigServiceAccounts, err := kubeStorageFactory.NewConfig(kapi.Resource("serviceaccounts"))
 	if err != nil {
 		return nil, err
 	}
+	storageConfigSecrets, err := kubeStorageFactory.NewConfig(kapi.Resource("secrets"))
+	if err != nil {
+		return nil, err
+	}
+
 	// TODO: by doing this we will not be able to authenticate while a master quorum is not present - reimplement
 	// as two storages called in succession (non quorum and then quorum).
-	storageConfig.Quorum = true
-	return sacontroller.NewGetterFromStorageInterface(storageConfig, kubeStorageFactory.ResourcePrefix(kapi.Resource("serviceaccounts")), kubeStorageFactory.ResourcePrefix(kapi.Resource("secrets"))), nil
+	storageConfigServiceAccounts.Quorum = true
+	storageConfigSecrets.Quorum = true
+
+	return sacontroller.NewGetterFromStorageInterface(
+		storageConfigServiceAccounts,
+		kubeStorageFactory.ResourcePrefix(kapi.Resource("serviceaccounts")),
+		storageConfigSecrets,
+		kubeStorageFactory.ResourcePrefix(kapi.Resource("secrets")),
+	), nil
 }
 
 func newAuthenticator(config configapi.MasterConfig, restOptionsGetter restoptions.Getter, tokenGetter serviceaccount.ServiceAccountTokenGetter, apiClientCAs *x509.CertPool, groupMapper identitymapper.UserToGroupMapper) (authenticator.Request, error) {

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -406,11 +406,20 @@ func BuildAuthenticator(s *options.ServerRunOptions, storageFactory serverstorag
 	if s.Authentication.ServiceAccounts.Lookup {
 		// we have to go direct to storage because the clientsets fail when they're initialized with some API versions excluded
 		// we should stop trying to control them like that.
-		storageConfig, err := storageFactory.NewConfig(api.Resource("serviceaccounts"))
+		storageConfigServiceAccounts, err := storageFactory.NewConfig(api.Resource("serviceaccounts"))
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to get serviceaccounts storage: %v", err)
 		}
-		authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromStorageInterface(storageConfig, storageFactory.ResourcePrefix(api.Resource("serviceaccounts")), storageFactory.ResourcePrefix(api.Resource("secrets")))
+		storageConfigSecrets, err := storageFactory.NewConfig(api.Resource("secrets"))
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to get secrets storage: %v", err)
+		}
+		authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromStorageInterface(
+			storageConfigServiceAccounts,
+			storageFactory.ResourcePrefix(api.Resource("serviceaccounts")),
+			storageConfigSecrets,
+			storageFactory.ResourcePrefix(api.Resource("secrets")),
+		)
 	}
 	if client == nil || reflect.ValueOf(client).IsNil() {
 		// TODO: Remove check once client can never be nil.

--- a/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokengetter.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/serviceaccount/tokengetter.go
@@ -85,9 +85,14 @@ func (r *registryGetter) GetSecret(namespace, name string) (*v1.Secret, error) {
 
 // NewGetterFromStorageInterface returns a ServiceAccountTokenGetter that
 // uses the specified storage to retrieve service accounts and secrets.
-func NewGetterFromStorageInterface(config *storagebackend.Config, saPrefix, secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
-	saOpts := generic.RESTOptions{StorageConfig: config, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix}
-	secretOpts := generic.RESTOptions{StorageConfig: config, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix}
+func NewGetterFromStorageInterface(
+	saConfig *storagebackend.Config,
+	saPrefix string,
+	secretConfig *storagebackend.Config,
+	secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
+
+	saOpts := generic.RESTOptions{StorageConfig: saConfig, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix}
+	secretOpts := generic.RESTOptions{StorageConfig: secretConfig, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix}
 	return NewGetterFromRegistries(
 		serviceaccountregistry.NewRegistry(serviceaccountstore.NewREST(saOpts)),
 		secret.NewRegistry(secretstore.NewREST(secretOpts)),


### PR DESCRIPTION
Backport of https://github.com/kubernetes/kubernetes/pull/47822 that is required for resources encryption in etcd.

PTAL @liggitt @smarterclayton 
CC @simo5 