### PR TITLE
UPSTREAM: 47973: include object fieldpath in event key

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -49,6 +49,7 @@ func getEventKey(event *v1.Event) string {
 		event.InvolvedObject.Kind,
 		event.InvolvedObject.Namespace,
 		event.InvolvedObject.Name,
+		event.InvolvedObject.FieldPath,
 		string(event.InvolvedObject.UID),
 		event.InvolvedObject.APIVersion,
 		event.Type,


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/pull/47973

https://bugzilla.redhat.com/show_bug.cgi?id=1464550

bug 1464550

we picked the PR that exposed this bug in https://github.com/openshift/origin/pull/14693

@derekwaynecarr @eparis @pmorie 