### PR TITLE
Make private tags not match when running make build.

### DIFF
--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -23,7 +23,7 @@ done
 
 # fail early if we don't have a proper kube version from the latest git tag
 function kube-version () {
-    local git_v=$(cd "${GOPATH}/src/k8s.io/kubernetes" && git describe --tags)
+    local git_v=$(cd "${GOPATH}/src/k8s.io/kubernetes" && git describe --tags --match 'v[0-9]*')
     echo "${git_v##-*}"
 }
 if ! [[ "$(kube-version)" =~ v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then

--- a/hack/lib/build/version.sh
+++ b/hack/lib/build/version.sh
@@ -36,7 +36,7 @@ function os::build::version::openshift_vars() {
 			fi
 		fi
 		# Use git describe to find the version based on annotated tags.
-		if [[ -n ${OS_GIT_VERSION-} ]] || OS_GIT_VERSION=$("${git[@]}" describe --long --tags --abbrev=7 "${OS_GIT_COMMIT}^{commit}" 2>/dev/null); then
+		if [[ -n ${OS_GIT_VERSION-} ]] || OS_GIT_VERSION=$("${git[@]}" describe --long --tags --abbrev=7 --match 'v[0-9]*' "${OS_GIT_COMMIT}^{commit}" 2>/dev/null); then
 			# Try to match the "git describe" output to a regex to try to extract
 			# the "major" and "minor" versions and whether this is the exact tagged
 			# version or whether the tree is between two tagged versions.


### PR DESCRIPTION
Addressing
```
$ make build
hack/build-go.sh
/home/test/openshift-origin/hack/lib/build/binaries.sh: line 449: OS_GIT_MAJOR: unbound variable
[ERROR] PID 2395: hack/lib/build/binaries.sh:449: `ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.majorFromGit" "${OS_GIT_MAJOR}"))` exited with status 1.
[INFO] 		Stack Trace:
[INFO] 		  1: hack/lib/build/binaries.sh:449: `ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.majorFromGit" "${OS_GIT_MAJOR}"))`
[...]
```
in repo where I use tags to track progress of pull requests.