### PR TITLE
Fix ClusterNetwork REST GetAttrs

### DIFF
--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/origin/pkg/sdn/api"
 	"github.com/openshift/origin/pkg/sdn/registry/clusternetwork"
-	"github.com/openshift/origin/pkg/user/registry/user"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -31,7 +30,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		DeleteStrategy: clusternetwork.Strategy,
 	}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: user.GetAttrs}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: clusternetwork.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@soltysh we used the wrong `GetAttrs` func during the move to `CompleteWithOptions`.

Signed-off-by: Monis Khan <mkhan@redhat.com>

[test]

@deads2k @liggitt PTAL