### PR TITLE
Get more error info if OVS ofport allocation fails

### DIFF
--- a/pkg/util/ovs/ovs_test.go
+++ b/pkg/util/ovs/ovs_test.go
@@ -194,6 +194,18 @@ func TestAddPort(t *testing.T) {
 		t.Fatalf("Got wrong error: %v", err)
 	}
 	ensureTestResults(t, fexec)
+
+	addTestResult(t, fexec, "ovs-vsctl --may-exist add-port br0 veth0 -- set Interface veth0 ofport_request=5", "", nil)
+	addTestResult(t, fexec, "ovs-vsctl get Interface veth0 ofport", "-1\n", nil)
+	addTestResult(t, fexec, "ovs-vsctl get Interface veth0 error", "could not open network device veth0 (No such device)\n", nil)
+	_, err = ovsif.AddPort("veth0", 5)
+	if err == nil {
+		t.Fatalf("Unexpectedly failed to get error")
+	}
+	if err.Error() != "error on port veth0: could not open network device veth0 (No such device)" {
+		t.Fatalf("Got wrong error: %v", err)
+	}
+	ensureTestResults(t, fexec)
 }
 
 func TestOVSVersion(t *testing.T) {


### PR DESCRIPTION
In an attempt to further debug #15052

Unlike dcbw's previous ovs error-related change, this change is actually causing us to return an error in a case where we previously did not return an error. However, the current (incorrect) behavior of not returning an error in the -1 case just kicks the failure down the road a little farther. In particular, it just guarantees that the immediately following "ovs-ofctl add-flow" command will fail, because "in_port=-1" is syntactically invalid.

@openshift/networking PTAL