### PR TITLE
Allow installation of missing Golang dependencies at run-time

### DIFF
--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -67,19 +67,29 @@ Provide the binary and try running $0 again."
 readonly -f os::util::ensure::built_binary_exists
 
 # os::util::ensure::gopath_binary_exists ensures that the
-# given binary exists on the system in $GOPATH.
+# given binary exists on the system in $GOPATH.  If it
+# doesn't, we will attempt to build it if we can determine
+# the correct install path for the binary.
 #
 # Globals:
 #  - GOPATH
 # Arguments:
 #  - 1: binary to search for
+#  - 2: [optional] path to install from
 # Returns:
 #  None
 function os::util::ensure::gopath_binary_exists() {
 	local binary="$1"
+	local install_path="${2:-}"
 
 	if ! os::util::find::gopath_binary "${binary}" >/dev/null 2>&1; then
-		os::log::fatal "Required \`${binary}\` binary was not found in \$GOPATH."
+		if [[ -n "${install_path:-}" ]]; then
+			os::log::info "No installed \`${binary}\` was found in \$GOPATH. Attempting to install using:
+  $ go get ${install_path}"
+  			go get "${install_path}"
+		else
+			os::log::fatal "Required \`${binary}\` binary was not found in \$GOPATH."
+		fi
 	fi
 }
 readonly -f os::util::ensure::gopath_binary_exists


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/14996

When a Golang binary is delcared as required, script authors can now
also optionally provide a URL to a repository hosting the tool so that
the Bash library can install the tool if it is missing at run-time,
similar to how the built binary declaration allows for binaries to be
built at run-time to fulfill dependencies.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @jupierce @fabianofranz 