### PR TITLE
UPSTREAM: 48960: No warning event for DNSSearchForming

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_network.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_network.go
@@ -98,9 +98,7 @@ func omitDuplicates(kl *Kubelet, pod *v1.Pod, combinedSearch []string) []string 
 			combinedSearch[len(uniqueDomains)] = dnsDomain
 			uniqueDomains[dnsDomain] = true
 		} else {
-			log := fmt.Sprintf("Found and omitted duplicated dns domain in host search line: '%s' during merging with cluster dns domains", dnsDomain)
-			kl.recorder.Event(pod, v1.EventTypeWarning, "DNSSearchForming", log)
-			glog.Error(log)
+			glog.V(5).Infof("Found and omitted duplicated dns domain in host search line: '%s' during merging with cluster dns domains", dnsDomain)
 		}
 	}
 	return combinedSearch[:len(uniqueDomains)]

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_network_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_network_test.go
@@ -143,10 +143,7 @@ func TestComposeDNSSearch(t *testing.T) {
 			[]string{"testNS.svc.TEST", "svc.TEST", "TEST"},
 			[]string{"AAA", "svc.TEST", "BBB", "TEST"},
 			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "AAA", "BBB"},
-			[]string{
-				"Found and omitted duplicated dns domain in host search line: 'svc.TEST' during merging with cluster dns domains",
-				"Found and omitted duplicated dns domain in host search line: 'TEST' during merging with cluster dns domains",
-			},
+			[]string{},
 		},
 
 		{
@@ -161,8 +158,6 @@ func TestComposeDNSSearch(t *testing.T) {
 			[]string{"AAA", "TEST", "BBB", "TEST", "CCC", "DDD"},
 			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "AAA", "BBB", "CCC"},
 			[]string{
-				"Found and omitted duplicated dns domain in host search line: 'TEST' during merging with cluster dns domains",
-				"Found and omitted duplicated dns domain in host search line: 'TEST' during merging with cluster dns domains",
 				"Search Line limits were exceeded, some dns names have been omitted, the applied search line is: testNS.svc.TEST svc.TEST TEST AAA BBB CCC",
 			},
 		},


### PR DESCRIPTION
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1471198

see: kubernetes/kubernetes#48960

this is modified slightly based on my own code review comments on @sjenning source pr. when @sjenning returns, he can update the upstream change.