### PR TITLE
Bootstrap OWNERS files for the repository

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,3 +14,4 @@ approvers:
   - liggitt
   - bparees
   - mfojtik
+  - eparis 

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - bparees
+  - mfojtik
+  - stevekuznetsov
+  - ncdc
+  - kargakis
+  - soltysh
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - bparees
+  - mfojtik

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - aveshagarwal
+  - pweil-
+  - mfojtik
+  - jpeeler
+  - soltysh
+  - liggitt
+  - ironcladlou
+approvers:
+  - smarterclayton
+  - deads2k
+  - pweil-
+  - mfojtik
+  - soltysh

--- a/cmd/cluster-capacity/OWNERS
+++ b/cmd/cluster-capacity/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - aveshagarwal
+  - smarterclayton
+approvers:
+  - smarterclayton

--- a/cmd/dockerregistry/OWNERS
+++ b/cmd/dockerregistry/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - pweil-
+  - ironcladlou
+  - smarterclayton
+  - miminar
+  - liggitt
+  - deads2k
+  - ncdc
+approvers:
+  - pweil-
+  - ironcladlou
+  - smarterclayton
+  - liggitt
+  - deads2k

--- a/cmd/gitserver/OWNERS
+++ b/cmd/gitserver/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - smarterclayton
+  - liggitt
+  - deads2k
+  - csrwng
+approvers:
+  - smarterclayton
+  - liggitt
+  - deads2k
+  - csrwng

--- a/cmd/kubefed/OWNERS
+++ b/cmd/kubefed/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+approvers:

--- a/cmd/oc/OWNERS
+++ b/cmd/oc/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - liggitt
+  - deads2k
+approvers:
+  - smarterclayton
+  - mfojtik
+  - liggitt
+  - deads2k

--- a/cmd/openshift/OWNERS
+++ b/cmd/openshift/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - mmahut
+  - liggitt
+  - deads2k
+approvers:
+  - smarterclayton
+  - mfojtik
+  - liggitt
+  - deads2k

--- a/cmd/service-catalog/OWNERS
+++ b/cmd/service-catalog/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - jpeeler
+  - deads2k
+  - smarterclayton
+  - aveshagarwal
+approvers:
+  - deads2k
+  - smarterclayton

--- a/examples/OWNERS
+++ b/examples/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - bparees
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - csrwng
+  - gabemontero
+  - soltysh
+  - danmcp
+approvers:
+  - bparees
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - csrwng

--- a/examples/atomic-registry/OWNERS
+++ b/examples/atomic-registry/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - aweiteka
+  - rhamilto
+approvers:

--- a/examples/data-population/OWNERS
+++ b/examples/data-population/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - smarterclayton
+  - derekwaynecarr
+  - stevekuznetsov
+approvers:
+  - smarterclayton
+  - derekwaynecarr
+  - stevekuznetsov

--- a/examples/db-templates/OWNERS
+++ b/examples/db-templates/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - bparees
+  - gabemontero
+  - mfojtik
+  - dinhxuanvu
+  - jim-minter
+  - spadgett
+approvers:
+  - bparees
+  - mfojtik
+  - spadgett
+  - kargakis
+  - jupierce

--- a/examples/deployment/OWNERS
+++ b/examples/deployment/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - smarterclayton
+  - sspeiche
+  - kargakis
+  - soltysh
+approvers:
+  - smarterclayton
+  - kargakis
+  - soltysh

--- a/examples/etcd/OWNERS
+++ b/examples/etcd/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - mfojtik
+  - smarterclayton
+approvers:
+  - mfojtik
+  - smarterclayton

--- a/examples/gitserver/OWNERS
+++ b/examples/gitserver/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - csrwng
+  - smarterclayton
+  - jim-minter
+  - bparees
+  - mfojtik
+  - deads2k
+approvers:
+  - csrwng
+  - smarterclayton
+  - bparees
+  - mfojtik
+  - deads2k

--- a/examples/glusterfs-image-storage/OWNERS
+++ b/examples/glusterfs-image-storage/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+approvers:

--- a/examples/ha/OWNERS
+++ b/examples/ha/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - smarterclayton
+approvers:
+  - smarterclayton

--- a/examples/heapster/OWNERS
+++ b/examples/heapster/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - smarterclayton
+approvers:
+  - smarterclayton

--- a/examples/hello-openshift/OWNERS
+++ b/examples/hello-openshift/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - mfojtik
+  - smarterclayton
+  - pweil-
+  - jwforres
+  - derekwaynecarr
+  - bparees
+  - knobunc
+approvers:
+  - mfojtik
+  - smarterclayton
+  - pweil-
+  - jwforres
+  - derekwaynecarr

--- a/examples/image-streams/OWNERS
+++ b/examples/image-streams/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - bparees
+  - sspeiche
+  - oatmealraisin
+  - mfojtik
+  - liggitt
+  - jcantrill
+  - hhorak
+  - csrwng
+approvers:
+  - bparees
+  - mfojtik
+  - liggitt
+  - jcantrill
+  - csrwng

--- a/examples/jenkins/OWNERS
+++ b/examples/jenkins/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - bparees
+  - gabemontero
+  - mfojtik
+  - deads2k
+  - csrwng
+  - smarterclayton
+  - jim-minter
+  - sspeiche
+  - jupierce
+  - liggitt
+approvers:
+  - bparees
+  - mfojtik
+  - deads2k
+  - csrwng
+  - smarterclayton

--- a/examples/logging/OWNERS
+++ b/examples/logging/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - csrwng
+  - liggitt
+approvers:
+  - csrwng
+  - liggitt

--- a/examples/privileged-pod-pvc/OWNERS
+++ b/examples/privileged-pod-pvc/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+approvers:

--- a/examples/project-quota/OWNERS
+++ b/examples/project-quota/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - derekwaynecarr
+  - kargakis
+  - soltysh
+  - jim-minter
+approvers:
+  - smarterclayton
+  - mfojtik
+  - derekwaynecarr
+  - kargakis
+  - soltysh

--- a/examples/project-spawner/OWNERS
+++ b/examples/project-spawner/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - derekwaynecarr
+  - deads2k
+approvers:
+  - derekwaynecarr
+  - deads2k

--- a/examples/prometheus/OWNERS
+++ b/examples/prometheus/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+approvers:
+  - smarterclayton
+  - mfojtik

--- a/examples/pruner/OWNERS
+++ b/examples/pruner/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - mfojtik
+approvers:
+  - mfojtik

--- a/examples/quickstarts/OWNERS
+++ b/examples/quickstarts/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - bparees
+  - gabemontero
+  - coreydaley
+  - dinhxuanvu
+  - sspeiche
+  - mfojtik
+  - jupierce
+approvers:
+  - bparees
+  - mfojtik
+  - jupierce

--- a/examples/sample-app/OWNERS
+++ b/examples/sample-app/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - bparees
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - csrwng
+  - liggitt
+approvers:
+  - bparees
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - soltysh

--- a/examples/service-catalog/OWNERS
+++ b/examples/service-catalog/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - bparees
+approvers:
+  - bparees

--- a/examples/statefulsets/OWNERS
+++ b/examples/statefulsets/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - soltysh
+  - ncdc
+approvers:
+  - soltysh

--- a/examples/storage-examples/OWNERS
+++ b/examples/storage-examples/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - screeley44
+  - soltysh
+  - rootfs
+approvers:
+  - soltysh

--- a/examples/wordpress/OWNERS
+++ b/examples/wordpress/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - markturansky
+  - jsafrane
+  - php-coder
+  - pweil-
+  - jim-minter
+  - rootfs
+  - coreydaley
+  - bparees
+approvers:
+  - jsafrane
+  - pweil-
+  - bparees

--- a/examples/zookeeper/OWNERS
+++ b/examples/zookeeper/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - mfojtik
+  - ghyde
+  - smarterclayton
+approvers:
+  - mfojtik
+  - smarterclayton

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - stevekuznetsov
+  - deads2k
+  - liggitt
+  - bparees
+  - mfojtik
+  - ncdc
+  - soltysh
+approvers:
+  - smarterclayton
+  - stevekuznetsov
+  - deads2k
+  - liggitt
+  - bparees

--- a/hack/clibyexample/OWNERS
+++ b/hack/clibyexample/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - fabianofranz
+approvers:
+  - fabianofranz

--- a/hack/lib/OWNERS
+++ b/hack/lib/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - stevekuznetsov
+  - smarterclayton
+  - kargakis
+  - deads2k
+  - soltysh
+  - liggitt
+  - jhadvig
+  - fabianofranz
+approvers:
+  - stevekuznetsov
+  - smarterclayton
+  - kargakis
+  - deads2k
+  - soltysh

--- a/hack/swagger-doc/OWNERS
+++ b/hack/swagger-doc/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - smarterclayton
+  - stevekuznetsov
+approvers:
+  - smarterclayton
+  - stevekuznetsov

--- a/hack/test-lib/OWNERS
+++ b/hack/test-lib/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - stevekuznetsov
+  - smarterclayton
+approvers:
+  - stevekuznetsov
+  - smarterclayton

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - smarterclayton
+  - giuseppe
+  - JacobTanenbaum
+  - pweil-
+  - pecameron
+  - mfojtik
+  - sdodson
+approvers:
+  - smarterclayton
+  - pweil-
+  - mfojtik
+  - sdodson
+  - stevekuznetsov

--- a/images/base/OWNERS
+++ b/images/base/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - sdodson
+  - tdawson
+  - kargakis
+  - rootfs
+  - stevekuznetsov
+  - sjenning
+  - csrwng
+approvers:
+  - smarterclayton
+  - sdodson
+  - tdawson
+  - kargakis
+  - stevekuznetsov

--- a/images/builder/OWNERS
+++ b/images/builder/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - soltysh
+  - bparees
+  - mfojtik
+  - csrwng
+  - smarterclayton
+  - tdawson
+  - kargakis
+  - sdodson
+approvers:
+  - soltysh
+  - bparees
+  - mfojtik
+  - csrwng
+  - smarterclayton

--- a/images/cluster-capacity/OWNERS
+++ b/images/cluster-capacity/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - kargakis
+  - aveshagarwal
+approvers:
+  - kargakis

--- a/images/deployer/OWNERS
+++ b/images/deployer/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - tdawson
+  - stevekuznetsov
+  - kargakis
+  - mfojtik
+  - deads2k
+  - smarterclayton
+  - ncdc
+approvers:
+  - tdawson
+  - stevekuznetsov
+  - kargakis
+  - mfojtik
+  - deads2k

--- a/images/dind/OWNERS
+++ b/images/dind/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - dcbw
+  - smarterclayton
+  - knobunc
+  - tdawson
+  - stevekuznetsov
+  - rajatchopra
+  - JacobTanenbaum
+  - bparees
+approvers:
+  - dcbw
+  - smarterclayton
+  - knobunc
+  - tdawson
+  - stevekuznetsov

--- a/images/dockerregistry/OWNERS
+++ b/images/dockerregistry/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - miminar
+  - smarterclayton
+  - ncdc
+  - legionus
+  - tdawson
+  - kargakis
+  - aweiteka
+  - stevekuznetsov
+  - pravisankar
+  - pweil-
+approvers:
+  - smarterclayton
+  - legionus
+  - tdawson
+  - kargakis
+  - stevekuznetsov

--- a/images/egress/OWNERS
+++ b/images/egress/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - kargakis
+approvers:
+  - kargakis

--- a/images/federation/OWNERS
+++ b/images/federation/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - kargakis
+approvers:
+  - kargakis

--- a/images/ipfailover/OWNERS
+++ b/images/ipfailover/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - pecameron
+  - smarterclayton
+  - deads2k
+  - tdawson
+  - pweil-
+  - kargakis
+approvers:
+  - smarterclayton
+  - deads2k
+  - tdawson
+  - pweil-
+  - kargakis

--- a/images/node/OWNERS
+++ b/images/node/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - giuseppe
+  - sdodson
+  - smarterclayton
+  - stevekuznetsov
+  - tdawson
+  - dcbw
+  - rootfs
+  - pravisankar
+  - kargakis
+  - jsafrane
+approvers:
+  - sdodson
+  - smarterclayton
+  - stevekuznetsov
+  - tdawson
+  - dcbw

--- a/images/observe/OWNERS
+++ b/images/observe/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - smarterclayton
+approvers:
+  - smarterclayton

--- a/images/openldap/OWNERS
+++ b/images/openldap/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - stevekuznetsov
+  - deads2k
+approvers:
+  - stevekuznetsov
+  - deads2k

--- a/images/openvswitch/OWNERS
+++ b/images/openvswitch/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - giuseppe
+  - sdodson
+  - smarterclayton
+  - tdawson
+  - stevekuznetsov
+  - kargakis
+approvers:
+  - sdodson
+  - smarterclayton
+  - tdawson
+  - stevekuznetsov
+  - kargakis

--- a/images/origin/OWNERS
+++ b/images/origin/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - giuseppe
+  - markturansky
+  - deads2k
+  - kargakis
+  - tdawson
+  - stevekuznetsov
+  - sdodson
+approvers:
+  - smarterclayton
+  - deads2k
+  - kargakis
+  - tdawson
+  - stevekuznetsov

--- a/images/pod/OWNERS
+++ b/images/pod/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - kargakis
+  - smarterclayton
+  - tdawson
+  - stevekuznetsov
+  - soltysh
+approvers:
+  - kargakis
+  - smarterclayton
+  - tdawson
+  - stevekuznetsov
+  - soltysh

--- a/images/recycler/OWNERS
+++ b/images/recycler/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - tdawson
+  - stevekuznetsov
+  - markturansky
+  - kargakis
+  - liggitt
+  - smarterclayton
+approvers:
+  - tdawson
+  - stevekuznetsov
+  - kargakis
+  - liggitt
+  - smarterclayton

--- a/images/release/OWNERS
+++ b/images/release/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - stevekuznetsov
+  - mfojtik
+  - tdawson
+  - fabianofranz
+  - ncdc
+  - php-coder
+  - liggitt
+  - jhadvig
+approvers:
+  - smarterclayton
+  - stevekuznetsov
+  - mfojtik
+  - tdawson
+  - fabianofranz

--- a/images/router/OWNERS
+++ b/images/router/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - JacobTanenbaum
+  - smarterclayton
+  - pweil-
+  - knobunc
+  - pecameron
+  - rajatchopra
+  - tdawson
+approvers:
+  - smarterclayton
+  - pweil-
+  - knobunc
+  - rajatchopra
+  - tdawson

--- a/images/service-catalog/OWNERS
+++ b/images/service-catalog/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - kargakis
+  - jpeeler
+approvers:
+  - kargakis

--- a/images/simple-authenticated-registry/OWNERS
+++ b/images/simple-authenticated-registry/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - smarterclayton
+approvers:
+  - smarterclayton

--- a/images/source/OWNERS
+++ b/images/source/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - kargakis
+  - stevekuznetsov
+approvers:
+  - kargakis
+  - stevekuznetsov

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - spadgett
+  - bparees
+  - mfojtik
+  - kargakis
+  - csrwng
+  - jwforres
+  - ncdc
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - spadgett
+  - bparees

--- a/pkg/api/OWNERS
+++ b/pkg/api/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - kargakis
+  - mfojtik
+  - liggitt
+  - ncdc
+  - soltysh
+  - gabemontero
+  - bparees
+approvers:
+  - smarterclayton
+  - deads2k
+  - kargakis
+  - mfojtik
+  - liggitt

--- a/pkg/assets/OWNERS
+++ b/pkg/assets/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - spadgett
+  - jwforres
+  - liggitt
+  - sg00dwin
+  - jhadvig
+  - rhamilto
+  - fabianofranz
+approvers:
+  - spadgett
+  - jwforres
+  - liggitt
+  - fabianofranz
+  - csrwng

--- a/pkg/auth/OWNERS
+++ b/pkg/auth/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - liggitt
+  - deads2k
+  - stevekuznetsov
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - sgallagher
+approvers:
+  - liggitt
+  - deads2k
+  - stevekuznetsov
+  - smarterclayton
+  - mfojtik

--- a/pkg/authorization/OWNERS
+++ b/pkg/authorization/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - liggitt
+  - enj
+  - mfojtik
+  - ncdc
+  - soltysh
+  - csrwng
+  - stevekuznetsov
+approvers:
+  - deads2k
+  - smarterclayton
+  - liggitt
+  - enj
+  - mfojtik

--- a/pkg/bootstrap/OWNERS
+++ b/pkg/bootstrap/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - csrwng
+  - bparees
+  - smarterclayton
+  - jim-minter
+  - gabemontero
+  - deads2k
+  - coreydaley
+  - ncdc
+  - php-coder
+  - dinhxuanvu
+approvers:
+  - csrwng
+  - bparees
+  - smarterclayton
+  - deads2k
+  - jupierce

--- a/pkg/build/OWNERS
+++ b/pkg/build/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - bparees
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - deads2k
+  - csrwng
+  - ncdc
+  - gabemontero
+approvers:
+  - bparees
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - deads2k

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - ncdc
+  - kargakis
+  - soltysh
+  - liggitt
+  - csrwng
+  - mfojtik
+approvers:
+  - deads2k
+  - smarterclayton
+  - kargakis
+  - soltysh
+  - liggitt

--- a/pkg/cmd/OWNERS
+++ b/pkg/cmd/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - kargakis
+  - ncdc
+  - soltysh
+  - juanvallejo
+  - csrwng
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - kargakis

--- a/pkg/config/OWNERS
+++ b/pkg/config/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - liggitt
+  - bparees
+  - stevekuznetsov
+approvers:
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - liggitt
+  - bparees

--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - ncdc
+  - kargakis
+  - soltysh
+  - bparees
+  - jim-minter
+  - csrwng
+approvers:
+  - smarterclayton
+  - deads2k
+  - kargakis
+  - soltysh
+  - bparees

--- a/pkg/deploy/OWNERS
+++ b/pkg/deploy/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - kargakis
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - ncdc
+  - soltysh
+  - abhgupta
+approvers:
+  - kargakis
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - soltysh

--- a/pkg/diagnostics/OWNERS
+++ b/pkg/diagnostics/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - pravisankar
+  - sosiouxme
+  - liggitt
+  - deads2k
+  - smarterclayton
+  - soltysh
+  - jcantrill
+  - dgoodwin
+  - ncdc
+  - stevekuznetsov
+approvers:
+  - pravisankar
+  - sosiouxme
+  - liggitt
+  - deads2k
+  - smarterclayton

--- a/pkg/dns/OWNERS
+++ b/pkg/dns/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - ncdc
+  - liggitt
+  - kargakis
+  - soltysh
+  - pweil-
+  - mfojtik
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - kargakis
+  - soltysh

--- a/pkg/dockerregistry/OWNERS
+++ b/pkg/dockerregistry/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - miminar
+  - smarterclayton
+  - ncdc
+  - legionus
+  - liggitt
+  - dmage
+  - deads2k
+  - soltysh
+  - mfojtik
+approvers:
+  - smarterclayton
+  - legionus
+  - liggitt
+  - deads2k
+  - soltysh

--- a/pkg/federation/OWNERS
+++ b/pkg/federation/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+approvers:

--- a/pkg/generate/OWNERS
+++ b/pkg/generate/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - csrwng
+  - bparees
+  - deads2k
+  - gabemontero
+  - mfojtik
+  - jim-minter
+  - ncdc
+approvers:
+  - smarterclayton
+  - csrwng
+  - bparees
+  - deads2k
+  - mfojtik

--- a/pkg/gitserver/OWNERS
+++ b/pkg/gitserver/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - csrwng
+  - liggitt
+  - deads2k
+  - ncdc
+  - kargakis
+  - jim-minter
+  - bparees
+approvers:
+  - smarterclayton
+  - csrwng
+  - liggitt
+  - deads2k
+  - kargakis

--- a/pkg/image/OWNERS
+++ b/pkg/image/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - ncdc
+  - deads2k
+  - soltysh
+  - miminar
+  - mfojtik
+  - liggitt
+  - legionus
+approvers:
+  - smarterclayton
+  - deads2k
+  - soltysh
+  - mfojtik
+  - liggitt

--- a/pkg/ingress/OWNERS
+++ b/pkg/ingress/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - JacobTanenbaum
+  - deads2k
+  - smarterclayton
+  - ncdc
+approvers:
+  - deads2k
+  - smarterclayton

--- a/pkg/ipfailover/OWNERS
+++ b/pkg/ipfailover/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - pecameron
+  - stevekuznetsov
+  - kargakis
+  - liggitt
+  - ncdc
+approvers:
+  - deads2k
+  - smarterclayton
+  - stevekuznetsov
+  - kargakis
+  - liggitt

--- a/pkg/oauth/OWNERS
+++ b/pkg/oauth/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - ncdc
+  - soltysh
+  - enj
+  - stevekuznetsov
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - soltysh

--- a/pkg/openapi/OWNERS
+++ b/pkg/openapi/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - bparees
+  - deads2k
+  - coreydaley
+  - soltysh
+  - jim-minter
+  - liggitt
+  - php-coder
+  - stevekuznetsov
+approvers:
+  - smarterclayton
+  - bparees
+  - deads2k
+  - soltysh
+  - liggitt

--- a/pkg/openservicebroker/OWNERS
+++ b/pkg/openservicebroker/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - jim-minter
+  - ncdc
+approvers:

--- a/pkg/pod/OWNERS
+++ b/pkg/pod/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - deads2k
+  - coreydaley
+approvers:
+  - deads2k

--- a/pkg/project/OWNERS
+++ b/pkg/project/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - liggitt
+  - derekwaynecarr
+  - mfojtik
+  - soltysh
+  - ncdc
+  - pweil-
+  - csrwng
+approvers:
+  - deads2k
+  - smarterclayton
+  - liggitt
+  - derekwaynecarr
+  - mfojtik

--- a/pkg/proxy/OWNERS
+++ b/pkg/proxy/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - DirectXMan12
+  - deads2k
+  - knobunc
+  - ncdc
+  - soltysh
+  - dcbw
+approvers:
+  - deads2k
+  - knobunc
+  - soltysh
+  - dcbw

--- a/pkg/quota/OWNERS
+++ b/pkg/quota/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - ncdc
+  - miminar
+  - mfojtik
+  - liggitt
+  - soltysh
+approvers:
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - liggitt
+  - soltysh

--- a/pkg/route/OWNERS
+++ b/pkg/route/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - pweil-
+  - kargakis
+  - mfojtik
+  - soltysh
+  - ncdc
+  - liggitt
+approvers:
+  - smarterclayton
+  - deads2k
+  - pweil-
+  - kargakis
+  - mfojtik

--- a/pkg/router/OWNERS
+++ b/pkg/router/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - smarterclayton
+  - rajatchopra
+  - pecameron
+  - knobunc
+  - deads2k
+  - pweil-
+approvers:
+  - smarterclayton
+  - rajatchopra
+  - knobunc
+  - deads2k
+  - pweil-

--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - pravisankar
+  - soltysh
+  - dobbymoodge
+  - liggitt
+approvers:
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - pravisankar
+  - soltysh

--- a/pkg/sdn/OWNERS
+++ b/pkg/sdn/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - pravisankar
+  - dcbw
+  - smarterclayton
+  - deads2k
+  - mfojtik
+  - ncdc
+  - rajatchopra
+  - soltysh
+approvers:
+  - pravisankar
+  - dcbw
+  - smarterclayton
+  - deads2k
+  - mfojtik

--- a/pkg/security/OWNERS
+++ b/pkg/security/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - pweil-
+  - soltysh
+  - ncdc
+  - mfojtik
+  - liggitt
+  - php-coder
+approvers:
+  - deads2k
+  - smarterclayton
+  - pweil-
+  - soltysh
+  - mfojtik

--- a/pkg/service/OWNERS
+++ b/pkg/service/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - soltysh
+  - ncdc
+  - mfojtik
+  - php-coder
+  - pravisankar
+  - pweil-
+approvers:
+  - deads2k
+  - smarterclayton
+  - soltysh
+  - mfojtik
+  - pravisankar

--- a/pkg/serviceaccounts/OWNERS
+++ b/pkg/serviceaccounts/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - deads2k
+  - liggitt
+  - smarterclayton
+  - mfojtik
+  - ncdc
+  - pweil-
+  - sgallagher
+  - enj
+approvers:
+  - deads2k
+  - liggitt
+  - smarterclayton
+  - mfojtik
+  - pweil-

--- a/pkg/template/OWNERS
+++ b/pkg/template/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - jim-minter
+  - bparees
+  - soltysh
+  - ncdc
+approvers:
+  - smarterclayton
+  - mfojtik
+  - deads2k
+  - bparees
+  - soltysh

--- a/pkg/unidling/OWNERS
+++ b/pkg/unidling/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - DirectXMan12
+  - ncdc
+  - mfojtik
+  - soltysh
+  - juanvallejo
+  - liggitt
+  - deads2k
+approvers:
+  - mfojtik
+  - soltysh
+  - liggitt
+  - deads2k

--- a/pkg/user/OWNERS
+++ b/pkg/user/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - soltysh
+  - ncdc
+  - pweil-
+  - stevekuznetsov
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - soltysh

--- a/pkg/util/OWNERS
+++ b/pkg/util/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - soltysh
+  - csrwng
+  - bparees
+  - kargakis
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - mfojtik
+  - soltysh

--- a/pkg/version/OWNERS
+++ b/pkg/version/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - juanvallejo
+  - liggitt
+  - deads2k
+approvers:
+  - smarterclayton
+  - mfojtik
+  - soltysh
+  - liggitt
+  - deads2k

--- a/pkg/volume/OWNERS
+++ b/pkg/volume/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - dgoodwin
+  - ncdc
+  - danmcp
+  - deads2k
+  - smarterclayton
+approvers:
+  - danmcp
+  - deads2k
+  - smarterclayton

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - bparees
+  - stevekuznetsov
+  - mfojtik
+  - kargakis
+  - csrwng
+  - soltysh
+approvers:
+  - smarterclayton
+  - deads2k
+  - liggitt
+  - bparees
+  - stevekuznetsov

--- a/test/cmd/OWNERS
+++ b/test/cmd/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - stevekuznetsov
+  - juanvallejo
+  - bparees
+  - liggitt
+  - kargakis
+  - fabianofranz
+  - pecameron
+approvers:
+  - smarterclayton
+  - deads2k
+  - stevekuznetsov
+  - bparees
+  - liggitt

--- a/test/common/OWNERS
+++ b/test/common/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - csrwng
+  - bparees
+  - ncdc
+  - soltysh
+  - deads2k
+approvers:
+  - csrwng
+  - bparees
+  - soltysh
+  - deads2k

--- a/test/end-to-end/OWNERS
+++ b/test/end-to-end/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - kargakis
+  - stevekuznetsov
+  - smarterclayton
+  - miminar
+  - soltysh
+  - liggitt
+  - deads2k
+  - legionus
+  - sosiouxme
+  - bparees
+approvers:
+  - kargakis
+  - stevekuznetsov
+  - smarterclayton
+  - soltysh
+  - liggitt

--- a/test/extended/OWNERS
+++ b/test/extended/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - bparees
+  - stevekuznetsov
+  - mfojtik
+  - gabemontero
+  - kargakis
+  - deads2k
+  - jim-minter
+approvers:
+  - smarterclayton
+  - bparees
+  - stevekuznetsov
+  - mfojtik
+  - kargakis

--- a/test/integration/OWNERS
+++ b/test/integration/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - liggitt
+  - mfojtik
+  - csrwng
+  - ncdc
+  - soltysh
+  - bparees
+  - kargakis
+approvers:
+  - deads2k
+  - smarterclayton
+  - liggitt
+  - mfojtik
+  - csrwng

--- a/test/old-start-configs/OWNERS
+++ b/test/old-start-configs/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - stevekuznetsov
+  - liggitt
+  - bparees
+  - soltysh
+approvers:
+  - deads2k
+  - smarterclayton
+  - stevekuznetsov
+  - liggitt
+  - bparees

--- a/test/templates/OWNERS
+++ b/test/templates/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - mfojtik
+  - pweil-
+  - jupierce
+  - deads2k
+  - bparees
+  - kargakis
+  - soltysh
+approvers:
+  - smarterclayton
+  - mfojtik
+  - pweil-
+  - jupierce
+  - deads2k

--- a/test/testdata/OWNERS
+++ b/test/testdata/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - enj
+  - liggitt
+  - kargakis
+  - ncdc
+  - soltysh
+  - jim-minter
+approvers:
+  - deads2k
+  - smarterclayton
+  - mfojtik
+  - enj
+  - liggitt

--- a/test/util/OWNERS
+++ b/test/util/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - liggitt
+  - deads2k
+  - mfojtik
+  - ncdc
+  - miminar
+  - soltysh
+  - sosiouxme
+approvers:
+  - smarterclayton
+  - liggitt
+  - deads2k
+  - mfojtik
+  - soltysh

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - smarterclayton
+  - stevekuznetsov
+  - deads2k
+  - soltysh
+  - ncdc
+  - liggitt
+  - juanvallejo
+  - php-coder
+approvers:
+  - smarterclayton
+  - stevekuznetsov
+  - deads2k
+  - soltysh
+  - liggitt

--- a/tools/buildanalyzer/OWNERS
+++ b/tools/buildanalyzer/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - bparees
+approvers:
+  - bparees

--- a/tools/clicheck/OWNERS
+++ b/tools/clicheck/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - fabianofranz
+approvers:
+  - fabianofranz

--- a/tools/etcdhelper/OWNERS
+++ b/tools/etcdhelper/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - enj
+  - soltysh
+  - deads2k
+approvers:
+  - enj
+  - soltysh
+  - deads2k

--- a/tools/genconversion/OWNERS
+++ b/tools/genconversion/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - smarterclayton
+  - deads2k
+  - ncdc
+  - stevekuznetsov
+  - pweil-
+  - mfojtik
+  - soltysh
+approvers:
+  - smarterclayton
+  - deads2k
+  - stevekuznetsov
+  - pweil-
+  - mfojtik

--- a/tools/gendeepcopy/OWNERS
+++ b/tools/gendeepcopy/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - deads2k
+  - smarterclayton
+  - soltysh
+  - ncdc
+  - stevekuznetsov
+  - pweil-
+approvers:
+  - deads2k
+  - smarterclayton
+  - soltysh
+  - stevekuznetsov
+  - pweil-

--- a/tools/gendefaults/OWNERS
+++ b/tools/gendefaults/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+  - ncdc
+approvers:

--- a/tools/gendocs/OWNERS
+++ b/tools/gendocs/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - stevekuznetsov
+  - liggitt
+  - smarterclayton
+approvers:
+  - stevekuznetsov
+  - liggitt
+  - smarterclayton

--- a/tools/geninformers/OWNERS
+++ b/tools/geninformers/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+approvers:

--- a/tools/genlisters/OWNERS
+++ b/tools/genlisters/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+  - ncdc
+approvers:

--- a/tools/genman/OWNERS
+++ b/tools/genman/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - juanvallejo
+  - smarterclayton
+  - kargakis
+  - soltysh
+approvers:
+  - smarterclayton
+  - kargakis
+  - soltysh

--- a/tools/genopenapi/OWNERS
+++ b/tools/genopenapi/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+  - ncdc
+approvers:

--- a/tools/genprotobuf/OWNERS
+++ b/tools/genprotobuf/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - ncdc
+  - deads2k
+  - soltysh
+  - smarterclayton
+approvers:
+  - deads2k
+  - soltysh
+  - smarterclayton

--- a/tools/genswaggerdoc/OWNERS
+++ b/tools/genswaggerdoc/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - stevekuznetsov
+  - ncdc
+approvers:
+  - stevekuznetsov

--- a/tools/godepversion/OWNERS
+++ b/tools/godepversion/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - stevekuznetsov
+approvers:
+  - stevekuznetsov

--- a/tools/junitmerge/OWNERS
+++ b/tools/junitmerge/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - smarterclayton
+approvers:
+  - smarterclayton

--- a/tools/junitreport/OWNERS
+++ b/tools/junitreport/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - stevekuznetsov
+  - smarterclayton
+  - soltysh
+  - adelton
+  - liggitt
+  - danmcp
+approvers:
+  - stevekuznetsov
+  - smarterclayton
+  - soltysh
+  - liggitt
+  - danmcp

--- a/tools/rebasehelpers/OWNERS
+++ b/tools/rebasehelpers/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+  - stevekuznetsov
+  - liggitt
+  - soltysh
+  - ncdc
+  - php-coder
+  - jpeeler
+  - deads2k
+  - smarterclayton
+approvers:
+  - stevekuznetsov
+  - liggitt
+  - soltysh
+  - deads2k
+  - smarterclayton

--- a/tools/testdebug/OWNERS
+++ b/tools/testdebug/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - deads2k
+approvers:
+  - deads2k


### PR DESCRIPTION
In order to satisfy the blunderbuss and approvers plugins for the k8s CI
systems we are about to adopt, we need to add OWNERS files to
directories in Origin. The files contain reviewers and approvers for the
directory. Reviewers are members that blunderbuss will assign pull
requests to; approvers are members from whom an LGTM is necessary to
merge a pull request that touches files in the directory.

The inital values in these OWNERS files are generated by looking at the
most active contributors to any directory. The top ten most active
contributors to a directory are listed as reviewers; the top five most
active contributors that have merge rights with the current system are
listed as approvers.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @kargakis @deads2k 

PTAL @openshift/team-project-committers