### PR TITLE
add indexer before the informers are started until the generator is rewritten

### DIFF
--- a/pkg/cmd/server/origin/controller/template.go
+++ b/pkg/cmd/server/origin/controller/template.go
@@ -1,23 +1,11 @@
 package controller
 
 import (
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	templatecontroller "github.com/openshift/origin/pkg/template/controller"
 )
 
 func RunTemplateInstanceController(ctx ControllerContext) (bool, error) {
-	err := ctx.TemplateInformers.Template().InternalVersion().Templates().Informer().AddIndexers(cache.Indexers{
-		templateapi.TemplateUIDIndex: func(obj interface{}) ([]string, error) {
-			return []string{string(obj.(*templateapi.Template).UID)}, nil
-		},
-	})
-	if err != nil {
-		return true, err
-	}
-
 	saName := bootstrappolicy.InfraTemplateInstanceControllerServiceAccountName
 
 	restConfig, err := ctx.ClientBuilder.Config(saName)

--- a/pkg/cmd/server/start/informers.go
+++ b/pkg/cmd/server/start/informers.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	kclientsetexternal "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kexternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
@@ -23,6 +24,7 @@ import (
 	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 	securityclient "github.com/openshift/origin/pkg/security/generated/internalclientset"
+	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 )
@@ -82,6 +84,23 @@ func NewInformers(options configapi.MasterConfig) (*informers, error) {
 	// before then we should try to eliminate our direct to storage access.  It's making us do weird things.
 	const defaultInformerResyncPeriod = 10 * time.Minute
 
+	templateInformers := templateinformer.NewSharedInformerFactory(templateClient, defaultInformerResyncPeriod)
+
+	// TODO remove this hack.  This is here because we need a new index conditionally added to an informer.
+	// Ideally, the generator produces an expansion method that allows us to provide a list of index functions
+	// to add to an informer if it is started.  This call actually causes the informer to be started, so we have to
+	// gate it
+	if options.TemplateServiceBrokerConfig != nil {
+		err := templateInformers.Template().InternalVersion().Templates().Informer().AddIndexers(cache.Indexers{
+			templateapi.TemplateUIDIndex: func(obj interface{}) ([]string, error) {
+				return []string{string(obj.(*templateapi.Template).UID)}, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &informers{
 		internalKubeInformers:  kinternalinformers.NewSharedInformerFactory(kubeInternal, defaultInformerResyncPeriod),
 		externalKubeInformers:  kexternalinformers.NewSharedInformerFactory(kubeExternal, defaultInformerResyncPeriod),
@@ -91,7 +110,7 @@ func NewInformers(options configapi.MasterConfig) (*informers, error) {
 		imageInformers:         imageinformer.NewSharedInformerFactory(imageClient, defaultInformerResyncPeriod),
 		quotaInformers:         quotainformer.NewSharedInformerFactory(quotaClient, defaultInformerResyncPeriod),
 		securityInformers:      securityinformer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
-		templateInformers:      templateinformer.NewSharedInformerFactory(templateClient, defaultInformerResyncPeriod),
+		templateInformers:      templateInformers,
 	}, nil
 }
 


### PR DESCRIPTION
We really need the informers to have an expansion to provide more indexes, but until that gets rewritten this conditionally adds the index before any informers are started.

[test]
@jim-minter can you add the right bucket of extended tests?