### PR TITLE
don't accept deleted tokens

### DIFF
--- a/pkg/auth/oauth/registry/tokenauthenticator.go
+++ b/pkg/auth/oauth/registry/tokenauthenticator.go
@@ -40,6 +40,9 @@ func (a *TokenAuthenticator) AuthenticateToken(value string) (kuser.Info, bool, 
 	if token.CreationTimestamp.Time.Add(time.Duration(token.ExpiresIn) * time.Second).Before(time.Now()) {
 		return nil, false, ErrExpired
 	}
+	if token.DeletionTimestamp != nil {
+		return nil, false, ErrExpired
+	}
 
 	u, err := a.users.GetUser(ctx, token.UserName, &metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
In 3.6 we added GC, which allows users to specify finalizers when they delete their tokens.  Doing this results in a zombie token that isn't deleted (separate problem), but was still valid against the API (this problem).  This prevents us from accepting deleted tokens.

I'll update the SA one upstream too and pick it down.

@openshift/security @enj 