### PR TITLE
Update list of allowed runAsUser types in the error message

### DIFF
--- a/pkg/security/apis/security/validation/scc_validation_test.go
+++ b/pkg/security/apis/security/validation/scc_validation_test.go
@@ -103,7 +103,7 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 		"no user options": {
 			scc:         noUserOptions,
 			errorType:   field.ErrorTypeInvalid,
-			errorDetail: "invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, RunAsAny",
+			errorDetail: "invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, MustRunAsRange, RunAsAny",
 		},
 		"no selinux options": {
 			scc:         noSELinuxOptions,
@@ -123,7 +123,7 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 		"invalid user strategy type": {
 			scc:         invalidUserStratType,
 			errorType:   field.ErrorTypeInvalid,
-			errorDetail: "invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, RunAsAny",
+			errorDetail: "invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, MustRunAsRange, RunAsAny",
 		},
 		"invalid selinux strategy type": {
 			scc:         invalidSELinuxStratType,
@@ -189,7 +189,7 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 
 	for k, v := range errorCases {
 		if errs := ValidateSecurityContextConstraints(v.scc); len(errs) == 0 || errs[0].Type != v.errorType || errs[0].Detail != v.errorDetail {
-			t.Errorf("Expected error type %s with detail %s for %s, got %v", v.errorType, v.errorDetail, k, errs)
+			t.Errorf("Expected error type %q with detail %q for %q, got %v", v.errorType, v.errorDetail, k, errs)
 		}
 	}
 

--- a/pkg/security/apis/security/validation/validation.go
+++ b/pkg/security/apis/security/validation/validation.go
@@ -33,7 +33,7 @@ func ValidateSecurityContextConstraints(scc *securityapi.SecurityContextConstrai
 	case securityapi.RunAsUserStrategyMustRunAs, securityapi.RunAsUserStrategyMustRunAsNonRoot, securityapi.RunAsUserStrategyRunAsAny, securityapi.RunAsUserStrategyMustRunAsRange:
 		//good types
 	default:
-		msg := fmt.Sprintf("invalid strategy type.  Valid values are %s, %s, %s", securityapi.RunAsUserStrategyMustRunAs, securityapi.RunAsUserStrategyMustRunAsNonRoot, securityapi.RunAsUserStrategyRunAsAny)
+		msg := fmt.Sprintf("invalid strategy type.  Valid values are %s, %s, %s, %s", securityapi.RunAsUserStrategyMustRunAs, securityapi.RunAsUserStrategyMustRunAsNonRoot, securityapi.RunAsUserStrategyMustRunAsRange, securityapi.RunAsUserStrategyRunAsAny)
 		allErrs = append(allErrs, field.Invalid(runAsUserPath.Child("type"), scc.RunAsUser.Type, msg))
 	}
 


### PR DESCRIPTION
`MustRunAsRange` strategy is missing in the list of valid strategies:

>$ oc create -f total-restricted.yaml
>The SecurityContextConstraints "total-restricted" is invalid: runAsUser.type: Invalid value: "MustRunAsRage": invalid strategy type.  Valid values are MustRunAs, MustRunAsNonRoot, RunAsAny

This PR adds it.

PTAL @pweil- @simo5 