### PR TITLE
Update default allowed registries

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -138,8 +138,8 @@ var (
 	// part of the domain name.
 	DefaultAllowedRegistriesForImport = &AllowedRegistries{
 		{DomainName: "docker.io"},
-		{DomainName: "*.docker.io"}, // registry-1.docker.io
-		{DomainName: "registry.access.redhat.com"},
+		{DomainName: "*.docker.io"},  // registry-1.docker.io
+		{DomainName: "*.redhat.com"}, // registry.connect.redhat.com and registry.access.redhat.com
 		{DomainName: "gcr.io"},
 		{DomainName: "quay.io"},
 		// FIXME: Probably need to have more fine-tuned pattern defined


### PR DESCRIPTION
While working on https://bugzilla.redhat.com/show_bug.cgi?id=1462606 I've noticed we have yet another redhat registry `registry.connect.redhat.com`, so I think it's just easier to accept all `*.redhat.com`, since I bet more will come. 

@mfojtik @smarterclayton wdyt?