### PR TITLE
SWEET32 mitigation: Disable Triple-DES

### DIFF
--- a/pkg/cmd/server/crypto/crypto.go
+++ b/pkg/cmd/server/crypto/crypto.go
@@ -142,10 +142,10 @@ func DefaultCiphers() []uint16 {
 		// the next one is in the intermediate suite, but go1.8 http2isBadCipher() complains when it is included at the recommended index
 		// because it comes after ciphers forbidden by the http/2 spec
 		// tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA,        // forbidden by http/2
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,        // forbidden by http/2
-		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, // forbidden by http/2
-		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,       // forbidden by http/2
+		// tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, // forbidden by http/2, disabled to mitigate SWEET32 attack
+		// tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,       // forbidden by http/2, disabled to mitigate SWEET32 attack
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA, // forbidden by http/2
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA, // forbidden by http/2
 	}
 }
 


### PR DESCRIPTION
Triple-DES (3DES-CBC, DES-CBC3) should no longer be used. It's an old
and slow block cipher with an effective key size of 112 bits. Since 3DES is
build around DES, it has a block size of 64 bits. 64 bit block ciphers
are vulnerable to a birthday attack known as SWEET32.

Since Origin requires a minimum TLS version of 1.2, 3DES can be disabled
safely. All relevant TLS 1.2 clients support AES.

Signed-off-by: Christian Heimes <cheimes@redhat.com>