### PR TITLE
UPSTREAM: 44756: Don't call spew unless we're logging

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -505,7 +505,9 @@ func buildServiceMap(allServices []*api.Service, oldServiceMap proxyServiceMap) 
 			}
 
 			newServiceMap[serviceName] = info
-			glog.V(4).Infof("added serviceInfo(%s): %s", serviceName, spew.Sdump(info))
+			if glog.V(4) {
+				glog.Infof("added serviceInfo(%s): %s", serviceName, spew.Sdump(info))
+			}
 		}
 	}
 


### PR DESCRIPTION
This is 10% of node CPU measured on large clusters, and may be causing even more allocations. Is effectively zero risk and high value.