### PR TITLE
use openshift service catalog in cluster up

### DIFF
--- a/examples/service-catalog/service-catalog.yaml
+++ b/examples/service-catalog/service-catalog.yaml
@@ -195,7 +195,9 @@ objects:
       spec:
         serviceAccountName: service-catalog-apiserver
         containers:
-        - args:
+        - command: 
+          - apiserver
+          args:
           - --admission-control
           - KubernetesNamespaceLifecycle
           - --storage-type
@@ -212,7 +214,7 @@ objects:
           - "10"
           - --cors-allowed-origins
           - ${CORS_ALLOWED_ORIGIN}
-          image: quay.io/kubernetes-service-catalog/apiserver:${SERVICE_CATALOG_TAG}
+          image: openshift/origin-service-catalog:${SERVICE_CATALOG_TAG}
           imagePullPolicy: IfNotPresent
           name: apiserver
           ports:
@@ -299,7 +301,9 @@ objects:
       spec:
         serviceAccountName: service-catalog-controller
         containers:
-        - args:
+        - command: 
+          - controller-manager
+          args:
           - -v
           - "5"
           - --service-catalog-api-server-url
@@ -308,7 +312,7 @@ objects:
           - service-catalog
           - --broker-relist-interval
           - "5m"
-          image: quay.io/kubernetes-service-catalog/controller-manager:${SERVICE_CATALOG_TAG}
+          image: openshift/origin-service-catalog:${SERVICE_CATALOG_TAG}
           imagePullPolicy: IfNotPresent
           name: controller-manager
           ports:
@@ -356,7 +360,7 @@ parameters:
   displayName: Service catalog image tag
   name: SERVICE_CATALOG_TAG
   required: true
-  value: canary
+  value: latest
 - description: Cluster ip address for the service catalog service
   displayName: Service Catalog Service IP
   name: SERVICE_CATALOG_SERVICE_IP

--- a/pkg/bootstrap/bindata.go
+++ b/pkg/bootstrap/bindata.go
@@ -13384,7 +13384,9 @@ objects:
       spec:
         serviceAccountName: service-catalog-apiserver
         containers:
-        - args:
+        - command: 
+          - apiserver
+          args:
           - --admission-control
           - KubernetesNamespaceLifecycle
           - --storage-type
@@ -13401,7 +13403,7 @@ objects:
           - "10"
           - --cors-allowed-origins
           - ${CORS_ALLOWED_ORIGIN}
-          image: quay.io/kubernetes-service-catalog/apiserver:${SERVICE_CATALOG_TAG}
+          image: openshift/origin-service-catalog:${SERVICE_CATALOG_TAG}
           imagePullPolicy: IfNotPresent
           name: apiserver
           ports:
@@ -13488,7 +13490,9 @@ objects:
       spec:
         serviceAccountName: service-catalog-controller
         containers:
-        - args:
+        - command: 
+          - controller-manager
+          args:
           - -v
           - "5"
           - --service-catalog-api-server-url
@@ -13497,7 +13501,7 @@ objects:
           - service-catalog
           - --broker-relist-interval
           - "5m"
-          image: quay.io/kubernetes-service-catalog/controller-manager:${SERVICE_CATALOG_TAG}
+          image: openshift/origin-service-catalog:${SERVICE_CATALOG_TAG}
           imagePullPolicy: IfNotPresent
           name: controller-manager
           ports:
@@ -13545,7 +13549,7 @@ parameters:
   displayName: Service catalog image tag
   name: SERVICE_CATALOG_TAG
   required: true
-  value: canary
+  value: latest
 - description: Cluster ip address for the service catalog service
   displayName: Service Catalog Service IP
   name: SERVICE_CATALOG_SERVICE_IP

--- a/pkg/bootstrap/docker/openshift/servicecatalog.go
+++ b/pkg/bootstrap/docker/openshift/servicecatalog.go
@@ -29,7 +29,7 @@ const (
 )
 
 // InstallServiceCatalog checks whether the service catalog is installed and installs it if not already installed
-func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, publicMaster, catalogHost string) error {
+func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, publicMaster, catalogHost string, tag string) error {
 	osClient, kubeClient, err := f.Clients()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
@@ -81,8 +81,9 @@ func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, publicMaster, catal
 	params := map[string]string{
 		"SERVICE_CATALOG_SERVICE_IP": ServiceCatalogServiceIP,
 		"CORS_ALLOWED_ORIGIN":        publicMaster,
+		"SERVICE_CATALOG_TAG":        tag,
 	}
-	glog.V(2).Infof("instantiating service catalog template")
+	glog.V(2).Infof("instantiating service catalog template with parameters %v", params)
 
 	// Stands up the service catalog apiserver, etcd, and controller manager
 	err = instantiateTemplate(osClient, clientcmd.ResourceMapper(f), OpenshiftInfraNamespace, catalogTemplate, catalogNamespace, params)

--- a/pkg/bootstrap/docker/up.go
+++ b/pkg/bootstrap/docker/up.go
@@ -1033,8 +1033,8 @@ func (c *ClientStartConfig) InstallServiceCatalog(out io.Writer) error {
 	if len(publicMaster) == 0 {
 		publicMaster = c.ServerIP
 	}
-
-	return c.OpenShiftHelper().InstallServiceCatalog(f, publicMaster, openshift.CatalogHost(c.RoutingSuffix, c.ServerIP))
+	tag := c.ImageVersion
+	return c.OpenShiftHelper().InstallServiceCatalog(f, publicMaster, openshift.CatalogHost(c.RoutingSuffix, c.ServerIP), tag)
 }
 
 // Login logs into the new server and sets up a default user and project


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/15237

we'll now use the openshift distributed service catalog images, and we'll tie the SC image tag to the --version flag (or the oc server version if no --version is passed)