### PR TITLE
UPSTREAM: 48261: fix removing finalizer for gc

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/operations.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/operations.go
@@ -115,7 +115,7 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 		for _, f := range finalizers {
 			if f == targetFinalizer {
 				found = true
-				break
+				continue
 			}
 			newFinalizers = append(newFinalizers, f)
 		}


### PR DESCRIPTION
The remove finalizer loop would remove everything that came later.

@ironcladlou 3.6 blocker.