### PR TITLE
Updates to the cleanup DC test

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -833,12 +833,13 @@ var _ = g.Describe("deploymentconfigs", func() {
 		g.It("should never persist more old deployments than acceptable after being observed by the controller", func() {
 			revisionHistoryLimit := 3 // as specified in the fixture
 
-			_, err := oc.Run("create").Args("-f", historyLimitedDeploymentFixture).Output()
+			dc, err := createDeploymentConfig(oc, historyLimitedDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
+			deploymentTimeout := time.Duration(*dc.Spec.Strategy.RollingParams.TimeoutSeconds) * time.Second
 
 			iterations := 10
 			for i := 0; i < iterations; i++ {
-				o.Expect(waitForLatestCondition(oc, "history-limit", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred(),
+				o.Expect(waitForLatestCondition(oc, "history-limit", deploymentTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred(),
 					"the current deployment needs to have finished before attempting to trigger a new deployment through configuration change")
 				e2e.Logf("%02d: triggering a new deployment with config change", i)
 				out, err := oc.Run("set", "env").Args("dc/history-limit", fmt.Sprintf("A=%d", i)).Output()
@@ -848,7 +849,7 @@ var _ = g.Describe("deploymentconfigs", func() {
 
 			o.Expect(waitForSyncedConfig(oc, "history-limit", deploymentRunTimeout)).NotTo(o.HaveOccurred())
 			g.By("waiting for the deployment to complete")
-			o.Expect(waitForLatestCondition(oc, "history-limit", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
+			o.Expect(waitForLatestCondition(oc, "history-limit", deploymentTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 			o.Expect(waitForSyncedConfig(oc, "history-limit", deploymentRunTimeout)).NotTo(o.HaveOccurred(),
 				"the controller needs to have synced with the updated deployment configuration before checking that the revision history limits are being adhered to")
 			var pollErr error
@@ -876,8 +877,9 @@ var _ = g.Describe("deploymentconfigs", func() {
 				return true, nil
 			})
 			if err == wait.ErrWaitTimeout {
-				o.Expect(pollErr).NotTo(o.HaveOccurred())
+				err = pollErr
 			}
+			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 	})
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -1829,25 +1829,15 @@ metadata:
   name: history-limit
 spec:
   replicas: 1
-  selector:
-    name: history-limit
   strategy:
     type: Rolling
-    rollingParams:
-      pre:
-        failurePolicy: Abort
-        execNewPod:
-          containerName: myapp
-          command:
-          - /bin/echo
-          - test pre hook executed
   template:
     metadata:
       labels:
         name: history-limit
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "docker.io/alpine:3.6"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/deployment-history-limit.yaml
+++ b/test/extended/testdata/deployments/deployment-history-limit.yaml
@@ -4,25 +4,15 @@ metadata:
   name: history-limit
 spec:
   replicas: 1
-  selector:
-    name: history-limit
   strategy:
     type: Rolling
-    rollingParams:
-      pre:
-        failurePolicy: Abort
-        execNewPod:
-          containerName: myapp
-          command:
-          - /bin/echo
-          - test pre hook executed
   template:
     metadata:
       labels:
         name: history-limit
     spec:
       containers:
-      - image: "docker.io/centos:centos7"
+      - image: "docker.io/alpine:3.6"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:


### PR DESCRIPTION
* use a more lightweight image to run in application pods
* don't run pre-hook since it's not required
* wait for the DC timeout for a complete deployment

Fixes https://github.com/openshift/origin/issues/15073

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>