### PR TITLE
Enable aggregator by default in new toy clusters

### DIFF
--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -179,39 +179,52 @@ func (o CreateMasterCertsOptions) Validate(args []string) error {
 func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 	glog.V(4).Infof("Creating all certs with: %#v", o)
 
+	getSignerCertOptions, err := o.createNewSigner(CAFilePrefix)
+	if err != nil {
+		return err
+	}
+	getFrontProxySignerCertOptions, err := o.createNewSigner(FrontProxyCAFilePrefix)
+	if err != nil {
+		return err
+	}
+
+	errs := parallel.Run(
+		func() error { return o.createCABundle(getSignerCertOptions) },
+		func() error { return o.createServerCerts(getSignerCertOptions) },
+		func() error { return o.createAPIClients(getSignerCertOptions) },
+		func() error { return o.createEtcdClientCerts(getSignerCertOptions) },
+		func() error { return o.createKubeletClientCerts(getSignerCertOptions) },
+		func() error { return o.createProxyClientCerts(getSignerCertOptions) },
+		func() error { return o.createServiceAccountKeys() },
+		func() error { return o.createServiceSigningCA(getSignerCertOptions) },
+		func() error { return o.createAggregatorClientCerts(getFrontProxySignerCertOptions) },
+	)
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o CreateMasterCertsOptions) createNewSigner(prefix string) (*SignerCertOptions, error) {
 	signerCertOptions := CreateSignerCertOptions{
-		CertFile:   DefaultCertFilename(o.CertDir, CAFilePrefix),
-		KeyFile:    DefaultKeyFilename(o.CertDir, CAFilePrefix),
-		SerialFile: DefaultSerialFilename(o.CertDir, CAFilePrefix),
+		CertFile:   DefaultCertFilename(o.CertDir, prefix),
+		KeyFile:    DefaultKeyFilename(o.CertDir, prefix),
+		SerialFile: DefaultSerialFilename(o.CertDir, prefix),
 		ExpireDays: o.SignerExpireDays,
 		Name:       o.SignerName,
 		Overwrite:  o.Overwrite,
 		Output:     o.Output,
 	}
 	if err := signerCertOptions.Validate(nil); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := signerCertOptions.CreateSignerCert(); err != nil {
-		return err
+		return nil, err
 	}
 	// once we've minted the signer, don't overwrite it
-	getSignerCertOptions := SignerCertOptions{
-		CertFile:   DefaultCertFilename(o.CertDir, CAFilePrefix),
-		KeyFile:    DefaultKeyFilename(o.CertDir, CAFilePrefix),
-		SerialFile: DefaultSerialFilename(o.CertDir, CAFilePrefix),
-	}
+	return &SignerCertOptions{
+		CertFile:   DefaultCertFilename(o.CertDir, prefix),
+		KeyFile:    DefaultKeyFilename(o.CertDir, prefix),
+		SerialFile: DefaultSerialFilename(o.CertDir, prefix),
+	}, nil
 
-	errs := parallel.Run(
-		func() error { return o.createCABundle(&getSignerCertOptions) },
-		func() error { return o.createServerCerts(&getSignerCertOptions) },
-		func() error { return o.createAPIClients(&getSignerCertOptions) },
-		func() error { return o.createEtcdClientCerts(&getSignerCertOptions) },
-		func() error { return o.createKubeletClientCerts(&getSignerCertOptions) },
-		func() error { return o.createProxyClientCerts(&getSignerCertOptions) },
-		func() error { return o.createServiceAccountKeys() },
-		func() error { return o.createServiceSigningCA(&getSignerCertOptions) },
-	)
-	return utilerrors.NewAggregate(errs)
 }
 
 func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *SignerCertOptions) error {
@@ -239,6 +252,13 @@ func (o CreateMasterCertsOptions) createAPIClients(getSignerCertOptions *SignerC
 		if _, err := createKubeConfigOptions.CreateKubeConfig(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (o CreateMasterCertsOptions) createAggregatorClientCerts(getSignerCertOptions *SignerCertOptions) error {
+	if err := o.createClientCert(DefaultAggregatorClientCertInfo(o.CertDir), getSignerCertOptions); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -76,7 +76,6 @@ type CreateMasterCertsOptions struct {
 	SignerExpireDays int
 
 	APIServerCAFiles []string
-	CABundleFile     string
 
 	Hostnames []string
 

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -15,6 +15,8 @@ const (
 	CAFilePrefix     = "ca"
 	CABundlePrefix   = "ca-bundle"
 	MasterFilePrefix = "master"
+
+	FrontProxyCAFilePrefix = "frontproxy-ca"
 )
 
 type ClientCertInfo struct {
@@ -116,6 +118,18 @@ func DefaultOpenshiftLoopbackClientCertInfo(certDir string) ClientCertInfo {
 		UnqualifiedUser: bootstrappolicy.MasterUnqualifiedUsername,
 		User:            bootstrappolicy.MasterUsername,
 		Groups:          sets.NewString(bootstrappolicy.MastersGroup),
+	}
+}
+
+func DefaultAggregatorClientCertInfo(certDir string) ClientCertInfo {
+	return ClientCertInfo{
+		CertLocation: configapi.CertInfo{
+			CertFile: DefaultCertFilename(certDir, bootstrappolicy.AggregatorUnqualifiedUsername),
+			KeyFile:  DefaultKeyFilename(certDir, bootstrappolicy.AggregatorUnqualifiedUsername),
+		},
+		UnqualifiedUser: bootstrappolicy.AggregatorUnqualifiedUsername,
+		User:            bootstrappolicy.AggregatorUsername,
+		Groups:          sets.String{},
 	}
 }
 

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -12,9 +12,11 @@ const (
 	BuilderServiceAccountName  = "builder"
 	DeployerServiceAccountName = "deployer"
 
-	MasterUnqualifiedUsername = "openshift-master"
+	MasterUnqualifiedUsername     = "openshift-master"
+	AggregatorUnqualifiedUsername = "openshift-aggregator"
 
 	MasterUsername      = "system:" + MasterUnqualifiedUsername
+	AggregatorUsername  = "system:" + AggregatorUnqualifiedUsername
 	SystemAdminUsername = "system:admin"
 
 	// Not granted any API permissions, just an identity for a client certificate for the API proxy to use

--- a/pkg/cmd/server/origin/aggregator.go
+++ b/pkg/cmd/server/origin/aggregator.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
@@ -75,6 +76,7 @@ func (c *MasterConfig) createAggregatorConfig(genericConfig genericapiserver.Con
 		ProxyClientCert:   certBytes,
 		ProxyClientKey:    keyBytes,
 		ServiceResolver:   serviceResolver,
+		ProxyTransport:    utilnet.SetTransportDefaults(&http.Transport{}),
 	}
 	return aggregatorConfig, nil
 }

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -197,6 +197,19 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		KubernetesMasterConfig: kubernetesMasterConfig,
 		EtcdConfig:             etcdConfig,
 
+		AuthConfig: configapi.MasterAuthConfig{
+			RequestHeader: &configapi.RequestHeaderAuthenticationOptions{
+				ClientCA:            admin.DefaultCertFilename(args.ConfigDir.Value(), admin.FrontProxyCAFilePrefix),
+				ClientCommonNames:   []string{bootstrappolicy.AggregatorUsername},
+				UsernameHeaders:     []string{"X-Remote-User"},
+				GroupHeaders:        []string{"X-Remote-Group"},
+				ExtraHeaderPrefixes: []string{"X-Remote-Extra-"}},
+		},
+
+		AggregatorConfig: configapi.AggregatorConfig{
+			ProxyClientInfo: admin.DefaultAggregatorClientCertInfo(args.ConfigDir.Value()).CertLocation,
+		},
+
 		OAuthConfig: oauthConfig,
 
 		PauseControllers: args.PauseControllers,

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -344,7 +344,6 @@ func (o MasterOptions) CreateCerts() error {
 		Hostnames:          hostnames.List(),
 		APIServerURL:       masterAddr.String(),
 		APIServerCAFiles:   o.MasterArgs.APIServerCAFiles,
-		CABundleFile:       admin.DefaultCABundleFile(o.MasterArgs.ConfigDir.Value()),
 		PublicAPIServerURL: publicMasterAddr.String(),
 		Output:             cmdutil.NewGLogWriterV(3),
 	}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/BUILD
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/BUILD
@@ -99,6 +99,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -365,7 +366,10 @@ func GetAvailableResources(clientBuilder controller.ControllerClientBuilder) (ma
 
 	resourceMap, err := discoveryClient.ServerResources()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get supported resources from server: %v", err)
+		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+	}
+	if len(resourceMap) == 0 {
+		return nil, fmt.Errorf("unable to get any supported resources from server")
 	}
 
 	allResources := map[schema.GroupVersionResource]bool{}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/core.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/core.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -291,7 +292,10 @@ func startGarbageCollectorController(ctx ControllerContext) (bool, error) {
 	gcClientset := ctx.ClientBuilder.ClientOrDie("generic-garbage-collector")
 	preferredResources, err := gcClientset.Discovery().ServerPreferredResources()
 	if err != nil {
-		return true, fmt.Errorf("failed to get supported resources from server: %v", err)
+		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+	}
+	if len(preferredResources) == 0 {
+		return true, fmt.Errorf("unable to get any supported resources from server: %v", err)
 	}
 	deletableResources := discovery.FilteredBy(discovery.SupportsAllVerbs{Verbs: []string{"get", "list", "watch", "patch", "update", "delete"}}, preferredResources)
 	deletableGroupVersionResources, err := discovery.GroupVersionResources(deletableResources)

--- a/vendor/k8s.io/kubernetes/pkg/controller/namespace/deletion/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/controller/namespace/deletion/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -165,7 +166,10 @@ func (d *namespacedResourcesDeleter) initOpCache() {
 	// TODO(sttts): get rid of opCache and http 405 logic around it and trust discovery info
 	resources, err := d.discoverResourcesFn()
 	if err != nil {
-		glog.Fatalf("Failed to get supported resources: %v", err)
+		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+	}
+	if len(resources) == 0 {
+		glog.Fatalf("Unable to get any supported resources from server: %v", err)
 	}
 	deletableGroupVersionResources := []schema.GroupVersionResource{}
 	for _, rl := range resources {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15381

This creates the certificates used by the aggregator, temporarily wires in the upstream namespaced roles (@openshift/security fyi), fixes discovery checks to avoid failures on missing resources, and adds a transport for the aggregator.

I can split these apart if necessary, but I wouldn't expect the review to be too bad.

@mfojtik got an "api server wiring" guy?