### PR TITLE
Set PodsPerCore to 0

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -169,7 +169,7 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	server.LowDiskSpaceThresholdMB = 256 // this the previous default
 	server.CPUCFSQuota = true            // enable cpu cfs quota enforcement by default
 	server.MaxPods = 250
-	server.PodsPerCore = 10
+	server.PodsPerCore = 0
 	server.CgroupDriver = "systemd"
 	server.DockerExecHandlerName = string(options.DockerConfig.ExecHandlerName)
 	server.RemoteRuntimeEndpoint = options.DockerConfig.DockerShimSocket


### PR DESCRIPTION
Fixes RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1473686

Taking that Kubernetes doesn't set a default value, at least that I could find
anyway, setting it to 10 feels a bit like guessing, while setting it to 0 won't
limit users by default.