### PR TITLE
Correct TLS cipher suite comments for HTTP/2

### DIFF
--- a/pkg/cmd/server/crypto/crypto.go
+++ b/pkg/cmd/server/crypto/crypto.go
@@ -124,6 +124,12 @@ func ValidCipherSuites() []string {
 	return validCipherSuites
 }
 func DefaultCiphers() []uint16 {
+	// HTTP/2 mandates TLS 1.2 or higher with an AEAD cipher
+	// suite (GCM, Poly1305) and ephemeral key exchange (ECDHE, DHE) for
+	// perfect forward secrecy. Servers may provide additional cipher
+	// suites for backwards compatibility with HTTP/1.1 clients.
+	// See RFC7540, section 9.2 (Use of TLS Features) and Appendix A
+	// (TLS 1.2 Cipher Suite Black List).
 	return []uint16{
 		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
@@ -131,14 +137,14 @@ func DefaultCiphers() []uint16 {
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, // required by http/2
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, // forbidden by http/2
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, // forbidden by http/2
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,   // forbidden by http/2
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,   // forbidden by http/2
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,      // forbidden by http/2
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,      // forbidden by http/2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, // forbidden by http/2, not flagged by http2isBadCipher() in go1.8
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,   // forbidden by http/2, not flagged by http2isBadCipher() in go1.8
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,    // forbidden by http/2
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,    // forbidden by http/2
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,      // forbidden by http/2
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,      // forbidden by http/2
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,         // forbidden by http/2
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,         // forbidden by http/2
 		// the next one is in the intermediate suite, but go1.8 http2isBadCipher() complains when it is included at the recommended index
 		// because it comes after ciphers forbidden by the http/2 spec
 		// tls.TLS_RSA_WITH_AES_128_CBC_SHA256,


### PR DESCRIPTION
The default cipher suite list flagged several TLS cipher suites as
forbidden by HTTP/2 RFC. The comment was missing for some additional
cipher suites that are also blacklisted for HTTP/2.

I grouped the suites by HTTP/2 and HTTP/1.1 fallback suites, referenced
the RFC sections, and added an explanation which classes of cipher suites
are permitted.

Signed-off-by: Christian Heimes <cheimes@redhat.com>