### PR TITLE
Test case for mixed/uppercase host name

### DIFF
--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -79,12 +79,12 @@ var _ = g.Describe("[Conformance][networking][router] openshift routers", func()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
-			err = waitForRouterOKResponseExec(ns, execPodName, routerURL, "first.example.com", changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPodName, routerURL+"/Letter", "FIRST.example.com", changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			for _, host := range []string{"second.example.com", "third.example.com"} {
 				g.By(fmt.Sprintf("checking that %s does not match a route", host))
-				err = expectRouteStatusCodeExec(ns, execPodName, routerURL, host, http.StatusServiceUnavailable)
+				err = expectRouteStatusCodeExec(ns, execPodName, routerURL+"/Letter", host, http.StatusServiceUnavailable)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 		})
@@ -128,18 +128,18 @@ var _ = g.Describe("[Conformance][networking][router] openshift routers", func()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the valid route to respond")
-			err = waitForRouterOKResponseExec(ns, execPodName, routerURL, fmt.Sprintf(pattern, "route-1", ns), changeTimeoutSeconds)
+			err = waitForRouterOKResponseExec(ns, execPodName, routerURL+"/Letter", fmt.Sprintf(pattern, "route-1", ns), changeTimeoutSeconds)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("checking that the stored domain name does not match a route")
 			host := "first.example.com"
-			err = expectRouteStatusCodeExec(ns, execPodName, routerURL, host, http.StatusServiceUnavailable)
+			err = expectRouteStatusCodeExec(ns, execPodName, routerURL+"/Letter", host, http.StatusServiceUnavailable)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			for _, host := range []string{"route-1", "route-2"} {
 				host = fmt.Sprintf(pattern, host, ns)
 				g.By(fmt.Sprintf("checking that %s matches a route", host))
-				err = expectRouteStatusCodeExec(ns, execPodName, routerURL, host, http.StatusOK)
+				err = expectRouteStatusCodeExec(ns, execPodName, routerURL+"/Letter", host, http.StatusOK)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 		})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -6760,6 +6760,7 @@ objects:
       select: first
   spec:
     host: first.example.com
+    path: /Letter
     to:
       name: endpoints
     ports:
@@ -6773,6 +6774,7 @@ objects:
       select: second
   spec:
     host: second.example.com
+    path: /Letter
     to:
       name: endpoints
     ports:

--- a/test/extended/testdata/scoped-router.yaml
+++ b/test/extended/testdata/scoped-router.yaml
@@ -82,6 +82,7 @@ objects:
       select: first
   spec:
     host: first.example.com
+    path: /Letter
     to:
       name: endpoints
     ports:
@@ -95,6 +96,7 @@ objects:
       select: second
   spec:
     host: second.example.com
+    path: /Letter
     to:
       name: endpoints
     ports:


### PR DESCRIPTION
This is a test case for PR 14157

When a  user provides a mixed or uppercase host name the router converts
it to lower case before matching it to existing routes.

Test for:
https://github.com/openshift/origin/pull/14157

bug 1461466
https://bugzilla.redhat.com/show_bug.cgi?id=1461466

Test case:
bug 1467006
https://bugzilla.redhat.com/show_bug.cgi?id=1467006