### PR TITLE
cluster up: Fix the regular expression used to parse openshift version

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper.go
+++ b/pkg/bootstrap/docker/openshift/helper.go
@@ -669,15 +669,17 @@ func (h *Helper) ServerPrereleaseVersion() (semver.Version, error) {
 	if len(versionStr) == 0 {
 		return semver.Version{}, fmt.Errorf("did not find version in command output")
 	}
+	return parseOpenshiftVersion(versionStr)
+}
 
+func parseOpenshiftVersion(versionStr string) (semver.Version, error) {
 	// The OCP version may have > 4 parts to the version string,
 	// e.g. 3.5.1.1-prerelease, whereas Origin will be 3.5.1-prerelease,
 	// drop the 4th digit for OCP.
-	re := regexp.MustCompile("([0-9]+).([0-9]+).([0-9]+).([0-9]+)(.*)")
+	re := regexp.MustCompile("([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)")
 	versionStr = re.ReplaceAllString(versionStr, "${1}.${2}.${3}${5}")
 
-	version, err := semver.Parse(versionStr)
-	return version, err
+	return semver.Parse(versionStr)
 }
 
 func useDNSIP(version semver.Version) bool {

--- a/pkg/bootstrap/docker/openshift/helper_test.go
+++ b/pkg/bootstrap/docker/openshift/helper_test.go
@@ -1,0 +1,44 @@
+package openshift
+
+import (
+	"testing"
+)
+
+func TestParseOpenshiftVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "1.3.1",
+			expected: "1.3.1",
+		},
+		{
+			input:    "3.5.5.4",
+			expected: "3.5.5",
+		},
+		{
+			input:    "3.5.5.18-alpha.3",
+			expected: "3.5.5-alpha.3",
+		},
+		{
+			input:    "3.4.144.2-1",
+			expected: "3.4.144-1",
+		},
+		{
+			input:    "3.6.0-alpha.2+2a00043-774",
+			expected: "3.6.0-alpha.2+2a00043-774",
+		},
+	}
+
+	for _, test := range tests {
+		v, err := parseOpenshiftVersion(test.input)
+		if err != nil {
+			t.Errorf("unexpected error for %s: %v", test.input, err)
+			continue
+		}
+		if v.String() != test.expected {
+			t.Errorf("unexpected output. Got: %v, expected: %s", v, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Factors out the code in a function and adds a unit test to test it. 
Fixes #15039