### PR TITLE
run must output message on container error

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
@@ -388,7 +388,7 @@ func Run(f cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr io
 				return unknownRcErr
 			}
 			return uexec.CodeExitError{
-				Err:  fmt.Errorf("pod %s/%s terminated", pod.Namespace, pod.Name),
+				Err:  fmt.Errorf("pod %s/%s terminated (%s)\n%s", pod.Namespace, pod.Name, pod.Status.ContainerStatuses[0].State.Terminated.Reason, pod.Status.ContainerStatuses[0].State.Terminated.Message),
 				Code: int(rc),
 			}
 		default:

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go
@@ -165,8 +165,7 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 		case utilerrors.Aggregate:
 			handleErr(MultipleErrors(prefix, err.Errors()), DefaultErrorExitCode)
 		case utilexec.ExitError:
-			// do not print anything, only terminate with given error
-			handleErr("", err.ExitStatus())
+			handleErr(err.Error(), err.ExitStatus())
 		default: // for any other error type
 			msg, ok := StandardErrorMessage(err)
 			if !ok {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers_test.go
@@ -277,7 +277,7 @@ func TestCheckExitError(t *testing.T) {
 	testCheckError(t, []checkErrTestCase{
 		{
 			uexec.CodeExitError{Err: fmt.Errorf("pod foo/bar terminated"), Code: 42},
-			"",
+			"pod foo/bar terminated",
 			42,
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15031
Picks https://github.com/kubernetes/kubernetes/pull/48578

`oc run` must output a message (instead of just exiting with an error code) on container error.

