### PR TITLE
UPSTREAM: 47347: actually check for a live discovery endpoint before aggregating

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller_test.go
@@ -146,7 +146,7 @@ func TestSync(t *testing.T) {
 				Type:    apiregistration.Available,
 				Status:  apiregistration.ConditionFalse,
 				Reason:  "FailedDiscoveryCheck",
-				Message: `no response from https:///apis: context deadline exceeded`,
+				Message: `no response from https:///apis: Get https:///apis: http: no Host in request URL`,
 			},
 		},
 	}


### PR DESCRIPTION
Unit test ensures that non-nil errors fail.

Fixes https://github.com/openshift/origin/issues/15014

@spadgett you can build and give it a try.  `oc cluster up` seems rather inconsistent, but this still works when running locally for me and removes any, "what is this doing" aspect.