### PR TITLE
remove /var/lib/docker volume from containerized node

### DIFF
--- a/contrib/systemd/containerized/origin-node.service
+++ b/contrib/systemd/containerized/origin-node.service
@@ -8,7 +8,7 @@ PartOf=docker.service
 [Service]
 EnvironmentFile=/etc/sysconfig/origin-node
 ExecStartPre=-/usr/bin/docker rm -f origin-node
-ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro,rslave -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:rw -v /var/lib/docker:/var/lib/docker -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/cni:/var/lib/cni -v /etc/cni/net.d:/etc/cni/net.d -v /var/lib/origin:/var/lib/origin:rslave -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
+ExecStart=/usr/bin/docker run --name origin-node --rm --privileged --net=host --pid=host --env-file=/etc/sysconfig/origin-node -v /:/rootfs:ro,rslave -v /etc/systemd/system:/host-etc/systemd/system -v /etc/localtime:/etc/localtime:ro -v /etc/machine-id:/etc/machine-id:ro -v /lib/modules:/lib/modules -v /run:/run -v /sys:/sys:rw -v /etc/origin/node:/etc/origin/node -v /etc/origin/openvswitch:/etc/openvswitch -v /etc/origin/sdn:/etc/openshift-sdn -v /var/lib/cni:/var/lib/cni -v /etc/cni/net.d:/etc/cni/net.d -v /var/lib/origin:/var/lib/origin:rslave -v /var/log:/var/log -v /dev:/dev -e HOST=/rootfs -e HOST_ETC=/host-etc openshift/node
 ExecStartPost=/usr/bin/sleep 10
 ExecStop=/usr/bin/docker stop origin-node
 Restart=always


### PR DESCRIPTION
xref https://bugzilla.redhat.com/show_bug.cgi?id=1467824

tl;dr upstream docker does not allow the forced removal of containers anymore.  Before, a forced removal, when using devicemapper graph driver, simply orphaned a thin device and those devices would eventually consume the pool.  The upstream docker change was backported to docker-1.12.6-40 to fix this issue.

However, the mounting of `/var/lib/docker` into the containerized node is causing other openshift services from being able to (re)start successfully since the systemd unit files first remove the old container, which fails due to the containerized node holding the mount point, then tries a docker run, which fails because a container with that name already exists.

To avoid this, the PR removes `/var/lib/docker` from the volumes mounted into the containerized node.

@derekwaynecarr @smarterclayton @eparis 