### PR TITLE
Add multitenant<->networkpolicy migration helper scripts

### DIFF
--- a/contrib/migration/migrate-network-policy.sh
+++ b/contrib/migration/migrate-network-policy.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+plugin="$(oc get clusternetwork default --template='{{.pluginName}}')"
+if [[ "${plugin}" != "redhat/openshift-ovs-multitenant" ]]; then
+   echo "Migration script must be run while still running multitenant plugin"
+   exit 1
+fi 
+
+function default-deny() {
+    oc create --namespace "$1" -f - <<EOF
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-deny
+spec:
+  podSelector:
+EOF
+}
+
+function allow-from-self() {
+    oc create --namespace "$1" -f - <<EOF
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: allow-from-self
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}
+EOF
+}
+
+function allow-from-other() {
+    oc create --namespace "$1" -f - <<EOF
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: $2
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          pod.network.openshift.io/legacy-netid: "$3"
+EOF
+}
+
+# Find multiply-used NetIDs
+last_id=""
+declare -A shared_ids
+for id in $(oc get netnamespaces --output=custom-columns='NETID:.netid' --sort-by='.netid' --no-headers); do
+    if [[ "${id}" == "${last_id}" ]]; then
+	shared_ids["${id}"]=1
+    fi
+    last_id="${id}"
+done
+
+# Create policies and labels
+declare -a shared_namespaces
+for netns in $(oc get netnamespaces --output=jsonpath='{range .items[*]}{.netname}:{.netid} {end}'); do
+    name="${netns%:*}"
+    id="${netns#*:}"
+    echo ""
+    echo "NAMESPACE: ${name}"
+
+    if [[ "${id}" == "0" ]]; then
+	echo "Namespace is global: adding label legacy-netid=${id}"
+	oc label namespace "${name}" "pod.network.openshift.io/legacy-netid=${id}" >/dev/null
+	if [[ "${name}" != "default" ]]; then
+	    shared_namespaces+=("${name}")
+	fi
+
+    else
+	# All other Namespaces get isolated, but allow traffic from themselves and global
+	# namespaces. We define these as separate policies so the allow-from-global-namespaces
+	# policy can be deleted if it is not needed.
+
+	default-deny "${name}"
+	allow-from-self "${name}"
+	allow-from-other "${name}" allow-from-global-namespaces 0
+
+	if [[ -n "${shared_ids[${id}]:-}" ]]; then
+	    echo "Namespace used a shared NetNamespace: adding label legacy-netid=${id}"
+	    oc label namespace "${name}" "pod.network.openshift.io/legacy-netid=${id}" >/dev/null
+	    allow-from-other "${name}" allow-from-legacy-netid-"${id}" "${id}"
+	    shared_namespaces+=("${name}")
+	fi
+    fi
+done
+
+echo ""
+
+# Uniquify VNIDs. (We do this separately at the end because it's the only step that actually
+# has an effect under the multitenant plugin. So if something goes wrong before this point,
+# then the script will bomb out without having damaged anything.)
+if [[ "${#shared_namespaces[@]}" != 0 ]]; then
+    echo "Renumbering formerly-shared namespaces: ${shared_namespaces[@]}"
+    oc adm pod-network isolate-projects "${shared_namespaces[@]}"
+fi

--- a/contrib/migration/unmigrate-network-policy.sh
+++ b/contrib/migration/unmigrate-network-policy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+plugin="$(oc get clusternetwork default --template='{{.pluginName}}')"
+if [[ "${plugin}" != "redhat/openshift-ovs-multitenant" ]]; then
+   echo "Migration script must be run after switching back to multitenant plugin"
+   exit 1
+fi
+
+declare -A ids
+for ns in $(oc get namespaces --output=jsonpath="{range .items[*]}{.metadata.name}:{.metadata.labels['pod\\.network\\.openshift\\.io/legacy-netid']} {end}"); do
+    name="${ns%:*}"
+    id="${ns#*:}"
+    if [[ -n "${id}" ]]; then
+	ids["${id}"]+=" ${name}"
+    fi
+done
+
+for id in ${!ids[@]}; do
+    if [[ "${id}" == 0 ]]; then
+	echo "Making global:${ids[${id}]}"
+	oc adm pod-network make-projects-global ${ids["${id}"]}
+    else
+	echo "Joining projects:${ids[${id}]}"
+	oc adm pod-network join-projects --to ${ids["${id}"]}
+    fi
+done


### PR DESCRIPTION
Adds two scripts, contrib/migration/migrate-network-policy.sh (which creates NetworkPolicies corresponding to the current multitenant "oadm pod-network" settings and then renumbers any joined netnamespaces) and contrib/migration/unmigrate-network-policy.sh (which runs "oadm pod-network join-projects" and "oadm pod-network make-projects-global" as needed to undo the effect of the above).

These aren't getting packaged/shipped (so there's no harm in committing before the 3.6 freeze). The idea is more just that we can point people to them in git like we did with the old debug script (so there's also no particular *advantage* to committing them before the 3.6 freeze...).

https://gist.github.com/danwinship/ae9e691dfe9b5abcd032389df01cb5df has some scripts I used to test it; setup-nptest.sh creates a bunch of namespaces, test-nptest.sh plots out the connectivity between them, and cleanup-nptest.sh cleans things up (such that you can try again after). Running setup-nptest.sh, test-nptest.sh, then migrate-network-policy.sh, then restarting the cluster with the networkpolicy plugin, and running test-nptest.sh again gets the same results as running test-nptest.sh the first time, and then flipping back to multitenant, running unmigrate-network-policy.sh, and running test-nptest.sh again gets the same results again.

@openshift/networking PTAL