### PR TITLE
Commands should not depend on the implementation of the factory

### DIFF
--- a/cmd/gitserver/gitserver.go
+++ b/cmd/gitserver/gitserver.go
@@ -1,16 +1,8 @@
 package main
 
 import (
-	"math/rand"
-	"os"
-	"path/filepath"
-	"runtime"
-	"time"
-
-	"k8s.io/kubernetes/pkg/util/logs"
-
 	"github.com/openshift/origin/pkg/cmd/infra/gitserver"
-	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+	"github.com/openshift/origin/pkg/cmd/util/standard"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
@@ -19,19 +11,5 @@ import (
 )
 
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
-	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
-	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
-
-	rand.Seed(time.Now().UTC().UnixNano())
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
-	basename := filepath.Base(os.Args[0])
-	command := gitserver.CommandFor(basename)
-	if err := command.Execute(); err != nil {
-		os.Exit(1)
-	}
+	standard.Run(gitserver.CommandFor)
 }

--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -1,16 +1,8 @@
 package main
 
 import (
-	"math/rand"
-	"os"
-	"path/filepath"
-	"runtime"
-	"time"
-
-	"k8s.io/kubernetes/pkg/util/logs"
-
 	"github.com/openshift/origin/pkg/cmd/cli"
-	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+	"github.com/openshift/origin/pkg/cmd/util/standard"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
@@ -21,19 +13,5 @@ import (
 )
 
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
-	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
-	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
-
-	rand.Seed(time.Now().UTC().UnixNano())
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
-	basename := filepath.Base(os.Args[0])
-	command := cli.CommandFor(basename)
-	if err := command.Execute(); err != nil {
-		os.Exit(1)
-	}
+	standard.Run(cli.CommandFor)
 }

--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -1,16 +1,8 @@
 package main
 
 import (
-	"math/rand"
-	"os"
-	"path/filepath"
-	"runtime"
-	"time"
-
-	"k8s.io/kubernetes/pkg/util/logs"
-
 	"github.com/openshift/origin/pkg/cmd/openshift"
-	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+	"github.com/openshift/origin/pkg/cmd/util/standard"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
@@ -21,19 +13,5 @@ import (
 )
 
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
-	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
-	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
-
-	rand.Seed(time.Now().UTC().UnixNano())
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
-	basename := filepath.Base(os.Args[0])
-	command := openshift.CommandFor(basename)
-	if err := command.Execute(); err != nil {
-		os.Exit(1)
-	}
+	standard.Run(openshift.CommandFor)
 }

--- a/docs/cli_hacking_guide.adoc
+++ b/docs/cli_hacking_guide.adoc
@@ -66,7 +66,7 @@ var (
 )
 
 // NewCmdMine implement the OpenShift cli mine command.
-func NewCmdMine(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdMine(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
   options := &MineOptions{}
   cmd := &cobra.Command{
     Use:     fmt.Sprintf("%s [--latest]", name),
@@ -90,7 +90,7 @@ func NewCmdMine(name, fullName string, f *clientcmd.Factory, out io.Writer) *cob
 }
 
 // Complete completes all the required options for mine.
-func (o *MineOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *MineOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
   return nil
 }
 
@@ -256,7 +256,7 @@ var (
 )
 
 // 4.
-func NewCmdDeploy(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdDeploy(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
   options := &DeployOptions{}
 
   cmd := &cobra.Command{
@@ -290,7 +290,7 @@ func NewCmdDeploy(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
   return cmd
 }
 
-func (o *DeployOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *DeployOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
   return nil
 }
 
@@ -307,7 +307,7 @@ func (o DeployOptions) RunDeploy() error {
 <3> Command examples. Try to cover every important command path (flags, arguments, etc).
 <4> This function creates the command. Notice it takes the parent command name as argument and also a `io.Writer` that will be used to print messages.
 <5> Command usage.
-<6> `Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error` is used to populate any object or variable that will be required to run the command and is still missing at this point. For example, if the command will make use of an API client it can be created from the factory in this method. Can also be used to take argument values from the `args` slice and hold it in explicit variables in your struct, store the `io.Writer` that will be used later, etc.
+<6> `Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error` is used to populate any object or variable that will be required to run the command and is still missing at this point. For example, if the command will make use of an API client it can be created from the factory in this method. Can also be used to take argument values from the `args` slice and hold it in explicit variables in your struct, store the `io.Writer` that will be used later, etc.
 <7> `Validate() error` perform validations on anything required in order to run this command. Notice that if the `Complete` and `Validate` methods implementations are simple enough, you may have only one of them that does both.
 <8> `Run<Command>() error` (e.g. `RunDeploy`, `RunCreate` and so on) does the actual command logic and returns errors as required. Notice that this method does not take anything as argument - it's expected that you previously extracted and stored in the `struct` anything that will be needed to run this command. This makes commands more easily testable once you can run and populate the command struct with the values you want to test and then just run this method and check for the returned error(s).
 <9> Try to always use the functions in `k8s.io/kubernetes/pkg/kubectl/cmd/util` to check and handle errors. It is not expected that commands call `glog.Fatalf`, `os.Exit` or anything similar directly.

--- a/pkg/bootstrap/docker/down.go
+++ b/pkg/bootstrap/docker/down.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/bootstrap/docker/dockerhelper"
 	"github.com/openshift/origin/pkg/bootstrap/docker/openshift"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const CmdDownRecommendedName = "down"
@@ -38,7 +38,7 @@ type ClientStopConfig struct {
 }
 
 // NewCmdDown creates a command that stops OpenShift
-func NewCmdDown(name, fullName string, f *osclientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdDown(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	config := &ClientStopConfig{}
 	cmd := &cobra.Command{
 		Use:     name,

--- a/pkg/bootstrap/docker/join.go
+++ b/pkg/bootstrap/docker/join.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/bootstrap/docker/openshift"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // CmdJoinRecommendedName is the recommended command name
@@ -46,7 +46,7 @@ var (
 )
 
 // NewCmdJoin creates a command that joins an existing OpenShift cluster.
-func NewCmdJoin(name, fullName string, f *osclientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
+func NewCmdJoin(name, fullName string, f factory.Interface, in io.Reader, out io.Writer) *cobra.Command {
 	config := &ClientJoinConfig{
 		CommonStartConfig: CommonStartConfig{
 			Out:      out,
@@ -86,7 +86,7 @@ func (config *ClientJoinConfig) Bind(flags *pflag.FlagSet) {
 }
 
 // Complete initializes fields based on command parameters and execution environment
-func (c *ClientJoinConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command) error {
+func (c *ClientJoinConfig) Complete(f factory.Interface, cmd *cobra.Command) error {
 	if len(c.Secret) == 0 && c.In != nil {
 		fmt.Fprintf(c.Out, "Please paste the contents of your secret here and hit ENTER:\n")
 		data, err := ioutil.ReadAll(c.In)

--- a/pkg/bootstrap/docker/openshift/admin.go
+++ b/pkg/bootstrap/docker/openshift/admin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/server/admin"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	"github.com/openshift/origin/pkg/security/legacyclient"
 )
@@ -37,7 +38,7 @@ const (
 )
 
 // InstallRegistry checks whether a registry is installed and installs one if not already installed
-func (h *Helper) InstallRegistry(kubeClient kclientset.Interface, f *clientcmd.Factory, configDir, images, pvDir string, out, errout io.Writer) error {
+func (h *Helper) InstallRegistry(kubeClient kclientset.Interface, f factory.Interface, configDir, images, pvDir string, out, errout io.Writer) error {
 	_, err := kubeClient.Core().Services(DefaultNamespace).Get(SvcDockerRegistry, metav1.GetOptions{})
 	if err == nil {
 		// If there's no error, the registry already exists
@@ -96,7 +97,7 @@ func (h *Helper) InstallRegistry(kubeClient kclientset.Interface, f *clientcmd.F
 }
 
 // InstallRouter installs a default router on the OpenShift server
-func (h *Helper) InstallRouter(kubeClient kclientset.Interface, f *clientcmd.Factory, configDir, images, hostIP string, portForwarding bool, out, errout io.Writer) error {
+func (h *Helper) InstallRouter(kubeClient kclientset.Interface, f factory.Interface, configDir, images, hostIP string, portForwarding bool, out, errout io.Writer) error {
 	_, err := kubeClient.Core().Services(DefaultNamespace).Get(SvcRouter, metav1.GetOptions{})
 	if err == nil {
 		// Router service already exists, nothing to do

--- a/pkg/bootstrap/docker/openshift/import.go
+++ b/pkg/bootstrap/docker/openshift/import.go
@@ -9,12 +9,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/bootstrap"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // ImportObjects imports objects into OpenShift from a particular location
 // into a given namespace
-func ImportObjects(f *clientcmd.Factory, ns, location string) error {
+func ImportObjects(f factory.Interface, ns, location string) error {
 	mapper, typer := f.Object()
 	schema, err := f.Validator(false, "")
 	if err != nil {

--- a/pkg/bootstrap/docker/openshift/logging.go
+++ b/pkg/bootstrap/docker/openshift/logging.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/bootstrap/docker/errors"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 )
 
 // InstallLoggingViaAnsible checks whether logging is installed and installs it if not already installed
-func (h *Helper) InstallLoggingViaAnsible(f *clientcmd.Factory, serverIP, publicHostname, loggerHost, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
+func (h *Helper) InstallLoggingViaAnsible(f factory.Interface, serverIP, publicHostname, loggerHost, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
 	_, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
@@ -56,7 +57,7 @@ func (h *Helper) InstallLoggingViaAnsible(f *clientcmd.Factory, serverIP, public
 }
 
 // InstallLogging checks whether logging is installed and installs it if not already installed
-func (h *Helper) InstallLogging(f *clientcmd.Factory, publicHostname, loggerHost, imagePrefix, imageVersion string) error {
+func (h *Helper) InstallLogging(f factory.Interface, publicHostname, loggerHost, imagePrefix, imageVersion string) error {
 	osClient, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())

--- a/pkg/bootstrap/docker/openshift/login.go
+++ b/pkg/bootstrap/docker/openshift/login.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/login"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // Login logs into the specified server using given credentials and CA file
-func Login(username, password, server, configDir string, f *clientcmd.Factory, c *cobra.Command, out io.Writer) error {
+func Login(username, password, server, configDir string, f factory.Interface, c *cobra.Command, out io.Writer) error {
 	existingConfig, err := f.OpenShiftClientConfig().RawConfig()
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/pkg/bootstrap/docker/openshift/metrics.go
+++ b/pkg/bootstrap/docker/openshift/metrics.go
@@ -9,7 +9,7 @@ import (
 	kbatch "k8s.io/kubernetes/pkg/apis/batch"
 
 	"github.com/openshift/origin/pkg/bootstrap/docker/errors"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 )
 
 // InstallMetricsViaAnsible checks whether metrics is installed and installs it if not already installed
-func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, publicHostname, hostName, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
+func (h *Helper) InstallMetricsViaAnsible(f factory.Interface, serverIP, publicHostname, hostName, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
 	_, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
@@ -54,7 +54,7 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, public
 }
 
 // InstallMetrics checks whether metrics is installed and installs it if not already installed
-func (h *Helper) InstallMetrics(f *clientcmd.Factory, hostName, imagePrefix, imageVersion string) error {
+func (h *Helper) InstallMetrics(f factory.Interface, hostName, imagePrefix, imageVersion string) error {
 	osClient, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())

--- a/pkg/bootstrap/docker/openshift/project.go
+++ b/pkg/bootstrap/docker/openshift/project.go
@@ -10,10 +10,11 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // CreateProject creates a project
-func CreateProject(f *clientcmd.Factory, name, display, desc, basecmd string, out io.Writer) error {
+func CreateProject(f factory.Interface, name, display, desc, basecmd string, out io.Writer) error {
 	client, _, err := f.Clients()
 	if err != nil {
 		return nil
@@ -45,14 +46,14 @@ func CreateProject(f *clientcmd.Factory, name, display, desc, basecmd string, ou
 	return nil
 }
 
-func setCurrentProject(f *clientcmd.Factory, name string, out io.Writer) error {
+func setCurrentProject(f factory.Interface, name string, out io.Writer) error {
 	pathOptions := config.NewPathOptionsWithConfig("")
 	opt := &cmd.ProjectOptions{PathOptions: pathOptions}
 	opt.Complete(f, []string{name}, out)
 	return opt.RunProject()
 }
 
-func LoggedInUserFactory() (*clientcmd.Factory, error) {
+func LoggedInUserFactory() (factory.Interface, error) {
 	cfg, err := config.NewOpenShiftClientConfigLoadingRules().Load()
 	if err != nil {
 		return nil, err

--- a/pkg/bootstrap/docker/openshift/servicecatalog.go
+++ b/pkg/bootstrap/docker/openshift/servicecatalog.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/openshift/origin/pkg/bootstrap/docker/errors"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -29,7 +30,7 @@ const (
 )
 
 // InstallServiceCatalog checks whether the service catalog is installed and installs it if not already installed
-func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, publicMaster, catalogHost string) error {
+func (h *Helper) InstallServiceCatalog(f factory.Interface, publicMaster, catalogHost string) error {
 	osClient, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())

--- a/pkg/bootstrap/docker/status.go
+++ b/pkg/bootstrap/docker/status.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/bootstrap/docker/openshift"
 	"github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // CmdStatusRecommendedName is the recommended command name
@@ -41,7 +41,7 @@ var (
 )
 
 // NewCmdStatus implements the OpenShift cluster status command.
-func NewCmdStatus(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdStatus(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	config := &ClientStatusConfig{}
 	cmd := &cobra.Command{
 		Use:     name,
@@ -68,7 +68,7 @@ type ClientStatusConfig struct {
 }
 
 // Status prints the OpenShift cluster status
-func (c *ClientStatusConfig) Status(f *clientcmd.Factory, out io.Writer) error {
+func (c *ClientStatusConfig) Status(f factory.Interface, out io.Writer) error {
 	dockerClient, err := getDockerClient(out, c.DockerMachine, false)
 	if err != nil {
 		return errors.ErrNoDockerClient(err)
@@ -175,7 +175,7 @@ func (c *ClientStatusConfig) Status(f *clientcmd.Factory, out io.Writer) error {
 	return nil
 }
 
-func isHealthy(f *clientcmd.Factory) (bool, error) {
+func isHealthy(f factory.Interface) (bool, error) {
 	osClient, _, err := f.Clients()
 	if err != nil {
 		return false, err

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -35,7 +35,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
 
@@ -131,7 +131,7 @@ var (
 )
 
 // NewCmdUp creates a command that starts OpenShift on Docker with reasonable defaults
-func NewCmdUp(name, fullName string, f *osclientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdUp(name, fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	config := &ClientStartConfig{
 		CommonStartConfig: CommonStartConfig{
 			Out:                 out,
@@ -220,8 +220,8 @@ type CommonStartConfig struct {
 	dockerHelper    *dockerhelper.Helper
 	hostHelper      *host.HostHelper
 	openshiftHelper *openshift.Helper
-	factory         *clientcmd.Factory
-	originalFactory *clientcmd.Factory
+	factory         factory.Interface
+	originalFactory factory.Interface
 	command         *cobra.Command
 
 	usingDefaultImages         bool
@@ -300,7 +300,7 @@ func (config *ClientStartConfig) Bind(flags *pflag.FlagSet) {
 	config.CommonStartConfig.Bind(flags)
 }
 
-func (c *CommonStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command) error {
+func (c *CommonStartConfig) Complete(f factory.Interface, cmd *cobra.Command) error {
 	c.originalFactory = f
 	c.command = cmd
 
@@ -369,7 +369,7 @@ func (c *CommonStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command)
 }
 
 // Complete initializes fields based on command parameters and execution environment
-func (c *ClientStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command) error {
+func (c *ClientStartConfig) Complete(f factory.Interface, cmd *cobra.Command) error {
 	if err := c.CommonStartConfig.Complete(f, cmd); err != nil {
 		return err
 	}
@@ -1159,7 +1159,7 @@ func (c *ClientStartConfig) checkProxySettings() string {
 }
 
 // Factory returns a command factory that works with OpenShift server's admin credentials
-func (c *ClientStartConfig) Factory() (*clientcmd.Factory, error) {
+func (c *ClientStartConfig) Factory() (factory.Interface, error) {
 	if c.factory == nil {
 		cfg, err := kclientcmd.LoadFromFile(filepath.Join(c.LocalConfigDir, "master", "admin.kubeconfig"))
 		if err != nil {

--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/router"
 	"github.com/openshift/origin/pkg/cmd/admin/top"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/experimental/buildchain"
 	exipfailover "github.com/openshift/origin/pkg/cmd/experimental/ipfailover"
 	"github.com/openshift/origin/pkg/cmd/server/admin"
@@ -147,7 +148,7 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 	)
 
 	if name == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, out, cmd.VersionOptions{}))
+		cmds.AddCommand(version.NewCmdVersion(fullName, f, out, version.VersionOptions{}))
 	}
 
 	return cmds

--- a/pkg/cmd/admin/diagnostics/diagnostics.go
+++ b/pkg/cmd/admin/diagnostics/diagnostics.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/diagnostics/log"
 	netutil "github.com/openshift/origin/pkg/diagnostics/networkpod/util"
@@ -48,7 +49,7 @@ type DiagnosticsOptions struct {
 	// creates flags as a byproduct, most of which we don't want.
 	// The command creates these and binds only the flags we want.
 	ClientFlags *flag.FlagSet
-	Factory     *osclientcmd.Factory
+	Factory     factory.Interface
 	// LogOptions determine globally what the user wants to see and how.
 	LogOptions *log.LoggerOptions
 	// The Logger is built with the options and should be used for all diagnostic output.

--- a/pkg/cmd/admin/groups/changemembership.go
+++ b/pkg/cmd/admin/groups/changemembership.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -48,7 +48,7 @@ type GroupModificationOptions struct {
 	Users []string
 }
 
-func NewCmdAddUsers(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddUsers(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &GroupModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -68,7 +68,7 @@ func NewCmdAddUsers(name, fullName string, f *clientcmd.Factory, out io.Writer) 
 	return cmd
 }
 
-func NewCmdRemoveUsers(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveUsers(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &GroupModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -88,7 +88,7 @@ func NewCmdRemoveUsers(name, fullName string, f *clientcmd.Factory, out io.Write
 	return cmd
 }
 
-func (o *GroupModificationOptions) Complete(f *clientcmd.Factory, args []string) error {
+func (o *GroupModificationOptions) Complete(f factory.Interface, args []string) error {
 	if len(args) < 2 {
 		return errors.New("you must specify at least two arguments: GROUP USER [USER ...]")
 	}

--- a/pkg/cmd/admin/groups/groups.go
+++ b/pkg/cmd/admin/groups/groups.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/admin/groups/sync/cli"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const GroupsRecommendedName = "groups"
@@ -18,7 +18,7 @@ var groupLong = templates.LongDesc(`
 
 	Groups are sets of users that can be used when describing policy.`)
 
-func NewCmdGroups(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdGroups(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/admin/groups/new.go
+++ b/pkg/cmd/admin/groups/new.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 )
 
@@ -47,7 +47,7 @@ type NewGroupOptions struct {
 	Printer kprinters.ResourcePrinterFunc
 }
 
-func NewCmdNewGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdNewGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &NewGroupOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -69,7 +69,7 @@ func NewCmdNewGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) 
 	return cmd
 }
 
-func (o *NewGroupOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *NewGroupOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("You must specify at least one argument: GROUP [USER ...]")
 	}

--- a/pkg/cmd/admin/groups/sync/cli/prune.go
+++ b/pkg/cmd/admin/groups/sync/cli/prune.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/api/validation"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PruneRecommendedName = "prune"
@@ -80,7 +80,7 @@ func NewPruneOptions() *PruneOptions {
 	}
 }
 
-func NewCmdPrune(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdPrune(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := NewPruneOptions()
 	options.Out = out
 
@@ -130,7 +130,7 @@ func NewCmdPrune(name, fullName string, f *clientcmd.Factory, out io.Writer) *co
 	return cmd
 }
 
-func (o *PruneOptions) Complete(whitelistFile, blacklistFile, configFile string, args []string, f *clientcmd.Factory) error {
+func (o *PruneOptions) Complete(whitelistFile, blacklistFile, configFile string, args []string, f factory.Interface) error {
 	var err error
 	o.Whitelist, err = buildOpenShiftGroupNameList(args, whitelistFile)
 	if err != nil {
@@ -170,7 +170,7 @@ func (o *PruneOptions) Validate() error {
 
 // Run creates the GroupSyncer specified and runs it to sync groups
 // the arguments are only here because its the only way to get the printer we need
-func (o *PruneOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
+func (o *PruneOptions) Run(cmd *cobra.Command, f factory.Interface) error {
 	bindPassword, err := api.ResolveStringValue(o.Config.BindPassword)
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/groups/sync/cli/sync.go
+++ b/pkg/cmd/admin/groups/sync/cli/sync.go
@@ -29,7 +29,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/api/validation"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const SyncRecommendedName = "sync"
@@ -127,7 +127,7 @@ func NewSyncOptions() *SyncOptions {
 	}
 }
 
-func NewCmdSync(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdSync(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := NewSyncOptions()
 	options.Out = out
 
@@ -184,7 +184,7 @@ func NewCmdSync(name, fullName string, f *clientcmd.Factory, out io.Writer) *cob
 	return cmd
 }
 
-func (o *SyncOptions) Complete(typeArg, whitelistFile, blacklistFile, configFile string, args []string, f *clientcmd.Factory) error {
+func (o *SyncOptions) Complete(typeArg, whitelistFile, blacklistFile, configFile string, args []string, f factory.Interface) error {
 	switch typeArg {
 	case string(GroupSyncSourceLDAP):
 		o.Source = GroupSyncSourceLDAP
@@ -337,7 +337,7 @@ func (o *SyncOptions) Validate() error {
 
 // Run creates the GroupSyncer specified and runs it to sync groups
 // the arguments are only here because its the only way to get the printer we need
-func (o *SyncOptions) Run(cmd *cobra.Command, f *clientcmd.Factory) error {
+func (o *SyncOptions) Run(cmd *cobra.Command, f factory.Interface) error {
 	bindPassword, err := api.ResolveStringValue(o.Config.BindPassword)
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/image/verify-signature.go
+++ b/pkg/cmd/admin/image/verify-signature.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containers/image/signature"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageutil "github.com/openshift/origin/pkg/image/util"
 
@@ -82,7 +82,7 @@ const (
 	VerifyRecommendedName = "verify-image-signature"
 )
 
-func NewCmdVerifyImageSignature(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdVerifyImageSignature(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	opts := &VerifyImageSignatureOptions{
 		ErrOut:       errOut,
 		Out:          out,
@@ -125,7 +125,7 @@ func (o *VerifyImageSignatureOptions) Validate() error {
 	}
 	return nil
 }
-func (o *VerifyImageSignatureOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *VerifyImageSignatureOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) != 1 {
 		return kcmdutil.UsageError(cmd, "exactly one image must be specified")
 	}

--- a/pkg/cmd/admin/migrate/authorization/authorization.go
+++ b/pkg/cmd/admin/migrate/authorization/authorization.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/controller/authorizationsync"
 	"github.com/openshift/origin/pkg/cmd/admin/migrate"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	"github.com/spf13/cobra"
 )
@@ -47,7 +47,7 @@ type MigrateAuthorizationOptions struct {
 	rbac rbacinternalversion.RbacInterface
 }
 
-func NewCmdMigrateAuthorization(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdMigrateAuthorization(name, fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &MigrateAuthorizationOptions{
 		ResourceOptions: migrate.ResourceOptions{
 			In:            in,
@@ -75,7 +75,7 @@ func NewCmdMigrateAuthorization(name, fullName string, f *clientcmd.Factory, in 
 	return cmd
 }
 
-func (o *MigrateAuthorizationOptions) Complete(name string, f *clientcmd.Factory, c *cobra.Command, args []string) error {
+func (o *MigrateAuthorizationOptions) Complete(name string, f factory.Interface, c *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return fmt.Errorf("%s takes no positional arguments", name)
 	}

--- a/pkg/cmd/admin/migrate/etcd/ttl.go
+++ b/pkg/cmd/admin/migrate/etcd/ttl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
@@ -49,7 +49,7 @@ type MigrateTTLReferenceOptions struct {
 }
 
 // NewCmdMigrateTTLs helps move etcd v2 TTL keys to etcd v3 lease keys.
-func NewCmdMigrateTTLs(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdMigrateTTLs(name, fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &MigrateTTLReferenceOptions{
 		Out:    out,
 		ErrOut: errout,

--- a/pkg/cmd/admin/migrate/images/imagerefs.go
+++ b/pkg/cmd/admin/migrate/images/imagerefs.go
@@ -19,8 +19,8 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/admin/migrate"
 	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
@@ -79,7 +79,7 @@ type MigrateImageReferenceOptions struct {
 }
 
 // NewCmdMigrateImageReferences implements a MigrateImages command
-func NewCmdMigrateImageReferences(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdMigrateImageReferences(name, fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &MigrateImageReferenceOptions{
 		ResourceOptions: migrate.ResourceOptions{
 			In:      in,
@@ -104,7 +104,7 @@ func NewCmdMigrateImageReferences(name, fullName string, f *clientcmd.Factory, i
 	return cmd
 }
 
-func (o *MigrateImageReferenceOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string) error {
+func (o *MigrateImageReferenceOptions) Complete(f factory.Interface, c *cobra.Command, args []string) error {
 	var remainingArgs []string
 	for _, s := range args {
 		if !strings.Contains(s, "=") {

--- a/pkg/cmd/admin/migrate/migrate.go
+++ b/pkg/cmd/admin/migrate/migrate.go
@@ -7,7 +7,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const MigrateRecommendedName = "migrate"
@@ -17,7 +17,7 @@ var migrateLong = templates.LongDesc(`
 
 	These commands assist administrators in performing preventative maintenance on a cluster.`)
 
-func NewCommandMigrate(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer, cmds ...*cobra.Command) *cobra.Command {
+func NewCommandMigrate(name, fullName string, f factory.Interface, out, errOut io.Writer, cmds ...*cobra.Command) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmd := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/admin/migrate/migrator.go
+++ b/pkg/cmd/admin/migrate/migrator.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // MigrateVisitFunc is invoked for each returned object, and may return a
@@ -91,7 +92,7 @@ func (o *ResourceOptions) Bind(c *cobra.Command) {
 	c.MarkFlagRequired("filename")
 }
 
-func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error {
+func (o *ResourceOptions) Complete(f factory.Interface, c *cobra.Command) error {
 	switch {
 	case len(o.Output) > 0:
 		printer, _, err := f.PrinterForCommand(c)

--- a/pkg/cmd/admin/migrate/storage/storage.go
+++ b/pkg/cmd/admin/migrate/storage/storage.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/admin/migrate"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -58,7 +58,7 @@ type MigrateAPIStorageOptions struct {
 }
 
 // NewCmdMigrateAPIStorage implements a MigrateStorage command
-func NewCmdMigrateAPIStorage(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdMigrateAPIStorage(name, fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &MigrateAPIStorageOptions{
 		ResourceOptions: migrate.ResourceOptions{
 			In:     in,
@@ -175,7 +175,7 @@ func NewCmdMigrateAPIStorage(name, fullName string, f *clientcmd.Factory, in io.
 	return cmd
 }
 
-func (o *MigrateAPIStorageOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string) error {
+func (o *MigrateAPIStorageOptions) Complete(f factory.Interface, c *cobra.Command, args []string) error {
 	o.ResourceOptions.SaveFn = o.save
 	if err := o.ResourceOptions.Complete(f, c); err != nil {
 		return err

--- a/pkg/cmd/admin/migrate/volumesource/volumesource.go
+++ b/pkg/cmd/admin/migrate/volumesource/volumesource.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/admin/migrate"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
 
 	"github.com/spf13/cobra"
@@ -55,7 +55,7 @@ type MigrateVolumeSourceOptions struct {
 	migrate.ResourceOptions
 }
 
-func NewCmdMigrateVolumeSource(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdMigrateVolumeSource(name, fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &MigrateVolumeSourceOptions{
 		ResourceOptions: migrate.ResourceOptions{
 			In:            in,
@@ -90,7 +90,7 @@ func NewCmdMigrateVolumeSource(name, fullName string, f *clientcmd.Factory, in i
 	return cmd
 }
 
-func (o *MigrateVolumeSourceOptions) Complete(name string, f *clientcmd.Factory, c *cobra.Command, args []string) error {
+func (o *MigrateVolumeSourceOptions) Complete(name string, f factory.Interface, c *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return fmt.Errorf("%s takes no positional arguments", name)
 	}

--- a/pkg/cmd/admin/network/isolate_projects.go
+++ b/pkg/cmd/admin/network/isolate_projects.go
@@ -10,7 +10,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
 )
 
@@ -34,7 +34,7 @@ type IsolateOptions struct {
 	Options *ProjectOptions
 }
 
-func NewCmdIsolateProjectsNetwork(commandName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdIsolateProjectsNetwork(commandName, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &ProjectOptions{}
 	isolateOp := &IsolateOptions{Options: opts}
 

--- a/pkg/cmd/admin/network/join_projects.go
+++ b/pkg/cmd/admin/network/join_projects.go
@@ -11,7 +11,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
 )
@@ -38,7 +38,7 @@ type JoinOptions struct {
 	joinProjectName string
 }
 
-func NewCmdJoinProjectsNetwork(commandName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdJoinProjectsNetwork(commandName, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &ProjectOptions{}
 	joinOp := &JoinOptions{Options: opts}
 

--- a/pkg/cmd/admin/network/make_projects_global.go
+++ b/pkg/cmd/admin/network/make_projects_global.go
@@ -10,7 +10,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
 )
@@ -35,7 +35,7 @@ type MakeGlobalOptions struct {
 	Options *ProjectOptions
 }
 
-func NewCmdMakeGlobalProjectsNetwork(commandName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdMakeGlobalProjectsNetwork(commandName, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &ProjectOptions{}
 	makeGlobalOp := &MakeGlobalOptions{Options: opts}
 

--- a/pkg/cmd/admin/network/pod_network.go
+++ b/pkg/cmd/admin/network/pod_network.go
@@ -7,7 +7,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PodNetworkCommandName = "pod-network"
@@ -19,7 +19,7 @@ var (
 		This command provides common pod network operations for administrators.`)
 )
 
-func NewCmdPodNetwork(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdPodNetwork(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
 )
@@ -45,7 +45,7 @@ type ProjectOptions struct {
 	CheckSelector bool
 }
 
-func (p *ProjectOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string, out io.Writer) error {
+func (p *ProjectOptions) Complete(f factory.Interface, c *cobra.Command, args []string, out io.Writer) error {
 	defaultNamespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/node/node.go
+++ b/pkg/cmd/admin/node/node.go
@@ -10,7 +10,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const ManageNodeCommandName = "manage-node"
@@ -63,7 +63,7 @@ type ManageNodeOptions struct {
 }
 
 // NewCommandManageNode implements the OpenShift cli manage-node command
-func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, out, errout io.Writer) *cobra.Command {
+func NewCommandManageNode(f factory.Interface, commandName, fullName string, out, errout io.Writer) *cobra.Command {
 	nodeOpts := &NodeOptions{}
 	schedulableOp := &SchedulableOptions{Options: nodeOpts}
 	evacuateOp := NewEvacuateOptions(nodeOpts)
@@ -109,7 +109,7 @@ func NewCommandManageNode(f *clientcmd.Factory, commandName, fullName string, ou
 	return cmd
 }
 
-func (n *ManageNodeOptions) Complete(c *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (n *ManageNodeOptions) Complete(c *cobra.Command, f factory.Interface, args []string) error {
 	return n.nodeOptions.Complete(f, c, args, n.out, n.errout)
 }
 

--- a/pkg/cmd/admin/node/node_options.go
+++ b/pkg/cmd/admin/node/node_options.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -19,8 +20,6 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	kprinters "k8s.io/kubernetes/pkg/printers"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 type NodeOptions struct {
@@ -44,7 +43,7 @@ type NodeOptions struct {
 	PodSelector string
 }
 
-func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string, out, errout io.Writer) error {
+func (n *NodeOptions) Complete(f factory.Interface, c *cobra.Command, args []string, out, errout io.Writer) error {
 	defaultNamespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/policy/cani.go
+++ b/pkg/cmd/admin/policy/cani.go
@@ -19,7 +19,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const CanIRecommendedName = "can-i"
@@ -44,7 +44,7 @@ type canIOptions struct {
 	Out io.Writer
 }
 
-func NewCmdCanI(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCanI(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &canIOptions{
 		Out: out,
 	}
@@ -90,7 +90,7 @@ const (
 	tabwriterFlags    = 0
 )
 
-func (o *canIOptions) Complete(f *clientcmd.Factory, args []string) error {
+func (o *canIOptions) Complete(f factory.Interface, args []string) error {
 	if o.ListAll && o.AllNamespaces {
 		return errors.New("--list and --all-namespaces are mutually exclusive")
 	}

--- a/pkg/cmd/admin/policy/modify_roles.go
+++ b/pkg/cmd/admin/policy/modify_roles.go
@@ -13,7 +13,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
@@ -50,7 +50,7 @@ type RoleModificationOptions struct {
 }
 
 // NewCmdAddRoleToGroup implements the OpenShift cli add-role-to-group command
-func NewCmdAddRoleToGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddRoleToGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -77,7 +77,7 @@ func NewCmdAddRoleToGroup(name, fullName string, f *clientcmd.Factory, out io.Wr
 }
 
 // NewCmdAddRoleToUser implements the OpenShift cli add-role-to-user command
-func NewCmdAddRoleToUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddRoleToUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RoleModificationOptions{}
 	saNames := []string{}
 
@@ -106,7 +106,7 @@ func NewCmdAddRoleToUser(name, fullName string, f *clientcmd.Factory, out io.Wri
 }
 
 // NewCmdRemoveRoleFromGroup implements the OpenShift cli remove-role-from-group command
-func NewCmdRemoveRoleFromGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveRoleFromGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -132,7 +132,7 @@ func NewCmdRemoveRoleFromGroup(name, fullName string, f *clientcmd.Factory, out 
 }
 
 // NewCmdRemoveRoleFromUser implements the OpenShift cli remove-role-from-user command
-func NewCmdRemoveRoleFromUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveRoleFromUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RoleModificationOptions{}
 	saNames := []string{}
 
@@ -160,7 +160,7 @@ func NewCmdRemoveRoleFromUser(name, fullName string, f *clientcmd.Factory, out i
 }
 
 // NewCmdAddClusterRoleToGroup implements the OpenShift cli add-cluster-role-to-group command
-func NewCmdAddClusterRoleToGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddClusterRoleToGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -184,7 +184,7 @@ func NewCmdAddClusterRoleToGroup(name, fullName string, f *clientcmd.Factory, ou
 }
 
 // NewCmdAddClusterRoleToUser implements the OpenShift cli add-cluster-role-to-user command
-func NewCmdAddClusterRoleToUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddClusterRoleToUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	saNames := []string{}
 	options := &RoleModificationOptions{}
 
@@ -211,7 +211,7 @@ func NewCmdAddClusterRoleToUser(name, fullName string, f *clientcmd.Factory, out
 }
 
 // NewCmdRemoveClusterRoleFromGroup implements the OpenShift cli remove-cluster-role-from-group command
-func NewCmdRemoveClusterRoleFromGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveClusterRoleFromGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RoleModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -235,7 +235,7 @@ func NewCmdRemoveClusterRoleFromGroup(name, fullName string, f *clientcmd.Factor
 }
 
 // NewCmdRemoveClusterRoleFromUser implements the OpenShift cli remove-cluster-role-from-user command
-func NewCmdRemoveClusterRoleFromUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveClusterRoleFromUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	saNames := []string{}
 	options := &RoleModificationOptions{}
 
@@ -261,7 +261,7 @@ func NewCmdRemoveClusterRoleFromUser(name, fullName string, f *clientcmd.Factory
 	return cmd
 }
 
-func (o *RoleModificationOptions) CompleteUserWithSA(f *clientcmd.Factory, args []string, saNames []string, isNamespaced bool) error {
+func (o *RoleModificationOptions) CompleteUserWithSA(f factory.Interface, args []string, saNames []string, isNamespaced bool) error {
 	if len(args) < 1 {
 		return errors.New("you must specify a role")
 	}
@@ -301,7 +301,7 @@ func (o *RoleModificationOptions) CompleteUserWithSA(f *clientcmd.Factory, args 
 	return nil
 }
 
-func (o *RoleModificationOptions) Complete(f *clientcmd.Factory, args []string, target *[]string, targetName string, isNamespaced bool) error {
+func (o *RoleModificationOptions) Complete(f factory.Interface, args []string, target *[]string, targetName string, isNamespaced bool) error {
 	if len(args) < 2 {
 		return fmt.Errorf("you must specify at least two arguments: <role> <%s> [%s]...", targetName, targetName)
 	}

--- a/pkg/cmd/admin/policy/modify_scc.go
+++ b/pkg/cmd/admin/policy/modify_scc.go
@@ -13,7 +13,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/security/legacyclient"
 	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
@@ -42,7 +42,7 @@ type SCCModificationOptions struct {
 	Subjects                []kapi.ObjectReference
 }
 
-func NewCmdAddSCCToGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddSCCToGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &SCCModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -63,7 +63,7 @@ func NewCmdAddSCCToGroup(name, fullName string, f *clientcmd.Factory, out io.Wri
 	return cmd
 }
 
-func NewCmdAddSCCToUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAddSCCToUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &SCCModificationOptions{}
 	saNames := []string{}
 
@@ -88,7 +88,7 @@ func NewCmdAddSCCToUser(name, fullName string, f *clientcmd.Factory, out io.Writ
 	return cmd
 }
 
-func NewCmdRemoveSCCFromGroup(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveSCCFromGroup(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &SCCModificationOptions{}
 
 	cmd := &cobra.Command{
@@ -109,7 +109,7 @@ func NewCmdRemoveSCCFromGroup(name, fullName string, f *clientcmd.Factory, out i
 	return cmd
 }
 
-func NewCmdRemoveSCCFromUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveSCCFromUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &SCCModificationOptions{}
 	saNames := []string{}
 
@@ -133,7 +133,7 @@ func NewCmdRemoveSCCFromUser(name, fullName string, f *clientcmd.Factory, out io
 	return cmd
 }
 
-func (o *SCCModificationOptions) CompleteUsers(f *clientcmd.Factory, args []string, saNames []string) error {
+func (o *SCCModificationOptions) CompleteUsers(f factory.Interface, args []string, saNames []string) error {
 	if len(args) < 1 {
 		return errors.New("you must specify a scc")
 	}
@@ -163,7 +163,7 @@ func (o *SCCModificationOptions) CompleteUsers(f *clientcmd.Factory, args []stri
 	return nil
 }
 
-func (o *SCCModificationOptions) CompleteGroups(f *clientcmd.Factory, args []string) error {
+func (o *SCCModificationOptions) CompleteGroups(f factory.Interface, args []string) error {
 	if len(args) < 2 {
 		return errors.New("you must specify at least two arguments: <scc> <group> [group]...")
 	}

--- a/pkg/cmd/admin/policy/policy.go
+++ b/pkg/cmd/admin/policy/policy.go
@@ -15,7 +15,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PolicyRecommendedName = "policy"
@@ -31,7 +31,7 @@ var policyLong = templates.LongDesc(`
 	and 'scc'.`)
 
 // NewCmdPolicy implements the OpenShift cli policy command
-func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdPolicy(name, fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/admin/policy/reconcile_clusterrolebindings.go
+++ b/pkg/cmd/admin/policy/reconcile_clusterrolebindings.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
@@ -74,7 +74,7 @@ var (
 )
 
 // NewCmdReconcileClusterRoleBindings implements the OpenShift cli reconcile-cluster-role-bindings command
-func NewCmdReconcileClusterRoleBindings(name, fullName string, f *clientcmd.Factory, out, err io.Writer) *cobra.Command {
+func NewCmdReconcileClusterRoleBindings(name, fullName string, f factory.Interface, out, err io.Writer) *cobra.Command {
 	o := &ReconcileClusterRoleBindingsOptions{
 		Out:   out,
 		Err:   err,
@@ -115,7 +115,7 @@ func NewCmdReconcileClusterRoleBindings(name, fullName string, f *clientcmd.Fact
 	return cmd
 }
 
-func (o *ReconcileClusterRoleBindingsOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string, excludeUsers, excludeGroups []string) error {
+func (o *ReconcileClusterRoleBindingsOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string, excludeUsers, excludeGroups []string) error {
 	oclient, _, err := f.Clients()
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func (o *ReconcileClusterRoleBindingsOptions) Validate() error {
 	return nil
 }
 
-func (o *ReconcileClusterRoleBindingsOptions) RunReconcileClusterRoleBindings(cmd *cobra.Command, f *clientcmd.Factory) error {
+func (o *ReconcileClusterRoleBindingsOptions) RunReconcileClusterRoleBindings(cmd *cobra.Command, f factory.Interface) error {
 	changedClusterRoleBindings, fetchErr := o.ChangedClusterRoleBindings()
 	if fetchErr != nil && !IsClusterRoleBindingLookupError(fetchErr) {
 		// we got an error that isn't due to a partial match, so we can't continue

--- a/pkg/cmd/admin/policy/reconcile_clusterroles.go
+++ b/pkg/cmd/admin/policy/reconcile_clusterroles.go
@@ -21,8 +21,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	osutil "github.com/openshift/origin/pkg/cmd/util"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // ReconcileProtectAnnotation is the name of an annotation which prevents reconciliation if set to "true"
@@ -74,7 +73,7 @@ var (
 )
 
 // NewCmdReconcileClusterRoles implements the OpenShift cli reconcile-cluster-roles command
-func NewCmdReconcileClusterRoles(name, fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdReconcileClusterRoles(name, fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	o := &ReconcileClusterRolesOptions{
 		Out:    out,
 		ErrOut: errout,
@@ -110,7 +109,7 @@ func NewCmdReconcileClusterRoles(name, fullName string, f *clientcmd.Factory, ou
 	return cmd
 }
 
-func (o *ReconcileClusterRolesOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *ReconcileClusterRolesOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	oclient, _, err := f.Clients()
 	if err != nil {
 		return err
@@ -146,7 +145,7 @@ func (o *ReconcileClusterRolesOptions) Validate() error {
 }
 
 // RunReconcileClusterRoles contains all the necessary functionality for the OpenShift cli reconcile-cluster-roles command
-func (o *ReconcileClusterRolesOptions) RunReconcileClusterRoles(cmd *cobra.Command, f *clientcmd.Factory) error {
+func (o *ReconcileClusterRolesOptions) RunReconcileClusterRoles(cmd *cobra.Command, f factory.Interface) error {
 	changedClusterRoles, skippedClusterRoles, err := o.ChangedClusterRoles()
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/policy/reconcile_sccs.go
+++ b/pkg/cmd/admin/policy/reconcile_sccs.go
@@ -19,8 +19,8 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 	"github.com/openshift/origin/pkg/security/legacyclient"
 )
@@ -80,7 +80,7 @@ func NewDefaultReconcileSCCOptions() *ReconcileSCCOptions {
 }
 
 // NewCmdReconcileSCC implements the OpenShift cli reconcile-sccs command.
-func NewCmdReconcileSCC(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdReconcileSCC(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := NewDefaultReconcileSCCOptions()
 	o.Out = out
 
@@ -111,7 +111,7 @@ func NewCmdReconcileSCC(name, fullName string, f *clientcmd.Factory, out io.Writ
 	return cmd
 }
 
-func (o *ReconcileSCCOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *ReconcileSCCOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	if len(args) != 0 {
 		return kcmdutil.UsageError(cmd, "no arguments are allowed")
 	}
@@ -139,7 +139,7 @@ func (o *ReconcileSCCOptions) Validate() error {
 
 // RunReconcileSCCs contains the functionality for the reconcile-sccs command for making or
 // previewing changes.
-func (o *ReconcileSCCOptions) RunReconcileSCCs(cmd *cobra.Command, f *clientcmd.Factory) error {
+func (o *ReconcileSCCOptions) RunReconcileSCCs(cmd *cobra.Command, f factory.Interface) error {
 	// get sccs that need updated
 	changedSCCs, err := o.ChangedSCCs()
 	if err != nil {

--- a/pkg/cmd/admin/policy/remove_from_project.go
+++ b/pkg/cmd/admin/policy/remove_from_project.go
@@ -14,7 +14,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
@@ -34,7 +34,7 @@ type RemoveFromProjectOptions struct {
 }
 
 // NewCmdRemoveGroupFromProject implements the OpenShift cli remove-group command
-func NewCmdRemoveGroupFromProject(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveGroupFromProject(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RemoveFromProjectOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -56,7 +56,7 @@ func NewCmdRemoveGroupFromProject(name, fullName string, f *clientcmd.Factory, o
 }
 
 // NewCmdRemoveUserFromProject implements the OpenShift cli remove-user command
-func NewCmdRemoveUserFromProject(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRemoveUserFromProject(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &RemoveFromProjectOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -77,7 +77,7 @@ func NewCmdRemoveUserFromProject(name, fullName string, f *clientcmd.Factory, ou
 	return cmd
 }
 
-func (o *RemoveFromProjectOptions) Complete(f *clientcmd.Factory, args []string, target *[]string, targetName string) error {
+func (o *RemoveFromProjectOptions) Complete(f factory.Interface, args []string, target *[]string, targetName string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("you must specify at least one argument: <%s> [%s]...", targetName, targetName)
 	}

--- a/pkg/cmd/admin/policy/review.go
+++ b/pkg/cmd/admin/policy/review.go
@@ -21,7 +21,7 @@ import (
 	ometa "github.com/openshift/origin/pkg/api/meta"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 	securityapiv1 "github.com/openshift/origin/pkg/security/apis/security/v1"
 )
@@ -64,7 +64,7 @@ type sccReviewOptions struct {
 	shortServiceAccountNames []string // it contains only short sa name for example 'bob'
 }
 
-func NewCmdSccReview(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdSccReview(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &sccReviewOptions{}
 	cmd := &cobra.Command{
 		Use:     name,
@@ -83,7 +83,7 @@ func NewCmdSccReview(name, fullName string, f *clientcmd.Factory, out io.Writer)
 	return cmd
 }
 
-func (o *sccReviewOptions) Complete(f *clientcmd.Factory, args []string, cmd *cobra.Command, out io.Writer) error {
+func (o *sccReviewOptions) Complete(f factory.Interface, args []string, cmd *cobra.Command, out io.Writer) error {
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
 		return kcmdutil.UsageError(cmd, cmd.Use)
 	}

--- a/pkg/cmd/admin/policy/subject_review.go
+++ b/pkg/cmd/admin/policy/subject_review.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 	securityapiv1 "github.com/openshift/origin/pkg/security/apis/security/v1"
 )
@@ -58,7 +58,7 @@ type sccSubjectReviewOptions struct {
 	serviceAccount             string
 }
 
-func NewCmdSccSubjectReview(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdSccSubjectReview(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &sccSubjectReviewOptions{}
 	cmd := &cobra.Command{
 		Use:     name,
@@ -79,7 +79,7 @@ func NewCmdSccSubjectReview(name, fullName string, f *clientcmd.Factory, out io.
 	return cmd
 }
 
-func (o *sccSubjectReviewOptions) Complete(f *clientcmd.Factory, args []string, cmd *cobra.Command, out io.Writer) error {
+func (o *sccSubjectReviewOptions) Complete(f factory.Interface, args []string, cmd *cobra.Command, out io.Writer) error {
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
 		return kcmdutil.UsageError(cmd, cmd.Use)
 	}

--- a/pkg/cmd/admin/policy/who_can.go
+++ b/pkg/cmd/admin/policy/who_can.go
@@ -15,7 +15,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const WhoCanRecommendedName = "who-can"
@@ -31,7 +31,7 @@ type whoCanOptions struct {
 }
 
 // NewCmdWhoCan implements the OpenShift cli who-can command
-func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdWhoCan(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &whoCanOptions{}
 
 	cmd := &cobra.Command{
@@ -59,7 +59,7 @@ func NewCmdWhoCan(name, fullName string, f *clientcmd.Factory, out io.Writer) *c
 	return cmd
 }
 
-func (o *whoCanOptions) complete(f *clientcmd.Factory, args []string) error {
+func (o *whoCanOptions) complete(f factory.Interface, args []string) error {
 	switch len(args) {
 	case 3:
 		o.resourceName = args[2]

--- a/pkg/cmd/admin/project/new_project.go
+++ b/pkg/cmd/admin/project/new_project.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/policy"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 )
@@ -44,7 +44,7 @@ var newProjectLong = templates.LongDesc(`
 	to restrict which nodes pods in this project can be scheduled to.`)
 
 // NewCmdNewProject implements the OpenShift cli new-project command
-func NewCmdNewProject(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdNewProject(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &NewProjectOptions{}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/admin/prune/builds.go
+++ b/pkg/cmd/admin/prune/builds.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/origin/pkg/build/prune"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PruneBuildsRecommendedName = "builds"
@@ -52,7 +52,7 @@ type PruneBuildsOptions struct {
 }
 
 // NewCmdPruneBuilds implements the OpenShift cli prune builds command.
-func NewCmdPruneBuilds(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+func NewCmdPruneBuilds(f factory.Interface, parentName, name string, out io.Writer) *cobra.Command {
 	opts := &PruneBuildsOptions{
 		Confirm:         false,
 		Orphans:         false,
@@ -83,7 +83,7 @@ func NewCmdPruneBuilds(f *clientcmd.Factory, parentName, name string, out io.Wri
 
 // Complete turns a partially defined PruneBuildsOptions into a solvent structure
 // which can be validated and used for pruning builds.
-func (o *PruneBuildsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *PruneBuildsOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		return kcmdutil.UsageError(cmd, "no arguments are allowed to this command")
 	}

--- a/pkg/cmd/admin/prune/deployments.go
+++ b/pkg/cmd/admin/prune/deployments.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	"github.com/openshift/origin/pkg/deploy/prune"
 )
@@ -53,7 +53,7 @@ type PruneDeploymentsOptions struct {
 }
 
 // NewCmdPruneDeployments implements the OpenShift cli prune deployments command.
-func NewCmdPruneDeployments(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+func NewCmdPruneDeployments(f factory.Interface, parentName, name string, out io.Writer) *cobra.Command {
 	opts := &PruneDeploymentsOptions{
 		Confirm:         false,
 		KeepYoungerThan: 60 * time.Minute,
@@ -85,7 +85,7 @@ func NewCmdPruneDeployments(f *clientcmd.Factory, parentName, name string, out i
 
 // Complete turns a partially defined PruneDeploymentsOptions into a solvent structure
 // which can be validated and used for pruning deployments.
-func (o *PruneDeploymentsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *PruneDeploymentsOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		return kcmdutil.UsageError(cmd, "no arguments are allowed to this command")
 	}

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/prune"
 	oserrors "github.com/openshift/origin/pkg/util/errors"
@@ -101,7 +101,7 @@ type PruneImagesOptions struct {
 }
 
 // NewCmdPruneImages implements the OpenShift cli prune images command.
-func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+func NewCmdPruneImages(f factory.Interface, parentName, name string, out io.Writer) *cobra.Command {
 	allImages := true
 	opts := &PruneImagesOptions{
 		Confirm:            false,
@@ -139,7 +139,7 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 
 // Complete turns a partially defined PruneImagesOptions into a solvent structure
 // which can be validated and used for pruning images.
-func (o *PruneImagesOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *PruneImagesOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		return kcmdutil.UsageError(cmd, "no arguments are allowed to this command")
 	}
@@ -465,7 +465,7 @@ func (p *describingManifestDeleter) DeleteManifest(registryClient *http.Client, 
 // getClients returns a Kube client, OpenShift client, and registry client. Note that
 // registryCABundle and registryInsecure=true are mutually exclusive. If registryInsecure=true is
 // specified, the ca bundle is ignored.
-func getClients(f *clientcmd.Factory, registryCABundle string, registryInsecure bool) (*client.Client, kclientset.Interface, *http.Client, error) {
+func getClients(f factory.Interface, registryCABundle string, registryInsecure bool) (*client.Client, kclientset.Interface, *http.Client, error) {
 	clientConfig, err := f.ClientConfig()
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/cmd/admin/prune/prune.go
+++ b/pkg/cmd/admin/prune/prune.go
@@ -8,7 +8,7 @@ import (
 
 	groups "github.com/openshift/origin/pkg/cmd/admin/groups/sync/cli"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -22,7 +22,7 @@ var pruneLong = templates.LongDesc(`
 	The commands here allow administrators to manage the older versions of resources on
 	the system by removing them.`)
 
-func NewCommandPrune(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCommandPrune(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
@@ -80,7 +81,7 @@ type RegistryOptions struct {
 	Config *RegistryConfig
 
 	// helpers required for Run.
-	factory       *clientcmd.Factory
+	factory       factory.Interface
 	cmd           *cobra.Command
 	out           io.Writer
 	label         map[string]string
@@ -144,7 +145,7 @@ const (
 )
 
 // NewCmdRegistry implements the OpenShift cli registry command
-func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out, errout io.Writer) *cobra.Command {
+func NewCmdRegistry(f factory.Interface, parentName, name string, out, errout io.Writer) *cobra.Command {
 	cfg := &RegistryConfig{
 		ImageTemplate:  variable.NewDefaultImageTemplate(),
 		Name:           "registry",
@@ -199,7 +200,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out, errout i
 }
 
 // Complete completes any options that are required by validate or run steps.
-func (opts *RegistryOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Writer, args []string) error {
+func (opts *RegistryOptions) Complete(f factory.Interface, cmd *cobra.Command, out, errout io.Writer, args []string) error {
 	if len(args) > 0 {
 		return kcmdutil.UsageError(cmd, "No arguments are allowed to this command")
 	}

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
@@ -248,7 +249,7 @@ const (
 )
 
 // NewCmdRouter implements the OpenShift CLI router command.
-func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out, errout io.Writer) *cobra.Command {
+func NewCmdRouter(f factory.Interface, parentName, name string, out, errout io.Writer) *cobra.Command {
 	cfg := &RouterConfig{
 		Name:          "router",
 		ImageTemplate: variable.NewDefaultImageTemplate(),
@@ -490,7 +491,7 @@ func generateMetricsExporterContainer(cfg *RouterConfig, env app.Environment) *k
 
 // RunCmdRouter contains all the necessary functionality for the
 // OpenShift CLI router command.
-func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Writer, cfg *RouterConfig, args []string) error {
+func RunCmdRouter(f factory.Interface, cmd *cobra.Command, out, errout io.Writer, cfg *RouterConfig, args []string) error {
 	switch len(args) {
 	case 0:
 		// uses default value

--- a/pkg/cmd/admin/top/images.go
+++ b/pkg/cmd/admin/top/images.go
@@ -18,7 +18,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 
@@ -43,7 +43,7 @@ var (
 )
 
 // NewCmdTopImages implements the OpenShift cli top images command.
-func NewCmdTopImages(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+func NewCmdTopImages(f factory.Interface, parentName, name string, out io.Writer) *cobra.Command {
 	opts := &TopImagesOptions{}
 	cmd := &cobra.Command{
 		Use:     name,
@@ -74,7 +74,7 @@ type TopImagesOptions struct {
 
 // Complete turns a partially defined TopImagesOptions into a solvent structure
 // which can be validated and used for showing limits usage.
-func (o *TopImagesOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *TopImagesOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	osClient, kClient, err := f.Clients()
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/top/imagestreams.go
+++ b/pkg/cmd/admin/top/imagestreams.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/openshift/origin/pkg/api/graph"
 	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
 )
@@ -35,7 +35,7 @@ var (
 )
 
 // NewCmdTopImageStreams implements the OpenShift cli top imagestreams command.
-func NewCmdTopImageStreams(f *clientcmd.Factory, parentName, name string, out io.Writer) *cobra.Command {
+func NewCmdTopImageStreams(f factory.Interface, parentName, name string, out io.Writer) *cobra.Command {
 	opts := &TopImageStreamsOptions{}
 	cmd := &cobra.Command{
 		Use:     name,
@@ -64,7 +64,7 @@ type TopImageStreamsOptions struct {
 
 // Complete turns a partially defined TopImageStreamsOptions into a solvent structure
 // which can be validated and used for showing limits usage.
-func (o *TopImageStreamsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *TopImageStreamsOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	osClient, _, err := f.Clients()
 	if err != nil {
 		return err

--- a/pkg/cmd/admin/top/top.go
+++ b/pkg/cmd/admin/top/top.go
@@ -9,7 +9,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const TopRecommendedName = "top"
@@ -20,7 +20,7 @@ var topLong = templates.LongDesc(`
 	This command analyzes resources managed by the platform and presents current
 	usage statistics.`)
 
-func NewCommandTop(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCommandTop(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -26,7 +24,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/policy"
 	"github.com/openshift/origin/pkg/cmd/cli/sa"
 	"github.com/openshift/origin/pkg/cmd/cli/secrets"
-	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/term"
@@ -275,16 +272,8 @@ func NewCmdKubectl(name string, out io.Writer) *cobra.Command {
 
 // CommandFor returns the appropriate command for this base name,
 // or the OpenShift CLI command.
-func CommandFor(basename string) *cobra.Command {
+func CommandFor(basename string, in io.Reader, out, errout io.Writer) *cobra.Command {
 	var cmd *cobra.Command
-
-	in, out, errout := os.Stdin, os.Stdout, os.Stderr
-
-	// Make case-insensitive and strip executable suffix if present
-	if runtime.GOOS == "windows" {
-		basename = strings.ToLower(basename)
-		basename = strings.TrimSuffix(basename, ".exe")
-	}
 
 	switch basename {
 	case "kubectl":
@@ -292,11 +281,6 @@ func CommandFor(basename string) *cobra.Command {
 	default:
 		cmd = NewCommandCLI("oc", "oc", in, out, errout)
 	}
-
-	if cmd.UsageFunc() == nil {
-		templates.ActsAsRootCommand(cmd, []string{"options"})
-	}
-	flagtypes.GLog(cmd.PersistentFlags())
 
 	return cmd
 }

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/rollout"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/rsync"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd/set"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/cli/policy"
 	"github.com/openshift/origin/pkg/cmd/cli/sa"
 	"github.com/openshift/origin/pkg/cmd/cli/secrets"
@@ -197,7 +198,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	cmds.AddCommand(experimental)
 
 	if name == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, out, cmd.VersionOptions{PrintClientFeatures: true}))
+		cmds.AddCommand(version.NewCmdVersion(fullName, f, out, version.VersionOptions{PrintClientFeatures: true}))
 	}
 	cmds.AddCommand(cmd.NewCmdOptions(out))
 

--- a/pkg/cmd/cli/cmd/buildlogs.go
+++ b/pkg/cmd/cli/cmd/buildlogs.go
@@ -15,7 +15,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -32,7 +32,7 @@ var (
 )
 
 // NewCmdBuildLogs implements the OpenShift cli build-logs command
-func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdBuildLogs(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := buildapi.BuildLogOptions{}
 	cmd := &cobra.Command{
 		Use:        "build-logs BUILD",
@@ -67,7 +67,7 @@ func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobr
 }
 
 // RunBuildLogs contains all the necessary functionality for the OpenShift cli build-logs command
-func RunBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, opts buildapi.BuildLogOptions, args []string) error {
+func RunBuildLogs(fullName string, f factory.Interface, out io.Writer, cmd *cobra.Command, opts buildapi.BuildLogOptions, args []string) error {
 	if len(args) != 1 {
 		cmdNamespace := kcmdutil.GetFlagString(cmd, "namespace")
 		var namespace string

--- a/pkg/cmd/cli/cmd/cancelbuild.go
+++ b/pkg/cmd/cli/cmd/cancelbuild.go
@@ -22,7 +22,7 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // CancelBuildRecommendedCommandName is the recommended command name.
@@ -72,7 +72,7 @@ type CancelBuildOptions struct {
 }
 
 // NewCmdCancelBuild implements the OpenShift cli cancel-build command
-func NewCmdCancelBuild(name, baseName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdCancelBuild(name, baseName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	o := &CancelBuildOptions{}
 
 	cmd := &cobra.Command{
@@ -94,7 +94,7 @@ func NewCmdCancelBuild(name, baseName string, f *clientcmd.Factory, in io.Reader
 }
 
 // Complete completes all the required options.
-func (o *CancelBuildOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
+func (o *CancelBuildOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
 	o.In = in
 	o.Out = out
 	o.ErrOut = errout

--- a/pkg/cmd/cli/cmd/cluster/cluster.go
+++ b/pkg/cmd/cli/cmd/cluster/cluster.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/bootstrap/docker"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const ClusterRecommendedName = "cluster"
@@ -36,7 +36,7 @@ var (
 		routing suffix, use the --routing-suffix flag.`)
 )
 
-func NewCmdCluster(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdCluster(name, fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   fmt.Sprintf("%s ACTION", name),

--- a/pkg/cmd/cli/cmd/create/clusterquota.go
+++ b/pkg/cmd/cli/cmd/create/clusterquota.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 )
 
@@ -47,7 +47,7 @@ type CreateClusterQuotaOptions struct {
 }
 
 // NewCmdCreateClusterQuota is a macro command to create a new cluster quota.
-func NewCmdCreateClusterQuota(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateClusterQuota(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreateClusterQuotaOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -71,7 +71,7 @@ func NewCmdCreateClusterQuota(name, fullName string, f *clientcmd.Factory, out i
 	return cmd
 }
 
-func (o *CreateClusterQuotaOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreateClusterQuotaOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("NAME is required: %v", args)
 	}

--- a/pkg/cmd/cli/cmd/create/deploymentconfig.go
+++ b/pkg/cmd/cli/cmd/create/deploymentconfig.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 )
 
@@ -44,7 +44,7 @@ type CreateDeploymentConfigOptions struct {
 }
 
 // NewCmdCreateDeploymentConfig is a macro command to create a new deployment config.
-func NewCmdCreateDeploymentConfig(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateDeploymentConfig(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreateDeploymentConfigOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -67,7 +67,7 @@ func NewCmdCreateDeploymentConfig(name, fullName string, f *clientcmd.Factory, o
 	return cmd
 }
 
-func (o *CreateDeploymentConfigOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreateDeploymentConfigOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	argsLenAtDash := cmd.ArgsLenAtDash()
 	switch {
 	case (argsLenAtDash == -1 && len(args) != 1),

--- a/pkg/cmd/cli/cmd/create/identity.go
+++ b/pkg/cmd/cli/cmd/create/identity.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 )
 
@@ -50,7 +50,7 @@ type CreateIdentityOptions struct {
 }
 
 // NewCmdCreateIdentity is a macro command to create a new identity
-func NewCmdCreateIdentity(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateIdentity(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreateIdentityOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -70,7 +70,7 @@ func NewCmdCreateIdentity(name, fullName string, f *clientcmd.Factory, out io.Wr
 	return cmd
 }
 
-func (o *CreateIdentityOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreateIdentityOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	switch len(args) {
 	case 0:
 		return fmt.Errorf("identity name in the format <PROVIDER_NAME>:<PROVIDER_USER_NAME> is required")

--- a/pkg/cmd/cli/cmd/create/imagestream.go
+++ b/pkg/cmd/cli/cmd/create/imagestream.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
@@ -50,7 +50,7 @@ type CreateImageStreamOptions struct {
 }
 
 // NewCmdCreateImageStream is a macro command to create a new image stream
-func NewCmdCreateImageStream(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateImageStream(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreateImageStreamOptions{
 		Out: out,
 		IS: &imageapi.ImageStream{
@@ -78,7 +78,7 @@ func NewCmdCreateImageStream(name, fullName string, f *clientcmd.Factory, out io
 	return cmd
 }
 
-func (o *CreateImageStreamOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreateImageStreamOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	o.DryRun = cmdutil.GetFlagBool(cmd, "dry-run")
 
 	switch len(args) {

--- a/pkg/cmd/cli/cmd/create/policy_binding.go
+++ b/pkg/cmd/cli/cmd/create/policy_binding.go
@@ -13,7 +13,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PolicyBindingRecommendedName = "policybinding"
@@ -41,7 +41,7 @@ type CreatePolicyBindingOptions struct {
 type ObjectPrinter func(runtime.Object, io.Writer) error
 
 // NewCmdCreatePolicyBinding is a macro command to create a new policy binding.
-func NewCmdCreatePolicyBinding(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreatePolicyBinding(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreatePolicyBindingOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -59,7 +59,7 @@ func NewCmdCreatePolicyBinding(name, fullName string, f *clientcmd.Factory, out 
 	return cmd
 }
 
-func (o *CreatePolicyBindingOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreatePolicyBindingOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("exactly one argument (policy namespace) is supported, not: %v", args)
 	}

--- a/pkg/cmd/cli/cmd/create/route.go
+++ b/pkg/cmd/cli/cmd/create/route.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	fileutil "github.com/openshift/origin/pkg/util/file"
 )
@@ -27,7 +27,7 @@ var (
 )
 
 // NewCmdCreateRoute is a macro command to create a secured route.
-func NewCmdCreateRoute(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdCreateRoute(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "route",
 		Short: "Expose containers externally via secured routes",
@@ -59,7 +59,7 @@ var (
 )
 
 // NewCmdCreateEdgeRoute is a macro command to create an edge route.
-func NewCmdCreateEdgeRoute(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateEdgeRoute(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "edge [NAME] --service=SERVICE",
 		Short:   "Create a route that uses edge TLS termination",
@@ -92,7 +92,7 @@ func NewCmdCreateEdgeRoute(fullName string, f *clientcmd.Factory, out io.Writer)
 }
 
 // CreateEdgeRoute implements the behavior to run the create edge route command.
-func CreateEdgeRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+func CreateEdgeRoute(f factory.Interface, out io.Writer, cmd *cobra.Command, args []string) error {
 	oc, kc, err := f.Clients()
 	if err != nil {
 		return err
@@ -188,7 +188,7 @@ var (
 )
 
 // NewCmdCreatePassthroughRoute is a macro command to create a passthrough route.
-func NewCmdCreatePassthroughRoute(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreatePassthroughRoute(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "passthrough [NAME] --service=SERVICE",
 		Short:   "Create a route that uses passthrough TLS termination",
@@ -214,7 +214,7 @@ func NewCmdCreatePassthroughRoute(fullName string, f *clientcmd.Factory, out io.
 }
 
 // CreatePassthroughRoute implements the behavior to run the create passthrough route command.
-func CreatePassthroughRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+func CreatePassthroughRoute(f factory.Interface, out io.Writer, cmd *cobra.Command, args []string) error {
 	oc, kc, err := f.Clients()
 	if err != nil {
 		return err
@@ -295,7 +295,7 @@ var (
 )
 
 // NewCmdCreateReencryptRoute is a macro command to create a reencrypt route.
-func NewCmdCreateReencryptRoute(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateReencryptRoute(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "reencrypt [NAME] --dest-ca-cert=FILENAME --service=SERVICE",
 		Short:   "Create a route that uses reencrypt TLS termination",
@@ -331,7 +331,7 @@ func NewCmdCreateReencryptRoute(fullName string, f *clientcmd.Factory, out io.Wr
 }
 
 // CreateReencryptRoute implements the behavior to run the create reencrypt route command.
-func CreateReencryptRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+func CreateReencryptRoute(f factory.Interface, out io.Writer, cmd *cobra.Command, args []string) error {
 	oc, kc, err := f.Clients()
 	if err != nil {
 		return err
@@ -415,7 +415,7 @@ func CreateReencryptRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comman
 	return nil
 }
 
-func resolveServiceName(f *clientcmd.Factory, resource string) (string, error) {
+func resolveServiceName(f factory.Interface, resource string) (string, error) {
 	if len(resource) == 0 {
 		return "", fmt.Errorf("you need to provide a service name via --service")
 	}

--- a/pkg/cmd/cli/cmd/create/user.go
+++ b/pkg/cmd/cli/cmd/create/user.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 )
 
@@ -49,7 +49,7 @@ type CreateUserOptions struct {
 }
 
 // NewCmdCreateUser is a macro command to create a new user
-func NewCmdCreateUser(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateUser(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreateUserOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -69,7 +69,7 @@ func NewCmdCreateUser(name, fullName string, f *clientcmd.Factory, out io.Writer
 	return cmd
 }
 
-func (o *CreateUserOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreateUserOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	switch len(args) {
 	case 0:
 		return fmt.Errorf("username is required")

--- a/pkg/cmd/cli/cmd/create/user_identity_mapping.go
+++ b/pkg/cmd/cli/cmd/create/user_identity_mapping.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 )
 
@@ -46,7 +46,7 @@ type CreateUserIdentityMappingOptions struct {
 }
 
 // NewCmdCreateUserIdentityMapping is a macro command to create a new identity
-func NewCmdCreateUserIdentityMapping(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateUserIdentityMapping(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &CreateUserIdentityMappingOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -65,7 +65,7 @@ func NewCmdCreateUserIdentityMapping(name, fullName string, f *clientcmd.Factory
 	return cmd
 }
 
-func (o *CreateUserIdentityMappingOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func (o *CreateUserIdentityMappingOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string) error {
 	switch len(args) {
 	case 0:
 		return fmt.Errorf("identity is required")

--- a/pkg/cmd/cli/cmd/debug.go
+++ b/pkg/cmd/cli/cmd/debug.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	generateapp "github.com/openshift/origin/pkg/generate/app"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -107,7 +107,7 @@ var (
 )
 
 // NewCmdDebug creates a command for debugging pods.
-func NewCmdDebug(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdDebug(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &DebugOptions{
 		Timeout: 15 * time.Minute,
 		Attach: kcmd.AttachOptions{
@@ -168,7 +168,7 @@ func NewCmdDebug(fullName string, f *clientcmd.Factory, in io.Reader, out, errou
 	return cmd
 }
 
-func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args []string, in io.Reader, out, errout io.Writer) error {
+func (o *DebugOptions) Complete(cmd *cobra.Command, f factory.Interface, args []string, in io.Reader, out, errout io.Writer) error {
 	if i := cmd.ArgsLenAtDash(); i != -1 && i < len(args) {
 		o.Command = args[i:]
 		args = args[:i]

--- a/pkg/cmd/cli/cmd/deploy.go
+++ b/pkg/cmd/cli/cmd/deploy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -95,7 +95,7 @@ var (
 )
 
 // NewCmdDeploy creates a new `deploy` command.
-func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdDeploy(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &DeployOptions{
 		baseCommandName: fullName,
 	}
@@ -133,7 +133,7 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 	return cmd
 }
 
-func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Writer) error {
+func (o *DeployOptions) Complete(f factory.Interface, args []string, out io.Writer) error {
 	if len(args) > 1 {
 		return errors.New("only one deployment config name is supported as argument.")
 	}

--- a/pkg/cmd/cli/cmd/example.go
+++ b/pkg/cmd/cli/cmd/example.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -30,7 +30,7 @@ type TYPEOptions struct {
 
 // NewCmdTYPE implements a TYPE command
 // This is an example type for templating.
-func NewCmdTYPE(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdTYPE(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &TYPEOptions{
 		In:     in,
 		Out:    out,
@@ -56,7 +56,7 @@ func NewCmdTYPE(fullName string, f *clientcmd.Factory, in io.Reader, out, errout
 	return cmd
 }
 
-func (o *TYPEOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string) error {
+func (o *TYPEOptions) Complete(f factory.Interface, c *cobra.Command, args []string) error {
 	return nil
 }
 

--- a/pkg/cmd/cli/cmd/export.go
+++ b/pkg/cmd/cli/cmd/export.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
 
@@ -51,7 +51,7 @@ var (
 	  %[1]s export service -o json`)
 )
 
-func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
+func NewCmdExport(fullName string, f factory.Interface, in io.Reader, out io.Writer) *cobra.Command {
 	exporter := &DefaultExporter{}
 	var filenames []string
 	cmd := &cobra.Command{
@@ -80,7 +80,7 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 	return cmd
 }
 
-func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Writer, cmd *cobra.Command, args []string, filenames []string) error {
+func RunExport(f factory.Interface, exporter Exporter, in io.Reader, out io.Writer, cmd *cobra.Command, args []string, filenames []string) error {
 	selector := kcmdutil.GetFlagString(cmd, "selector")
 	allNamespaces := kcmdutil.GetFlagBool(cmd, "all-namespaces")
 	exact := kcmdutil.GetFlagBool(cmd, "exact")

--- a/pkg/cmd/cli/cmd/expose.go
+++ b/pkg/cmd/cli/cmd/expose.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -52,7 +52,7 @@ var (
 )
 
 // NewCmdExpose is a wrapper for the Kubernetes cli expose command
-func NewCmdExpose(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdExpose(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdExposeService(f, out)
 	cmd.Short = "Expose a replicated application as a service or route"
 	cmd.Long = exposeLong
@@ -82,7 +82,7 @@ func NewCmdExpose(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 
 // validate adds one layer of validation prior to calling the upstream
 // expose command.
-func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
+func validate(cmd *cobra.Command, f factory.Interface, args []string) error {
 	namespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/extract.go
+++ b/pkg/cmd/cli/cmd/extract.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -54,7 +54,7 @@ type ExtractOptions struct {
 	ExtractFileContentsFn func(runtime.Object) (map[string][]byte, bool, error)
 }
 
-func NewCmdExtract(fullName string, f *clientcmd.Factory, in io.Reader, out, errOut io.Writer) *cobra.Command {
+func NewCmdExtract(fullName string, f factory.Interface, in io.Reader, out, errOut io.Writer) *cobra.Command {
 	options := &ExtractOptions{
 		Out: out,
 		Err: errOut,
@@ -86,7 +86,7 @@ func NewCmdExtract(fullName string, f *clientcmd.Factory, in io.Reader, out, err
 	return cmd
 }
 
-func (o *ExtractOptions) Complete(f *clientcmd.Factory, in io.Reader, out io.Writer, cmd *cobra.Command, args []string) error {
+func (o *ExtractOptions) Complete(f factory.Interface, in io.Reader, out io.Writer, cmd *cobra.Command, args []string) error {
 	o.ExtractFileContentsFn = f.ExtractFileContents
 
 	cmdNamespace, explicit, err := f.DefaultNamespace()

--- a/pkg/cmd/cli/cmd/importer/appjson.go
+++ b/pkg/cmd/cli/cmd/importer/appjson.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	"github.com/openshift/origin/pkg/generate/app"
 	appcmd "github.com/openshift/origin/pkg/generate/app/cmd"
@@ -72,7 +73,7 @@ type AppJSONOptions struct {
 
 // NewCmdAppJSON imports an app.json file (schema described here: https://devcenter.heroku.com/articles/app-json-schema)
 // as a template.
-func NewCmdAppJSON(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdAppJSON(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &AppJSONOptions{
 		Action: configcmd.BulkAction{
 			Out:    out,
@@ -112,7 +113,7 @@ func NewCmdAppJSON(fullName string, f *clientcmd.Factory, in io.Reader, out, err
 	return cmd
 }
 
-func (o *AppJSONOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *AppJSONOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	version, _ := cmd.Flags().GetString("output-version")
 	for _, v := range strings.Split(version, ",") {
 		gv, err := schema.ParseGroupVersion(v)

--- a/pkg/cmd/cli/cmd/importer/import.go
+++ b/pkg/cmd/cli/cmd/importer/import.go
@@ -8,7 +8,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -19,7 +19,7 @@ var (
 )
 
 // NewCmdImport exposes commands for modifying objects.
-func NewCmdImport(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdImport(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import COMMAND",
 		Short: "Commands that import applications",

--- a/pkg/cmd/cli/cmd/importimage.go
+++ b/pkg/cmd/cli/cmd/importimage.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
@@ -44,7 +44,7 @@ var (
 )
 
 // NewCmdImportImage implements the OpenShift cli import-image command.
-func NewCmdImportImage(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdImportImage(fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	opts := &ImportImageOptions{}
 	cmd := &cobra.Command{
 		Use:        "import-image IMAGESTREAM[:TAG]",
@@ -96,7 +96,7 @@ type ImportImageOptions struct {
 
 // Complete turns a partially defined ImportImageOptions into a solvent structure
 // which can be validated and used for aa import.
-func (o *ImportImageOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, commandName string, out, errout io.Writer) error {
+func (o *ImportImageOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, commandName string, out, errout io.Writer) error {
 	o.CommandName = commandName
 
 	if len(args) > 0 {

--- a/pkg/cmd/cli/cmd/login/login.go
+++ b/pkg/cmd/cli/cmd/login/login.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -47,7 +47,7 @@ var (
 )
 
 // NewCmdLogin implements the OpenShift cli login command
-func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
+func NewCmdLogin(fullName string, f factory.Interface, reader io.Reader, out io.Writer) *cobra.Command {
 	options := &LoginOptions{
 		Reader: reader,
 		Out:    out,
@@ -95,7 +95,7 @@ func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out 
 	return cmds
 }
 
-func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string, commandName string) error {
+func (o *LoginOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, commandName string) error {
 	kubeconfig, err := f.OpenShiftClientConfig().RawConfig()
 	o.StartingKubeConfig = &kubeconfig
 	if err != nil {

--- a/pkg/cmd/cli/cmd/login/logout.go
+++ b/pkg/cmd/cli/cmd/login/logout.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 type LogoutOptions struct {
@@ -47,7 +47,7 @@ var (
 )
 
 // NewCmdLogout implements the OpenShift cli logout command
-func NewCmdLogout(name, fullName, ocLoginFullCommand string, f *osclientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
+func NewCmdLogout(name, fullName, ocLoginFullCommand string, f factory.Interface, reader io.Reader, out io.Writer) *cobra.Command {
 	options := &LogoutOptions{
 		Out: out,
 	}
@@ -78,7 +78,7 @@ func NewCmdLogout(name, fullName, ocLoginFullCommand string, f *osclientcmd.Fact
 	return cmds
 }
 
-func (o *LogoutOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *LogoutOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	kubeconfig, err := f.OpenShiftClientConfig().RawConfig()
 	o.StartingKubeConfig = &kubeconfig
 	if err != nil {

--- a/pkg/cmd/cli/cmd/logs.go
+++ b/pkg/cmd/cli/cmd/logs.go
@@ -19,7 +19,7 @@ import (
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 )
 
@@ -74,7 +74,7 @@ type OpenShiftLogsOptions struct {
 }
 
 // NewCmdLogs creates a new logs command that supports OpenShift resources.
-func NewCmdLogs(name, baseName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdLogs(name, baseName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := OpenShiftLogsOptions{
 		KubeLogOptions: &kcmd.LogsOptions{},
 	}
@@ -115,7 +115,7 @@ func isPipelineBuild(obj runtime.Object) (bool, *buildapi.BuildConfig, bool, *bu
 // Complete calls the upstream Complete for the logs command and then resolves the
 // resource a user requested to view its logs and creates the appropriate logOptions
 // object for it.
-func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *OpenShiftLogsOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if err := o.KubeLogOptions.Complete(f, out, cmd, args); err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -32,8 +32,8 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	dockerutil "github.com/openshift/origin/pkg/cmd/util/docker"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	"github.com/openshift/origin/pkg/generate"
 	newapp "github.com/openshift/origin/pkg/generate/app"
@@ -137,7 +137,7 @@ type NewAppOptions struct {
 }
 
 //Complete sets all common default options for commands (new-app and new-build)
-func (o *ObjectGeneratorOptions) Complete(baseName, commandName string, f *clientcmd.Factory, c *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
+func (o *ObjectGeneratorOptions) Complete(baseName, commandName string, f factory.Interface, c *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
 	cmdutil.WarnAboutCommaSeparation(errout, o.Config.Environment, "--env")
 	cmdutil.WarnAboutCommaSeparation(errout, o.Config.BuildEnvironment, "--build-env")
 
@@ -193,7 +193,7 @@ func (o *ObjectGeneratorOptions) Complete(baseName, commandName string, f *clien
 }
 
 // NewCmdNewApplication implements the OpenShift cli new-app command.
-func NewCmdNewApplication(name, baseName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdNewApplication(name, baseName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	config := newcmd.NewAppConfig()
 	config.Deploy = true
 	o := &NewAppOptions{&ObjectGeneratorOptions{Config: config}}
@@ -252,7 +252,7 @@ func NewCmdNewApplication(name, baseName string, f *clientcmd.Factory, in io.Rea
 }
 
 // Complete sets any default behavior for the command
-func (o *NewAppOptions) Complete(baseName, commandName string, f *clientcmd.Factory, c *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
+func (o *NewAppOptions) Complete(baseName, commandName string, f factory.Interface, c *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
 	ao := o.ObjectGeneratorOptions
 	cmdutil.WarnAboutCommaSeparation(errout, ao.Config.TemplateParameters, "--param")
 	err := ao.Complete(baseName, commandName, f, c, args, in, out, errout)
@@ -492,7 +492,7 @@ func getDockerClient() (*docker.Client, error) {
 	return nil, err
 }
 
-func CompleteAppConfig(config *newcmd.AppConfig, f *clientcmd.Factory, c *cobra.Command, args []string) error {
+func CompleteAppConfig(config *newcmd.AppConfig, f factory.Interface, c *cobra.Command, args []string) error {
 	mapper, typer := f.Object()
 	if config.Mapper == nil {
 		config.Mapper = mapper

--- a/pkg/cmd/cli/cmd/newbuild.go
+++ b/pkg/cmd/cli/cmd/newbuild.go
@@ -14,7 +14,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	newapp "github.com/openshift/origin/pkg/generate/app"
 	newcmd "github.com/openshift/origin/pkg/generate/app/cmd"
@@ -84,7 +84,7 @@ type NewBuildOptions struct {
 }
 
 // NewCmdNewBuild implements the OpenShift cli new-build command
-func NewCmdNewBuild(name, baseName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdNewBuild(name, baseName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	config := newcmd.NewAppConfig()
 	config.ExpectToBuild = true
 	o := &NewBuildOptions{ObjectGeneratorOptions: &ObjectGeneratorOptions{Config: config}}
@@ -141,7 +141,7 @@ func NewCmdNewBuild(name, baseName string, f *clientcmd.Factory, in io.Reader, o
 }
 
 // Complete sets any default behavior for the command
-func (o *NewBuildOptions) Complete(baseName, commandName string, f *clientcmd.Factory, c *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
+func (o *NewBuildOptions) Complete(baseName, commandName string, f factory.Interface, c *cobra.Command, args []string, in io.Reader, out, errout io.Writer) error {
 	bo := o.ObjectGeneratorOptions
 	err := bo.Complete(baseName, commandName, f, c, args, in, out, errout)
 	if err != nil {

--- a/pkg/cmd/cli/cmd/observe/observe.go
+++ b/pkg/cmd/cli/cmd/observe/observe.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/util/proc"
 )
 
@@ -161,7 +161,7 @@ var (
 )
 
 // NewCmdObserve creates the observe command.
-func NewCmdObserve(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdObserve(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &ObserveOptions{
 		baseCommandName: fullName,
 		retryCount:      2,
@@ -272,7 +272,7 @@ type ObserveOptions struct {
 	baseCommandName string
 }
 
-func (o *ObserveOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out, errOut io.Writer) error {
+func (o *ObserveOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out, errOut io.Writer) error {
 	var err error
 
 	var command []string

--- a/pkg/cmd/cli/cmd/process.go
+++ b/pkg/cmd/cli/cmd/process.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/generate/app"
 	"github.com/openshift/origin/pkg/template"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
@@ -73,7 +73,7 @@ var (
 )
 
 // NewCmdProcess implements the OpenShift cli process command
-func NewCmdProcess(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdProcess(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "process (TEMPLATE | -f FILENAME) [-p=KEY=VALUE]",
 		Short:   "Process a template into list of resources",
@@ -113,7 +113,7 @@ func NewCmdProcess(fullName string, f *clientcmd.Factory, in io.Reader, out, err
 }
 
 // RunProcess contains all the necessary functionality for the OpenShift cli process command
-func RunProcess(f *clientcmd.Factory, in io.Reader, out, errout io.Writer, cmd *cobra.Command, args []string) error {
+func RunProcess(f factory.Interface, in io.Reader, out, errout io.Writer, cmd *cobra.Command, args []string) error {
 	templateName, templateParams := "", []string{}
 	for _, s := range args {
 		isValue := strings.Contains(s, "=")

--- a/pkg/cmd/cli/cmd/project.go
+++ b/pkg/cmd/cli/cmd/project.go
@@ -19,6 +19,7 @@ import (
 	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectapihelpers "github.com/openshift/origin/pkg/project/apis/project/helpers"
 	projectutil "github.com/openshift/origin/pkg/project/util"
@@ -64,7 +65,7 @@ var (
 )
 
 // NewCmdProject implements the OpenShift cli rollback command
-func NewCmdProject(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdProject(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &ProjectOptions{}
 
 	cmd := &cobra.Command{
@@ -88,7 +89,7 @@ func NewCmdProject(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.
 	return cmd
 }
 
-func (o *ProjectOptions) Complete(f *clientcmd.Factory, args []string, out io.Writer) error {
+func (o *ProjectOptions) Complete(f factory.Interface, args []string, out io.Writer) error {
 	var err error
 
 	argsLength := len(args)

--- a/pkg/cmd/cli/cmd/projects.go
+++ b/pkg/cmd/cli/cmd/projects.go
@@ -16,6 +16,7 @@ import (
 	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectapihelpers "github.com/openshift/origin/pkg/project/apis/project/helpers"
 
@@ -58,7 +59,7 @@ var (
 )
 
 // NewCmdProjects implements the OpenShift cli rollback command
-func NewCmdProjects(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdProjects(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &ProjectsOptions{}
 
 	cmd := &cobra.Command{
@@ -82,7 +83,7 @@ func NewCmdProjects(fullName string, f *clientcmd.Factory, out io.Writer) *cobra
 	return cmd
 }
 
-func (o *ProjectsOptions) Complete(f *clientcmd.Factory, args []string, commandName string, out io.Writer) error {
+func (o *ProjectsOptions) Complete(f factory.Interface, args []string, commandName string, out io.Writer) error {
 	if len(args) > 0 {
 		return fmt.Errorf("no arguments should be passed")
 	}

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	cliconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 )
 
@@ -73,7 +73,7 @@ To switch to this project and start adding applications, use:
 )
 
 // NewCmdRequestProject implement the OpenShift cli RequestProject command.
-func NewCmdRequestProject(name, baseName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdRequestProject(name, baseName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	o := &NewProjectOptions{}
 	o.Out = out
 	o.Name = baseName
@@ -102,7 +102,7 @@ func NewCmdRequestProject(name, baseName string, f *clientcmd.Factory, out, erro
 }
 
 // Complete completes all the required options.
-func (o *NewProjectOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *NewProjectOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		cmd.Help()
 		return errors.New("must have exactly one argument")

--- a/pkg/cmd/cli/cmd/rollback.go
+++ b/pkg/cmd/cli/cmd/rollback.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	describe "github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -60,7 +60,7 @@ var (
 )
 
 // NewCmdRollback creates a CLI rollback command.
-func NewCmdRollback(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRollback(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &RollbackOptions{}
 	cmd := &cobra.Command{
 		Use:     "rollback (DEPLOYMENTCONFIG | DEPLOYMENT)",
@@ -122,7 +122,7 @@ type RollbackOptions struct {
 
 // Complete turns a partially defined RollbackActions into a solvent structure
 // which can be validated and used for a rollback.
-func (o *RollbackOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *RollbackOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	// Extract basic flags.
 	if len(args) == 1 {
 		o.TargetName = args[0]

--- a/pkg/cmd/cli/cmd/rollout/cancel.go
+++ b/pkg/cmd/cli/cmd/rollout/cancel.go
@@ -15,7 +15,7 @@ import (
 
 	units "github.com/docker/go-units"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	"github.com/spf13/cobra"
@@ -53,7 +53,7 @@ event will be emitted.`)
   %[1]s rollout cancel dc/nginx`)
 )
 
-func NewCmdRolloutCancel(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutCancel(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &CancelOptions{}
 	cmd := &cobra.Command{
 		Use:     "cancel (TYPE NAME | TYPE/NAME) [flags]",
@@ -70,7 +70,7 @@ func NewCmdRolloutCancel(fullName string, f *clientcmd.Factory, out io.Writer) *
 	return cmd
 }
 
-func (o *CancelOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
+func (o *CancelOptions) Complete(f factory.Interface, cmd *cobra.Command, out io.Writer, args []string) error {
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
 		return kcmdutil.UsageError(cmd, cmd.Use)
 	}

--- a/pkg/cmd/cli/cmd/rollout/latest.go
+++ b/pkg/cmd/cli/cmd/rollout/latest.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -53,7 +53,7 @@ type RolloutLatestOptions struct {
 }
 
 // NewCmdRolloutLatest implements the oc rollout latest subcommand.
-func NewCmdRolloutLatest(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutLatest(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &RolloutLatestOptions{
 		baseCommandName: fullName,
 	}
@@ -84,7 +84,7 @@ func NewCmdRolloutLatest(fullName string, f *clientcmd.Factory, out io.Writer) *
 	return cmd
 }
 
-func (o *RolloutLatestOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *RolloutLatestOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) != 1 {
 		return errors.New("one deployment config name is needed as argument.")
 	}

--- a/pkg/cmd/cli/cmd/rollout/retry.go
+++ b/pkg/cmd/cli/cmd/rollout/retry.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	"github.com/spf13/cobra"
@@ -54,7 +54,7 @@ var (
 `)
 )
 
-func NewCmdRolloutRetry(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutRetry(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &RetryOptions{}
 	cmd := &cobra.Command{
 		Use:     "retry (TYPE NAME | TYPE/NAME) [flags]",
@@ -71,7 +71,7 @@ func NewCmdRolloutRetry(fullName string, f *clientcmd.Factory, out io.Writer) *c
 	return cmd
 }
 
-func (o *RetryOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
+func (o *RetryOptions) Complete(f factory.Interface, cmd *cobra.Command, out io.Writer, args []string) error {
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
 		return kcmdutil.UsageError(cmd, cmd.Use)
 	}

--- a/pkg/cmd/cli/cmd/rollout/rollout.go
+++ b/pkg/cmd/cli/cmd/rollout/rollout.go
@@ -9,7 +9,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -33,7 +33,7 @@ var (
 )
 
 // NewCmdRollout facilitates kubectl rollout subcommands
-func NewCmdRollout(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdRollout(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rollout SUBCOMMAND",
 		Short: "Manage a Kubernetes deployment or OpenShift deployment config",
@@ -70,7 +70,7 @@ var (
 )
 
 // NewCmdRolloutHistory is a wrapper for the Kubernetes cli rollout history command
-func NewCmdRolloutHistory(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutHistory(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := rollout.NewCmdRolloutHistory(f, out)
 	cmd.Long = rolloutHistoryLong
 	cmd.Example = fmt.Sprintf(rolloutHistoryExample, fullName)
@@ -93,7 +93,7 @@ var (
 )
 
 // NewCmdRolloutPause is a wrapper for the Kubernetes cli rollout pause command
-func NewCmdRolloutPause(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutPause(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := rollout.NewCmdRolloutPause(f, out)
 	cmd.Long = rolloutPauseLong
 	cmd.Example = fmt.Sprintf(rolloutPauseExample, fullName)
@@ -114,7 +114,7 @@ var (
 )
 
 // NewCmdRolloutResume is a wrapper for the Kubernetes cli rollout resume command
-func NewCmdRolloutResume(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutResume(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := rollout.NewCmdRolloutResume(f, out)
 	cmd.Long = rolloutResumeLong
 	cmd.Example = fmt.Sprintf(rolloutResumeExample, fullName)
@@ -152,7 +152,7 @@ var (
 )
 
 // NewCmdRolloutUndo is a wrapper for the Kubernetes cli rollout undo command
-func NewCmdRolloutUndo(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutUndo(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := rollout.NewCmdRolloutUndo(f, out)
 	cmd.Long = rolloutUndoLong
 	cmd.Example = fmt.Sprintf(rolloutUndoExample, fullName)
@@ -170,7 +170,7 @@ var (
 )
 
 // NewCmdRolloutStatus is a wrapper for the Kubernetes cli rollout status command
-func NewCmdRolloutStatus(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdRolloutStatus(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := rollout.NewCmdRolloutStatus(f, out)
 	cmd.Long = rolloutStatusLong
 	cmd.Example = fmt.Sprintf(rolloutStatusExample, fullName)

--- a/pkg/cmd/cli/cmd/rsh.go
+++ b/pkg/cmd/cli/cmd/rsh.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -64,7 +64,7 @@ type RshOptions struct {
 }
 
 // NewCmdRsh returns a command that attempts to open a shell session to the server.
-func NewCmdRsh(name string, parent string, f *clientcmd.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
+func NewCmdRsh(name string, parent string, f factory.Interface, in io.Reader, out, err io.Writer) *cobra.Command {
 	options := &RshOptions{
 		ForceTTY:   false,
 		DisableTTY: false,
@@ -105,7 +105,7 @@ func NewCmdRsh(name string, parent string, f *clientcmd.Factory, in io.Reader, o
 }
 
 // Complete applies the command environment to RshOptions
-func (o *RshOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *RshOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	switch {
 	case o.ForceTTY && o.DisableTTY:
 		return kcmdutil.UsageError(cmd, "you may not specify -t and -T together")

--- a/pkg/cmd/cli/cmd/rsync/copyrsync.go
+++ b/pkg/cmd/cli/cmd/rsync/copyrsync.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 // rsyncStrategy implements the rsync copy strategy
@@ -32,7 +32,7 @@ type rsyncStrategy struct {
 // rshExcludeFlags are flags that are passed to oc rsync, and should not be passed on to the underlying command being invoked via oc rsh.
 var rshExcludeFlags = sets.NewString("delete", "strategy", "quiet", "include", "exclude", "progress", "no-perms", "watch")
 
-func newRsyncStrategy(f *clientcmd.Factory, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
+func newRsyncStrategy(f factory.Interface, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
 	// Determine the rsh command to pass to the local rsync command
 	rsh := cmdutil.SiblingCommand(c, "rsh")
 	rshCmd := []string{rsh}

--- a/pkg/cmd/cli/cmd/rsync/copyrsyncd.go
+++ b/pkg/cmd/cli/cmd/rsync/copyrsyncd.go
@@ -13,11 +13,10 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	krand "k8s.io/apimachinery/pkg/util/rand"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 const (
@@ -287,7 +286,7 @@ func (s *rsyncDaemonStrategy) Validate() error {
 	return nil
 }
 
-func newRsyncDaemonStrategy(f *clientcmd.Factory, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
+func newRsyncDaemonStrategy(f factory.Interface, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
 	flags := []string{"-a", "--omit-dir-times", "--numeric-ids"}
 	flags = append(flags, rsyncFlagsFromOptions(o)...)
 

--- a/pkg/cmd/cli/cmd/rsync/copytar.go
+++ b/pkg/cmd/cli/cmd/rsync/copytar.go
@@ -12,13 +12,12 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	s2iutil "github.com/openshift/source-to-image/pkg/util"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 // tarStrategy implements the tar copy strategy.
@@ -35,7 +34,7 @@ type tarStrategy struct {
 	IgnoredFlags   []string
 }
 
-func newTarStrategy(f *clientcmd.Factory, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
+func newTarStrategy(f factory.Interface, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
 
 	tarHelper := tar.New(s2iutil.NewFileSystem())
 	tarHelper.SetExclusionPattern(nil)

--- a/pkg/cmd/cli/cmd/rsync/execremote.go
+++ b/pkg/cmd/cli/cmd/rsync/execremote.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	restclient "k8s.io/client-go/rest"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 // remoteExecutor will execute commands on a given pod/container by using the kube Exec command
@@ -54,7 +53,7 @@ func (e *remoteExecutor) Execute(command []string, in io.Reader, out, errOut io.
 	return err
 }
 
-func newRemoteExecutor(f *clientcmd.Factory, o *RsyncOptions) (executor, error) {
+func newRemoteExecutor(f factory.Interface, o *RsyncOptions) (executor, error) {
 	config, err := f.ClientConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/cli/cmd/rsync/forwarder.go
+++ b/pkg/cmd/cli/cmd/rsync/forwarder.go
@@ -3,12 +3,12 @@ package rsync
 import (
 	"io"
 
+	"github.com/openshift/origin/pkg/cmd/util/factory"
+
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 // portForwarder starts port forwarding to a given pod
@@ -54,7 +54,7 @@ func (f *portForwarder) ForwardPorts(ports []string, stopChan <-chan struct{}) e
 }
 
 // newPortForwarder creates a new forwarder for use with rsync
-func newPortForwarder(f *clientcmd.Factory, o *RsyncOptions) (forwarder, error) {
+func newPortForwarder(f factory.Interface, o *RsyncOptions) (forwarder, error) {
 	client, err := f.ClientSet()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/cli/cmd/rsync/rsync.go
+++ b/pkg/cmd/cli/cmd/rsync/rsync.go
@@ -13,7 +13,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/util/fsnotification"
 )
 
@@ -90,7 +90,7 @@ type RsyncOptions struct {
 }
 
 // NewCmdRsync creates a new sync command
-func NewCmdRsync(name, parent string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdRsync(name, parent string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	o := RsyncOptions{
 		Out:    out,
 		ErrOut: errOut,
@@ -132,7 +132,7 @@ func warnNoRsync(out io.Writer) {
 	fmt.Fprintf(out, noRsyncUnixWarning)
 }
 
-func (o *RsyncOptions) determineStrategy(f *clientcmd.Factory, cmd *cobra.Command, name string) (copyStrategy, error) {
+func (o *RsyncOptions) determineStrategy(f factory.Interface, cmd *cobra.Command, name string) (copyStrategy, error) {
 	switch name {
 	case "":
 		// Default case, use an rsync strategy first and then fallback to Tar
@@ -175,7 +175,7 @@ func (o *RsyncOptions) determineStrategy(f *clientcmd.Factory, cmd *cobra.Comman
 }
 
 // Complete verifies command line arguments and loads data from the command environment
-func (o *RsyncOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *RsyncOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	switch n := len(args); {
 	case n == 0:
 		cmd.Help()

--- a/pkg/cmd/cli/cmd/set/buildhook.go
+++ b/pkg/cmd/cli/cmd/set/buildhook.go
@@ -16,7 +16,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -81,7 +81,7 @@ type BuildHookOptions struct {
 }
 
 // NewCmdBuildHook implements the set build-hook command
-func NewCmdBuildHook(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdBuildHook(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &BuildHookOptions{
 		Out: out,
 		Err: errOut,
@@ -121,7 +121,7 @@ func NewCmdBuildHook(fullName string, f *clientcmd.Factory, out, errOut io.Write
 	return cmd
 }
 
-func (o *BuildHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *BuildHookOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	resources := args
 	if i := cmd.ArgsLenAtDash(); i != -1 {
 		resources = args[:i]

--- a/pkg/cmd/cli/cmd/set/buildsecret.go
+++ b/pkg/cmd/cli/cmd/set/buildsecret.go
@@ -17,7 +17,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -79,7 +79,7 @@ type BuildSecretOptions struct {
 }
 
 // NewCmdBuildSecret implements the set build-secret command
-func NewCmdBuildSecret(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdBuildSecret(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &BuildSecretOptions{
 		Out: out,
 		Err: errOut,
@@ -121,7 +121,7 @@ func NewCmdBuildSecret(fullName string, f *clientcmd.Factory, out, errOut io.Wri
 
 var supportedBuildTypes = []string{"buildconfigs"}
 
-func (o *BuildSecretOptions) secretFromArg(f *clientcmd.Factory, mapper meta.RESTMapper, typer runtime.ObjectTyper, namespace, arg string) (string, error) {
+func (o *BuildSecretOptions) secretFromArg(f factory.Interface, mapper meta.RESTMapper, typer runtime.ObjectTyper, namespace, arg string) (string, error) {
 	builder := resource.NewBuilder(mapper, typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
 		NamespaceParam(namespace).DefaultNamespace().
 		RequireObject(false).
@@ -146,7 +146,7 @@ func (o *BuildSecretOptions) secretFromArg(f *clientcmd.Factory, mapper meta.RES
 	return secretName, nil
 }
 
-func (o *BuildSecretOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *BuildSecretOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	var secretArg string
 	if !o.Remove {
 		if len(args) < 1 {

--- a/pkg/cmd/cli/cmd/set/deploymenthook.go
+++ b/pkg/cmd/cli/cmd/set/deploymenthook.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 )
 
@@ -92,7 +92,7 @@ type DeploymentHookOptions struct {
 }
 
 // NewCmdDeploymentHook implements the set deployment-hook command
-func NewCmdDeploymentHook(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdDeploymentHook(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &DeploymentHookOptions{
 		Out: out,
 		Err: errOut,
@@ -139,7 +139,7 @@ func NewCmdDeploymentHook(fullName string, f *clientcmd.Factory, out, errOut io.
 	return cmd
 }
 
-func (o *DeploymentHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *DeploymentHookOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	resources := args
 	if i := cmd.ArgsLenAtDash(); i != -1 {
 		resources = args[:i]

--- a/pkg/cmd/cli/cmd/set/env.go
+++ b/pkg/cmd/cli/cmd/set/env.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	envutil "github.com/openshift/origin/pkg/util/env"
 )
 
@@ -110,7 +110,7 @@ type EnvOptions struct {
 }
 
 // NewCmdEnv implements the OpenShift cli env command
-func NewCmdEnv(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdEnv(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	options := &EnvOptions{
 		Out: out,
 		Err: errout,
@@ -166,7 +166,7 @@ func keyToEnvName(key string) string {
 	return strings.ToUpper(validEnvNameRegexp.ReplaceAllString(key, "_"))
 }
 
-func (o *EnvOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *EnvOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	resources, envArgs, ok := cmdutil.SplitEnvironmentFromResources(args)
 	if !ok {
 		return kcmdutil.UsageError(o.Cmd, "all resources must be specified before environment changes: %s", strings.Join(args, " "))
@@ -201,7 +201,7 @@ func (o *EnvOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 
 // RunEnv contains all the necessary functionality for the OpenShift cli env command
 // TODO: refactor to share the common "patch resource" pattern of probe
-func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
+func (o *EnvOptions) RunEnv(f factory.Interface) error {
 	clientConfig, err := f.ClientConfig()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/set/imagelookup.go
+++ b/pkg/cmd/cli/cmd/set/imagelookup.go
@@ -18,7 +18,7 @@ import (
 
 	ometa "github.com/openshift/origin/pkg/api/meta"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
@@ -106,7 +106,7 @@ type ImageLookupOptions struct {
 }
 
 // NewCmdImageLookup implements the set image-lookup command
-func NewCmdImageLookup(fullName, parentName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdImageLookup(fullName, parentName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &ImageLookupOptions{
 		Out:     out,
 		Err:     errOut,
@@ -140,7 +140,7 @@ func NewCmdImageLookup(fullName, parentName string, f *clientcmd.Factory, out, e
 }
 
 // Complete takes command line information to fill out ImageLookupOptions or returns an error.
-func (o *ImageLookupOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *ImageLookupOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	cmdNamespace, explicit, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/set/probe.go
+++ b/pkg/cmd/cli/cmd/set/probe.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -114,7 +114,7 @@ type ProbeOptions struct {
 }
 
 // NewCmdProbe implements the set probe command
-func NewCmdProbe(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdProbe(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &ProbeOptions{
 		Out: out,
 		Err: errOut,
@@ -164,7 +164,7 @@ func NewCmdProbe(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *
 	return cmd
 }
 
-func (o *ProbeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *ProbeOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	resources := args
 	if i := cmd.ArgsLenAtDash(); i != -1 {
 		resources = args[:i]

--- a/pkg/cmd/cli/cmd/set/routebackends.go
+++ b/pkg/cmd/cli/cmd/set/routebackends.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 )
 
@@ -99,7 +99,7 @@ type BackendsOptions struct {
 }
 
 // NewCmdRouteBackends implements the set route-backends command
-func NewCmdRouteBackends(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdRouteBackends(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &BackendsOptions{
 		Out: out,
 		Err: errOut,
@@ -138,7 +138,7 @@ func NewCmdRouteBackends(fullName string, f *clientcmd.Factory, out, errOut io.W
 }
 
 // Complete takes command line information to fill out BackendOptions or returns an error.
-func (o *BackendsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *BackendsOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	cmdNamespace, explicit, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/set/set.go
+++ b/pkg/cmd/cli/cmd/set/set.go
@@ -9,7 +9,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 var (
@@ -20,7 +20,7 @@ var (
 )
 
 // NewCmdSet exposes commands for modifying objects.
-func NewCmdSet(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdSet(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	set := &cobra.Command{
 		Use:   "set COMMAND",
 		Short: "Commands that help set specific features on objects",
@@ -87,7 +87,7 @@ Update existing container image(s) of resources.`)
 )
 
 // NewCmdImage is a wrapper for the Kubernetes CLI set image command
-func NewCmdImage(fullName string, f *clientcmd.Factory, out, err io.Writer) *cobra.Command {
+func NewCmdImage(fullName string, f factory.Interface, out, err io.Writer) *cobra.Command {
 	cmd := set.NewCmdImage(f, out, err)
 	cmd.Long = setImageLong
 	cmd.Example = fmt.Sprintf(setImageExample, fullName)
@@ -127,7 +127,7 @@ Possible resources include (case insensitive):
 )
 
 // NewCmdResources is a wrapper for the Kubernetes CLI set resources command
-func NewCmdResources(fullName string, f *clientcmd.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
+func NewCmdResources(fullName string, f factory.Interface, out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd := set.NewCmdResources(f, out, errOut)
 	cmd.Long = setResourcesLong
 	cmd.Example = fmt.Sprintf(setResourcesExample, fullName)

--- a/pkg/cmd/cli/cmd/set/triggers.go
+++ b/pkg/cmd/cli/cmd/set/triggers.go
@@ -28,7 +28,7 @@ import (
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	"github.com/openshift/origin/pkg/generate/app"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -124,7 +124,7 @@ type TriggersOptions struct {
 }
 
 // NewCmdTriggers implements the set triggers command
-func NewCmdTriggers(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdTriggers(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	options := &TriggersOptions{
 		Out: out,
 		Err: errOut,
@@ -173,7 +173,7 @@ func NewCmdTriggers(fullName string, f *clientcmd.Factory, out, errOut io.Writer
 	return cmd
 }
 
-func (o *TriggersOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *TriggersOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	cmdNamespace, explicit, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/set/volume.go
+++ b/pkg/cmd/cli/cmd/set/volume.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const (
@@ -150,7 +150,7 @@ type AddVolumeOptions struct {
 	TypeChanged bool
 }
 
-func NewCmdVolume(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdVolume(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	addOpts := &AddVolumeOptions{}
 	opts := &VolumeOptions{AddOpts: addOpts}
 	cmd := &cobra.Command{
@@ -362,7 +362,7 @@ func (a *AddVolumeOptions) Validate(isAddOp bool) error {
 	return nil
 }
 
-func (v *VolumeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out, errOut io.Writer) error {
+func (v *VolumeOptions) Complete(f factory.Interface, cmd *cobra.Command, out, errOut io.Writer) error {
 	_, kc, err := f.Clients()
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -38,7 +38,7 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/generate/git"
 	oerrors "github.com/openshift/origin/pkg/util/errors"
 )
@@ -84,7 +84,7 @@ var (
 )
 
 // NewCmdStartBuild implements the OpenShift cli start-build command
-func NewCmdStartBuild(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdStartBuild(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	o := &StartBuildOptions{}
 
 	cmd := &cobra.Command{
@@ -159,7 +159,7 @@ type StartBuildOptions struct {
 	Namespace   string
 }
 
-func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, errout io.Writer, cmd *cobra.Command, cmdFullName string, args []string) error {
+func (o *StartBuildOptions) Complete(f factory.Interface, in io.Reader, out, errout io.Writer, cmd *cobra.Command, cmdFullName string, args []string) error {
 	o.In = in
 	o.Out = out
 	o.ErrOut = errout

--- a/pkg/cmd/cli/cmd/status.go
+++ b/pkg/cmd/cli/cmd/status.go
@@ -14,7 +14,7 @@ import (
 	loginutil "github.com/openshift/origin/pkg/cmd/cli/cmd/login/util"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	dotutil "github.com/openshift/origin/pkg/util/dot"
 )
 
@@ -61,7 +61,7 @@ type StatusOptions struct {
 
 // NewCmdStatus implements the OpenShift cli status command.
 // baseCLIName is the path from root cmd to the parent of this cmd.
-func NewCmdStatus(name, baseCLIName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdStatus(name, baseCLIName, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &StatusOptions{}
 
 	cmd := &cobra.Command{
@@ -90,7 +90,7 @@ func NewCmdStatus(name, baseCLIName, fullName string, f *clientcmd.Factory, out 
 }
 
 // Complete completes the options for the Openshift cli status command.
-func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, baseCLIName string, args []string, out io.Writer) error {
+func (o *StatusOptions) Complete(f factory.Interface, cmd *cobra.Command, baseCLIName string, args []string, out io.Writer) error {
 	if len(args) > 0 {
 		return kcmdutil.UsageError(cmd, "no arguments should be provided")
 	}

--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
@@ -81,7 +81,7 @@ const (
 )
 
 // NewCmdTag implements the OpenShift cli tag command.
-func NewCmdTag(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdTag(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	opts := &TagOptions{}
 
 	cmd := &cobra.Command{
@@ -130,7 +130,7 @@ func parseStreamName(defaultNamespace, name string) (string, string, error) {
 	return namespace, streamName, nil
 }
 
-func determineSourceKind(f *clientcmd.Factory, input string) string {
+func determineSourceKind(f factory.Interface, input string) string {
 	mapper, _ := f.Object()
 	gvks, err := mapper.KindsFor(schema.GroupVersionResource{Group: imageapi.GroupName, Resource: input})
 	if err == nil {
@@ -147,7 +147,7 @@ func determineSourceKind(f *clientcmd.Factory, input string) string {
 }
 
 // Complete completes all the required options for the tag command.
-func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *TagOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) < 2 && (len(args) < 1 && !o.deleteTag) {
 		return kcmdutil.UsageError(cmd, "you must specify a source and at least one destination or one or more tags to delete")
 	}

--- a/pkg/cmd/cli/cmd/types.go
+++ b/pkg/cmd/cli/cmd/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -222,7 +222,7 @@ var (
 	  %[1]s describe is ruby-centos7`)
 )
 
-func NewCmdTypes(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdTypes(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	buf := &bytes.Buffer{}
 	for _, c := range concepts {
 		writeConcept(buf, c)

--- a/pkg/cmd/cli/cmd/version/version.go
+++ b/pkg/cmd/cli/cmd/version/version.go
@@ -1,4 +1,4 @@
-package cmd
+package version
 
 import (
 	"encoding/json"

--- a/pkg/cmd/cli/cmd/version/version.go
+++ b/pkg/cmd/cli/cmd/version/version.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 	"github.com/openshift/origin/pkg/version"
 
@@ -44,7 +45,7 @@ type VersionOptions struct {
 }
 
 // NewCmdVersion creates a command for displaying the version of this binary
-func NewCmdVersion(fullName string, f *clientcmd.Factory, out io.Writer, options VersionOptions) *cobra.Command {
+func NewCmdVersion(fullName string, f factory.Interface, out io.Writer, options VersionOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display client and server versions",
@@ -65,7 +66,7 @@ func NewCmdVersion(fullName string, f *clientcmd.Factory, out io.Writer, options
 	return cmd
 }
 
-func (o *VersionOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, out io.Writer) error {
+func (o *VersionOptions) Complete(cmd *cobra.Command, f factory.Interface, out io.Writer) error {
 	o.Out = out
 
 	if f == nil {

--- a/pkg/cmd/cli/cmd/whoami.go
+++ b/pkg/cmd/cli/cmd/whoami.go
@@ -11,7 +11,7 @@ import (
 
 	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 )
 
@@ -30,7 +30,7 @@ type WhoAmIOptions struct {
 	Out io.Writer
 }
 
-func NewCmdWhoAmI(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdWhoAmI(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &WhoAmIOptions{}
 
 	cmd := &cobra.Command{
@@ -59,7 +59,7 @@ func (o WhoAmIOptions) WhoAmI() (*userapi.User, error) {
 	return me, err
 }
 
-func RunWhoAmI(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string, o *WhoAmIOptions) error {
+func RunWhoAmI(f factory.Interface, out io.Writer, cmd *cobra.Command, args []string, o *WhoAmIOptions) error {
 	if kcmdutil.GetFlagBool(cmd, "show-token") {
 		cfg, err := f.OpenShiftClientConfig().ClientConfig()
 		if err != nil {

--- a/pkg/cmd/cli/cmd/wrappers.go
+++ b/pkg/cmd/cli/cmd/wrappers.go
@@ -18,7 +18,7 @@ import (
 	cmdconfig "github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 func adjustCmdExamples(cmd *cobra.Command, parentName string, name string) {
@@ -62,7 +62,7 @@ var (
 )
 
 // NewCmdGet is a wrapper for the Kubernetes cli get command
-func NewCmdGet(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdGet(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdGet(f, out, errOut)
 	cmd.Long = fmt.Sprintf(getLong, fullName)
 	cmd.Example = fmt.Sprintf(getExample, fullName)
@@ -88,7 +88,7 @@ var (
 )
 
 // NewCmdReplace is a wrapper for the Kubernetes cli replace command
-func NewCmdReplace(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdReplace(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdReplace(f, out)
 	cmd.Long = replaceLong
 	cmd.Example = fmt.Sprintf(replaceExample, fullName)
@@ -107,7 +107,7 @@ var (
 )
 
 // NewCmdPatch is a wrapper for the Kubernetes cli patch command
-func NewCmdPatch(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdPatch(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdPatch(f, out)
 	cmd.Long = patchLong
 	cmd.Example = fmt.Sprintf(patchExample, fullName)
@@ -150,7 +150,7 @@ var (
 )
 
 // NewCmdDelete is a wrapper for the Kubernetes cli delete command
-func NewCmdDelete(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdDelete(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdDelete(f, out, errOut)
 	cmd.Long = deleteLong
 	cmd.Short = "Delete one or more resources"
@@ -174,7 +174,7 @@ var (
 )
 
 // NewCmdCreate is a wrapper for the Kubernetes cli create command
-func NewCmdCreate(parentName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdCreate(parentName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdCreate(f, out, errOut)
 	cmd.Long = createLong
 	cmd.Example = fmt.Sprintf(createExample, parentName)
@@ -224,7 +224,7 @@ var (
 	  * zsh completions are only supported in versions of zsh >= 5.2`)
 )
 
-func NewCmdCompletion(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCompletion(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmdHelpName := fullName
 
 	if strings.HasSuffix(fullName, "completion") {
@@ -249,7 +249,7 @@ var (
 )
 
 // NewCmdExec is a wrapper for the Kubernetes cli exec command
-func NewCmdExec(fullName string, f *clientcmd.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
+func NewCmdExec(fullName string, f factory.Interface, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdExec(f, cmdIn, cmdOut, cmdErr)
 	cmd.Use = "exec [options] POD [-c CONTAINER] -- COMMAND [args...]"
 	cmd.Long = execLong
@@ -276,7 +276,7 @@ var (
 )
 
 // NewCmdPortForward is a wrapper for the Kubernetes cli port-forward command
-func NewCmdPortForward(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdPortForward(fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdPortForward(f, out, errout)
 	cmd.Long = portForwardLong
 	cmd.Example = fmt.Sprintf(portForwardExample, fullName)
@@ -300,7 +300,7 @@ var (
 )
 
 // NewCmdDescribe is a wrapper for the Kubernetes cli describe command
-func NewCmdDescribe(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdDescribe(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdDescribe(f, out, errOut)
 	cmd.Long = describeLong
 	cmd.Example = fmt.Sprintf(describeExample, fullName)
@@ -325,7 +325,7 @@ var (
 )
 
 // NewCmdProxy is a wrapper for the Kubernetes cli proxy command
-func NewCmdProxy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdProxy(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdProxy(f, out)
 	cmd.Long = proxyLong
 	cmd.Example = fmt.Sprintf(proxyExample, fullName)
@@ -360,7 +360,7 @@ var (
 )
 
 // NewCmdScale is a wrapper for the Kubernetes cli scale command
-func NewCmdScale(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdScale(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdScale(f, out)
 	cmd.ValidArgs = append(cmd.ValidArgs, "deploymentconfig")
 	cmd.Short = "Change the number of pods in a deployment"
@@ -388,7 +388,7 @@ var (
 )
 
 // NewCmdAutoscale is a wrapper for the Kubernetes cli autoscale command
-func NewCmdAutoscale(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAutoscale(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdAutoscale(f, out)
 	cmd.Short = "Autoscale a deployment config, deployment, replication controller, or replica set"
 	cmd.Long = autoScaleLong
@@ -444,7 +444,7 @@ var (
 )
 
 // NewCmdRun is a wrapper for the Kubernetes cli run command
-func NewCmdRun(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdRun(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	opts := &kcmd.RunOptions{DefaultRestartAlwaysGenerator: "deploymentconfig/v1", DefaultGenerator: kcmdutil.RunPodV1GeneratorName}
 	cmd := kcmd.NewCmdRunWithOptions(f, opts, in, out, errout)
 	cmd.Long = runLong
@@ -477,7 +477,7 @@ var (
 )
 
 // NewCmdAttach is a wrapper for the Kubernetes cli attach command
-func NewCmdAttach(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdAttach(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdAttach(f, in, out, errout)
 	cmd.Long = attachLong
 	cmd.Example = fmt.Sprintf(attachExample, fullName)
@@ -519,7 +519,7 @@ var (
 )
 
 // NewCmdAnnotate is a wrapper for the Kubernetes cli annotate command
-func NewCmdAnnotate(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdAnnotate(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdAnnotate(f, out)
 	cmd.Long = fmt.Sprintf(annotateLong, fullName)
 	cmd.Example = fmt.Sprintf(annotateExample, fullName)
@@ -555,7 +555,7 @@ var (
 )
 
 // NewCmdLabel is a wrapper for the Kubernetes cli label command
-func NewCmdLabel(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdLabel(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdLabel(f, out)
 	cmd.Long = fmt.Sprintf(labelLong, kvalidation.LabelValueMaxLength)
 	cmd.Example = fmt.Sprintf(labelExample, fullName)
@@ -577,7 +577,7 @@ var (
 )
 
 // NewCmdApply is a wrapper for the Kubernetes cli apply command
-func NewCmdApply(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdApply(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdApply(f, out, errOut)
 	cmd.Long = applyLong
 	cmd.Example = fmt.Sprintf(applyExample, fullName)
@@ -602,7 +602,7 @@ var (
 )
 
 // NewCmdExplain is a wrapper for the Kubernetes cli explain command
-func NewCmdExplain(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdExplain(fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdExplain(f, out, errOut)
 	cmd.Long = explainLong
 	cmd.Example = fmt.Sprintf(explainExample, fullName)
@@ -634,7 +634,7 @@ var (
 )
 
 // NewCmdConvert is a wrapper for the Kubernetes cli convert command
-func NewCmdConvert(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdConvert(fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdConvert(f, out)
 	cmd.Long = convertLong
 	cmd.Example = fmt.Sprintf(convertExample, fullName)
@@ -678,7 +678,7 @@ var (
 )
 
 // NewCmdEdit is a wrapper for the Kubernetes cli edit command
-func NewCmdEdit(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdEdit(fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdEdit(f, out, errout)
 	cmd.Long = editLong
 	cmd.Example = fmt.Sprintf(editExample, fullName)
@@ -747,13 +747,13 @@ var (
 )
 
 // NewCmdCp is a wrapper for the Kubernetes cli cp command
-func NewCmdCp(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdCp(fullName string, f factory.Interface, in io.Reader, out, errout io.Writer) *cobra.Command {
 	cmd := kcmd.NewCmdCp(f, in, out, errout)
 	cmd.Example = fmt.Sprintf(cpExample, fullName)
 	return cmd
 }
 
-func NewCmdAuth(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdAuth(fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	cmd := kcmdauth.NewCmdAuth(f, out, errout)
 	return cmd
 }

--- a/pkg/cmd/cli/policy/policy.go
+++ b/pkg/cmd/cli/policy/policy.go
@@ -7,12 +7,12 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	adminpolicy "github.com/openshift/origin/pkg/cmd/admin/policy"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PolicyRecommendedName = "policy"
 
-func NewCmdPolicy(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdPolicy(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   name,

--- a/pkg/cmd/cli/sa/create_kubeconfig.go
+++ b/pkg/cmd/cli/sa/create_kubeconfig.go
@@ -16,7 +16,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/serviceaccounts"
 )
 
@@ -56,7 +56,7 @@ type CreateKubeconfigOptions struct {
 	Err io.Writer
 }
 
-func NewCommandCreateKubeconfig(name, fullname string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCommandCreateKubeconfig(name, fullname string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &CreateKubeconfigOptions{
 		Out: out,
 		Err: os.Stderr,
@@ -77,7 +77,7 @@ func NewCommandCreateKubeconfig(name, fullname string, f *clientcmd.Factory, out
 	return cmd
 }
 
-func (o *CreateKubeconfigOptions) Complete(args []string, f *clientcmd.Factory, cmd *cobra.Command) error {
+func (o *CreateKubeconfigOptions) Complete(args []string, f factory.Interface, cmd *cobra.Command) error {
 	if len(args) != 1 {
 		return cmdutil.UsageError(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
 	}

--- a/pkg/cmd/cli/sa/gettoken.go
+++ b/pkg/cmd/cli/sa/gettoken.go
@@ -14,7 +14,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/term"
 	"github.com/openshift/origin/pkg/serviceaccounts"
 )
@@ -51,7 +51,7 @@ type GetServiceAccountTokenOptions struct {
 	Err io.Writer
 }
 
-func NewCommandGetServiceAccountToken(name, fullname string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCommandGetServiceAccountToken(name, fullname string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &GetServiceAccountTokenOptions{
 		Out: out,
 		Err: os.Stderr,
@@ -72,7 +72,7 @@ func NewCommandGetServiceAccountToken(name, fullname string, f *clientcmd.Factor
 	return getServiceAccountTokenCommand
 }
 
-func (o *GetServiceAccountTokenOptions) Complete(args []string, f *clientcmd.Factory, cmd *cobra.Command) error {
+func (o *GetServiceAccountTokenOptions) Complete(args []string, f factory.Interface, cmd *cobra.Command) error {
 	if len(args) != 1 {
 		return cmdutil.UsageError(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
 	}

--- a/pkg/cmd/cli/sa/newtoken.go
+++ b/pkg/cmd/cli/sa/newtoken.go
@@ -19,7 +19,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/term"
 	"github.com/openshift/origin/pkg/serviceaccounts"
 	osautil "github.com/openshift/origin/pkg/serviceaccounts/util"
@@ -65,7 +65,7 @@ type NewServiceAccountTokenOptions struct {
 	Err io.Writer
 }
 
-func NewCommandNewServiceAccountToken(name, fullname string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCommandNewServiceAccountToken(name, fullname string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &NewServiceAccountTokenOptions{
 		Out:    out,
 		Err:    os.Stderr,
@@ -90,7 +90,7 @@ func NewCommandNewServiceAccountToken(name, fullname string, f *clientcmd.Factor
 	return newServiceAccountTokenCommand
 }
 
-func (o *NewServiceAccountTokenOptions) Complete(args []string, requestedLabels string, f *clientcmd.Factory, cmd *cobra.Command) error {
+func (o *NewServiceAccountTokenOptions) Complete(args []string, requestedLabels string, f factory.Interface, cmd *cobra.Command) error {
 	if len(args) != 1 {
 		return cmdutil.UsageError(cmd, fmt.Sprintf("expected one service account name as an argument, got %q", args))
 	}

--- a/pkg/cmd/cli/sa/subcommand.go
+++ b/pkg/cmd/cli/sa/subcommand.go
@@ -7,7 +7,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const ServiceAccountsRecommendedName = "serviceaccounts"
@@ -20,7 +20,7 @@ const (
 	serviceAccountsShort = `Manage service accounts in your project`
 )
 
-func NewCmdServiceAccounts(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
+func NewCmdServiceAccounts(name, fullName string, f factory.Interface, out, errOut io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:     name,
 		Short:   serviceAccountsShort,

--- a/pkg/cmd/cli/secrets/new.go
+++ b/pkg/cmd/cli/secrets/new.go
@@ -16,7 +16,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +71,7 @@ type CreateSecretOptions struct {
 	AllowUnknownTypes bool
 }
 
-func NewCmdCreateSecret(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdCreateSecret(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := NewCreateSecretOptions()
 	options.Out = out
 
@@ -118,7 +118,7 @@ func NewCreateSecretOptions() *CreateSecretOptions {
 	}
 }
 
-func (o *CreateSecretOptions) Complete(args []string, f *clientcmd.Factory) error {
+func (o *CreateSecretOptions) Complete(args []string, f factory.Interface) error {
 	// Fill name from args[0]
 	if len(args) > 0 {
 		o.Name = args[0]

--- a/pkg/cmd/cli/secrets/subcommand.go
+++ b/pkg/cmd/cli/secrets/subcommand.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/openshift/origin/pkg/build/builder/cmd/scmauth"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const SecretsRecommendedName = "secrets"
@@ -35,7 +35,7 @@ var (
     Docker registries.`)
 )
 
-func NewCmdSecrets(name, fullName string, f *clientcmd.Factory, reader io.Reader, out, errOut io.Writer, ocEditFullName string) *cobra.Command {
+func NewCmdSecrets(name, fullName string, f factory.Interface, reader io.Reader, out, errOut io.Writer, ocEditFullName string) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:     name,

--- a/pkg/cmd/experimental/buildchain/buildchain.go
+++ b/pkg/cmd/experimental/buildchain/buildchain.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	osutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagegraph "github.com/openshift/origin/pkg/image/graph/nodes"
 )
@@ -60,7 +60,7 @@ type BuildChainOptions struct {
 }
 
 // NewCmdBuildChain implements the OpenShift experimental build-chain command
-func NewCmdBuildChain(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdBuildChain(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	options := &BuildChainOptions{
 		namespaces: sets.NewString(),
 	}
@@ -84,7 +84,7 @@ func NewCmdBuildChain(name, fullName string, f *clientcmd.Factory, out io.Writer
 }
 
 // Complete completes the required options for build-chain
-func (o *BuildChainOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *BuildChainOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string, out io.Writer) error {
 	if len(args) != 1 {
 		return cmdutil.UsageError(cmd, "Must pass an image stream tag. If only an image stream name is specified, 'latest' will be used for the tag.")
 	}

--- a/pkg/cmd/experimental/config/config.go
+++ b/pkg/cmd/experimental/config/config.go
@@ -7,14 +7,14 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const ConfigRecommendedName = "config"
 
 var configLong = templates.LongDesc(`Manage cluster configuration files like master-config.yaml.`)
 
-func NewCmdConfig(name, fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
+func NewCmdConfig(name, fullName string, f factory.Interface, out, errout io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   name,
 		Short: "Manage config",

--- a/pkg/cmd/experimental/config/patch.go
+++ b/pkg/cmd/experimental/config/patch.go
@@ -22,7 +22,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	configapiinstall "github.com/openshift/origin/pkg/cmd/server/api/install"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const PatchRecommendedName = "patch"
@@ -49,7 +49,7 @@ var (
 		%[1]s openshift.local.config/master/master-config.yaml --patch='{"auditConfig": {"enabled": true}}'`)
 )
 
-func NewCmdPatch(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdPatch(name, fullName string, f factory.Interface, out io.Writer) *cobra.Command {
 	o := &PatchOptions{Out: out}
 
 	cmd := &cobra.Command{
@@ -70,7 +70,7 @@ func NewCmdPatch(name, fullName string, f *clientcmd.Factory, out io.Writer) *co
 	return cmd
 }
 
-func (o *PatchOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
+func (o *PatchOptions) Complete(f factory.Interface, cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("exactly one FILENAME is allowed: %v", args)
 	}

--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/templates"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	configcmd "github.com/openshift/origin/pkg/config/cmd"
 	"github.com/openshift/origin/pkg/ipfailover"
@@ -60,7 +61,7 @@ var (
 	  %[1]s %[2]s ipf-alt --selector="hagroup=us-west-ha" --virtual-ips="1.2.3.4" -o yaml --images=myrepo/myipfailover:mytag`)
 )
 
-func NewCmdIPFailoverConfig(f *clientcmd.Factory, parentName, name string, out, errout io.Writer) *cobra.Command {
+func NewCmdIPFailoverConfig(f factory.Interface, parentName, name string, out, errout io.Writer) *cobra.Command {
 	options := &ipfailover.IPFailoverConfigCmdOptions{
 		Action: configcmd.BulkAction{
 			Out:    out,
@@ -133,7 +134,7 @@ func getConfigurationName(args []string) (string, error) {
 }
 
 //  Get the configurator based on the ipfailover type.
-func getPlugin(name string, f *clientcmd.Factory, options *ipfailover.IPFailoverConfigCmdOptions) (ipfailover.IPFailoverConfiguratorPlugin, error) {
+func getPlugin(name string, f factory.Interface, options *ipfailover.IPFailoverConfigCmdOptions) (ipfailover.IPFailoverConfiguratorPlugin, error) {
 	if options.Type == ipfailover.DefaultType {
 		plugin, err := keepalived.NewIPFailoverConfiguratorPlugin(name, f, options)
 		if err != nil {
@@ -147,7 +148,7 @@ func getPlugin(name string, f *clientcmd.Factory, options *ipfailover.IPFailover
 }
 
 // Run runs the ipfailover command.
-func Run(f *clientcmd.Factory, options *ipfailover.IPFailoverConfigCmdOptions, cmd *cobra.Command, args []string) error {
+func Run(f factory.Interface, options *ipfailover.IPFailoverConfigCmdOptions, cmd *cobra.Command, args []string) error {
 	name, err := getConfigurationName(args)
 	if err != nil {
 		return err

--- a/pkg/cmd/infra/builder/builder.go
+++ b/pkg/cmd/infra/builder/builder.go
@@ -8,7 +8,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/build/builder/cmd"
-	ocmd "github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/templates"
 )
 
@@ -38,7 +38,7 @@ func NewCommandS2IBuilder(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(version.NewCmdVersion(name, nil, os.Stdout, version.VersionOptions{}))
 	return cmd
 }
 
@@ -53,6 +53,6 @@ func NewCommandDockerBuilder(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(version.NewCmdVersion(name, nil, os.Stdout, version.VersionOptions{}))
 	return cmd
 }

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -18,7 +18,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/client"
-	ocmd "github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
@@ -81,7 +81,7 @@ func NewCommandDeployer(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(version.NewCmdVersion(name, nil, os.Stdout, version.VersionOptions{}))
 
 	flag := cmd.Flags()
 	flag.StringVar(&cfg.rcName, "deployment", util.Env("OPENSHIFT_DEPLOYMENT_NAME", ""), "The deployment name to start")

--- a/pkg/cmd/infra/gitserver/gitserver.go
+++ b/pkg/cmd/infra/gitserver/gitserver.go
@@ -34,10 +34,8 @@ var (
 )
 
 // CommandFor returns gitrepo-buildconfigs command or gitserver command
-func CommandFor(basename string) *cobra.Command {
+func CommandFor(basename string, in io.Reader, out, errout io.Writer) *cobra.Command {
 	var cmd *cobra.Command
-
-	out := os.Stdout
 
 	setLogLevel()
 

--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -11,7 +11,7 @@ import (
 
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
-	ocmd "github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -152,7 +152,7 @@ func NewCommandF5Router(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(version.NewCmdVersion(name, nil, os.Stdout, version.VersionOptions{}))
 
 	flag := cmd.Flags()
 	options.Config.Bind(flag)

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
-	ocmd "github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/templates"
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
@@ -31,7 +31,7 @@ import (
 	"github.com/openshift/origin/pkg/router/metrics/haproxy"
 	templateplugin "github.com/openshift/origin/pkg/router/template"
 	"github.com/openshift/origin/pkg/util/proc"
-	"github.com/openshift/origin/pkg/version"
+	oversion "github.com/openshift/origin/pkg/version"
 )
 
 // defaultReloadInterval is how often to do reloads in seconds.
@@ -152,7 +152,7 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(version.NewCmdVersion(name, nil, os.Stdout, version.VersionOptions{}))
 
 	flag := cmd.Flags()
 	options.Config.Bind(flag)
@@ -243,7 +243,7 @@ func (o *TemplateRouterOptions) Validate() error {
 
 // Run launches a template router using the provided options. It never exits.
 func (o *TemplateRouterOptions) Run() error {
-	glog.Infof("Starting template router (%s)", version.Get())
+	glog.Infof("Starting template router (%s)", oversion.Get())
 
 	statsPort := o.StatsPort
 	switch {

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/admin/validate"
 	"github.com/openshift/origin/pkg/cmd/cli"
 	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	"github.com/openshift/origin/pkg/cmd/experimental/buildchain"
 	configcmd "github.com/openshift/origin/pkg/cmd/experimental/config"
 	exipfailover "github.com/openshift/origin/pkg/cmd/experimental/ipfailover"
@@ -105,7 +106,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 	root.AddCommand(cli.NewCmdKubectl("kube", out))
 	root.AddCommand(newExperimentalCommand("ex", name+" ex"))
 	root.AddCommand(newCompletionCommand("completion", name+" completion"))
-	root.AddCommand(cmd.NewCmdVersion(name, f, out, cmd.VersionOptions{PrintEtcdVersion: true, IsServer: true}))
+	root.AddCommand(version.NewCmdVersion(name, f, out, version.VersionOptions{PrintEtcdVersion: true, IsServer: true}))
 
 	// infra commands are those that are bundled with the binary but not displayed to end users
 	// directly

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -2,9 +2,8 @@ package openshift
 
 import (
 	"fmt"
+	"io"
 	"os"
-	"runtime"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -20,7 +19,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/experimental/buildchain"
 	configcmd "github.com/openshift/origin/pkg/cmd/experimental/config"
 	exipfailover "github.com/openshift/origin/pkg/cmd/experimental/ipfailover"
-	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/infra/builder"
 	"github.com/openshift/origin/pkg/cmd/infra/deployer"
 	irouter "github.com/openshift/origin/pkg/cmd/infra/router"
@@ -44,16 +42,8 @@ var (
 
 // CommandFor returns the appropriate command for this base name,
 // or the global OpenShift command
-func CommandFor(basename string) *cobra.Command {
+func CommandFor(basename string, in io.Reader, out, errout io.Writer) *cobra.Command {
 	var cmd *cobra.Command
-
-	in, out, errout := os.Stdin, os.Stdout, os.Stderr
-
-	// Make case-insensitive and strip executable suffix if present
-	if runtime.GOOS == "windows" {
-		basename = strings.ToLower(basename)
-		basename = strings.TrimSuffix(basename, ".exe")
-	}
 
 	switch basename {
 	case "openshift-router":
@@ -91,11 +81,6 @@ func CommandFor(basename string) *cobra.Command {
 	default:
 		cmd = NewCommandOpenShift("openshift")
 	}
-
-	if cmd.UsageFunc() == nil {
-		templates.ActsAsRootCommand(cmd, []string{"options"})
-	}
-	flagtypes.GLog(cmd.PersistentFlags())
 
 	return cmd
 }

--- a/pkg/cmd/openshift/openshift_test.go
+++ b/pkg/cmd/openshift/openshift_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 func TestCommandFor(t *testing.T) {
-	cmd := CommandFor("openshift-router")
+	cmd := CommandFor("openshift-router", nil, nil, nil)
 	if !strings.HasPrefix(cmd.Use, "openshift-router ") {
 		t.Errorf("expected command to start with prefix: %#v", cmd)
 	}
 
-	cmd = CommandFor("unknown")
+	cmd = CommandFor("unknown", nil, nil, nil)
 	if cmd.Use != "openshift" {
 		t.Errorf("expected command to be openshift: %#v", cmd)
 	}

--- a/pkg/cmd/server/admin/create_bootstrap_project_template.go
+++ b/pkg/cmd/server/admin/create_bootstrap_project_template.go
@@ -8,7 +8,7 @@ import (
 
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/project/registry/projectrequest/delegated"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
@@ -19,7 +19,7 @@ type CreateBootstrapProjectTemplateOptions struct {
 	Name string
 }
 
-func NewCommandCreateBootstrapProjectTemplate(f *clientcmd.Factory, commandName string, fullName string, out io.Writer) *cobra.Command {
+func NewCommandCreateBootstrapProjectTemplate(f factory.Interface, commandName string, fullName string, out io.Writer) *cobra.Command {
 	options := &CreateBootstrapProjectTemplateOptions{}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/server/admin/create_error_template.go
+++ b/pkg/cmd/server/admin/create_error_template.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/server/errorpage"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const CreateErrorTemplateCommand = "create-error-template"
@@ -32,7 +32,7 @@ var errorLongDescription = templates.LongDesc(`
 
 type CreateErrorTemplateOptions struct{}
 
-func NewCommandCreateErrorTemplate(f *clientcmd.Factory, commandName string, fullName string, out io.Writer) *cobra.Command {
+func NewCommandCreateErrorTemplate(f factory.Interface, commandName string, fullName string, out io.Writer) *cobra.Command {
 	options := &CreateErrorTemplateOptions{}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/server/admin/create_login_template.go
+++ b/pkg/cmd/server/admin/create_login_template.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/server/login"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const CreateLoginTemplateCommand = "create-login-template"
@@ -33,7 +33,7 @@ var longDescription = templates.LongDesc(`
 
 type CreateLoginTemplateOptions struct{}
 
-func NewCommandCreateLoginTemplate(f *clientcmd.Factory, commandName string, fullName string, out io.Writer) *cobra.Command {
+func NewCommandCreateLoginTemplate(f factory.Interface, commandName string, fullName string, out io.Writer) *cobra.Command {
 	options := &CreateLoginTemplateOptions{}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/server/admin/create_provider_selection_template.go
+++ b/pkg/cmd/server/admin/create_provider_selection_template.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/server/selectprovider"
 	"github.com/openshift/origin/pkg/cmd/templates"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 )
 
 const CreateProviderSelectionTemplateCommand = "create-provider-selection-template"
@@ -33,7 +33,7 @@ var providerSelectionLongDescription = templates.LongDesc(`
 
 type CreateProviderSelectionTemplateOptions struct{}
 
-func NewCommandCreateProviderSelectionTemplate(f *clientcmd.Factory, commandName string, fullName string, out io.Writer) *cobra.Command {
+func NewCommandCreateProviderSelectionTemplate(f factory.Interface, commandName string, fullName string, out io.Writer) *cobra.Command {
 	options := &CreateProviderSelectionTemplateOptions{}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/server/start/kubernetes/kubernetes.go
+++ b/pkg/cmd/server/start/kubernetes/kubernetes.go
@@ -11,7 +11,7 @@ import (
 
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 )
 
@@ -36,7 +36,7 @@ func NewCommand(name, fullName string, out, errOut io.Writer) *cobra.Command {
 	cmds.AddCommand(NewProxyCommand("proxy", fullName+" proxy", out))
 	cmds.AddCommand(NewSchedulerCommand("scheduler", fullName+" scheduler", out))
 	if "hyperkube" == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, nil, out, cmd.VersionOptions{}))
+		cmds.AddCommand(version.NewCmdVersion(fullName, nil, out, version.VersionOptions{}))
 	}
 
 	return cmds

--- a/pkg/cmd/util/clientcmd/factory_client_access.go
+++ b/pkg/cmd/util/clientcmd/factory_client_access.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/config"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deploycmd "github.com/openshift/origin/pkg/deploy/cmd"
 	imageutil "github.com/openshift/origin/pkg/image/util"
@@ -44,19 +45,11 @@ import (
 
 type ring0Factory struct {
 	clientConfig            kclientcmd.ClientConfig
-	imageResolutionOptions  FlagBinder
+	imageResolutionOptions  factory.FlagBinder
 	kubeClientAccessFactory kcmdutil.ClientAccessFactory
 }
 
-type ClientAccessFactory interface {
-	kcmdutil.ClientAccessFactory
-
-	Clients() (*client.Client, kclientset.Interface, error)
-	OpenShiftClientConfig() kclientcmd.ClientConfig
-	ImageResolutionOptions() FlagBinder
-}
-
-func NewClientAccessFactory(optionalClientConfig kclientcmd.ClientConfig) ClientAccessFactory {
+func NewClientAccessFactory(optionalClientConfig kclientcmd.ClientConfig) factory.ClientAccess {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 
 	clientConfig := optionalClientConfig
@@ -310,7 +303,7 @@ func (o *imageResolutionOptions) Bind(f *pflag.FlagSet) {
 	o.bound = true
 }
 
-func (f *ring0Factory) ImageResolutionOptions() FlagBinder {
+func (f *ring0Factory) ImageResolutionOptions() factory.FlagBinder {
 	return f.imageResolutionOptions
 }
 

--- a/pkg/cmd/util/clientcmd/factory_object_mapping.go
+++ b/pkg/cmd/util/clientcmd/factory_object_mapping.go
@@ -34,6 +34,7 @@ import (
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deploycmd "github.com/openshift/origin/pkg/deploy/cmd"
 	"github.com/openshift/origin/pkg/security/legacyclient"
@@ -42,11 +43,11 @@ import (
 )
 
 type ring1Factory struct {
-	clientAccessFactory      ClientAccessFactory
+	clientAccessFactory      factory.ClientAccess
 	kubeObjectMappingFactory kcmdutil.ObjectMappingFactory
 }
 
-func NewObjectMappingFactory(clientAccessFactory ClientAccessFactory) kcmdutil.ObjectMappingFactory {
+func NewObjectMappingFactory(clientAccessFactory factory.ClientAccess) kcmdutil.ObjectMappingFactory {
 	return &ring1Factory{
 		clientAccessFactory:      clientAccessFactory,
 		kubeObjectMappingFactory: kcmdutil.NewObjectMappingFactory(clientAccessFactory),

--- a/pkg/cmd/util/factory/interfaces.go
+++ b/pkg/cmd/util/factory/interfaces.go
@@ -1,0 +1,60 @@
+package factory
+
+import (
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kclientcmd "k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/api"
+	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+
+	"github.com/openshift/origin/pkg/client"
+)
+
+// Interface provides common options for OpenShift commands
+type Interface interface {
+	ClientAccess
+	ObjectMapping
+	Builder
+}
+
+// ClientAccess wraps the Kubernetes client access factory with helpers for OpenShift
+// specific needs.
+type ClientAccess interface {
+	kcmdutil.ClientAccessFactory
+
+	Clients() (*client.Client, kclientset.Interface, error)
+	OpenShiftClientConfig() kclientcmd.ClientConfig
+	ImageResolutionOptions() FlagBinder
+}
+
+// FlagBinder represents an interface that allows to bind extra flags into commands.
+type FlagBinder interface {
+	// Bound returns true if the flag is already bound to a command.
+	Bound() bool
+	// Bind allows to bind an extra flag to a command
+	Bind(*pflag.FlagSet)
+}
+
+// ObjectMapping provides extensions to the ObjectMappingFactory
+type ObjectMapping interface {
+	kcmdutil.ObjectMappingFactory
+
+	ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error)
+	UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.EnvVar) error) (bool, error)
+	ExtractFileContents(obj runtime.Object) (map[string][]byte, bool, error)
+}
+
+// Builder provides extensions to the BuilderFactory.
+type Builder interface {
+	kcmdutil.BuilderFactory
+
+	PrintResourceInfos(cmd *cobra.Command, infos []*resource.Info, out io.Writer) error
+	PodForResource(resource string, timeout time.Duration) (string, error)
+}

--- a/pkg/cmd/util/standard/standard.go
+++ b/pkg/cmd/util/standard/standard.go
@@ -1,0 +1,55 @@
+package standard
+
+import (
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/util/logs"
+
+	"github.com/openshift/origin/pkg/cmd/flagtypes"
+	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+)
+
+// InitFunc creates a command for the given basename.
+type InitFunc func(basename string, in io.Reader, out, errout io.Writer) *cobra.Command
+
+// Run takes a function to initialize the given top level command and executes it with the consistent
+// logging, crash behavior, random seed, and base name handling.
+func Run(fn InitFunc) {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	rand.Seed(time.Now().UTC().UnixNano())
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	in, out, errout := os.Stdin, os.Stdout, os.Stderr
+
+	// Make case-insensitive and strip executable suffix if present
+	basename := filepath.Base(os.Args[0])
+	if runtime.GOOS == "windows" {
+		basename = strings.ToLower(basename)
+		basename = strings.TrimSuffix(basename, ".exe")
+	}
+
+	cmd := fn(basename, in, out, errout)
+
+	if cmd.UsageFunc() == nil {
+		templates.ActsAsRootCommand(cmd, []string{"options"})
+	}
+	flagtypes.GLog(cmd.PersistentFlags())
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/diagnostics/client/run_diagnostics_pod.go
+++ b/pkg/diagnostics/client/run_diagnostics_pod.go
@@ -11,7 +11,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/diagnostics/types"
 )
@@ -25,7 +25,7 @@ type DiagnosticPod struct {
 	KubeClient          kclientset.Interface
 	Namespace           string
 	Level               int
-	Factory             *osclientcmd.Factory
+	Factory             factory.Interface
 	PreventModification bool
 	ImageTemplate       variable.ImageTemplate
 }

--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -16,7 +16,7 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/diagnostics/networkpod/util"
 	"github.com/openshift/origin/pkg/diagnostics/types"
 )
@@ -31,7 +31,7 @@ type NetworkDiagnostic struct {
 	OSClient            *osclient.Client
 	ClientFlags         *flag.FlagSet
 	Level               int
-	Factory             *osclientcmd.Factory
+	Factory             factory.Interface
 	PreventModification bool
 	LogDir              string
 	PodImage            string

--- a/pkg/diagnostics/networkpod/util/util.go
+++ b/pkg/diagnostics/networkpod/util/util.go
@@ -12,7 +12,7 @@ import (
 	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
 	"github.com/openshift/origin/pkg/util/netutils"
@@ -186,7 +186,7 @@ func ExpectedConnectionStatus(ns1, ns2 string, vnidMap map[string]uint32) bool {
 }
 
 // Execute() will run a command in a pod and streams the out/err
-func Execute(factory *osclientcmd.Factory, command []string, pod *kapi.Pod, in io.Reader, out, errOut io.Writer) error {
+func Execute(factory factory.Interface, command []string, pod *kapi.Pod, in io.Reader, out, errOut io.Writer) error {
 	config, err := factory.ClientConfig()
 	if err != nil {
 		return err

--- a/pkg/federation/kubefed/kubefed.go
+++ b/pkg/federation/kubefed/kubefed.go
@@ -14,9 +14,9 @@ import (
 	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 
-	"github.com/openshift/origin/pkg/cmd/cli/cmd"
+	"github.com/openshift/origin/pkg/cmd/cli/cmd/version"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/version"
+	oversion "github.com/openshift/origin/pkg/version"
 )
 
 // This file was copied from vendor/k8s.io/kubernetes/federation/pkg/kubefed and
@@ -36,7 +36,7 @@ var (
 
 // NewKubeFedCommand creates the `kubefed` command and its nested children.
 func NewKubeFedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
-	defaultServerImage := fmt.Sprintf("%s:%s", serverImageName, version.Get())
+	defaultServerImage := fmt.Sprintf("%s:%s", serverImageName, oversion.Get())
 
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
@@ -75,7 +75,7 @@ func NewKubeFedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
 	// Use the openshift-specific version command
-	cmds.AddCommand(cmd.NewCmdVersion("kubefed", f, out, cmd.VersionOptions{PrintClientFeatures: true}))
+	cmds.AddCommand(version.NewCmdVersion("kubefed", f, out, version.VersionOptions{PrintClientFeatures: true}))
 
 	cmds.AddCommand(kubectl.NewCmdOptions(out))
 

--- a/pkg/ipfailover/keepalived/plugin.go
+++ b/pkg/ipfailover/keepalived/plugin.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/cmd/util/factory"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	"github.com/openshift/origin/pkg/generate/app"
 	"github.com/openshift/origin/pkg/ipfailover"
@@ -19,12 +19,12 @@ import (
 // KeepalivedPlugin is an IP Failover configurator plugin for keepalived sidecar.
 type KeepalivedPlugin struct {
 	Name    string
-	Factory *clientcmd.Factory
+	Factory factory.Interface
 	Options *ipfailover.IPFailoverConfigCmdOptions
 }
 
 // NewIPFailoverConfiguratorPlugin creates a new IPFailoverConfigurator (keepalived) plugin instance.
-func NewIPFailoverConfiguratorPlugin(name string, f *clientcmd.Factory, options *ipfailover.IPFailoverConfigCmdOptions) (*KeepalivedPlugin, error) {
+func NewIPFailoverConfiguratorPlugin(name string, f factory.Interface, options *ipfailover.IPFailoverConfigCmdOptions) (*KeepalivedPlugin, error) {
 	glog.V(4).Infof("Creating new KeepAlived plugin: %q", name)
 
 	p := &KeepalivedPlugin{

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -3,13 +3,13 @@ package env
 import (
 	"fmt"
 
+	"github.com/openshift/origin/pkg/cmd/util/factory"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/fieldpath"
-
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 // ResourceStore defines a new resource store data structure
@@ -72,7 +72,7 @@ func getResourceFieldRef(from *kapi.EnvVarSource, c *kapi.Container) (string, er
 }
 
 // GenEnvVarRefValue returns the value referenced by the supplied EnvVarSource given the other supplied information
-func GetEnvVarRefValue(f *clientcmd.Factory, kc kclientset.Interface, ns string, store *ResourceStore, from *kapi.EnvVarSource, obj runtime.Object, c *kapi.Container) (string, error) {
+func GetEnvVarRefValue(f factory.Interface, kc kclientset.Interface, ns string, store *ResourceStore, from *kapi.EnvVarSource, obj runtime.Object, c *kapi.Container) (string, error) {
 	var kubeClient kclientset.Interface
 	var namespace string
 	var err error
@@ -90,7 +90,7 @@ func GetEnvVarRefValue(f *clientcmd.Factory, kc kclientset.Interface, ns string,
 		kubeClient = kc
 		namespace = ns
 	} else {
-		return "", fmt.Errorf("You must supply either a clientcmd.Factory or kclientset.Interface")
+		return "", fmt.Errorf("You must supply either a factory.Interface or kclientset.Interface")
 	}
 
 	if from.SecretKeyRef != nil {


### PR DESCRIPTION
Commands that want the factory to get client access shouldn't be required to pull in all of the underlying logic that serves those. This separates the interfaces from the implementation, and sets the stage for passing smaller interfaces to each command in the future.

[test]

The first two commits belong to another PR for cutting dependencies