### PR TITLE
Update lastTriggeredImage if not set when instantiating DCs

### DIFF
--- a/pkg/deploy/registry/instantiate/rest.go
+++ b/pkg/deploy/registry/instantiate/rest.go
@@ -164,7 +164,7 @@ func processTriggers(config *deployapi.DeploymentConfig, isn client.ImageStreams
 			if !names.Has(container.Name) {
 				continue
 			}
-			if container.Image != latestReference {
+			if container.Image != latestReference || params.LastTriggeredImage != latestReference {
 				// Update the image
 				container.Image = latestReference
 				// Log the last triggered image ID
@@ -176,7 +176,7 @@ func processTriggers(config *deployapi.DeploymentConfig, isn client.ImageStreams
 			if !names.Has(container.Name) {
 				continue
 			}
-			if container.Image != latestReference {
+			if container.Image != latestReference || params.LastTriggeredImage != latestReference {
 				// Update the image
 				container.Image = latestReference
 				// Log the last triggered image ID


### PR DESCRIPTION
Otherwise, the endpoint will think that the image is missing
from the cluster in cases where the image hash is already set
but the lastTriggeredImage is not set.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>