### PR TITLE
Add limiter for blobwriter

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -43,3 +43,7 @@ openshift:
     # Attention! A weak secret can lead to the leakage of private data.
     #
     # secret: TopSecretLongToken
+  storage:
+    # The maximum value of the concurrent write requests.
+    # There is no limit if set to 0.
+    maxwriters: 0

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -8,12 +8,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus/formatters/logstash"
 	gorillahandlers "github.com/gorilla/handlers"
 
-	"github.com/Sirupsen/logrus/formatters/logstash"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/health"
@@ -35,14 +36,13 @@ import (
 	_ "github.com/docker/distribution/registry/storage/driver/s3-aws"
 	_ "github.com/docker/distribution/registry/storage/driver/swift"
 
-	"strings"
-
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/dockerregistry/server"
 	"github.com/openshift/origin/pkg/dockerregistry/server/api"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
 	registryconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/writelimiter"
 )
 
 // Execute runs the Docker registry.
@@ -78,6 +78,10 @@ func Execute(configFile io.Reader) {
 			Logger:           context.GetLogger(ctx),
 			SafeClientConfig: registryClient.SafeClientConfig(),
 		}
+	}
+
+	if extraConfig.Storage.MaxWriters > 0 {
+		ctx = server.WithBlobStoreFactory(ctx, writelimiter.NewBlobStoreFactory(extraConfig.Storage.MaxWriters))
 	}
 
 	app := handlers.NewApp(ctx, dockerConfig)

--- a/pkg/dockerregistry/server/configuration/configuration.go
+++ b/pkg/dockerregistry/server/configuration/configuration.go
@@ -28,11 +28,16 @@ type openshiftConfig struct {
 type Configuration struct {
 	Version configuration.Version `yaml:"version"`
 	Metrics Metrics               `yaml:"metrics"`
+	Storage Storage               `yaml:"storage"`
 }
 
 type Metrics struct {
 	Enabled bool   `yaml:"enabled"`
 	Secret  string `yaml:"secret"`
+}
+
+type Storage struct {
+	MaxWriters int `yaml:"maxwriters"`
 }
 
 type versionInfo struct {

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/types"
 )
 
 type contextKey string
@@ -33,6 +34,9 @@ const (
 
 	// configurationKey is the key for Configuration in Context.
 	configurationKey contextKey = "configuration"
+
+	// blobStoreFactoryKey is the key for BlobStoreFactory in Context.
+	blobStoreFactoryKey contextKey = "blobStoreFactory"
 )
 
 // withRepository returns a new Context that carries value repo.
@@ -116,4 +120,13 @@ func WithConfiguration(ctx context.Context, config *configuration.Configuration)
 // It will panic otherwise.
 func ConfigurationFrom(ctx context.Context) *configuration.Configuration {
 	return ctx.Value(configurationKey).(*configuration.Configuration)
+}
+
+func WithBlobStoreFactory(ctx context.Context, f types.BlobStoreFactory) context.Context {
+	return context.WithValue(ctx, blobStoreFactoryKey, f)
+}
+
+func BlobStoreFactoryFrom(ctx context.Context) (types.BlobStoreFactory, bool) {
+	f, ok := ctx.Value(blobStoreFactoryKey).(types.BlobStoreFactory)
+	return f, ok
 }

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -333,6 +333,10 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		}
 	}
 
+	if blobStoreFactory, ok := BlobStoreFactoryFrom(ctx); ok {
+		bs = blobStoreFactory.BlobStore(bs)
+	}
+
 	return bs
 }
 

--- a/pkg/dockerregistry/server/types/blobstorefactory.go
+++ b/pkg/dockerregistry/server/types/blobstorefactory.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/docker/distribution"
+
+// BlobStoreFactory creates middleware for BlobStore
+type BlobStoreFactory interface {
+	BlobStore(bs distribution.BlobStore) distribution.BlobStore
+}

--- a/pkg/dockerregistry/server/writelimiter/blobstore.go
+++ b/pkg/dockerregistry/server/writelimiter/blobstore.go
@@ -1,0 +1,110 @@
+package writelimiter
+
+import (
+	"errors"
+	"runtime"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/types"
+)
+
+// ErrRequistCanceled is returned when the context is canceled
+var ErrRequistCanceled = errors.New("request canceled")
+
+type blobWriter struct {
+	distribution.BlobWriter
+	release LockFinalizer
+}
+
+var _ distribution.BlobWriter = blobWriter{}
+
+func (bw blobWriter) Close() error {
+	bw.release()
+	return bw.BlobWriter.Close()
+}
+
+func (bw blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) {
+	bw.release()
+	return bw.BlobWriter.Commit(ctx, desc)
+}
+
+func (bw blobWriter) Cancel(ctx context.Context) error {
+	bw.release()
+	return bw.BlobWriter.Cancel(ctx)
+}
+
+type blobStore struct {
+	distribution.BlobStore
+	lock *cancellableLock
+}
+
+var _ distribution.BlobStore = blobStore{}
+
+func (bs blobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	release, ok := bs.lock.Acquire(ctx)
+	if !ok {
+		return nil, ErrRequistCanceled
+	}
+
+	bw, err := bs.BlobStore.Create(ctx, options...)
+	if err != nil {
+		release()
+		return bw, err
+	}
+
+	blobwriter := blobWriter{
+		BlobWriter: bw,
+		release:    release,
+	}
+
+	// We must be sure that the lock is released even if Close() has not been called.
+	// Otherwise, a leak could happen.
+	runtime.SetFinalizer(blobwriter, func(*blobWriter) { release() })
+
+	return blobwriter, nil
+}
+
+func (bs blobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	release, ok := bs.lock.Acquire(ctx)
+	if !ok {
+		return nil, ErrRequistCanceled
+	}
+
+	bw, err := bs.BlobStore.Resume(ctx, id)
+	if err != nil {
+		release()
+		return bw, err
+	}
+
+	blobwriter := &blobWriter{
+		BlobWriter: bw,
+		release:    release,
+	}
+
+	// We must be sure that the lock is released even if Close() has not been called.
+	// Otherwise, a leak could happen.
+	runtime.SetFinalizer(blobwriter, func(*blobWriter) { release() })
+
+	return blobwriter, nil
+}
+
+type blobStoreFactory struct {
+	*cancellableLock
+}
+
+var _ types.BlobStoreFactory = blobStoreFactory{}
+
+func NewBlobStoreFactory(limit int) types.BlobStoreFactory {
+	return blobStoreFactory{
+		cancellableLock: newCancellableLock(limit),
+	}
+}
+
+func (f blobStoreFactory) BlobStore(bs distribution.BlobStore) distribution.BlobStore {
+	return blobStore{
+		BlobStore: bs,
+		lock:      f.cancellableLock,
+	}
+}

--- a/pkg/dockerregistry/server/writelimiter/doc.go
+++ b/pkg/dockerregistry/server/writelimiter/doc.go
@@ -1,0 +1,3 @@
+// Package writelimiter provides middleware that limits the number of concurrent write requests.
+// Requests over the limit don't fail, but are queued and processed later.
+package writelimiter

--- a/pkg/dockerregistry/server/writelimiter/locker.go
+++ b/pkg/dockerregistry/server/writelimiter/locker.go
@@ -1,0 +1,38 @@
+package writelimiter
+
+import (
+	"sync/atomic"
+
+	"github.com/docker/distribution/context"
+)
+
+type LockFinalizer func()
+
+type cancellableLock struct {
+	sem chan struct{}
+}
+
+func newCancellableLock(size int) *cancellableLock {
+	return &cancellableLock{
+		sem: make(chan struct{}, size),
+	}
+}
+
+func (l cancellableLock) Acquire(ctx context.Context) (LockFinalizer, bool) {
+	// LOCK_BEGIN++
+	sem := l.sem
+	// LOCK_WAIT_BEGIN++
+	select {
+	case sem <- struct{}{}:
+		// LOCK_WAIT_END++
+		done := int32(0)
+		return func() {
+			if atomic.SwapInt32(&done, 1) == 0 {
+				<-sem
+				// LOCK_END++
+			}
+		}, true
+	case <-ctx.Done():
+		return nil, false
+	}
+}


### PR DESCRIPTION
With a heavy load on the registry, the s3 storage driver consumes memory.
This is because the data S3 sent in chunks. We can't use stream in this case
and are forced to accumulate data in the buffer.

To avoid extreme memory consumption, we limit the number of concurrent write
requests. Requests over limit don't fail, but are queued and processed later.

/cc @mfojtik @miminar @dmage 