### PR TITLE
print typed podlist for correct serialization

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -78,6 +78,8 @@ os::cmd::expect_success_and_not_text 'oadm manage-node --selector= --schedulable
 os::cmd::expect_success_and_not_text 'oc get node -o yaml' 'unschedulable: true'
 os::cmd::expect_success_and_text 'oadm manage-node --selector= --schedulable=false' 'SchedulingDisabled'
 os::cmd::expect_success_and_text 'oc get node -o yaml' 'unschedulable: true'
+# ensure correct serialization of podList output
+os::cmd::expect_success_and_text "oadm manage-node --list-pods --selector= -o jsonpath='{ .kind }'" 'List'
 echo "manage-node: ok"
 os::test::junit::declare_suite_end
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1473455

Pass a typed list of pods to the printer in order to have correctly
serialized output.

**Before**
```
$ oadm manage-node --list-pods localhost -o yaml | head -n 20

Items:
- Spec:
    ActiveDeadlineSeconds: null
    Affinity: null
    AutomountServiceAccountToken: null
    Containers:
    - Args: null
      Command: null
      Env:
      - Name: REGISTRY_HTTP_ADDR
        Value: :5000
        ValueFrom: null
      - Name: REGISTRY_HTTP_NET
        Value: tcp
        ValueFrom: null
      - Name: REGISTRY_HTTP_SECRET
        Value: oQg1bMYH9dGM4S7D4p4W6eXG+wA91syQdJMIjB0v52A=
        ValueFrom: null
      - Name: REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA
...
```

**After**
```
$ oadm manage-node --list-pods localhost -o yaml | head -n 20

apiVersion: v1
items:
- metadata:
    creationTimestamp: null
  spec:
    containers:
    - env:
      - name: REGISTRY_HTTP_ADDR
        value: :5000
      - name: REGISTRY_HTTP_NET
        value: tcp
      - name: REGISTRY_HTTP_SECRET
        value: oQg1bMYH9dGM4S7D4p4W6eXG+wA91syQdJMIjB0v52A=
      - name: REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA
        value: "false"
      image: openshift/origin-docker-registry:v3.6.0-alpha.2
      imagePullPolicy: IfNotPresent
      livenessProbe:
        failureThreshold: 3
        httpGet:
...
```

cc @openshift/cli-review @smarterclayton 