### PR TITLE
Check for golang 1.8.

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -82,9 +82,9 @@ function os::build::setup_env() {
   if [[ "${TRAVIS:-}" != "true" ]]; then
     local go_version
     go_version=($(go version))
-    if [[ "${go_version[2]}" < "go1.7" ]]; then
+    if [[ "${go_version[2]}" < "go1.8" ]]; then
       os::log::fatal "Detected Go version: ${go_version[*]}.
-Origin builds require Go version 1.7 or greater."
+Origin builds require Go version 1.8 or greater."
     fi
   fi
   # For any tools that expect this to be set (it is default in golang 1.6),

--- a/hack/lib/util/golang.sh
+++ b/hack/lib/util/golang.sh
@@ -8,11 +8,10 @@ function os::golang::verify_go_version() {
 
 	local go_version
 	go_version=($(go version))
-	if [[ "${go_version[2]}" != go1.7* ]]; then
+	if [[ "${go_version[2]}" != go1.8* ]]; then
 		os::log::info "Detected go version: ${go_version[*]}."
 		if [[ -z "${PERMISSIVE_GO:-}" ]]; then
-			os::log::error "Please install Go version 1.7 or use PERMISSIVE_GO=y to bypass this check."
-			return 0
+			os::log::fatal "Please install Go version 1.8 or use PERMISSIVE_GO=y to bypass this check."
 		else
 			os::log::warning "Detected golang version doesn't match preferred Go version for Origin."
 			os::log::warning "This version mismatch could lead to differences in execution between this run and the Origin CI systems."

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-# TODO skip the version check until we update for 1.8
-# os::golang::verify_go_version
+os::golang::verify_go_version
 
 bad_files=$(os::util::list_go_src_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15270

Addressing
```
[INFO] Detected go version: go version go1.8.3 linux/amd64.
[ERROR] Please install Go version 1.7 or use PERMISSIVE_GO=y to bypass this check.
```
with

```
$ rpm -q golang
golang-1.8.3-2.fc26.x86_64
$ go version
go version go1.8.3 linux/amd64
```