### PR TITLE
Tolerate deletion of resources during migration

### DIFF
--- a/pkg/cmd/admin/migrate/migrator.go
+++ b/pkg/cmd/admin/migrate/migrator.go
@@ -485,7 +485,8 @@ func canRetry(err error) bool {
 // All other errors are left in their natural state - they will not be retried unless
 // they define a Temporary() method that returns true.
 func DefaultRetriable(info *resource.Info, err error) error {
-	if err == nil {
+	// tolerate the deletion of resources during migration
+	if err == nil || errors.IsNotFound(err) {
 		return nil
 	}
 	switch {


### PR DESCRIPTION
Signed-off-by: Monis Khan <mkhan@redhat.com>

@jupierce I believe this should prevent the occurrence of:

`"error:     imagestreams/pull-07042210z-gy -n ops-health-monitoring: the server could not find the requested resource (get imagestreams pull-07042210z-gy)"`

Fixes #15122

xref: #15007 

[test]