### PR TITLE
cluster up: fix version parsing

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -679,7 +679,7 @@ func parseOpenshiftVersion(versionStr string) (semver.Version, error) {
 	// The OCP version may have > 4 parts to the version string,
 	// e.g. 3.5.1.1-prerelease, whereas Origin will be 3.5.1-prerelease,
 	// drop the 4th digit for OCP.
-	re := regexp.MustCompile("([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)")
+	re := regexp.MustCompile("([0-9]+)\\.([0-9]+)\\.([0-9]+)((?:\\.[0-9]+)+)(.*)")
 	versionStr = re.ReplaceAllString(versionStr, "${1}.${2}.${3}${5}")
 
 	return semver.Parse(versionStr)

--- a/pkg/oc/bootstrap/docker/openshift/helper_test.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper_test.go
@@ -29,6 +29,10 @@ func TestParseOpenshiftVersion(t *testing.T) {
 			input:    "3.6.0-alpha.2+2a00043-774",
 			expected: "3.6.0-alpha.2+2a00043-774",
 		},
+		{
+			input:    "3.6.172.0.4",
+			expected: "3.6.172",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Version parsing assumed only four version parts for OCP, instead of 4+

Fixes: https://github.com/openshift/origin/issues/13815