### PR TITLE
Add windows detail info at compile time for binary oc.exe

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -219,6 +219,50 @@ os::build::internal::build_binaries() {
         local_ldflags+=" -s"
       fi
 
+      #Add Windows File Properties/Version Info and Icon Resource for oc.exe
+      if [[ "$platform" == "windows/amd64" ]]; then
+        os::build::version::get_vars
+        os::util::ensure::gopath_binary_exists 'goversioninfo'
+        local major="${OS_GIT_MAJOR}"
+        local minor="${OS_GIT_MINOR%+}"
+        local windows_versioninfo_file=`mktemp --suffix=".versioninfo.json"`
+        cat <<EOF >"${windows_versioninfo_file}"
+{
+	"FixedFileInfo":
+	{
+		"FileFlagsMask": "3f",
+		"FileFlags ": "00",
+		"FileOS": "040004",
+		"FileType": "01",
+		"FileSubType": "00"
+	},
+	"StringFileInfo":
+	{
+		"Comments": "",
+		"CompanyName": "Red Hat, Inc.",
+		"InternalName": "openshift client",
+		"FileVersion": "${OS_GIT_VERSION}",
+		"InternalName": "oc",
+		"LegalCopyright": "© Red Hat, Inc. Licensed under the Apache License, Version 2.0",
+		"LegalTrademarks": "",
+		"OriginalFilename": "oc.exe",
+		"PrivateBuild": "",
+		"ProductName": "OpenShift Client",
+		"ProductVersion": "${OS_GIT_VERSION}",
+		"SpecialBuild": ""
+	},
+	"VarFileInfo":
+	{
+		"Translation": {
+			"LangID": "0409",
+			"CharsetID": "04B0"
+		}
+	}
+}
+EOF
+        goversioninfo -o ${OS_ROOT}/cmd/oc/oc.syso ${windows_versioninfo_file} 
+      fi
+
       if [[ ${#nonstatics[@]} -gt 0 ]]; then
         GOOS=${platform%/*} GOARCH=${platform##*/} go install \
           -pkgdir "${OS_OUTPUT_PKGDIR}/${platform}" \
@@ -232,6 +276,10 @@ os::build::internal::build_binaries() {
           local platform_src="/${platform//\//_}"
           mv "${OS_TARGET_BIN}/${platform_src}/"* "${OS_OUTPUT_BINPATH}/${platform}/"
         fi
+      fi
+
+      if [[ "$platform" == "windows/amd64" ]]; then
+        rm ${OS_ROOT}/cmd/oc/oc.syso
       fi
 
       for test in "${tests[@]:+${tests[@]}}"; do


### PR DESCRIPTION
Ref: https://trello.com/c/Cn8IaH8g/209-properly-sign-and-package-oc-binary-for-windows
I really know a little about bash programing, so I think it's better to have an early review to puts those things into the right places, @stevekuznetsov would you mind to take a look at this ? I feel that `go get` could be put to a better place, but I just don't know where.

@fabianofranz currently that `goversioninfo`  will read information from `windows_versioninfo.json` file but that information can be overrided with some ENV I put here, I just not sure which field in `windows_versioninfo.json` shoud be static and which filed should be dynamic. currently the whole json file I just fill with some random number, not sure what exactly value shoud we fill.

also I tested that generated resource.syso file with a small hello world program running `go install` on windows, it works, I will make the whole `build-cross.sh` pass on windows as long as this pr has been polished enough.  
<img width="275" alt="test" src="https://user-images.githubusercontent.com/6284003/27486790-4f18fdea-5864-11e7-9bb7-832de979f7f3.png">
sorry for the commit message was a little unclear, will squash and amend that when I back to the office
