### PR TITLE
protoc seems to be needed for make check.

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -85,7 +85,7 @@ $ sudo dnf install git docker-latest
 ----
 In order to do builds locally, install the following build dependencies:
 ----
-$ sudo dnf install golang golang-race make gcc zip mercurial krb5-devel bsdtar bc rsync bind-utils file jq tito createrepo openssl gpgme gpgme-devel libassuan libassuan-devel
+$ sudo dnf install golang golang-race make gcc zip mercurial krb5-devel bsdtar bc rsync bind-utils file jq tito createrepo openssl gpgme gpgme-devel libassuan libassuan-devel protobuf-compiler
 ----
 
 ===== CentOS / RHEL


### PR DESCRIPTION
Addressing
```
===== Verifying Generated OpenAPI =====
rm -rf /home/test/openshift-origin/_output/diff
[FATAL] Required `protoc` binary was not found in $PATH.
[ERROR] PID 14970: hack/verify-generated-protobuf.sh:19: `"${OS_ROOT}/hack/update-generated-protobuf.sh"` exited with status 1.
[INFO] 		Stack Trace:
[INFO] 		  1: hack/verify-generated-protobuf.sh:19: `"${OS_ROOT}/hack/update-generated-protobuf.sh"`
[INFO]   Exiting with code 1.
rm -rf /home/test/openshift-origin/_output/diff
```