### PR TITLE
Add a helper for finding dependency chains

### DIFF
--- a/hack/deps
+++ b/hack/deps
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+if [[ $# -eq 0 || ! -f "${OS_OUTPUT}/deps" ]]; then
+  echo "Generating dependency graph ..." 1>&2
+  mkdir -p "${OS_OUTPUT}"
+  go list -f '{{.ImportPath}}{{.Imports}}' ./pkg/... ./cmd/... | tr '[]' '  ' | 
+    grep -vE '^github.com/openshift/origin/cmd/(service-catalog|cluster-capacity)' |
+    sed -e 's|github.com/openshift/origin/vendor/||g' | 
+    sed -e 's|github.com/openshift/origin/pkg/build/vendor/||g' > "${OS_OUTPUT}/deps"
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "Dependencies generated to ${OS_OUTPUT}/deps"
+  echo
+  echo "Install digraph with: go get -u golang.org/x/tools/cmd/digraph"
+  echo 
+  echo "To see the list of all dependencies of a package: "
+  echo "  hack/deps.sh forward github.com/openshift/origin/cmd/openshift"
+  echo 
+  echo "To see how a package was included into a binary (one particular way): "
+  echo "  hack/deps.sh somepath github.com/openshift/origin/cmd/openshift FULL_PACKAGE_NAME"
+  exit 0
+fi
+
+os::util::ensure::system_binary_exists 'digraph'
+cat "${OS_OUTPUT}/deps" | digraph $@


### PR DESCRIPTION
hack/deps.sh

will generate a dependency tree using go list, then can run the
`digraph` command

    # all dependencies of .../server/bootstrappolicy
    hack/deps.sh forward github.com/openshift/origin/pkg/cmd/server/bootstrappolicy

    # link between two packages
    hack/deps.sh somepath github.com/openshift/origin/cmd/oc github.com/openshift/origin/pkg/cmd/server/bootstrappolicy

[merge]