### PR TITLE
Use preferred version when encoding nested objects

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -213,7 +213,7 @@ func (c *codec) Encode(obj runtime.Object, w io.Writer) error {
 	}
 
 	if e, ok := out.(runtime.NestedObjectEncoder); ok {
-		if err := e.EncodeNestedObjects(DirectEncoder{Encoder: c.encoder, ObjectTyper: c.typer}); err != nil {
+		if err := e.EncodeNestedObjects(DirectEncoder{Version: c.encodeVersion, Encoder: c.encoder, ObjectTyper: c.typer}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #14820

When we have a preferred version for encoding, make it available to nested object encoders