### PR TITLE
Move CapabilityAll from k8s types and rename it to AllowAllCapabilities

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -67,7 +67,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				},
 			},
 			AllowPrivilegedContainer: true,
-			AllowedCapabilities:      []kapi.Capability{kapi.CapabilityAll},
+			AllowedCapabilities:      []kapi.Capability{securityapi.AllowAllCapabilities},
 			Volumes:                  []securityapi.FSType{securityapi.FSTypeAll},
 			AllowHostNetwork:         true,
 			AllowHostPorts:           true,

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -53,7 +53,7 @@ func TestAdmitCaps(t *testing.T) {
 
 	allowAllInAllowed := restrictiveSCC()
 	allowAllInAllowed.Name = "allowAllCapsInAllowed"
-	allowAllInAllowed.AllowedCapabilities = []kapi.Capability{kapi.CapabilityAll}
+	allowAllInAllowed.AllowedCapabilities = []kapi.Capability{securityapi.AllowAllCapabilities}
 
 	tc := map[string]struct {
 		pod                  *kapi.Pod

--- a/pkg/security/apis/security/types.go
+++ b/pkg/security/apis/security/types.go
@@ -5,6 +5,11 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 )
 
+// AllowAllCapabilities can be used as a value for the
+// SecurityContextConstraints.AllowAllCapabilities field and means that any
+// capabilities are allowed to be requested.
+var AllowAllCapabilities kapi.Capability = "*"
+
 // +genclient=true
 // +nonNamespaced=true
 

--- a/pkg/security/apis/security/v1/types.go
+++ b/pkg/security/apis/security/v1/types.go
@@ -5,6 +5,11 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api/v1"
 )
 
+// AllowAllCapabilities can be used as a value for the
+// SecurityContextConstraints.AllowAllCapabilities field and means that any
+// capabilities are allowed to be requested.
+var AllowAllCapabilities kapi.Capability = "*"
+
 // +genclient=true
 // +nonNamespaced=true
 

--- a/pkg/security/apis/security/validation/scc_validation_test.go
+++ b/pkg/security/apis/security/validation/scc_validation_test.go
@@ -93,7 +93,7 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 
 	wildcardAllowedCapAndRequiredDrop := validSCC()
 	wildcardAllowedCapAndRequiredDrop.RequiredDropCapabilities = []kapi.Capability{"foo"}
-	wildcardAllowedCapAndRequiredDrop.AllowedCapabilities = []kapi.Capability{kapi.CapabilityAll}
+	wildcardAllowedCapAndRequiredDrop.AllowedCapabilities = []kapi.Capability{securityapi.AllowAllCapabilities}
 
 	errorCases := map[string]struct {
 		scc         *securityapi.SecurityContextConstraints

--- a/pkg/security/apis/security/validation/validation.go
+++ b/pkg/security/apis/security/validation/validation.go
@@ -72,7 +72,7 @@ func ValidateSecurityContextConstraints(scc *securityapi.SecurityContextConstrai
 	allErrs = append(allErrs, validateSCCCapsAgainstDrops(scc.RequiredDropCapabilities, scc.DefaultAddCapabilities, field.NewPath("defaultAddCapabilities"))...)
 	allErrs = append(allErrs, validateSCCCapsAgainstDrops(scc.RequiredDropCapabilities, scc.AllowedCapabilities, field.NewPath("allowedCapabilities"))...)
 
-	if hasCap(kapi.CapabilityAll, scc.AllowedCapabilities) && len(scc.RequiredDropCapabilities) > 0 {
+	if hasCap(securityapi.AllowAllCapabilities, scc.AllowedCapabilities) && len(scc.RequiredDropCapabilities) > 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("requiredDropCapabilities"), scc.RequiredDropCapabilities,
 			"required capabilities must be empty when all capabilities are allowed by a wildcard"))
 	}

--- a/pkg/security/securitycontextconstraints/capabilities/mustrunas.go
+++ b/pkg/security/securitycontextconstraints/capabilities/mustrunas.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api"
+
+	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
 
 // defaultCapabilities implements the CapabilitiesSecurityContextConstraintsStrategy interface
@@ -86,7 +88,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container) f
 	}
 
 	allowedAdd := makeCapSet(s.allowedCaps)
-	allowAllCaps := allowedAdd.Has(string(api.CapabilityAll))
+	allowAllCaps := allowedAdd.Has(string(securityapi.AllowAllCapabilities))
 	if allowAllCaps {
 		// skip validation against allowed/defaultAdd/requiredDrop because all capabilities are allowed by a wildcard
 		return allErrs

--- a/pkg/security/securitycontextconstraints/capabilities/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/capabilities/mustrunas_test.go
@@ -1,9 +1,12 @@
 package capabilities
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"reflect"
 	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+
+	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
 
 func TestGenerateAdds(t *testing.T) {
@@ -243,7 +246,7 @@ func TestValidateAdds(t *testing.T) {
 			shouldPass: true,
 		},
 		"no required, all allowed, container requests valid": {
-			allowedCaps: []api.Capability{api.CapabilityAll},
+			allowedCaps: []api.Capability{securityapi.AllowAllCapabilities},
 			containerCaps: &api.Capabilities{
 				Add: []api.Capability{"foo"},
 			},

--- a/vendor/k8s.io/kubernetes/pkg/api/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/types.go
@@ -1580,9 +1580,6 @@ const (
 // Capability represent POSIX capabilities type
 type Capability string
 
-// CapabilityAll represent all POSIX capabilities types.
-var CapabilityAll Capability = "*"
-
 // Capabilities represent POSIX capabilities that can be added or removed to a running container.
 type Capabilities struct {
 	// Added capabilities

--- a/vendor/k8s.io/kubernetes/pkg/api/v1/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/v1/types.go
@@ -1684,9 +1684,6 @@ const (
 // Capability represent POSIX capabilities type
 type Capability string
 
-// CapabilityAll represent all POSIX capabilities types.
-var CapabilityAll Capability = "*"
-
 // Adds and removes POSIX capabilities from running containers.
 type Capabilities struct {
 	// Added capabilities


### PR DESCRIPTION
Move `CapabilityAll` from k8s types to openshift, close to the SCC definition and also rename it to `AllowAllCapabilities`.

Addresses https://github.com/openshift/origin/pull/12875#issuecomment-313492662 and fixes #15273

PTAL @deads2k @pweil- 
CC @simo5 