### PR TITLE
Restore cAdvisor prometheus metrics

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -177,25 +177,9 @@ objects:
         kubernetes_sd_configs:
         - role: endpoints
 
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
         scheme: https
-
-        # This TLS & bearer token file config is used to connect to the actual scrape
-        # endpoints for cluster components. This is separate to discovery auth
-        # configuration because discovery & scraping are two separate concerns in
-        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-        # the cluster. Otherwise, more config options have to be provided within the
-        # <kubernetes_sd_config>.
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
         # Keep only the default/kubernetes service endpoints for the https port. This
@@ -206,33 +190,42 @@ objects:
           action: keep
           regex: default;kubernetes;https
 
+      # Scrape config for nodes.
+      #
+      # Each node exposes a /metrics endpoint that contains operational metrics for
+      # the Kubelet and other components.
       - job_name: 'kubernetes-nodes'
 
-        # Default to scraping over https. If required, just disable this or change to
-        # `http`.
         scheme: https
-
-        # This TLS & bearer token file config is used to connect to the actual scrape
-        # endpoints for cluster components. This is separate to discovery auth
-        # configuration because discovery & scraping are two separate concerns in
-        # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-        # the cluster. Otherwise, more config options have to be provided within the
-        # <kubernetes_sd_config>.
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          # If your node certificates are self-signed or use a different CA to the
-          # master CA, then disable certificate verification below. Note that
-          # certificate verification is an integral part of a secure infrastructure
-          # so this should only be disabled in a controlled environment. You can
-          # disable certificate verification by uncommenting the line below.
-          #
-          # insecure_skip_verify: true
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
         kubernetes_sd_configs:
         - role: node
 
         relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+
+      # Scrape config for cAdvisor.
+      #
+      # Beginning in Kube 1.7, each node exposes a /metrics/cadvisor endpoint that
+      # reports container metrics for each running pod. Scrape those by default.
+      - job_name: 'kubernetes-cadvisor'
+
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        kubernetes_sd_configs:
+        - role: node
+
+        relabel_configs:
+        - action: replace
+          target_label: __metrics_path__
+          regex: /metrics/cadvisor
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
 

--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -111,7 +111,8 @@ objects:
           - -email-domain=*
           - -upstream=http://localhost:9090
           - -client-id=system:serviceaccount:${NAMESPACE}:prometheus
-          - '-openshift-sar={"namespace": "${NAMESPACE}", "verb": "list", "resource": "services"}'
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}}'
           - -tls-cert=/etc/tls/private/tls.crt
           - -tls-key=/etc/tls/private/tls.key
           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
@@ -121,7 +122,9 @@ objects:
           - mountPath: /etc/tls/private
             name: prometheus-tls
           - mountPath: /etc/proxy/secrets
-            name: secrets
+            name: prometheus-secrets
+          - mountPath: /prometheus
+            name: prometheus-data
 
         - name: prometheus
           args:
@@ -132,24 +135,25 @@ objects:
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - mountPath: /etc/prometheus
-            name: config-volume
+            name: prometheus-config
           - mountPath: /prometheus
-            name: data-volume
+            name: prometheus-data
 
         restartPolicy: Always
         volumes:
-        - configMap:
+        - name: prometheus-config
+          configMap:
             defaultMode: 420
             name: prometheus
-          name: config-volume
-        - name: secrets
+        - name: prometheus-secrets
           secret:
             secretName: prometheus-proxy
         - name: prometheus-tls
           secret:
             secretName: prometheus-tls
-        - emptyDir: {}
-          name: data-volume
+        - name: prometheus-data
+          emptyDir: {}
+
 - apiVersion: v1
   kind: ConfigMap
   metadata:
@@ -219,13 +223,12 @@ objects:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
+        metrics_path: /metrics/cadvisor
+
         kubernetes_sd_configs:
         - role: node
 
         relabel_configs:
-        - action: replace
-          target_label: __metrics_path__
-          regex: /metrics/cadvisor
         - action: labelmap
           regex: __meta_kubernetes_node_label_(.+)
 

--- a/hack/update-generated-bindata.sh
+++ b/hack/update-generated-bindata.sh
@@ -4,7 +4,6 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env
 
-EXAMPLES=examples
 OUTPUT_PARENT=${OUTPUT_ROOT:-$OS_ROOT}
 
 pushd vendor/github.com/jteeuwen/go-bindata > /dev/null
@@ -23,15 +22,15 @@ pushd "${OS_ROOT}" > /dev/null
     -ignore ".*\.go$" \
     -ignore "\.DS_Store" \
     -ignore application-template.json \
-    ${EXAMPLES}/image-streams/... \
-    ${EXAMPLES}/db-templates/... \
-    ${EXAMPLES}/jenkins \
-    ${EXAMPLES}/jenkins/pipeline \
-    ${EXAMPLES}/quickstarts/... \
-    ${EXAMPLES}/logging/... \
-    ${EXAMPLES}/heapster/... \
-    ${EXAMPLES}/prometheus/... \
-    ${EXAMPLES}/service-catalog/... \
+    examples/image-streams/... \
+    examples/db-templates/... \
+    examples/jenkins \
+    examples/jenkins/pipeline \
+    examples/quickstarts/... \
+    examples/logging/... \
+    examples/heapster/... \
+    examples/prometheus/... \
+    examples/service-catalog/... \
     pkg/image/admission/imagepolicy/api/v1/...
 
 "$(os::util::find::gopath_binary go-bindata)" \
@@ -47,13 +46,14 @@ pushd "${OS_ROOT}" > /dev/null
     examples/db-templates \
     examples/image-streams \
     examples/sample-app \
+    examples/prometheus/... \
     examples/hello-openshift \
     examples/jenkins/...
 
 popd > /dev/null
 
 # If you hit this, please reduce other tests instead of importing more
-if [[ "$( cat "${OUTPUT_PARENT}/test/extended/testdata/bindata.go" | wc -c )" -gt 700000 ]]; then
+if [[ "$( cat "${OUTPUT_PARENT}/test/extended/testdata/bindata.go" | wc -c )" -gt 740000 ]]; then
     echo "error: extended bindata is $( cat "${OUTPUT_PARENT}/test/extended/testdata/bindata.go" | wc -c ) bytes, reduce the size of the import" 1>&2
     exit 1
 fi

--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"
 	_ "github.com/openshift/origin/test/extended/networking"
+	_ "github.com/openshift/origin/test/extended/prometheus"
 	_ "github.com/openshift/origin/test/extended/registry"
 	_ "github.com/openshift/origin/test/extended/router"
 	_ "github.com/openshift/origin/test/extended/security"

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -1,0 +1,316 @@
+package prometheus
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/pkg/client/conditions"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLI("prometheus", exutil.KubeConfigPath())
+
+		execPodName, ns, host, bearerToken string
+		statsPort                          int
+	)
+
+	g.BeforeEach(func() {
+		ns = oc.KubeFramework().Namespace.Name
+		host = "prometheus.kube-system.svc"
+		statsPort = 443
+		mustCreate := false
+		if _, err := oc.AdminKubeClient().Extensions().Deployments("kube-system").Get("prometheus", metav1.GetOptions{}); err != nil {
+			if !kapierrs.IsNotFound(err) {
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+			mustCreate = true
+		}
+
+		if mustCreate {
+			e2e.Logf("Installing Prometheus onto the cluster for testing")
+			configPath := exutil.FixturePath("..", "..", "examples", "prometheus", "prometheus.yaml")
+			stdout, _, err := oc.WithoutNamespace().Run("process").Args("-f", configPath).Outputs()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = oc.WithoutNamespace().AsAdmin().Run("create").Args("-f", "-").InputString(stdout).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.WaitForDeploymentStatus(oc.AdminKubeClient(), &extensions.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: "kube-system"}})
+		}
+
+		waitForServiceAccountInNamespace(oc.AdminKubeClient(), "kube-system", "prometheus", 2*time.Minute)
+		secrets, err := oc.AdminKubeClient().Core().Secrets("kube-system").List(metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, secret := range secrets.Items {
+			if secret.Type != v1.SecretTypeServiceAccountToken {
+				continue
+			}
+			if !strings.HasPrefix(secret.Name, "prometheus-") {
+				continue
+			}
+			bearerToken = string(secret.Data[v1.ServiceAccountTokenKey])
+			break
+		}
+		o.Expect(bearerToken).ToNot(o.BeEmpty())
+	})
+
+	g.Describe("when installed to the cluster", func() {
+		g.It("should start and expose a secured proxy and unsecured metrics", func() {
+			execPodName = e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) {
+				pod.Spec.Containers[0].Image = "centos:7"
+			})
+			defer func() { oc.AdminKubeClient().Core().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
+
+			g.By("checking the unsecured metrics path")
+			success := false
+			var metrics map[string]*dto.MetricFamily
+			for i := 0; i < 30; i++ {
+				results, err := getInsecureURLViaPod(ns, execPodName, fmt.Sprintf("https://%s:%d/metrics", host, statsPort))
+				if err != nil {
+					e2e.Logf("unable to get unsecured metrics: %v", err)
+					continue
+				}
+				//e2e.Logf("Metrics:\n%s", results)
+
+				p := expfmt.TextParser{}
+				metrics, err = p.TextToMetricFamilies(bytes.NewBufferString(results))
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				counts := findCountersWithLabels(metrics["tsdb_samples_appended_total"], labels{})
+				if len(counts) == 0 || counts[0] == 0 {
+					time.Sleep(time.Second)
+					continue
+				}
+				success = true
+				break
+			}
+			o.Expect(success).To(o.BeTrue(), fmt.Sprintf("Did not find tsdb_samples_appended_total in:\n%#v,", metrics))
+
+			g.By("verifying the oauth-proxy reports a 403 on the root URL")
+			err := expectURLStatusCodeExec(ns, execPodName, fmt.Sprintf("https://%s:%d", host, statsPort), 403)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying a service account token is able to authenticate")
+			err = expectBearerTokenURLStatusCodeExec(ns, execPodName, fmt.Sprintf("https://%s:%d/graph", host, statsPort), bearerToken, 200)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying a service account token is able to access the Prometheus API")
+			// expect all endpoints within 60 seconds
+			var lastErrs []error
+			for i := 0; i < 60; i++ {
+				contents, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("https://%s:%d/api/v1/targets", host, statsPort), bearerToken)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				targets := &prometheusTargets{}
+				err = json.Unmarshal([]byte(contents), targets)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("verifying all expected jobs have a working target")
+				lastErrs = all(
+					targets.Expect(labels{"job": "kubernetes-apiservers"}, "up", "^https://.*/metrics$"),
+					targets.Expect(labels{"job": "kubernetes-service-endpoints", "kubernetes_name": "prometheus", "kubernetes_namespace": "kube-system", "name": "prometheus"}, "up", "^https://.*/metrics$"),
+					targets.Expect(labels{"job": "kubernetes-nodes"}, "up", "^https://.*/metrics$"),
+					targets.Expect(labels{"job": "kubernetes-cadvisor"}, "up", "^https://.*/metrics/cadvisor$"),
+				)
+				if len(lastErrs) == 0 {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+			o.Expect(lastErrs).To(o.BeEmpty())
+		})
+	})
+})
+
+func all(errs ...error) []error {
+	var result []error
+	for _, err := range errs {
+		if err != nil {
+			result = append(result, err)
+		}
+	}
+	return result
+}
+
+type prometheusTargets struct {
+	Data struct {
+		ActiveTargets []struct {
+			Labels    map[string]string
+			Health    string
+			ScrapeUrl string
+		}
+	}
+	Status string
+}
+
+func (t *prometheusTargets) Expect(l labels, health, scrapeURLPattern string) error {
+	for _, target := range t.Data.ActiveTargets {
+		match := true
+		for k, v := range l {
+			if target.Labels[k] != v {
+				match = false
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		if health != target.Health {
+			continue
+		}
+		o.Expect(target.ScrapeUrl).To(o.MatchRegexp(scrapeURLPattern))
+		return nil
+	}
+	return fmt.Errorf("no match for %v with health %s", l, health)
+}
+
+type labels map[string]string
+
+func (l labels) With(name, value string) labels {
+	n := make(labels)
+	for k, v := range l {
+		n[k] = v
+	}
+	n[name] = value
+	return n
+}
+
+func findEnvVar(vars []kapi.EnvVar, key string) string {
+	for _, v := range vars {
+		if v.Name == key {
+			return v.Value
+		}
+	}
+	return ""
+}
+
+func findMetricsWithLabels(f *dto.MetricFamily, labels map[string]string) []*dto.Metric {
+	var result []*dto.Metric
+	if f == nil {
+		return result
+	}
+	for _, m := range f.Metric {
+		matched := map[string]struct{}{}
+		for _, l := range m.Label {
+			if expect, ok := labels[l.GetName()]; ok {
+				if expect != l.GetValue() {
+					break
+				}
+				matched[l.GetName()] = struct{}{}
+			}
+		}
+		if len(matched) != len(labels) {
+			continue
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+func findCountersWithLabels(f *dto.MetricFamily, labels map[string]string) []float64 {
+	var result []float64
+	for _, m := range findMetricsWithLabels(f, labels) {
+		result = append(result, m.Counter.GetValue())
+	}
+	return result
+}
+
+func findGaugesWithLabels(f *dto.MetricFamily, labels map[string]string) []float64 {
+	var result []float64
+	for _, m := range findMetricsWithLabels(f, labels) {
+		result = append(result, m.Gauge.GetValue())
+	}
+	return result
+}
+
+func findMetricLabels(f *dto.MetricFamily, labels map[string]string, match string) []string {
+	var result []string
+	for _, m := range findMetricsWithLabels(f, labels) {
+		for _, l := range m.Label {
+			if l.GetName() == match {
+				result = append(result, l.GetValue())
+				break
+			}
+		}
+	}
+	return result
+}
+
+func expectURLStatusCodeExec(ns, execPodName, url string, statusCode int) error {
+	cmd := fmt.Sprintf("curl -k -s -o /dev/null -w '%%{http_code}' %q", url)
+	output, err := e2e.RunHostCmd(ns, execPodName, cmd)
+	if err != nil {
+		return fmt.Errorf("host command failed: %v\n%s", err, output)
+	}
+	if output != strconv.Itoa(statusCode) {
+		return fmt.Errorf("last response from server was not %d: %s", statusCode, output)
+	}
+	return nil
+}
+
+func expectBearerTokenURLStatusCodeExec(ns, execPodName, url, bearer string, statusCode int) error {
+	cmd := fmt.Sprintf("curl -k -s -H 'Authorization: Bearer %s' -o /dev/null -w '%%{http_code}' %q", bearer, url)
+	output, err := e2e.RunHostCmd(ns, execPodName, cmd)
+	if err != nil {
+		return fmt.Errorf("host command failed: %v\n%s", err, output)
+	}
+	if output != strconv.Itoa(statusCode) {
+		return fmt.Errorf("last response from server was not %d: %s", statusCode, output)
+	}
+	return nil
+}
+
+func getBearerTokenURLViaPod(ns, execPodName, url, bearer string) (string, error) {
+	cmd := fmt.Sprintf("curl -s -k -H 'Authorization: Bearer %s' %q", bearer, url)
+	output, err := e2e.RunHostCmd(ns, execPodName, cmd)
+	if err != nil {
+		return "", fmt.Errorf("host command failed: %v\n%s", err, output)
+	}
+	return output, nil
+}
+
+func getAuthenticatedURLViaPod(ns, execPodName, url, user, pass string) (string, error) {
+	cmd := fmt.Sprintf("curl -s -u %s:%s %q", user, pass, url)
+	output, err := e2e.RunHostCmd(ns, execPodName, cmd)
+	if err != nil {
+		return "", fmt.Errorf("host command failed: %v\n%s", err, output)
+	}
+	return output, nil
+}
+
+func getInsecureURLViaPod(ns, execPodName, url string) (string, error) {
+	cmd := fmt.Sprintf("curl -s -k %q", url)
+	output, err := e2e.RunHostCmd(ns, execPodName, cmd)
+	if err != nil {
+		return "", fmt.Errorf("host command failed: %v\n%s", err, output)
+	}
+	return output, nil
+}
+
+func waitForServiceAccountInNamespace(c clientset.Interface, ns, serviceAccountName string, timeout time.Duration) error {
+	w, err := c.Core().ServiceAccounts(ns).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: serviceAccountName}))
+	if err != nil {
+		return err
+	}
+	_, err = watch.Until(timeout, w, conditions.ServiceAccountHasSecrets)
+	return err
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -217,6 +217,7 @@
 // examples/sample-app/cleanup.sh
 // examples/sample-app/github-webhook-example.json
 // examples/sample-app/pullimages.sh
+// examples/prometheus/prometheus.yaml
 // examples/hello-openshift/Dockerfile
 // examples/hello-openshift/hello-pod.json
 // examples/hello-openshift/hello-project.json
@@ -18125,6 +18126,311 @@ func examplesSampleAppPullimagesSh() (*asset, error) {
 	return a, nil
 }
 
+var _examplesPrometheusPrometheusYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: prometheus
+  annotations:
+    "openshift.io/display-name": Prometheus
+    description: |
+      A monitoring solution for an OpenShift cluster - collect and gather metrics from nodes, services, and the infrastructure. This is a tech preview feature.
+    iconClass: icon-cogs
+    tags: "monitoring,prometheus,time-series"
+parameters:
+- description: The namespace to instantiate prometheus under. Defaults to 'kube-system'.
+  name: NAMESPACE
+  value: kube-system
+- description: The location of the proxy image
+  name: IMAGE_PROXY
+  value: openshift/oauth-proxy:v1.0.0
+- description: The location of the prometheus image
+  name: IMAGE_PROMETHEUS
+  value: openshift/prometheus:v2.0.0-dev
+- description: The session secret for the proxy
+  name: SESSION_SECRET
+  generate: expression
+  from: "[a-zA-Z0-9]{43}"
+objects:
+# Authorize the prometheus service account to read data about the cluster
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: prometheus
+    namespace: "${NAMESPACE}"
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus"}}'
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: prometheus-cluster-reader
+  roleRef:
+    name: cluster-reader
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: "${NAMESPACE}"
+# Create a fully end-to-end TLS connection to the proxy
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: prometheus
+    namespace: "${NAMESPACE}"
+  spec:
+    to:
+      name: prometheus
+    tls:
+      termination: Reencrypt
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/scheme: https
+      service.alpha.openshift.io/serving-cert-secret-name: prometheus-tls
+    labels:
+      name: prometheus
+    name: prometheus
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - name: prometheus
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    selector:
+      app: prometheus
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: prometheus-proxy
+    namespace: "${NAMESPACE}"
+  stringData:
+    session_secret: "${SESSION_SECRET}="
+# Deploy Prometheus behind an oauth proxy
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: prometheus
+    name: prometheus
+    namespace: "${NAMESPACE}"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: prometheus
+    template:
+      metadata:
+        labels:
+          app: prometheus
+        name: prometheus
+      spec:
+        serviceAccountName: prometheus
+        containers:
+        - name: oauth-proxy
+          image: ${IMAGE_PROXY}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8443
+            name: web
+          args:
+          - -provider=openshift
+          - -https-address=:8443
+          - -email-domain=*
+          - -upstream=http://localhost:9090
+          - -client-id=system:serviceaccount:${NAMESPACE}:prometheus
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}"}}'
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: prometheus-tls
+          - mountPath: /etc/proxy/secrets
+            name: prometheus-secrets
+          - mountPath: /prometheus
+            name: prometheus-data
+
+        - name: prometheus
+          args:
+          - --storage.tsdb.retention=6h
+          - --config.file=/etc/prometheus/prometheus.yml
+          - --web.listen-address=localhost:9090
+          image: ${IMAGE_PROMETHEUS}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - mountPath: /etc/prometheus
+            name: prometheus-config
+          - mountPath: /prometheus
+            name: prometheus-data
+
+        restartPolicy: Always
+        volumes:
+        - name: prometheus-config
+          configMap:
+            defaultMode: 420
+            name: prometheus
+        - name: prometheus-secrets
+          secret:
+            secretName: prometheus-proxy
+        - name: prometheus-tls
+          secret:
+            secretName: prometheus-tls
+        - name: prometheus-data
+          emptyDir: {}
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: prometheus
+    namespace: "${NAMESPACE}"
+  data:
+    prometheus.yml: |
+      # A scrape configuration for running Prometheus on a Kubernetes cluster.
+      # This uses separate scrape configs for cluster components (i.e. API server, node)
+      # and services to allow each to use different authentication configs.
+      #
+      # Kubernetes labels will be added as Prometheus labels on metrics via the
+      # `+"`"+`labelmap`+"`"+` relabeling action.
+
+      # Scrape config for API servers.
+      #
+      # Kubernetes exposes API servers as endpoints to the default/kubernetes
+      # service so this uses `+"`"+`endpoints`+"`"+` role and uses relabelling to only keep
+      # the endpoints associated with the default/kubernetes service using the
+      # default named port `+"`"+`https`+"`"+`. This works for single API server deployments as
+      # well as HA API server deployments.
+      scrape_configs:
+      - job_name: 'kubernetes-apiservers'
+
+        kubernetes_sd_configs:
+        - role: endpoints
+
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # Keep only the default/kubernetes service endpoints for the https port. This
+        # will add targets for each API server which Kubernetes adds an endpoint to
+        # the default/kubernetes service.
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          action: keep
+          regex: default;kubernetes;https
+
+      # Scrape config for nodes.
+      #
+      # Each node exposes a /metrics endpoint that contains operational metrics for
+      # the Kubelet and other components.
+      - job_name: 'kubernetes-nodes'
+
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        kubernetes_sd_configs:
+        - role: node
+
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+
+      # Scrape config for cAdvisor.
+      #
+      # Beginning in Kube 1.7, each node exposes a /metrics/cadvisor endpoint that
+      # reports container metrics for each running pod. Scrape those by default.
+      - job_name: 'kubernetes-cadvisor'
+
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        metrics_path: /metrics/cadvisor
+
+        kubernetes_sd_configs:
+        - role: node
+
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+
+      # Scrape config for service endpoints.
+      #
+      # The relabeling allows the actual service scrape endpoint to be configured
+      # via the following annotations:
+      #
+      # * `+"`"+`prometheus.io/scrape`+"`"+`: Only scrape services that have a value of `+"`"+`true`+"`"+`
+      # * `+"`"+`prometheus.io/scheme`+"`"+`: If the metrics endpoint is secured then you will need
+      # to set this to `+"`"+`https`+"`"+` & most likely set the `+"`"+`tls_config`+"`"+` of the scrape config.
+      # * `+"`"+`prometheus.io/path`+"`"+`: If the metrics path is not `+"`"+`/metrics`+"`"+` override this.
+      # * `+"`"+`prometheus.io/port`+"`"+`: If the metrics are exposed on a different port to the
+      # service then set this appropriately.
+      - job_name: 'kubernetes-service-endpoints'
+
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          # TODO: this should be per target
+          insecure_skip_verify: true
+
+        kubernetes_sd_configs:
+        - role: endpoints
+
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+          action: replace
+          target_label: __scheme__
+          regex: (https?)
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: (.+)(?::\d+);(\d+)
+          replacement: $1:$2
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_username]
+          action: replace
+          target_label: __basic_auth_username__
+          regex: (.+)
+        - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_password]
+          action: replace
+          target_label: __basic_auth_password__
+          regex: (.+)
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_service_name]
+          action: replace
+          target_label: kubernetes_name
+`)
+
+func examplesPrometheusPrometheusYamlBytes() ([]byte, error) {
+	return _examplesPrometheusPrometheusYaml, nil
+}
+
+func examplesPrometheusPrometheusYaml() (*asset, error) {
+	bytes, err := examplesPrometheusPrometheusYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "examples/prometheus/prometheus.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _examplesHelloOpenshiftDockerfile = []byte(`FROM scratch
 MAINTAINER Jessica Forrester <jforrest@redhat.com>
 COPY bin/hello-openshift /hello-openshift
@@ -20783,6 +21089,7 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/sample-app/cleanup.sh": examplesSampleAppCleanupSh,
 	"examples/sample-app/github-webhook-example.json": examplesSampleAppGithubWebhookExampleJson,
 	"examples/sample-app/pullimages.sh": examplesSampleAppPullimagesSh,
+	"examples/prometheus/prometheus.yaml": examplesPrometheusPrometheusYaml,
 	"examples/hello-openshift/Dockerfile": examplesHelloOpenshiftDockerfile,
 	"examples/hello-openshift/hello-pod.json": examplesHelloOpenshiftHelloPodJson,
 	"examples/hello-openshift/hello-project.json": examplesHelloOpenshiftHelloProjectJson,
@@ -20869,6 +21176,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"openshift-client-plugin-pipeline.yaml": &bintree{examplesJenkinsPipelineOpenshiftClientPluginPipelineYaml, map[string]*bintree{}},
 				"samplepipeline.yaml": &bintree{examplesJenkinsPipelineSamplepipelineYaml, map[string]*bintree{}},
 			}},
+		}},
+		"prometheus": &bintree{nil, map[string]*bintree{
+			"prometheus.yaml": &bintree{examplesPrometheusPrometheusYaml, map[string]*bintree{}},
 		}},
 		"sample-app": &bintree{nil, map[string]*bintree{
 			"application-template-custombuild.json": &bintree{examplesSampleAppApplicationTemplateCustombuildJson, map[string]*bintree{}},

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_cadvisor.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_cadvisor.go
@@ -76,6 +76,11 @@ func (kl *Kubelet) GetRawContainerInfo(containerName string, req *cadvisorapi.Co
 	}
 }
 
+// GetVersionInfo returns information about the version of cAdvisor in use.
+func (kl *Kubelet) GetVersionInfo() (*cadvisorapi.VersionInfo, error) {
+	return kl.cadvisor.VersionInfo()
+}
+
 // GetCachedMachineInfo assumes that the machine info can't change without a reboot
 func (kl *Kubelet) GetCachedMachineInfo() (*cadvisorapi.MachineInfo, error) {
 	if kl.machineInfo == nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/server/server.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/server/server.go
@@ -34,7 +34,9 @@ import (
 	"github.com/golang/glog"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	"github.com/google/cadvisor/metrics"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,16 +60,18 @@ import (
 	remotecommandserver "k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
+	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util/configz"
 	"k8s.io/kubernetes/pkg/util/limitwriter"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
 const (
-	metricsPath = "/metrics"
-	specPath    = "/spec/"
-	statsPath   = "/stats/"
-	logsPath    = "/logs/"
+	metricsPath         = "/metrics"
+	cadvisorMetricsPath = "/metrics/cadvisor"
+	specPath            = "/spec/"
+	statsPath           = "/stats/"
+	logsPath            = "/logs/"
 )
 
 // Server is a http.Handler which exposes kubelet functionality over HTTP.
@@ -173,6 +177,7 @@ type HostInterface interface {
 	GetContainerInfo(podFullName string, uid types.UID, containerName string, req *cadvisorapi.ContainerInfoRequest) (*cadvisorapi.ContainerInfo, error)
 	GetContainerInfoV2(name string, options cadvisorapiv2.RequestOptions) (map[string]cadvisorapiv2.ContainerInfo, error)
 	GetRawContainerInfo(containerName string, req *cadvisorapi.ContainerInfoRequest, subcontainers bool) (map[string]*cadvisorapi.ContainerInfo, error)
+	GetVersionInfo() (*cadvisorapi.VersionInfo, error)
 	GetCachedMachineInfo() (*cadvisorapi.MachineInfo, error)
 	GetPods() []*v1.Pod
 	GetRunningPods() ([]*v1.Pod, error)
@@ -283,6 +288,13 @@ func (s *Server) InstallDefaultHandlers() {
 
 	s.restfulCont.Add(stats.CreateHandlers(statsPath, s.host, s.resourceAnalyzer))
 	s.restfulCont.Handle(metricsPath, prometheus.Handler())
+
+	// cAdvisor metrics are exposed under the secured handler as well
+	r := prometheus.NewRegistry()
+	r.MustRegister(metrics.NewPrometheusCollector(prometheusHostAdapter{s.host}, containerPrometheusLabels))
+	s.restfulCont.Handle(cadvisorMetricsPath,
+		promhttp.HandlerFor(r, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}),
+	)
 
 	ws = new(restful.WebService)
 	ws.
@@ -783,4 +795,46 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		),
 	).Log()
 	s.restfulCont.ServeHTTP(w, req)
+}
+
+// prometheusHostAdapter adapts the HostInterface to the interface expected by the
+// cAdvisor prometheus collector.
+type prometheusHostAdapter struct {
+	host HostInterface
+}
+
+func (a prometheusHostAdapter) SubcontainersInfo(containerName string, query *cadvisorapi.ContainerInfoRequest) ([]*cadvisorapi.ContainerInfo, error) {
+	all, err := a.host.GetRawContainerInfo(containerName, query, true)
+	items := make([]*cadvisorapi.ContainerInfo, 0, len(all))
+	for _, v := range all {
+		items = append(items, v)
+	}
+	return items, err
+}
+func (a prometheusHostAdapter) GetVersionInfo() (*cadvisorapi.VersionInfo, error) {
+	return a.host.GetVersionInfo()
+}
+func (a prometheusHostAdapter) GetMachineInfo() (*cadvisorapi.MachineInfo, error) {
+	return a.host.GetCachedMachineInfo()
+}
+
+// containerPrometheusLabels maps cAdvisor labels to prometheus labels.
+func containerPrometheusLabels(c *cadvisorapi.ContainerInfo) map[string]string {
+	set := map[string]string{metrics.LabelID: c.Name}
+	if len(c.Aliases) > 0 {
+		set[metrics.LabelName] = c.Aliases[0]
+	}
+	if image := c.Spec.Image; len(image) > 0 {
+		set[metrics.LabelImage] = image
+	}
+	if v, ok := c.Spec.Labels[kubelettypes.KubernetesPodNameLabel]; ok {
+		set["pod_name"] = v
+	}
+	if v, ok := c.Spec.Labels[kubelettypes.KubernetesPodNamespaceLabel]; ok {
+		set["namespace"] = v
+	}
+	if v, ok := c.Spec.Labels[kubelettypes.KubernetesContainerNameLabel]; ok {
+		set["container_name"] = v
+	}
+	return set
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/server/server_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/server/server_test.go
@@ -108,6 +108,10 @@ func (fk *fakeKubelet) GetCachedMachineInfo() (*cadvisorapi.MachineInfo, error) 
 	return fk.machineInfoFunc()
 }
 
+func (_ *fakeKubelet) GetVersionInfo() (*cadvisorapi.VersionInfo, error) {
+	return &cadvisorapi.VersionInfo{}, nil
+}
+
 func (fk *fakeKubelet) GetPods() []*v1.Pod {
 	return fk.podsFunc()
 }
@@ -605,7 +609,7 @@ func TestAuthFilters(t *testing.T) {
 
 	// This is a sanity check that the Handle->HandleWithFilter() delegation is working
 	// Ideally, these would move to registered web services and this list would get shorter
-	expectedPaths := []string{"/healthz", "/metrics"}
+	expectedPaths := []string{"/healthz", "/metrics", "/metrics/cadvisor"}
 	paths := sets.NewString(fw.serverUnderTest.restfulCont.RegisteredHandlePaths()...)
 	for _, expectedPath := range expectedPaths {
 		if !paths.Has(expectedPath) {


### PR DESCRIPTION
Kube 1.7 removed cAdvisor prometheus metrics, and kubernetes/kubernetes#49079 reintroduces it for 1.7 under /metrics/advisor.

Cherry-pick the change and update Prometheus to gather the metrics from that endpoint

[test]