### PR TITLE
Increase default max in flight requests and lengthen short timeouts

### DIFF
--- a/pkg/cmd/server/api/serialization_test.go
+++ b/pkg/cmd/server/api/serialization_test.go
@@ -55,7 +55,7 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 				obj.ServingInfo.RequestTimeoutSeconds = 60 * 60
 			}
 			if obj.ServingInfo.MaxRequestsInFlight == 0 {
-				obj.ServingInfo.MaxRequestsInFlight = 500
+				obj.ServingInfo.MaxRequestsInFlight = 1200
 			}
 			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
 				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -32,7 +32,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 				obj.ServingInfo.RequestTimeoutSeconds = 60 * 60
 			}
 			if obj.ServingInfo.MaxRequestsInFlight == 0 {
-				obj.ServingInfo.MaxRequestsInFlight = 500
+				obj.ServingInfo.MaxRequestsInFlight = 1200
 			}
 			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
 				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -324,7 +324,7 @@ func GetAvailableResources(clientBuilder controller.ControllerClientBuilder) (ma
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.
-	err := wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+	err := wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
 		client, err := clientBuilder.Client("controller-discovery")
 		if err != nil {
 			glog.Errorf("Failed to get api versions from server: %v", err)

--- a/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/client_ca_hook.go
@@ -49,7 +49,7 @@ func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.Pos
 	// intializing CAs is important so that aggregated API servers can come up with "normal" config.
 	// We've seen lagging etcd before, so we want to retry this a few times before we decide to crashloop
 	// the API server on it.
-	err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
+	err := wait.Poll(1*time.Second, 5*time.Minute, func() (done bool, err error) {
 		// retry building the config since sometimes the server can be in an inbetween state which caused
 		// some kind of auto detection failure as I recall from other post start hooks.
 		// TODO see if this is still true and fix the RBAC one too if it isn't.


### PR DESCRIPTION
Very large clusters configured with `openshift start master` now are unable to startup.  We support existing clusters installed in this fashion (this is how single master installs work today unless the user specifies `etcd_host`)

Increase two default vendored timeouts to be longer. Max in flight is increased to 1200 out of the box because it matches to reasonably large clusters.

[test] @liggitt