### PR TITLE
use git-show--s instead of git-show--quiet

### DIFF
--- a/pkg/generate/git/repository.go
+++ b/pkg/generate/git/repository.go
@@ -313,7 +313,7 @@ func (r *repository) SubmoduleUpdate(location string, init, recursive bool) erro
 
 // ShowFormat formats the ref with the given git show format string
 func (r *repository) ShowFormat(location, ref, format string) (string, error) {
-	out, _, err := r.git(location, "show", "--quiet", ref, fmt.Sprintf("--format=%s", format))
+	out, _, err := r.git(location, "show", "-s", ref, fmt.Sprintf("--format=%s", format))
 	return out, err
 }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/14111

The --quiet flag is not supported in git clients 1.7.10.4 or older,
causing patch output to end up on the rest object source revision
message, and ultimately causing oc-start-build to fail when a patch 
diff is too long.

cc @openshift/cli-review @stevekuznetsov 