### PR TITLE
Fix for go vet warning on ldaputil/client.go

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -5,9 +5,8 @@ os::golang::verify_go_version
 
 bad_files=$(os::util::list_go_src_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then
-	echo "!!! gofmt needs to be run on the following files: " >&2
+	os::log::warning "!!! gofmt needs to be run on the following files: "
 	echo "${bad_files}"
-	echo "Try running 'gofmt -s -d [path]'" >&2
-	echo "Or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'" >&2
-	exit 1
+	os::log::fatal "Try running 'gofmt -s -d [path]'
+Or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'"
 fi

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -4,7 +4,6 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::golang::verify_go_version
 
 govet_blacklist=(
-	"pkg/auth/ldaputil/client.go:[0-9]+: assignment copies lock value to c: crypto/tls.Config contains sync.Once contains sync.Mutex"
 	"pkg/.*/client/clientset_generated/internalclientset/fake/clientset_generated.go:[0-9]+: literal copies lock value from fakePtr: github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/client/testing/core.Fake"
 	"pkg/.*/client/clientset_generated/release_v1_./fake/clientset_generated.go:[0-9]+: literal copies lock value from fakePtr: github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/client/testing/core.Fake"
 	"pkg/.*/clientset/internalclientset/fake/clientset_generated.go:[0-9]+: literal copies lock value from fakePtr: github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/client/testing/core.Fake"

--- a/pkg/auth/ldaputil/client.go
+++ b/pkg/auth/ldaputil/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/util/cert"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil/ldapclient"
@@ -66,13 +67,13 @@ func (l *ldapClientConfig) Connect() (ldap.Client, error) {
 	// Ensure tlsConfig specifies the server we're connecting to
 	if tlsConfig != nil && !tlsConfig.InsecureSkipVerify && len(tlsConfig.ServerName) == 0 {
 		// Add to a copy of the tlsConfig to avoid mutating the original
-		c := *tlsConfig
+		c := utilnet.CloneTLSConfig(tlsConfig)
 		if host, _, err := net.SplitHostPort(l.host); err == nil {
 			c.ServerName = host
 		} else {
 			c.ServerName = l.host
 		}
-		tlsConfig = &c
+		tlsConfig = c
 	}
 
 	switch l.scheme {


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/12393

@enj I believe this fixes the issue.