### PR TITLE
Allow checking credentials for image imports against repo url, not just passed url

### DIFF
--- a/pkg/image/importer/credentials.go
+++ b/pkg/image/importer/credentials.go
@@ -1,16 +1,23 @@
 package importer
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 
 	"github.com/docker/distribution/registry/client/auth"
 
+	"k8s.io/client-go/tools/cache"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/credentialprovider"
+)
+
+const (
+	defaultRealmCacheTTL = time.Minute
 )
 
 var (
@@ -101,13 +108,14 @@ type keyringCredentialStore struct {
 }
 
 func (s *keyringCredentialStore) Basic(url *url.URL) (string, string) {
-	return basicCredentialsFromKeyring(s.DockerKeyring, url)
+	return basicCredentialsFromKeyring(s.DockerKeyring, url, nil)
 }
 
 func NewCredentialsForSecrets(secrets []kapiv1.Secret) *SecretCredentialStore {
 	return &SecretCredentialStore{
 		secrets:           secrets,
 		refreshTokenStore: &refreshTokenStore{},
+		realmStore:        cache.NewTTLStore(realmKeyFunc, defaultRealmCacheTTL),
 	}
 }
 
@@ -115,27 +123,65 @@ func NewLazyCredentialsForSecrets(secretsFn func() ([]kapiv1.Secret, error)) *Se
 	return &SecretCredentialStore{
 		secretsFn:         secretsFn,
 		refreshTokenStore: &refreshTokenStore{},
+		realmStore:        cache.NewTTLStore(realmKeyFunc, defaultRealmCacheTTL),
 	}
 }
 
 type SecretCredentialStore struct {
-	lock      sync.Mutex
-	secrets   []kapiv1.Secret
-	secretsFn func() ([]kapiv1.Secret, error)
-	err       error
-	keyring   credentialprovider.DockerKeyring
+	lock       sync.Mutex
+	realmStore cache.Store
+	secrets    []kapiv1.Secret
+	secretsFn  func() ([]kapiv1.Secret, error)
+	err        error
+	keyring    credentialprovider.DockerKeyring
 
 	*refreshTokenStore
 }
 
 func (s *SecretCredentialStore) Basic(url *url.URL) (string, string) {
-	return basicCredentialsFromKeyring(s.init(), url)
+	// the store holds realm entries, if the target URL matches one it means
+	// we should auth against registry URL rather than realm one
+	entry, exists, err := s.realmStore.GetByKey(url.String())
+	if exists && err == nil {
+		if ru, ok := entry.(*realmURL); ok {
+			return basicCredentialsFromKeyring(s.init(), url, &ru.registries)
+		}
+	}
+
+	return basicCredentialsFromKeyring(s.init(), url, nil)
 }
 
 func (s *SecretCredentialStore) Err() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.err
+}
+
+func (s *SecretCredentialStore) AddRealm(registry, realm *url.URL) {
+	entry, exists, err := s.realmStore.GetByKey(realm.String())
+	if !exists {
+		ru := &realmURL{
+			realm:    *realm,
+			registry: {*registry},
+		}
+		s.realmStore.Add(ru)
+	}
+	if exists && err == nil {
+		if ru, ok := entry.(*realmURL); ok {
+			found := false
+			for _, reg := range ru.registries {
+				if reg.String() == registry.String() {
+					found = true
+				}
+			}
+			if !found {
+				s.lock.Lock()
+				defer s.lock.Unlock()
+				ru.registries = append(ru.registries, *registry)
+				s.realmStore.Update(ru)
+			}
+		}
+	}
 }
 
 func (s *SecretCredentialStore) init() credentialprovider.DockerKeyring {
@@ -163,7 +209,7 @@ func (s *SecretCredentialStore) init() credentialprovider.DockerKeyring {
 	return keyring
 }
 
-func basicCredentialsFromKeyring(keyring credentialprovider.DockerKeyring, target *url.URL) (string, string) {
+func basicCredentialsFromKeyring(keyring credentialprovider.DockerKeyring, target *url.URL, nonRealmURL *url.URL) (string, string) {
 	// TODO: compare this logic to Docker authConfig in v2 configuration
 	var value string
 	if len(target.Scheme) == 0 || target.Scheme == "https" {
@@ -187,12 +233,16 @@ func basicCredentialsFromKeyring(keyring credentialprovider.DockerKeyring, targe
 		// do a special case check for docker.io to match historical lookups when we respond to a challenge
 		if value == "auth.docker.io/token" {
 			glog.V(5).Infof("Being asked for %s, trying %s for legacy behavior", target, "index.docker.io/v1")
-			return basicCredentialsFromKeyring(keyring, &url.URL{Host: "index.docker.io", Path: "/v1"})
+			return basicCredentialsFromKeyring(keyring, &url.URL{Host: "index.docker.io", Path: "/v1"}, nil)
 		}
 		// docker 1.9 saves 'docker.io' in config in f23, see https://bugzilla.redhat.com/show_bug.cgi?id=1309739
 		if value == "index.docker.io" {
 			glog.V(5).Infof("Being asked for %s, trying %s for legacy behavior", target, "docker.io")
-			return basicCredentialsFromKeyring(keyring, &url.URL{Host: "docker.io"})
+			return basicCredentialsFromKeyring(keyring, &url.URL{Host: "docker.io"}, nil)
+		}
+		if nonRealmURL != nil {
+			glog.V(5).Infof("Trying non realm url %s for target %s", nonRealmURL, target)
+			return basicCredentialsFromKeyring(keyring, nonRealmURL, nil)
 		}
 
 		// try removing the canonical ports for the given requests
@@ -201,7 +251,7 @@ func basicCredentialsFromKeyring(keyring credentialprovider.DockerKeyring, targe
 			host := strings.SplitN(target.Host, ":", 2)[0]
 			glog.V(5).Infof("Being asked for %s, trying %s without port", target, host)
 
-			return basicCredentialsFromKeyring(keyring, &url.URL{Scheme: target.Scheme, Host: host, Path: target.Path})
+			return basicCredentialsFromKeyring(keyring, &url.URL{Scheme: target.Scheme, Host: host, Path: target.Path}, nil)
 		}
 
 		glog.V(5).Infof("Unable to find a secret to match %s (%s)", target, value)
@@ -209,4 +259,22 @@ func basicCredentialsFromKeyring(keyring credentialprovider.DockerKeyring, targe
 	}
 	glog.V(5).Infof("Found secret to match %s (%s): %s", target, value, configs[0].ServerAddress)
 	return configs[0].Username, configs[0].Password
+}
+
+// realmURL is a container associating a realm URL with an actual registry URL
+type realmURL struct {
+	realm      url.URL
+	registries []url.URL
+}
+
+// realmKeyFunc returns an actual registry URL for given realm URL
+func realmKeyFunc(obj interface{}) (string, error) {
+	if key, ok := obj.(cache.ExplicitKey); ok {
+		return string(key), nil
+	}
+	ru, ok := obj.(*realmURL)
+	if !ok {
+		return "", fmt.Errorf("object %T is not a realmURL object", obj)
+	}
+	return ru.realm.String(), nil
 }

--- a/pkg/image/importer/credentials.go
+++ b/pkg/image/importer/credentials.go
@@ -47,17 +47,14 @@ func (s *refreshTokenStore) SetRefreshToken(url *url.URL, service string, token 
 type noopCredentialStore struct{}
 
 func (s *noopCredentialStore) Basic(url *url.URL) (string, string) {
-	glog.Infof("asked to provide Basic credentials for %s", url)
 	return "", ""
 }
 
 func (s *noopCredentialStore) RefreshToken(url *url.URL, service string) string {
-	glog.Infof("asked to provide RefreshToken for %s", url)
 	return ""
 }
 
 func (s *noopCredentialStore) SetRefreshToken(url *url.URL, service string, token string) {
-	glog.Infof("asked to provide SetRefreshToken for %s", url)
 }
 
 func NewBasicCredentials() *BasicCredentials {

--- a/pkg/image/importer/credentials_test.go
+++ b/pkg/image/importer/credentials_test.go
@@ -50,7 +50,7 @@ func (k *mockKeyring) Lookup(image string) ([]credentialprovider.LazyAuthConfigu
 
 func TestHubFallback(t *testing.T) {
 	k := &mockKeyring{}
-	basicCredentialsFromKeyring(k, &url.URL{Host: "auth.docker.io", Path: "/token"})
+	basicCredentialsFromKeyring(k, &url.URL{Host: "auth.docker.io", Path: "/token"}, nil)
 	if !reflect.DeepEqual([]string{"auth.docker.io/token", "index.docker.io", "docker.io"}, k.calls) {
 		t.Errorf("unexpected calls: %v", k.calls)
 	}
@@ -113,7 +113,7 @@ func Test_basicCredentialsFromKeyring(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			user, password := basicCredentialsFromKeyring(tt.args.keyring, tt.args.target)
+			user, password := basicCredentialsFromKeyring(tt.args.keyring, tt.args.target, nil)
 			if user != tt.user {
 				t.Errorf("basicCredentialsFromKeyring() user = %v, actual = %v", user, tt.user)
 			}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/9584 and https://bugzilla.redhat.com/show_bug.cgi?id=1462606.

Here's the story. Currently our credentials store (during image import) is passed a url, which we then match against secrets. Unfortunately, in some cases the url of the repository and the one passed to that credentials store are different, which causes frustration, because people first of all need to know the 2nd url and most importantly create it. This situation happens when authentication is redirecting to a different url. Whereas pull secrets don't require this, because they are matching secrets against repository url, not the authn (even if it's different). This simple fix passes the repository url down to the credentials store, which can then try to get the proper credentials using either one or the other url. 

@smarterclayton @miminar wdyt of this approach? I guess some tests are needed, but I don't want to spend time working on tests when the approach will be bad. I couldn't find a better way of passing the original repo url, other than this somehow nasty hack. 