### PR TITLE
Remove &lt; from pre-formatted block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Many Docker containers expect to run as root (and therefore edit all the content
 
     * Don't run as root
     * Make directories you want to write to group-writable and owned by group id 0
-    * Set the net-bind capability on your executables if they need to bind to ports &lt;1024
+    * Set the net-bind capability on your executables if they need to bind to ports < 1024
 
 If you are running your own cluster and want to run a container as root, you can grant that permission to the containers in your current project with the following command:
 


### PR DESCRIPTION
HTML-entities do not get properly rendered inside pre-formatted blocks in the Markdown preview on Github.