### PR TITLE
UPSTREAM: Do not mutate pods on update that are scheduled

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission.go
@@ -68,6 +68,6 @@ func (a *alwaysPullImages) Admit(attributes admission.Attributes) (err error) {
 // NewAlwaysPullImages creates a new always pull images admission control handler
 func NewAlwaysPullImages() admission.Interface {
 	return &alwaysPullImages{
-		Handler: admission.NewHandler(admission.Create, admission.Update),
+		Handler: admission.NewHandler(admission.Create),
 	}
 }

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages/admission_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package alwayspullimages
 
 import (
+	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +61,37 @@ func TestAdmission(t *testing.T) {
 		if c.ImagePullPolicy != api.PullAlways {
 			t.Errorf("Container %v: expected pull always, got %v", c, c.ImagePullPolicy)
 		}
+	}
+}
+
+func TestAdmissionOnUpdate(t *testing.T) {
+	namespace := "test"
+	handler := &alwaysPullImages{}
+	pod := &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
+		Spec: api.PodSpec{
+			InitContainers: []api.Container{
+				{Name: "init1", Image: "image"},
+				{Name: "init2", Image: "image", ImagePullPolicy: api.PullNever},
+				{Name: "init3", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
+				{Name: "init4", Image: "image", ImagePullPolicy: api.PullAlways},
+			},
+			Containers: []api.Container{
+				{Name: "ctr1", Image: "image"},
+				{Name: "ctr2", Image: "image", ImagePullPolicy: api.PullNever},
+				{Name: "ctr3", Image: "image", ImagePullPolicy: api.PullIfNotPresent},
+				{Name: "ctr4", Image: "image", ImagePullPolicy: api.PullAlways},
+			},
+		},
+	}
+	copied, _ := api.Scheme.Copy(pod)
+	original := copied.(*api.Pod)
+	err := handler.Admit(admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler")
+	}
+	if !reflect.DeepEqual(copied, original) {
+		t.Fatalf("Pod should not be modified on update")
 	}
 }
 


### PR DESCRIPTION
That is an illegal operation in validation, which means these cannot be turned on after a cluster is already running.

[test] @deads2k

Fixes #15188

Will update commit with correct upstream shortly