### PR TITLE
set default build prune limits for group api

### DIFF
--- a/pkg/build/apis/build/types.go
+++ b/pkg/build/apis/build/types.go
@@ -80,11 +80,23 @@ const (
 	BuildCancelledEventReason = "BuildCancelled"
 	// BuildCancelledEventMessage is the message associated with the event registered when build is cancelled.
 	BuildCancelledEventMessage = "Build %s/%s has been cancelled"
+
+	// DefaultSuccessfulBuildsHistoryLimit is the default number of successful builds to retain
+	// if the buildconfig does not specify a value.  This only applies to buildconfigs created
+	// via the new group api resource, not the legacy resource.
+	DefaultSuccessfulBuildsHistoryLimit = int32(5)
+
+	// DefaultFailedBuildsHistoryLimit is the default number of failed builds to retain
+	// if the buildconfig does not specify a value.  This only applies to buildconfigs created
+	// via the new group api resource, not the legacy resource.
+	DefaultFailedBuildsHistoryLimit = int32(5)
 )
 
-// WhitelistEnvVarNames is a list of environment variable keys that are allowed to be set by the
-// user on the build pod.
-var WhitelistEnvVarNames = [2]string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY"}
+var (
+	// WhitelistEnvVarNames is a list of environment variable keys that are allowed to be set by the
+	// user on the build pod.
+	WhitelistEnvVarNames = [2]string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY"}
+)
 
 // +genclient=true
 

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -24,9 +24,9 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		QualifiedResource: buildapi.Resource("buildconfigs"),
 		PredicateFunc:     buildconfig.Matcher,
 
-		CreateStrategy: buildconfig.Strategy,
-		UpdateStrategy: buildconfig.Strategy,
-		DeleteStrategy: buildconfig.Strategy,
+		CreateStrategy: buildconfig.GroupStrategy,
+		UpdateStrategy: buildconfig.GroupStrategy,
+		DeleteStrategy: buildconfig.GroupStrategy,
 	}
 
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: buildconfig.GetAttrs}

--- a/pkg/build/registry/buildconfig/strategy_test.go
+++ b/pkg/build/registry/buildconfig/strategy_test.go
@@ -10,12 +10,12 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 )
 
-func TestBuildConfigStrategy(t *testing.T) {
+func TestBuildConfigGroupStrategy(t *testing.T) {
 	ctx := apirequest.NewDefaultContext()
-	if !Strategy.NamespaceScoped() {
+	if !GroupStrategy.NamespaceScoped() {
 		t.Errorf("BuildConfig is namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if GroupStrategy.AllowCreateOnUpdate() {
 		t.Errorf("BuildConfig should not allow create on update")
 	}
 	buildConfig := &buildapi.BuildConfig{
@@ -88,34 +88,163 @@ func TestBuildConfigStrategy(t *testing.T) {
 			LastVersion: 9,
 		},
 	}
-	Strategy.PrepareForCreate(ctx, buildConfig)
-	errs := Strategy.Validate(ctx, buildConfig)
+	GroupStrategy.PrepareForCreate(ctx, buildConfig)
+	errs := GroupStrategy.Validate(ctx, buildConfig)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)
+	}
+	if buildConfig.Spec.SuccessfulBuildsHistoryLimit == nil {
+		t.Errorf("Expected successful limit %d, got nil", buildapi.DefaultSuccessfulBuildsHistoryLimit)
+	}
+	if *buildConfig.Spec.SuccessfulBuildsHistoryLimit != buildapi.DefaultSuccessfulBuildsHistoryLimit {
+		t.Errorf("Expected successful limit %d, got %d", buildapi.DefaultSuccessfulBuildsHistoryLimit, *buildConfig.Spec.SuccessfulBuildsHistoryLimit)
+	}
+	if buildConfig.Spec.FailedBuildsHistoryLimit == nil {
+		t.Errorf("Expected failed limit %d, got nil", buildapi.DefaultFailedBuildsHistoryLimit)
+	}
+	if *buildConfig.Spec.FailedBuildsHistoryLimit != buildapi.DefaultFailedBuildsHistoryLimit {
+		t.Errorf("Expected failed limit %d, got %d", buildapi.DefaultFailedBuildsHistoryLimit, *buildConfig.Spec.FailedBuildsHistoryLimit)
 	}
 
 	// lastversion cannot go backwards
 	newBC.Status.LastVersion = 9
-	Strategy.PrepareForUpdate(ctx, newBC, buildConfig)
+	GroupStrategy.PrepareForUpdate(ctx, newBC, buildConfig)
 	if newBC.Status.LastVersion != buildConfig.Status.LastVersion {
 		t.Errorf("Expected version=%d, got %d", buildConfig.Status.LastVersion, newBC.Status.LastVersion)
 	}
 
 	// lastversion can go forwards
 	newBC.Status.LastVersion = 11
-	Strategy.PrepareForUpdate(ctx, newBC, buildConfig)
+	GroupStrategy.PrepareForUpdate(ctx, newBC, buildConfig)
 	if newBC.Status.LastVersion != 11 {
 		t.Errorf("Expected version=%d, got %d", 11, newBC.Status.LastVersion)
 	}
 
-	Strategy.PrepareForCreate(ctx, buildConfig)
-	errs = Strategy.Validate(ctx, buildConfig)
+	GroupStrategy.PrepareForCreate(ctx, buildConfig)
+	errs = GroupStrategy.Validate(ctx, buildConfig)
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error validating %v", errs)
 	}
 
 	invalidBuildConfig := &buildapi.BuildConfig{}
-	errs = Strategy.Validate(ctx, invalidBuildConfig)
+	errs = GroupStrategy.Validate(ctx, invalidBuildConfig)
+	if len(errs) == 0 {
+		t.Errorf("Expected error validating")
+	}
+}
+
+func TestBuildConfigLegacyStrategy(t *testing.T) {
+	ctx := apirequest.NewDefaultContext()
+	if !LegacyStrategy.NamespaceScoped() {
+		t.Errorf("BuildConfig is namespace scoped")
+	}
+	if LegacyStrategy.AllowCreateOnUpdate() {
+		t.Errorf("BuildConfig should not allow create on update")
+	}
+	buildConfig := &buildapi.BuildConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "config-id", Namespace: "namespace"},
+		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
+			Triggers: []buildapi.BuildTriggerPolicy{
+				{
+					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},
+					Type:          buildapi.GitHubWebHookBuildTriggerType,
+				},
+				{
+					Type: "unknown",
+				},
+			},
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
+						URI: "http://github.com/my/repository",
+					},
+					ContextDir: "context",
+				},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+			},
+		},
+		Status: buildapi.BuildConfigStatus{
+			LastVersion: 10,
+		},
+	}
+	newBC := &buildapi.BuildConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "config-id", Namespace: "namespace"},
+		Spec: buildapi.BuildConfigSpec{
+			RunPolicy: buildapi.BuildRunPolicySerial,
+			Triggers: []buildapi.BuildTriggerPolicy{
+				{
+					GitHubWebHook: &buildapi.WebHookTrigger{Secret: "12345"},
+					Type:          buildapi.GitHubWebHookBuildTriggerType,
+				},
+				{
+					Type: "unknown",
+				},
+			},
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
+						URI: "http://github.com/my/repository",
+					},
+					ContextDir: "context",
+				},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+			},
+		},
+		Status: buildapi.BuildConfigStatus{
+			LastVersion: 9,
+		},
+	}
+	LegacyStrategy.PrepareForCreate(ctx, buildConfig)
+	errs := LegacyStrategy.Validate(ctx, buildConfig)
+	if len(errs) != 0 {
+		t.Errorf("Unexpected error validating %v", errs)
+	}
+	if buildConfig.Spec.SuccessfulBuildsHistoryLimit != nil {
+		t.Errorf("Expected successful limit to be nil, got %d", *buildConfig.Spec.SuccessfulBuildsHistoryLimit)
+	}
+	if buildConfig.Spec.FailedBuildsHistoryLimit != nil {
+		t.Errorf("Expected failed limit to be nil, got %d", *buildConfig.Spec.FailedBuildsHistoryLimit)
+	}
+
+	// lastversion cannot go backwards
+	newBC.Status.LastVersion = 9
+	LegacyStrategy.PrepareForUpdate(ctx, newBC, buildConfig)
+	if newBC.Status.LastVersion != buildConfig.Status.LastVersion {
+		t.Errorf("Expected version=%d, got %d", buildConfig.Status.LastVersion, newBC.Status.LastVersion)
+	}
+
+	// lastversion can go forwards
+	newBC.Status.LastVersion = 11
+	LegacyStrategy.PrepareForUpdate(ctx, newBC, buildConfig)
+	if newBC.Status.LastVersion != 11 {
+		t.Errorf("Expected version=%d, got %d", 11, newBC.Status.LastVersion)
+	}
+
+	LegacyStrategy.PrepareForCreate(ctx, buildConfig)
+	errs = LegacyStrategy.Validate(ctx, buildConfig)
+	if len(errs) != 0 {
+		t.Errorf("Unexpected error validating %v", errs)
+	}
+
+	invalidBuildConfig := &buildapi.BuildConfig{}
+	errs = LegacyStrategy.Validate(ctx, invalidBuildConfig)
 	if len(errs) == 0 {
 		t.Errorf("Expected error validating")
 	}

--- a/pkg/cmd/cli/cmd/exporter.go
+++ b/pkg/cmd/cli/cmd/exporter.go
@@ -148,7 +148,10 @@ func (e *DefaultExporter) Export(obj runtime.Object, exact bool) error {
 		return deployrest.Strategy.Export(ctx, obj, exact)
 
 	case *buildapi.BuildConfig:
-		buildconfigrest.Strategy.PrepareForCreate(ctx, obj)
+		// Use the legacy strategy to avoid setting prune defaults if
+		// the object wasn't created with them in the first place.
+		// TODO: use the exportstrategy pattern instead.
+		buildconfigrest.LegacyStrategy.PrepareForCreate(ctx, obj)
 		// TODO: should be handled by prepare for create
 		t.Status.LastVersion = 0
 		for i := range t.Spec.Triggers {

--- a/pkg/cmd/server/origin/legacy.go
+++ b/pkg/cmd/server/origin/legacy.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	buildconfig "github.com/openshift/origin/pkg/build/registry/buildconfig"
 	buildconfigetcd "github.com/openshift/origin/pkg/build/registry/buildconfig/etcd"
 	deploymentconfigetcd "github.com/openshift/origin/pkg/deploy/registry/deployconfig/etcd"
 )
@@ -197,7 +198,8 @@ func LegacyStorage(storage map[schema.GroupVersion]map[string]rest.Storage) map[
 				case "buildConfigs":
 					restStorage := s.(*buildconfigetcd.REST)
 					store := *restStorage.Store
-					store.DeleteStrategy = orphanByDefault(store.DeleteStrategy)
+					store.DeleteStrategy = buildconfig.LegacyStrategy
+					store.CreateStrategy = buildconfig.LegacyStrategy
 					legacyStorage[resource] = &buildconfigetcd.REST{Store: &store}
 				case "deploymentConfigs":
 					restStorage := s.(*deploymentconfigetcd.REST)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -12,6 +12,8 @@
 // test/extended/testdata/build-extended/bc-scripts-in-the-image.yaml
 // test/extended/testdata/build-extended/jvm-runner-with-scripts.yaml
 // test/extended/testdata/build-extended/jvm-runner.yaml
+// test/extended/testdata/build-pruning/default-group-build-config.yaml
+// test/extended/testdata/build-pruning/default-legacy-build-config.yaml
 // test/extended/testdata/build-pruning/errored-build-config.yaml
 // test/extended/testdata/build-pruning/failed-build-config.yaml
 // test/extended/testdata/build-pruning/imagestream.yaml
@@ -684,6 +686,72 @@ func testExtendedTestdataBuildExtendedJvmRunnerYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataBuildPruningDefaultGroupBuildConfigYaml = []byte(`apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: myphp
+spec:
+  source:
+    type: Git
+    git:
+      uri: 'https://github.com/openshift/cakephp-ex.git'
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        namespace: openshift
+        name: 'php:7.0'
+`)
+
+func testExtendedTestdataBuildPruningDefaultGroupBuildConfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildPruningDefaultGroupBuildConfigYaml, nil
+}
+
+func testExtendedTestdataBuildPruningDefaultGroupBuildConfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildPruningDefaultGroupBuildConfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/build-pruning/default-group-build-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYaml = []byte(`apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: myphp
+spec:
+  source:
+    type: Git
+    git:
+      uri: 'https://github.com/openshift/cakephp-ex.git'
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        namespace: openshift
+        name: 'php:7.0'
+`)
+
+func testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYaml, nil
+}
+
+func testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/build-pruning/default-legacy-build-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataBuildPruningErroredBuildConfigYaml = []byte(`apiVersion: v1
 kind: BuildConfig
 metadata:
@@ -734,13 +802,10 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   failedBuildsHistoryLimit: 2
-  triggers: {}
-  runPolicy: Serial
   source:
     type: Git
     git:
       uri: 'https://github.com/openshift/non-working-example.git'
-      ref: master
   strategy:
     type: Source
     sourceStrategy:
@@ -748,14 +813,6 @@ spec:
         kind: ImageStreamTag
         namespace: openshift
         name: 'php:7.0'
-  output:
-    to:
-      kind: ImageStreamTag
-      name: 'myphp:latest'
-  resources: {}
-  postCommit: {}
-  nodeSelector: null
-status:
 `)
 
 func testExtendedTestdataBuildPruningFailedBuildConfigYamlBytes() ([]byte, error) {
@@ -804,13 +861,10 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   successfulBuildsHistoryLimit: 2
-  triggers: {}
-  runPolicy: Serial
   source:
     type: Git
     git:
       uri: 'https://github.com/openshift/cakephp-ex.git'
-      ref: master
   strategy:
     type: Source
     sourceStrategy:
@@ -818,14 +872,6 @@ spec:
         kind: ImageStreamTag
         namespace: openshift
         name: 'php:7.0'
-  output:
-    to:
-      kind: ImageStreamTag
-      name: 'myphp:latest'
-  resources: {}
-  postCommit: {}
-  nodeSelector: null
-status:
 `)
 
 func testExtendedTestdataBuildPruningSuccessfulBuildConfigYamlBytes() ([]byte, error) {
@@ -20254,6 +20300,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/build-extended/bc-scripts-in-the-image.yaml": testExtendedTestdataBuildExtendedBcScriptsInTheImageYaml,
 	"test/extended/testdata/build-extended/jvm-runner-with-scripts.yaml": testExtendedTestdataBuildExtendedJvmRunnerWithScriptsYaml,
 	"test/extended/testdata/build-extended/jvm-runner.yaml": testExtendedTestdataBuildExtendedJvmRunnerYaml,
+	"test/extended/testdata/build-pruning/default-group-build-config.yaml": testExtendedTestdataBuildPruningDefaultGroupBuildConfigYaml,
+	"test/extended/testdata/build-pruning/default-legacy-build-config.yaml": testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYaml,
 	"test/extended/testdata/build-pruning/errored-build-config.yaml": testExtendedTestdataBuildPruningErroredBuildConfigYaml,
 	"test/extended/testdata/build-pruning/failed-build-config.yaml": testExtendedTestdataBuildPruningFailedBuildConfigYaml,
 	"test/extended/testdata/build-pruning/imagestream.yaml": testExtendedTestdataBuildPruningImagestreamYaml,
@@ -20568,6 +20616,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"jvm-runner.yaml": &bintree{testExtendedTestdataBuildExtendedJvmRunnerYaml, map[string]*bintree{}},
 				}},
 				"build-pruning": &bintree{nil, map[string]*bintree{
+					"default-group-build-config.yaml": &bintree{testExtendedTestdataBuildPruningDefaultGroupBuildConfigYaml, map[string]*bintree{}},
+					"default-legacy-build-config.yaml": &bintree{testExtendedTestdataBuildPruningDefaultLegacyBuildConfigYaml, map[string]*bintree{}},
 					"errored-build-config.yaml": &bintree{testExtendedTestdataBuildPruningErroredBuildConfigYaml, map[string]*bintree{}},
 					"failed-build-config.yaml": &bintree{testExtendedTestdataBuildPruningFailedBuildConfigYaml, map[string]*bintree{}},
 					"imagestream.yaml": &bintree{testExtendedTestdataBuildPruningImagestreamYaml, map[string]*bintree{}},

--- a/test/extended/testdata/build-pruning/default-group-build-config.yaml
+++ b/test/extended/testdata/build-pruning/default-group-build-config.yaml
@@ -1,17 +1,12 @@
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: myphp
-  labels:
-    app: myphp
-  annotations:
-    openshift.io/generated-by: OpenShiftWebConsole
 spec:
-  failedBuildsHistoryLimit: 2
   source:
     type: Git
     git:
-      uri: 'https://github.com/openshift/non-working-example.git'
+      uri: 'https://github.com/openshift/cakephp-ex.git'
   strategy:
     type: Source
     sourceStrategy:

--- a/test/extended/testdata/build-pruning/default-legacy-build-config.yaml
+++ b/test/extended/testdata/build-pruning/default-legacy-build-config.yaml
@@ -2,16 +2,11 @@ apiVersion: v1
 kind: BuildConfig
 metadata:
   name: myphp
-  labels:
-    app: myphp
-  annotations:
-    openshift.io/generated-by: OpenShiftWebConsole
 spec:
-  failedBuildsHistoryLimit: 2
   source:
     type: Git
     git:
-      uri: 'https://github.com/openshift/non-working-example.git'
+      uri: 'https://github.com/openshift/cakephp-ex.git'
   strategy:
     type: Source
     sourceStrategy:

--- a/test/extended/testdata/build-pruning/successful-build-config.yaml
+++ b/test/extended/testdata/build-pruning/successful-build-config.yaml
@@ -8,13 +8,10 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   successfulBuildsHistoryLimit: 2
-  triggers: {}
-  runPolicy: Serial
   source:
     type: Git
     git:
       uri: 'https://github.com/openshift/cakephp-ex.git'
-      ref: master
   strategy:
     type: Source
     sourceStrategy:
@@ -22,11 +19,3 @@ spec:
         kind: ImageStreamTag
         namespace: openshift
         name: 'php:7.0'
-  output:
-    to:
-      kind: ImageStreamTag
-      name: 'myphp:latest'
-  resources: {}
-  postCommit: {}
-  nodeSelector: null
-status:


### PR DESCRIPTION
introduces behavior that will default a successful and failed build history limit for buildconfigs that are created via the new group api.  legacy api behavior remains the same (no default limit, all builds are kept).
