### PR TITLE
ResolverConfig should be left on so search path is inherited

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -171,10 +171,6 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	server.MaxPods = 250
 	server.PodsPerCore = 10
 	server.CgroupDriver = "systemd"
-	if enableDNS {
-		// if we are running local DNS, skydns will load the default recursive nameservers for us
-		server.ResolverConfig = ""
-	}
 	server.DockerExecHandlerName = string(options.DockerConfig.ExecHandlerName)
 	server.RemoteRuntimeEndpoint = options.DockerConfig.DockerShimSocket
 	server.RemoteImageEndpoint = options.DockerConfig.DockerShimSocket


### PR DESCRIPTION
The changes to DNS coming from the node can't be merged because the GCE provider name `metadata` isn't resolving inside containers, because the hosts search path isn't being copied into a container. We used to set this field empty, but instead we should use the default when we are not the all-in-one.