### PR TITLE
Git spec handling revamp for 3.7

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2967,118 +2967,138 @@
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api/describe",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api/validation",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies/layered",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies/onbuild",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies/sti",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
-			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/empty",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/downloaders",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
-			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/file",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/downloaders/empty",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
+		},
+		{
+			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/downloaders/file",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
+		},
+		{
+			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/downloaders/git",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/git",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
-		},
-		{
-			"ImportPath": "github.com/openshift/source-to-image/pkg/test",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
+		},
+		{
+			"ImportPath": "github.com/openshift/source-to-image/pkg/util/cmd",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
+		},
+		{
+			"ImportPath": "github.com/openshift/source-to-image/pkg/util/cygpath",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
+		},
+		{
+			"ImportPath": "github.com/openshift/source-to-image/pkg/util/fs",
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/glog",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/interrupt",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/status",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/user",
-			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Comment": "v1.1.7-20-g7da3d3e",
+			"Rev": "7da3d3e97565e652a59fd81286f3956fd43e85a8"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/pkg/build/apis/build/validation/validation_test.go
+++ b/pkg/build/apis/build/validation/validation_test.go
@@ -841,7 +841,7 @@ func TestValidateSource(t *testing.T) {
 			path: "git.uri",
 			source: &buildapi.BuildSource{
 				Git: &buildapi.GitBuildSource{
-					URI: "::",
+					URI: "http://%",
 				},
 			},
 		},

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -440,14 +440,14 @@ func scriptProxyConfig(build *buildapi.Build) (*s2iapi.ProxyConfig, error) {
 	}
 	config := &s2iapi.ProxyConfig{}
 	if len(httpProxy) > 0 {
-		proxyURL, err := url.Parse(httpProxy)
+		proxyURL, err := util.ParseProxyURL(httpProxy)
 		if err != nil {
 			return nil, err
 		}
 		config.HTTPProxy = proxyURL
 	}
 	if len(httpsProxy) > 0 {
-		proxyURL, err := url.Parse(httpsProxy)
+		proxyURL, err := util.ParseProxyURL(httpsProxy)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/build/controller/build/defaults/api/validation/validation.go
+++ b/pkg/build/controller/build/defaults/api/validation/validation.go
@@ -6,13 +6,14 @@ import (
 
 	buildvalidation "github.com/openshift/origin/pkg/build/apis/build/validation"
 	"github.com/openshift/origin/pkg/build/controller/build/defaults/api"
+	"github.com/openshift/origin/pkg/build/util"
 )
 
 // ValidateBuildDefaultsConfig tests required fields for a Build.
 func ValidateBuildDefaultsConfig(config *api.BuildDefaultsConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateURL(config.GitHTTPProxy, field.NewPath("gitHTTPProxy"))...)
-	allErrs = append(allErrs, validateURL(config.GitHTTPSProxy, field.NewPath("gitHTTPSProxy"))...)
+	allErrs = append(allErrs, validateProxyURL(config.GitHTTPProxy, field.NewPath("gitHTTPProxy"))...)
+	allErrs = append(allErrs, validateProxyURL(config.GitHTTPSProxy, field.NewPath("gitHTTPSProxy"))...)
 	allErrs = append(allErrs, buildvalidation.ValidateStrategyEnv(config.Env, field.NewPath("env"))...)
 	allErrs = append(allErrs, buildvalidation.ValidateImageLabels(config.ImageLabels, field.NewPath("imageLabels"))...)
 	allErrs = append(allErrs, buildvalidation.ValidateNodeSelector(config.NodeSelector, field.NewPath("nodeSelector"))...)
@@ -21,10 +22,10 @@ func ValidateBuildDefaultsConfig(config *api.BuildDefaultsConfig) field.ErrorLis
 }
 
 //
-func validateURL(u string, path *field.Path) field.ErrorList {
+func validateProxyURL(u string, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if !buildvalidation.IsValidURL(u) {
-		allErrs = append(allErrs, field.Invalid(path, u, "invalid URL"))
+	if _, err := util.ParseProxyURL(u); err != nil {
+		allErrs = append(allErrs, field.Invalid(path, u, err.Error()))
 	}
 	return allErrs
 }

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -461,3 +461,23 @@ func FindDockerSecretAsReference(secrets []kapi.Secret, image string) *kapi.Loca
 	}
 	return nil
 }
+
+// ParseProxyURL parses a proxy URL and allows fallback to non-URLs like
+// myproxy:80 (for example) which url.Parse no longer accepts in Go 1.8.  The
+// logic is copied from net/http.ProxyFromEnvironment to try to maintain
+// backwards compatibility.
+func ParseProxyURL(proxy string) (*url.URL, error) {
+	proxyURL, err := url.Parse(proxy)
+
+	// logic copied from net/http.ProxyFromEnvironment
+	if err != nil || !strings.HasPrefix(proxyURL.Scheme, "http") {
+		// proxy was bogus. Try prepending "http://" to it and see if that
+		// parses correctly. If not, we fall through and complain about the
+		// original one.
+		if proxyURL, err := url.Parse("http://" + proxy); err == nil {
+			return proxyURL, nil
+		}
+	}
+
+	return proxyURL, err
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -7438,7 +7438,7 @@ spec:
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
-          value: ":http://example.org"
+          value: "http://%"
 `)
 
 func testExtendedTestdataStatusfailGenericreasonYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/statusfail-genericreason.yaml
+++ b/test/extended/testdata/statusfail-genericreason.yaml
@@ -15,4 +15,4 @@ spec:
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
-          value: ":http://example.org"
+          value: "http://%"


### PR DESCRIPTION
improve git repository spec parsing and hopefully avoid hitting issues due to tightened URL parsing in go 1.8.

fix #14831 
fix #15005