### PR TITLE
Cleanup integration tests for use with etcd3 and parallelism

### DIFF
--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -552,11 +552,19 @@ func StartAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig, informers *i
 
 	// verify we can connect to etcd with the provided config
 	if len(kc.Options.APIServerArguments) > 0 && len(kc.Options.APIServerArguments["storage-backend"]) > 0 && kc.Options.APIServerArguments["storage-backend"][0] == "etcd3" {
-		if _, err := etcd.GetAndTestEtcdClientV3(oc.Options.EtcdClientInfo); err != nil {
+		etcdClient, err := etcd.MakeEtcdClientV3(oc.Options.EtcdClientInfo)
+		if err != nil {
+			return err
+		}
+		if err := etcd.TestEtcdClientV3(etcdClient); err != nil {
 			return err
 		}
 	} else {
-		if _, err := etcd.GetAndTestEtcdClient(oc.Options.EtcdClientInfo); err != nil {
+		etcdClient, err := etcd.MakeEtcdClient(oc.Options.EtcdClientInfo)
+		if err != nil {
+			return err
+		}
+		if err := etcd.TestEtcdClient(etcdClient); err != nil {
 			return err
 		}
 	}

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -33,8 +33,7 @@ type TestPluginConfig struct {
 
 func (obj *TestPluginConfig) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
 
-func setupAdmissionTest(t *testing.T, setupConfig func(*configapi.MasterConfig)) (kclientset.Interface, *client.Client) {
-	testutil.RequireEtcd(t)
+func setupAdmissionTest(t *testing.T, setupConfig func(*configapi.MasterConfig)) (kclientset.Interface, *client.Client, func()) {
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -52,7 +51,9 @@ func setupAdmissionTest(t *testing.T, setupConfig func(*configapi.MasterConfig))
 	if err != nil {
 		t.Fatalf("error getting openshift client: %v", err)
 	}
-	return kubeClient, openshiftClient
+	return kubeClient, openshiftClient, func() {
+		testserver.CleanupMasterEtcd(t, masterConfig)
+	}
 }
 
 // testAdmissionPlugin sets a label with its name on the object getting admitted
@@ -191,11 +192,11 @@ func setupAdmissionPluginTestConfig(t *testing.T, value string) string {
 }
 
 func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
-	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
+	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 	})
+	defer fn()
 
 	createdPod, err := kubeClient.Core().Pods(metav1.NamespaceDefault).Create(admissionTestPod())
 	if err != nil {
@@ -207,11 +208,10 @@ func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
 }
 
 func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	configFile := setupAdmissionPluginTestConfig(t, "plugin1configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
-	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
+	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 		config.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin1": {
@@ -219,6 +219,7 @@ func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
 			},
 		}
 	})
+	defer fn()
 	createdPod, err := kubeClient.Core().Pods(metav1.NamespaceDefault).Create(admissionTestPod())
 	if err = checkAdmissionObjectLabelValues(createdPod.Labels, map[string]string{"plugin1": "plugin1configvalue", "plugin2": "default"}); err != nil {
 		t.Errorf("Error: %v", err)
@@ -226,10 +227,9 @@ func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
 }
 
 func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
-	kubeClient, _ := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
+	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 		config.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin1": {
@@ -239,6 +239,7 @@ func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
 			},
 		}
 	})
+	defer fn()
 	createdPod, err := kubeClient.Core().Pods(metav1.NamespaceDefault).Create(admissionTestPod())
 	if err = checkAdmissionObjectLabelValues(createdPod.Labels, map[string]string{"plugin1": "embeddedvalue1", "plugin2": "default"}); err != nil {
 		t.Errorf("Error: %v", err)
@@ -246,11 +247,11 @@ func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginOrderOverride(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
-	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
+	_, openshiftClient, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 	})
+	defer fn()
 
 	createdBuild, err := openshiftClient.Builds(metav1.NamespaceDefault).Create(admissionTestBuild())
 	if err != nil {
@@ -262,11 +263,10 @@ func TestOpenshiftAdmissionPluginOrderOverride(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	configFile := setupAdmissionPluginTestConfig(t, "plugin2configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
-	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
+	_, openshiftClient, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 		config.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin2": {
@@ -274,6 +274,7 @@ func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
 			},
 		}
 	})
+	defer fn()
 	createdBuild, err := openshiftClient.Builds(metav1.NamespaceDefault).Create(admissionTestBuild())
 	if err = checkAdmissionObjectLabelValues(createdBuild.Labels, map[string]string{"plugin1": "default", "plugin2": "plugin2configvalue"}); err != nil {
 		t.Errorf("Error: %v", err)
@@ -281,10 +282,9 @@ func TestOpenshiftAdmissionPluginConfigFile(t *testing.T) {
 }
 
 func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
-	_, openshiftClient := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
+	_, openshiftClient, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
 		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 		config.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin2": {
@@ -294,6 +294,7 @@ func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
 			},
 		}
 	})
+	defer fn()
 	createdBuild, err := openshiftClient.Builds(metav1.NamespaceDefault).Create(admissionTestBuild())
 	if err = checkAdmissionObjectLabelValues(createdBuild.Labels, map[string]string{"plugin1": "default", "plugin2": "embeddedvalue2"}); err != nil {
 		t.Errorf("Error: %v", err)
@@ -301,13 +302,11 @@ func TestOpenshiftAdmissionPluginEmbeddedConfig(t *testing.T) {
 }
 
 func TestAlwaysPullImagesOn(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"AlwaysPullImages": {
 			Configuration: &configapi.DefaultAdmissionConfig{},
@@ -352,13 +351,11 @@ func TestAlwaysPullImagesOn(t *testing.T) {
 }
 
 func TestAlwaysPullImagesOff(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, kubeConfigFile, err := testserver.StartTestMaster()
+	masterConfig, kubeConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting server: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	kubeClientset, err := testutil.GetClusterAdminKubeClient(kubeConfigFile)
 	if err != nil {
 		t.Fatalf("error getting client: %v", err)

--- a/test/integration/aggregator_test.go
+++ b/test/integration/aggregator_test.go
@@ -17,13 +17,11 @@ import (
 )
 
 func TestAggregator(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	// Set up the aggregator ca and proxy cert
 	caDir, err := ioutil.TempDir("", "aggregator-ca")

--- a/test/integration/api_paths_test.go
+++ b/test/integration/api_paths_test.go
@@ -17,13 +17,11 @@ import (
 )
 
 func TestRootAPIPaths(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, adminConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error starting test master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clientConfig, err := testutil.GetClusterAdminClientConfig(adminConfigFile)
 	if err != nil {

--- a/test/integration/auth_proxy_test.go
+++ b/test/integration/auth_proxy_test.go
@@ -31,13 +31,11 @@ func TestAuthProxyOnAuthorize(t *testing.T) {
 	idp.Provider = &configapi.RequestHeaderIdentityProvider{Headers: []string{"X-Remote-User"}}
 	idp.MappingMethod = "claim"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.OAuthConfig.IdentityProviders = []configapi.IdentityProvider{idp}
 
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -91,13 +91,11 @@ func prettyPrintReviewResponse(resp *authorizationapi.ResourceAccessReviewRespon
 }
 
 func TestClusterReaderCoverage(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -198,13 +196,11 @@ func TestClusterReaderCoverage(t *testing.T) {
 }
 
 func TestAuthorizationRestrictedAccessForProjectAdmins(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -271,13 +267,11 @@ func waitForProject(t *testing.T, client client.Interface, projectName string, d
 }
 
 func TestAuthorizationResolution(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -507,13 +501,11 @@ func (test localResourceAccessReviewTest) run(t *testing.T) {
 }
 
 func TestAuthorizationResourceAccessReview(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -846,13 +838,11 @@ func toKubeClusterSAR(sar *authorizationapi.SubjectAccessReview) *kubeauthorizat
 }
 
 func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -990,13 +980,11 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 }
 
 func TestAuthorizationSubjectAccessReview(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -1434,13 +1422,11 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 // TestOldLocalSubjectAccessReviewEndpoint checks to make sure that the old subject access review endpoint still functions properly
 // this is needed to support old docker registry images
 func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -1563,13 +1549,11 @@ func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 // TestOldLocalResourceAccessReviewEndpoint checks to make sure that the old resource access review endpoint still functions properly
 // this is needed to support old who-can client
 func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -1644,13 +1628,11 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 
 // TestClusterPolicyCache confirms that the creation of cluster role bindings fallback to live lookups when the referenced cluster role is not cached
 func TestClusterPolicyCache(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -1676,13 +1658,11 @@ func TestClusterPolicyCache(t *testing.T) {
 
 // TestPolicyCache confirms that the creation of role bindings fallback to live lookups when the referenced role is not cached
 func TestPolicyCache(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/bootstrap_policy_test.go
+++ b/test/integration/bootstrap_policy_test.go
@@ -20,13 +20,11 @@ import (
 )
 
 func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
@@ -78,13 +76,11 @@ func TestBootstrapPolicyAuthenticatedUsersAgainstOpenshiftNamespace(t *testing.T
 }
 
 func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	client, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -125,13 +121,11 @@ func TestBootstrapPolicyOverwritePolicyCommand(t *testing.T) {
 }
 
 func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
@@ -175,13 +169,11 @@ func TestBootstrapPolicySelfSubjectAccessReviews(t *testing.T) {
 }
 
 func TestSelfSubjectAccessReviewsNonExistingNamespace(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/build_admission_test.go
+++ b/test/integration/build_admission_test.go
@@ -9,6 +9,7 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/client"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	policy "github.com/openshift/origin/pkg/oc/admin/policy"
 	testutil "github.com/openshift/origin/test/util"
@@ -27,8 +28,8 @@ func buildStrategyTypesRestricted() []string {
 }
 
 func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, false)
+	clusterAdminClient, projectAdminClient, projectEditorClient, fn := setupBuildStrategyTest(t, false)
+	defer fn()
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
 	builds := map[string]*buildapi.Build{}
@@ -103,8 +104,8 @@ func TestPolicyBasedRestrictionOfBuildCreateAndCloneByStrategy(t *testing.T) {
 }
 
 func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	clusterAdminClient, projectAdminClient, projectEditorClient := setupBuildStrategyTest(t, true)
+	clusterAdminClient, projectAdminClient, projectEditorClient, fn := setupBuildStrategyTest(t, true)
+	defer fn()
 
 	clients := map[string]*client.Client{"admin": projectAdminClient, "editor": projectEditorClient}
 	buildConfigs := map[string]*buildapi.BuildConfig{}
@@ -178,19 +179,22 @@ func TestPolicyBasedRestrictionOfBuildConfigCreateAndInstantiateByStrategy(t *te
 	}
 }
 
-func setupBuildStrategyTest(t *testing.T, includeControllers bool) (clusterAdminClient, projectAdminClient, projectEditorClient *client.Client) {
-	testutil.RequireEtcd(t)
+func setupBuildStrategyTest(t *testing.T, includeControllers bool) (clusterAdminClient, projectAdminClient, projectEditorClient *client.Client, cleanup func()) {
 	namespace := testutil.Namespace()
 	var clusterAdminKubeConfig string
+	var masterConfig *configapi.MasterConfig
 	var err error
 
 	if includeControllers {
-		_, clusterAdminKubeConfig, err = testserver.StartTestMaster()
+		masterConfig, clusterAdminKubeConfig, err = testserver.StartTestMaster()
 	} else {
-		_, clusterAdminKubeConfig, err = testserver.StartTestMasterAPI()
+		masterConfig, clusterAdminKubeConfig, err = testserver.StartTestMasterAPI()
 	}
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	cleanup = func() {
+		testserver.CleanupMasterEtcd(t, masterConfig)
 	}
 
 	clusterAdminClient, err = testutil.GetClusterAdminClient(clusterAdminKubeConfig)

--- a/test/integration/buildpod_admission_test.go
+++ b/test/integration/buildpod_admission_test.go
@@ -27,11 +27,11 @@ import (
 var buildPodAdmissionTestTimeout time.Duration = 30 * time.Second
 
 func TestBuildDefaultGitHTTPProxy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	httpProxy := "http://my.test.proxy:12345"
-	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
+	oclient, kclientset, fn := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		GitHTTPProxy: httpProxy,
 	})
+	defer fn()
 	build, _ := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := build.Spec.Source.Git.HTTPProxy; actual == nil || *actual != httpProxy {
 		t.Errorf("Resulting build did not get expected HTTP proxy: %v", actual)
@@ -39,11 +39,11 @@ func TestBuildDefaultGitHTTPProxy(t *testing.T) {
 }
 
 func TestBuildDefaultGitHTTPSProxy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	httpsProxy := "https://my.test.proxy:12345"
-	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
+	oclient, kclientset, fn := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		GitHTTPSProxy: httpsProxy,
 	})
+	defer fn()
 	build, _ := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := build.Spec.Source.Git.HTTPSProxy; actual == nil || *actual != httpsProxy {
 		t.Errorf("Resulting build did not get expected HTTPS proxy: %v", actual)
@@ -51,7 +51,6 @@ func TestBuildDefaultGitHTTPSProxy(t *testing.T) {
 }
 
 func TestBuildDefaultEnvironment(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	env := []kapi.EnvVar{
 		{
 			Name:  "VAR1",
@@ -62,9 +61,10 @@ func TestBuildDefaultEnvironment(t *testing.T) {
 			Value: "VALUE2",
 		},
 	}
-	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
+	oclient, kclientset, fn := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		Env: env,
 	})
+	defer fn()
 	build, _ := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := build.Spec.Strategy.DockerStrategy.Env; !reflect.DeepEqual(env, actual) {
 		t.Errorf("Resulting build did not get expected environment: %v", actual)
@@ -72,11 +72,11 @@ func TestBuildDefaultEnvironment(t *testing.T) {
 }
 
 func TestBuildDefaultLabels(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	labels := []buildapi.ImageLabel{{Name: "KEY", Value: "VALUE"}}
-	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
+	oclient, kclientset, fn := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		ImageLabels: labels,
 	})
+	defer fn()
 	build, _ := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := build.Spec.Output.ImageLabels; !reflect.DeepEqual(labels, actual) {
 		t.Errorf("Resulting build did not get expected labels: %v", actual)
@@ -84,11 +84,11 @@ func TestBuildDefaultLabels(t *testing.T) {
 }
 
 func TestBuildDefaultNodeSelectors(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	selectors := map[string]string{"KEY": "VALUE"}
-	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
+	oclient, kclientset, fn := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		NodeSelector: selectors,
 	})
+	defer fn()
 	_, pod := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := pod.Spec.NodeSelector; !reflect.DeepEqual(selectors, actual) {
 		t.Errorf("Resulting pod did not get expected nodeselectors: %v", actual)
@@ -96,11 +96,11 @@ func TestBuildDefaultNodeSelectors(t *testing.T) {
 }
 
 func TestBuildDefaultAnnotations(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	annotations := map[string]string{"KEY": "VALUE"}
-	oclient, kclientset := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
+	oclient, kclientset, fn := setupBuildDefaultsAdmissionTest(t, &defaultsapi.BuildDefaultsConfig{
 		Annotations: annotations,
 	})
+	defer fn()
 	_, pod := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := pod.Annotations; strings.Compare(actual["KEY"], annotations["KEY"]) != 0 {
 		t.Errorf("Resulting pod did not get expected annotations: actual: %v, expected: %v", actual["KEY"], annotations["KEY"])
@@ -108,10 +108,10 @@ func TestBuildDefaultAnnotations(t *testing.T) {
 }
 
 func TestBuildOverrideForcePull(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
+	oclient, kclientset, fn := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ForcePull: true,
 	})
+	defer fn()
 	build, _ := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if !build.Spec.Strategy.DockerStrategy.ForcePull {
 		t.Errorf("ForcePull was not set on resulting build")
@@ -119,10 +119,10 @@ func TestBuildOverrideForcePull(t *testing.T) {
 }
 
 func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
+	oclient, kclientset, fn := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ForcePull: true,
 	})
+	defer fn()
 	build, pod := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestCustomBuild())
 	if pod.Spec.Containers[0].ImagePullPolicy != v1.PullAlways {
 		t.Errorf("Pod ImagePullPolicy is not PullAlways")
@@ -133,11 +133,11 @@ func TestBuildOverrideForcePullCustomStrategy(t *testing.T) {
 }
 
 func TestBuildOverrideLabels(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	labels := []buildapi.ImageLabel{{Name: "KEY", Value: "VALUE"}}
-	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
+	oclient, kclientset, fn := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		ImageLabels: labels,
 	})
+	defer fn()
 	build, _ := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := build.Spec.Output.ImageLabels; !reflect.DeepEqual(labels, actual) {
 		t.Errorf("Resulting build did not get expected labels: %v", actual)
@@ -145,11 +145,11 @@ func TestBuildOverrideLabels(t *testing.T) {
 }
 
 func TestBuildOverrideNodeSelectors(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	selectors := map[string]string{"KEY": "VALUE"}
-	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
+	oclient, kclientset, fn := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		NodeSelector: selectors,
 	})
+	defer fn()
 	_, pod := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := pod.Spec.NodeSelector; !reflect.DeepEqual(selectors, actual) {
 		t.Errorf("Resulting build did not get expected nodeselectors: %v", actual)
@@ -157,11 +157,11 @@ func TestBuildOverrideNodeSelectors(t *testing.T) {
 }
 
 func TestBuildOverrideAnnotations(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	annotations := map[string]string{"KEY": "VALUE"}
-	oclient, kclientset := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
+	oclient, kclientset, fn := setupBuildOverridesAdmissionTest(t, &overridesapi.BuildOverridesConfig{
 		Annotations: annotations,
 	})
+	defer fn()
 	_, pod := runBuildPodAdmissionTest(t, oclient, kclientset, buildPodAdmissionTestDockerBuild())
 	if actual := pod.Annotations; strings.Compare(actual["KEY"], annotations["KEY"]) != 0 {
 		t.Errorf("Resulting build did not get expected annotations: %v", actual)
@@ -242,7 +242,7 @@ func runBuildPodAdmissionTest(t *testing.T, client *client.Client, kclientset kc
 	return nil, nil
 }
 
-func setupBuildDefaultsAdmissionTest(t *testing.T, defaultsConfig *defaultsapi.BuildDefaultsConfig) (*client.Client, kclientset.Interface) {
+func setupBuildDefaultsAdmissionTest(t *testing.T, defaultsConfig *defaultsapi.BuildDefaultsConfig) (*client.Client, kclientset.Interface, func()) {
 	return setupBuildPodAdmissionTest(t, map[string]configapi.AdmissionPluginConfig{
 		"BuildDefaults": {
 			Configuration: defaultsConfig,
@@ -250,7 +250,7 @@ func setupBuildDefaultsAdmissionTest(t *testing.T, defaultsConfig *defaultsapi.B
 	})
 }
 
-func setupBuildOverridesAdmissionTest(t *testing.T, overridesConfig *overridesapi.BuildOverridesConfig) (*client.Client, kclientset.Interface) {
+func setupBuildOverridesAdmissionTest(t *testing.T, overridesConfig *overridesapi.BuildOverridesConfig) (*client.Client, kclientset.Interface, func()) {
 	return setupBuildPodAdmissionTest(t, map[string]configapi.AdmissionPluginConfig{
 		"BuildOverrides": {
 			Configuration: overridesConfig,
@@ -258,8 +258,7 @@ func setupBuildOverridesAdmissionTest(t *testing.T, overridesConfig *overridesap
 	})
 }
 
-func setupBuildPodAdmissionTest(t *testing.T, pluginConfig map[string]configapi.AdmissionPluginConfig) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
+func setupBuildPodAdmissionTest(t *testing.T, pluginConfig map[string]configapi.AdmissionPluginConfig) (*client.Client, kclientset.Interface, func()) {
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)
@@ -305,5 +304,7 @@ func setupBuildPodAdmissionTest(t *testing.T, pluginConfig map[string]configapi.
 		t.Fatalf("%v", err)
 	}
 
-	return clusterAdminClient, clusterAdminKubeClientset
+	return clusterAdminClient, clusterAdminKubeClientset, func() {
+		testserver.CleanupMasterEtcd(t, master)
+	}
 }

--- a/test/integration/cli_get_token_test.go
+++ b/test/integration/cli_get_token_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 func TestCLIGetToken(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/clientset_test.go
+++ b/test/integration/clientset_test.go
@@ -20,12 +20,12 @@ import (
 
 func TestClientSet_v1_3(t *testing.T) {
 	const namespace = "test-clientset-v13"
-	testutil.RequireEtcd(t)
 
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -19,12 +19,11 @@ import (
 )
 
 func TestClusterQuota(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -18,12 +18,11 @@ import (
 func TestDeployScale(t *testing.T) {
 	const namespace = "test-deploy-scale"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -24,12 +24,11 @@ const maxUpdateRetries = 10
 func TestTriggers_manual(t *testing.T) {
 	const namespace = "test-triggers-manual"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -105,12 +104,11 @@ func TestTriggers_manual(t *testing.T) {
 // TestTriggers_imageChange ensures that a deployment config with an ImageChange trigger
 // will start a new deployment when an image change happens.
 func TestTriggers_imageChange(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	openshiftClusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatalf("error getting cluster admin client: %v", err)
@@ -211,12 +209,11 @@ waitForNewConfig:
 // TestTriggers_imageChange_nonAutomatic ensures that a deployment config with a non-automatic
 // trigger will have its image updated when a deployment is started manually.
 func TestTriggers_imageChange_nonAutomatic(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	openshiftClusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatalf("error getting cluster admin client: %v", err)
@@ -391,12 +388,11 @@ loop:
 // TestTriggers_MultipleICTs ensures that a deployment config with more than one ImageChange trigger
 // will start a new deployment iff all images are resolved.
 func TestTriggers_MultipleICTs(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	openshiftClusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatalf("error getting cluster admin client: %v", err)
@@ -556,12 +552,11 @@ out:
 func TestTriggers_configChange(t *testing.T) {
 	const namespace = "test-triggers-configchange"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/diag_nodes_test.go
+++ b/test/integration/diag_nodes_test.go
@@ -16,12 +16,11 @@ import (
 )
 
 func TestDiagNodeConditions(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, nodeConfig, clientFile, err := testserver.StartTestAllInOne()
+	masterConfig, nodeConfig, clientFile, err := testserver.StartTestAllInOne()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	client, err := testutil.GetClusterAdminKubeClient(clientFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -13,12 +13,11 @@ import (
 )
 
 func TestDiscoveryGroupVersions(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error starting test master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/dns_test.go
+++ b/test/integration/dns_test.go
@@ -20,12 +20,11 @@ import (
 )
 
 func TestDNS(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, clientFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	localAddr := ""
 	if ip, err := cmdutil.DefaultLocalIP4(); err == nil {

--- a/test/integration/dockerregistry_pullthrough_test.go
+++ b/test/integration/dockerregistry_pullthrough_test.go
@@ -130,13 +130,11 @@ func testPullThroughStatBlob(stream *imageapi.ImageStreamImport, user, token, di
 }
 
 func TestPullThroughInsecure(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatalf("error getting cluster admin client: %v", err)

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -52,12 +52,11 @@ func testOne(t *testing.T, client kclientset.Interface, namespace, addrType stri
 }
 
 func TestEndpointAdmission(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		serviceadmit.RestrictedEndpointsPluginName: {
 			Configuration: &configapi.DefaultAdmissionConfig{},

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -845,7 +845,7 @@ const testNamespace = "etcdstoragepathtestnamespace"
 // It will also fail when a type gets moved to a different location. Be very careful in this situation because
 // it essentially means that you will be break old clusters unless you create some migration path for the old data.
 func TestEtcd2StoragePath(t *testing.T) {
-	etcdServer := testutil.RequireEtcd(t)
+	etcdServer := testutil.RequireEtcd2(t)
 	defer etcdServer.DumpEtcdOnFailure(t)
 
 	getter := &etcd2Getter{
@@ -874,7 +874,7 @@ func TestEtcd3StoragePath(t *testing.T) {
 */
 
 func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, getter etcdGetter) {
-	masterConfig, err := testserver.DefaultMasterOptions()
+	masterConfig, err := testserver.DefaultMasterOptionsWithTweaks(false, false)
 	if err != nil {
 		t.Fatalf("error getting master config: %#v", err)
 	}

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -846,12 +846,12 @@ const testNamespace = "etcdstoragepathtestnamespace"
 // it essentially means that you will be break old clusters unless you create some migration path for the old data.
 func TestEtcd2StoragePath(t *testing.T) {
 	etcdServer := testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer etcdServer.DumpEtcdOnFailure(t)
 
 	getter := &etcd2Getter{
 		keys: etcd.NewKeysAPI(etcdServer.Client),
 	}
-	testEtcdStoragePath(t, etcdServer, getter)
+	testEtcdStoragePath(t, etcdServer.EtcdTestServer, getter)
 }
 
 // TestEtcd3StoragePath tests to make sure that all objects are stored in an expected location in etcd.

--- a/test/integration/extension_apiserver_test.go
+++ b/test/integration/extension_apiserver_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 func TestExtensionAPIServerConfigMap(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/extensions_api_deletion_test.go
+++ b/test/integration/extensions_api_deletion_test.go
@@ -19,12 +19,11 @@ import (
 func TestExtensionsAPIDeletion(t *testing.T) {
 	const projName = "ext-deletion-proj"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -15,12 +15,11 @@ import (
 func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
 	const projName = "ext-disabled-batch-enabled-proj"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	// Disable all extensions API versions
 	// Leave autoscaling/batch APIs enabled

--- a/test/integration/front_proxy_test.go
+++ b/test/integration/front_proxy_test.go
@@ -30,13 +30,11 @@ import (
 )
 
 func TestFrontProxy(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	frontProxyCAPrefix := "frontproxycatest"
 	proxyCertCommonName := "frontproxycerttest"

--- a/test/integration/gc_default_test.go
+++ b/test/integration/gc_default_test.go
@@ -16,12 +16,11 @@ import (
 )
 
 func TestGCDefaults(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -19,12 +19,11 @@ import (
 )
 
 func TestBasicUserBasedGroupManipulation(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
@@ -108,12 +107,11 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 }
 
 func TestBasicGroupManipulation(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
@@ -179,12 +177,11 @@ func TestBasicGroupManipulation(t *testing.T) {
 }
 
 func TestGroupCommands(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/imagechange_buildtrigger_test.go
+++ b/test/integration/imagechange_buildtrigger_test.go
@@ -22,8 +22,8 @@ const (
 )
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	projectAdminClient, _ := setup(t)
+	projectAdminClient, _, fn := setup(t)
+	defer fn()
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
 	strategy := stiStrategy("ImageStreamTag", streamName+":"+tag)
@@ -32,8 +32,8 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	projectAdminClient, _ := setup(t)
+	projectAdminClient, _, fn := setup(t)
+	defer fn()
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
 	strategy := stiStrategy("ImageStreamTag", streamName+":"+tag)
@@ -42,8 +42,8 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(t *t
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	projectAdminClient, _ := setup(t)
+	projectAdminClient, _, fn := setup(t)
+	defer fn()
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
 	strategy := dockerStrategy("ImageStreamTag", streamName+":"+tag)
@@ -52,8 +52,8 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	projectAdminClient, _ := setup(t)
+	projectAdminClient, _, fn := setup(t)
+	defer fn()
 	imageStream := mockImageStream2(tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, "registry:8080/openshift/test-image-trigger:"+tag)
 	strategy := dockerStrategy("ImageStreamTag", streamName+":"+tag)
@@ -62,8 +62,8 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(t
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	projectAdminClient, clusterAdminClient := setup(t)
+	projectAdminClient, clusterAdminClient, fn := setup(t)
+	defer fn()
 
 	clusterRoleBindingAccessor := policy.NewClusterRoleBindingAccessor(clusterAdminClient)
 	subjects := []kapi.ObjectReference{
@@ -92,8 +92,8 @@ func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(t *testing.T) {
 }
 
 func TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	projectAdminClient, _ := setup(t)
+	projectAdminClient, _, fn := setup(t)
+	defer fn()
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(testutil.GetBaseDir() + "/openshift.local.config/master/admin.kubeconfig")
 	if err != nil {
@@ -228,9 +228,8 @@ func mockImageStreamMapping(stream, image, tag, reference string) *imageapi.Imag
 	}
 }
 
-func setup(t *testing.T) (*client.Client, *client.Client) {
-	testutil.RequireEtcd(t)
-	_, clusterAdminKubeConfigFile, err := testserver.StartTestMaster()
+func setup(t *testing.T) (*client.Client, *client.Client, func()) {
+	masterConfig, clusterAdminKubeConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +249,9 @@ func setup(t *testing.T) (*client.Client, *client.Client) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	return projectAdminClient, clusterAdminClient
+	return projectAdminClient, clusterAdminClient, func() {
+		testserver.CleanupMasterEtcd(t, masterConfig)
+	}
 }
 
 func runTest(t *testing.T, testname string, projectAdminClient *client.Client, imageStream *imageapi.ImageStream, imageStreamMapping *imageapi.ImageStreamMapping, config *buildapi.BuildConfig, tag string) {
@@ -415,7 +416,6 @@ func runTest(t *testing.T, testname string, projectAdminClient *client.Client, i
 }
 
 func TestMultipleImageChangeBuildTriggers(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	mockImageStream := func(name, tag string) *imageapi.ImageStream {
 		return &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -476,7 +476,8 @@ func TestMultipleImageChangeBuildTriggers(t *testing.T) {
 		}
 		return bc
 	}
-	projectAdminClient, _ := setup(t)
+	projectAdminClient, _, fn := setup(t)
+	defer fn()
 	config := multipleImageChangeBuildConfig()
 	triggersToTest := []struct {
 		triggerIndex int

--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -32,12 +32,11 @@ import (
 )
 
 func TestImageStreamImport(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	c, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -233,9 +232,6 @@ func testImageStreamImportWithPath(t *testing.T, reponame string) {
 		imageSize += size
 	}
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	// start regular HTTP servers
 	requireAuth := false
 	count := 0
@@ -289,10 +285,11 @@ func testImageStreamImportWithPath(t *testing.T, reponame string) {
 	url, _ := url.Parse(server.URL)
 
 	// start a master
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	c, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -356,8 +353,6 @@ func TestImageStreamImportOfMultiSegmentDockerReference(t *testing.T) {
 }
 
 func TestImageStreamImportAuthenticated(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	// start regular HTTP servers
 	count := 0
 	server := httptest.NewServer(mockRegistryHandler(t, true, &count))
@@ -380,10 +375,11 @@ func TestImageStreamImportAuthenticated(t *testing.T) {
 	url3, _ := url.Parse(server3.URL)
 
 	// start a master
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	kc, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -523,8 +519,6 @@ func TestImageStreamImportAuthenticated(t *testing.T) {
 // Verifies that individual errors for particular tags are handled properly when pulling all tags from a
 // repository.
 func TestImageStreamImportTagsFromRepository(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	// start regular HTTP servers
 	count := 0
 	server := httptest.NewServer(mockRegistryHandler(t, false, &count))
@@ -532,10 +526,11 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 	url, _ := url.Parse(server.URL)
 
 	// start a master
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	/*
 		_, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 		if err != nil {
@@ -624,8 +619,6 @@ func TestImageStreamImportTagsFromRepository(t *testing.T) {
 // test controller interval), updates the image stream only when there are changes, and if an
 // error occurs writes the error only once (instead of every interval)
 func TestImageStreamImportScheduled(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	written := make(chan struct{}, 1)
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -661,10 +654,11 @@ func TestImageStreamImportScheduled(t *testing.T) {
 			t.Fatalf("unexpected request %s: %#v", r.URL.Path, r)
 		}
 	}))
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	c, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -20,12 +20,11 @@ import (
 )
 
 func TestImageStreamList(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -50,12 +49,11 @@ func mockImageStream() *imageapi.ImageStream {
 }
 
 func TestImageStreamCreate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -98,12 +96,11 @@ func TestImageStreamCreate(t *testing.T) {
 }
 
 func TestImageStreamMappingCreate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -286,12 +283,11 @@ func TestImageStreamMappingCreate(t *testing.T) {
 }
 
 func TestImageStreamWithoutDockerImageConfig(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -384,12 +380,11 @@ func TestImageStreamWithoutDockerImageConfig(t *testing.T) {
 }
 
 func TestImageStreamTagLifecycleHook(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminKubeClientset, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/ingressip_test.go
+++ b/test/integration/ingressip_test.go
@@ -17,7 +17,6 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/service/controller/ingressip"
-	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
@@ -26,12 +25,11 @@ const sentinelName = "sentinel"
 // TestIngressIPAllocation validates that ingress ip allocation is
 // performed correctly even when multiple controllers are running.
 func TestIngressIPAllocation(t *testing.T) {
-	testutil.RequireEtcd(t)
-
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.NetworkConfig.ExternalIPNetworkCIDRs = []string{"172.16.0.0/24"}
 	masterConfig.NetworkConfig.IngressIPNetworkCIDR = "172.16.1.0/24"
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterWithOptions(masterConfig, testserver.TestOptions{})

--- a/test/integration/leaderlease_test.go
+++ b/test/integration/leaderlease_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestLeaderLeaseAcquire(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)
@@ -56,8 +55,7 @@ func TestLeaderLeaseAcquire(t *testing.T) {
 }
 
 func TestLeaderLeaseWait(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)
@@ -102,8 +100,7 @@ func TestLeaderLeaseWait(t *testing.T) {
 }
 
 func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)
@@ -138,8 +135,7 @@ func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
 }
 
 func TestLeaderLeaseReacquire(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/leaderlease_test.go
+++ b/test/integration/leaderlease_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestLeaderLeaseAcquire(t *testing.T) {
-	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd2(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestLeaderLeaseAcquire(t *testing.T) {
 }
 
 func TestLeaderLeaseWait(t *testing.T) {
-	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd2(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func TestLeaderLeaseWait(t *testing.T) {
 }
 
 func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
-	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd2(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +135,7 @@ func TestLeaderLeaseSwapWhileWaiting(t *testing.T) {
 }
 
 func TestLeaderLeaseReacquire(t *testing.T) {
-	defer testutil.RequireEtcd(t).DumpEtcdOnFailure(t)
+	defer testutil.RequireEtcd2(t).DumpEtcdOnFailure(t)
 	c, err := testutil.MakeNewEtcdClient()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -22,14 +22,11 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
-
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -108,12 +108,11 @@ var expectedIndex = []string{
 }
 
 func TestRootRedirect(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	transport, err := anonymousHttpTransport(clusterAdminKubeConfig)
 	if err != nil {
@@ -164,12 +163,11 @@ func TestRootRedirect(t *testing.T) {
 }
 
 func TestWellKnownOAuth(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	transport, err := anonymousHttpTransport(clusterAdminKubeConfig)
 	if err != nil {
@@ -195,12 +193,11 @@ func TestWellKnownOAuth(t *testing.T) {
 }
 
 func TestWellKnownOAuthOff(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.OAuthConfig = nil
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)
 	if err != nil {
@@ -254,12 +251,11 @@ var preferredVersions = map[string]string{
 }
 
 func TestApiGroupPreferredVersions(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.OAuthConfig = nil
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)
 	if err != nil {
@@ -299,12 +295,11 @@ func TestApiGroupPreferredVersions(t *testing.T) {
 }
 
 func TestApiGroups(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.OAuthConfig = nil
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)
 	if err != nil {

--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 func TestNamespaceLifecycleAdmission(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -29,13 +29,12 @@ type testRequest struct {
 }
 
 func TestNodeAuth(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	// Server config
 	masterConfig, nodeConfig, adminKubeConfigFile, err := testserver.StartTestAllInOne()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	// Cluster admin clients and client configs
 	adminClient, err := testutil.GetClusterAdminKubeClient(adminKubeConfigFile)

--- a/test/integration/oauth_basicauth_test.go
+++ b/test/integration/oauth_basicauth_test.go
@@ -307,12 +307,11 @@ func TestOAuthBasicAuthPassword(t *testing.T) {
 	}()
 
 	// Build master config
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	masterOptions.OAuthConfig.IdentityProviders[0] = configapi.IdentityProvider{
 		Name:            "basicauth",

--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -38,13 +38,12 @@ func TestOAuthCertFallback(t *testing.T) {
 		anonymousError    = `User "system:anonymous" cannot get users at the cluster scope`
 	)
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	// Build master config
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	// Start server
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterOptions)

--- a/test/integration/oauth_disabled_test.go
+++ b/test/integration/oauth_disabled_test.go
@@ -12,13 +12,12 @@ import (
 )
 
 func TestOAuthDisabled(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	// Build master config
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	// Disable OAuth
 	masterOptions.OAuthConfig = nil

--- a/test/integration/oauth_htpasswd_test.go
+++ b/test/integration/oauth_htpasswd_test.go
@@ -22,12 +22,11 @@ func TestOAuthHTPasswd(t *testing.T) {
 	}
 	defer os.Remove(htpasswdFile.Name())
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	masterOptions.OAuthConfig.IdentityProviders[0] = configapi.IdentityProvider{
 		Name:            "htpasswd",

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -80,12 +80,11 @@ func TestOAuthLDAP(t *testing.T) {
 	ldapServer.Start(ldapAddress)
 	defer ldapServer.Stop()
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	// Generate an encrypted file/keyfile to contain the bindPassword
 	bindPasswordFile, err := ioutil.TempFile("", "bindPassword")

--- a/test/integration/oauth_oidc_test.go
+++ b/test/integration/oauth_oidc_test.go
@@ -65,13 +65,11 @@ func TestOAuthOIDC(t *testing.T) {
 	}
 
 	// Get master config
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	// Set up a dummy OIDC server
 	oidcServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/integration/oauth_request_header_test.go
+++ b/test/integration/oauth_request_header_test.go
@@ -44,12 +44,11 @@ func TestOAuthRequestHeader(t *testing.T) {
 	}
 
 	// Get master config
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 	masterURL, _ := url.Parse(masterOptions.OAuthConfig.MasterPublicURL)
 
 	// Set up an auth proxy

--- a/test/integration/oauth_serviceaccount_client_test.go
+++ b/test/integration/oauth_serviceaccount_client_test.go
@@ -37,12 +37,11 @@ import (
 )
 
 func TestOAuthServiceAccountClient(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	authorizationCodes := make(chan string, 1)
 	authorizationErrors := make(chan string, 1)

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -22,7 +22,6 @@ import (
 	clientetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclient/etcd"
 	"github.com/openshift/origin/pkg/oauth/server/osinserver"
 	registrystorage "github.com/openshift/origin/pkg/oauth/server/osinserver/registrystorage"
-	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
@@ -53,13 +52,11 @@ func (u *testUser) ConvertFromAccessToken(*oauthapi.OAuthAccessToken) (interface
 }
 
 func TestOAuthStorage(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	optsGetter, err := originrest.StorageOptions(*masterOptions)
 	if err != nil {

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -105,6 +105,10 @@ func TestOAuthStorage(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
+	if _, err := testserver.StartConfiguredMasterAPI(masterOptions); err != nil {
+		t.Fatal(err)
+	}
+
 	ch := make(chan *osincli.AccessData, 1)
 	var oaclient *osincli.Client
 	var authReq *osincli.AuthorizeRequest

--- a/test/integration/ownerrefs_test.go
+++ b/test/integration/ownerrefs_test.go
@@ -15,12 +15,11 @@ import (
 
 func TestOwnerRefRestriction(t *testing.T) {
 	// functionality of the plugin has a unit test, we just need to make sure its called.
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/patch_test.go
+++ b/test/integration/patch_test.go
@@ -22,15 +22,11 @@ import (
 )
 
 func TestPatchConflicts(t *testing.T) {
-
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
-
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -21,38 +21,37 @@ import (
 )
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeNameClusterAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
-	oclient, kclientset := setupClusterAdminPodNodeConstraintsTest(t, &pluginapi.PodNodeConstraintsConfig{})
+	oclient, kclientset, fn := setupClusterAdminPodNodeConstraintsTest(t, &pluginapi.PodNodeConstraintsConfig{})
+	defer fn()
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node name, cluster admin", kclientset, oclient, "nodename.example.com", nil, false)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeNameNonAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	config := &pluginapi.PodNodeConstraintsConfig{}
-	oclient, kclientset := setupUserPodNodeConstraintsTest(t, config, "derples")
+	oclient, kclientset, fn := setupUserPodNodeConstraintsTest(t, config, "derples")
+	defer fn()
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node name, regular user", kclientset, oclient, "nodename.example.com", nil, true)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorClusterAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	config := &pluginapi.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"hostname"},
 	}
-	oclient, kclientset := setupClusterAdminPodNodeConstraintsTest(t, config)
+	oclient, kclientset, fn := setupClusterAdminPodNodeConstraintsTest(t, config)
+	defer fn()
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node selector, cluster admin", kclientset, oclient, "", map[string]string{"hostname": "foo"}, false)
 }
 
 func TestPodNodeConstraintsAdmissionPluginSetNodeSelectorNonAdmin(t *testing.T) {
-	defer testutil.DumpEtcdOnFailure(t)
 	config := &pluginapi.PodNodeConstraintsConfig{
 		NodeSelectorLabelBlacklist: []string{"hostname"},
 	}
-	oclient, kclientset := setupUserPodNodeConstraintsTest(t, config, "derples")
+	oclient, kclientset, fn := setupUserPodNodeConstraintsTest(t, config, "derples")
+	defer fn()
 	testPodNodeConstraintsObjectCreationWithPodTemplate(t, "set node selector, regular user", kclientset, oclient, "", map[string]string{"hostname": "foo"}, true)
 }
 
-func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNodeConstraintsConfig) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
+func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNodeConstraintsConfig) (*client.Client, kclientset.Interface, func()) {
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -86,11 +85,12 @@ func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *plugina
 	if err := testserver.WaitForPodCreationServiceAccounts(kubeClientset, testutil.Namespace()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	return openShiftClient, kubeClientset
+	return openShiftClient, kubeClientset, func() {
+		testserver.CleanupMasterEtcd(t, masterConfig)
+	}
 }
 
-func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNodeConstraintsConfig, user string) (*client.Client, kclientset.Interface) {
-	testutil.RequireEtcd(t)
+func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNodeConstraintsConfig, user string) (*client.Client, kclientset.Interface, func()) {
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
@@ -140,7 +140,9 @@ func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNo
 	if err := addUser.AddRole(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	return userClient, userkubeClientset
+	return userClient, userkubeClientset, func() {
+		testserver.CleanupMasterEtcd(t, masterConfig)
+	}
 }
 
 func testPodNodeConstraintsPodSpec(nodeName string, nodeSelector map[string]string) kapi.PodSpec {
@@ -225,7 +227,6 @@ func testPodNodeConstraintsDeploymentConfig(nodeName string, nodeSelector map[st
 // testPodNodeConstraintsObjectCreationWithPodTemplate attempts to create different object types that contain pod templates
 // using the passed in nodeName and nodeSelector. It will use the expectError flag to determine if an error should be returned or not
 func testPodNodeConstraintsObjectCreationWithPodTemplate(t *testing.T, name string, kclientset kclientset.Interface, client client.Interface, nodeName string, nodeSelector map[string]string, expectError bool) {
-
 	checkForbiddenErr := func(objType string, err error) {
 		if err == nil && expectError {
 			t.Errorf("%s (%s): expected forbidden error but did not receive one", name, objType)

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 func TestPolicyCommands(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/project_request_test.go
+++ b/test/integration/project_request_test.go
@@ -20,9 +20,6 @@ import (
 )
 
 func TestProjectRequestError(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	const (
 		ns                = "testns"
 		templateNamespace = "default"
@@ -32,6 +29,7 @@ func TestProjectRequestError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	masterConfig.ProjectConfig.ProjectRequestTemplate = templateNamespace + "/" + templateName
 

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -29,12 +29,11 @@ import (
 
 // TestProjectIsNamespace verifies that a project is a namespace, and a namespace is a project
 func TestProjectIsNamespace(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	originClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -98,7 +97,7 @@ func TestProjectIsNamespace(t *testing.T) {
 // and that openshift content is cleaned up when a project is deleted.
 func TestProjectLifecycle(t *testing.T) {
 	etcdServer := testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
+	defer etcdServer.DumpEtcdOnFailure(t)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -211,12 +210,11 @@ func TestProjectLifecycle(t *testing.T) {
 }
 
 func TestProjectWatch(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -382,12 +380,11 @@ func waitForOnlyDelete(projectName string, w watch.Interface, t *testing.T) {
 }
 
 func TestScopedProjectAccess(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -514,12 +511,11 @@ func TestScopedProjectAccess(t *testing.T) {
 }
 
 func TestInvalidRoleRefs(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/rbac_controller_test.go
+++ b/test/integration/rbac_controller_test.go
@@ -15,12 +15,11 @@ import (
 )
 
 func TestRBACController(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	originClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -17,13 +17,11 @@ import (
 )
 
 func TestRestrictUsers(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"openshift.io/RestrictSubjectBindings": {

--- a/test/integration/scc_test.go
+++ b/test/integration/scc_test.go
@@ -12,12 +12,11 @@ import (
 )
 
 func TestPodUpdateSCCEnforcement(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -22,12 +22,11 @@ import (
 )
 
 func TestScopedTokens(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -99,12 +98,11 @@ func TestScopedTokens(t *testing.T) {
 }
 
 func TestScopedImpersonation(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -144,12 +142,11 @@ func TestScopedImpersonation(t *testing.T) {
 }
 
 func TestScopeEscalations(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -225,12 +222,11 @@ func TestScopeEscalations(t *testing.T) {
 }
 
 func TestTokensWithIllegalScopes(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/sdn_test.go
+++ b/test/integration/sdn_test.go
@@ -75,12 +75,11 @@ func updateNetNamespace(osClient *osclient.Client, netns *sdnapi.NetNamespace, a
 }
 
 func TestOadmPodNetwork(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.NetworkConfig.NetworkPluginName = sdnapi.MultiTenantPluginName
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -29,17 +29,16 @@ import (
 )
 
 func TestServiceAccountAuthorization(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	saNamespace := api.NamespaceDefault
 	saName := serviceaccountadmission.DefaultServiceAccountName
 	saUsername := apiserverserviceaccount.MakeUsername(saNamespace, saName)
 
 	// Start one OpenShift master as "cluster1" to play the external kube server
-	_, cluster1AdminConfigFile, err := testserver.StartTestMaster()
+	masterConfig, cluster1AdminConfigFile, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	cluster1AdminConfig, err := testutil.GetClusterAdminClientConfig(cluster1AdminConfigFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -169,12 +168,11 @@ func TestAutomaticCreationOfPullSecrets(t *testing.T) {
 	saNamespace := api.NamespaceDefault
 	saName := serviceaccountadmission.DefaultServiceAccountName
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminKubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -227,13 +225,12 @@ func getServiceAccountPullSecret(client kclientset.Interface, ns, name string) (
 }
 
 func TestEnforcingServiceAccount(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, err := testserver.DefaultMasterOptions()
 	masterConfig.ServiceAccountConfig.LimitSecretReferences = false
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminConfig, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
@@ -323,13 +320,11 @@ func TestEnforcingServiceAccount(t *testing.T) {
 }
 
 func TestDockercfgTokenDeletedController(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/service_serving_cert_signer_test.go
+++ b/test/integration/service_serving_cert_signer_test.go
@@ -18,13 +18,11 @@ import (
 func TestServiceServingCertSigner(t *testing.T) {
 	ns := "service-serving-cert-signer"
 
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/sni_test.go
+++ b/test/integration/sni_test.go
@@ -13,7 +13,6 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/util"
-	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
@@ -27,8 +26,6 @@ const (
 )
 
 func TestSNI(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	// Create tempfiles with certs and keys we're going to use
 	certNames := map[string]string{}
 	for certName, certContents := range sniCerts {
@@ -48,6 +45,7 @@ func TestSNI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	// Set custom cert
 	masterOptions.ServingInfo.NamedCertificates = []configapi.NamedCertificate{

--- a/test/integration/storage_versions_test.go
+++ b/test/integration/storage_versions_test.go
@@ -67,8 +67,8 @@ func TestStorageVersions(t *testing.T) {
 	ns := "storageversions"
 	batchVersion := batch_v1.SchemeGroupVersion
 
-	defer testutil.DumpEtcdOnFailure(t)
 	etcdServer := testutil.RequireEtcd(t)
+	defer etcdServer.DumpEtcdOnFailure(t)
 	masterConfig, kubeClient := setupStorageTests(t, ns)
 
 	jobTestcases := map[string]struct {

--- a/test/integration/template_test.go
+++ b/test/integration/template_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestTemplate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, path, err := testserver.StartTestMasterAPI()
+	masterConfig, path, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
 	for _, version := range []schema.GroupVersion{v1.SchemeGroupVersion} {
 		config, err := testutil.GetClusterAdminClientConfig(path)
 		if err != nil {
@@ -119,12 +119,11 @@ func walkJSONFiles(inDir string, fn func(name, path string, data []byte)) error 
 }
 
 func TestTemplateTransformationFromConfig(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/tls_test.go
+++ b/test/integration/tls_test.go
@@ -5,17 +5,15 @@ import (
 	"testing"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
-	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
 func TestTLSDefaults(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	master, node, components, err := testserver.DefaultAllInOneOptions()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, master)
 	_, err = testserver.StartConfiguredAllInOne(master, node, components)
 	if err != nil {
 		t.Fatal(err)
@@ -83,12 +81,11 @@ func TestTLSDefaults(t *testing.T) {
 }
 
 func TestTLSOverrides(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	master, node, components, err := testserver.DefaultAllInOneOptions()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer testserver.CleanupMasterEtcd(t, master)
 
 	// Pick these ciphers because the first is http2 compatible, and the second works with TLS10
 	master.ServingInfo.MinTLSVersion = "VersionTLS10"

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -45,12 +45,11 @@ import (
 )
 
 func TestUnprivilegedNewProject(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
 	if err != nil {
@@ -116,8 +115,6 @@ func TestUnprivilegedNewProject(t *testing.T) {
 
 }
 func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	namespace := "foo"
 	templateName := "bar"
 
@@ -125,6 +122,7 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 	masterOptions.ProjectConfig.ProjectRequestTemplate = namespace + "/" + templateName
 
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterOptions)
@@ -212,12 +210,11 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 }
 
 func TestUnprivilegedNewProjectDenied(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/userclient_test.go
+++ b/test/integration/userclient_test.go
@@ -68,12 +68,11 @@ func makeMapping(user, identity string) *userapi.UserIdentityMapping {
 }
 
 func TestUserInitialization(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -77,12 +77,11 @@ func signedManifest(name string, blobs []digest.Digest) ([]byte, digest.Digest, 
 }
 
 func TestV2RegistryGetTags(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
 		t.Fatalf("error getting cluster admin client: %v", err)

--- a/test/integration/watch_cache_test.go
+++ b/test/integration/watch_cache_test.go
@@ -114,13 +114,11 @@ func testWatchCacheWithConfig(t *testing.T, master *configapi.MasterConfig, expe
 }
 
 func TestDefaultWatchCacheSize(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, master)
 
 	// test that the origin default really applies and that we don't fall back to kube's default
 	etcdOptions := apiserveroptions.NewEtcdOptions(&storagebackend.Config{})
@@ -132,13 +130,11 @@ func TestDefaultWatchCacheSize(t *testing.T) {
 }
 
 func TestWatchCacheSizeWithFlag(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	master, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, master)
 	if master.KubernetesMasterConfig.APIServerArguments == nil {
 		master.KubernetesMasterConfig.APIServerArguments = configapi.ExtendedArguments{}
 	}

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -17,7 +17,6 @@ import (
 	knet "k8s.io/apimachinery/pkg/util/net"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
@@ -82,15 +81,14 @@ func tryAccessURL(t *testing.T, url string, expectedStatus int, expectedRedirect
 }
 
 func TestAccessOriginWebConsole(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err = testserver.StartConfiguredMaster(masterOptions); err != nil {
+	if _, err := testserver.StartConfiguredMaster(masterOptions); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	for endpoint, exp := range map[string]struct {
 		statusCode int
@@ -110,8 +108,6 @@ func TestAccessOriginWebConsole(t *testing.T) {
 }
 
 func TestAccessDisabledWebConsole(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -120,6 +116,7 @@ func TestAccessDisabledWebConsole(t *testing.T) {
 	if _, err := testserver.StartConfiguredMaster(masterOptions); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	resp := tryAccessURL(t, masterOptions.AssetConfig.MasterPublicURL+"/", http.StatusOK, "", nil)
 	body, err := ioutil.ReadAll(resp.Body)
@@ -149,8 +146,6 @@ func TestAccessDisabledWebConsole(t *testing.T) {
 }
 
 func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -184,9 +179,10 @@ func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
 	})
 
 	// Launch the configured server
-	if _, err = testserver.StartConfiguredMaster(masterOptions); err != nil {
+	if _, err := testserver.StartConfiguredMaster(masterOptions); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	// Create a map of URLs to test
 	type urlResults struct {
@@ -243,9 +239,6 @@ func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
 }
 
 func TestAccessStandaloneOriginWebConsole(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -261,9 +254,10 @@ func TestAccessStandaloneOriginWebConsole(t *testing.T) {
 	masterOptions.AssetConfig.PublicURL = assetBaseURL + "/console/"
 	masterOptions.OAuthConfig.AssetPublicURL = assetBaseURL + "/console/"
 
-	if _, err = testserver.StartConfiguredMaster(masterOptions); err != nil {
+	if _, err := testserver.StartConfiguredMaster(masterOptions); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 
 	for endpoint, exp := range map[string]struct {
 		statusCode int

--- a/test/integration/web_console_extensions_test.go
+++ b/test/integration/web_console_extensions_test.go
@@ -16,7 +16,6 @@ import (
 	knet "k8s.io/apimachinery/pkg/util/net"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
@@ -52,13 +51,12 @@ func TestWebConsoleExtensions(t *testing.T) {
 	}
 
 	// Build master config.
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
 	masterOptions, err := testserver.DefaultMasterOptions()
 	if err != nil {
 		t.Fatalf("Failed creating master configuration: %v", err)
 		return
 	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
 	masterOptions.AssetConfig.ExtensionScripts = []string{
 		filepath.Join(tmpDir, "script1.js"),
 		filepath.Join(tmpDir, "script2.js"),

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -21,12 +21,11 @@ import (
 )
 
 func TestWebhook(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unable to start master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	kubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -132,12 +131,11 @@ func TestWebhook(t *testing.T) {
 }
 
 func TestWebhookGitHubPushWithImage(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -246,12 +244,11 @@ func TestWebhookGitHubPushWithImage(t *testing.T) {
 }
 
 func TestWebhookGitHubPushWithImageStream(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	clusterAdminClient, err := testutil.GetClusterAdminClient(clusterAdminKubeConfig)
 	if err != nil {
@@ -347,12 +344,11 @@ func TestWebhookGitHubPushWithImageStream(t *testing.T) {
 }
 
 func TestWebhookGitHubPing(t *testing.T) {
-	testutil.RequireEtcd(t)
-	defer testutil.DumpEtcdOnFailure(t)
-	_, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unable to start master: %v", err)
 	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	kubeClient, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
 	if err != nil {

--- a/test/util/etcd.go
+++ b/test/util/etcd.go
@@ -8,12 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
-
-	"github.com/coreos/pkg/capnslog"
-
 	etcdclient "github.com/coreos/etcd/client"
 	etcdclientv3 "github.com/coreos/etcd/clientv3"
+	"github.com/coreos/pkg/capnslog"
+	"golang.org/x/net/context"
 
 	etcdtest "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -40,11 +38,24 @@ func init() {
 // url is the url for the launched etcd server
 var url string
 
+type EtcdTestServer struct {
+	*etcdtest.EtcdTestServer
+}
+
 // RequireEtcd verifies if the etcd is running and accessible for testing
-func RequireEtcd(t *testing.T) *etcdtest.EtcdTestServer {
+func RequireEtcd(t *testing.T) EtcdTestServer {
+	s, _ := etcdtest.NewUnsecuredEtcd3TestClientServer(t, kapi.Scheme)
+	t.Logf("endpoints: %v", s.V3Client.Endpoints())
+	url = s.V3Client.Endpoints()[0]
+	return EtcdTestServer{s}
+}
+
+// RequireEtcd verifies if the etcd is running and accessible for testing
+// TODO: remove use of etcd2 specific apis in 1.6
+func RequireEtcd2(t *testing.T) EtcdTestServer {
 	s := etcdtest.NewUnsecuredEtcdTestClientServer(t)
 	url = s.Client.Endpoints()[0]
-	return s
+	return EtcdTestServer{s}
 }
 
 func RequireEtcd3(t *testing.T) (*etcdtest.EtcdTestServer, *storagebackend.Config) {
@@ -96,7 +107,19 @@ func GetEtcdURL() string {
 	return url
 }
 
-func DumpEtcdOnFailure(t *testing.T) {
+func (s EtcdTestServer) DumpEtcdOnFailure(t *testing.T) {
+	defer func() {
+		s.Terminate(t)
+		dir := s.DataDir
+		if len(dir) > 0 {
+			t.Logf("Removing etcd dir %s", dir)
+			if err := os.RemoveAll(dir); err != nil {
+				t.Errorf("Unable to remove contents of etcd data directory %s: %v", dir, err)
+			}
+		} else {
+			t.Logf("No data directory, nothing to clean up")
+		}
+	}()
 	if !t.Failed() {
 		return
 	}
@@ -109,31 +132,62 @@ func DumpEtcdOnFailure(t *testing.T) {
 		last = 0
 	}
 	name := f.Name()[last:]
-	client := NewEtcdClient()
-	keyClient := etcdclient.NewKeysAPI(client)
 
-	response, err := keyClient.Get(context.Background(), "/", &etcdclient.GetOptions{Recursive: true, Sort: true})
-	if err != nil {
-		t.Logf("error dumping etcd: %v", err)
+	if s.Client != nil {
+		keyClient := etcdclient.NewKeysAPI(s.Client)
+
+		response, err := keyClient.Get(context.Background(), "/", &etcdclient.GetOptions{Recursive: true, Sort: true})
+		if err != nil {
+			t.Logf("error dumping etcd: %v", err)
+			return
+		}
+		jsonResponse, err := json.Marshal(response.Node)
+		if err != nil {
+			t.Logf("error encoding etcd dump: %v", err)
+			return
+		}
+
+		t.Logf("dumping etcd to %q", GetBaseDir()+"/etcd-dump-"+name+".json")
+		dumpFile, err := os.OpenFile(GetBaseDir()+"/etcd-dump-"+name+".json", os.O_WRONLY|os.O_CREATE, 0444)
+		if err != nil {
+			t.Logf("error writing etcd dump: %v", err)
+			return
+		}
+		defer dumpFile.Close()
+		_, err = dumpFile.Write(jsonResponse)
+		if err != nil {
+			t.Logf("error writing etcd dump: %v", err)
+			return
+		}
 		return
 	}
-	jsonResponse, err := json.Marshal(response.Node)
+
+	client := s.V3Client
+	r, err := client.KV.Get(context.Background(), "\x00", etcdclientv3.WithFromKey())
 	if err != nil {
-		t.Logf("error encoding etcd dump: %v", err)
+		t.Logf("error reading all keys: %v", err)
 		return
 	}
-
-	t.Logf("dumping etcd to %q", GetBaseDir()+"/etcd-dump-"+name+".json")
 	dumpFile, err := os.OpenFile(GetBaseDir()+"/etcd-dump-"+name+".json", os.O_WRONLY|os.O_CREATE, 0444)
 	if err != nil {
 		t.Logf("error writing etcd dump: %v", err)
 		return
 	}
 	defer dumpFile.Close()
-	_, err = dumpFile.Write(jsonResponse)
-	if err != nil {
-		t.Logf("error writing etcd dump: %v", err)
-		return
+	w := json.NewEncoder(dumpFile)
+	result := struct {
+		Key            string
+		Value          []byte
+		CreateRevision int64
+		ModRevision    int64
+	}{}
+	for _, v := range r.Kvs {
+		result.Key = string(v.Key)
+		result.Value = v.Value
+		result.CreateRevision, result.ModRevision = v.CreateRevision, v.ModRevision
+		if err := w.Encode(result); err != nil {
+			t.Logf("error writing etcd dump: %v", err)
+			return
+		}
 	}
-
 }

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -102,6 +102,7 @@ func setupStartOptions(startEtcd, useDefaultPort bool) (*start.MasterArgs, *star
 	}
 
 	if !startEtcd {
+		masterArgs.EtcdAddr.Provided = true
 		masterArgs.EtcdAddr.Set(util.GetEtcdURL())
 	}
 
@@ -126,6 +127,7 @@ func DefaultMasterOptionsWithTweaks(startEtcd, useDefaultPort bool) (*configapi.
 	startOptions := start.MasterOptions{}
 	startOptions.MasterArgs, _, _, _, _ = setupStartOptions(startEtcd, useDefaultPort)
 	startOptions.Complete()
+	// reset, since Complete alters the default
 	startOptions.MasterArgs.ConfigDir.Default(path.Join(util.GetBaseDir(), "openshift.local.config", "master"))
 
 	if err := CreateMasterCerts(startOptions.MasterArgs); err != nil {


### PR DESCRIPTION
A set of cleanup to the integration tests that will allow them to be run in parallel. Also moves to etcd3 (we were still testing only the etcd2 code path).

@deads2k

The parallelism changes depend on these