### PR TITLE
Disable ThirdPartyController

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -439,6 +439,8 @@ func buildKubeApiserverConfig(
 	genericConfig.Authenticator = originAuthenticator // this is used to fulfill the tokenreviews endpoint which is used by node authentication
 	genericConfig.Authorizer = kubeAuthorizer         // this is used to fulfill the kube SAR endpoints
 	genericConfig.DisabledPostStartHooks.Insert(rbacrest.PostStartHookName)
+	// This disables the ThirdPartyController which removes handlers from our go-restful containers.  The remove functionality is broken and destroys the serve mux.
+	genericConfig.DisabledPostStartHooks.Insert("extensions/third-party-resources")
 	genericConfig.AdmissionControl = admissionControl
 	genericConfig.RequestContextMapper = requestContextMapper
 	genericConfig.OpenAPIConfig = DefaultOpenAPIConfig()

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -958,7 +958,7 @@ func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, gett
 			defer func() {
 				if !t.Failed() { // do not cleanup if test has already failed since we may need things in the etcd dump
 					if err := client.cleanup(all); err != nil {
-						t.Fatalf("failed to clean up etcd: %#v", err)
+						t.Errorf("failed to clean up etcd: %#v", err)
 					}
 				}
 			}()

--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -84,7 +84,7 @@ var expectedIndex = []string{
 	"/healthz/ping",
 	"/healthz/poststarthook/bootstrap-controller",
 	"/healthz/poststarthook/ca-registration",
-	"/healthz/poststarthook/extensions/third-party-resources",
+	// "/healthz/poststarthook/extensions/third-party-resources",  // Do not enable this controller, we do not support it
 	"/healthz/ready",
 	"/metrics",
 	"/oapi",


### PR DESCRIPTION
This change makes it so that the third party resource controller does not run.  This controller breaks the API's go-restful containers by removing handlers.  The remove functionality is broken, and destroys the server mux when it is called.

Supersedes #14739
Fixes #14878

xref emicklei/go-restful/issues/344

@openshift/security 

[test]