### PR TITLE
Add gRPC client side metrics to apiservers

### DIFF
--- a/pkg/cmd/server/etcd/etcd.go
+++ b/pkg/cmd/server/etcd/etcd.go
@@ -112,6 +112,7 @@ func MakeEtcdClientV3Config(etcdClientInfo configapi.EtcdConnectionInfo) (*clien
 		Endpoints:   etcdClientInfo.URLs,
 		DialTimeout: 30 * time.Second,
 		TLS:         tlsConfig,
+		DialOptions: clientv3.PrometheusInterceptors(),
 	}, nil
 }
 

--- a/vendor/github.com/coreos/etcd/clientv3/metrics.go
+++ b/vendor/github.com/coreos/etcd/clientv3/metrics.go
@@ -1,0 +1,19 @@
+package clientv3
+
+// This file exposes constructors for DialOptions that are not accessible to the caller
+// because etcd maintains its own vendoring tree. Once the need for the gRPC vendor tree
+// is removed, this file can be removed and direct initialization provided.
+
+import (
+	prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"google.golang.org/grpc"
+)
+
+// PrometheusInterceptors initializes grpc.DialOptions for monitoring the etcdv3 client
+// via prometheus. It is exposed here so that callers can access the vendored types.
+func PrometheusInterceptors() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithUnaryInterceptor(prometheus.UnaryClientInterceptor),
+		grpc.WithStreamInterceptor(prometheus.StreamClientInterceptor),
+	}
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -43,8 +43,9 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 		tlsConfig = nil
 	}
 	cfg := clientv3.Config{
-		Endpoints: c.ServerList,
-		TLS:       tlsConfig,
+		Endpoints:   c.ServerList,
+		TLS:         tlsConfig,
+		DialOptions: clientv3.PrometheusInterceptors(),
 	}
 	client, err := clientv3.New(cfg)
 	if err != nil {


### PR DESCRIPTION
Better than nothing, even though this requires carries due to the vendoring of grpc under etcd.