### PR TITLE
[1.5] Update lastTriggeredImage if not set when instantiating DCs

### DIFF
--- a/pkg/deploy/registry/instantiate/rest.go
+++ b/pkg/deploy/registry/instantiate/rest.go
@@ -154,7 +154,7 @@ func processTriggers(config *deployapi.DeploymentConfig, isn client.ImageStreams
 				continue
 			}
 
-			if container.Image != latestReference {
+			if container.Image != latestReference || params.LastTriggeredImage != latestReference {
 				// Update the image
 				container.Image = latestReference
 				// Log the last triggered image ID

--- a/pkg/deploy/registry/instantiate/rest_test.go
+++ b/pkg/deploy/registry/instantiate/rest_test.go
@@ -124,8 +124,9 @@ func TestProcess_matchScenarios(t *testing.T) {
 	tests := []struct {
 		name string
 
-		param    *deployapi.DeploymentTriggerImageChangeParams
-		notFound bool
+		param              *deployapi.DeploymentTriggerImageChangeParams
+		containerImageFunc func() string
+		notFound           bool
 
 		expected bool
 	}{
@@ -202,6 +203,23 @@ func TestProcess_matchScenarios(t *testing.T) {
 
 			expected: false,
 		},
+		{
+			name: "allow lastTriggeredImage to resolve",
+
+			containerImageFunc: func() string {
+				image := "registry:5000/openshift/test-image-stream@sha256:0000000000000000000000000000000000000000000000000000000000000001"
+				return image
+			},
+			param: &deployapi.DeploymentTriggerImageChangeParams{
+				Automatic:          true,
+				ContainerNames:     []string{"container1"},
+				From:               kapi.ObjectReference{Name: imageapi.JoinImageStreamTag(deploytest.ImageStreamName, imageapi.DefaultImageTag)},
+				LastTriggeredImage: "",
+			},
+			notFound: false,
+
+			expected: true,
+		},
 	}
 
 	for i := range tests {
@@ -227,6 +245,9 @@ func TestProcess_matchScenarios(t *testing.T) {
 			},
 		}
 
+		if test.containerImageFunc != nil {
+			config.Spec.Template.Spec.Containers[0].Image = test.containerImageFunc()
+		}
 		image := config.Spec.Template.Spec.Containers[0].Image
 
 		err := processTriggers(config, fake, false)
@@ -234,10 +255,16 @@ func TestProcess_matchScenarios(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 			continue
 		}
-		if test.expected && config.Spec.Template.Spec.Containers[0].Image == image {
+		if test.containerImageFunc == nil && test.expected && config.Spec.Template.Spec.Containers[0].Image == image {
 			t.Errorf("%s: expected an image update but got none", test.name)
-		} else if !test.expected && config.Spec.Template.Spec.Containers[0].Image != image {
+			continue
+		}
+		if !test.expected && config.Spec.Template.Spec.Containers[0].Image != image {
 			t.Errorf("%s: didn't expect an image update but got %s", test.name, image)
+			continue
+		}
+		if test.containerImageFunc != nil && image != config.Spec.Triggers[0].ImageChangeParams.LastTriggeredImage {
+			t.Errorf("%s: expected a lastTriggeredImage update to %q, got none", test.name, image)
 		}
 	}
 }


### PR DESCRIPTION
Otherwise, the endpoint will think that the image is missing
from the cluster in cases where the image hash is already set
but the lastTriggeredImage is not set.

Fixes https://github.com/openshift/origin/issues/15136

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>