### PR TITLE
Add limiter for blobwriter

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -43,3 +43,7 @@ openshift:
     # Attention! A weak secret can lead to the leakage of private data.
     #
     # secret: TopSecretLongToken
+  storage:
+    # The maximum value of the concurrent write requests.
+    # There is no limit if set to 0.
+    maxwriters: 0

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -8,12 +8,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus/formatters/logstash"
 	gorillahandlers "github.com/gorilla/handlers"
 
-	"github.com/Sirupsen/logrus/formatters/logstash"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/health"
@@ -35,14 +36,13 @@ import (
 	_ "github.com/docker/distribution/registry/storage/driver/s3-aws"
 	_ "github.com/docker/distribution/registry/storage/driver/swift"
 
-	"strings"
-
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/dockerregistry/server"
 	"github.com/openshift/origin/pkg/dockerregistry/server/api"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
 	registryconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/writelimiter"
 )
 
 // Execute runs the Docker registry.
@@ -78,6 +78,10 @@ func Execute(configFile io.Reader) {
 			Logger:           context.GetLogger(ctx),
 			SafeClientConfig: registryClient.SafeClientConfig(),
 		}
+	}
+
+	if extraConfig.Storage.MaxWriters > 0 {
+		ctx = server.WithBlobStoreFactory(ctx, writelimiter.NewBlobStoreFactory(extraConfig.Storage.MaxWriters))
 	}
 
 	app := handlers.NewApp(ctx, dockerConfig)

--- a/pkg/dockerregistry/server/configuration/configuration.go
+++ b/pkg/dockerregistry/server/configuration/configuration.go
@@ -28,11 +28,16 @@ type openshiftConfig struct {
 type Configuration struct {
 	Version configuration.Version `yaml:"version"`
 	Metrics Metrics               `yaml:"metrics"`
+	Storage Storage               `yaml:"storage"`
 }
 
 type Metrics struct {
 	Enabled bool   `yaml:"enabled"`
 	Secret  string `yaml:"secret"`
+}
+
+type Storage struct {
+	MaxWriters int `yaml:"maxwriters"`
 }
 
 type versionInfo struct {

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/types"
 )
 
 type contextKey string
@@ -33,6 +34,9 @@ const (
 
 	// configurationKey is the key for Configuration in Context.
 	configurationKey contextKey = "configuration"
+
+	// blobStoreFactoryKey is the key for BlobStoreFactory in Context.
+	blobStoreFactoryKey contextKey = "blobStoreFactory"
 )
 
 // withRepository returns a new Context that carries value repo.
@@ -116,4 +120,15 @@ func WithConfiguration(ctx context.Context, config *configuration.Configuration)
 // It will panic otherwise.
 func ConfigurationFrom(ctx context.Context) *configuration.Configuration {
 	return ctx.Value(configurationKey).(*configuration.Configuration)
+}
+
+// WithBlobStoreFactory returns a new Context with the provided BlobStore factory.
+func WithBlobStoreFactory(ctx context.Context, factory types.BlobStoreFactory) context.Context {
+	return context.WithValue(ctx, blobStoreFactoryKey, factory)
+}
+
+// BlobStoreFactoryFrom returns the BlobStore factory stored in ctx, if any.
+func BlobStoreFactoryFrom(ctx context.Context) (types.BlobStoreFactory, bool) {
+	factory, ok := ctx.Value(blobStoreFactoryKey).(types.BlobStoreFactory)
+	return factory, ok
 }

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -333,6 +333,10 @@ func (r *repository) Blobs(ctx context.Context) distribution.BlobStore {
 		}
 	}
 
+	if blobStoreFactory, ok := BlobStoreFactoryFrom(ctx); ok {
+		bs = blobStoreFactory.BlobStore(bs)
+	}
+
 	return bs
 }
 

--- a/pkg/dockerregistry/server/types/blobstorefactory.go
+++ b/pkg/dockerregistry/server/types/blobstorefactory.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/docker/distribution"
+
+// BlobStoreFactory creates a middleware for BlobStore.
+type BlobStoreFactory interface {
+	BlobStore(bs distribution.BlobStore) distribution.BlobStore
+}

--- a/pkg/dockerregistry/server/writelimiter/blobstore.go
+++ b/pkg/dockerregistry/server/writelimiter/blobstore.go
@@ -1,0 +1,119 @@
+package writelimiter
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+
+	"github.com/openshift/origin/pkg/dockerregistry/server/types"
+)
+
+// ErrResourcesExhausted is returned when no more BlobWriters can be created
+// because of the limit.
+var ErrResourcesExhausted = errors.New("writers limit is reached")
+
+type writerBouncer struct {
+	sem  *semaphore
+	once sync.Once
+}
+
+func newWriterBouncer(sem *semaphore) (*writerBouncer, error) {
+	if !sem.TryDown() {
+		return nil, ErrResourcesExhausted
+	}
+	return &writerBouncer{
+		sem: sem,
+	}, nil
+}
+
+func (g *writerBouncer) Release() {
+	g.once.Do(g.sem.Up)
+}
+
+type blobWriter struct {
+	distribution.BlobWriter
+	bouncer *writerBouncer
+}
+
+var _ distribution.BlobWriter = blobWriter{}
+
+func (bw blobWriter) Close() error {
+	bw.bouncer.Release()
+	return bw.BlobWriter.Close()
+}
+
+func (bw blobWriter) Commit(ctx context.Context, desc distribution.Descriptor) (distribution.Descriptor, error) {
+	bw.bouncer.Release()
+	return bw.BlobWriter.Commit(ctx, desc)
+}
+
+func (bw blobWriter) Cancel(ctx context.Context) error {
+	bw.bouncer.Release()
+	return bw.BlobWriter.Cancel(ctx)
+}
+
+type blobStore struct {
+	distribution.BlobStore
+	sem *semaphore
+}
+
+var _ distribution.BlobStore = blobStore{}
+
+func (bs blobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	bouncer, err := newWriterBouncer(bs.sem)
+	if err != nil {
+		return nil, err
+	}
+
+	bw, err := bs.BlobStore.Create(ctx, options...)
+	if err != nil {
+		bouncer.Release()
+		return bw, err
+	}
+
+	return blobWriter{
+		BlobWriter: bw,
+		bouncer:    bouncer,
+	}, nil
+}
+
+func (bs blobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	bouncer, err := newWriterBouncer(bs.sem)
+	if err != nil {
+		return nil, err
+	}
+
+	bw, err := bs.BlobStore.Resume(ctx, id)
+	if err != nil {
+		bouncer.Release()
+		return bw, err
+	}
+
+	return blobWriter{
+		BlobWriter: bw,
+		bouncer:    bouncer,
+	}, nil
+}
+
+type blobStoreFactory struct {
+	sem *semaphore
+}
+
+var _ types.BlobStoreFactory = blobStoreFactory{}
+
+// NewBlobStoreFactory creates a factory of BlobStores which together can
+// create no more than limit BlobWriters at a time.
+func NewBlobStoreFactory(limit int) types.BlobStoreFactory {
+	return blobStoreFactory{
+		sem: newSemaphore(limit),
+	}
+}
+
+func (f blobStoreFactory) BlobStore(bs distribution.BlobStore) distribution.BlobStore {
+	return blobStore{
+		BlobStore: bs,
+		sem:       f.sem,
+	}
+}

--- a/pkg/dockerregistry/server/writelimiter/doc.go
+++ b/pkg/dockerregistry/server/writelimiter/doc.go
@@ -1,0 +1,3 @@
+// Package writelimiter provides middleware that limits the number of
+// concurrent write requests. Requests over the limit are declined.
+package writelimiter

--- a/pkg/dockerregistry/server/writelimiter/semaphore.go
+++ b/pkg/dockerregistry/server/writelimiter/semaphore.go
@@ -1,0 +1,24 @@
+package writelimiter
+
+type semaphore struct {
+	c chan struct{}
+}
+
+func newSemaphore(count int) *semaphore {
+	return &semaphore{
+		c: make(chan struct{}, count),
+	}
+}
+
+func (s *semaphore) Up() {
+	<-s.c
+}
+
+func (s *semaphore) TryDown() bool {
+	select {
+	case s.c <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
With a heavy load on the registry, the S3 storage driver has excessive memory usage. The reason is that data is sent to S3 in chunks and we are forced to accumulate it in buffers.

To avoid extreme memory consumption, we limit the number of concurrent write requests. Requests over the limit is declined.