### PR TITLE
Update oc cmds to use upstream clientcmd/Factory#NewBuilder

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -67,16 +67,16 @@ func NewFactory(optionalClientConfig kclientcmd.ClientConfig) *Factory {
 
 // PrintResourceInfos receives a list of resource infos and prints versioned objects if a generic output format was specified
 // otherwise, it iterates through info objects, printing each resource with a unique printer for its mapping
-func (f *Factory) PrintResourceInfos(cmd *cobra.Command, infos []*resource.Info, out io.Writer) error {
+func (f *Factory) PrintResourceInfos(cmd *cobra.Command, isLocal bool, infos []*resource.Info, out io.Writer) error {
 	// mirrors PrintResourceInfoForCommand upstream
-	printer, err := f.PrinterForCommand(cmd, false, nil, printers.PrintOptions{})
+	printer, err := f.PrinterForCommand(cmd, isLocal, nil, printers.PrintOptions{})
 	if err != nil {
 		return nil
 	}
 	if !printer.IsGeneric() {
 		for _, info := range infos {
 			mapping := info.ResourceMapping()
-			printer, err := f.PrinterForMapping(cmd, false, nil, mapping, false)
+			printer, err := f.PrinterForMapping(cmd, isLocal, nil, mapping, false)
 			if err != nil {
 				return err
 			}

--- a/pkg/oc/admin/node/node_options.go
+++ b/pkg/oc/admin/node/node_options.go
@@ -40,6 +40,8 @@ type NodeOptions struct {
 	CmdPrinter       kprinters.ResourcePrinter
 	CmdPrinterOutput bool
 
+	Builder *resource.Builder
+
 	NodeNames []string
 
 	// Common optional params
@@ -73,6 +75,7 @@ func (n *NodeOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []st
 	}
 	mapper, typer := f.Object()
 
+	n.Builder = f.NewBuilder(true)
 	n.DefaultNamespace = defaultNamespace
 	n.ExternalKubeClient = externalkc
 	n.KubeClient = kc
@@ -128,7 +131,7 @@ func (n *NodeOptions) GetNodes() ([]*kapi.Node, error) {
 		nameArgs = append(nameArgs, n.NodeNames...)
 	}
 
-	r := resource.NewBuilder(n.Mapper, n.CategoryExpander, n.Typer, resource.ClientMapperFunc(n.RESTClientFactory), kapi.Codecs.UniversalDecoder()).
+	r := n.Builder.
 		ContinueOnError().
 		NamespaceParam(n.DefaultNamespace).
 		SelectorParam(n.Selector).

--- a/pkg/oc/admin/policy/subject_review.go
+++ b/pkg/oc/admin/policy/subject_review.go
@@ -48,9 +48,7 @@ type sccSubjectReviewOptions struct {
 	namespace                  string
 	enforceNamespace           bool
 	out                        io.Writer
-	mapper                     meta.RESTMapper
-	typer                      runtime.ObjectTyper
-	categoryExpander           resource.CategoryExpander
+	builder                    *resource.Builder
 	RESTClientFactory          func(mapping *meta.RESTMapping) (resource.RESTClient, error)
 	printer                    sccSubjectReviewPrinter
 	FilenameOptions            resource.FilenameOptions
@@ -110,8 +108,7 @@ func (o *sccSubjectReviewOptions) Complete(f *clientcmd.Factory, args []string, 
 	}
 	o.sccSubjectReviewClient = oclient
 	o.sccSelfSubjectReviewClient = oclient
-	o.mapper, o.typer = f.Object()
-	o.categoryExpander = f.CategoryExpander()
+	o.builder = f.NewBuilder(true)
 	o.RESTClientFactory = f.ClientForMapping
 
 	if len(kcmdutil.GetFlagString(cmd, "output")) != 0 {
@@ -132,7 +129,7 @@ func (o *sccSubjectReviewOptions) Run(args []string) error {
 	if len(o.serviceAccount) > 0 {
 		userOrSA = o.serviceAccount
 	}
-	r := resource.NewBuilder(o.mapper, o.categoryExpander, o.typer, resource.ClientMapperFunc(o.RESTClientFactory), kapi.Codecs.UniversalDecoder()).
+	r := o.builder.
 		NamespaceParam(o.namespace).
 		FilenameParam(o.enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/oc/bootstrap/docker/openshift/import.go
+++ b/pkg/oc/bootstrap/docker/openshift/import.go
@@ -15,7 +15,6 @@ import (
 // ImportObjects imports objects into OpenShift from a particular location
 // into a given namespace
 func ImportObjects(f *clientcmd.Factory, ns, location string) error {
-	mapper, typer := f.Object()
 	schema, err := f.Validator(false, "")
 	if err != nil {
 		return err
@@ -25,7 +24,7 @@ func ImportObjects(f *clientcmd.Factory, ns, location string) error {
 		return err
 	}
 	glog.V(8).Infof("Importing data:\n%s\n", string(data))
-	r := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	r := f.NewBuilder(true).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(ns).

--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -217,8 +217,8 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 		return err
 	}
 
-	mapper, typer := f.Object()
-	b := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	b := f.NewBuilder(true).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		SingleResourceType().
 		ResourceNames("pods", resources...).

--- a/pkg/oc/cli/cmd/deploy.go
+++ b/pkg/oc/cli/cmd/deploy.go
@@ -148,9 +148,7 @@ func (o *DeployOptions) Complete(f *clientcmd.Factory, args []string, out io.Wri
 		return err
 	}
 
-	mapper, typer := f.Object()
-	o.builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder())
-
+	o.builder = f.NewBuilder(true)
 	o.out = out
 
 	if len(args) > 0 {

--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -112,7 +112,7 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 	}
 
 	mapper, typer := f.Object()
-	b := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	b := f.NewBuilder(true).
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: filenames}).
 		SelectorParam(selector).

--- a/pkg/oc/cli/cmd/expose.go
+++ b/pkg/oc/cli/cmd/expose.go
@@ -93,8 +93,7 @@ func validate(cmd *cobra.Command, f *clientcmd.Factory, args []string) error {
 		return err
 	}
 
-	mapper, typer := f.Object()
-	r := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	r := f.NewBuilder(true).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &resource.FilenameOptions{Recursive: false, Filenames: kcmdutil.GetFlagStringSlice(cmd, "filename")}).

--- a/pkg/oc/cli/cmd/extract.go
+++ b/pkg/oc/cli/cmd/extract.go
@@ -12,7 +12,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -94,8 +93,7 @@ func (o *ExtractOptions) Complete(f *clientcmd.Factory, in io.Reader, out io.Wri
 		return err
 	}
 
-	mapper, typer := f.Object()
-	b := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	b := f.NewBuilder(true).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
 		ResourceNames("", args...).

--- a/pkg/oc/cli/cmd/idle.go
+++ b/pkg/oc/cli/cmd/idle.go
@@ -115,8 +115,7 @@ func (o *IdleOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []
 		return fmt.Errorf("resource names, selectors, and the all flag may not be be specified if a filename is specified")
 	}
 
-	mapper, typer := f.Object()
-	o.svcBuilder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	o.svcBuilder = f.NewBuilder(true).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().AllNamespaces(o.allNamespaces).
 		Flatten().

--- a/pkg/oc/cli/cmd/logs.go
+++ b/pkg/oc/cli/cmd/logs.go
@@ -14,7 +14,6 @@ import (
 	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildutil "github.com/openshift/origin/pkg/build/util"
@@ -127,8 +126,7 @@ func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command
 
 	podLogOptions := o.KubeLogOptions.Options.(*kapi.PodLogOptions)
 
-	mapper, typer := f.Object()
-	infos, err := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	infos, err := f.NewBuilder(true).
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		ResourceNames("pods", args...).
 		SingleResourceType().RequireObject(false).

--- a/pkg/oc/cli/cmd/rollback.go
+++ b/pkg/oc/cli/cmd/rollback.go
@@ -134,9 +134,8 @@ func (o *RollbackOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 	o.Namespace = namespace
 
 	// Set up client based support.
-	mapper, typer := f.Object()
 	o.getBuilder = func() *resource.Builder {
-		return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder())
+		return f.NewBuilder(true)
 	}
 
 	oClient, kClient, err := f.Clients()

--- a/pkg/oc/cli/cmd/rollout/cancel.go
+++ b/pkg/oc/cli/cmd/rollout/cancel.go
@@ -89,7 +89,7 @@ func (o *CancelOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out i
 		return err
 	}
 
-	r := resource.NewBuilder(o.Mapper, f.CategoryExpander(), o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	r := f.NewBuilder(true).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/oc/cli/cmd/rollout/latest.go
+++ b/pkg/oc/cli/cmd/rollout/latest.go
@@ -102,7 +102,7 @@ func (o *RolloutLatestOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command
 	}
 
 	o.mapper, o.typer = f.Object()
-	o.infos, err = resource.NewBuilder(o.mapper, f.CategoryExpander(), o.typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	o.infos, err = f.NewBuilder(true).
 		ContinueOnError().
 		NamespaceParam(namespace).
 		ResourceNames("deploymentconfigs", args[0]).

--- a/pkg/oc/cli/cmd/rollout/retry.go
+++ b/pkg/oc/cli/cmd/rollout/retry.go
@@ -90,7 +90,7 @@ func (o *RetryOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, out io
 		return err
 	}
 
-	r := resource.NewBuilder(o.Mapper, f.CategoryExpander(), o.Typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	r := f.NewBuilder(true).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/oc/cli/cmd/set/buildhook.go
+++ b/pkg/oc/cli/cmd/set/buildhook.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -138,8 +137,8 @@ func (o *BuildHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, ar
 
 	o.Cmd = cmd
 
-	mapper, typer := f.Object()
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -158,7 +157,7 @@ func (o *BuildHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, ar
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")
 	o.PrintObject = func(infos []*resource.Info) error {
-		return f.PrintResourceInfos(cmd, infos, o.Out)
+		return f.PrintResourceInfos(cmd, o.Local, infos, o.Out)
 	}
 
 	o.Encoder = f.JSONEncoder()

--- a/pkg/oc/cli/cmd/set/buildsecret.go
+++ b/pkg/oc/cli/cmd/set/buildsecret.go
@@ -122,7 +122,7 @@ func NewCmdBuildSecret(fullName string, f *clientcmd.Factory, out, errOut io.Wri
 var supportedBuildTypes = []string{"buildconfigs"}
 
 func (o *BuildSecretOptions) secretFromArg(f *clientcmd.Factory, mapper meta.RESTMapper, typer runtime.ObjectTyper, namespace, arg string) (string, error) {
-	builder := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	builder := f.NewBuilder(!o.Local).
 		NamespaceParam(namespace).DefaultNamespace().
 		RequireObject(false).
 		ContinueOnError().
@@ -174,7 +174,7 @@ func (o *BuildSecretOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 			return err
 		}
 	}
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -193,7 +193,7 @@ func (o *BuildSecretOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")
 	o.PrintObject = func(infos []*resource.Info) error {
-		return f.PrintResourceInfos(cmd, infos, o.Out)
+		return f.PrintResourceInfos(cmd, o.Local, infos, o.Out)
 	}
 
 	o.Encoder = f.JSONEncoder()

--- a/pkg/oc/cli/cmd/set/deploymenthook.go
+++ b/pkg/oc/cli/cmd/set/deploymenthook.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -156,8 +155,8 @@ func (o *DeploymentHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Comman
 
 	o.Cmd = cmd
 
-	mapper, typer := f.Object()
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -175,7 +174,7 @@ func (o *DeploymentHookOptions) Complete(f *clientcmd.Factory, cmd *cobra.Comman
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")
 	o.PrintObject = func(infos []*resource.Info) error {
-		return f.PrintResourceInfos(cmd, infos, o.Out)
+		return f.PrintResourceInfos(cmd, o.Local, infos, o.Out)
 	}
 
 	o.Encoder = f.JSONEncoder()

--- a/pkg/oc/cli/cmd/set/env.go
+++ b/pkg/oc/cli/cmd/set/env.go
@@ -225,8 +225,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 	}
 
 	if len(o.From) != 0 {
-		mapper, typer := f.Object()
-		b := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+		b := f.NewBuilder(!o.Local).
 			ContinueOnError().
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -288,8 +287,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 		}
 	}
 
-	mapper, typer := f.Object()
-	b := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true)).
+	b := f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -443,7 +441,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 	}
 
 	if len(o.Output) > 0 || o.Local || kcmdutil.GetDryRunFlag(o.Cmd) {
-		return f.PrintResourceInfos(o.Cmd, infos, o.Out)
+		return f.PrintResourceInfos(o.Cmd, o.Local, infos, o.Out)
 	}
 
 	objects, err := resource.AsVersionedObjects(infos, gv, kapi.Codecs.LegacyCodec(gv))
@@ -484,6 +482,7 @@ updates:
 			return fmt.Errorf("at least one environment variable must be provided")
 		}
 
+		mapper, _ := f.Object()
 		kcmdutil.PrintSuccess(mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, false, "updated")
 	}
 	if failed {

--- a/pkg/oc/cli/cmd/set/imagelookup.go
+++ b/pkg/oc/cli/cmd/set/imagelookup.go
@@ -163,8 +163,8 @@ func (o *ImageLookupOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, 
 
 	o.PrintTable = (len(args) == 0 && !o.All) || o.List
 
-	mapper, typer := f.Object()
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).

--- a/pkg/oc/cli/cmd/set/probe.go
+++ b/pkg/oc/cli/cmd/set/probe.go
@@ -181,8 +181,8 @@ func (o *ProbeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 
 	o.Cmd = cmd
 
-	mapper, typer := f.Object()
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -196,7 +196,7 @@ func (o *ProbeOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")
 	o.PrintObject = func(infos []*resource.Info) error {
-		return f.PrintResourceInfos(cmd, infos, o.Out)
+		return f.PrintResourceInfos(cmd, o.Local, infos, o.Out)
 	}
 
 	o.Encoder = f.JSONEncoder()

--- a/pkg/oc/cli/cmd/set/routebackends.go
+++ b/pkg/oc/cli/cmd/set/routebackends.go
@@ -161,8 +161,8 @@ func (o *BackendsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 
 	o.Cmd = cmd
 
-	mapper, typer := f.Object()
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).

--- a/pkg/oc/cli/cmd/set/triggers.go
+++ b/pkg/oc/cli/cmd/set/triggers.go
@@ -221,8 +221,8 @@ func (o *TriggersOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 		o.Auto = true
 	}
 
-	mapper, typer := f.Object()
-	o.Builder = resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), kapi.Codecs.UniversalDecoder()).
+	mapper, _ := f.Object()
+	o.Builder = f.NewBuilder(!o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
@@ -236,7 +236,7 @@ func (o *TriggersOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, arg
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")
 	o.PrintObject = func(infos []*resource.Info) error {
-		return f.PrintResourceInfos(cmd, infos, o.Out)
+		return f.PrintResourceInfos(cmd, o.Local, infos, o.Out)
 	}
 
 	o.Encoder = f.JSONEncoder()

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/tokencmd"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T) {


### PR DESCRIPTION
Fixes #15278 

1. Makes use of upstream's `util/clientcmd/Factory#NewBuilder` method.
2. Wires through commands' `local` option to the `util/clientcmd/Factory#PrinterForCommand` method (enables local commands to work without a connection to an api server)

cc @openshift/cli-review @deads2k 