### PR TITLE
Allow libprotoc 3.2.0.

### DIFF
--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/update-generated-protobuf.sh
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/update-generated-protobuf.sh
@@ -7,8 +7,8 @@ if [[ "${PROTO_OPTIONAL:-}" == "1" ]]; then
 fi
 
 os::util::ensure::system_binary_exists 'protoc'
-if [[ "$(protoc --version)" != "libprotoc 3.0."* ]]; then
-  os::log::fatal "Generating protobuf requires protoc 3.0.x. Please download and
+if [[ "$(protoc --version)" != "libprotoc 3."* ]]; then
+  os::log::fatal "Generating protobuf requires protoc 3. Please download and
 install the platform appropriate Protobuf package for your OS:
 
   https://github.com/google/protobuf/releases

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -7,8 +7,8 @@ if [[ "${PROTO_OPTIONAL:-}" == "1" ]]; then
 fi
 
 os::util::ensure::system_binary_exists 'protoc'
-if [[ "$(protoc --version)" != "libprotoc 3.0."* ]]; then
-  os::log::fatal "Generating protobuf requires protoc 3.0.x. Please download and
+if [[ "$(protoc --version)" != "libprotoc 3."* ]]; then
+  os::log::fatal "Generating protobuf requires protoc 3. Please download and
 install the platform appropriate Protobuf package for your OS:
 
   https://github.com/google/protobuf/releases


### PR DESCRIPTION
Looking at the history of changes for the test, the goal is to
have at least version 3, not specifically 3.0.

Addressing
```
rm -rf /home/test/openshift-origin/_output/diff
[FATAL] Generating protobuf requires protoc 3.0.x. Please download and
[FATAL] install the platform appropriate Protobuf package for your OS:
[FATAL]   https://github.com/google/protobuf/releases
[FATAL] To skip protobuf generation, set $PROTO_OPTIONAL.
[ERROR] PID 24141: hack/verify-generated-protobuf.sh:19: `"${OS_ROOT}/hack/update-generated-protobuf.sh"` exited with status 1.
[INFO] 		Stack Trace:
```
in `make check`.