### PR TITLE
UPSTREAM: <drop>: Increase SAControllerClientBuilder timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/client_builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/client_builder.go
@@ -140,7 +140,7 @@ func (b SAControllerClientBuilder) Config(name string) (*restclient.Config, erro
 			return b.CoreClient.Secrets(b.Namespace).Watch(options)
 		},
 	}
-	_, err = cache.ListWatchUntil(30*time.Second, lw,
+	_, err = cache.ListWatchUntil(2*time.Minute, lw,
 		func(event watch.Event) (bool, error) {
 			switch event.Type {
 			case watch.Deleted:


### PR DESCRIPTION
On very large clusters, secrets may not load within 30s. Temporarily
incraese this value.

Fixes #15084

[test] @deads2k