### PR TITLE
Correct the url for the memory stats in the router test

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -178,7 +178,7 @@ var _ = g.Describe("[Conformance][networking][router] openshift router metrics",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("at /debug/pprof")
-			results, err := getAuthenticatedURLViaPod(ns, execPodName, fmt.Sprintf("http://%s:%d/debug/pprof/heap", host, statsPort), username, password)
+			results, err := getAuthenticatedURLViaPod(ns, execPodName, fmt.Sprintf("http://%s:%d/debug/pprof/heap?debug=1", host, statsPort), username, password)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(results).To(o.ContainSubstring("# runtime.MemStats"))
 		})


### PR DESCRIPTION
We were missing the debug=1 argument on the memory stats, so were getting them in a binary format.  With the flag added we pass tests properly.

Fixes https://github.com/openshift/origin/issues/15356