### PR TITLE
Builds should be able to reference image stream tags and images

### DIFF
--- a/pkg/api/meta/builds.go
+++ b/pkg/api/meta/builds.go
@@ -1,40 +1,71 @@
 package meta
 
 import (
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 )
 
 type buildSpecMutator struct {
-	spec *buildapi.CommonSpec
-	path *field.Path
+	spec   *buildapi.CommonSpec
+	path   *field.Path
+	output bool
+}
+
+// NewBuildMutator returns an ImageReferenceMutator that includes the output field.
+func NewBuildMutator(build *buildapi.Build) ImageReferenceMutator {
+	return &buildSpecMutator{
+		spec:   &build.Spec.CommonSpec,
+		path:   field.NewPath("spec"),
+		output: true,
+	}
 }
 
 func (m *buildSpecMutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	var errs field.ErrorList
 	for i, image := range m.spec.Source.Images {
 		if err := fn(&image.From); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("source", "images").Index(i).Child("from", "name"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("source", "images").Index(i).Child("from", "name")))
 			continue
 		}
 	}
 	if s := m.spec.Strategy.CustomStrategy; s != nil {
 		if err := fn(&s.From); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("strategy", "customStrategy", "from", "name"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "customStrategy", "from", "name")))
 		}
 	}
 	if s := m.spec.Strategy.DockerStrategy; s != nil {
 		if s.From != nil {
 			if err := fn(s.From); err != nil {
-				errs = append(errs, field.InternalError(m.path.Child("strategy", "dockerStrategy", "from", "name"), err))
+				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "dockerStrategy", "from", "name")))
 			}
 		}
 	}
 	if s := m.spec.Strategy.SourceStrategy; s != nil {
 		if err := fn(&s.From); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("strategy", "sourceStrategy", "from", "name"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "sourceStrategy", "from", "name")))
+		}
+	}
+	if m.output {
+		if s := m.spec.Output.To; s != nil {
+			if err := fn(s); err != nil {
+				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("output", "to")))
+			}
 		}
 	}
 	return errs
+}
+
+func fieldErrorOrInternal(err error, path *field.Path) *field.Error {
+	if ferr, ok := err.(*field.Error); ok {
+		if len(ferr.Field) == 0 {
+			ferr.Field = path.String()
+		}
+		return ferr
+	}
+	if errors.IsNotFound(err) {
+		return field.NotFound(path, err)
+	}
+	return field.InternalError(path, err)
 }

--- a/pkg/api/meta/pods.go
+++ b/pkg/api/meta/pods.go
@@ -270,11 +270,11 @@ func (m *podSpecMutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	for i := range m.spec.InitContainers {
 		ref := kapi.ObjectReference{Kind: "DockerImage", Name: m.spec.InitContainers[i].Image}
 		if err := fn(&ref); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("initContainers").Index(i).Child("image"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("initContainers").Index(i).Child("image")))
 			continue
 		}
 		if ref.Kind != "DockerImage" {
-			errs = append(errs, field.InternalError(m.path.Child("initContainers").Index(i).Child("image"), fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind)))
+			errs = append(errs, fieldErrorOrInternal(fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind), m.path.Child("initContainers").Index(i).Child("image")))
 			continue
 		}
 		m.spec.InitContainers[i].Image = ref.Name
@@ -282,11 +282,11 @@ func (m *podSpecMutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	for i := range m.spec.Containers {
 		ref := kapi.ObjectReference{Kind: "DockerImage", Name: m.spec.Containers[i].Image}
 		if err := fn(&ref); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("containers").Index(i).Child("image"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("containers").Index(i).Child("image")))
 			continue
 		}
 		if ref.Kind != "DockerImage" {
-			errs = append(errs, field.InternalError(m.path.Child("containers").Index(i).Child("image"), fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind)))
+			errs = append(errs, fieldErrorOrInternal(fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind), m.path.Child("containers").Index(i).Child("image")))
 			continue
 		}
 		m.spec.Containers[i].Image = ref.Name
@@ -345,11 +345,11 @@ func (m *podSpecV1Mutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	for i := range m.spec.InitContainers {
 		ref := kapi.ObjectReference{Kind: "DockerImage", Name: m.spec.InitContainers[i].Image}
 		if err := fn(&ref); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("initContainers").Index(i).Child("image"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("initContainers").Index(i).Child("image")))
 			continue
 		}
 		if ref.Kind != "DockerImage" {
-			errs = append(errs, field.InternalError(m.path.Child("initContainers").Index(i).Child("image"), fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind)))
+			errs = append(errs, fieldErrorOrInternal(fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind), m.path.Child("initContainers").Index(i).Child("image")))
 			continue
 		}
 		m.spec.InitContainers[i].Image = ref.Name
@@ -357,11 +357,11 @@ func (m *podSpecV1Mutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	for i := range m.spec.Containers {
 		ref := kapi.ObjectReference{Kind: "DockerImage", Name: m.spec.Containers[i].Image}
 		if err := fn(&ref); err != nil {
-			errs = append(errs, field.InternalError(m.path.Child("containers").Index(i).Child("image"), err))
+			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("containers").Index(i).Child("image")))
 			continue
 		}
 		if ref.Kind != "DockerImage" {
-			errs = append(errs, field.InternalError(m.path.Child("containers").Index(i).Child("image"), fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind)))
+			errs = append(errs, fieldErrorOrInternal(fmt.Errorf("pod specs may only contain references to docker images, not %q", ref.Kind), m.path.Child("containers").Index(i).Child("image")))
 			continue
 		}
 		m.spec.Containers[i].Image = ref.Name

--- a/pkg/build/apis/build/types.go
+++ b/pkg/build/apis/build/types.go
@@ -442,6 +442,10 @@ const (
 	// output is an invalid reference.
 	StatusReasonInvalidOutputReference StatusReason = "InvalidOutputReference"
 
+	// StatusReasonInvalidImageReference is an error condition when the build
+	// references an invalid image.
+	StatusReasonInvalidImageReference StatusReason = "InvalidImageReference"
+
 	// StatusReasonCancelBuildFailed is an error condition when cancelling a build
 	// fails.
 	StatusReasonCancelBuildFailed StatusReason = "CancelBuildFailed"
@@ -516,6 +520,7 @@ const (
 	StatusMessageCannotCreateBuildPodSpec        = "Failed to create pod spec."
 	StatusMessageCannotCreateBuildPod            = "Failed creating build pod."
 	StatusMessageInvalidOutputRef                = "Output image could not be resolved."
+	StatusMessageInvalidImageRef                 = "Referenced image could not be resolved."
 	StatusMessageCancelBuildFailed               = "Failed to cancel build."
 	StatusMessageBuildPodDeleted                 = "The pod for this build was deleted before the build completed."
 	StatusMessageExceededRetryTimeout            = "Build did not complete and retrying timed out."

--- a/pkg/build/apis/build/validation/validation_test.go
+++ b/pkg/build/apis/build/validation/validation_test.go
@@ -2869,6 +2869,28 @@ func TestValidateBuildImageRefs(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name: "invalid docker image ref",
+			build: buildapi.Build{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default"},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Binary: &buildapi.BinaryBuildSource{},
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "DockerImage",
+									Name: "!!!myimage:tag",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "not a valid Docker pull specification: invalid reference format",
+		},
+		{
 			name: "valid s2i build w/ runtimeImage",
 			build: buildapi.Build{
 				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default"},
@@ -2907,14 +2929,14 @@ func TestValidateBuildImageRefs(t *testing.T) {
 							DockerStrategy: &buildapi.DockerBuildStrategy{
 								From: &kapi.ObjectReference{
 									Kind: "ImageStreamTag",
-									Name: "myimagestream:tag",
+									Name: "myimagestream",
 								},
 							},
 						},
 					},
 				},
 			},
-			expectedError: "only DockerImage references",
+			expectedError: "must be <name>:<tag>",
 		},
 		{
 			name: "s2i build with valid source image references",
@@ -2976,7 +2998,7 @@ func TestValidateBuildImageRefs(t *testing.T) {
 								{
 									From: kapi.ObjectReference{
 										Kind: "ImageStreamTag",
-										Name: "myimagestream:tag",
+										Name: "",
 									},
 									Paths: []buildapi.ImageSourcePath{
 										{
@@ -2998,7 +3020,7 @@ func TestValidateBuildImageRefs(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "only DockerImage references",
+			expectedError: "Required value",
 		},
 		{
 			name: "s2i build with ImageStreamTag runtimeImage",
@@ -3017,14 +3039,14 @@ func TestValidateBuildImageRefs(t *testing.T) {
 								},
 								RuntimeImage: &kapi.ObjectReference{
 									Kind: "ImageStreamTag",
-									Name: "runtimestream:tag",
+									Name: "",
 								},
 							},
 						},
 					},
 				},
 			},
-			expectedError: "only DockerImage references",
+			expectedError: "Required value",
 		},
 		{
 			name: "custom build with ImageStreamTag in from",
@@ -3039,19 +3061,128 @@ func TestValidateBuildImageRefs(t *testing.T) {
 							CustomStrategy: &buildapi.CustomBuildStrategy{
 								From: kapi.ObjectReference{
 									Kind: "ImageStreamTag",
-									Name: "myimagestream:tag",
+									Name: ":tag",
 								},
 							},
 						},
 					},
 				},
 			},
-			expectedError: "only DockerImage references",
+			expectedError: "invalid",
 		},
 	}
 
 	for _, tc := range tests {
 		errs := ValidateBuild(&tc.build)
+		if tc.expectedError == "" && len(errs) > 0 {
+			t.Errorf("%s: Unexpected validation result: %v", tc.name, errs)
+		}
+
+		if tc.expectedError != "" {
+			found := false
+			for _, err := range errs {
+				if strings.Contains(err.Error(), tc.expectedError) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%s: Expected to fail with %q, result: %v", tc.name, tc.expectedError, errs)
+			}
+		}
+	}
+}
+
+func TestValidateBuildUpdateImageReferences(t *testing.T) {
+	tests := []struct {
+		name          string
+		old           buildapi.Build
+		build         buildapi.Build
+		expectedError string
+	}{
+		{
+			name: "invalid docker image reference is ignored if it doesn't change",
+			build: buildapi.Build{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", ResourceVersion: "10"},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Binary: &buildapi.BinaryBuildSource{},
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "DockerImage",
+									Name: "!!!myimage:tag",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: buildapi.Build{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default"},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Binary: &buildapi.BinaryBuildSource{},
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "DockerImage",
+									Name: "!!!myimage:tag",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "docker image reference is immutable",
+			build: buildapi.Build{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", ResourceVersion: "10"},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Binary: &buildapi.BinaryBuildSource{},
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "DockerImage",
+									Name: "myimage:tag2",
+								},
+							},
+						},
+					},
+				},
+			},
+			old: buildapi.Build{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default"},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Binary: &buildapi.BinaryBuildSource{},
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "DockerImage",
+									Name: "myimage:tag",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: "spec is immutable",
+		},
+	}
+
+	for _, tc := range tests {
+		errs := ValidateBuildUpdate(&tc.build, &tc.old)
 		if tc.expectedError == "" && len(errs) > 0 {
 			t.Errorf("%s: Unexpected validation result: %v", tc.name, errs)
 		}

--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -3,12 +3,15 @@ package build
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientv1 "k8s.io/client-go/pkg/api/v1"
@@ -22,8 +25,8 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kexternalcoreinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions/core/v1"
 	v1lister "k8s.io/kubernetes/pkg/client/listers/core/v1"
-	kcontroller "k8s.io/kubernetes/pkg/controller"
 
+	"github.com/openshift/origin/pkg/api/meta"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/apis/build/validation"
 	buildclient "github.com/openshift/origin/pkg/build/client"
@@ -49,8 +52,71 @@ const (
 	maxExcerptLength = 5
 )
 
+// resourceTriggerQueue tracks a set of resource keys to trigger when another object changes.
+type resourceTriggerQueue struct {
+	lock  sync.Mutex
+	queue map[string][]string
+}
+
+// newResourceTriggerQueue creates a resourceTriggerQueue.
+func newResourceTriggerQueue() *resourceTriggerQueue {
+	return &resourceTriggerQueue{
+		queue: make(map[string][]string),
+	}
+}
+
+// Add ensures resource will be returned the next time any of on are invoked
+// on Pop().
+func (q *resourceTriggerQueue) Add(resource string, on []string) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for _, key := range on {
+		q.queue[key] = append(q.queue[key], resource)
+	}
+}
+
+func (q *resourceTriggerQueue) Remove(resource string, on []string) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	for _, key := range on {
+		resources := q.queue[key]
+		newResources := make([]string, 0, len(resources))
+		for _, existing := range resources {
+			if existing == resource {
+				continue
+			}
+			newResources = append(newResources, existing)
+		}
+		q.queue[key] = newResources
+	}
+}
+
+func (q *resourceTriggerQueue) Pop(key string) []string {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	resources := q.queue[key]
+	delete(q.queue, key)
+	return resources
+}
+
 // BuildController watches builds and synchronizes them with their
-// corresponding build pods
+// corresponding build pods. It is also responsible for resolving image
+// stream references in the Build to docker images prior to invoking the pod.
+// The build controller late binds image stream references so that users can
+// create a build config before they create the image stream (or before
+// an image is pushed to a tag) which allows actions to converge. It also
+// allows multiple Build objects to directly reference images created by another
+// Build, acting as a simple dependency graph for a logical multi-image build
+// that reuses many individual Builds.
+//
+// Like other controllers that do "on behalf of" image resolution, the controller
+// resolves the reference which allows users to see what image ID corresponds to a tag
+// simply by requesting resolution. This is consistent with other image policy in the
+// system (image tag references in deployments, triggers, and image policy). The only
+// leaked image information is the ID which is considered acceptable. Secrets are also
+// resolved, allowing a user in the same namespace to in theory infer the presence of
+// a secret or make it usable by a build - but this is identical to our existing model
+// where a service account determines access to secrets used in pods.
 type BuildController struct {
 	buildPatcher      buildclient.BuildPatcher
 	buildLister       buildlister.BuildLister
@@ -59,7 +125,8 @@ type BuildController struct {
 	podClient         kexternalcoreclient.PodsGetter
 	kubeClient        kclientset.Interface
 
-	queue workqueue.RateLimitingInterface
+	queue            workqueue.RateLimitingInterface
+	imageStreamQueue *resourceTriggerQueue
 
 	buildStore       buildlister.BuildLister
 	secretStore      v1lister.SecretLister
@@ -129,7 +196,9 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 		buildDefaults:  params.BuildDefaults,
 		buildOverrides: params.BuildOverrides,
 
-		queue:       workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		imageStreamQueue: newResourceTriggerQueue(),
+
 		recorder:    eventBroadcaster.NewRecorder(kapi.Scheme, clientv1.EventSource{Component: "build-controller"}),
 		runPolicies: policy.GetAllRunPolicies(buildLister, buildClient),
 	}
@@ -142,6 +211,10 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 		AddFunc:    c.buildAdded,
 		UpdateFunc: c.buildUpdated,
 	})
+	params.ImageStreamInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.imageStreamAdded,
+		UpdateFunc: c.imageStreamUpdated,
+	})
 
 	c.buildStoreSynced = c.buildInformer.HasSynced
 	c.podStoreSynced = c.podInformer.HasSynced
@@ -152,12 +225,12 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 }
 
 // Run begins watching and syncing.
-func (c *BuildController) Run(workers int, stopCh <-chan struct{}) {
+func (bc *BuildController) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
+	defer bc.queue.ShutDown()
 
 	// Wait for the controller stores to sync before starting any work in this controller.
-	if !cache.WaitForCacheSync(stopCh, c.buildStoreSynced, c.podStoreSynced, c.secretStoreSynced, c.imageStreamStoreSynced) {
+	if !cache.WaitForCacheSync(stopCh, bc.buildStoreSynced, bc.podStoreSynced, bc.secretStoreSynced, bc.imageStreamStoreSynced) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 		return
 	}
@@ -165,7 +238,7 @@ func (c *BuildController) Run(workers int, stopCh <-chan struct{}) {
 	glog.Infof("Starting build controller")
 
 	for i := 0; i < workers; i++ {
-		go wait.Until(c.worker, time.Second, stopCh)
+		go wait.Until(bc.worker, time.Second, stopCh)
 	}
 
 	<-stopCh
@@ -329,31 +402,11 @@ func (bc *BuildController) handleNewBuild(build *buildapi.Build, pod *v1.Pod) (*
 	return bc.createBuildPod(build)
 }
 
-// createPodSpec creates a pod spec for the given build
-func (bc *BuildController) createPodSpec(originalBuild *buildapi.Build, ref string, secret *kapi.LocalObjectReference) (*v1.Pod, error) {
-	// TODO(rhcarvalho)
-	// The S2I and Docker builders expect build.Spec.Output.To to contain a
-	// resolved reference to a Docker image. Since build.Spec is immutable, we
-	// change a copy (that is never persisted) and pass it to
-	// createStrategy.createBuildPod. We should make the builders use
-	// build.Status.OutputDockerImageReference, which will make copying the build
-	// unnecessary.
-	build, err := buildutil.BuildDeepCopy(originalBuild)
-	if err != nil {
-		return nil, fmt.Errorf("unable to copy build %s: %v", buildDesc(originalBuild), err)
+// createPodSpec creates a pod spec for the given build, with all references already resolved.
+func (bc *BuildController) createPodSpec(build *buildapi.Build) (*v1.Pod, error) {
+	if build.Spec.Output.To != nil {
+		build.Status.OutputDockerImageReference = build.Spec.Output.To.Name
 	}
-
-	build.Status.OutputDockerImageReference = ref
-	if build.Spec.Output.To != nil && len(build.Spec.Output.To.Name) != 0 {
-		build.Spec.Output.To = &kapi.ObjectReference{
-			Kind: "DockerImage",
-			Name: ref,
-		}
-	}
-
-	// set the pushSecret that will be needed by the build to push the image to the registry
-	// at the end of the build.
-	build.Spec.Output.PushSecret = secret
 
 	// ensure the build object the pod sees starts with a clean set of reasons/messages,
 	// rather than inheriting the potential "invalidoutputreference" message from the current
@@ -382,59 +435,6 @@ func (bc *BuildController) createPodSpec(originalBuild *buildapi.Build, ref stri
 		return nil, err
 	}
 	return podSpec, nil
-}
-
-// resolveOutputDockerImageReference returns a Docker image name
-// computed from the build.Spec.Output.To reference.
-// Note that we are using controller level permissions to resolve the imagestream and secret,
-// meaning users could theoretically define a build that references an imagestream they cannot
-// see, and 1) get the docker image reference of that imagestream and 2) a reference to a secret
-// associated with a service account that can push to that location.  However they still cannot view the secret,
-// and ability to use a service account implies access to its secrets, so this is considered safe.
-// Furthermore it's necessary to enable triggered builds since a triggered build is not "requested"
-// by a particular user, so there are no user permissions to validate against in that case.
-func (bc *BuildController) resolveOutputDockerImageReference(build *buildapi.Build) (string, error) {
-	outputTo := build.Spec.Output.To
-	if outputTo == nil || outputTo.Name == "" {
-		return "", nil
-	}
-	var ref string
-	switch outputTo.Kind {
-	case "DockerImage":
-		ref = outputTo.Name
-	case "ImageStream", "ImageStreamTag":
-		// TODO(smarterclayton): security, ensure that the reference image stream is actually visible
-		namespace := outputTo.Namespace
-		if len(namespace) == 0 {
-			namespace = build.Namespace
-		}
-
-		var tag string
-		streamName := outputTo.Name
-		if outputTo.Kind == "ImageStreamTag" {
-			var ok bool
-			streamName, tag, ok = imageapi.SplitImageStreamTag(streamName)
-			if !ok {
-				return "", fmt.Errorf("the referenced image stream tag is invalid: %s", outputTo.Name)
-			}
-			tag = ":" + tag
-		}
-		stream, err := bc.imageStreamStore.ImageStreams(namespace).Get(streamName)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return "", fmt.Errorf("the referenced output image stream %s/%s does not exist", namespace, streamName)
-			}
-			return "", fmt.Errorf("the referenced output image stream %s/%s could not be found by build %s/%s: %v", namespace, streamName, build.Namespace, build.Name, err)
-		}
-		if len(stream.Status.DockerImageRepository) == 0 {
-			e := fmt.Errorf("the image stream %s/%s cannot be used as the output for build %s/%s because the integrated Docker registry is not configured and no external registry was defined", namespace, outputTo.Name, build.Namespace, build.Name)
-			bc.recorder.Eventf(build, kapi.EventTypeWarning, "invalidOutput", "Error starting build: %v", e)
-			return "", e
-		}
-		ref = fmt.Sprintf("%s%s", stream.Status.DockerImageRepository, tag)
-	}
-
-	return ref, nil
 }
 
 // resolvePushSecretAsReference returns a LocalObjectReference to a secret that should
@@ -472,39 +472,281 @@ func (bc *BuildController) resolvePushSecretAsReference(build *buildapi.Build, i
 	return pushSecret, nil
 }
 
-// createBuildPod creates a new pod to run a build
-func (bc *BuildController) createBuildPod(build *buildapi.Build) (*buildUpdate, error) {
+// resourceName creates a string that can be used to uniquely key the provided resource.
+func resourceName(namespace, name string) string {
+	return namespace + "/" + name
+}
 
-	update := &buildUpdate{}
+var (
+	// errInvalidImageReferences is a marker error for when a build contains invalid object
+	// reference names.
+	errInvalidImageReferences = fmt.Errorf("one or more image references were invalid")
+	// errNoIntegratedRegistry is a marker error for when the output image points to a registry
+	// that cannot be resolved.
+	errNoIntegratedRegistry = fmt.Errorf("the integrated registry is not configured")
+)
 
-	// Set the output Docker image reference as well as look up the pushsecret that
-	// should be used to push to the resolved image reference.  We are late-resolving this information
-	// so users can create a build before the output imagestream exists.  Resolving it at
-	// build instantiate time would mean we'd have to fail the build request immediately if
-	// the output imagestream did not already exist.
-	ref, err := bc.resolveOutputDockerImageReference(build)
+// unresolvedImageStreamReferences finds all image stream references in the provided
+// mutator that need to be resolved prior to the resource being accepted and returns
+// them as an array of "namespace/name" strings. If any references are invalid, an error
+// is returned.
+func unresolvedImageStreamReferences(m meta.ImageReferenceMutator, defaultNamespace string) ([]string, error) {
+	var streams []string
+	fn := func(ref *kapi.ObjectReference) error {
+		switch ref.Kind {
+		case "ImageStreamImage":
+			namespace := ref.Namespace
+			if len(namespace) == 0 {
+				namespace = defaultNamespace
+			}
+			name, _, ok := imageapi.SplitImageStreamImage(ref.Name)
+			if !ok {
+				return errInvalidImageReferences
+			}
+			streams = append(streams, resourceName(namespace, name))
+		case "ImageStreamTag":
+			namespace := ref.Namespace
+			if len(namespace) == 0 {
+				namespace = defaultNamespace
+			}
+			name, _, ok := imageapi.SplitImageStreamTag(ref.Name)
+			if !ok {
+				return errInvalidImageReferences
+			}
+			streams = append(streams, resourceName(namespace, name))
+		}
+		return nil
+	}
+	errs := m.Mutate(fn)
+	if len(errs) > 0 {
+		return nil, errInvalidImageReferences
+	}
+	return streams, nil
+}
+
+// resolveImageStreamLocation transforms the provided reference into a string pointing to the integrated registry,
+// or returns an error.
+func resolveImageStreamLocation(ref *kapi.ObjectReference, lister imagelister.ImageStreamLister, defaultNamespace string) (string, error) {
+	namespace := ref.Namespace
+	if len(namespace) == 0 {
+		namespace = defaultNamespace
+	}
+
+	var (
+		name string
+		tag  string
+	)
+	switch ref.Kind {
+	case "ImageStreamImage":
+		var ok bool
+		name, _, ok = imageapi.SplitImageStreamImage(ref.Name)
+		if !ok {
+			return "", errInvalidImageReferences
+		}
+		// for backwards compatibility, image stream images will be resolved to the :latest tag
+		tag = imageapi.DefaultImageTag
+	case "ImageStreamTag":
+		var ok bool
+		name, tag, ok = imageapi.SplitImageStreamTag(ref.Name)
+		if !ok {
+			return "", errInvalidImageReferences
+		}
+	case "ImageStream":
+		name = ref.Name
+	}
+
+	stream, err := lister.ImageStreams(namespace).Get(name)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", err
+		}
+		return "", fmt.Errorf("the referenced output image stream %s/%s could not be found: %v", namespace, name, err)
+	}
+
+	// TODO: this check will not work if the admin installs the registry without restarting the controller, because
+	// only a relist from the API server will correct the empty value here (no watch events are sent)
+	if len(stream.Status.DockerImageRepository) == 0 {
+		return "", errNoIntegratedRegistry
+	}
+
+	repo, err := imageapi.ParseDockerImageReference(stream.Status.DockerImageRepository)
+	if err != nil {
+		return "", fmt.Errorf("the referenced output image stream does not represent a valid reference name: %v", err)
+	}
+	repo.ID = ""
+	repo.Tag = tag
+	return repo.Exact(), nil
+}
+
+func resolveImageStreamImage(ref *kapi.ObjectReference, lister imagelister.ImageStreamLister, defaultNamespace string) (*kapi.ObjectReference, error) {
+	namespace := ref.Namespace
+	if len(namespace) == 0 {
+		namespace = defaultNamespace
+	}
+	name, imageID, ok := imageapi.SplitImageStreamImage(ref.Name)
+	if !ok {
+		return nil, errInvalidImageReferences
+	}
+	stream, err := lister.ImageStreams(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("the referenced image stream %s/%s could not be found: %v", namespace, name, err)
+	}
+	event, err := imageapi.ResolveImageID(stream, imageID)
+	if err != nil {
+		return nil, err
+	}
+	if len(event.DockerImageReference) == 0 {
+		return nil, fmt.Errorf("the referenced image stream image %s/%s does not have a pull spec", namespace, ref.Name)
+	}
+	return &kapi.ObjectReference{Kind: "DockerImage", Name: event.DockerImageReference}, nil
+}
+
+func resolveImageStreamTag(ref *kapi.ObjectReference, lister imagelister.ImageStreamLister, defaultNamespace string) (*kapi.ObjectReference, error) {
+	namespace := ref.Namespace
+	if len(namespace) == 0 {
+		namespace = defaultNamespace
+	}
+	name, tag, ok := imageapi.SplitImageStreamTag(ref.Name)
+	if !ok {
+		return nil, errInvalidImageReferences
+	}
+	stream, err := lister.ImageStreams(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("the referenced image stream %s/%s could not be found: %v", namespace, name, err)
+	}
+	if newRef, ok := imageapi.ResolveLatestTaggedImage(stream, tag); ok {
+		return &kapi.ObjectReference{Kind: "DockerImage", Name: newRef}, nil
+	}
+	return nil, fmt.Errorf("the referenced image stream tag %s/%s does not exist", namespace, ref.Name)
+}
+
+// resolveOutputDockerImageReference updates the output spec to a docker image reference.
+func (bc *BuildController) resolveOutputDockerImageReference(build *buildapi.Build) error {
+	ref := build.Spec.Output.To
+	if ref == nil || ref.Name == "" {
+		return nil
+	}
+
+	switch ref.Kind {
+	case "ImageStream", "ImageStreamTag":
+		newRef, err := resolveImageStreamLocation(ref, bc.imageStreamStore, build.Namespace)
+		if err != nil {
+			return err
+		}
+		*ref = kapi.ObjectReference{Kind: "DockerImage", Name: newRef}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// resolveImageReferences resolves references to Docker images computed from the build.Spec. It will update
+// the output spec as well if it has not already been updated.
+func (bc *BuildController) resolveImageReferences(build *buildapi.Build, update *buildUpdate) error {
+	m := meta.NewBuildMutator(build)
+
+	// get a list of all unresolved references to add to the cache
+	streams, err := unresolvedImageStreamReferences(m, build.Namespace)
+	if err != nil {
+		return err
+	}
+	if len(streams) == 0 {
+		glog.V(5).Infof("Build %s contains no unresolved image references", build.Name)
+		return nil
+	}
+
+	// build references are level driven, so we queue here to ensure we get notified if
+	// we are racing against updates in the image stream store
+	buildKey := resourceName(build.Namespace, build.Name)
+	bc.imageStreamQueue.Add(buildKey, streams)
+
+	// resolve the output image reference
+	if err := bc.resolveOutputDockerImageReference(build); err != nil {
 		// If we cannot resolve the output reference, the output image stream
 		// may not yet exist. The build should remain in the new state and show the
 		// reason that it is still in the new state.
 		update.setReason(buildapi.StatusReasonInvalidOutputReference)
 		update.setMessage(buildapi.StatusMessageInvalidOutputRef)
+		if err == errNoIntegratedRegistry {
+			e := fmt.Errorf("an image stream cannot be used as build output because the integrated Docker registry is not configured")
+			bc.recorder.Eventf(build, kapi.EventTypeWarning, "InvalidOutput", "Error starting build: %v", e)
+		}
+		return err
+	}
+
+	// resolve the remaining references
+	errs := m.Mutate(func(ref *kapi.ObjectReference) error {
+		switch ref.Kind {
+		case "ImageStreamImage":
+			newRef, err := resolveImageStreamImage(ref, bc.imageStreamStore, build.Namespace)
+			if err != nil {
+				return err
+			}
+			*ref = *newRef
+		case "ImageStreamTag":
+			newRef, err := resolveImageStreamTag(ref, bc.imageStreamStore, build.Namespace)
+			if err != nil {
+				return err
+			}
+			*ref = *newRef
+		}
+		return nil
+	})
+
+	if len(errs) > 0 {
+		update.setReason(buildapi.StatusReasonInvalidImageReference)
+		update.setMessage(buildapi.StatusMessageInvalidImageRef)
+		return errs.ToAggregate()
+	}
+	// we have resolved all images, and will not need any further notifications
+	bc.imageStreamQueue.Remove(buildKey, streams)
+	return nil
+}
+
+// createBuildPod creates a new pod to run a build
+func (bc *BuildController) createBuildPod(build *buildapi.Build) (*buildUpdate, error) {
+	update := &buildUpdate{}
+
+	// image reference resolution requires a copy of the build
+	var err error
+	build, err = buildutil.BuildDeepCopy(build)
+	if err != nil {
+		return nil, fmt.Errorf("unable to copy build %s: %v", buildDesc(build), err)
+	}
+
+	// Resolve all Docker image references to valid values.
+	if err := bc.resolveImageReferences(build, update); err != nil {
+		// if we're waiting for an image stream to exist, we will get an update via the
+		// trigger, and thus don't need to be requeued.
+		if hasError(err, errors.IsNotFound, field.NewErrorTypeMatcher(field.ErrorTypeNotFound)) {
+			return update, nil
+		}
 		return update, err
 	}
+
+	// Set the pushSecret that will be needed by the build to push the image to the registry
+	// at the end of the build.
 	pushSecret := build.Spec.Output.PushSecret
 	// Only look up a push secret if the user hasn't explicitly provided one.
 	if build.Spec.Output.PushSecret == nil && build.Spec.Output.To != nil && len(build.Spec.Output.To.Name) > 0 {
 		var err error
-		pushSecret, err = bc.resolvePushSecretAsReference(build, ref)
+		pushSecret, err = bc.resolvePushSecretAsReference(build, build.Spec.Output.To.Name)
 		if err != nil {
 			update.setReason(buildapi.StatusReasonCannotRetrieveServiceAccount)
 			update.setMessage(buildapi.StatusMessageCannotRetrieveServiceAccount)
 			return update, err
 		}
 	}
+	build.Spec.Output.PushSecret = pushSecret
 
 	// Create the build pod spec
-	buildPod, err := bc.createPodSpec(build, ref, pushSecret)
+	buildPod, err := bc.createPodSpec(build)
 	if err != nil {
 		switch err.(type) {
 		case common.ErrEnvVarResolver:
@@ -560,13 +802,14 @@ func (bc *BuildController) createBuildPod(build *buildapi.Build) (*buildUpdate, 
 	}
 
 	update.setPodNameAnnotation(buildPod.Name)
-	update.setOutputRef(ref)
+	if build.Spec.Output.To != nil {
+		update.setOutputRef(build.Spec.Output.To.Name)
+	}
 	return update, nil
 }
 
 // handleActiveBuild handles a build in either pending or running state
 func (bc *BuildController) handleActiveBuild(build *buildapi.Build, pod *v1.Pod) (*buildUpdate, error) {
-
 	if pod == nil {
 		pod = bc.findMissingPod(build)
 		if pod == nil {
@@ -808,18 +1051,29 @@ func (bc *BuildController) buildUpdated(old, cur interface{}) {
 
 // enqueueBuild adds the given build to the queue.
 func (bc *BuildController) enqueueBuild(build *buildapi.Build) {
-	key, err := kcontroller.KeyFunc(build)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for build %#v: %v", build, err))
-		return
-	}
+	key := resourceName(build.Namespace, build.Name)
 	bc.queue.Add(key)
 }
 
 // enqueueBuildForPod adds the build corresponding to the given pod to the controller
 // queue. If a build is not found for the pod, then an error is logged.
 func (bc *BuildController) enqueueBuildForPod(pod *v1.Pod) {
-	bc.queue.Add(fmt.Sprintf("%s/%s", pod.Namespace, buildutil.GetBuildName(pod)))
+	bc.queue.Add(resourceName(pod.Namespace, buildutil.GetBuildName(pod)))
+}
+
+// imageStreamAdded queues any builds that have registered themselves for this image stream.
+// Because builds are level driven when resolving images, we are not concerned with duplicate
+// build events.
+func (bc *BuildController) imageStreamAdded(obj interface{}) {
+	stream := obj.(*imageapi.ImageStream)
+	for _, buildKey := range bc.imageStreamQueue.Pop(resourceName(stream.Namespace, stream.Name)) {
+		bc.queue.Add(buildKey)
+	}
+}
+
+// imageStreamUpdated queues any builds that have registered themselves for the image stream.
+func (bc *BuildController) imageStreamUpdated(old, cur interface{}) {
+	bc.imageStreamAdded(cur)
 }
 
 // handleError is called by the main work loop to check the return of calling handleBuild.
@@ -936,4 +1190,26 @@ func setBuildCompletionData(build *buildapi.Build, pod *v1.Pod, update *buildUpd
 		}
 	}
 
+}
+
+// hasError returns true if any error (aggregate or no) matches any of the
+// provided functions.
+func hasError(err error, fns ...utilerrors.Matcher) bool {
+	if err == nil {
+		return false
+	}
+	if agg, ok := err.(utilerrors.Aggregate); ok {
+		for _, err := range agg.Errors() {
+			if hasError(err, fns...) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, fn := range fns {
+		if fn(err) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
With image resolution in place, image stream tags are resolved
automatically if the tag/image already exists when the user creates the
build. Relax validation to allow users to set `ImageStreamTag` and
`ImageStreamImage` as `kind` on all build references, and resolve them
in the controller.

Change the build controller to be level driven for image references and
to be triggered whenever an image reference is resolved. The resolver
will queue any unresolved image references and watch for changes to
image streams.

Tighten validation on other build object references - DockerImage now
*must* be valid on all refs (it would fail to build, so at worst users
can't trigger new builds until they resolve their issue).

[test] @csrwng @bparees for 3.7, but this allows the following construct:

```
kind: ImageStream
metadata:
  name: test
---
kind: Build
metadata:
  name: binaries
spec:
  output:
    to:
      kind: ImageStreamTag
      name: test:binaries
  strategy:
    source:
      ...
---
kind: Build
metadata:
  name: layer
spec:
  source:
    images:
    - from:
        kind: ImageStreamTag
        name: test:binaries
```

So someone can execute builds directly, and have each build depend on the output of the last. Will allow Jenkins systems to do chained builds without having a build config, or a local dev to build directly from some blob binary.

Still need to add more e2e test