### PR TITLE
UPSTREAM: 44962: Remove misleading error from CronJob controller when it can't find parent

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/cronjob/utils.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/cronjob/utils.go
@@ -91,7 +91,7 @@ func groupJobsByParent(sjs []batchv2alpha1.CronJob, js []batchv1.Job) map[types.
 	for _, job := range js {
 		parentUID, found := getParentUIDFromJob(job)
 		if !found {
-			glog.Errorf("Unable to get uid from job %s in namespace %s", job.Name, job.Namespace)
+			glog.V(4).Infof("Unable to get parent uid from job %s in namespace %s", job.Name, job.Namespace)
 			continue
 		}
 		jobsBySj[parentUID] = append(jobsBySj[parentUID], job)


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/13349