### PR TITLE
UPSTREAM: 48778: stop jsonpath panicing on negative index

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -259,10 +259,10 @@ func (j *JSONPath) evalArray(input []reflect.Value, node *ArrayNode) ([]reflect.
 
 		sliceLength := value.Len()
 		if params[1].Value != params[0].Value { // if you're requesting zero elements, allow it through.
-			if params[0].Value >= sliceLength {
+			if params[0].Value >= sliceLength || params[0].Value < 0 {
 				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[0].Value, sliceLength)
 			}
-			if params[1].Value > sliceLength {
+			if params[1].Value > sliceLength || params[1].Value < 0 {
 				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[1].Value-1, sliceLength)
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15075

Checks to see that `params[0].Value` and `params[1].Value` are not still negative after adding the length of the input value

*Sample cases*

```
$ oc get pods --selector app=doesnotexist -o jsonpath='{.items[-100:].metadata.name}'
Error executing template: array index out of bounds: negative index -100. Printing more information for debugging the template:
        template was:
                {.items[-100:].metadata.name}
        object given to jsonpath engine was:
                map[string]interface {}{"kind":"List", "apiVersion":"v1", "metadata":map[string]interface {}{}, "selfLink":"", "resourceVersion":"", "items":[]interface {}{}}

error: error executing jsonpath "{.items[-100:].metadata.name}": array index out of bounds: negative index -100
```
```
$ oc get pods --selector app=doesnotexist -o jsonpath='{.items[-1:-1].metadata.name}'tyank
Error executing template: array index out of bounds: negative index -1. Printing more information for debugging the template:
        template was:
                {.items[-1:-1].metadata.name}tyank
        object given to jsonpath engine was:
                map[string]interface {}{"items":[]interface {}{}, "kind":"List", "apiVersion":"v1", "metadata":map[string]interface {}{}, "selfLink":"", "resourceVersion":""}

error: error executing jsonpath "{.items[-1:-1].metadata.name}tyank": array index out of bounds: negative index -1
```

cc @openshift/cli-review 