### PR TITLE
Use live lookups to resolve uncached role refs

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/registry.go
+++ b/pkg/authorization/registry/clusterpolicy/registry.go
@@ -121,7 +121,7 @@ func (s *simulatedStorage) DeletePolicy(ctx apirequest.Context, name string) err
 }
 
 type ReadOnlyClusterPolicy struct {
-	Registry
+	Registry Registry
 }
 
 func (s ReadOnlyClusterPolicy) List(options metav1.ListOptions) (*authorizationapi.ClusterPolicyList, error) {
@@ -129,15 +129,15 @@ func (s ReadOnlyClusterPolicy) List(options metav1.ListOptions) (*authorizationa
 	if err := metainternal.Convert_v1_ListOptions_To_internalversion_ListOptions(&options, &optint, nil); err != nil {
 		return nil, err
 	}
-	return s.ListClusterPolicies(apirequest.WithNamespace(apirequest.NewContext(), ""), &optint)
+	return s.Registry.ListClusterPolicies(apirequest.WithNamespace(apirequest.NewContext(), ""), &optint)
 }
 
 func (s ReadOnlyClusterPolicy) Get(name string, options *metav1.GetOptions) (*authorizationapi.ClusterPolicy, error) {
-	return s.GetClusterPolicy(apirequest.WithNamespace(apirequest.NewContext(), ""), name, options)
+	return s.Registry.GetClusterPolicy(apirequest.WithNamespace(apirequest.NewContext(), ""), name, options)
 }
 
 type ReadOnlyClusterPolicyClientShim struct {
-	ReadOnlyClusterPolicy
+	ReadOnlyClusterPolicy ReadOnlyClusterPolicy
 }
 
 func (r *ReadOnlyClusterPolicyClientShim) List(label labels.Selector) ([]*authorizationapi.ClusterPolicy, error) {

--- a/pkg/authorization/registry/clusterpolicybinding/registry.go
+++ b/pkg/authorization/registry/clusterpolicybinding/registry.go
@@ -121,7 +121,7 @@ func (s *simulatedStorage) DeletePolicyBinding(ctx apirequest.Context, name stri
 }
 
 type ReadOnlyClusterPolicyBinding struct {
-	Registry
+	Registry Registry
 }
 
 func (s ReadOnlyClusterPolicyBinding) List(options metav1.ListOptions) (*authorizationapi.ClusterPolicyBindingList, error) {
@@ -129,15 +129,15 @@ func (s ReadOnlyClusterPolicyBinding) List(options metav1.ListOptions) (*authori
 	if err := metainternal.Convert_v1_ListOptions_To_internalversion_ListOptions(&options, &optint, nil); err != nil {
 		return nil, err
 	}
-	return s.ListClusterPolicyBindings(apirequest.WithNamespace(apirequest.NewContext(), ""), &optint)
+	return s.Registry.ListClusterPolicyBindings(apirequest.WithNamespace(apirequest.NewContext(), ""), &optint)
 }
 
 func (s ReadOnlyClusterPolicyBinding) Get(name string, options *metav1.GetOptions) (*authorizationapi.ClusterPolicyBinding, error) {
-	return s.GetClusterPolicyBinding(apirequest.WithNamespace(apirequest.NewContext(), ""), name, options)
+	return s.Registry.GetClusterPolicyBinding(apirequest.WithNamespace(apirequest.NewContext(), ""), name, options)
 }
 
 type ReadOnlyClusterPolicyBindingClientShim struct {
-	ReadOnlyClusterPolicyBinding
+	ReadOnlyClusterPolicyBinding ReadOnlyClusterPolicyBinding
 }
 
 func (r *ReadOnlyClusterPolicyBindingClientShim) List(label labels.Selector) ([]*authorizationapi.ClusterPolicyBinding, error) {

--- a/pkg/authorization/registry/clusterrole/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
+	"github.com/openshift/origin/pkg/authorization/registry/clusterrole"
 	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
 	rolestorage "github.com/openshift/origin/pkg/authorization/registry/role/policybased"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
@@ -18,7 +19,7 @@ type ClusterRoleStorage struct {
 	roleStorage rolestorage.VirtualStorage
 }
 
-func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleStorage {
+func NewClusterRoleStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) clusterrole.Storage {
 	return &ClusterRoleStorage{
 		roleStorage: rolestorage.VirtualStorage{
 			PolicyStorage: clusterpolicyregistry.NewSimulatedRegistry(clusterPolicyRegistry),

--- a/pkg/authorization/registry/clusterrole/registry.go
+++ b/pkg/authorization/registry/clusterrole/registry.go
@@ -1,28 +1,11 @@
 package clusterrole
 
 import (
-	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
-
-// Registry is an interface for things that know how to store ClusterRoles.
-type Registry interface {
-	// ListClusterRoles obtains list of policyClusterRoles that match a selector.
-	ListClusterRoles(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.ClusterRoleList, error)
-	// GetClusterRole retrieves a specific policyClusterRole.
-	GetClusterRole(ctx apirequest.Context, id string, options *metav1.GetOptions) (*authorizationapi.ClusterRole, error)
-	// CreateClusterRole creates a new policyClusterRole.
-	CreateClusterRole(ctx apirequest.Context, policyClusterRole *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error)
-	// UpdateClusterRole updates a policyClusterRole.
-	UpdateClusterRole(ctx apirequest.Context, policyClusterRole *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, bool, error)
-	// DeleteClusterRole deletes a policyClusterRole.
-	DeleteClusterRole(ctx apirequest.Context, id string) error
-}
 
 // Storage is an interface for a standard REST Storage backend
 type Storage interface {
@@ -32,57 +15,7 @@ type Storage interface {
 	rest.GracefulDeleter
 
 	// CreateRoleWithEscalation creates a new policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
-	CreateRoleWithEscalation(ctx apirequest.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, error)
+	CreateClusterRoleWithEscalation(ctx apirequest.Context, policyRole *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error)
 	// UpdateRoleWithEscalation updates a policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
-	UpdateRoleWithEscalation(ctx apirequest.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, bool, error)
-}
-
-// storage puts strong typing around storage calls
-type storage struct {
-	Storage
-}
-
-// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
-// types will panic.
-func NewRegistry(s Storage) Registry {
-	return &storage{s}
-}
-
-func (s *storage) ListClusterRoles(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.ClusterRoleList, error) {
-	obj, err := s.List(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.ClusterRoleList), nil
-}
-
-func (s *storage) CreateClusterRole(ctx apirequest.Context, node *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, error) {
-	obj, err := s.Create(ctx, node)
-	if err != nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.ClusterRole), err
-}
-
-func (s *storage) UpdateClusterRole(ctx apirequest.Context, node *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, bool, error) {
-	obj, created, err := s.Update(ctx, node.Name, rest.DefaultUpdatedObjectInfo(node, kapi.Scheme))
-	if err != nil {
-		return nil, created, err
-	}
-	return obj.(*authorizationapi.ClusterRole), created, err
-}
-
-func (s *storage) GetClusterRole(ctx apirequest.Context, name string, options *metav1.GetOptions) (*authorizationapi.ClusterRole, error) {
-	obj, err := s.Get(ctx, name, options)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*authorizationapi.ClusterRole), nil
-}
-
-func (s *storage) DeleteClusterRole(ctx apirequest.Context, name string) error {
-	_, _, err := s.Delete(ctx, name, nil)
-	return err
+	UpdateClusterRoleWithEscalation(ctx apirequest.Context, policyRole *authorizationapi.ClusterRole) (*authorizationapi.ClusterRole, bool, error)
 }

--- a/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
+	"github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding"
 	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
 	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
@@ -18,7 +19,7 @@ type ClusterRoleBindingStorage struct {
 	roleBindingStorage rolebindingstorage.VirtualStorage
 }
 
-func NewClusterRoleBindingStorage(clusterBindingRegistry clusterpolicybindingregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleBindingStorage {
+func NewClusterRoleBindingStorage(clusterBindingRegistry clusterpolicybindingregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) clusterrolebinding.Storage {
 	return &ClusterRoleBindingStorage{
 		roleBindingStorage: rolebindingstorage.VirtualStorage{
 			BindingRegistry: clusterpolicybindingregistry.NewSimulatedRegistry(clusterBindingRegistry),

--- a/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy/proxy.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
 	rolebindingregistry "github.com/openshift/origin/pkg/authorization/registry/rolebinding"
 	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
@@ -19,25 +18,12 @@ type ClusterRoleBindingStorage struct {
 	roleBindingStorage rolebindingstorage.VirtualStorage
 }
 
-func NewClusterRoleBindingStorage(clusterPolicyRegistry clusterpolicyregistry.Registry, clusterPolicyBindingRegistry clusterpolicybindingregistry.Registry, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleBindingStorage {
-	simulatedPolicyBindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(clusterPolicyBindingRegistry)
-
-	ruleResolver := rulevalidation.NewDefaultRuleResolver(
-		nil,
-		nil,
-		&clusterpolicyregistry.ReadOnlyClusterPolicyClientShim{
-			ReadOnlyClusterPolicy: clusterpolicyregistry.ReadOnlyClusterPolicy{Registry: clusterPolicyRegistry},
-		},
-		&clusterpolicybindingregistry.ReadOnlyClusterPolicyBindingClientShim{
-			ReadOnlyClusterPolicyBinding: clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterPolicyBindingRegistry},
-		},
-	)
-
+func NewClusterRoleBindingStorage(clusterBindingRegistry clusterpolicybindingregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) *ClusterRoleBindingStorage {
 	return &ClusterRoleBindingStorage{
-		rolebindingstorage.VirtualStorage{
-			BindingRegistry: simulatedPolicyBindingRegistry,
+		roleBindingStorage: rolebindingstorage.VirtualStorage{
+			BindingRegistry: clusterpolicybindingregistry.NewSimulatedRegistry(clusterBindingRegistry),
 
-			RuleResolver:       ruleResolver,
+			RuleResolver:       liveRuleResolver,
 			CachedRuleResolver: cachedRuleResolver,
 
 			CreateStrategy: rolebindingregistry.ClusterStrategy,

--- a/pkg/authorization/registry/clusterrolebinding/registry.go
+++ b/pkg/authorization/registry/clusterrolebinding/registry.go
@@ -1,28 +1,11 @@
 package clusterrolebinding
 
 import (
-	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
-
-// Registry is an interface for things that know how to store RoleBindings.
-type Registry interface {
-	// ListRoleBindings obtains list of policyRoleBindings that match a selector.
-	ListRoleBindings(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.RoleBindingList, error)
-	// GetRoleBinding retrieves a specific policyRoleBinding.
-	GetRoleBinding(ctx apirequest.Context, id string, options *metav1.GetOptions) (*authorizationapi.RoleBinding, error)
-	// CreateRoleBinding creates a new policyRoleBinding.
-	CreateRoleBinding(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error)
-	// UpdateRoleBinding updates a policyRoleBinding.
-	UpdateRoleBinding(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error)
-	// DeleteRoleBinding deletes a policyRoleBinding.
-	DeleteRoleBinding(ctx apirequest.Context, id string) error
-}
 
 // Storage is an interface for a standard REST Storage backend
 type Storage interface {
@@ -32,56 +15,7 @@ type Storage interface {
 	rest.GracefulDeleter
 
 	// CreateRoleBinding creates a new policyRoleBinding.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
-	CreateRoleBindingWithEscalation(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error)
+	CreateClusterRoleBindingWithEscalation(ctx apirequest.Context, policyRoleBinding *authorizationapi.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error)
 	// UpdateRoleBinding updates a policyRoleBinding.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
-	UpdateRoleBindingWithEscalation(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error)
-}
-
-// storage puts strong typing around storage calls
-type storage struct {
-	Storage
-}
-
-// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
-// types will panic.
-func NewRegistry(s Storage) Registry {
-	return &storage{s}
-}
-
-func (s *storage) ListRoleBindings(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.RoleBindingList, error) {
-	obj, err := s.List(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.RoleBindingList), nil
-}
-
-func (s *storage) CreateRoleBinding(ctx apirequest.Context, binding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
-	obj, err := s.Create(ctx, binding)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*authorizationapi.RoleBinding), err
-}
-
-func (s *storage) UpdateRoleBinding(ctx apirequest.Context, binding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error) {
-	obj, created, err := s.Update(ctx, binding.Name, rest.DefaultUpdatedObjectInfo(binding, kapi.Scheme))
-	if err != nil {
-		return nil, created, err
-	}
-	return obj.(*authorizationapi.RoleBinding), created, err
-}
-
-func (s *storage) GetRoleBinding(ctx apirequest.Context, name string, options *metav1.GetOptions) (*authorizationapi.RoleBinding, error) {
-	obj, err := s.Get(ctx, name, options)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*authorizationapi.RoleBinding), nil
-}
-
-func (s *storage) DeleteRoleBinding(ctx apirequest.Context, name string) error {
-	_, _, err := s.Delete(ctx, name, nil)
-	return err
+	UpdateClusterRoleBindingWithEscalation(ctx apirequest.Context, policyRoleBinding *authorizationapi.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, bool, error)
 }

--- a/pkg/authorization/registry/policybinding/registry.go
+++ b/pkg/authorization/registry/policybinding/registry.go
@@ -3,12 +3,14 @@ package policybinding
 import (
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	authorizationlister "github.com/openshift/origin/pkg/authorization/generated/listers/authorization/internalversion"
 )
 
 // Registry is an interface for things that know how to store PolicyBindings.
@@ -81,4 +83,37 @@ func (s *storage) GetPolicyBinding(ctx apirequest.Context, name string, options 
 func (s *storage) DeletePolicyBinding(ctx apirequest.Context, name string) error {
 	_, _, err := s.Delete(ctx, name, nil)
 	return err
+}
+
+type ReadOnlyPolicyBindingListerNamespacer struct {
+	Registry Registry
+}
+
+func (s ReadOnlyPolicyBindingListerNamespacer) PolicyBindings(namespace string) authorizationlister.PolicyBindingNamespaceLister {
+	return policyBindingLister{registry: s.Registry, namespace: namespace}
+}
+
+func (s ReadOnlyPolicyBindingListerNamespacer) List(label labels.Selector) ([]*authorizationapi.PolicyBinding, error) {
+	return s.PolicyBindings("").List(label)
+}
+
+type policyBindingLister struct {
+	registry  Registry
+	namespace string
+}
+
+func (s policyBindingLister) List(label labels.Selector) ([]*authorizationapi.PolicyBinding, error) {
+	list, err := s.registry.ListPolicyBindings(apirequest.WithNamespace(apirequest.NewContext(), s.namespace), &metainternal.ListOptions{LabelSelector: label})
+	if err != nil {
+		return nil, err
+	}
+	var items []*authorizationapi.PolicyBinding
+	for i := range list.Items {
+		items = append(items, &list.Items[i])
+	}
+	return items, nil
+}
+
+func (s policyBindingLister) Get(name string) (*authorizationapi.PolicyBinding, error) {
+	return s.registry.GetPolicyBinding(apirequest.WithNamespace(apirequest.NewContext(), s.namespace), name, &metav1.GetOptions{})
 }

--- a/pkg/authorization/registry/role/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage.go
@@ -38,8 +38,17 @@ type VirtualStorage struct {
 }
 
 // NewVirtualStorage creates a new REST for policies.
-func NewVirtualStorage(policyStorage policyregistry.Registry, ruleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver, resource schema.GroupResource) roleregistry.Storage {
-	return &VirtualStorage{policyStorage, ruleResolver, cachedRuleResolver, roleregistry.LocalStrategy, roleregistry.LocalStrategy, resource}
+func NewVirtualStorage(policyRegistry policyregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) roleregistry.Storage {
+	return &VirtualStorage{
+		PolicyStorage: policyRegistry,
+
+		RuleResolver:       liveRuleResolver,
+		CachedRuleResolver: cachedRuleResolver,
+
+		CreateStrategy: roleregistry.LocalStrategy,
+		UpdateStrategy: roleregistry.LocalStrategy,
+		Resource:       authorizationapi.Resource("role"),
+	}
 }
 
 func (m *VirtualStorage) New() runtime.Object {

--- a/pkg/authorization/registry/role/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/role/policybased/virtual_storage_test.go
@@ -15,29 +15,11 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	_ "github.com/openshift/origin/pkg/authorization/apis/authorization/install"
-	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
 	roleregistry "github.com/openshift/origin/pkg/authorization/registry/role"
 	"github.com/openshift/origin/pkg/authorization/registry/test"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 )
 
-func testNewClusterPolicies() []authorizationapi.ClusterPolicy {
-	return []authorizationapi.ClusterPolicy{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: authorizationapi.PolicyName},
-			Roles: map[string]*authorizationapi.ClusterRole{
-				"cluster-admin": {
-					ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
-					Rules:      []authorizationapi.PolicyRule{{Verbs: sets.NewString("*"), Resources: sets.NewString("*")}},
-				},
-				"admin": {
-					ObjectMeta: metav1.ObjectMeta{Name: "admin"},
-					Rules:      []authorizationapi.PolicyRule{{Verbs: sets.NewString("*"), Resources: sets.NewString("*")}},
-				},
-			},
-		},
-	}
-}
 func testNewLocalPolicies() []authorizationapi.Policy {
 	return []authorizationapi.Policy{
 		{
@@ -50,14 +32,7 @@ func testNewLocalPolicies() []authorizationapi.Policy {
 func makeLocalTestStorage() roleregistry.Storage {
 	policyRegistry := test.NewPolicyRegistry(testNewLocalPolicies(), nil)
 
-	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, &test.PolicyBindingRegistry{}, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), nil, authorizationapi.Resource("role"))
-}
-
-func makeClusterTestStorage() roleregistry.Storage {
-	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
-	policyRegistry := clusterpolicyregistry.NewSimulatedRegistry(clusterPolicyRegistry)
-
-	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(nil, &test.PolicyBindingRegistry{}, clusterPolicyRegistry, &test.ClusterPolicyBindingRegistry{}), nil, authorizationapi.Resource("clusterrole"))
+	return NewVirtualStorage(policyRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, &test.PolicyBindingRegistry{}, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), nil)
 }
 
 func TestCreateValidationError(t *testing.T) {

--- a/pkg/authorization/registry/role/registry.go
+++ b/pkg/authorization/registry/role/registry.go
@@ -1,28 +1,11 @@
 package role
 
 import (
-	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
-
-// Registry is an interface for things that know how to store Roles.
-type Registry interface {
-	// ListRoles obtains list of policyRoles that match a selector.
-	ListRoles(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.RoleList, error)
-	// GetRole retrieves a specific policyRole.
-	GetRole(ctx apirequest.Context, id string, options *metav1.GetOptions) (*authorizationapi.Role, error)
-	// CreateRole creates a new policyRole.
-	CreateRole(ctx apirequest.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, error)
-	// UpdateRole updates a policyRole.
-	UpdateRole(ctx apirequest.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, bool, error)
-	// DeleteRole deletes a policyRole.
-	DeleteRole(ctx apirequest.Context, id string) error
-}
 
 // Storage is an interface for a standard REST Storage backend
 type Storage interface {
@@ -35,47 +18,4 @@ type Storage interface {
 	CreateRoleWithEscalation(ctx apirequest.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, error)
 	// UpdateRoleWithEscalation updates a policyRole.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
 	UpdateRoleWithEscalation(ctx apirequest.Context, policyRole *authorizationapi.Role) (*authorizationapi.Role, bool, error)
-}
-
-// storage puts strong typing around storage calls
-type storage struct {
-	Storage
-}
-
-// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
-// types will panic.
-func NewRegistry(s Storage) Registry {
-	return &storage{s}
-}
-
-func (s *storage) ListRoles(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.RoleList, error) {
-	obj, err := s.List(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.RoleList), nil
-}
-
-func (s *storage) CreateRole(ctx apirequest.Context, role *authorizationapi.Role) (*authorizationapi.Role, error) {
-	obj, err := s.Create(ctx, role)
-	return obj.(*authorizationapi.Role), err
-}
-
-func (s *storage) UpdateRole(ctx apirequest.Context, role *authorizationapi.Role) (*authorizationapi.Role, bool, error) {
-	obj, created, err := s.Update(ctx, role.Name, rest.DefaultUpdatedObjectInfo(role, kapi.Scheme))
-	return obj.(*authorizationapi.Role), created, err
-}
-
-func (s *storage) GetRole(ctx apirequest.Context, name string, options *metav1.GetOptions) (*authorizationapi.Role, error) {
-	obj, err := s.Get(ctx, name, options)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*authorizationapi.Role), nil
-}
-
-func (s *storage) DeleteRole(ctx apirequest.Context, name string) error {
-	_, _, err := s.Delete(ctx, name, nil)
-	return err
 }

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage.go
@@ -36,16 +36,16 @@ type VirtualStorage struct {
 }
 
 // NewVirtualStorage creates a new REST for policies.
-func NewVirtualStorage(bindingRegistry policybindingregistry.Registry, ruleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver, resource schema.GroupResource) rolebindingregistry.Storage {
+func NewVirtualStorage(policyBindingRegistry policybindingregistry.Registry, liveRuleResolver, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) rolebindingregistry.Storage {
 	return &VirtualStorage{
-		BindingRegistry: bindingRegistry,
+		BindingRegistry: policyBindingRegistry,
 
-		RuleResolver:       ruleResolver,
+		RuleResolver:       liveRuleResolver,
 		CachedRuleResolver: cachedRuleResolver,
 
 		CreateStrategy: rolebindingregistry.LocalStrategy,
 		UpdateStrategy: rolebindingregistry.LocalStrategy,
-		Resource:       resource,
+		Resource:       authorizationapi.Resource("rolebinding"),
 	}
 }
 

--- a/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
+++ b/pkg/authorization/registry/rolebinding/policybased/virtual_storage_test.go
@@ -70,7 +70,7 @@ func makeTestStorage() rolebindingregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	policyRegistry := test.NewPolicyRegistry([]authorizationapi.Policy{}, nil)
 
-	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, bindingRegistry, clusterPolicyRegistry, clusterBindingRegistry), nil, authorizationapi.Resource("rolebinding"))
+	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(policyRegistry, bindingRegistry, clusterPolicyRegistry, clusterBindingRegistry), nil)
 }
 
 func makeClusterTestStorage() rolebindingregistry.Storage {
@@ -78,7 +78,7 @@ func makeClusterTestStorage() rolebindingregistry.Storage {
 	clusterPolicyRegistry := test.NewClusterPolicyRegistry(testNewClusterPolicies(), nil)
 	bindingRegistry := clusterpolicybindingregistry.NewSimulatedRegistry(clusterBindingRegistry)
 
-	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(nil, nil, clusterPolicyRegistry, clusterBindingRegistry), nil, authorizationapi.Resource("clusterrolebinding"))
+	return NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(nil, nil, clusterPolicyRegistry, clusterBindingRegistry), nil)
 }
 
 func TestCreateValidationError(t *testing.T) {
@@ -355,7 +355,7 @@ func TestDeleteError(t *testing.T) {
 	bindingRegistry := &test.PolicyBindingRegistry{}
 	bindingRegistry.Err = errors.New("Sample Error")
 
-	storage := NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(&test.PolicyRegistry{}, bindingRegistry, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), nil, authorizationapi.Resource("rolebinding"))
+	storage := NewVirtualStorage(bindingRegistry, rulevalidation.NewDefaultRuleResolver(&test.PolicyRegistry{}, bindingRegistry, &test.ClusterPolicyRegistry{}, &test.ClusterPolicyBindingRegistry{}), nil)
 	ctx := apirequest.WithUser(apirequest.WithNamespace(apirequest.NewContext(), "unittest"), &user.DefaultInfo{Name: "system:admin"})
 	_, _, err := storage.Delete(ctx, "foo", nil)
 	if err != bindingRegistry.Err {

--- a/pkg/authorization/registry/rolebinding/registry.go
+++ b/pkg/authorization/registry/rolebinding/registry.go
@@ -1,28 +1,11 @@
 package rolebinding
 
 import (
-	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
-
-// Registry is an interface for things that know how to store RoleBindings.
-type Registry interface {
-	// ListRoleBindings obtains list of policyRoleBindings that match a selector.
-	ListRoleBindings(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.RoleBindingList, error)
-	// GetRoleBinding retrieves a specific policyRoleBinding.
-	GetRoleBinding(ctx apirequest.Context, id string, options *metav1.GetOptions) (*authorizationapi.RoleBinding, error)
-	// CreateRoleBinding creates a new policyRoleBinding.
-	CreateRoleBinding(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error)
-	// UpdateRoleBinding updates a policyRoleBinding.
-	UpdateRoleBinding(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error)
-	// DeleteRoleBinding deletes a policyRoleBinding.
-	DeleteRoleBinding(ctx apirequest.Context, id string) error
-}
 
 // Storage is an interface for a standard REST Storage backend
 type Storage interface {
@@ -35,47 +18,4 @@ type Storage interface {
 	CreateRoleBindingWithEscalation(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error)
 	// UpdateRoleBindingWithEscalation updates a policyRoleBinding.  Skipping the escalation check should only be done during bootstrapping procedures where no users are currently bound.
 	UpdateRoleBindingWithEscalation(ctx apirequest.Context, policyRoleBinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error)
-}
-
-// storage puts strong typing around storage calls
-type storage struct {
-	Storage
-}
-
-// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
-// types will panic.
-func NewRegistry(s Storage) Registry {
-	return &storage{s}
-}
-
-func (s *storage) ListRoleBindings(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.RoleBindingList, error) {
-	obj, err := s.List(ctx, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return obj.(*authorizationapi.RoleBindingList), nil
-}
-
-func (s *storage) CreateRoleBinding(ctx apirequest.Context, rolebinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, error) {
-	obj, err := s.Create(ctx, rolebinding)
-	return obj.(*authorizationapi.RoleBinding), err
-}
-
-func (s *storage) UpdateRoleBinding(ctx apirequest.Context, rolebinding *authorizationapi.RoleBinding) (*authorizationapi.RoleBinding, bool, error) {
-	obj, created, err := s.Update(ctx, rolebinding.Name, rest.DefaultUpdatedObjectInfo(rolebinding, kapi.Scheme))
-	return obj.(*authorizationapi.RoleBinding), created, err
-}
-
-func (s *storage) GetRoleBinding(ctx apirequest.Context, name string, options *metav1.GetOptions) (*authorizationapi.RoleBinding, error) {
-	obj, err := s.Get(ctx, name, options)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*authorizationapi.RoleBinding), nil
-}
-
-func (s *storage) DeleteRoleBinding(ctx apirequest.Context, name string) error {
-	_, _, err := s.Delete(ctx, name, nil)
-	return err
 }

--- a/pkg/authorization/rulevalidation/find_rules.go
+++ b/pkg/authorization/rulevalidation/find_rules.go
@@ -4,7 +4,6 @@ import (
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
@@ -149,18 +148,4 @@ func (a *DefaultRuleResolver) RulesFor(user user.Info, namespace string) ([]auth
 	}
 
 	return rules, kerrors.NewAggregate(errs)
-}
-
-func appliesToUser(ruleUsers, ruleGroups sets.String, user user.Info) bool {
-	if ruleUsers.Has(user.GetName()) {
-		return true
-	}
-
-	for _, currGroup := range user.GetGroups() {
-		if ruleGroups.Has(currGroup) {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/authorization/util/util.go
+++ b/pkg/authorization/util/util.go
@@ -10,10 +10,23 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
+	clusterpolicyetcd "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy/etcd"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
+	clusterpolicybindingetcd "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding/etcd"
+	"github.com/openshift/origin/pkg/authorization/registry/clusterrole"
+	clusterrolestorage "github.com/openshift/origin/pkg/authorization/registry/clusterrole/proxy"
+	"github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding"
+	clusterrolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding/proxy"
 	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
+	policyetcd "github.com/openshift/origin/pkg/authorization/registry/policy/etcd"
 	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
+	policybindingetcd "github.com/openshift/origin/pkg/authorization/registry/policybinding/etcd"
+	"github.com/openshift/origin/pkg/authorization/registry/role"
+	rolestorage "github.com/openshift/origin/pkg/authorization/registry/role/policybased"
+	"github.com/openshift/origin/pkg/authorization/registry/rolebinding"
+	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
 	"github.com/openshift/origin/pkg/authorization/rulevalidation"
+	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
 // AddUserToSAR adds the requisite user information to a SubjectAccessReview.
@@ -68,4 +81,59 @@ func NewLiveRuleResolver(policyRegistry policyregistry.Registry, policyBindingRe
 			ReadOnlyClusterPolicyBinding: clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterBindingRegistry},
 		},
 	)
+}
+
+func GetAuthorizationStorage(optsGetter restoptions.Getter, cachedRuleResolver rulevalidation.AuthorizationRuleResolver) (*AuthorizationStorage, error) {
+	policyStorage, err := policyetcd.NewREST(optsGetter)
+	if err != nil {
+		return nil, err
+	}
+	policyRegistry := policyregistry.NewRegistry(policyStorage)
+
+	policyBindingStorage, err := policybindingetcd.NewREST(optsGetter)
+	if err != nil {
+		return nil, err
+	}
+	policyBindingRegistry := policybindingregistry.NewRegistry(policyBindingStorage)
+
+	clusterPolicyStorage, err := clusterpolicyetcd.NewREST(optsGetter)
+	if err != nil {
+		return nil, err
+	}
+	clusterPolicyRegistry := clusterpolicyregistry.NewRegistry(clusterPolicyStorage)
+
+	clusterPolicyBindingStorage, err := clusterpolicybindingetcd.NewREST(optsGetter)
+	if err != nil {
+		return nil, err
+	}
+	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewRegistry(clusterPolicyBindingStorage)
+
+	liveRuleResolver := NewLiveRuleResolver(policyRegistry, policyBindingRegistry, clusterPolicyRegistry, clusterPolicyBindingRegistry)
+
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, liveRuleResolver, cachedRuleResolver)
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, liveRuleResolver, cachedRuleResolver)
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, liveRuleResolver, cachedRuleResolver)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyBindingRegistry, liveRuleResolver, cachedRuleResolver)
+
+	return &AuthorizationStorage{
+		Policy:               policyStorage,
+		PolicyBinding:        policyBindingStorage,
+		ClusterPolicy:        clusterPolicyStorage,
+		ClusterPolicyBinding: clusterPolicyBindingStorage,
+		Role:                 roleStorage,
+		RoleBinding:          roleBindingStorage,
+		ClusterRole:          clusterRoleStorage,
+		ClusterRoleBinding:   clusterRoleBindingStorage,
+	}, nil
+}
+
+type AuthorizationStorage struct {
+	Policy               policyregistry.Storage
+	PolicyBinding        policybindingregistry.Storage
+	ClusterPolicy        clusterpolicyregistry.Storage
+	ClusterPolicyBinding clusterpolicybindingregistry.Storage
+	Role                 role.Storage
+	RoleBinding          rolebinding.Storage
+	ClusterRole          clusterrole.Storage
+	ClusterRoleBinding   clusterrolebinding.Storage
 }

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -10,9 +10,6 @@ import (
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -21,13 +18,13 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	authorizationlister "github.com/openshift/origin/pkg/authorization/generated/listers/authorization/internalversion"
 	policyregistry "github.com/openshift/origin/pkg/authorization/registry/policy"
 	policyetcd "github.com/openshift/origin/pkg/authorization/registry/policy/etcd"
 	policybindingregistry "github.com/openshift/origin/pkg/authorization/registry/policybinding"
 	policybindingetcd "github.com/openshift/origin/pkg/authorization/registry/policybinding/etcd"
 	rolestorage "github.com/openshift/origin/pkg/authorization/registry/role/policybased"
 	rolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/rolebinding/policybased"
+	"github.com/openshift/origin/pkg/authorization/util"
 
 	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
 	clusterpolicyetcd "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy/etcd"
@@ -35,7 +32,6 @@ import (
 	clusterpolicybindingetcd "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding/etcd"
 	clusterrolestorage "github.com/openshift/origin/pkg/authorization/registry/clusterrole/proxy"
 	clusterrolebindingstorage "github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding/proxy"
-	"github.com/openshift/origin/pkg/authorization/rulevalidation"
 
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
@@ -159,21 +155,12 @@ func OverwriteBootstrapPolicy(optsGetter restoptions.Getter, policyFile, createB
 	}
 	clusterPolicyBindingRegistry := clusterpolicybindingregistry.NewRegistry(clusterPolicyBindingStorage)
 
-	ruleResolver := rulevalidation.NewDefaultRuleResolver(
-		policyListerNamespacer{registry: policyRegistry},
-		policyBindingListerNamespacer{registry: policyBindingRegistry},
-		&clusterpolicyregistry.ReadOnlyClusterPolicyClientShim{
-			ReadOnlyClusterPolicy: clusterpolicyregistry.ReadOnlyClusterPolicy{Registry: clusterPolicyRegistry},
-		},
-		&clusterpolicybindingregistry.ReadOnlyClusterPolicyBindingClientShim{
-			ReadOnlyClusterPolicyBinding: clusterpolicybindingregistry.ReadOnlyClusterPolicyBinding{Registry: clusterPolicyBindingRegistry},
-		},
-	)
+	liveRuleResolver := util.NewLiveRuleResolver(policyRegistry, policyBindingRegistry, clusterPolicyRegistry, clusterPolicyBindingRegistry)
 
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, ruleResolver, nil, authorizationapi.Resource("role"))
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, ruleResolver, nil, authorizationapi.Resource("rolebinding"))
-	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, nil)
-	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, nil)
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, liveRuleResolver, nil)
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, liveRuleResolver, nil)
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, liveRuleResolver, nil)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyBindingRegistry, liveRuleResolver, nil)
 
 	return r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
@@ -299,70 +286,4 @@ func OverwriteBootstrapPolicy(optsGetter restoptions.Getter, policyFile, createB
 		}
 		return kerrors.NewAggregate(errs)
 	})
-}
-
-type policyListerNamespacer struct {
-	registry policyregistry.Registry
-}
-
-func (s policyListerNamespacer) Policies(namespace string) authorizationlister.PolicyNamespaceLister {
-	return policyLister{registry: s.registry, namespace: namespace}
-}
-
-func (s policyListerNamespacer) List(label labels.Selector) ([]*authorizationapi.Policy, error) {
-	return s.Policies("").List(label)
-}
-
-type policyLister struct {
-	registry  policyregistry.Registry
-	namespace string
-}
-
-func (s policyLister) List(label labels.Selector) ([]*authorizationapi.Policy, error) {
-	list, err := s.registry.ListPolicies(apirequest.WithNamespace(apirequest.NewContext(), s.namespace), &metainternal.ListOptions{LabelSelector: label})
-	if err != nil {
-		return nil, err
-	}
-	var items []*authorizationapi.Policy
-	for i := range list.Items {
-		items = append(items, &list.Items[i])
-	}
-	return items, nil
-}
-
-func (s policyLister) Get(name string) (*authorizationapi.Policy, error) {
-	return s.registry.GetPolicy(apirequest.WithNamespace(apirequest.NewContext(), s.namespace), name, &metav1.GetOptions{})
-}
-
-type policyBindingListerNamespacer struct {
-	registry policybindingregistry.Registry
-}
-
-func (s policyBindingListerNamespacer) PolicyBindings(namespace string) authorizationlister.PolicyBindingNamespaceLister {
-	return policyBindingLister{registry: s.registry, namespace: namespace}
-}
-
-func (s policyBindingListerNamespacer) List(label labels.Selector) ([]*authorizationapi.PolicyBinding, error) {
-	return s.PolicyBindings("").List(label)
-}
-
-type policyBindingLister struct {
-	registry  policybindingregistry.Registry
-	namespace string
-}
-
-func (s policyBindingLister) List(label labels.Selector) ([]*authorizationapi.PolicyBinding, error) {
-	list, err := s.registry.ListPolicyBindings(apirequest.WithNamespace(apirequest.NewContext(), s.namespace), &metainternal.ListOptions{LabelSelector: label})
-	if err != nil {
-		return nil, err
-	}
-	var items []*authorizationapi.PolicyBinding
-	for i := range list.Items {
-		items = append(items, &list.Items[i])
-	}
-	return items, nil
-}
-
-func (s policyBindingLister) Get(name string) (*authorizationapi.PolicyBinding, error) {
-	return s.registry.GetPolicyBinding(apirequest.WithNamespace(apirequest.NewContext(), s.namespace), name, &metav1.GetOptions{})
 }

--- a/pkg/cmd/server/origin/storage.go
+++ b/pkg/cmd/server/origin/storage.go
@@ -17,6 +17,7 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
 	authzapiv1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
+	"github.com/openshift/origin/pkg/authorization/util"
 	buildapiv1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildgenerator "github.com/openshift/origin/pkg/build/generator"
@@ -90,7 +91,6 @@ import (
 	clusterresourcequotaetcd "github.com/openshift/origin/pkg/quota/registry/clusterresourcequota/etcd"
 
 	"github.com/openshift/origin/pkg/api/v1"
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	clusterpolicyregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy"
 	clusterpolicyetcd "github.com/openshift/origin/pkg/authorization/registry/clusterpolicy/etcd"
 	clusterpolicybindingregistry "github.com/openshift/origin/pkg/authorization/registry/clusterpolicybinding"
@@ -238,10 +238,12 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver, clusterPolicies)
 	subjectRulesReviewStorage := subjectrulesreview.NewREST(c.RuleResolver, clusterPolicies)
 
-	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, c.RuleResolver, nil, authorizationapi.Resource("role"))
-	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, c.RuleResolver, nil, authorizationapi.Resource("rolebinding"))
-	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, c.RuleResolver)
-	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyRegistry, clusterPolicyBindingRegistry, c.RuleResolver)
+	liveRuleResolver := util.NewLiveRuleResolver(policyRegistry, policyBindingRegistry, clusterPolicyRegistry, clusterPolicyBindingRegistry)
+
+	roleStorage := rolestorage.NewVirtualStorage(policyRegistry, liveRuleResolver, c.RuleResolver)
+	roleBindingStorage := rolebindingstorage.NewVirtualStorage(policyBindingRegistry, liveRuleResolver, c.RuleResolver)
+	clusterRoleStorage := clusterrolestorage.NewClusterRoleStorage(clusterPolicyRegistry, liveRuleResolver, c.RuleResolver)
+	clusterRoleBindingStorage := clusterrolebindingstorage.NewClusterRoleBindingStorage(clusterPolicyBindingRegistry, liveRuleResolver, c.RuleResolver)
 
 	subjectAccessReviewStorage := subjectaccessreview.NewREST(c.GenericConfig.Authorizer)
 	subjectAccessReviewRegistry := subjectaccessreview.NewRegistry(subjectAccessReviewStorage)

--- a/pkg/security/securitycontextconstraints/selinux/runasany_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/runasany_test.go
@@ -26,7 +26,7 @@ func TestRunAsAnyGenerate(t *testing.T) {
 	}
 	uid, err := s.Generate(nil, nil)
 	if uid != nil {
-		t.Errorf("expected nil uid but got %d", *uid)
+		t.Errorf("expected nil uid but got %v", *uid)
 	}
 	if err != nil {
 		t.Errorf("unexpected error generating uid %v", err)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/flowcontrol"
 	kapi "k8s.io/kubernetes/pkg/api"
 	appsapi "k8s.io/kubernetes/pkg/apis/apps"
 	kubeauthorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
@@ -1637,6 +1638,83 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 			!reflect.DeepEqual(actualResponse.Users.List(), expectedResponse.Users.List()) ||
 			!reflect.DeepEqual(actualResponse.Groups.List(), expectedResponse.Groups.List()) {
 			t.Errorf("review\n\t%#v\nexpected\n\t%#v\ngot\n\t%#v", rar, expectedResponse, actualResponse)
+		}
+	}
+}
+
+// TestClusterPolicyCache confirms that the creation of cluster role bindings fallback to live lookups when the referenced cluster role is not cached
+func TestClusterPolicyCache(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClient.RESTClient.Throttle = flowcontrol.NewFakeAlwaysRateLimiter() // turn off rate limiting so cache misses are more likely
+
+	for i := 0; i < 100; i++ { // usually takes less than 60 attempts for this to cache miss
+		clusterRole := &authorizationapi.ClusterRole{ObjectMeta: metav1.ObjectMeta{GenerateName: time.Now().String()}}
+		clusterRole, err = clusterAdminClient.ClusterRoles().Create(clusterRole)
+		if err != nil {
+			t.Fatalf("unexpected error creating cluster role %q: %v", clusterRole.Name, err)
+		}
+		clusterRoleBinding := &authorizationapi.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterRole.Name},
+			Subjects:   []kapi.ObjectReference{{Name: "user", Kind: authorizationapi.UserKind}},
+			RoleRef:    kapi.ObjectReference{Name: clusterRole.Name}}
+		if _, err := clusterAdminClient.ClusterRoleBindings().Create(clusterRoleBinding); err != nil {
+			t.Fatalf("cache error creating cluster role binding %d %q: %v", i, clusterRoleBinding.Name, err)
+		}
+	}
+}
+
+// TestPolicyCache confirms that the creation of role bindings fallback to live lookups when the referenced role is not cached
+func TestPolicyCache(t *testing.T) {
+	testutil.RequireEtcd(t)
+	defer testutil.DumpEtcdOnFailure(t)
+
+	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	user := "harold"
+	namespace := "hammer-project"
+
+	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	haroldClient.RESTClient.Throttle = flowcontrol.NewFakeAlwaysRateLimiter() // turn off rate limiting so cache misses are more likely
+
+	for i := 0; i < 100; i++ { // usually takes less than 60 attempts for this to cache miss
+		role := &authorizationapi.Role{ObjectMeta: metav1.ObjectMeta{GenerateName: time.Now().String()}}
+		role, err = haroldClient.Roles(namespace).Create(role)
+		if err != nil {
+			t.Fatalf("unexpected error creating role %q: %v", role.Name, err)
+		}
+		roleBinding := &authorizationapi.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: role.Name},
+			Subjects:   []kapi.ObjectReference{{Name: user, Kind: authorizationapi.UserKind}},
+			RoleRef:    kapi.ObjectReference{Name: role.Name, Namespace: namespace}}
+		if _, err := haroldClient.RoleBindings(namespace).Create(roleBinding); err != nil {
+			t.Fatalf("cache error creating role binding %d %q: %v", i, roleBinding.Name, err)
 		}
 	}
 }


### PR DESCRIPTION
This change makes it so that a live lookup is done when a role is not cached but is being referenced in a role binding.  This prevents race conditions in templates that quickly create roles followed by associated bindings.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@bparees xref https://bugzilla.redhat.com/show_bug.cgi?id=1463630
@openshift/security @liggitt 
@deads2k PTAL, this has always been broken.  I refactored, deleted and moved a decent chunk of code.

[test]