### PR TITLE
add type assertions for registries

### DIFF
--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -8292,6 +8292,59 @@
     ]
    },
    {
+    "path": "/oapi/v1/namespaces/{namespace}/generatedeploymentconfigs/{name}",
+    "description": "OpenShift REST API, version v1",
+    "operations": [
+     {
+      "type": "v1.DeploymentConfig",
+      "method": "GET",
+      "summary": "read the specified DeploymentConfig",
+      "nickname": "readNamespacedDeploymentConfig",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the DeploymentConfig",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.DeploymentConfig"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/oapi/v1/groups",
     "description": "OpenShift REST API, version v1",
     "operations": [

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -78342,6 +78342,65 @@
      }
     ]
    },
+   "/oapi/v1/namespaces/{namespace}/generatedeploymentconfigs/{name}": {
+    "get": {
+     "description": "read the specified DeploymentConfig",
+     "consumes": [
+      "*/*"
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "schemes": [
+      "https"
+     ],
+     "operationId": "generateNamespacedDeploymentConfig",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/com.github.openshift.origin.pkg.deploy.apis.apps.v1.DeploymentConfig"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     },
+     "x-kubernetes-action": "get",
+     "x-kubernetes-group-version-kind": {
+      "group": "",
+      "version": "latest",
+      "kind": "DeploymentConfig"
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "name of the DeploymentConfig",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "If 'true', then the output is pretty printed.",
+      "name": "pretty",
+      "in": "query"
+     }
+    ]
+   },
    "/oapi/v1/namespaces/{namespace}/imagestreamimages/{name}": {
     "get": {
      "description": "read the specified ImageStreamImage",

--- a/pkg/authorization/registry/localresourceaccessreview/rest.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
@@ -17,6 +18,8 @@ import (
 type REST struct {
 	clusterRARRegistry resourceaccessreview.Registry
 }
+
+var _ rest.Creater = &REST{}
 
 func NewREST(clusterRARRegistry resourceaccessreview.Registry) *REST {
 	return &REST{clusterRARRegistry}

--- a/pkg/authorization/registry/localsubjectaccessreview/rest.go
+++ b/pkg/authorization/registry/localsubjectaccessreview/rest.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
@@ -17,6 +18,8 @@ import (
 type REST struct {
 	clusterSARRegistry subjectaccessreview.Registry
 }
+
+var _ rest.Creater = &REST{}
 
 func NewREST(clusterSARRegistry subjectaccessreview.Registry) *REST {
 	return &REST{clusterSARRegistry}

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
@@ -20,6 +21,8 @@ type REST struct {
 	authorizer     kauthorizer.Authorizer
 	subjectLocator authorizer.SubjectLocator
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST creates a new REST for policies.
 func NewREST(authorizer kauthorizer.Authorizer, subjectLocator authorizer.SubjectLocator) *REST {

--- a/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
+++ b/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
@@ -14,6 +15,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against nodes.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/authorization/registry/selfsubjectrulesreview/storage.go
+++ b/pkg/authorization/registry/selfsubjectrulesreview/storage.go
@@ -8,6 +8,7 @@ import (
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
@@ -20,6 +21,8 @@ type REST struct {
 	ruleResolver        rulevalidation.AuthorizationRuleResolver
 	clusterPolicyGetter authorizationlister.ClusterPolicyLister
 }
+
+var _ rest.Creater = &REST{}
 
 func NewREST(ruleResolver rulevalidation.AuthorizationRuleResolver, clusterPolicyGetter authorizationlister.ClusterPolicyLister) *REST {
 	return &REST{ruleResolver: ruleResolver, clusterPolicyGetter: clusterPolicyGetter}

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
@@ -19,6 +20,8 @@ import (
 type REST struct {
 	authorizer kauthorizer.Authorizer
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST creates a new REST for policies.
 func NewREST(authorizer kauthorizer.Authorizer) *REST {

--- a/pkg/authorization/registry/subjectrulesreview/storage.go
+++ b/pkg/authorization/registry/subjectrulesreview/storage.go
@@ -9,6 +9,7 @@ import (
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
@@ -20,6 +21,8 @@ type REST struct {
 	ruleResolver        rulevalidation.AuthorizationRuleResolver
 	clusterPolicyGetter authorizationlister.ClusterPolicyLister
 }
+
+var _ rest.Creater = &REST{}
 
 func NewREST(ruleResolver rulevalidation.AuthorizationRuleResolver, clusterPolicyGetter authorizationlister.ClusterPolicyLister) *REST {
 	return &REST{ruleResolver: ruleResolver, clusterPolicyGetter: clusterPolicyGetter}

--- a/pkg/build/registry/build/etcd/etcd.go
+++ b/pkg/build/registry/build/etcd/etcd.go
@@ -17,6 +17,8 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against Build objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, *DetailsREST, error) {
 	store := &registry.Store{
@@ -45,6 +47,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, *DetailsREST, error) {
 type DetailsREST struct {
 	store *registry.Store
 }
+
+var _ rest.Updater = &DetailsREST{}
 
 // New returns an empty object that can be used with Update after request data has been put into it.
 func (r *DetailsREST) New() runtime.Object {

--- a/pkg/build/registry/buildclone/rest.go
+++ b/pkg/build/registry/buildclone/rest.go
@@ -20,6 +20,8 @@ type CloneREST struct {
 	generator *generator.BuildGenerator
 }
 
+var _ rest.Creater = &CloneREST{}
+
 // New creates a new build clone request
 func (s *CloneREST) New() runtime.Object {
 	return &buildapi.BuildRequest{}

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
@@ -14,6 +15,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against BuildConfig.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/build/registry/buildconfiginstantiate/rest.go
+++ b/pkg/build/registry/buildconfiginstantiate/rest.go
@@ -46,6 +46,8 @@ type InstantiateREST struct {
 	generator *generator.BuildGenerator
 }
 
+var _ rest.Creater = &InstantiateREST{}
+
 // New creates a new build generation request
 func (s *InstantiateREST) New() runtime.Object {
 	return &buildapi.BuildRequest{}
@@ -86,6 +88,8 @@ type BinaryInstantiateREST struct {
 	ConnectionInfo kubeletclient.ConnectionInfoGetter
 	Timeout        time.Duration
 }
+
+var _ rest.Connecter = &BinaryInstantiateREST{}
 
 // New creates a new build generation request
 func (s *BinaryInstantiateREST) New() runtime.Object {

--- a/pkg/deploy/registry/deployconfig/etcd/etcd.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd.go
@@ -24,6 +24,8 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a deploymentConfigREST containing the REST storage for DeploymentConfig objects,
 // a statusREST containing the REST storage for changing the status of a DeploymentConfig,
 // and a scaleREST containing the REST storage for the Scale subresources of DeploymentConfigs.

--- a/pkg/deploy/registry/generator/rest.go
+++ b/pkg/deploy/registry/generator/rest.go
@@ -1,8 +1,10 @@
 package generator
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 )
@@ -14,6 +16,8 @@ type REST struct {
 	codec     runtime.Codec
 }
 
+var _ rest.Getter = &REST{}
+
 func NewREST(generator *DeploymentConfigGenerator, codec runtime.Codec) *REST {
 	return &REST{generator: generator, codec: codec}
 }
@@ -22,6 +26,6 @@ func (s *REST) New() runtime.Object {
 	return &deployapi.DeploymentConfig{}
 }
 
-func (s *REST) Get(ctx apirequest.Context, id string) (runtime.Object, error) {
+func (s *REST) Get(ctx apirequest.Context, id string, _ *metav1.GetOptions) (runtime.Object, error) {
 	return s.generator.Generate(ctx, id)
 }

--- a/pkg/deploy/registry/rollback/rest.go
+++ b/pkg/deploy/registry/rollback/rest.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
@@ -24,6 +25,8 @@ type REST struct {
 	rn        kcoreclient.ReplicationControllersGetter
 	codec     runtime.Codec
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST safely creates a new REST.
 func NewREST(oc client.Interface, kc kclientset.Interface, codec runtime.Codec) *REST {

--- a/pkg/deploy/registry/rollback/rest_deprecated.go
+++ b/pkg/deploy/registry/rollback/rest_deprecated.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
@@ -20,6 +21,8 @@ type DeprecatedREST struct {
 	generator GeneratorClient
 	codec     runtime.Codec
 }
+
+var _ rest.Creater = &REST{}
 
 // GeneratorClient defines a local interface to a rollback generator for testability.
 type GeneratorClient interface {

--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a new REST.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/image/registry/imagesecret/rest.go
+++ b/pkg/image/registry/imagesecret/rest.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
@@ -16,6 +17,8 @@ import (
 type REST struct {
 	secrets kcoreclient.SecretsGetter
 }
+
+var _ rest.GetterWithOptions = &REST{}
 
 // NewREST returns a new REST.
 func NewREST(secrets kcoreclient.SecretsGetter) *REST {

--- a/pkg/image/registry/imagesignature/rest.go
+++ b/pkg/image/registry/imagesignature/rest.go
@@ -18,6 +18,9 @@ type REST struct {
 	imageClient client.ImageInterface
 }
 
+var _ rest.Creater = &REST{}
+var _ rest.Deleter = &REST{}
+
 // NewREST returns a new REST.
 func NewREST(imageClient client.ImageInterface) *REST {
 	return &REST{imageClient: imageClient}

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -22,6 +22,8 @@ type REST struct {
 	subjectAccessReviewRegistry subjectaccessreview.Registry
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a new REST.
 func NewREST(optsGetter restoptions.Getter, defaultRegistry imageapi.DefaultRegistry, subjectAccessReviewRegistry subjectaccessreview.Registry, limitVerifier imageadmission.LimitVerifier) (*REST, *StatusREST, *InternalREST, error) {
 	store := registry.Store{
@@ -71,6 +73,9 @@ type StatusREST struct {
 	store *registry.Store
 }
 
+var _ rest.Getter = &StatusREST{}
+var _ rest.Updater = &StatusREST{}
+
 // StatusREST implements Patcher
 var _ = rest.Patcher(&StatusREST{})
 
@@ -92,6 +97,9 @@ func (r *StatusREST) Update(ctx apirequest.Context, name string, objInfo rest.Up
 type InternalREST struct {
 	store *registry.Store
 }
+
+var _ rest.Creater = &InternalREST{}
+var _ rest.Updater = &InternalREST{}
 
 func (r *InternalREST) New() runtime.Object {
 	return &imageapi.ImageStream{}

--- a/pkg/image/registry/imagestreamimage/rest.go
+++ b/pkg/image/registry/imagestreamimage/rest.go
@@ -5,6 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/registry/image"
@@ -19,6 +20,8 @@ type REST struct {
 	imageRegistry       image.Registry
 	imageStreamRegistry imagestream.Registry
 }
+
+var _ rest.Getter = &REST{}
 
 // NewREST returns a new REST.
 func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry) *REST {

--- a/pkg/image/registry/imagestreamimport/rest.go
+++ b/pkg/image/registry/imagestreamimport/rest.go
@@ -51,6 +51,8 @@ type REST struct {
 	sarClient         client.SubjectAccessReviewInterface
 }
 
+var _ rest.Creater = &REST{}
+
 // NewREST returns a REST storage implementation that handles importing images. The clientFn argument is optional
 // if v1 Docker Registry importing is not required. Insecure transport is optional, and both transports should not
 // include client certs unless you wish to allow the entire cluster to import using those certs.

--- a/pkg/image/registry/imagestreammapping/rest.go
+++ b/pkg/image/registry/imagestreammapping/rest.go
@@ -31,6 +31,8 @@ type REST struct {
 	strategy            Strategy
 }
 
+var _ rest.Creater = &REST{}
+
 // NewREST returns a new REST.
 func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry, defaultRegistry imageapi.DefaultRegistry) *REST {
 	return &REST{

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -28,11 +28,10 @@ func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Regis
 	return &REST{imageRegistry: imageRegistry, imageStreamRegistry: imageStreamRegistry}
 }
 
-var _ rest.Creater = &REST{}
-var _ rest.Lister = &REST{}
 var _ rest.Getter = &REST{}
+var _ rest.Lister = &REST{}
+var _ rest.CreaterUpdater = &REST{}
 var _ rest.Deleter = &REST{}
-var _ rest.Updater = &REST{}
 
 // New is only implemented to make REST implement RESTStorage
 func (r *REST) New() runtime.Object {

--- a/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
@@ -22,6 +22,8 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against access tokens
 func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter, backends ...storage.Interface) (*REST, error) {
 	strategy := oauthaccesstoken.NewStrategy(clientGetter)

--- a/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
@@ -16,6 +17,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against authorize tokens
 func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*REST, error) {

--- a/pkg/oauth/registry/oauthclient/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclient/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against oauth clients
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
@@ -16,6 +17,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against oauth clients
 func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*REST, error) {

--- a/pkg/project/registry/project/proxy/proxy.go
+++ b/pkg/project/registry/project/proxy/proxy.go
@@ -40,6 +40,11 @@ type REST struct {
 	projectCache *projectcache.ProjectCache
 }
 
+var _ rest.Lister = &REST{}
+var _ rest.CreaterUpdater = &REST{}
+var _ rest.Deleter = &REST{}
+var _ rest.Watcher = &REST{}
+
 // NewREST returns a RESTStorage object that will work against Project resources
 func NewREST(client kcoreclient.NamespaceInterface, lister projectauth.Lister, authCache *projectauth.AuthorizationCache, projectCache *projectcache.ProjectCache) *REST {
 	return &REST{
@@ -62,8 +67,6 @@ func (s *REST) New() runtime.Object {
 func (*REST) NewList() runtime.Object {
 	return &projectapi.ProjectList{}
 }
-
-var _ = rest.Lister(&REST{})
 
 // List retrieves a list of Projects that match label.
 

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -44,6 +44,9 @@ type REST struct {
 	policyBindings authorizationlister.PolicyBindingLister
 }
 
+var _ rest.Lister = &REST{}
+var _ rest.Creater = &REST{}
+
 func NewREST(message, templateNamespace, templateName string, openshiftClient *client.Client, restConfig *restclient.Config, policyBindingCache authorizationlister.PolicyBindingLister) *REST {
 	return &REST{
 		message:           message,

--- a/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
@@ -18,6 +18,8 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against ClusterResourceQuota objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, error) {
 	store := &registry.Store{

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -6,12 +6,13 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapirest "k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/route"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
-	rest "github.com/openshift/origin/pkg/route/registry/route"
+	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -19,15 +20,17 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against routes.
-func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarClient rest.SubjectAccessReviewInterface) (*REST, *StatusREST, error) {
-	strategy := rest.NewStrategy(allocator, sarClient)
+func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarClient routeregistry.SubjectAccessReviewInterface) (*REST, *StatusREST, error) {
+	strategy := routeregistry.NewStrategy(allocator, sarClient)
 
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
 		NewFunc:           func() runtime.Object { return &routeapi.Route{} },
 		NewListFunc:       func() runtime.Object { return &routeapi.RouteList{} },
-		PredicateFunc:     rest.Matcher,
+		PredicateFunc:     routeregistry.Matcher,
 		QualifiedResource: routeapi.Resource("routes"),
 
 		CreateStrategy: strategy,
@@ -35,13 +38,13 @@ func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarC
 		DeleteStrategy: strategy,
 	}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: rest.GetAttrs}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: routeregistry.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, nil, err
 	}
 
 	statusStore := *store
-	statusStore.UpdateStrategy = rest.StatusStrategy
+	statusStore.UpdateStrategy = routeregistry.StatusStrategy
 
 	return &REST{store}, &StatusREST{&statusStore}, nil
 }

--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against subnets
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
+++ b/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against egress network policy
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/sdn/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/sdn/registry/hostsubnet/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against subnets
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/sdn/registry/netnamespace/etcd/etcd.go
+++ b/pkg/sdn/registry/netnamespace/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	sdnapi "github.com/openshift/origin/pkg/sdn/apis/network"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against netnamespaces
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/security/registry/podsecuritypolicyreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicyreview/rest.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
@@ -28,6 +29,8 @@ type REST struct {
 	saCache    kcorelisters.ServiceAccountLister
 	client     clientset.Interface
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST creates a new REST for policies..
 func NewREST(m oscc.SCCMatcher, saCache kcorelisters.ServiceAccountLister, c clientset.Interface) *REST {

--- a/pkg/security/registry/podsecuritypolicyselfsubjectreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicyselfsubjectreview/rest.go
@@ -8,6 +8,7 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/serviceaccount"
@@ -24,6 +25,8 @@ type REST struct {
 	sccMatcher oscc.SCCMatcher
 	client     clientset.Interface
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST creates a new REST for policies..
 func NewREST(m oscc.SCCMatcher, c clientset.Interface) *REST {

--- a/pkg/security/registry/podsecuritypolicysubjectreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicysubjectreview/rest.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapiref "k8s.io/kubernetes/pkg/api/ref"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -27,6 +28,8 @@ type REST struct {
 	sccMatcher oscc.SCCMatcher
 	client     clientset.Interface
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST creates a new REST for policies..
 func NewREST(m oscc.SCCMatcher, c clientset.Interface) *REST {

--- a/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
+++ b/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against security context constraints objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {

--- a/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
+++ b/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
@@ -4,10 +4,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
-	rest "github.com/openshift/origin/pkg/template/registry/brokertemplateinstance"
+	"github.com/openshift/origin/pkg/template/registry/brokertemplateinstance"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -16,21 +17,23 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against brokertemplateinstances.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
 		NewFunc:           func() runtime.Object { return &templateapi.BrokerTemplateInstance{} },
 		NewListFunc:       func() runtime.Object { return &templateapi.BrokerTemplateInstanceList{} },
-		PredicateFunc:     rest.Matcher,
+		PredicateFunc:     brokertemplateinstance.Matcher,
 		QualifiedResource: templateapi.Resource("brokertemplateinstances"),
 
-		CreateStrategy: rest.Strategy,
-		UpdateStrategy: rest.Strategy,
-		DeleteStrategy: rest.Strategy,
+		CreateStrategy: brokertemplateinstance.Strategy,
+		UpdateStrategy: brokertemplateinstance.Strategy,
+		DeleteStrategy: brokertemplateinstance.Strategy,
 	}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: rest.GetAttrs}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: brokertemplateinstance.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, err
 	}

--- a/pkg/template/registry/template/etcd/etcd.go
+++ b/pkg/template/registry/template/etcd/etcd.go
@@ -4,10 +4,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
-	rest "github.com/openshift/origin/pkg/template/registry/template"
+	"github.com/openshift/origin/pkg/template/registry/template"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -16,23 +17,25 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against templates.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
 		NewFunc:           func() runtime.Object { return &templateapi.Template{} },
 		NewListFunc:       func() runtime.Object { return &templateapi.TemplateList{} },
-		PredicateFunc:     rest.Matcher,
+		PredicateFunc:     template.Matcher,
 		QualifiedResource: templateapi.Resource("templates"),
 
-		CreateStrategy: rest.Strategy,
-		UpdateStrategy: rest.Strategy,
-		DeleteStrategy: rest.Strategy,
+		CreateStrategy: template.Strategy,
+		UpdateStrategy: template.Strategy,
+		DeleteStrategy: template.Strategy,
 
 		ReturnDeletedObject: true,
 	}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: rest.GetAttrs}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: template.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, err
 	}

--- a/pkg/template/registry/template/rest.go
+++ b/pkg/template/registry/template/rest.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/openshift/origin/pkg/template"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
@@ -19,6 +20,8 @@ import (
 // REST implements RESTStorage interface for processing Template objects.
 type REST struct {
 }
+
+var _ rest.Creater = &REST{}
 
 // NewREST creates new RESTStorage interface for processing Template objects. If
 // legacyReturn is used, a Config object is returned. Otherwise, a List is returned

--- a/pkg/template/registry/templateinstance/etcd/etcd.go
+++ b/pkg/template/registry/templateinstance/etcd/etcd.go
@@ -6,12 +6,12 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	kapirest "k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
-	rest "github.com/openshift/origin/pkg/template/registry/templateinstance"
+	"github.com/openshift/origin/pkg/template/registry/templateinstance"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -20,15 +20,17 @@ type REST struct {
 	*registry.Store
 }
 
+var _ rest.StandardStorage = &REST{}
+
 // NewREST returns a RESTStorage object that will work against templateinstances.
 func NewREST(optsGetter restoptions.Getter, kc kclientset.Interface) (*REST, *StatusREST, error) {
-	strategy := rest.NewStrategy(kc)
+	strategy := templateinstance.NewStrategy(kc)
 
 	store := &registry.Store{
 		Copier:            kapi.Scheme,
 		NewFunc:           func() runtime.Object { return &templateapi.TemplateInstance{} },
 		NewListFunc:       func() runtime.Object { return &templateapi.TemplateInstanceList{} },
-		PredicateFunc:     rest.Matcher,
+		PredicateFunc:     templateinstance.Matcher,
 		QualifiedResource: templateapi.Resource("templateinstances"),
 
 		CreateStrategy: strategy,
@@ -36,13 +38,13 @@ func NewREST(optsGetter restoptions.Getter, kc kclientset.Interface) (*REST, *St
 		DeleteStrategy: strategy,
 	}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: rest.GetAttrs}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: templateinstance.GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
 		return nil, nil, err
 	}
 
 	statusStore := *store
-	statusStore.UpdateStrategy = rest.StatusStrategy
+	statusStore.UpdateStrategy = templateinstance.StatusStrategy
 
 	return &REST{store}, &StatusREST{&statusStore}, nil
 }
@@ -53,7 +55,7 @@ type StatusREST struct {
 }
 
 // StatusREST implements Patcher
-var _ = kapirest.Patcher(&StatusREST{})
+var _ = rest.Patcher(&StatusREST{})
 
 // New creates a new templateInstance resource
 func (r *StatusREST) New() runtime.Object {
@@ -66,6 +68,6 @@ func (r *StatusREST) Get(ctx request.Context, name string, options *metav1.GetOp
 }
 
 // Update alters the status subset of an object.
-func (r *StatusREST) Update(ctx request.Context, name string, objInfo kapirest.UpdatedObjectInfo) (runtime.Object, bool, error) {
+func (r *StatusREST) Update(ctx request.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo)
 }

--- a/pkg/user/registry/identity/etcd/etcd.go
+++ b/pkg/user/registry/identity/etcd/etcd.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
@@ -15,6 +16,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against identites
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/user/registry/user/etcd/etcd.go
+++ b/pkg/user/registry/user/etcd/etcd.go
@@ -12,6 +12,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -25,6 +26,8 @@ import (
 type REST struct {
 	*registry.Store
 }
+
+var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against users
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {

--- a/pkg/user/registry/useridentitymapping/rest.go
+++ b/pkg/user/registry/useridentitymapping/rest.go
@@ -26,6 +26,10 @@ type REST struct {
 	identityRegistry identity.Registry
 }
 
+var _ rest.Getter = &REST{}
+var _ rest.CreaterUpdater = &REST{}
+var _ rest.Deleter = &REST{}
+
 // NewREST returns a new REST.
 func NewREST(userRegistry user.Registry, identityRegistry identity.Registry) *REST {
 	return &REST{userRegistry: userRegistry, identityRegistry: identityRegistry}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15268

This just adds type assertions to all the registry types to avoid losing verbs on REST storage during rebases silently because that really really sucks.

