### PR TITLE
Set the GC thresholds higher in dind

### DIFF
--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -63,6 +63,8 @@ function ensure-node-config() {
 kubeletArguments:
   cgroups-per-qos: ["false"]
   enforce-node-allocatable: [""]
+  image-gc-low-threshold: ["95"]
+  image-gc-high-threshold: ["97"]
 EOF
   fi
 


### PR DESCRIPTION
The dind environment has a high percentage of disk usage for some
partitions... but they are large, so there is plenty of free space.
But this confuses the default image GC thresholds and they are purged
as soon as an image no longer references them.  This means we are
always pulling deployer and pod images, and makes things really slow.