### PR TITLE
move the panic handler first

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -243,7 +243,6 @@ func (c *MasterConfig) buildHandlerChain(assetConfig *AssetConfig) (func(http.Ha
 		}
 
 		handler = apiserverfilters.WithCORS(handler, c.Options.CORSAllowedOrigins, nil, nil, nil, "true")
-		handler = apiserverfilters.WithPanicRecovery(handler)
 		handler = apiserverfilters.WithTimeoutForNonLongRunningRequests(handler, contextMapper, kc.LongRunningFunc)
 		// TODO: MaxRequestsInFlight should be subdivided by intent, type of behavior, and speed of
 		// execution - updates vs reads, long reads vs short reads, fat reads vs skinny reads.
@@ -251,6 +250,7 @@ func (c *MasterConfig) buildHandlerChain(assetConfig *AssetConfig) (func(http.Ha
 		handler = apiserverfilters.WithMaxInFlightLimit(handler, kc.MaxRequestsInFlight, kc.MaxMutatingRequestsInFlight, contextMapper, kc.LongRunningFunc)
 		handler = apifilters.WithRequestInfo(handler, apiserver.NewRequestInfoResolver(kc), contextMapper)
 		handler = apirequest.WithRequestContext(handler, contextMapper)
+		handler = apiserverfilters.WithPanicRecovery(handler)
 
 		return handler
 	}, nil


### PR DESCRIPTION
Move the panic handler to the beginning of the chain so that panics will get information in the log beyond a stack.

@derekwaynecarr this should give you better debug output.

[severity:blocker]