### PR TITLE
Be verbose when when goimports is not found, allow use of rpm-installed goimports.

### DIFF
--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/update-generated-protobuf.sh
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/update-generated-protobuf.sh
@@ -16,8 +16,8 @@ install the platform appropriate Protobuf package for your OS:
 To skip protobuf generation, set \$PROTO_OPTIONAL."
 fi
 
-os::util::ensure::gopath_binary_exists 'goimports'
 os::build::setup_env
+os::util::ensure::gopath_binary_exists 'goimports'
 
 os::util::ensure::built_binary_exists 'genprotobuf'
 os::util::ensure::built_binary_exists 'protoc-gen-gogo' vendor/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protoc-gen-gogo

--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/update-generated-protobuf.sh
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/update-generated-protobuf.sh
@@ -17,7 +17,7 @@ To skip protobuf generation, set \$PROTO_OPTIONAL."
 fi
 
 os::build::setup_env
-os::util::ensure::gopath_binary_exists 'goimports'
+os::util::find::system_binary 'goimports' >/dev/null 2>&1 || os::util::ensure::gopath_binary_exists 'goimports'
 
 os::util::ensure::built_binary_exists 'genprotobuf'
 os::util::ensure::built_binary_exists 'protoc-gen-gogo' vendor/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protoc-gen-gogo

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -16,8 +16,8 @@ install the platform appropriate Protobuf package for your OS:
 To skip protobuf generation, set \$PROTO_OPTIONAL."
 fi
 
-os::util::ensure::gopath_binary_exists 'goimports'
 os::build::setup_env
+os::util::ensure::gopath_binary_exists 'goimports'
 
 os::util::ensure::built_binary_exists 'genprotobuf'
 os::util::ensure::built_binary_exists 'protoc-gen-gogo' vendor/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protoc-gen-gogo

--- a/hack/update-generated-protobuf.sh
+++ b/hack/update-generated-protobuf.sh
@@ -17,7 +17,7 @@ To skip protobuf generation, set \$PROTO_OPTIONAL."
 fi
 
 os::build::setup_env
-os::util::ensure::gopath_binary_exists 'goimports'
+os::util::find::system_binary 'goimports' >/dev/null 2>&1 || os::util::ensure::gopath_binary_exists 'goimports'
 
 os::util::ensure::built_binary_exists 'genprotobuf'
 os::util::ensure::built_binary_exists 'protoc-gen-gogo' vendor/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protoc-gen-gogo


### PR DESCRIPTION
Addressing (hidden by `>/dev/null 2>&1`)
```
/home/test/openshift-origin/hack/lib/util/find.sh: line 60: GOPATH: unbound variable
```
when `GOPATH` is not set.