### PR TITLE
add the nodes local IP address to OVS rules for egressnetworkpolicy

### DIFF
--- a/pkg/sdn/plugin/ovscontroller_test.go
+++ b/pkg/sdn/plugin/ovscontroller_test.go
@@ -17,7 +17,7 @@ import (
 func setup(t *testing.T) (ovs.Interface, *ovsController, []string) {
 	ovsif := ovs.NewFake(BR)
 	oc := NewOVSController(ovsif, 0, true)
-	err := oc.SetupOVS("10.128.0.0/14", "172.30.0.0/16", "10.128.0.0/23", "10.128.0.1")
+	err := oc.SetupOVS("10.128.0.0/14", "172.30.0.0/16", "10.128.0.0/23", "10.128.0.1", "172.17.0.4")
 	if err != nil {
 		t.Fatalf("Unexpected error setting up OVS: %v", err)
 	}

--- a/pkg/sdn/plugin/sdn_controller.go
+++ b/pkg/sdn/plugin/sdn_controller.go
@@ -155,7 +155,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	}
 	glog.V(5).Infof("[SDN setup] full SDN setup required")
 
-	err = plugin.oc.SetupOVS(clusterNetworkCIDR, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway)
+	err = plugin.oc.SetupOVS(clusterNetworkCIDR, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway, plugin.localIP)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
this change adds the nodes local IP address to the ovs rules when using
egressnetworkpolicies to limit egress from the cluster. Adding the nodes
local IP allows for dns resolution when dns is accessable on the node.

bug 1458849 [Link](https://bugzilla.redhat.com/show_bug.cgi?id=1458849)