### PR TITLE
add build prometheus metrics

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	metrics "github.com/openshift/origin/pkg/build/metrics/prometheus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -240,6 +241,8 @@ func (bc *BuildController) Run(workers int, stopCh <-chan struct{}) {
 	for i := 0; i < workers; i++ {
 		go wait.Until(bc.worker, time.Second, stopCh)
 	}
+
+	metrics.IntializeMetricsCollector(bc.buildLister)
 
 	<-stopCh
 	glog.Infof("Shutting down build controller")

--- a/pkg/build/metrics/prometheus/doc.go
+++ b/pkg/build/metrics/prometheus/doc.go
@@ -1,0 +1,3 @@
+// Package prometheus contains code for injecting build related metrics
+// into the prometheus registry running in the openshift master
+package prometheus

--- a/pkg/build/metrics/prometheus/metrics.go
+++ b/pkg/build/metrics/prometheus/metrics.go
@@ -1,0 +1,122 @@
+package prometheus
+
+import (
+	kselector "k8s.io/apimachinery/pkg/labels"
+	"strings"
+
+	"github.com/golang/glog"
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	internalversion "github.com/openshift/origin/pkg/build/generated/listers/build/internalversion"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	separator               = "_"
+	buildSubsystem          = "openshift_build"
+	terminalBuildCount      = "terminal_phase_total"
+	terminalBuildCountQuery = buildSubsystem + separator + terminalBuildCount
+	activeBuildCount        = "running_phase_start_time_seconds"
+	activeBuildCountQuery   = buildSubsystem + separator + activeBuildCount
+)
+
+var (
+	// decided not to have a separate counter for failed builds, which have reasons,
+	// vs. the other "finished" builds phases, where the reason is not set
+	terminalBuildCountDesc = prometheus.NewDesc(
+		buildSubsystem+separator+terminalBuildCount,
+		"Counts total teriminal builds by phase",
+		[]string{"phase"},
+		nil,
+	)
+	activeBuildCountDesc = prometheus.NewDesc(
+		buildSubsystem+separator+activeBuildCount,
+		"Show the start time in unix epoch form of running builds by namespace, name, and phase",
+		[]string{"namespace", "name", "phase"},
+		nil,
+	)
+	bc             = buildCollector{}
+	registered     = false
+	failedPhase    = strings.ToLower(string(buildapi.BuildPhaseFailed))
+	errorPhase     = strings.ToLower(string(buildapi.BuildPhaseError))
+	cancelledPhase = strings.ToLower(string(buildapi.BuildPhaseCancelled))
+	completePhase  = strings.ToLower(string(buildapi.BuildPhaseComplete))
+)
+
+type buildCollector struct {
+	lister internalversion.BuildLister
+}
+
+// InitializeMetricsCollector calls into prometheus to register the buildCollector struct as a Collector in prometheus
+// for the terminal and active build metrics; note, in comparing with how kube-state-metrics integrates with prometheus,
+// kube-state-metrics leverages the prometheus.Registerer function, but it does not exist in the version of prometheus
+// vendored into origin as of this writing
+func IntializeMetricsCollector(buildLister internalversion.BuildLister) {
+	bc.lister = buildLister
+	// unit tests unearthed multiple (sequential, not in parallel) registrations with prometheus via multiple calls to new build controller
+	if !registered {
+		prometheus.MustRegister(&bc)
+		registered = true
+	}
+	glog.V(4).Info("build metrics registered with prometheus")
+}
+
+// Describe implements the prometheus.Collector interface.
+func (bc *buildCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- terminalBuildCountDesc
+	ch <- activeBuildCountDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (bc *buildCollector) Collect(ch chan<- prometheus.Metric) {
+	result, err := bc.lister.List(kselector.Everything())
+
+	if err != nil {
+		glog.V(4).Infof("Collect err %v", err)
+		return
+	}
+
+	// since we do not collect terminal build metrics on a per build basis, collectBuild will return counts
+	// to be added to the total amount posted to prometheus
+	var failed, error, cancelled, complete int
+	for _, b := range result {
+		f, e, cc, cp := bc.collectBuild(ch, b)
+		failed = failed + f
+		error = error + e
+		cancelled = cancelled + cc
+		complete = complete + cp
+	}
+	addCountGauge(ch, terminalBuildCountDesc, failedPhase, float64(failed))
+	addCountGauge(ch, terminalBuildCountDesc, errorPhase, float64(error))
+	addCountGauge(ch, terminalBuildCountDesc, cancelledPhase, float64(cancelled))
+	addCountGauge(ch, terminalBuildCountDesc, completePhase, float64(complete))
+}
+
+func addCountGauge(ch chan<- prometheus.Metric, desc *prometheus.Desc, phase string, v float64) {
+	lv := []string{phase}
+	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+}
+
+func addTimeGauge(ch chan<- prometheus.Metric, b *buildapi.Build, desc *prometheus.Desc) {
+	if b.Status.StartTimestamp != nil {
+		lv := []string{b.ObjectMeta.Namespace, b.ObjectMeta.Name, strings.ToLower(string(b.Status.Phase))}
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(b.Status.StartTimestamp.Unix()), lv...)
+	}
+}
+
+func (bc *buildCollector) collectBuild(ch chan<- prometheus.Metric, b *buildapi.Build) (failed, error, cancelled, complete int) {
+
+	switch b.Status.Phase {
+	// remember, new and pending builds don't have a start time
+	case buildapi.BuildPhaseRunning:
+		addTimeGauge(ch, b, activeBuildCountDesc)
+	case buildapi.BuildPhaseFailed:
+		failed++
+	case buildapi.BuildPhaseError:
+		error++
+	case buildapi.BuildPhaseCancelled:
+		cancelled++
+	case buildapi.BuildPhaseComplete:
+		complete++
+	}
+	return
+}

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -1,0 +1,192 @@
+package prometheus
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/api/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Feature:Prometheus][builds] Prometheus", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLI("prometheus", exutil.KubeConfigPath())
+
+		execPodName, ns, host, bearerToken string
+		statsPort                          int
+	)
+
+	g.BeforeEach(func() {
+		ns, host, bearerToken, statsPort = bringUpPrometheusFromTemplate(oc)
+	})
+
+	g.Describe("when installed to the cluster", func() {
+		g.It("should start and expose a secured proxy and verify build metrics after a completed build", func() {
+			const (
+				terminalBuildCountQuery = "openshift_build_terminal_phase_total"
+				activeBuildCountQuery   = "openshift_build_running_phase_start_time_seconds"
+			)
+
+			appTemplate := exutil.FixturePath("..", "..", "examples", "jenkins", "application-template.json")
+
+			execPodName = e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) {
+				pod.Spec.Containers[0].Image = "centos:7"
+			})
+			defer func() { oc.AdminKubeClient().Core().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
+
+			g.By("verifying the oauth-proxy reports a 403 on the root URL")
+			err := expectURLStatusCodeExec(ns, execPodName, fmt.Sprintf("https://%s:%d", host, statsPort), 403)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying a service account token is able to authenticate")
+			err = expectBearerTokenURLStatusCodeExec(ns, execPodName, fmt.Sprintf("https://%s:%d/graph", host, statsPort), bearerToken, 200)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			executeOpenShiftBuild(oc, appTemplate)
+
+			g.By("verifying a service account token is able to query build metrics from the Prometheus API")
+			metricTests := map[string][]metricTest{
+				// NOTE - activeBuildCountQuery is dependent on prometheus querying while the build is running;
+				// so far the prometheus query interval and the length of the frontend build have
+				// been sufficient for reliable success here, but bear in mind the timing windows
+				// if this particular metricTest starts flaking
+				activeBuildCountQuery: {
+					metricTest{
+						labels:      map[string]string{"phase": "running"},
+						greaterThan: "0",
+					},
+				},
+				terminalBuildCountQuery: {
+					metricTest{
+						labels:      map[string]string{"phase": "complete"},
+						greaterThan: "0",
+					},
+					metricTest{
+						labels: map[string]string{"phase": "error"},
+						equals: "0",
+					},
+					metricTest{
+						labels: map[string]string{"phase": "failed"},
+						equals: "0",
+					},
+					metricTest{
+						labels: map[string]string{"phase": "cancelled"},
+						equals: "0",
+					},
+				},
+			}
+			// expect all correct metrics within 60 seconds
+			lastErrsMap := map[string]error{}
+			for i := 0; i < 60; i++ {
+				for query, tcs := range metricTests {
+					g.By("perform prometheus metric query " + query)
+					contents, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("https://%s:%d/api/v1/query?query=%s", host, statsPort, query), bearerToken)
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					correctMetrics := map[int]bool{}
+					for i, tc := range tcs {
+						result := prometheusResponse{}
+						json.Unmarshal([]byte(contents), &result)
+						metrics := result.Data.Result
+
+						for _, sample := range metrics {
+							// first see if a metric has all the label names and label values we are looking for
+							foundCorrectLabels := true
+							for labelName, labelValue := range tc.labels {
+								if v, ok := sample.Metric[model.LabelName(labelName)]; ok {
+									if string(v) != labelValue {
+										foundCorrectLabels = false
+										break
+									}
+								} else {
+									foundCorrectLabels = false
+									break
+								}
+							}
+
+							// if found metric with correct set of labels, now see if the metric value is what we are expecting
+							if foundCorrectLabels {
+								switch {
+								case len(tc.equals) > 0:
+									if x, err := strconv.ParseFloat(tc.equals, 64); err == nil && float64(sample.Value) == x {
+										correctMetrics[i] = true
+										break
+									}
+								case len(tc.greaterThan) > 0:
+									if x, err := strconv.ParseFloat(tc.greaterThan, 64); err == nil && float64(sample.Value) > x {
+										correctMetrics[i] = true
+										break
+									}
+								}
+							}
+
+						}
+					}
+
+					if len(correctMetrics) == len(tcs) {
+						delete(metricTests, query) // delete in case there are retries on remaining tests
+						delete(lastErrsMap, query)
+					} else {
+						// maintain separate map of errors for diagnostics
+						lastErrsMap[query] = fmt.Errorf("query %s with results %s only had correct metrics %v", query, contents, correctMetrics)
+					}
+				}
+
+				if len(metricTests) == 0 {
+					break
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			o.Expect(lastErrsMap).To(o.BeEmpty())
+		})
+	})
+})
+
+type prometheusResponse struct {
+	Status string                 `json:"status"`
+	Data   prometheusResponseData `json:"data"`
+}
+
+type prometheusResponseData struct {
+	ResultType string       `json:"resultType"`
+	Result     model.Vector `json:"result"`
+}
+
+type metricTest struct {
+	labels      map[string]string
+	equals      string
+	greaterThan string
+}
+
+func executeOpenShiftBuild(oc *exutil.CLI, appTemplate string) {
+	g.By("waiting for builder service account")
+	err := exutil.WaitForBuilderAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()))
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By(fmt.Sprintf("calling oc new-app  %s ", appTemplate))
+	err = oc.Run("new-app").Args(appTemplate).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.By("wait on imagestreams used by build")
+	err = exutil.WaitForOpenShiftNamespaceImageStreams(oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	g.By("explicitly set up image stream tag, avoid timing window")
+	err = oc.AsAdmin().Run("tag").Args("openshift/nodejs:latest", oc.Namespace()+"/nodejs-010-centos7:latest").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("start build, wait for completion")
+	br, err := exutil.StartBuildAndWait(oc, "frontend")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	br.AssertSuccess()
+}


### PR DESCRIPTION
@openshift/devex fyi / ptal 

https://trello.com/c/aVaNGVI2/1227-5-prometheus-metrics-for-builds-builds

For some info on the metric types, see https://prometheus.io/docs/concepts/metric_types/

I am now moving toward investigating the router metric extended tests to see if something viable can be borrowed for our new metrics.  But I wanted to get the review going on the runtime changes.