### PR TITLE
Break up os::cleanup::all

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -13,17 +13,13 @@
 #  - SKIP_TEARDOWN
 #  - SKIP_IMAGE_CLEANUP
 # Arguments:
-#  1 - return code of the script
+#  None
 # Returns:
 #  None
 function os::cleanup::all() {
-	local return_code="$1"
-
 	# All of our cleanup is best-effort, so we do not care
 	# if any specific step fails.
 	set +o errexit
-
-	os::test::junit::generate_report
 
 	os::log::info "[CLEANUP] Beginning cleanup routines..."
 	os::cleanup::dump_events
@@ -38,7 +34,6 @@ function os::cleanup::all() {
 		os::cleanup::processes
 		os::cleanup::prune_etcd
 	fi
-	os::util::describe_return_code "${return_code}"
 }
 readonly -f os::cleanup::all
 

--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -10,6 +10,7 @@
 #
 # Globals:
 #  - ARTIFACT_DIR
+#  - SKIP_CLEANUP
 #  - SKIP_TEARDOWN
 #  - SKIP_IMAGE_CLEANUP
 # Arguments:
@@ -17,6 +18,11 @@
 # Returns:
 #  None
 function os::cleanup::all() {
+	if [[ -n "${SKIP_CLEANUP:-}" ]]; then
+		os::log::warning "[CLEANUP] Skipping cleanup routines..."
+		return 0
+	fi
+
 	# All of our cleanup is best-effort, so we do not care
 	# if any specific step fails.
 	set +o errexit

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -7,7 +7,9 @@ os::util::environment::setup_time_vars
 
 function cleanup() {
   return_code=$?
-  os::cleanup::all "${return_code}"
+  os::test::junit::generate_report
+  os::cleanup::all
+  os::util::describe_return_code "${return_code}"
   exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -21,7 +21,9 @@ fi
 
 function cleanup() {
 	return_code=$?
-	os::cleanup::all "${return_code}"
+
+	os::test::junit::generate_report
+	os::cleanup::all
 
 	# restore journald to previous form
 	if os::util::ensure::system_binary_exists 'systemctl'; then
@@ -33,6 +35,7 @@ function cleanup() {
 		${USE_SUDO:+sudo} systemctl restart docker.service
 	fi
 
+	os::util::describe_return_code "${return_code}"
 	exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -21,9 +21,11 @@ os::util::ensure::iptables_privileges_exist
 os::log::info "Starting end-to-end test"
 
 function cleanup() {
-	return_code=$?
-	os::cleanup::all "${return_code}"
-	exit "${return_code}"
+  return_code=$?
+  os::test::junit::generate_report
+  os::cleanup::all
+  os::util::describe_return_code "${return_code}"
+  exit "${return_code}"
 }
 trap "cleanup" EXIT
 

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -21,8 +21,8 @@
 #  - DLV_DEBUG            toggles running tests using delve debugger
 function cleanup() {
     return_code=$?
-    os::cleanup::all "${return_code}"
 
+    os::test::junit::generate_report
     if [[ "${JUNIT_REPORT_NUM_FAILED:-}" == "0 failed" ]]; then
         if [[ "${return_code}" -ne "0" ]]; then
             os::log::warning "While the jUnit report found no failed tests, the \`go test\` process failed."
@@ -30,6 +30,7 @@ function cleanup() {
         fi
     fi
 
+    os::util::describe_return_code "${return_code}"
     exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -15,7 +15,10 @@ function cleanup() {
 	# this is a domain socket. CI falls over it.
 	rm -f "${BASETMPDIR}/dockershim.sock"
 
-	os::cleanup::all "${return_code}"
+	os::test::junit::generate_report
+	os::cleanup::all
+	os::util::describe_return_code "${return_code}"
+
 	exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/hack/test-lib.sh
+++ b/hack/test-lib.sh
@@ -5,7 +5,8 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {
     return_code=$?
-    os::cleanup::all "${return_code}"
+	os::test::junit::generate_report
+	os::util::describe_return_code "${return_code}"
     exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -5,7 +5,9 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {
     return_code=$?
-    os::cleanup::all "${return_code}"
+    os::test::junit::generate_report
+    os::cleanup::all
+    os::util::describe_return_code "${return_code}"
     exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/test/extended/alternate_certs.sh
+++ b/test/extended/alternate_certs.sh
@@ -8,11 +8,12 @@ os::util::environment::setup_all_server_vars
 
 function cleanup() {
 	return_code=$?
-	os::cleanup::all "${return_code}"
+	os::test::junit::generate_report
+	os::cleanup::all
+	os::util::describe_return_code "${return_code}"
 	exit "${return_code}"
 }
 trap "cleanup" EXIT
-
 
 os::log::info "Starting server as distinct processes"
 os::log::info "`openshift version`"

--- a/test/extended/alternate_launches.sh
+++ b/test/extended/alternate_launches.sh
@@ -11,7 +11,9 @@ os::util::environment::setup_all_server_vars
 
 function cleanup() {
 	return_code=$?
-	os::cleanup::all "${return_code}"
+	os::test::junit::generate_report
+	os::cleanup::all
+	os::util::describe_return_code "${return_code}"
 	exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -14,7 +14,9 @@ function cleanup() {
 
 	docker rmi test/scratchimage
 
-	os::cleanup::all "${return_code}"
+	os::test::junit::generate_report
+	os::cleanup::all
+	os::util::describe_return_code "${return_code}"
 	exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -31,7 +31,9 @@ os::cmd::expect_success_and_text 'oc version' 'GSSAPI Kerberos SPNEGO'
 
 function cleanup() {
     return_code=$?
-    os::cleanup::all "${return_code}"
+    os::test::junit::generate_report
+    os::cleanup::all
+    os::util::describe_return_code "${return_code}"
     exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -10,7 +10,9 @@ os::build::setup_env
 
 function cleanup() {
 	return_code=$?
-	os::cleanup::all "${return_code}"
+	os::test::junit::generate_report
+	os::cleanup::all
+	os::util::describe_return_code "${return_code}"
 	exit "${return_code}"
 }
 trap "cleanup" EXIT

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -42,7 +42,9 @@ function os::test::extended::setup () {
 
 	function cleanup() {
 		return_code=$?
-		os::cleanup::all "${return_code}"
+		os::test::junit::generate_report
+		os::cleanup::all
+		os::util::describe_return_code "${return_code}"
 		exit "${return_code}"
 	}
 	trap "cleanup" EXIT


### PR DESCRIPTION
The previous attempt to DRY out cleanup code went too far. Generating
jUnit, cleaning up after a cluster and describing the outcome of a
script are separate steps and it makes sense to choose to run them
independently. This allows scripts like the unit tests to not spend time
tearing down clusters, etc.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

[test]

/cc @csrwng @DirectXMan12 