### PR TITLE
Set mutation limit proportional to read limit by default

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -155,6 +155,7 @@ func BuildKubeAPIserverOptions(masterConfig configapi.MasterConfig) (*kapiserver
 	server.Etcd.DefaultWatchCacheSize = DefaultWatchCacheSize
 
 	server.GenericServerRunOptions.MaxRequestsInFlight = masterConfig.ServingInfo.MaxRequestsInFlight
+	server.GenericServerRunOptions.MaxMutatingRequestsInFlight = masterConfig.ServingInfo.MaxRequestsInFlight / 2
 	server.GenericServerRunOptions.MinRequestTimeout = masterConfig.ServingInfo.RequestTimeoutSeconds
 	for _, nc := range masterConfig.ServingInfo.NamedCertificates {
 		sniCert := utilflag.NamedCertKey{


### PR DESCRIPTION
If you set 1200 as the default, keeping mutation 200 isn't very useful.

[test]