### PR TITLE
fix #15205. Allow ansible to set hawkular route name using subdomain

### DIFF
--- a/pkg/bootstrap/docker/openshift/ansible.go
+++ b/pkg/bootstrap/docker/openshift/ansible.go
@@ -38,12 +38,12 @@ nodes
 
 openshift_deployment_type={{.OSEDeploymentType}} 
 
+openshift_master_default_subdomain={{.DefaultSubdomain}}
+
 openshift_metrics_install_metrics=True
 openshift_metrics_image_prefix={{.MetricsImagePrefix}}
 openshift_metrics_image_version={{.MetricsImageVersion}}
 openshift_metrics_resolution={{.MetricsResolution}}
-
-openshift_metrics_hawkular_hostname={{.HawkularHostName}}
 
 [masters]
 {{.MasterIP}} ansible_connection=local
@@ -95,10 +95,10 @@ type ansibleMetricsInventoryParams struct {
 	MetricsImagePrefix  string
 	MetricsImageVersion string
 	MetricsResolution   string
-	HawkularHostName    string
 }
 
 type ansibleInventoryParams struct {
+	DefaultSubdomain  string
 	MasterIP          string
 	MasterPublicURL   string
 	OSERelease        string

--- a/pkg/bootstrap/docker/openshift/metrics.go
+++ b/pkg/bootstrap/docker/openshift/metrics.go
@@ -22,7 +22,7 @@ const (
 )
 
 // InstallMetricsViaAnsible checks whether metrics is installed and installs it if not already installed
-func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, publicHostname, hostName, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
+func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, publicHostname, defaultSubdomain, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
 	_, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
@@ -44,7 +44,7 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, public
 	params.OSERelease = imageVersion
 	params.MetricsImagePrefix = fmt.Sprintf("%s-", imagePrefix)
 	params.MetricsImageVersion = imageVersion
-	params.HawkularHostName = hostName
+	params.DefaultSubdomain = defaultSubdomain
 	params.MetricsResolution = "10s"
 
 	runner := newAnsibleRunner(h, kubeClient, infraNamespace, imageStreams, "metrics")


### PR DESCRIPTION
This PR fixes #15205 by allowing the ansible installer to create the hawkular route using the provided subdomain.