### PR TITLE
UPSTREAM: 47347: actually check for a live discovery endpoint before …

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
@@ -146,7 +146,7 @@ func TestSync(t *testing.T) {
 				Type:    apiregistration.Available,
 				Status:  apiregistration.ConditionFalse,
 				Reason:  "FailedDiscoveryCheck",
-				Message: `no response from https:///apis: Get https:///apis: http: no Host in request URL`,
+				Message: `no response from https:///apis: context deadline exceeded`,
 			},
 		},
 	}


### PR DESCRIPTION
…aggregating (part 2)

Fixes https://github.com/openshift/origin/issues/14842

It seems that using a timeout on a request doesn't make the request call return (weird), but it does kick the context.Done() and give a valid error message back.  https://godoc.org/golang.org/x/net/context#Context

[test]