### PR TITLE
Perform live OAuth client check only if scopes were added to the client authorization

### DIFF
--- a/pkg/oauth/registry/oauthclientauthorization/strategy_test.go
+++ b/pkg/oauth/registry/oauthclientauthorization/strategy_test.go
@@ -1,0 +1,94 @@
+package oauthclientauthorization
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+)
+
+// TestValidateScopeUpdate asserts that a live client lookup only occurs when new scopes are added during an update
+func TestValidateScopeUpdate(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		expectedCalled bool
+		obj            []string
+		old            []string
+	}{
+		{
+			name:           "both empty",
+			expectedCalled: false,
+			obj:            []string{},
+			old:            []string{},
+		},
+		{
+			name:           "both equal",
+			expectedCalled: false,
+			obj:            []string{scope.UserAccessCheck},
+			old:            []string{scope.UserAccessCheck},
+		},
+		{
+			name:           "new scopes from empty",
+			expectedCalled: true,
+			obj:            []string{scope.UserFull},
+			old:            []string{},
+		},
+		{
+			name:           "new scopes from non-empty",
+			expectedCalled: true,
+			obj:            []string{scope.UserFull},
+			old:            []string{scope.UserInfo},
+		},
+		{
+			name:           "deleted scopes",
+			expectedCalled: false,
+			obj:            []string{scope.UserFull},
+			old:            []string{scope.UserFull, scope.UserInfo},
+		},
+		{
+			name:           "deleted and added scopes",
+			expectedCalled: true,
+			obj:            []string{scope.UserFull, scope.UserAccessCheck},
+			old:            []string{scope.UserFull, scope.UserInfo},
+		},
+		{
+			name:           "deleted scopes to empty",
+			expectedCalled: true,
+			obj:            []string{},
+			old:            []string{scope.UserFull},
+		},
+	} {
+		clientGetter := &wasCalledClientGetter{}
+		s := strategy{clientGetter: clientGetter}
+		if errs := s.ValidateUpdate(nil, validClientWithScopes(test.obj), validClientWithScopes(test.old)); len(errs) > 0 {
+			t.Errorf("%s: unexpected update error: %s", test.name, errs)
+			continue
+		}
+		if test.expectedCalled != clientGetter.called {
+			t.Errorf("%s: expected call behavior %v does not match %v", test.name, test.expectedCalled, clientGetter.called)
+		}
+	}
+}
+
+type wasCalledClientGetter struct {
+	called bool
+}
+
+func (g *wasCalledClientGetter) GetClient(_ request.Context, _ string, _ *v1.GetOptions) (*oauth.OAuthClient, error) {
+	g.called = true
+	return &oauth.OAuthClient{}, nil
+}
+
+func validClientWithScopes(scopes []string) *oauthapi.OAuthClientAuthorization {
+	return &oauthapi.OAuthClientAuthorization{
+		ObjectMeta: v1.ObjectMeta{Name: "un:cn", ResourceVersion: "0"},
+		ClientName: "cn",
+		UserName:   "un",
+		UserUID:    "uid",
+		Scopes:     scopes,
+	}
+}

--- a/test/cmd/migrate.sh
+++ b/test/cmd/migrate.sh
@@ -27,6 +27,17 @@ os::cmd::expect_success_and_not_text 'oadm migrate storage --loglevel=2 --includ
 os::cmd::expect_success_and_text     'oadm migrate storage --loglevel=2 --confirm' 'unchanged:'
 os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/migrate/storage_oauthclientauthorizations"
+# Create valid OAuth client
+os::cmd::expect_success_and_text     'oc create -f test/testdata/oauth/client.yaml' 'oauthclient "test-oauth-client" created'
+# Create OAuth client authorization for client
+os::cmd::expect_success_and_text     'oc create -f test/testdata/oauth/clientauthorization.yaml' 'oauthclientauthorization "user1:test-oauth-client" created'
+# Delete client
+os::cmd::expect_success_and_text     'oc delete oauthclient test-oauth-client' 'oauthclient "test-oauth-client" deleted'
+# Assert that migration/update still works even though the client authorization is no longer valid
+os::cmd::expect_success_and_text 'oadm migrate storage --loglevel=6 --include=oauthclientauthorizations --confirm' 'PUT.*oauthclientauthorizations/user1:test-oauth-client'
+os::test::junit::declare_suite_end
+
 os::test::junit::declare_suite_start "cmd/migrate/imagereferences"
 # create alternating items in history
 os::cmd::expect_success 'oc import-image --from=mysql:latest test:1 --confirm'

--- a/test/testdata/oauth/client.yaml
+++ b/test/testdata/oauth/client.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+grantMethod: auto
+kind: OAuthClient
+metadata:
+  name: test-oauth-client
+redirectURIs:
+- https://localhost:9000

--- a/test/testdata/oauth/clientauthorization.yaml
+++ b/test/testdata/oauth/clientauthorization.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+clientName: test-oauth-client
+kind: OAuthClientAuthorization
+metadata:
+  name: user1:test-oauth-client
+scopes:
+- user:check-access
+userName: user1
+userUID: uid


### PR DESCRIPTION
This change makes it so that `OAuthClientAuthorization` update validation only does a live OAuth client check to validate scopes if new scopes were added to the client authorization.  If the scopes were unchanged or only removed (removal of all scopes is considered an addition since an empty slice means all scopes), than no live lookup is performed under the assumption that the create method did a successful live lookup at some earlier point.  This makes it so that an update to a client authorization with identical data (for example, during storage migration) will not fail if the referenced client is no longer valid or has been deleted.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Fixes #15007 

xref: https://github.com/openshift/origin/issues/15007#issuecomment-314310463

> issue was with lookup of OAuth client in order to validate scopes. we only need to do this if scopes are being added to the authorization. @enj will make the lookup conditional

[test]

@jupierce @openshift/security 

@liggitt PTAL