### PR TITLE
Remove use of policy API from CLI

### DIFF
--- a/pkg/authorization/apis/authorization/helpers.go
+++ b/pkg/authorization/apis/authorization/helpers.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"unicode"
 
@@ -105,25 +104,6 @@ func (r PolicyRule) CompactString() string {
 	return fmt.Sprintf(formatString, formatArgs...)
 }
 
-func getRoleBindingValues(roleBindingMap map[string]*RoleBinding) []*RoleBinding {
-	ret := []*RoleBinding{}
-	for _, currBinding := range roleBindingMap {
-		ret = append(ret, currBinding)
-	}
-
-	return ret
-}
-func SortRoleBindings(roleBindingMap map[string]*RoleBinding, reverse bool) []*RoleBinding {
-	roleBindings := getRoleBindingValues(roleBindingMap)
-	if reverse {
-		sort.Sort(sort.Reverse(RoleBindingSorter(roleBindings)))
-	} else {
-		sort.Sort(RoleBindingSorter(roleBindings))
-	}
-
-	return roleBindings
-}
-
 type PolicyBindingSorter []PolicyBinding
 
 func (s PolicyBindingSorter) Len() int {
@@ -136,7 +116,7 @@ func (s PolicyBindingSorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-type RoleBindingSorter []*RoleBinding
+type RoleBindingSorter []RoleBinding
 
 func (s RoleBindingSorter) Len() int {
 	return len(s)

--- a/test/cmd/policy-storage-admin.sh
+++ b/test/cmd/policy-storage-admin.sh
@@ -31,8 +31,8 @@ os::cmd::expect_success_and_text 'oc policy can-i create pv' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i create storageclass' 'yes'
 
 # Test failure to change policy on users for storage-admin
-os::cmd::expect_failure_and_text 'oc policy add-role-to-user admin storage-adm' 'cannot get policybindings'
-os::cmd::expect_failure_and_text 'oc policy remove-user screeley' 'cannot list policybindings'
+os::cmd::expect_failure_and_text 'oc policy add-role-to-user admin storage-adm' 'cannot list rolebindings'
+os::cmd::expect_failure_and_text 'oc policy remove-user screeley' 'cannot list rolebindings'
 os::cmd::expect_success 'oc logout'
 
 # Test that scoped storage-admin now an admin in project foo


### PR DESCRIPTION
This change removes the use of the policy API in CLI commands that interact with roles and bindings.  The policy API is deprecated and will be removed in the 3.7 release.  Thus this is required to make sure that a 3.6 `oc` binary continues to work with a 3.7 master.

Signed-off-by: Monis Khan <mkhan@redhat.com>