### PR TITLE
AggregatedLogging diagnostic: bz1421623

### DIFF
--- a/pkg/diagnostics/cluster/aggregated_logging/serviceaccounts.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/serviceaccounts.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-var serviceAccountNames = sets.NewString("logging-deployer", "aggregated-logging-kibana", "aggregated-logging-curator", "aggregated-logging-elasticsearch", fluentdServiceAccountName)
+var serviceAccountNames = sets.NewString("aggregated-logging-kibana", "aggregated-logging-curator", "aggregated-logging-elasticsearch", fluentdServiceAccountName)
 
 const serviceAccountsMissing = `
 Did not find ServiceAccounts: %s.  The logging infrastructure will not function 

--- a/pkg/diagnostics/cluster/aggregated_logging/services_test.go
+++ b/pkg/diagnostics/cluster/aggregated_logging/services_test.go
@@ -65,8 +65,8 @@ func TestCheckingServicesWhenMissingServices(t *testing.T) {
 
 	checkServices(d, d, fakeProject)
 	d.assertMessage("AGL0215",
-		"Exp an warning when an expected sercies is not found",
-		log.WarnLevel)
+		"Exp an info when an expected service is not found",
+		log.InfoLevel)
 }
 
 func TestCheckingServicesWarnsWhenRetrievingEndpointsErrors(t *testing.T) {
@@ -88,8 +88,8 @@ func TestCheckingServicesWarnsWhenServiceHasNoEndpoints(t *testing.T) {
 
 	checkServices(d, d, fakeProject)
 	d.assertMessage("AGL0225",
-		"Exp a warning when an expected service has no endpoints",
-		log.WarnLevel)
+		"Exp an error when an existing service has no endpoints",
+		log.ErrorLevel)
 }
 
 func TestCheckingServicesHasNoErrorsOrWarningsForExpServices(t *testing.T) {


### PR DESCRIPTION
Fix [bug 1421623](https://bugzilla.redhat.com/show_bug.cgi?id=1421623)

The deployer service account is no longer created or needed.
Also the handling of optional components needed some tweaking. Now checks for mux. Missing optional component messages are Info level now.
The warning message for services missing endpoints has become an error.