### PR TITLE
cluster up: make socat resilient to errors

### DIFF
--- a/pkg/bootstrap/docker/openshift/helper_unix.go
+++ b/pkg/bootstrap/docker/openshift/helper_unix.go
@@ -64,7 +64,9 @@ func (h *Helper) startSocatTunnel(bindIP string) error {
 	if err != nil {
 		glog.V(1).Infof("error: cannot kill socat: %v", err)
 	}
-	cmd := exec.Command("socat", fmt.Sprintf("TCP-L:8443,reuseaddr,fork,backlog=20,bind=%s", bindIP), "SYSTEM:\"docker exec -i origin socat - TCP\\:localhost\\:8443\"")
+	// The -s flag tells socat not to quit even when it gets errors on the other end.
+	// This may happen because the server is initially slow in responding.
+	cmd := exec.Command("socat", "-s", fmt.Sprintf("TCP-L:8443,reuseaddr,fork,backlog=20,bind=%s", bindIP), "SYSTEM:\"docker exec -i origin socat - TCP\\:localhost\\:8443\"")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
Errors may occur when socat tries to initially communicate with the API
server. By default, after a number of errors socat will abort and exit.
Passing the -s flag stops socat from quitting and allows the healthz
endpoint retries to be managed by the oc client.