### PR TITLE
Remove download of goversioninfo

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -261,7 +261,6 @@ readonly -f os::build::build_binaries
 # Generates the .syso file used to add compile-time VERSIONINFO metadata to the
 # Windows binary.
 function os::build::generate_windows_versioninfo() {
-  os::util::ensure::gopath_binary_exists 'goversioninfo' 'github.com/josephspurrier/goversioninfo/cmd/goversioninfo'
   os::build::version::get_vars
   local major="${OS_GIT_MAJOR}"
   local minor="${OS_GIT_MINOR%+}"


### PR DESCRIPTION
I was wrong about brew. Any traffic out for build is prohibited. I've gone through the pain of creating an RPM for this package.
@stevekuznetsov @smarterclayton 