### PR TITLE
UPSTREAM: 48733: Never prevent deletion of resources as part of namespace lifecycle

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -104,6 +104,11 @@ func (l *lifecycle) Admit(a admission.Attributes) error {
 		return nil
 	}
 
+	// always allow deletion of other resources
+	if a.GetOperation() == admission.Delete {
+		return nil
+	}
+
 	// always allow access review checks.  Returning status about the namespace would be leaking information
 	if isAccessReview(a) {
 		return nil


### PR DESCRIPTION
Related to #15006