### PR TITLE
Add an option to refresh to newest hack/env image

### DIFF
--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -205,6 +205,11 @@ function os::build::environment::run() {
     fi
   fi
 
+  if [[ -n "${OS_BUILD_ENV_PULL_IMAGE:-}" ]]; then
+    os::log::info "Pulling the ${OS_BUILD_ENV_IMAGE} image to update it..."
+    docker pull "${OS_BUILD_ENV_IMAGE}"
+  fi
+
   os::log::debug "Using commit ${commit}"
   os::log::debug "Using volume ${volume}"
 


### PR DESCRIPTION
If we pre-pull the `openshift/origin-release` image onto the nodes that
run our CI we still need to ensure that we are updating to the newest
version of the image that is released when we run the CI, regardless of
when the underlying AMI was created for that job. This patch allows for
a user to pass in `$OS_BUILD_ENV_PULL_IMAGE` to force a new image to be
pulled.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton FYI