### PR TITLE
Improve release process to fail faster on typical issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ clean:
 #
 # Example:
 #   make release
-official-release: build-rpms build-cross
+official-release: build-cross build-rpms
 	hack/build-images.sh
 .PHONY: official-release
 

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -52,9 +52,6 @@ if [[ -z "${tito_output_directory}" ]]; then
         os::log::fatal 'No _output artifact directory found in tito rpmbuild artifacts!'
 fi
 
-# clean up our local state so we can unpack the tito artifacts cleanly
-make clean
-
 # migrate the tito artifacts to the Origin directory
 mkdir -p "${OS_OUTPUT}"
 # mv exits prematurely with status 1 in the following scenario: running as root,
@@ -70,6 +67,7 @@ else
   cp -R "${tito_output_directory}"/* "${OS_OUTPUT}"
   rm -rf "${tito_output_directory}"/*
 fi
+rm -rf "${OS_OUTPUT_RPMPATH}"
 mkdir -p "${OS_OUTPUT_RPMPATH}"
 mv "${tito_tmp_dir}"/*src.rpm "${OS_OUTPUT_RPMPATH}"
 mv "${tito_tmp_dir}"/*/*.rpm "${OS_OUTPUT_RPMPATH}"

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -27,7 +27,7 @@ mkdir -p "${tito_tmp_dir}"
 tito build --offline --srpm --rpmbuild-options="--define 'dist .el7'" --output="${tito_tmp_dir}"
 tito build --output="${tito_tmp_dir}" --rpm --no-cleanup --quiet --offline \
            --rpmbuild-options="--define 'make_redistributable ${make_redistributable}' ${RPM_BUILD_OPTS:-}"
-tito tag --undo --offline
+tito tag --undo --offline || true
 
 os::log::info 'Unpacking tito artifacts for reuse...'
 output_directories=( $( find "${tito_tmp_dir}" -type d -name "rpmbuild-${OS_RPM_NAME}*" ) )

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -15,10 +15,12 @@ elif [[ "$( git rev-parse "${tag}" )" != "$( git rev-parse HEAD )" ]]; then
 fi
 commit="$( git rev-parse ${tag} )"
 
-# Ensure that the build is using the latest release image
-docker pull "${OS_BUILD_ENV_IMAGE}"
+# Ensure that the build is using the latest release image and base content
+if [[ -z "${OS_RELEASE_STALE-}" ]]; then
+  docker pull "${OS_BUILD_ENV_IMAGE}"
+  hack/build-base-images.sh
+fi
 
-hack/build-base-images.sh
 hack/env OS_GIT_COMMIT="${commit}" make official-release
 OS_PUSH_ALWAYS=1 OS_PUSH_TAG="${tag}" OS_TAG="" OS_PUSH_LOCAL="1" hack/push-release.sh
 


### PR DESCRIPTION
We break more in build-cross.sh today, and it should be possible to skip
rebuilding base images multiple times.