### PR TITLE
Restore Unidler

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node.go
+++ b/pkg/cmd/server/kubernetes/node/node.go
@@ -13,8 +13,8 @@ import (
 	dockerclient "github.com/fsouza/go-dockerclient"
 	"github.com/golang/glog"
 
-	// "github.com/openshift/origin/pkg/proxy/hybrid"
-	// "github.com/openshift/origin/pkg/proxy/unidler"
+	"github.com/openshift/origin/pkg/proxy/hybrid"
+	"github.com/openshift/origin/pkg/proxy/unidler"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -430,37 +430,38 @@ func (c *NodeConfig) RunProxy() {
 		c.ProxyConfig.ConfigSyncPeriod.Duration,
 	)
 
-	// if c.EnableUnidling {
-	// 	unidlingLoadBalancer := userspace.NewLoadBalancerRR()
-	// 	signaler := unidler.NewEventSignaler(recorder)
-	// 	unidlingUserspaceProxy, err := unidler.NewUnidlerProxier(unidlingLoadBalancer, bindAddr, iptInterface, execer, *portRange, c.ProxyConfig.IPTablesSyncPeriod.Duration, c.ProxyConfig.IPTablesMinSyncPeriod.Duration, c.ProxyConfig.UDPIdleTimeout.Duration, signaler)
-	// 	if err != nil {
-	// 		if c.Containerized {
-	// 			glog.Fatalf("error: Could not initialize Kubernetes Proxy: %v\n When running in a container, you must run the container in the host network namespace with --net=host and with --privileged", err)
-	// 		} else {
-	// 			glog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root to use the service proxy: %v", err)
-	// 		}
-	// 	}
-	// 	hybridProxier, err := hybrid.NewHybridProxier(
-	// 		unidlingLoadBalancer,
-	// 		unidlingUserspaceProxy,
-	// 		endpointsHandler,
-	// 		proxier,
-	// 		servicesHandler,
-	// 		c.ProxyConfig.IPTablesSyncPeriod.Duration,
-	// 		c.InternalKubeInformers.Core().InternalVersion().Services().Lister(),
-	// 	)
-	// 	if err != nil {
-	// 		if c.Containerized {
-	// 			glog.Fatalf("error: Could not initialize Kubernetes Proxy: %v\n When running in a container, you must run the container in the host network namespace with --net=host and with --privileged", err)
-	// 		} else {
-	// 			glog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root to use the service proxy: %v", err)
-	// 		}
-	// 	}
-	// 	endpointsHandler = hybridProxier
-	// 	servicesHandler = hybridProxier
-	// 	proxier = hybridProxier
-	// }
+	if c.EnableUnidling {
+		unidlingLoadBalancer := userspace.NewLoadBalancerRR()
+		signaler := unidler.NewEventSignaler(recorder)
+		unidlingUserspaceProxy, err := unidler.NewUnidlerProxier(unidlingLoadBalancer, bindAddr, iptInterface, execer, *portRange, c.ProxyConfig.IPTables.SyncPeriod.Duration, c.ProxyConfig.IPTables.MinSyncPeriod.Duration, c.ProxyConfig.UDPIdleTimeout.Duration, signaler)
+		if err != nil {
+			if c.Containerized {
+				glog.Fatalf("error: Could not initialize Kubernetes Proxy: %v\n When running in a container, you must run the container in the host network namespace with --net=host and with --privileged", err)
+			} else {
+				glog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root to use the service proxy: %v", err)
+			}
+		}
+		hybridProxier, err := hybrid.NewHybridProxier(
+			unidlingLoadBalancer,
+			unidlingUserspaceProxy,
+			endpointsHandler,
+			servicesHandler,
+			proxier,
+			unidlingUserspaceProxy,
+			c.ProxyConfig.IPTables.SyncPeriod.Duration,
+			c.InternalKubeInformers.Core().InternalVersion().Services().Lister(),
+		)
+		if err != nil {
+			if c.Containerized {
+				glog.Fatalf("error: Could not initialize Kubernetes Proxy: %v\n When running in a container, you must run the container in the host network namespace with --net=host and with --privileged", err)
+			} else {
+				glog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root to use the service proxy: %v", err)
+			}
+		}
+		endpointsHandler = hybridProxier
+		servicesHandler = hybridProxier
+		proxier = hybridProxier
+	}
 
 	iptInterface.AddReloadFunc(proxier.Sync)
 	serviceConfig.RegisterEventHandler(servicesHandler)

--- a/pkg/proxy/hybrid/proxy.go
+++ b/pkg/proxy/hybrid/proxy.go
@@ -7,173 +7,282 @@ import (
 
 	"github.com/golang/glog"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/api"
-	apihelper "k8s.io/kubernetes/pkg/api/helper"
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 
 	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
-	"k8s.io/kubernetes/pkg/proxy/userspace"
 )
 
-// EndpointsConfigHandler is an abstract interface of objects which receive update notifications for the set of endpoints.
-type EndpointsConfigHandler interface {
-	// OnEndpointsUpdate gets called when endpoints configuration is changed for a given
-	// service on any of the configuration sources. An example is when a new
-	// service comes up, or when containers come up or down for an existing service.
-	OnEndpointsUpdate(endpoints []*api.Endpoints)
-}
-
-// ServiceConfigHandler is an abstract interface of objects which receive update notifications for the set of services.
-type ServiceConfigHandler interface {
-	// OnServiceUpdate gets called when a configuration has been changed by one of the sources.
-	// This is the union of all the configuration sources.
-	OnServiceUpdate(services []*api.Service)
-}
-
+// HybridProxier runs an unidling proxy and a primary proxy at the same time,
+// delegating idled services to the unidling proxy and other services to the
+// primary proxy.
 type HybridProxier struct {
-	unidlingProxy        *userspace.Proxier
-	unidlingLoadBalancer EndpointsConfigHandler
-	mainEndpointsHandler EndpointsConfigHandler
-	mainServicesHandler  ServiceConfigHandler
-	mainProxy            proxy.ProxyProvider
-	syncPeriod           time.Duration
-	serviceLister        kcorelisters.ServiceLister
+	unidlingServiceHandler   proxyconfig.ServiceHandler
+	unidlingEndpointsHandler proxyconfig.EndpointsHandler
+	mainEndpointsHandler     proxyconfig.EndpointsHandler
+	mainServicesHandler      proxyconfig.ServiceHandler
+	mainProxy                proxy.ProxyProvider
+	unidlingProxy            proxy.ProxyProvider
+	syncPeriod               time.Duration
+	serviceLister            kcorelisters.ServiceLister
 
 	// TODO(directxman12): figure out a good way to avoid duplicating this information
 	// (it's saved in the individual proxies as well)
-	usingUserspace     map[types.NamespacedName]struct{}
+	// usingUserspace is *NOT* a set -- we care about the value, and use it to keep track of
+	// when we need to delete from an existing proxier when adding to a new one.
+	usingUserspace     map[types.NamespacedName]bool
 	usingUserspaceLock sync.Mutex
 }
 
 func NewHybridProxier(
-	unidlingLoadBalancer EndpointsConfigHandler,
-	unidlingProxy *userspace.Proxier,
-	mainEndpointsHandler EndpointsConfigHandler,
+	unidlingEndpointsHandler proxyconfig.EndpointsHandler,
+	unidlingServiceHandler proxyconfig.ServiceHandler,
+	mainEndpointsHandler proxyconfig.EndpointsHandler,
+	mainServicesHandler proxyconfig.ServiceHandler,
 	mainProxy proxy.ProxyProvider,
-	mainServicesHandler ServiceConfigHandler,
+	unidlingProxy proxy.ProxyProvider,
 	syncPeriod time.Duration,
 	serviceLister kcorelisters.ServiceLister,
 ) (*HybridProxier, error) {
 	return &HybridProxier{
-		unidlingLoadBalancer: unidlingLoadBalancer,
-		unidlingProxy:        unidlingProxy,
-		mainEndpointsHandler: mainEndpointsHandler,
-		mainProxy:            mainProxy,
-		mainServicesHandler:  mainServicesHandler,
-		syncPeriod:           syncPeriod,
-		serviceLister:        serviceLister,
+		unidlingEndpointsHandler: unidlingEndpointsHandler,
+		unidlingServiceHandler:   unidlingServiceHandler,
+		mainEndpointsHandler:     mainEndpointsHandler,
+		mainServicesHandler:      mainServicesHandler,
+		mainProxy:                mainProxy,
+		unidlingProxy:            unidlingProxy,
+		syncPeriod:               syncPeriod,
+		serviceLister:            serviceLister,
 
-		usingUserspace: nil,
+		usingUserspace: make(map[types.NamespacedName]bool),
 	}, nil
 }
 
-func (p *HybridProxier) OnServiceUpdate(services []*api.Service) {
-	forIPTables := make([]*api.Service, 0, len(services))
-	forUserspace := []*api.Service{}
+func (p *HybridProxier) OnServiceAdd(service *api.Service) {
+	svcName := types.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
 
 	p.usingUserspaceLock.Lock()
 	defer p.usingUserspaceLock.Unlock()
 
-	for _, service := range services {
-		if !apihelper.IsServiceIPSet(service) {
-			// Skip service with no ClusterIP set
-			continue
-		}
-		svcName := types.NamespacedName{
-			Namespace: service.Namespace,
-			Name:      service.Name,
-		}
-		if _, ok := p.usingUserspace[svcName]; ok {
-			forUserspace = append(forUserspace, service)
-		} else {
-			forIPTables = append(forIPTables, service)
-		}
+	// since this is an Add, we know the service isn't already in another
+	// proxy, so don't bother trying to remove like on an update
+	if isUsingUserspace, ok := p.usingUserspace[svcName]; ok && isUsingUserspace {
+		glog.V(6).Infof("hybrid proxy: add svc %s in unidling proxy", service.Name)
+		p.unidlingServiceHandler.OnServiceAdd(service)
+	} else {
+		glog.V(1).Infof("hybrid proxy: add svc %s in main proxy", service.Name)
+		p.mainServicesHandler.OnServiceAdd(service)
 	}
-
-	p.unidlingProxy.OnServiceUpdate(forUserspace)
-	p.mainServicesHandler.OnServiceUpdate(forIPTables)
 }
 
-func (p *HybridProxier) updateUsingUserspace(endpoints []*api.Endpoints) {
+func (p *HybridProxier) OnServiceUpdate(oldService, service *api.Service) {
+	svcName := types.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+
 	p.usingUserspaceLock.Lock()
 	defer p.usingUserspaceLock.Unlock()
 
-	p.usingUserspace = make(map[types.NamespacedName]struct{}, len(endpoints))
-	for _, endpoint := range endpoints {
-		hasEndpoints := false
-		for _, subset := range endpoint.Subsets {
-			if len(subset.Addresses) > 0 {
-				hasEndpoints = true
-				break
-			}
-		}
-
-		if !hasEndpoints {
-			if _, ok := endpoint.Annotations[unidlingapi.IdledAtAnnotation]; ok {
-				svcName := types.NamespacedName{
-					Namespace: endpoint.Namespace,
-					Name:      endpoint.Name,
-				}
-				p.usingUserspace[svcName] = struct{}{}
-			}
-		}
+	// NB: usingUserspace can only change in the endpoints handler,
+	// so that should deal with calling OnServiceDelete on switches
+	if isUsingUserspace, ok := p.usingUserspace[svcName]; ok && isUsingUserspace {
+		glog.V(6).Infof("hybrid proxy: update svc %s in unidling proxy", service.Name)
+		p.unidlingServiceHandler.OnServiceUpdate(oldService, service)
+	} else {
+		glog.V(6).Infof("hybrid proxy: update svc %s in main proxy", service.Name)
+		p.mainServicesHandler.OnServiceUpdate(oldService, service)
 	}
 }
 
-func (p *HybridProxier) getIPTablesEndpoints(endpoints []*api.Endpoints) []*api.Endpoints {
+func (p *HybridProxier) OnServiceDelete(service *api.Service) {
+	svcName := types.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+
 	p.usingUserspaceLock.Lock()
 	defer p.usingUserspaceLock.Unlock()
 
-	forIPTables := []*api.Endpoints{}
-	for _, endpoint := range endpoints {
-		svcName := types.NamespacedName{
-			Namespace: endpoint.Namespace,
-			Name:      endpoint.Name,
-		}
-		if _, ok := p.usingUserspace[svcName]; !ok {
-			forIPTables = append(forIPTables, endpoint)
-		}
+	if isUsingUserspace, ok := p.usingUserspace[svcName]; ok && isUsingUserspace {
+		glog.V(1).Infof("hybrid proxy: del svc %s in unidling proxy", service.Name)
+		p.unidlingServiceHandler.OnServiceDelete(service)
+	} else {
+		glog.V(1).Infof("hybrid proxy: del svc %s in main proxy", service.Name)
+		p.mainServicesHandler.OnServiceDelete(service)
 	}
-	return forIPTables
 }
 
-func (p *HybridProxier) OnEndpointsUpdate(endpoints []*api.Endpoints) {
-	p.updateUsingUserspace(endpoints)
+func (p *HybridProxier) OnServiceSynced() {
+	p.unidlingServiceHandler.OnServiceSynced()
+	p.mainServicesHandler.OnServiceSynced()
+	glog.V(1).Infof("hybrid proxy: services synced")
+}
 
-	p.unidlingLoadBalancer.OnEndpointsUpdate(endpoints)
+// shouldEndpointsUseUserspace checks to see if the given endpoints have the correct
+// annotations and size to use the unidling proxy.
+func (p *HybridProxier) shouldEndpointsUseUserspace(endpoints *api.Endpoints) bool {
+	hasEndpoints := false
+	for _, subset := range endpoints.Subsets {
+		if len(subset.Addresses) > 0 {
+			hasEndpoints = true
+			break
+		}
+	}
 
-	forIPTables := p.getIPTablesEndpoints(endpoints)
-	p.mainEndpointsHandler.OnEndpointsUpdate(forIPTables)
+	if !hasEndpoints {
+		if _, ok := endpoints.Annotations[unidlingapi.IdledAtAnnotation]; ok {
+			return true
+		}
+	}
 
-	services, err := p.serviceLister.List(labels.Everything())
+	return false
+}
+
+func (p *HybridProxier) switchService(name types.NamespacedName) {
+	svc, err := p.serviceLister.Services(name.Namespace).Get(name.Name)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error while listing services from cache: %v", err))
+		utilruntime.HandleError(fmt.Errorf("Error while getting service %s from cache: %v", name.String(), err))
 		return
 	}
-	if services == nil {
-		services = []*api.Service{}
+
+	if p.usingUserspace[name] {
+		glog.V(1).Infof("hybrid proxy: switching svc %s to unidling proxy", svc.Name)
+		p.unidlingServiceHandler.OnServiceAdd(svc)
+		p.mainServicesHandler.OnServiceDelete(svc)
+	} else {
+		glog.V(1).Infof("hybrid proxy: switching svc %s to main proxy", svc.Name)
+		p.mainServicesHandler.OnServiceAdd(svc)
+		p.unidlingServiceHandler.OnServiceDelete(svc)
 	}
-	p.OnServiceUpdate(services)
+}
+
+func (p *HybridProxier) OnEndpointsAdd(endpoints *api.Endpoints) {
+	// we track all endpoints in the unidling endpoints handler so that we can succesfully
+	// detect when a service become unidling
+	glog.V(1).Infof("hybrid proxy: (always) add ep %s in unidling proxy", endpoints.Name)
+	p.unidlingEndpointsHandler.OnEndpointsAdd(endpoints)
+
+	p.usingUserspaceLock.Lock()
+	defer p.usingUserspaceLock.Unlock()
+
+	svcName := types.NamespacedName{
+		Namespace: endpoints.Namespace,
+		Name:      endpoints.Name,
+	}
+
+	wasUsingUserspace, knownEndpoints := p.usingUserspace[svcName]
+	p.usingUserspace[svcName] = p.shouldEndpointsUseUserspace(endpoints)
+
+	if !p.usingUserspace[svcName] {
+		glog.V(1).Infof("hybrid proxy: add ep %s in main proxy", endpoints.Name)
+		p.mainEndpointsHandler.OnEndpointsAdd(endpoints)
+	}
+
+	// a service could appear before endpoints, so we have to treat this as a potential
+	// state modification for services, and not just an addition (since we could flip proxies).
+	if knownEndpoints && wasUsingUserspace != p.usingUserspace[svcName] {
+		p.switchService(svcName)
+	}
+}
+
+func (p *HybridProxier) OnEndpointsUpdate(oldEndpoints, endpoints *api.Endpoints) {
+	// we track all endpoints in the unidling endpoints handler so that we can succesfully
+	// detect when a service become unidling
+	glog.V(1).Infof("hybrid proxy: (always) update ep %s in unidling proxy", endpoints.Name)
+	p.unidlingEndpointsHandler.OnEndpointsUpdate(oldEndpoints, endpoints)
+
+	p.usingUserspaceLock.Lock()
+	defer p.usingUserspaceLock.Unlock()
+
+	svcName := types.NamespacedName{
+		Namespace: endpoints.Namespace,
+		Name:      endpoints.Name,
+	}
+
+	wasUsingUserspace, knownEndpoints := p.usingUserspace[svcName]
+	p.usingUserspace[svcName] = p.shouldEndpointsUseUserspace(endpoints)
+
+	if !knownEndpoints {
+		utilruntime.HandleError(fmt.Errorf("received update for unknown endpoints %s", svcName.String()))
+		return
+	}
+
+	isSwitch := wasUsingUserspace != p.usingUserspace[svcName]
+
+	if !isSwitch && !p.usingUserspace[svcName] {
+		glog.V(1).Infof("hybrid proxy: update ep %s in main proxy", endpoints.Name)
+		p.mainEndpointsHandler.OnEndpointsUpdate(oldEndpoints, endpoints)
+		return
+	}
+
+	if p.usingUserspace[svcName] {
+		glog.V(1).Infof("hybrid proxy: del ep %s in main proxy", endpoints.Name)
+		p.mainEndpointsHandler.OnEndpointsDelete(oldEndpoints)
+	} else {
+		glog.V(1).Infof("hybrid proxy: add ep %s in main proxy", endpoints.Name)
+		p.mainEndpointsHandler.OnEndpointsAdd(endpoints)
+	}
+
+	p.switchService(svcName)
+}
+
+func (p *HybridProxier) OnEndpointsDelete(endpoints *api.Endpoints) {
+	// we track all endpoints in the unidling endpoints handler so that we can succesfully
+	// detect when a service become unidling
+	glog.V(1).Infof("hybrid proxy: (always) del ep %s in unidling proxy", endpoints.Name)
+	p.unidlingEndpointsHandler.OnEndpointsDelete(endpoints)
+
+	p.usingUserspaceLock.Lock()
+	defer p.usingUserspaceLock.Unlock()
+
+	svcName := types.NamespacedName{
+		Namespace: endpoints.Namespace,
+		Name:      endpoints.Name,
+	}
+
+	usingUserspace, knownEndpoints := p.usingUserspace[svcName]
+
+	if !knownEndpoints {
+		utilruntime.HandleError(fmt.Errorf("received delete for unknown endpoints %s", svcName.String()))
+		return
+	}
+
+	if !usingUserspace {
+		glog.V(1).Infof("hybrid proxy: del ep %s in main proxy", endpoints.Name)
+		p.mainEndpointsHandler.OnEndpointsDelete(endpoints)
+	}
+
+	delete(p.usingUserspace, svcName)
+}
+
+func (p *HybridProxier) OnEndpointsSynced() {
+	p.unidlingEndpointsHandler.OnEndpointsSynced()
+	p.mainEndpointsHandler.OnEndpointsSynced()
+	glog.V(1).Infof("hybrid proxy: endpoints synced")
 }
 
 // Sync is called to immediately synchronize the proxier state to iptables
 func (p *HybridProxier) Sync() {
 	p.mainProxy.Sync()
 	p.unidlingProxy.Sync()
+	glog.V(5).Infof("hybrid proxy: proxies synced")
 }
 
 // SyncLoop runs periodic work.  This is expected to run as a goroutine or as the main loop of the app.  It does not return.
 func (p *HybridProxier) SyncLoop() {
-	t := time.NewTicker(p.syncPeriod)
-	defer t.Stop()
-	for {
-		<-t.C
-		glog.V(6).Infof("Periodic sync")
-		p.mainProxy.Sync()
-		p.unidlingProxy.Sync()
-	}
+	// the iptables proxier now lies about how it works.  sync doesn't actually sync now --
+	// it just adds to a queue that's processed by a loop launched by SyncLoop, so we
+	// *must* start the sync loops, and not just use our own...
+	go p.mainProxy.SyncLoop()
+	go p.unidlingProxy.SyncLoop()
+
+	select {}
 }

--- a/pkg/proxy/unidler/unidlerproxy.go
+++ b/pkg/proxy/unidler/unidlerproxy.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/record"
@@ -18,23 +19,20 @@ import (
 type NeedPodsSignaler interface {
 	// NeedPods signals that endpoint addresses are needed in order to
 	// service a traffic coming to the given service and port
-	NeedPods(serviceRef api.ObjectReference, port string) error
+	NeedPods(serviceName types.NamespacedName, port string) error
 }
 
 type eventSignaler struct {
 	recorder record.EventRecorder
 }
 
-func (sig *eventSignaler) NeedPods(serviceRefInt api.ObjectReference, port string) error {
-	// TODO(directxman12): fix upstream so that it passes around v1.ObjectReference instead of api.ObjectReference
-	// NB: api.ObjectReference doesn't appear to be registered as a type, so we have to do manual conversion...
+func (sig *eventSignaler) NeedPods(serviceName types.NamespacedName, port string) error {
+	// TODO: we need to fake this since upstream removed our handle to the ObjectReference
+	// This *should* be sufficient for the unidling controller
 	serviceRef := v1.ObjectReference{
-		Kind:            serviceRefInt.Kind,
-		Namespace:       serviceRefInt.Namespace,
-		Name:            serviceRefInt.Name,
-		UID:             serviceRefInt.UID,
-		APIVersion:      serviceRefInt.APIVersion,
-		ResourceVersion: serviceRefInt.ResourceVersion,
+		Kind:      "Service",
+		Namespace: serviceName.Namespace,
+		Name:      serviceName.Name,
 	}
 
 	// HACK: make the message different to prevent event aggregation

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -1,468 +1,468 @@
 package idling
 
-// import (
-// 	"encoding/json"
-// 	"fmt"
-// 	"io/ioutil"
-// 	"net"
-// 	"os"
-// 	"strings"
-// 	"sync"
-// 	"time"
-
-// 	g "github.com/onsi/ginkgo"
-// 	o "github.com/onsi/gomega"
-
-// 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-// 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
-
-// 	// unidlingproxy "github.com/openshift/origin/pkg/proxy/unidler"
-// 	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
-// 	exutil "github.com/openshift/origin/test/extended/util"
-// )
-
-// func tryEchoUDPOnce(ip net.IP, udpPort int, expectedBuff []byte, readTimeout time.Duration) ([]byte, error) {
-// 	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: ip, Port: udpPort})
-// 	if err != nil {
-// 		return nil, fmt.Errorf("unable to connect to service: %v", err)
-// 	}
-// 	defer conn.Close()
-
-// 	var n int
-// 	if n, err = conn.Write(expectedBuff); err != nil {
-// 		// It's technically possible to get some errors on write while switching over
-// 		return nil, nil
-// 	} else if n != len(expectedBuff) {
-// 		return nil, fmt.Errorf("unable to write entire %v bytes to UDP echo server socket", len(expectedBuff))
-// 	}
-
-// 	if err = conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
-// 		return nil, fmt.Errorf("unable to set deadline on read from echo server: %v", err)
-// 	}
-
-// 	actualBuff := make([]byte, n)
-// 	var amtRead int
-// 	amtRead, _, err = conn.ReadFromUDP(actualBuff)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("unable to read from UDP echo server: %v", err)
-// 	} else if amtRead != n {
-// 		// we should never read back the *wrong* thing
-// 		return nil, fmt.Errorf("read back incorrect number of bytes from echo server")
-// 	}
-
-// 	if string(expectedBuff) != string(actualBuff) {
-// 		return nil, fmt.Errorf("written contents %q didn't equal read contents %q from echo server: %v", string(expectedBuff), string(actualBuff), err)
-// 	}
-
-// 	return actualBuff, nil
-// }
-
-// func tryEchoUDP(svc *kapiv1.Service) error {
-// 	rawIP := svc.Spec.ClusterIP
-// 	o.Expect(rawIP).NotTo(o.BeEmpty(), "The service should have a cluster IP set")
-// 	ip := net.ParseIP(rawIP)
-// 	o.Expect(ip).NotTo(o.BeNil(), "The service should have a valid cluster IP, but %q was not valid", rawIP)
-
-// 	var udpPort int
-// 	for _, port := range svc.Spec.Ports {
-// 		if port.Protocol == "UDP" {
-// 			udpPort = int(port.Port)
-// 			break
-// 		}
-// 	}
-// 	o.Expect(udpPort).NotTo(o.Equal(0), "The service should have a UDP port exposed")
-
-// 	// For UDP, we just drop packets on the floor rather than queue them up
-// 	readTimeout := 5 * time.Second
-
-// 	expectedBuff := []byte("It's time to UDP!\n")
-// 	o.Eventually(func() ([]byte, error) { return tryEchoUDPOnce(ip, udpPort, expectedBuff, readTimeout) }, 2*time.Minute, readTimeout).Should(o.Equal(expectedBuff))
-
-// 	return nil
-// }
-
-// func tryEchoTCP(svc *kapiv1.Service) error {
-// 	rawIP := svc.Spec.ClusterIP
-// 	if rawIP == "" {
-// 		return fmt.Errorf("no ClusterIP specified on service %s", svc.Name)
-// 	}
-// 	ip := net.ParseIP(rawIP)
-
-// 	var tcpPort int
-// 	for _, port := range svc.Spec.Ports {
-// 		if port.Protocol == "TCP" {
-// 			tcpPort = int(port.Port)
-// 			break
-// 		}
-// 	}
-
-// 	if tcpPort == 0 {
-// 		return fmt.Errorf("Unable to find any TCP ports on service %s", svc.Name)
-// 	}
-
-// 	conn, err := net.DialTCP("tcp", nil, &net.TCPAddr{IP: ip, Port: tcpPort})
-// 	if err != nil {
-// 		return fmt.Errorf("unable to connect to service %s: %v", svc.Name, err)
-// 	}
-
-// 	if err = conn.SetDeadline(time.Now().Add(2 * time.Minute)); err != nil {
-// 		return fmt.Errorf("unable to set timeout on TCP connection to service %s: %v", svc.Name, err)
-// 	}
-
-// 	expectedBuff := []byte("It's time to TCP!\n")
-// 	var n int
-// 	if n, err = conn.Write(expectedBuff); err != nil {
-// 		return fmt.Errorf("unable to write data to echo server for service %s: %v", svc.Name, err)
-// 	} else if n != len(expectedBuff) {
-// 		return fmt.Errorf("unable to write all data to echo server for service %s", svc.Name)
-// 	}
-
-// 	actualBuff := make([]byte, n)
-// 	var amtRead int
-// 	amtRead, err = conn.Read(actualBuff)
-// 	if err != nil {
-// 		return fmt.Errorf("unable to read data from echo server for service %s: %v", svc.Name, err)
-// 	} else if amtRead != n {
-// 		return fmt.Errorf("unable to read all data written from echo server for service %s: %v", svc.Name, err)
-// 	}
-
-// 	if string(expectedBuff) != string(actualBuff) {
-// 		return fmt.Errorf("written contents %q didn't equal read contents %q from echo server for service %s: %v", string(expectedBuff), string(actualBuff), svc.Name, err)
-// 	}
-
-// 	return nil
-// }
-
-// func createFixture(oc *exutil.CLI, path string) ([]string, []string, error) {
-// 	output, err := oc.Run("create").Args("-f", path, "-o", "name").Output()
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-
-// 	lines := strings.Split(output, "\n")
-
-// 	resources := make([]string, 0, len(lines)-1)
-// 	names := make([]string, 0, len(lines)-1)
-
-// 	for _, line := range lines {
-// 		if line == "" {
-// 			continue
-// 		}
-// 		parts := strings.Split(line, "/")
-// 		if len(parts) != 2 {
-// 			return nil, nil, fmt.Errorf("expected type/name syntax, got: %q", line)
-// 		}
-// 		resources = append(resources, parts[0])
-// 		names = append(names, parts[1])
-// 	}
-
-// 	return resources, names, nil
-// }
-
-// func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]string, resourceName string, kind string) {
-// 	g.By("Idling the service")
-// 	_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
-// 	o.Expect(err).ToNot(o.HaveOccurred())
-
-// 	g.By("Ensuring the scale is zero (and stays zero)")
-// 	objName := resources[resourceName][0]
-// 	// make sure we don't get woken up by an incorrect router health check or anything like that
-// 	o.Consistently(func() (string, error) {
-// 		return oc.Run("get").Args(resourceName+"/"+objName, "--output=jsonpath=\"{.spec.replicas}\"").Output()
-// 	}, 20*time.Second, 500*time.Millisecond).Should(o.ContainSubstring("0"))
-
-// 	g.By("Fetching the service and checking the annotations are present")
-// 	serviceName := resources["service"][0]
-// 	endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 	o.Expect(err).NotTo(o.HaveOccurred())
-
-// 	o.Expect(endpoints.Annotations).To(o.HaveKey(unidlingapi.IdledAtAnnotation))
-// 	o.Expect(endpoints.Annotations).To(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
-
-// 	g.By("Checking the idled-at time")
-// 	idledAtAnnotation := endpoints.Annotations[unidlingapi.IdledAtAnnotation]
-// 	idledAtTime, err := time.Parse(time.RFC3339, idledAtAnnotation)
-// 	o.Expect(err).ToNot(o.HaveOccurred())
-// 	o.Expect(idledAtTime).To(o.BeTemporally("~", time.Now(), 5*time.Minute))
-
-// 	g.By("Checking the idle targets")
-// 	unidleTargetAnnotation := endpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
-// 	unidleTargets := []unidlingapi.RecordedScaleReference{}
-// 	err = json.Unmarshal([]byte(unidleTargetAnnotation), &unidleTargets)
-// 	o.Expect(err).ToNot(o.HaveOccurred())
-// 	o.Expect(unidleTargets).To(o.Equal([]unidlingapi.RecordedScaleReference{
-// 		{
-// 			Replicas: 2,
-// 			CrossGroupObjectReference: unidlingapi.CrossGroupObjectReference{
-// 				Name: resources[resourceName][0],
-// 				Kind: kind,
-// 			},
-// 		},
-// 	}))
-// }
-
-// var _ = g.Describe("idling and unidling", func() {
-// 	defer g.GinkgoRecover()
-// 	var (
-// 		oc                  = exutil.NewCLI("cli-idling", exutil.KubeConfigPath()).Verbose()
-// 		echoServerFixture   = exutil.FixturePath("testdata", "idling-echo-server.yaml")
-// 		echoServerRcFixture = exutil.FixturePath("testdata", "idling-echo-server-rc.yaml")
-// 		framework           = oc.KubeFramework()
-// 	)
-
-// 	// path to the fixture
-// 	var fixture string
-
-// 	// path to the idling file
-// 	var idlingFile string
-
-// 	// map of all resources created from the fixtures
-// 	var resources map[string][]string
-
-// 	g.JustBeforeEach(func() {
-// 		g.By("Creating the resources")
-// 		rawResources, rawResourceNames, err := createFixture(oc, fixture)
-// 		o.Expect(err).ToNot(o.HaveOccurred())
-
-// 		resources = make(map[string][]string)
-// 		for i, resource := range rawResources {
-// 			resources[resource] = append(resources[resource], rawResourceNames[i])
-// 		}
-
-// 		g.By("Creating the idling file")
-// 		serviceNames := resources["service"]
-
-// 		targetFile, err := ioutil.TempFile(exutil.TestContext.OutputDir, "idling-services-")
-// 		o.Expect(err).ToNot(o.HaveOccurred())
-// 		defer targetFile.Close()
-// 		idlingFile = targetFile.Name()
-// 		_, err = targetFile.Write([]byte(strings.Join(serviceNames, "\n")))
-// 		o.Expect(err).ToNot(o.HaveOccurred())
-
-// 		g.By("Waiting for the endpoints to exist")
-// 		serviceName := resources["service"][0]
-// 		g.By("Waiting for endpoints to be up")
-// 		err = waitForEndpointsAvailable(oc, serviceName)
-// 		o.Expect(err).ToNot(o.HaveOccurred())
-// 	})
-
-// 	g.AfterEach(func() {
-// 		g.By("Cleaning up the idling file")
-// 		os.Remove(idlingFile)
-// 	})
-
-// 	g.Describe("idling", func() {
-// 		g.Context("with a single service and DeploymentConfig [Conformance]", func() {
-// 			g.BeforeEach(func() {
-// 				framework.BeforeEach()
-// 				fixture = echoServerFixture
-// 			})
-
-// 			g.It("should idle the service and DeploymentConfig properly", func() {
-// 				checkSingleIdle(oc, idlingFile, resources, "deploymentconfig", "DeploymentConfig")
-// 			})
-// 		})
-
-// 		g.Context("with a single service and ReplicationController", func() {
-// 			g.BeforeEach(func() {
-// 				framework.BeforeEach()
-// 				fixture = echoServerRcFixture
-// 			})
-
-// 			g.It("should idle the service and ReplicationController properly", func() {
-// 				checkSingleIdle(oc, idlingFile, resources, "replicationcontroller", "ReplicationController")
-// 			})
-// 		})
-// 	})
-
-// 	g.Describe("unidling", func() {
-// 		g.BeforeEach(func() {
-// 			framework.BeforeEach()
-// 			fixture = echoServerFixture
-// 		})
-
-// 		g.It("should work with TCP (when fully idled) [Conformance] [local]", func() {
-// 			g.By("Idling the service")
-// 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Waiting for the pods to have terminated")
-// 			err = waitForNoPodsAvailable(oc)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Connecting to the service IP and checking the echo")
-// 			serviceName := resources["service"][0]
-// 			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			err = tryEchoTCP(svc)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Waiting until we have endpoints")
-// 			err = waitForEndpointsAvailable(oc, serviceName)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Making sure the endpoints are no longer marked as idled")
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
-// 		})
-
-// 		g.It("should work with TCP (while idling) [local]", func() {
-// 			g.By("Idling the service")
-// 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Connecting to the service IP and repeatedly connecting, making sure we seamlessly idle and come back up")
-// 			serviceName := resources["service"][0]
-// 			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			o.Consistently(func() error { return tryEchoTCP(svc) }, 10*time.Second, 500*time.Millisecond).ShouldNot(o.HaveOccurred())
-
-// 			g.By("Waiting until we have endpoints")
-// 			err = waitForEndpointsAvailable(oc, serviceName)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Making sure the endpoints are no longer marked as idled")
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
-// 		})
-
-// 		g.It("should handle many TCP connections by dropping those under a certain bound [local]", func() {
-// 			g.By("Idling the service")
-// 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Waiting for the pods to have terminated")
-// 			serviceName := resources["service"][0]
-// 			err = waitForNoPodsAvailable(oc)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Connecting to the service IP many times and checking the echo")
-// 			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			connectionsToStart := 100
-
-// 			errors := make([]error, connectionsToStart)
-// 			var connWG sync.WaitGroup
-// 			// spawn many connections
-// 			for i := 0; i < connectionsToStart; i++ {
-// 				connWG.Add(1)
-// 				go func(ind int) {
-// 					defer connWG.Done()
-// 					err = tryEchoTCP(svc)
-// 					errors[ind] = err
-// 				}(i)
-// 			}
-
-// 			connWG.Wait()
-
-// 			g.By(fmt.Sprintf("Expecting all but %v of those connections to fail", unidlingproxy.MaxHeldConnections))
-// 			errCount := 0
-// 			for _, err := range errors {
-// 				if err != nil {
-// 					errCount++
-// 				}
-// 			}
-// 			o.Expect(errCount).To(o.Equal(connectionsToStart - unidlingproxy.MaxHeldConnections))
-
-// 			g.By("Waiting until we have endpoints")
-// 			err = waitForEndpointsAvailable(oc, serviceName)
-
-// 			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Making sure the endpoints are no longer marked as idled")
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
-// 		})
-
-// 		g.It("should work with UDP [local]", func() {
-// 			g.By("Idling the service")
-// 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Waiting for the pods to have terminated")
-// 			err = waitForNoPodsAvailable(oc)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Connecting to the service IP and checking the echo")
-// 			serviceName := resources["service"][0]
-// 			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			err = tryEchoUDP(svc)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Waiting until we have endpoints")
-// 			err = waitForEndpointsAvailable(oc, serviceName)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Making sure the endpoints are no longer marked as idled")
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
-// 		})
-
-// 		// TODO: Work out how to make this test work correctly when run on AWS
-// 		g.XIt("should handle many UDP senders (by continuing to drop all packets on the floor) [local]", func() {
-// 			g.By("Idling the service")
-// 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Waiting for the pods to have terminated")
-// 			err = waitForNoPodsAvailable(oc)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Connecting to the service IP many times and checking the echo")
-// 			serviceName := resources["service"][0]
-// 			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			connectionsToStart := 100
-// 			errors := make([]error, connectionsToStart)
-// 			var connWG sync.WaitGroup
-// 			// spawn many connectors
-// 			for i := 0; i < connectionsToStart; i++ {
-// 				connWG.Add(1)
-// 				go func(ind int) {
-// 					defer g.GinkgoRecover()
-// 					defer connWG.Done()
-// 					err = tryEchoUDP(svc)
-// 					errors[ind] = err
-// 				}(i)
-// 			}
-
-// 			connWG.Wait()
-
-// 			// all of the echoers should eventually succeed
-// 			errCount := 0
-// 			for _, err := range errors {
-// 				if err != nil {
-// 					errCount++
-// 				}
-// 			}
-// 			o.Expect(errCount).To(o.Equal(0))
-
-// 			g.By("Waiting until we have endpoints")
-// 			err = waitForEndpointsAvailable(oc, serviceName)
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
-// 			o.Expect(err).ToNot(o.HaveOccurred())
-
-// 			g.By("Making sure the endpoints are no longer marked as idled")
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
-// 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
-// 		})
-// 	})
-// })
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+
+	unidlingproxy "github.com/openshift/origin/pkg/proxy/unidler"
+	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+func tryEchoUDPOnce(ip net.IP, udpPort int, expectedBuff []byte, readTimeout time.Duration) ([]byte, error) {
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: ip, Port: udpPort})
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to service: %v", err)
+	}
+	defer conn.Close()
+
+	var n int
+	if n, err = conn.Write(expectedBuff); err != nil {
+		// It's technically possible to get some errors on write while switching over
+		return nil, nil
+	} else if n != len(expectedBuff) {
+		return nil, fmt.Errorf("unable to write entire %v bytes to UDP echo server socket", len(expectedBuff))
+	}
+
+	if err = conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+		return nil, fmt.Errorf("unable to set deadline on read from echo server: %v", err)
+	}
+
+	actualBuff := make([]byte, n)
+	var amtRead int
+	amtRead, _, err = conn.ReadFromUDP(actualBuff)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read from UDP echo server: %v", err)
+	} else if amtRead != n {
+		// we should never read back the *wrong* thing
+		return nil, fmt.Errorf("read back incorrect number of bytes from echo server")
+	}
+
+	if string(expectedBuff) != string(actualBuff) {
+		return nil, fmt.Errorf("written contents %q didn't equal read contents %q from echo server: %v", string(expectedBuff), string(actualBuff), err)
+	}
+
+	return actualBuff, nil
+}
+
+func tryEchoUDP(svc *kapiv1.Service) error {
+	rawIP := svc.Spec.ClusterIP
+	o.Expect(rawIP).NotTo(o.BeEmpty(), "The service should have a cluster IP set")
+	ip := net.ParseIP(rawIP)
+	o.Expect(ip).NotTo(o.BeNil(), "The service should have a valid cluster IP, but %q was not valid", rawIP)
+
+	var udpPort int
+	for _, port := range svc.Spec.Ports {
+		if port.Protocol == "UDP" {
+			udpPort = int(port.Port)
+			break
+		}
+	}
+	o.Expect(udpPort).NotTo(o.Equal(0), "The service should have a UDP port exposed")
+
+	// For UDP, we just drop packets on the floor rather than queue them up
+	readTimeout := 5 * time.Second
+
+	expectedBuff := []byte("It's time to UDP!\n")
+	o.Eventually(func() ([]byte, error) { return tryEchoUDPOnce(ip, udpPort, expectedBuff, readTimeout) }, 2*time.Minute, readTimeout).Should(o.Equal(expectedBuff))
+
+	return nil
+}
+
+func tryEchoTCP(svc *kapiv1.Service) error {
+	rawIP := svc.Spec.ClusterIP
+	if rawIP == "" {
+		return fmt.Errorf("no ClusterIP specified on service %s", svc.Name)
+	}
+	ip := net.ParseIP(rawIP)
+
+	var tcpPort int
+	for _, port := range svc.Spec.Ports {
+		if port.Protocol == "TCP" {
+			tcpPort = int(port.Port)
+			break
+		}
+	}
+
+	if tcpPort == 0 {
+		return fmt.Errorf("Unable to find any TCP ports on service %s", svc.Name)
+	}
+
+	conn, err := net.DialTCP("tcp", nil, &net.TCPAddr{IP: ip, Port: tcpPort})
+	if err != nil {
+		return fmt.Errorf("unable to connect to service %s: %v", svc.Name, err)
+	}
+
+	if err = conn.SetDeadline(time.Now().Add(2 * time.Minute)); err != nil {
+		return fmt.Errorf("unable to set timeout on TCP connection to service %s: %v", svc.Name, err)
+	}
+
+	expectedBuff := []byte("It's time to TCP!\n")
+	var n int
+	if n, err = conn.Write(expectedBuff); err != nil {
+		return fmt.Errorf("unable to write data to echo server for service %s: %v", svc.Name, err)
+	} else if n != len(expectedBuff) {
+		return fmt.Errorf("unable to write all data to echo server for service %s", svc.Name)
+	}
+
+	actualBuff := make([]byte, n)
+	var amtRead int
+	amtRead, err = conn.Read(actualBuff)
+	if err != nil {
+		return fmt.Errorf("unable to read data from echo server for service %s: %v", svc.Name, err)
+	} else if amtRead != n {
+		return fmt.Errorf("unable to read all data written from echo server for service %s: %v", svc.Name, err)
+	}
+
+	if string(expectedBuff) != string(actualBuff) {
+		return fmt.Errorf("written contents %q didn't equal read contents %q from echo server for service %s: %v", string(expectedBuff), string(actualBuff), svc.Name, err)
+	}
+
+	return nil
+}
+
+func createFixture(oc *exutil.CLI, path string) ([]string, []string, error) {
+	output, err := oc.Run("create").Args("-f", path, "-o", "name").Output()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lines := strings.Split(output, "\n")
+
+	resources := make([]string, 0, len(lines)-1)
+	names := make([]string, 0, len(lines)-1)
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "/")
+		if len(parts) != 2 {
+			return nil, nil, fmt.Errorf("expected type/name syntax, got: %q", line)
+		}
+		resources = append(resources, parts[0])
+		names = append(names, parts[1])
+	}
+
+	return resources, names, nil
+}
+
+func checkSingleIdle(oc *exutil.CLI, idlingFile string, resources map[string][]string, resourceName string, kind string) {
+	g.By("Idling the service")
+	_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
+	o.Expect(err).ToNot(o.HaveOccurred())
+
+	g.By("Ensuring the scale is zero (and stays zero)")
+	objName := resources[resourceName][0]
+	// make sure we don't get woken up by an incorrect router health check or anything like that
+	o.Consistently(func() (string, error) {
+		return oc.Run("get").Args(resourceName+"/"+objName, "--output=jsonpath=\"{.spec.replicas}\"").Output()
+	}, 20*time.Second, 500*time.Millisecond).Should(o.ContainSubstring("0"))
+
+	g.By("Fetching the service and checking the annotations are present")
+	serviceName := resources["service"][0]
+	endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	o.Expect(endpoints.Annotations).To(o.HaveKey(unidlingapi.IdledAtAnnotation))
+	o.Expect(endpoints.Annotations).To(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+
+	g.By("Checking the idled-at time")
+	idledAtAnnotation := endpoints.Annotations[unidlingapi.IdledAtAnnotation]
+	idledAtTime, err := time.Parse(time.RFC3339, idledAtAnnotation)
+	o.Expect(err).ToNot(o.HaveOccurred())
+	o.Expect(idledAtTime).To(o.BeTemporally("~", time.Now(), 5*time.Minute))
+
+	g.By("Checking the idle targets")
+	unidleTargetAnnotation := endpoints.Annotations[unidlingapi.UnidleTargetAnnotation]
+	unidleTargets := []unidlingapi.RecordedScaleReference{}
+	err = json.Unmarshal([]byte(unidleTargetAnnotation), &unidleTargets)
+	o.Expect(err).ToNot(o.HaveOccurred())
+	o.Expect(unidleTargets).To(o.Equal([]unidlingapi.RecordedScaleReference{
+		{
+			Replicas: 2,
+			CrossGroupObjectReference: unidlingapi.CrossGroupObjectReference{
+				Name: resources[resourceName][0],
+				Kind: kind,
+			},
+		},
+	}))
+}
+
+var _ = g.Describe("idling and unidling", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc                  = exutil.NewCLI("cli-idling", exutil.KubeConfigPath()).Verbose()
+		echoServerFixture   = exutil.FixturePath("testdata", "idling-echo-server.yaml")
+		echoServerRcFixture = exutil.FixturePath("testdata", "idling-echo-server-rc.yaml")
+		framework           = oc.KubeFramework()
+	)
+
+	// path to the fixture
+	var fixture string
+
+	// path to the idling file
+	var idlingFile string
+
+	// map of all resources created from the fixtures
+	var resources map[string][]string
+
+	g.JustBeforeEach(func() {
+		g.By("Creating the resources")
+		rawResources, rawResourceNames, err := createFixture(oc, fixture)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		resources = make(map[string][]string)
+		for i, resource := range rawResources {
+			resources[resource] = append(resources[resource], rawResourceNames[i])
+		}
+
+		g.By("Creating the idling file")
+		serviceNames := resources["service"]
+
+		targetFile, err := ioutil.TempFile(exutil.TestContext.OutputDir, "idling-services-")
+		o.Expect(err).ToNot(o.HaveOccurred())
+		defer targetFile.Close()
+		idlingFile = targetFile.Name()
+		_, err = targetFile.Write([]byte(strings.Join(serviceNames, "\n")))
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		g.By("Waiting for the endpoints to exist")
+		serviceName := resources["service"][0]
+		g.By("Waiting for endpoints to be up")
+		err = waitForEndpointsAvailable(oc, serviceName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
+
+	g.AfterEach(func() {
+		g.By("Cleaning up the idling file")
+		os.Remove(idlingFile)
+	})
+
+	g.Describe("idling", func() {
+		g.Context("with a single service and DeploymentConfig [Conformance]", func() {
+			g.BeforeEach(func() {
+				framework.BeforeEach()
+				fixture = echoServerFixture
+			})
+
+			g.It("should idle the service and DeploymentConfig properly", func() {
+				checkSingleIdle(oc, idlingFile, resources, "deploymentconfig", "DeploymentConfig")
+			})
+		})
+
+		g.Context("with a single service and ReplicationController", func() {
+			g.BeforeEach(func() {
+				framework.BeforeEach()
+				fixture = echoServerRcFixture
+			})
+
+			g.It("should idle the service and ReplicationController properly", func() {
+				checkSingleIdle(oc, idlingFile, resources, "replicationcontroller", "ReplicationController")
+			})
+		})
+	})
+
+	g.Describe("unidling", func() {
+		g.BeforeEach(func() {
+			framework.BeforeEach()
+			fixture = echoServerFixture
+		})
+
+		g.It("should work with TCP (when fully idled) [Conformance] [local]", func() {
+			g.By("Idling the service")
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Waiting for the pods to have terminated")
+			err = waitForNoPodsAvailable(oc)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Connecting to the service IP and checking the echo")
+			serviceName := resources["service"][0]
+			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			err = tryEchoTCP(svc)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Waiting until we have endpoints")
+			err = waitForEndpointsAvailable(oc, serviceName)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Making sure the endpoints are no longer marked as idled")
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+		})
+
+		g.It("should work with TCP (while idling) [local]", func() {
+			g.By("Idling the service")
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Connecting to the service IP and repeatedly connecting, making sure we seamlessly idle and come back up")
+			serviceName := resources["service"][0]
+			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			o.Consistently(func() error { return tryEchoTCP(svc) }, 10*time.Second, 500*time.Millisecond).ShouldNot(o.HaveOccurred())
+
+			g.By("Waiting until we have endpoints")
+			err = waitForEndpointsAvailable(oc, serviceName)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Making sure the endpoints are no longer marked as idled")
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+		})
+
+		g.It("should handle many TCP connections by dropping those under a certain bound [local]", func() {
+			g.By("Idling the service")
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Waiting for the pods to have terminated")
+			serviceName := resources["service"][0]
+			err = waitForNoPodsAvailable(oc)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Connecting to the service IP many times and checking the echo")
+			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			connectionsToStart := 100
+
+			errors := make([]error, connectionsToStart)
+			var connWG sync.WaitGroup
+			// spawn many connections
+			for i := 0; i < connectionsToStart; i++ {
+				connWG.Add(1)
+				go func(ind int) {
+					defer connWG.Done()
+					err = tryEchoTCP(svc)
+					errors[ind] = err
+				}(i)
+			}
+
+			connWG.Wait()
+
+			g.By(fmt.Sprintf("Expecting all but %v of those connections to fail", unidlingproxy.MaxHeldConnections))
+			errCount := 0
+			for _, err := range errors {
+				if err != nil {
+					errCount++
+				}
+			}
+			o.Expect(errCount).To(o.Equal(connectionsToStart - unidlingproxy.MaxHeldConnections))
+
+			g.By("Waiting until we have endpoints")
+			err = waitForEndpointsAvailable(oc, serviceName)
+
+			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Making sure the endpoints are no longer marked as idled")
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+		})
+
+		g.It("should work with UDP [local]", func() {
+			g.By("Idling the service")
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Waiting for the pods to have terminated")
+			err = waitForNoPodsAvailable(oc)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Connecting to the service IP and checking the echo")
+			serviceName := resources["service"][0]
+			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			err = tryEchoUDP(svc)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Waiting until we have endpoints")
+			err = waitForEndpointsAvailable(oc, serviceName)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Making sure the endpoints are no longer marked as idled")
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+		})
+
+		// TODO: Work out how to make this test work correctly when run on AWS
+		g.XIt("should handle many UDP senders (by continuing to drop all packets on the floor) [local]", func() {
+			g.By("Idling the service")
+			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Waiting for the pods to have terminated")
+			err = waitForNoPodsAvailable(oc)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Connecting to the service IP many times and checking the echo")
+			serviceName := resources["service"][0]
+			svc, err := oc.KubeClient().CoreV1().Services(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			connectionsToStart := 100
+			errors := make([]error, connectionsToStart)
+			var connWG sync.WaitGroup
+			// spawn many connectors
+			for i := 0; i < connectionsToStart; i++ {
+				connWG.Add(1)
+				go func(ind int) {
+					defer g.GinkgoRecover()
+					defer connWG.Done()
+					err = tryEchoUDP(svc)
+					errors[ind] = err
+				}(i)
+			}
+
+			connWG.Wait()
+
+			// all of the echoers should eventually succeed
+			errCount := 0
+			for _, err := range errors {
+				if err != nil {
+					errCount++
+				}
+			}
+			o.Expect(errCount).To(o.Equal(0))
+
+			g.By("Waiting until we have endpoints")
+			err = waitForEndpointsAvailable(oc, serviceName)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			endpoints, err := oc.KubeClient().CoreV1().Endpoints(oc.Namespace()).Get(serviceName, metav1.GetOptions{})
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			g.By("Making sure the endpoints are no longer marked as idled")
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.IdledAtAnnotation))
+			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
+		})
+	})
+})


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15101

The unidler was broken by changes to the structure of the proxies upstream.
This PR refactors the hybrid proxier to follow the event-driven model used by the
upstream proxies, and works around the lack of the ObjectReference in ServiceInfo
(we fake a lightweight ObjectReference using service name and namespace, which is
just enough for the unidler controller).