### PR TITLE
oc rsh: fix "object does not implement the Object interfaces"

### DIFF
--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -53,7 +53,7 @@ func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
 	// we're allowed to use the SA the pod is using.  Otherwise, user-A creates pod and user-B (who can't use the SA) can exec into it.
 	createAttributes := admission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion(""), a.GetNamespace(), a.GetName(), a.GetResource(), "", admission.Create, a.GetUserInfo())
 	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
-		return admission.NewForbidden(a, fmt.Errorf("%s operation is not allowed because the pod's security context exceeds your permissions: %v", a.GetSubresource(), err))
+		return admission.NewForbidden(createAttributes, fmt.Errorf("%s operation is not allowed because the pod's security context exceeds your permissions: %v", a.GetSubresource(), err))
 	}
 
 	return nil


### PR DESCRIPTION
Prior this change, we were passing an object of type `*rest.ConnectRequest` and we had the "object does not implement the Object interfaces" error when `NewForbidden` function tried to extract meta data from it. Instead we are now passing an object with information about pod (the same that we provided to the SCC admission plugin).

This change also affects on what error is returned: now Forbidden error is being return instead of Internal Error.

Example output after the fix:
> $ oc rsh  nodejs-ex-1-build
> Error from server (Forbidden): pods "nodejs-ex-1-build" is forbidden: exec operation is not allowed because the pod's security context exceeds your permissions: pods "nodejs-ex-1-build" is forbidden: unable to validate against any security context constraint: [provider restricted: .spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed provider restricted: .spec.containers[0].securityContext.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]

PTAL @deads2k @enj @simo5 

Fixes #13390