### PR TITLE
Fixing oc rsync command fails if oc command has space in path

### DIFF
--- a/pkg/cmd/util/sibling.go
+++ b/pkg/cmd/util/sibling.go
@@ -20,7 +20,7 @@ func SiblingCommand(cmd *cobra.Command, name string) string {
 	// Replace the root command with what was actually used
 	// in the command line
 	glog.V(4).Infof("Setting root command to: %s", os.Args[0])
-	command[0] = os.Args[0]
+	command[0] = "\"" + os.Args[0] + "\""
 
 	// Append the sibling command
 	command = append(command, name)


### PR DESCRIPTION
oc sibling commands (example rsync) fail if there is a space
in the path to the oc command

escapes spaces in the command path

Fixes #15187