### PR TITLE
UPSTREAM: 48763: Add Local and Unstructured resource builder attributes and handle <rsrsc> / <name> pairs when --local is set

### DIFF
--- a/cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/stop.go
+++ b/cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/stop.go
@@ -84,7 +84,7 @@ func RunStop(f cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer
 	}
 
 	mapper, _ := f.Object()
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(false, args...).

--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -218,7 +218,7 @@ func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error
 		break
 	}
 
-	o.Builder = f.NewBuilder(true).
+	o.Builder = f.NewBuilder().
 		AllNamespaces(allNamespaces).
 		FilenameParam(false, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
 		ContinueOnError().

--- a/pkg/oc/admin/network/project_options.go
+++ b/pkg/oc/admin/network/project_options.go
@@ -58,7 +58,7 @@ func (p *ProjectOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args [
 		return err
 	}
 
-	p.Builder = f.NewBuilder(true)
+	p.Builder = f.NewBuilder()
 	p.DefaultNamespace = defaultNamespace
 	p.Oclient = networkClient
 	p.Kclient = kc

--- a/pkg/oc/admin/node/node_options.go
+++ b/pkg/oc/admin/node/node_options.go
@@ -75,7 +75,7 @@ func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []st
 	}
 	mapper, typer := f.Object()
 
-	n.Builder = f.NewBuilder(true)
+	n.Builder = f.NewBuilder()
 	n.DefaultNamespace = defaultNamespace
 	n.ExternalKubeClient = externalkc
 	n.KubeClient = kc

--- a/pkg/oc/admin/policy/review.go
+++ b/pkg/oc/admin/policy/review.go
@@ -107,7 +107,7 @@ func (o *sccReviewOptions) Complete(f *clientcmd.Factory, args []string, cmd *co
 		return fmt.Errorf("unable to obtain client: %v", err)
 	}
 	o.client = securityClient.Security()
-	o.builder = f.NewBuilder(true)
+	o.builder = f.NewBuilder()
 	o.RESTClientFactory = f.ClientForMapping
 
 	output := kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/admin/policy/subject_review.go
+++ b/pkg/oc/admin/policy/subject_review.go
@@ -108,7 +108,7 @@ func (o *sccSubjectReviewOptions) Complete(f *clientcmd.Factory, args []string, 
 	}
 	o.sccSubjectReviewClient = securityClient.Security()
 	o.sccSelfSubjectReviewClient = securityClient.Security()
-	o.builder = f.NewBuilder(true)
+	o.builder = f.NewBuilder()
 	o.RESTClientFactory = f.ClientForMapping
 
 	output := kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/bootstrap/docker/openshift/import.go
+++ b/pkg/oc/bootstrap/docker/openshift/import.go
@@ -24,7 +24,7 @@ func ImportObjects(f *clientcmd.Factory, ns, location string) error {
 		return err
 	}
 	glog.V(8).Infof("Importing data:\n%s\n", string(data))
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(ns).

--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -222,7 +222,7 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 	}
 
 	mapper, _ := f.Object()
-	b := f.NewBuilder(true).
+	b := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		SingleResourceType().
 		ResourceNames("pods", resources...).

--- a/pkg/oc/cli/cmd/deploy.go
+++ b/pkg/oc/cli/cmd/deploy.go
@@ -155,7 +155,7 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 		return err
 	}
 
-	o.builder = f.NewBuilder(true)
+	o.builder = f.NewBuilder()
 	o.out = out
 
 	if len(args) > 0 {

--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -110,17 +110,13 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		return err
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
-	if err != nil {
-		return err
-	}
-
 	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	b := builder.
+	b := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: filenames}).
 		SelectorParam(selector).

--- a/pkg/oc/cli/cmd/expose.go
+++ b/pkg/oc/cli/cmd/expose.go
@@ -93,7 +93,7 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &resource.FilenameOptions{Recursive: false, Filenames: kcmdutil.GetFlagStringSlice(cmd, "filename")}).

--- a/pkg/oc/cli/cmd/extract.go
+++ b/pkg/oc/cli/cmd/extract.go
@@ -98,7 +98,7 @@ func (o *ExtractOptions) Complete(f *clientcmd.Factory, in io.Reader, out io.Wri
 		return err
 	}
 
-	b := f.NewBuilder(true).
+	b := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
 		ResourceNames("", args...).

--- a/pkg/oc/cli/cmd/idle.go
+++ b/pkg/oc/cli/cmd/idle.go
@@ -114,7 +114,7 @@ func (o *IdleOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []
 		return fmt.Errorf("resource names, selectors, and the all flag may not be be specified if a filename is specified")
 	}
 
-	o.svcBuilder = f.NewBuilder(true).
+	o.svcBuilder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().AllNamespaces(o.allNamespaces).
 		Flatten().

--- a/pkg/oc/cli/cmd/logs.go
+++ b/pkg/oc/cli/cmd/logs.go
@@ -126,7 +126,7 @@ func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command
 
 	podLogOptions := o.KubeLogOptions.Options.(*kapi.PodLogOptions)
 
-	infos, err := f.NewBuilder(true).
+	infos, err := f.NewBuilder().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		ResourceNames("pods", args...).
 		SingleResourceType().RequireObject(false).

--- a/pkg/oc/cli/cmd/process.go
+++ b/pkg/oc/cli/cmd/process.go
@@ -221,8 +221,14 @@ func RunProcess(f *clientcmd.Factory, in io.Reader, out, errout io.Writer, cmd *
 		templateObj.CreationTimestamp = metav1.Now()
 		infos = append(infos, &resource.Info{Object: templateObj})
 	} else {
-		infos, err = f.NewBuilder(!local).
-			FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: []string{filename}}).
+		b := f.NewBuilder().
+			FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: []string{filename}})
+
+		if local {
+			b = b.Local(f.ClientForMapping)
+		}
+
+		infos, err = b.
 			Do().
 			Infos()
 		if err != nil {

--- a/pkg/oc/cli/cmd/rollback.go
+++ b/pkg/oc/cli/cmd/rollback.go
@@ -135,7 +135,7 @@ func (o *RollbackOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 
 	// Set up client based support.
 	o.getBuilder = func() *resource.Builder {
-		return f.NewBuilder(true)
+		return f.NewBuilder()
 	}
 
 	kClient, err := f.ClientSet()

--- a/pkg/oc/cli/cmd/rollout/cancel.go
+++ b/pkg/oc/cli/cmd/rollout/cancel.go
@@ -89,7 +89,7 @@ func (o *CancelOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out i
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/oc/cli/cmd/rollout/latest.go
+++ b/pkg/oc/cli/cmd/rollout/latest.go
@@ -107,7 +107,7 @@ func (o *RolloutLatestOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command
 	o.appsClient = appsClient.Apps()
 
 	o.mapper, o.typer = f.Object()
-	o.infos, err = f.NewBuilder(true).
+	o.infos, err = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).
 		ResourceNames("deploymentconfigs", args[0]).

--- a/pkg/oc/cli/cmd/rollout/retry.go
+++ b/pkg/oc/cli/cmd/rollout/retry.go
@@ -90,7 +90,7 @@ func (o *RetryOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out io
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/oc/cli/cmd/rsync/pathspec.go
+++ b/pkg/oc/cli/cmd/rsync/pathspec.go
@@ -92,7 +92,7 @@ func resolveResourceKindPath(f kcmdutil.Factory, path, namespace string) (string
 		podName = podSegs[1]
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(namespace).
 		SingleResourceType().
 		ResourceNames("pods", podName).

--- a/pkg/oc/cli/cmd/set/buildhook.go
+++ b/pkg/oc/cli/cmd/set/buildhook.go
@@ -137,7 +137,7 @@ func (o *BuildHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, ar
 	o.Cmd = cmd
 
 	mapper, _ := f.Object()
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -159,6 +159,8 @@ func (o *BuildHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, ar
 		if len(resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/buildhook.go
+++ b/pkg/oc/cli/cmd/set/buildhook.go
@@ -152,6 +152,13 @@ func (o *BuildHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, ar
 		if o.All {
 			o.Builder.ResourceTypes("buildconfigs").SelectAllParam(o.All)
 		}
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/buildsecret.go
+++ b/pkg/oc/cli/cmd/set/buildsecret.go
@@ -188,6 +188,13 @@ func (o *BuildSecretOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 		if o.All {
 			o.Builder.ResourceTypes(supportedBuildTypes...).SelectAllParam(o.All)
 		}
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/buildsecret.go
+++ b/pkg/oc/cli/cmd/set/buildsecret.go
@@ -121,7 +121,7 @@ func NewCmdBuildSecret(fullName string, f *clientcmd.Factory, out, errOut io.Wri
 var supportedBuildTypes = []string{"buildconfigs"}
 
 func (o *BuildSecretOptions) secretFromArg(f *clientcmd.Factory, mapper meta.RESTMapper, typer runtime.ObjectTyper, namespace, arg string) (string, error) {
-	builder := f.NewBuilder(!o.Local).
+	builder := f.NewBuilder().
 		NamespaceParam(namespace).DefaultNamespace().
 		RequireObject(false).
 		ContinueOnError().
@@ -173,7 +173,7 @@ func (o *BuildSecretOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 			return err
 		}
 	}
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -195,6 +195,8 @@ func (o *BuildSecretOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 		if len(resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/deploymenthook.go
+++ b/pkg/oc/cli/cmd/set/deploymenthook.go
@@ -156,7 +156,7 @@ func (o *DeploymentHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Comman
 	o.Cmd = cmd
 
 	mapper, _ := f.Object()
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -177,6 +177,8 @@ func (o *DeploymentHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Comman
 		if len(resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/deploymenthook.go
+++ b/pkg/oc/cli/cmd/set/deploymenthook.go
@@ -170,6 +170,13 @@ func (o *DeploymentHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Comman
 			o.Builder.ResourceTypes("deploymentconfigs").SelectAllParam(o.All)
 		}
 
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/env.go
+++ b/pkg/oc/cli/cmd/set/env.go
@@ -297,6 +297,13 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 		b = b.
 			SelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, o.Resources...)
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(o.Resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	one := false

--- a/pkg/oc/cli/cmd/set/env.go
+++ b/pkg/oc/cli/cmd/set/env.go
@@ -225,7 +225,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 	}
 
 	if len(o.From) != 0 {
-		b := f.NewBuilder(!o.Local).
+		b := f.NewBuilder().
 			ContinueOnError().
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -235,6 +235,8 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 			b = b.
 				SelectorParam(o.Selector).
 				ResourceTypeOrNameArgs(o.All, o.From)
+		} else {
+			b = b.Local(f.ClientForMapping)
 		}
 
 		one := false
@@ -287,7 +289,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 		}
 	}
 
-	b := f.NewBuilder(!o.Local).
+	b := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -304,6 +306,8 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 		if len(o.Resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		b = b.Local(f.ClientForMapping)
 	}
 
 	one := false

--- a/pkg/oc/cli/cmd/set/imagelookup.go
+++ b/pkg/oc/cli/cmd/set/imagelookup.go
@@ -164,7 +164,7 @@ func (o *ImageLookupOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 	o.PrintTable = (len(args) == 0 && !o.All) || o.List
 
 	mapper, _ := f.Object()
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -175,7 +175,7 @@ func (o *ImageLookupOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 		return kcmdutil.UsageErrorf(cmd, "Pass files with -f when using --local")
 	case o.Local:
 		// perform no lookups on the server
-		// TODO: discovery still requires a running server, doesn't fall back correctly
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	case len(args) == 0 && len(o.Filenames) == 0:
 		o.Builder = o.Builder.
 			SelectorParam(o.Selector).

--- a/pkg/oc/cli/cmd/set/probe.go
+++ b/pkg/oc/cli/cmd/set/probe.go
@@ -191,6 +191,13 @@ func (o *ProbeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 		o.Builder = o.Builder.
 			SelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, resources...)
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/probe.go
+++ b/pkg/oc/cli/cmd/set/probe.go
@@ -181,7 +181,7 @@ func (o *ProbeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 	o.Cmd = cmd
 
 	mapper, _ := f.Object()
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -198,6 +198,8 @@ func (o *ProbeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 		if len(resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/routebackends.go
+++ b/pkg/oc/cli/cmd/set/routebackends.go
@@ -175,6 +175,13 @@ func (o *BackendsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 		if len(resources) == 0 {
 			o.Builder.ResourceTypes("routes")
 		}
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/routebackends.go
+++ b/pkg/oc/cli/cmd/set/routebackends.go
@@ -161,7 +161,7 @@ func (o *BackendsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 	o.Cmd = cmd
 
 	mapper, _ := f.Object()
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -182,6 +182,8 @@ func (o *BackendsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 		if len(resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/triggers.go
+++ b/pkg/oc/cli/cmd/set/triggers.go
@@ -230,6 +230,13 @@ func (o *TriggersOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 		o.Builder = o.Builder.
 			SelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, args...)
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(args) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/triggers.go
+++ b/pkg/oc/cli/cmd/set/triggers.go
@@ -220,7 +220,7 @@ func (o *TriggersOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 	}
 
 	mapper, _ := f.Object()
-	o.Builder = f.NewBuilder(!o.Local).
+	o.Builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -237,6 +237,8 @@ func (o *TriggersOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 		if len(args) > 0 {
 			return resource.LocalResourceError
 		}
+
+		o.Builder = o.Builder.Local(f.ClientForMapping)
 	}
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")

--- a/pkg/oc/cli/cmd/set/volume.go
+++ b/pkg/oc/cli/cmd/set/volume.go
@@ -437,6 +437,13 @@ func (v *VolumeOptions) RunVolume(args []string, f *clientcmd.Factory) error {
 		b = b.
 			SelectorParam(v.Selector).
 			ResourceTypeOrNameArgs(v.All, args...)
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(args) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	singleItemImplied := false

--- a/pkg/oc/cli/cmd/set/volume.go
+++ b/pkg/oc/cli/cmd/set/volume.go
@@ -427,7 +427,7 @@ func (v *VolumeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out, 
 }
 
 func (v *VolumeOptions) RunVolume(args []string, f *clientcmd.Factory) error {
-	b := f.NewBuilder(!v.Local).
+	b := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(v.DefaultNamespace).DefaultNamespace().
 		FilenameParam(v.ExplicitNamespace, &resource.FilenameOptions{Recursive: false, Filenames: v.Filenames}).
@@ -444,6 +444,8 @@ func (v *VolumeOptions) RunVolume(args []string, f *clientcmd.Factory) error {
 		if len(args) > 0 {
 			return resource.LocalResourceError
 		}
+
+		b = b.Local(f.ClientForMapping)
 	}
 
 	singleItemImplied := false

--- a/pkg/oc/cli/secrets/options.go
+++ b/pkg/oc/cli/secrets/options.go
@@ -26,7 +26,7 @@ type SecretOptions struct {
 
 	Namespace string
 
-	BuilderFunc    func(bool) *resource.Builder
+	BuilderFunc    func() *resource.Builder
 	KubeCoreClient kcoreclient.CoreInterface
 
 	Out io.Writer
@@ -84,7 +84,7 @@ func (o SecretOptions) Validate() error {
 
 // GetServiceAccount Retrieve the service account object specified by the command
 func (o SecretOptions) GetServiceAccount() (*kapi.ServiceAccount, error) {
-	r := o.BuilderFunc(true).
+	r := o.BuilderFunc().
 		NamespaceParam(o.Namespace).
 		ResourceNames("serviceaccounts", o.TargetName).
 		SingleResourceType().
@@ -161,7 +161,7 @@ func (o SecretOptions) GetSecrets(allowNonExisting bool) ([]*kapi.Secret, bool, 
 	hasNotFound := false
 
 	for _, secretName := range o.SecretNames {
-		r := o.BuilderFunc(true).
+		r := o.BuilderFunc().
 			NamespaceParam(o.Namespace).
 			ResourceNames("secrets", secretName).
 			SingleResourceType().

--- a/test/cmd/set-image.sh
+++ b/test/cmd/set-image.sh
@@ -18,7 +18,7 @@ os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.0'
 
 # test --local flag
-os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --local' 'You must provide one or more resources by argument or filename'
+os::cmd::expect_failure_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --local' 'you must specify resources by \-\-filename when \-\-local is set'
 # test --dry-run flag with -o formats
 os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run' 'test-deployment-config'
 os::cmd::expect_success_and_text 'oc set image dc/test-deployment-config ruby-helloworld=ruby:2.0 --source=istag --dry-run -o name' 'deploymentconfigs/test-deployment-config'

--- a/test/cmd/set-liveness-probe.sh
+++ b/test/cmd/set-liveness-probe.sh
@@ -16,7 +16,7 @@ os::cmd::expect_success_and_text 'oc create -f pkg/api/graph/test/simple-deploym
 os::cmd::expect_success_and_text 'oc status -v' 'dc/simple-deployment has no liveness probe'
 
 # test --local flag
-os::cmd::expect_failure_and_text 'oc set probe dc/simple-deployment --liveness --get-url=http://google.com:80 --local' 'You must provide one or more resources by argument or filename'
+os::cmd::expect_failure_and_text 'oc set probe dc/simple-deployment --liveness --get-url=http://google.com:80 --local' 'you must specify resources by \-\-filename when \-\-local is set'
 # test --dry-run flag with -o formats
 os::cmd::expect_success_and_text 'oc set probe dc/simple-deployment --liveness --get-url=http://google.com:80 --dry-run' 'simple-deployment'
 os::cmd::expect_success_and_text 'oc set probe dc/simple-deployment --liveness --get-url=http://google.com:80 --dry-run -o name' 'deploymentconfigs/simple-deployment'

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
@@ -198,7 +198,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		return err
 	}
 
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
@@ -210,16 +210,12 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		}
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
-	if err != nil {
-		return err
-	}
-
 	// include the uninitialized objects by default if --prune is true
 	// unless explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, options.Prune)
 
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -122,12 +122,13 @@ func (o *SetLastAppliedOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) 
 }
 
 func (o *SetLastAppliedOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) error {
-	builder, err := f.NewUnstructuredBuilder(true)
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
 		Latest().

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -87,12 +87,13 @@ func (o *ViewLastAppliedOptions) Complete(f cmdutil.Factory, args []string) erro
 		return err
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(enforceNamespace, args...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
@@ -142,7 +142,7 @@ func (p *AttachOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn [
 		return cmdutil.UsageErrorf(cmd, err.Error())
 	}
 
-	builder := f.NewBuilder(true).
+	builder := f.NewBuilder().
 		NamespaceParam(namespace).DefaultNamespace()
 
 	switch len(argsIn) {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/auth/reconcile.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/auth/reconcile.go
@@ -92,7 +92,7 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 	if err != nil {
 		return err
 	}
-	o.ResourceBuilder = f.NewBuilder(true).
+	o.ResourceBuilder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/autoscale.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/autoscale.go
@@ -90,8 +90,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		return err
 	}
 
-	mapper, typer := f.Object()
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
@@ -145,6 +144,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 			return err
 		}
 
+		mapper, typer := f.Object()
 		resourceMapper := &resource.Mapper{
 			ObjectTyper:  typer,
 			RESTMapper:   mapper,

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/certificates.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/certificates.go
@@ -167,7 +167,7 @@ func (options *CertificateOptions) modifyCertificateCondition(f cmdutil.Factory,
 	if err != nil {
 		return err
 	}
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		ContinueOnError().
 		FilenameParam(false, &options.FilenameOptions).
 		ResourceNames("certificatesigningrequest", options.csrNames...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/clusterinfo.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/clusterinfo.go
@@ -71,7 +71,7 @@ func RunClusterInfo(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error 
 	}
 
 	// TODO use generalized labels once they are implemented (#341)
-	b := f.NewBuilder(true).
+	b := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		SelectorParam("kubernetes.io/cluster-service=true").
 		ResourceTypeOrNameArgs(false, []string{"services"}...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/convert.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/convert.go
@@ -126,14 +126,17 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 	}
 
 	// build the builder
-	o.builder = f.NewBuilder(!o.local)
+	o.builder = f.NewBuilder()
 	if !o.local {
 		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"), cmdutil.GetFlagBool(cmd, "openapi-validation"), cmdutil.GetFlagString(cmd, "schema-cache-dir"))
 		if err != nil {
 			return err
 		}
 		o.builder = o.builder.Schema(schema)
+	} else {
+		o.builder = o.builder.Local(f.ClientForMapping)
 	}
+
 	cmdNamespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create.go
@@ -125,17 +125,13 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		return err
 	}
 
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
-	if err != nil {
-		return err
-	}
-
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/delete.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/delete.go
@@ -170,19 +170,15 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args 
 	}
 
 	// Set up client based support.
-	mapper, _, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
-	builder, err := f.NewUnstructuredBuilder(true)
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
 	o.Mapper = mapper
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/describe.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/describe.go
@@ -117,7 +117,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,8 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 	// unless user explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, true)
 
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(enforceNamespace, options).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
@@ -217,7 +217,7 @@ func (o *DrainOptions) SetupDrain(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	r := o.Factory.NewBuilder(true).
+	r := o.Factory.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		ResourceNames("node", args[0]).
 		Do()

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/expose.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/expose.go
@@ -126,7 +126,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	}
 
 	mapper, typer := f.Object()
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/label.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/label.go
@@ -181,13 +181,8 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 
 	changeCause := f.Command(cmd, false)
 
-	builder, err := f.NewUnstructuredBuilder(!o.local)
-	if err != nil {
-		return err
-	}
-
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	b := builder.
+	b := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -195,10 +190,22 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 		Flatten()
 
 	if !o.local {
+		// call this method here, as it requires an api call
+		// and will cause the command to fail when there is
+		// no connection to a server
+		mapper, typer, err := f.UnstructuredObject()
+		if err != nil {
+			return err
+		}
+
 		b = b.SelectorParam(o.selector).
+			Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 			ResourceTypeOrNameArgs(o.all, o.resources...).
 			Latest()
+	} else {
+		b = b.Local(f.ClientForMapping)
 	}
+
 	one := false
 	r := b.Do().IntoSingleItemImplied(&one)
 	if err := r.Err(); err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/logs.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/logs.go
@@ -192,7 +192,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Comm
 	}
 
 	if o.Object == nil {
-		builder := f.NewBuilder(true).
+		builder := f.NewBuilder().
 			NamespaceParam(o.Namespace).DefaultNamespace().
 			SingleResourceType()
 		if o.ResourceArg != "" {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/patch.go
@@ -152,12 +152,13 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 
 	// TODO: fix --local to work with customresources without making use of the discovery client.
 	// https://github.com/kubernetes/kubernetes/issues/46722
-	builder, err := f.NewUnstructuredBuilder(true)
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/replace.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/replace.go
@@ -125,12 +125,13 @@ func RunReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		return err
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	r := builder.
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
@@ -250,12 +251,8 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		})
 	})
 
-	builder, err := f.NewUnstructuredBuilder(true)
-	if err != nil {
-		return err
-	}
-
-	r = builder.
+	r = f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollingupdate.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollingupdate.go
@@ -199,7 +199,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 			return err
 		}
 
-		request := f.NewBuilder(true).
+		request := f.NewBuilder().
 			Schema(schema).
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(enforceNamespace, &resource.FilenameOptions{Recursive: false, Filenames: []string{filename}}).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -79,7 +79,7 @@ func RunHistory(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []str
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
 		ResourceTypeOrNameArgs(true, args...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -111,7 +111,7 @@ func (o *PauseConfig) CompletePause(f cmdutil.Factory, cmd *cobra.Command, out i
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -109,7 +109,7 @@ func (o *ResumeConfig) CompleteResume(f cmdutil.Factory, cmd *cobra.Command, out
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -82,7 +82,7 @@ func RunStatus(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []stri
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
 		ResourceTypeOrNameArgs(true, args...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -110,7 +110,7 @@ func (o *UndoOptions) CompleteUndo(f cmdutil.Factory, cmd *cobra.Command, out io
 		return err
 	}
 
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
@@ -369,7 +369,7 @@ func RunRun(f cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr
 				if err != nil {
 					return err
 				}
-				r := f.NewBuilder(true).
+				r := f.NewBuilder().
 					ContinueOnError().
 					NamespaceParam(namespace).DefaultNamespace().
 					ResourceNames(obj.Mapping.Resource, name).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/scale.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/scale.go
@@ -99,7 +99,7 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 	}
 
 	mapper, _ := f.Object()
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_env.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_env.go
@@ -231,7 +231,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 	}
 
 	if len(o.From) != 0 {
-		b := f.NewBuilder(!o.Local).
+		b := f.NewBuilder().
 			ContinueOnError().
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -293,7 +293,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 		}
 	}
 
-	b := f.NewBuilder(!o.Local).
+	b := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -304,6 +304,8 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 			SelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, o.Resources...).
 			Latest()
+	} else {
+		b = b.Local(f.ClientForMapping)
 	}
 
 	o.Infos, err = b.Do().Infos()

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_image.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_image.go
@@ -139,12 +139,13 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	}
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder(!o.Local).
+	builder := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		IncludeUninitialized(includeUninitialized).
 		Flatten()
+
 	if !o.Local {
 		builder = builder.
 			SelectorParam(o.Selector).
@@ -157,6 +158,8 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		if len(o.Resources) > 0 {
 			return resource.LocalResourceError
 		}
+
+		builder = builder.Local(f.ClientForMapping)
 	}
 	o.Infos, err = builder.Do().Infos()
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_image.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_image.go
@@ -150,6 +150,13 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 			SelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, o.Resources...).
 			Latest()
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(o.Resources) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 	o.Infos, err = builder.Do().Infos()
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_resources.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_resources.go
@@ -143,7 +143,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	}
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder(!o.Local).
+	builder := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -162,6 +162,8 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		if len(args) > 0 {
 			return resource.LocalResourceError
 		}
+
+		builder = builder.Local(f.ClientForMapping)
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_resources.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_resources.go
@@ -155,6 +155,13 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 			SelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, args...).
 			Latest()
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(args) > 0 {
+			return resource.LocalResourceError
+		}
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_resources_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_resources_test.go
@@ -60,7 +60,7 @@ func TestResourcesLocal(t *testing.T) {
 		Requests:          "cpu=200m,memory=512Mi",
 		ContainerSelector: "*"}
 
-	err := opts.Complete(f, cmd, []string{""})
+	err := opts.Complete(f, cmd, []string{})
 	if err == nil {
 		err = opts.Validate()
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -126,7 +126,7 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	saConfig.serviceAccountName = args[len(args)-1]
 	resources := args[:len(args)-1]
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder(!saConfig.local).ContinueOnError().
+	builder := f.NewBuilder().ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &saConfig.fileNameOptions).
 		IncludeUninitialized(includeUninitialized).
@@ -134,6 +134,8 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	if !saConfig.local {
 		builder.ResourceTypeOrNameArgs(saConfig.all, resources...).
 			Latest()
+	} else {
+		builder = builder.Local(f.ClientForMapping)
 	}
 	saConfig.infos, err = builder.Do().Infos()
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_subject.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/set/set_subject.go
@@ -126,7 +126,7 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	}
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder(!o.Local).
+	builder := f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -142,6 +142,15 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	o.Infos, err = builder.Do().Infos()
 	if err != nil {
 		return err
+	} else {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(args) > 0 {
+			return resource.LocalResourceError
+		}
+
+		builder = builder.Local(f.ClientForMapping)
 	}
 
 	return nil

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/taint.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/taint.go
@@ -148,7 +148,7 @@ func (o *TaintOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Com
 	if o.taintsToAdd, o.taintsToRemove, err = taintutils.ParseTaints(taintArgs); err != nil {
 		return cmdutil.UsageErrorf(cmd, err.Error())
 	}
-	o.builder = f.NewBuilder(true).
+	o.builder = f.NewBuilder().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace()
 	if o.selector != "" {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/testing/fake.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/testing/fake.go
@@ -29,7 +29,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -488,21 +487,9 @@ func (f *FakeFactory) PrinterForMapping(cmd *cobra.Command, isLocal bool, output
 	return f.tf.Printer, f.tf.Err
 }
 
-func (f *FakeFactory) NewBuilder(allowRemoteCalls bool) *resource.Builder {
-	return nil
-}
-
-func (f *FakeFactory) NewUnstructuredBuilder(allowRemoteCalls bool) (*resource.Builder, error) {
-	if !allowRemoteCalls {
-		return f.NewBuilder(allowRemoteCalls), nil
-	}
-
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return nil, err
-	}
-
-	return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), unstructured.UnstructuredJSONScheme), nil
+func (f *FakeFactory) NewBuilder() *resource.Builder {
+	mapper, typer := f.Object()
+	return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true))
 }
 
 func (f *FakeFactory) DefaultResourceFilterOptions(cmd *cobra.Command, withNamespace bool) *printers.PrintOptions {
@@ -777,23 +764,9 @@ func (f *fakeAPIFactory) PrinterForMapping(cmd *cobra.Command, isLocal bool, out
 	return f.tf.Printer, f.tf.Err
 }
 
-func (f *fakeAPIFactory) NewBuilder(allowRemoteCalls bool) *resource.Builder {
+func (f *fakeAPIFactory) NewBuilder() *resource.Builder {
 	mapper, typer := f.Object()
-
 	return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true))
-}
-
-func (f *fakeAPIFactory) NewUnstructuredBuilder(allowRemoteCalls bool) (*resource.Builder, error) {
-	if !allowRemoteCalls {
-		return f.NewBuilder(allowRemoteCalls), nil
-	}
-
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return nil, err
-	}
-
-	return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), unstructured.UnstructuredJSONScheme), nil
 }
 
 func (f *fakeAPIFactory) SuggestedPodTemplateResources() []schema.GroupResource {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -111,10 +111,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 		return err
 	}
 
-	b, err := f.NewUnstructuredBuilder(true)
-	if err != nil {
-		return err
-	}
+	b := f.NewBuilder().Unstructured(f.UnstructuredClientForMapping, mapper, typer)
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
 		// when do normal edit or apply edit we need to always retrieve the latest resource from server
 		b = b.ResourceTypeOrNameArgs(true, args...).Latest()

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -261,9 +261,7 @@ type BuilderFactory interface {
 	// PrintObject prints an api object given command line flags to modify the output format
 	PrintObject(cmd *cobra.Command, isLocal bool, mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error
 	// One stop shopping for a Builder
-	NewBuilder(allowRemoteCalls bool) *resource.Builder
-	// Resource builder for working with unstructured objects
-	NewUnstructuredBuilder(allowRemoteCalls bool) (*resource.Builder, error)
+	NewBuilder() *resource.Builder
 	// PluginLoader provides the implementation to be used to load cli plugins.
 	PluginLoader() plugins.PluginLoader
 	// PluginRunner provides the implementation to be used to run cli plugins.

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_builder.go
@@ -140,37 +140,13 @@ func (f *ring2Factory) PrintObject(cmd *cobra.Command, isLocal bool, mapper meta
 
 // NewBuilder returns a new resource builder.
 // Receives a bool flag and avoids remote calls if set to false
-func (f *ring2Factory) NewBuilder(allowRemoteCalls bool) *resource.Builder {
-	var clientMapper resource.ClientMapper
+func (f *ring2Factory) NewBuilder() *resource.Builder {
 	clientMapperFunc := resource.ClientMapperFunc(f.objectMappingFactory.ClientForMapping)
 
 	mapper, typer := f.objectMappingFactory.Object()
 	categoryExpander := f.objectMappingFactory.CategoryExpander()
 
-	if allowRemoteCalls {
-		clientMapper = clientMapperFunc
-	} else {
-		clientMapper = resource.DisabledClientForMapping{ClientMapper: clientMapperFunc}
-	}
-
-	return resource.NewBuilder(mapper, categoryExpander, typer, clientMapper, f.clientAccessFactory.Decoder(true))
-}
-
-func (f *ring2Factory) NewUnstructuredBuilder(allowRemoteCalls bool) (*resource.Builder, error) {
-	if !allowRemoteCalls {
-		return f.NewBuilder(allowRemoteCalls), nil
-	}
-
-	clientMapperFunc := resource.ClientMapperFunc(f.objectMappingFactory.UnstructuredClientForMapping)
-
-	mapper, typer, err := f.objectMappingFactory.UnstructuredObject()
-	if err != nil {
-		return nil, err
-	}
-
-	categoryExpander := f.objectMappingFactory.CategoryExpander()
-	return resource.NewBuilder(mapper, categoryExpander, typer, clientMapperFunc, unstructured.UnstructuredJSONScheme), nil
-
+	return resource.NewBuilder(mapper, categoryExpander, typer, clientMapperFunc, f.clientAccessFactory.Decoder(true))
 }
 
 // PluginLoader loads plugins from a path set by the KUBECTL_PLUGINS_PATH env var.

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
@@ -68,9 +68,6 @@ type Builder struct {
 	defaultNamespace bool
 	requireNamespace bool
 
-	isLocal        bool
-	isUnstructured bool
-
 	flatten bool
 	latest  bool
 
@@ -85,8 +82,6 @@ type Builder struct {
 
 	schema validation.Schema
 }
-
-var LocalUnstructuredBuilderError = fmt.Errorf("Unstructured objects cannot be handled with a local builder - Local and Unstructured attributes cannot be used in conjunction")
 
 var missingResourceError = fmt.Errorf(`You must provide one or more resources by argument or filename.
 Example resource specifications include:
@@ -169,12 +164,6 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 
 // Local wraps the builder's clientMapper in a DisabledClientMapperForMapping
 func (b *Builder) Local(mapperFunc ClientMapperFunc) *Builder {
-	if b.isUnstructured {
-		b.errs = append(b.errs, LocalUnstructuredBuilderError)
-		return b
-	}
-
-	b.isLocal = true
 	b.mapper.ClientMapper = DisabledClientForMapping{ClientMapper: ClientMapperFunc(mapperFunc)}
 	return b
 }
@@ -182,12 +171,6 @@ func (b *Builder) Local(mapperFunc ClientMapperFunc) *Builder {
 // Unstructured updates the builder's ClientMapper, RESTMapper,
 // ObjectTyper, and codec for working with unstructured api objects
 func (b *Builder) Unstructured(mapperFunc ClientMapperFunc, mapper meta.RESTMapper, typer runtime.ObjectTyper) *Builder {
-	if b.isLocal {
-		b.errs = append(b.errs, LocalUnstructuredBuilderError)
-		return b
-	}
-
-	b.isUnstructured = true
 	b.mapper.RESTMapper = mapper
 	b.mapper.ObjectTyper = typer
 	b.mapper.Decoder = unstructured.UnstructuredJSONScheme

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,6 +68,9 @@ type Builder struct {
 	defaultNamespace bool
 	requireNamespace bool
 
+	isLocal        bool
+	isUnstructured bool
+
 	flatten bool
 	latest  bool
 
@@ -81,6 +85,8 @@ type Builder struct {
 
 	schema validation.Schema
 }
+
+var LocalUnstructuredBuilderError = fmt.Errorf("Unstructured objects cannot be handled with a local builder - Local and Unstructured attributes cannot be used in conjunction")
 
 var missingResourceError = fmt.Errorf(`You must provide one or more resources by argument or filename.
 Example resource specifications include:
@@ -157,6 +163,35 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 	if enforceNamespace {
 		b.RequireNamespace()
 	}
+
+	return b
+}
+
+// Local wraps the builder's clientMapper in a DisabledClientMapperForMapping
+func (b *Builder) Local(mapperFunc ClientMapperFunc) *Builder {
+	if b.isUnstructured {
+		b.errs = append(b.errs, LocalUnstructuredBuilderError)
+		return b
+	}
+
+	b.isLocal = true
+	b.mapper.ClientMapper = DisabledClientForMapping{ClientMapper: ClientMapperFunc(mapperFunc)}
+	return b
+}
+
+// Unstructured updates the builder's ClientMapper, RESTMapper,
+// ObjectTyper, and codec for working with unstructured api objects
+func (b *Builder) Unstructured(mapperFunc ClientMapperFunc, mapper meta.RESTMapper, typer runtime.ObjectTyper) *Builder {
+	if b.isLocal {
+		b.errs = append(b.errs, LocalUnstructuredBuilderError)
+		return b
+	}
+
+	b.isUnstructured = true
+	b.mapper.RESTMapper = mapper
+	b.mapper.ObjectTyper = typer
+	b.mapper.Decoder = unstructured.UnstructuredJSONScheme
+	b.mapper.ClientMapper = ClientMapperFunc(mapperFunc)
 
 	return b
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -87,6 +88,11 @@ Example resource specifications include:
    '--filename=rsrc.json'
    '<resource> <name>'
    '<resource>'`)
+
+var LocalResourceError = errors.New(`error: you must specify resources by --filename when --local is set.
+Example resource specifications include:
+   '-f rsrc.yaml'
+   '--filename=rsrc.json'`)
 
 // TODO: expand this to include other errors.
 func IsUsageError(err error) bool {


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1390139

Adds an error message if a <resource> / <name> pair is specified in an `oc set ...` sub command with a `--local` flag.

```
# oc set image dc/idling-echo idling-tcp-echo=ruby:2.0 --local -o yaml
error: you must specify resources by --filename when --local is set.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
```

cc @openshift/cli-review 