### PR TITLE
Restructuring tuned profile hierarchy.

### DIFF
--- a/contrib/tuned/openshift-control-plane/tuned.conf
+++ b/contrib/tuned/openshift-control-plane/tuned.conf
@@ -1,0 +1,25 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize systems running OpenShift control plane
+include=openshift
+
+[sysctl]
+# ktune sysctl settings, maximizing i/o throughput
+#
+# Minimal preemption granularity for CPU-bound tasks:
+# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
+kernel.sched_min_granularity_ns=10000000
+
+# The total time the scheduler will consider a migrated process
+# "cache hot" and thus less likely to be re-migrated
+# (system default is 500000, i.e. 0.5 ms)
+kernel.sched_migration_cost_ns=5000000
+
+# SCHED_OTHER wake-up granularity.
+#
+# Preemption granularity when tasks wake up.  Lower the value to improve 
+# wake-up latency and throughput for latency critical tasks.
+kernel.sched_wakeup_granularity_ns = 4000000

--- a/contrib/tuned/openshift-node/tuned.conf
+++ b/contrib/tuned/openshift-node/tuned.conf
@@ -1,0 +1,10 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize systems running OpenShift nodes
+include=openshift
+
+[sysctl]
+net.ipv4.tcp_fastopen=3

--- a/contrib/tuned/openshift/tuned.conf
+++ b/contrib/tuned/openshift/tuned.conf
@@ -1,0 +1,21 @@
+#
+# tuned configuration
+#
+
+[main]
+summary=Optimize systems running OpenShift (parent profile)
+include=virtual-${f:virt_check:guest:host}
+
+[selinux]
+avc_cache_threshold=65536
+
+[net]
+nf_conntrack_hashsize=131072
+
+[sysctl]
+kernel.pid_max=131072
+net.netfilter.nf_conntrack_max=1048576
+fs.inotify.max_user_watches=65536
+net.ipv4.neigh.default.gc_thresh1=8192
+net.ipv4.neigh.default.gc_thresh2=32768
+net.ipv4.neigh.default.gc_thresh3=65536

--- a/contrib/tuned/recommend/recommend.conf
+++ b/contrib/tuned/recommend/recommend.conf
@@ -1,0 +1,8 @@
+[openshift-control-plane,master]
+/etc/origin/master/master-config.yaml=.*
+
+[openshift-control-plane,node]
+/etc/origin/node/node-config.yaml=.*region=infra
+
+[openshift-node]
+/etc/origin/node/node-config.yaml=.*region=primary

--- a/origin.spec
+++ b/origin.spec
@@ -11,7 +11,8 @@
 # docker_version is the version of docker requires by packages
 %global docker_version 1.12
 # tuned_version is the version of tuned requires by packages
-%global tuned_version  2.3
+# tuned-2.8.0-1.el7 introduced auto-parent functionality (BZ1426654), see openshift profile
+%global tuned_version 2.8
 # openvswitch_version is the version of openvswitch requires by packages
 %global openvswitch_version 2.3.1
 # this is the version we obsolete up to. The packaging changed for Origin
@@ -353,6 +354,12 @@ install -m 0644 contrib/systemd/origin-node.sysconfig %{buildroot}%{_sysconfdir}
 install -d -m 0755 %{buildroot}%{_prefix}/lib/tuned/%{name}-node-{guest,host}
 install -m 0644 contrib/tuned/origin-node-guest/tuned.conf %{buildroot}%{_prefix}/lib/tuned/%{name}-node-guest/tuned.conf
 install -m 0644 contrib/tuned/origin-node-host/tuned.conf %{buildroot}%{_prefix}/lib/tuned/%{name}-node-host/tuned.conf
+install -d -m 0755 %{buildroot}%{_prefix}/lib/tuned/openshift{,-control-plane,-node}
+install -d -m 0755 %{buildroot}%{_sysconfdir}/tuned/
+install -m 0644 contrib/tuned/openshift/tuned.conf %{buildroot}%{_prefix}/lib/tuned/openshift/tuned.conf
+install -m 0644 contrib/tuned/openshift-control-plane/tuned.conf %{buildroot}%{_prefix}/lib/tuned/openshift-control-plane/tuned.conf
+install -m 0644 contrib/tuned/openshift-node/tuned.conf %{buildroot}%{_prefix}/lib/tuned/openshift-node/tuned.conf
+install -m 0644 contrib/tuned/recommend/recommend.conf %{buildroot}%{_sysconfdir}/tuned/recommend.conf
 
 # Install man1 man pages
 install -d -m 0755 %{buildroot}%{_mandir}/man1
@@ -567,22 +574,10 @@ fi
 %{_prefix}/lib/tuned/%{name}-node-host
 %{_prefix}/lib/tuned/%{name}-node-guest
 %{_mandir}/man7/tuned-profiles-%{name}-node.7*
-
-%post -n tuned-profiles-%{name}-node
-recommended=`/usr/sbin/tuned-adm recommend`
-if [[ "${recommended}" =~ guest ]] ; then
-  /usr/sbin/tuned-adm profile %{name}-node-guest > /dev/null 2>&1
-else
-  /usr/sbin/tuned-adm profile %{name}-node-host > /dev/null 2>&1
-fi
-
-%preun -n tuned-profiles-%{name}-node
-# reset the tuned profile to the recommended profile
-# $1 = 0 when we're being removed > 0 during upgrades
-if [ "$1" = 0 ]; then
-  recommended=`/usr/sbin/tuned-adm recommend`
-  /usr/sbin/tuned-adm profile $recommended > /dev/null 2>&1
-fi
+%{_prefix}/lib/tuned/openshift
+%{_prefix}/lib/tuned/openshift-control-plane
+%{_prefix}/lib/tuned/openshift-node
+%{_sysconfdir}/tuned/recommend.conf
 
 %files clients
 %license LICENSE


### PR DESCRIPTION
Proposing openshift-{control-plane,node} profiles.  The plan is to eventually retire origin-node-{guest,host} profiles.

The current profile structure:

    throughput-performance
        |          |______________
        |                         |
    virtual-guest                 |
        |                         |
        |                         |
    origin-node-guest       origin-node-host

Proposed profile structure:

    throughput-performance
                 |
                 |
            openshift (using tuned 2.8.x auto-parent functionality)
                 |
        ---------+---------------
       |                         |
       |                         |
    openshift-control-plane   openshift-node

There is an associated  https://github.com/openshift/openshift-ansible/pull/4566 against openshift-ansible.  This PR adds a dependency on tuned 2.8.x, because of its auto-parent functionality.