### PR TITLE
UPSTREAM: 49118: Allow unmounting bind-mounted directories.

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/flexvolume/unmounter.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/flexvolume/unmounter.go
@@ -51,22 +51,14 @@ func (f *flexVolumeUnmounter) TearDownAt(dir string) error {
 		return nil
 	}
 
-	notmnt, err := isNotMounted(f.mounter, dir)
+	call := f.plugin.NewDriverCall(unmountCmd)
+	call.Append(dir)
+	_, err := call.Run()
+	if isCmdNotSupportedErr(err) {
+		err = (*unmounterDefaults)(f).TearDownAt(dir)
+	}
 	if err != nil {
 		return err
-	}
-	if notmnt {
-		glog.Warningf("Warning: Path: %v already unmounted", dir)
-	} else {
-		call := f.plugin.NewDriverCall(unmountCmd)
-		call.Append(dir)
-		_, err := call.Run()
-		if isCmdNotSupportedErr(err) {
-			err = (*unmounterDefaults)(f).TearDownAt(dir)
-		}
-		if err != nil {
-			return err
-		}
 	}
 
 	// Flexvolume driver may remove the directory. Ignore if it does.


### PR DESCRIPTION
For files, we cannot use `path/..`;
we could use `filepath.Dir` but for bind-mounted, `isNotMounted`
which calls `IsLikelyNotMountPoint` would not work anyway.
Let's just have the driver do the work.

Addressing
```
Error: UnmountVolume.TearDown failed for volume "..." (volume.spec.Name: "...") pod "..." (UID: "...") with: lstat /path/.../test-flex/..: not a directory
```