### PR TITLE
Do not resolve images on job/build/statefulset updates

### DIFF
--- a/pkg/image/admission/imagepolicy/accept.go
+++ b/pkg/image/admission/imagepolicy/accept.go
@@ -67,7 +67,7 @@ func accept(accepter rules.Accepter, policy imageResolutionPolicy, resolver imag
 					// if we resolved properly, assign the attributes and rewrite the pull spec if we need to
 					decision.attrs = resolvedAttrs
 
-					if policy.RewriteImagePullSpec(resolvedAttrs, gr) {
+					if policy.RewriteImagePullSpec(resolvedAttrs, attr.GetOperation() == admission.Update, gr) {
 						ref.Namespace = ""
 						ref.Name = decision.attrs.Name.Exact()
 						ref.Kind = "DockerImage"


### PR DESCRIPTION
Jobs, builds, and stateful sets have image references which are
immutable on update. Because this is an API level restriction, image
policy should ignore resolution on updates to those operations. In 3.7
statefulsets will be mutable, but all builds and jobs will remain
locked.

Fixes #15117 @liggitt review