### PR TITLE
update bootstrappolicy/dead addDeadClusterRole to include systemOnly annotation

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/dead.go
+++ b/pkg/cmd/server/bootstrappolicy/dead.go
@@ -21,7 +21,12 @@ func addDeadClusterRole(name string) {
 
 	deadClusterRoles = append(deadClusterRoles,
 		authorizationapi.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Annotations: map[string]string{
+					roleSystemOnly: roleIsSystemOnly,
+				},
+			},
 		},
 	)
 }

--- a/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
+++ b/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
@@ -62,9 +62,12 @@ func TestSystemOnlyRoles(t *testing.T) {
 
 	for _, role := range GetBootstrapClusterRoles() {
 		if isControllerRole(&role) {
-			continue // assume all controller roles can be ignored
+			if !isSystemOnlyRole(&role) {
+				t.Errorf("Controller role %q is missing the system only annotation", role.Name)
+			}
+			continue // assume all controller roles can be ignored even though we require the annotation
 		}
-		if isSystemOnlyRole(role) {
+		if isSystemOnlyRole(&role) {
 			hide.Insert(role.Name)
 		} else {
 			show.Insert(role.Name)
@@ -86,7 +89,7 @@ func TestSystemOnlyRoles(t *testing.T) {
 
 // this logic must stay in sync w/the web console for this test to be valid/valuable
 // it is the same logic that is run on the membership page
-func isSystemOnlyRole(role authorizationapi.ClusterRole) bool {
+func isSystemOnlyRole(role *authorizationapi.ClusterRole) bool {
 	return role.Annotations[roleSystemOnly] == roleIsSystemOnly
 }
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2838,90 +2838,120 @@ items:
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:replication-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:endpoint-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:replicaset-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:garbage-collector-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:job-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:hpa-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:daemonset-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:disruption-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:namespace-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:gc-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:certificate-signing-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:statefulset-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:build-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:deploymentconfig-controller
   rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
     creationTimestamp: null
     name: system:deployment-controller
   rules: []


### PR DESCRIPTION
Roles that have been replaced by kube controller roles should receive
the systemOnly annotation to ensure they are not visible to typical
end users (such as those who would use the web console).

- updates bootstrappolicy/dead addDeadClusterRole
- updates bootstrappolicy/web_console_role_test TestSystemOnlyRoles
	- still skips controller roles (maintenance simplicity), but will throw an error if the annotation is missing