### PR TITLE
Register SDN informers synchronously

### DIFF
--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -67,7 +67,7 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 
 	// try this for a while before just dying
 	var getError error
-	err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
 		// reset this so that failures come through correctly.
 		getError = nil
 		existingCN, err := master.osClient.ClusterNetwork().Get(osapi.ClusterNetworkDefault, metav1.GetOptions{})


### PR DESCRIPTION
Pick of https://github.com/openshift/origin/pull/15353 and more contained version of https://github.com/openshift/origin/pull/15364

The SDN controller was registering shared informer event handlers in a goroutine, so registration raced with informer start. If the registration lost, then SDN event handlers would never get namespace events.