### PR TITLE
Make sdn pod teardown robust

### DIFF
--- a/pkg/sdn/plugin/ovscontroller_test.go
+++ b/pkg/sdn/plugin/ovscontroller_test.go
@@ -300,7 +300,7 @@ func TestOVSPod(t *testing.T) {
 	}
 
 	// Delete
-	err = oc.TearDownPod("veth1", "10.128.0.2")
+	err = oc.TearDownPod("veth1", "10.128.0.2", sandboxID)
 	if err != nil {
 		t.Fatalf("Unexpected error deleting pod rules: %v", err)
 	}

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -361,8 +361,6 @@ func (m *podManager) update(req *cniserver.PodRequest) (uint32, error) {
 
 // Clean up all pod networking (clear OVS flows, release IPAM lease, remove host/container veth)
 func (m *podManager) teardown(req *cniserver.PodRequest) error {
-	errList := []error{}
-
 	netnsValid := true
 	if err := ns.IsNSorErr(req.Netns); err != nil {
 		if _, ok := err.(ns.NSPathNotExistErr); ok {
@@ -371,13 +369,14 @@ func (m *podManager) teardown(req *cniserver.PodRequest) error {
 		}
 	}
 
+	errList := []error{}
 	if netnsValid {
 		hostVethName, _, podIP, err := getVethInfo(req.Netns, podInterfaceName)
 		if err != nil {
 			return err
 		}
 
-		if err := m.ovs.TearDownPod(hostVethName, podIP); err != nil {
+		if err := m.ovs.TearDownPod(hostVethName, podIP, req.SandboxID); err != nil {
 			errList = append(errList, err)
 		}
 	}


### PR DESCRIPTION
We have seen bugs where podIP is not valid/empty for teardown operation,
in this case ovs flows are left out. This change will fix this case
by picking the podIP from ovs flows (using 'note' field that was derived from
pod sandbox ID)
