### PR TITLE
Fix avaibility reporting for DC with MinReadySeconds set

### DIFF
--- a/pkg/deploy/util/util.go
+++ b/pkg/deploy/util/util.go
@@ -407,8 +407,9 @@ func MakeDeploymentV1(config *deployapi.DeploymentConfig, codec runtime.Codec) (
 		},
 		Spec: v1.ReplicationControllerSpec{
 			// The deployment should be inactive initially
-			Replicas: &zero,
-			Selector: selector,
+			Replicas:        &zero,
+			Selector:        selector,
+			MinReadySeconds: config.Spec.MinReadySeconds,
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      podLabels,

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -563,3 +563,11 @@ func readDCFixture(path string) (*deployapi.DeploymentConfig, error) {
 	err = deployapiv1.Convert_v1_DeploymentConfig_To_apps_DeploymentConfig(dcv1, dc, nil)
 	return dc, err
 }
+
+func readDCFixtureOrDie(path string) *deployapi.DeploymentConfig {
+	data, err := readDCFixture(path)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -1955,7 +1955,7 @@ metadata:
   name: minreadytest
 spec:
   replicas: 2
-  minReadySeconds: 500
+  minReadySeconds: 60
   selector:
     name: minreadytest
   template:

--- a/test/extended/testdata/deployments/deployment-min-ready-seconds.yaml
+++ b/test/extended/testdata/deployments/deployment-min-ready-seconds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minreadytest
 spec:
   replicas: 2
-  minReadySeconds: 500
+  minReadySeconds: 60
   selector:
     name: minreadytest
   template:


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1463594

Makes AvailableReplicas work with MinReadySeconds set. Also removes obsolete counting of pods which makes it overlap with AvailableReplicas.

@kargakis PTAL. I want to be sure there was no gotcha for not using RC with MinReadySeconds except it might not be available at the time this was written.

cc: @mfojtik 