### PR TITLE
Fix issues related to the migration to RBAC and the Kubernetes authorizer

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -229,7 +229,7 @@ func init() {
 	addControllerRole(rbac.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraClusterQuotaReconciliationControllerServiceAccountName},
 		Rules: []rbac.PolicyRule{
-			rbac.NewRule("get", "list").Groups(kapiGroup).Resources("configMaps").RuleOrDie(),
+			rbac.NewRule("get", "list").Groups(kapiGroup).Resources("configmaps").RuleOrDie(),
 			rbac.NewRule("get", "list").Groups(kapiGroup).Resources("secrets").RuleOrDie(),
 			rbac.NewRule("update").Groups(quotaGroup, legacyQuotaGroup).Resources("clusterresourcequotas/status").RuleOrDie(),
 			eventsRule(),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3752,7 +3752,7 @@ items:
     - ""
     attributeRestrictions: null
     resources:
-    - configMaps
+    - configmaps
     verbs:
     - get
     - list


### PR DESCRIPTION
Update quota controller's role for Kube authorizer

This change normalizes the cluster-quota-reconciliation-controller's
bootstrap role so that it will work with the Kubernetes authorizer
which is case sensitive.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Fix conversion for role binding to cluster role

This change makes it so that the conversion for authorization
policy correctly handles when a RBAC role binding references a
cluster role.  The code incorrectly assumed that the role binding's
namespace was the referenced role's namespace as well.  Now we use
the role's kind to determine its namespace.  This was missed by the
fuzzer tests because they only made role bindings to roles.  The
tests have been updated to create bindings to both types of roles.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

@deads2k @liggitt @simo5 PTAL.  I noticed these while working on #15021.  I will open a PR to the 3.6 branch once you guys are happy.

@openshift/security 

[test]