### PR TITLE
UPSTREAM: 46771: Allow persistent-volume-binder to List Nodes/Zones Available in the Cluster

### DIFF
--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -4676,6 +4676,14 @@ items:
     - ""
     attributeRestrictions: null
     resources:
+    - nodes
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
     - events
     verbs:
     - watch

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -188,6 +188,8 @@ func init() {
 			rbac.NewRule("get", "list", "watch").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 			rbac.NewRule("get", "create", "delete").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
 			rbac.NewRule("get").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
+			// openstack
+			rbac.NewRule("get", "list").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 
 			// recyclerClient.WatchPod
 			rbac.NewRule("watch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -661,6 +661,13 @@ items:
   - apiGroups:
     - ""
     resources:
+    - nodes
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    resources:
     - events
     verbs:
     - watch


### PR DESCRIPTION
Backport of K8s PR #46771.

Cinder provisioner chooses a zone from the list of zones available in the cluster in case no zone is specified in the corresponding Storage Class. However, currently the provisioner (persistent-volume-binder) does not have right to get the list of nodes/zones available in the cluster.

That's why the persistent-volume-binder is being given permission to list and watch nodes in the cluster.

Note: the above problem was fixed in https://github.com/openshift/ose/commit/54b994c9b75aebfcf87e22c510796e0452809ed7
however, the fix was mistakenly "deleted" in https://github.com/openshift/ose/commit/8c7065fd602edeaf9ef20a350572e908aa0ab7e0

IMPORTANT: this PR was NOT tested.

This PR should resolves this bug: https://bugzilla.redhat.com/show_bug.cgi?id=1457092

This PR does not require any documentation changes.
