### PR TITLE
Send HTTP Unauthorized (401) for router metrics URL

### DIFF
--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -29,7 +29,7 @@ func Listen(listenAddr string, username, password string, checks ...healthz.Heal
 			protected.Handle("/metrics", prometheus.Handler())
 			mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 				if u, p, ok := req.BasicAuth(); !ok || u != username || p != password {
-					http.Error(w, "Forbidden", http.StatusForbidden)
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 					return
 				}
 				protected.ServeHTTP(w, req)


### PR DESCRIPTION
We were previously sending Forbidden (403) which doesn't make the browser prompt for a username and password.  It is better to send Unauthorized (401) so that they can present credentials using the browser widget rather than having to jam them in the URL.

Fixes bug 1467257 (https://bugzilla.redhat.com/show_bug.cgi?id=1467257)