### PR TITLE
swagger.json should be accessible to anonymous users

### DIFF
--- a/pkg/authorization/apis/authorization/types.go
+++ b/pkg/authorization/apis/authorization/types.go
@@ -49,7 +49,7 @@ var DiscoveryRule = PolicyRule{
 		"/api", "/api/*",
 		"/apis", "/apis/*",
 		"/oapi", "/oapi/*",
-		"/swaggerapi", "/swaggerapi/*",
+		"/swaggerapi", "/swaggerapi/*", "/swagger.json",
 		"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
 		"/.well-known", "/.well-known/*",
 	),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1790,6 +1790,7 @@ items:
     - /oapi/*
     - /osapi
     - /osapi/
+    - /swagger.json
     - /swaggerapi
     - /swaggerapi/*
     - /version
@@ -2513,6 +2514,7 @@ items:
     - /oapi/*
     - /osapi
     - /osapi/
+    - /swagger.json
     - /swaggerapi
     - /swaggerapi/*
     - /version


### PR DESCRIPTION
It is part of the public Kube API

[severity:blocker][merge]

Replaces #14955 for 3.6