### PR TITLE
move templateservicebroker to its own server

### DIFF
--- a/pkg/cmd/server/origin/nonapiserver.go
+++ b/pkg/cmd/server/origin/nonapiserver.go
@@ -7,15 +7,9 @@ import (
 	"github.com/golang/glog"
 
 	genericmux "k8s.io/apiserver/pkg/server/mux"
-	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/plug"
 	oauthutil "github.com/openshift/origin/pkg/oauth/util"
-	openservicebrokerserver "github.com/openshift/origin/pkg/openservicebroker/server"
-	templateapi "github.com/openshift/origin/pkg/template/apis/template"
-	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
-	templateservicebroker "github.com/openshift/origin/pkg/template/servicebroker"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
@@ -28,12 +22,6 @@ type OpenshiftNonAPIConfig struct {
 
 	MasterPublicURL string
 	EnableOAuth     bool
-
-	// these are only needed for the template service broker, which should move out
-	KubeClientInternal          kclientsetinternal.Interface
-	EnableTemplateServiceBroker bool
-	TemplateInformers           templateinformer.SharedInformerFactory
-	TemplateNamespaces          []string
 }
 
 // OpenshiftNonAPIServer serves non-API endpoints for openshift.
@@ -69,21 +57,6 @@ func (c completedOpenshiftNonAPIConfig) New(delegationTarget genericapiserver.De
 
 	// TODO punt this out to its own "unrelated gorp" delegation target.  It is not related to API
 	initControllerRoutes(s.GenericAPIServer.Handler.GoRestfulContainer, "/controllers", c.ControllerPlug)
-
-	// TODO punt this out to its own "unrelated gorp" delegation target.  It is not related to API
-	if c.EnableTemplateServiceBroker {
-		openservicebrokerserver.Route(
-			s.GenericAPIServer.Handler.GoRestfulContainer,
-			templateapi.ServiceBrokerRoot,
-			templateservicebroker.NewBroker(
-				*c.GenericConfig.LoopbackClientConfig,
-				c.KubeClientInternal,
-				bootstrappolicy.DefaultOpenShiftInfraNamespace,
-				c.TemplateInformers.Template().InternalVersion().Templates(),
-				c.TemplateNamespaces,
-			),
-		)
-	}
 
 	// TODO move this up to the spot where we wire the oauth endpoint
 	// Set up OAuth metadata only if we are configured to use OAuth

--- a/pkg/openservicebroker/server/apiserver.go
+++ b/pkg/openservicebroker/server/apiserver.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	templateapi "github.com/openshift/origin/pkg/template/apis/template"
+	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
+	templateservicebroker "github.com/openshift/origin/pkg/template/servicebroker"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+)
+
+type TemplateServiceBrokerConfig struct {
+	GenericConfig *genericapiserver.Config
+
+	KubeClientInternal kclientsetinternal.Interface
+	TemplateInformers  templateinformer.SharedInformerFactory
+	TemplateNamespaces []string
+}
+
+type TemplateServiceBrokerServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+}
+
+type completedTemplateServiceBrokerConfig struct {
+	*TemplateServiceBrokerConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *TemplateServiceBrokerConfig) Complete() completedTemplateServiceBrokerConfig {
+	c.GenericConfig.Complete()
+
+	return completedTemplateServiceBrokerConfig{c}
+}
+
+// SkipComplete provides a way to construct a server instance without config completion.
+func (c *TemplateServiceBrokerConfig) SkipComplete() completedTemplateServiceBrokerConfig {
+	return completedTemplateServiceBrokerConfig{c}
+}
+
+func (c completedTemplateServiceBrokerConfig) New(delegationTarget genericapiserver.DelegationTarget, stopCh <-chan struct{}) (*TemplateServiceBrokerServer, error) {
+	genericServer, err := c.TemplateServiceBrokerConfig.GenericConfig.SkipComplete().New("template-service-broker", delegationTarget) // completion is done in Complete, no need for a second time
+	if err != nil {
+		return nil, err
+	}
+
+	s := &TemplateServiceBrokerServer{
+		GenericAPIServer: genericServer,
+	}
+
+	Route(
+		s.GenericAPIServer.Handler.GoRestfulContainer,
+		templateapi.ServiceBrokerRoot,
+		templateservicebroker.NewBroker(
+			*c.GenericConfig.LoopbackClientConfig,
+			c.KubeClientInternal,
+			bootstrappolicy.DefaultOpenShiftInfraNamespace,
+			c.TemplateInformers.Template().InternalVersion().Templates(),
+			c.TemplateNamespaces,
+		),
+	)
+
+	// TODO, when/if the TSB becomes a separate entity, this should stop creating the SA and instead die if it cannot find it
+	s.GenericAPIServer.AddPostStartHook("template-service-broker-ensure-service-account", func(context genericapiserver.PostStartHookContext) error {
+		// TODO jim-minter - this is the spot to create the namespace if needed and create the SA if needed.
+		// be tolerant of failures and retry a few times.
+		return nil
+	})
+
+	return s, nil
+}


### PR DESCRIPTION
This separates the template service broker into its own apiserver which is added to the openshift apiserver chain.

@soltysh ptal
@bparees I don't know jimminter's github id and github autocompletion is down.