### PR TITLE
fail closed on versioned pods

### DIFF
--- a/pkg/security/admission/admission.go
+++ b/pkg/security/admission/admission.go
@@ -69,9 +69,11 @@ func (c *constraint) Admit(a admission.Attributes) error {
 	}
 
 	pod, ok := a.GetObject().(*kapi.Pod)
-	// if we can't convert then we don't handle this object so just return
+	// if we can't convert then fail closed since we've already checked that this is supposed to be a pod object.
+	// this shouldn't normally happen during admission but could happen if an integrator passes a versioned
+	// pod object rather than an internal object.
 	if !ok {
-		return nil
+		return admission.NewForbidden(a, fmt.Errorf("object was marked as kind pod but was unable to be converted: %v", a.GetObject()))
 	}
 
 	// if this is an update, see if we are only updating the ownerRef.  Garbage collection does this

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
+	v1kapi "k8s.io/kubernetes/pkg/api/v1"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	clientsetfake "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
@@ -27,6 +28,20 @@ func NewTestAdmission(lister securitylisters.SecurityContextConstraintsLister, k
 		Handler:   kadmission.NewHandler(kadmission.Create),
 		client:    kclient,
 		sccLister: lister,
+	}
+}
+
+func TestFailClosedOnInvalidPod(t *testing.T) {
+	plugin := NewTestAdmission(nil, nil)
+	pod := &v1kapi.Pod{}
+	attrs := kadmission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
+	err := plugin.Admit(attrs)
+
+	if err == nil {
+		t.Fatalf("expected versioned pod object to fail admission")
+	}
+	if !strings.Contains(err.Error(), "object was marked as kind pod but was unable to be converted") {
+		t.Errorf("expected error to be conversion erorr but got: %v", err)
 	}
 }
 


### PR DESCRIPTION
We already check the resource and subresource.  If we cannot convert to the internal pod type then we should fail.

Note: this should not happen during the normal admission process but could happen if someone manually integrates with the admission controller - as in the instance of builds.

Ref: https://github.com/openshift/origin/pull/14891

## Note
must merge after https://github.com/openshift/origin/pull/14891 and must be backported as a group if backports are desired
