### PR TITLE
allow anonymous users to access /swagger.json

### DIFF
--- a/pkg/authorization/apis/authorization/types.go
+++ b/pkg/authorization/apis/authorization/types.go
@@ -49,7 +49,7 @@ var DiscoveryRule = PolicyRule{
 		"/api", "/api/*",
 		"/apis", "/apis/*",
 		"/oapi", "/oapi/*",
-		"/swaggerapi", "/swaggerapi/*",
+		"/swaggerapi", "/swaggerapi/*", "/swagger.json",
 		"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
 		"/.well-known", "/.well-known/*",
 	),


### PR DESCRIPTION
can we allow anonymous users to access /swagger.json (openapi v2 spec endpoint) as well as /swaggerapi (v1.2 spec)?