### PR TITLE
ImageStreamTag update should ignore missing labels

### DIFF
--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -219,6 +219,12 @@ func (r *REST) Update(ctx apirequest.Context, tagName string, objInfo rest.Updat
 		return nil, false, kapierrors.NewConflict(imageapi.Resource("imagestreamtags"), istag.Name, fmt.Errorf("another caller has updated the resource version to %s", imageStream.ResourceVersion))
 	}
 
+	// When we began returning image stream labels in 3.6, old clients that didn't need to send labels would be
+	// broken on update. Explicitly default labels if they are unset.  We don't support mutation of labels on update.
+	if len(imageStream.Labels) > 0 && len(istag.Labels) == 0 {
+		istag.Labels = imageStream.Labels
+	}
+
 	if create {
 		if err := rest.BeforeCreate(Strategy, ctx, obj); err != nil {
 			return nil, false, err

--- a/test/cmd/images_tests.sh
+++ b/test/cmd/images_tests.sh
@@ -181,6 +181,10 @@ os::cmd::expect_success_and_text "oc get is/mysql --template='{{(index .spec.tag
 
 os::cmd::expect_failure_and_text 'oc tag mysql:latest tagtest:tag1 --alias' 'cannot set alias across'
 
+# tag labeled image
+os::cmd::expect_success 'oc label is/mysql labelA=value'
+os::cmd::expect_success 'oc tag mysql:latest mysql:labeled'
+os::cmd::expect_success_and_text "oc get istag/mysql:labeled -o jsonpath='{.metadata.labels.labelA}'" 'value'
 # test copying tags
 os::cmd::expect_success 'oc tag registry-1.docker.io/openshift/origin:v1.0.4 newrepo:latest'
 os::cmd::expect_success_and_text "oc get is/newrepo --template='{{(index .spec.tags 0).from.kind}}'" 'DockerImage'


### PR DESCRIPTION
When we started returning labels for image stream tags in 3.6, old clients that
retrieved the tag and updated the field were broken if the image stream
had tags, since they would send empty labels (not having received them
via the API) on update, and labels are immutable.

This preserves the legacy behavior by defaulting the user provided image
stream tag labels to the image stream labels if no labels are set in the
image stream tag.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1463890

[test] @mfojtik @deads2k