### PR TITLE
Add limit for number of concurrent connections to registry

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -43,3 +43,18 @@ openshift:
     # Attention! A weak secret can lead to the leakage of private data.
     #
     # secret: TopSecretLongToken
+  requests:
+    # GET and HEAD requests
+    read:
+      # maxrunning is a limit for the number of in-flight requests. A zero value means there is no limit.
+      maxrunning: 0
+      # maxinqueue sets the maximum number of requests that can be queued if the limit for the number of in-flight requests is reached.
+      maxinqueue: 0
+      # maxwaitinqueue is how long a request can wait in the queue. A zero value means it can wait forever.
+      maxwaitinqueue: 0
+    # PUT, PATCH, POST, DELETE requests and internal mirroring requests
+    write:
+      # See description of openshift.requests.read.
+      maxrunning: 0
+      maxinqueue: 0
+      maxwaitinqueue: 0

--- a/pkg/dockerregistry/server/configuration/configuration.go
+++ b/pkg/dockerregistry/server/configuration/configuration.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -26,13 +27,25 @@ type openshiftConfig struct {
 }
 
 type Configuration struct {
-	Version configuration.Version `yaml:"version"`
-	Metrics Metrics               `yaml:"metrics"`
+	Version  configuration.Version `yaml:"version"`
+	Metrics  Metrics               `yaml:"metrics"`
+	Requests Requests              `yaml:"requests"`
 }
 
 type Metrics struct {
 	Enabled bool   `yaml:"enabled"`
 	Secret  string `yaml:"secret"`
+}
+
+type Requests struct {
+	Read  RequestsLimits
+	Write RequestsLimits
+}
+
+type RequestsLimits struct {
+	MaxRunning     int
+	MaxInQueue     int
+	MaxWaitInQueue time.Duration
 }
 
 type versionInfo struct {

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/origin/pkg/dockerregistry/server/maxconnections"
 )
 
 type contextKey string
@@ -19,6 +20,9 @@ const (
 
 	// registryClientKey is the key for RegistryClient values in Contexts.
 	registryClientKey contextKey = "registryClient"
+
+	// writeLimiterKey is the key for write limiters in Contexts.
+	writeLimiterKey contextKey = "writeLimiter"
 
 	// userClientKey is the key for a origin's client with the current user's
 	// credentials in Contexts.
@@ -69,6 +73,17 @@ func WithRegistryClient(ctx context.Context, client RegistryClient) context.Cont
 // It will panic otherwise.
 func RegistryClientFrom(ctx context.Context) RegistryClient {
 	return ctx.Value(registryClientKey).(RegistryClient)
+}
+
+// WithWriteLimiter returns a new Context with a write limiter.
+func WithWriteLimiter(ctx context.Context, writeLimiter maxconnections.Limiter) context.Context {
+	return context.WithValue(ctx, writeLimiterKey, writeLimiter)
+}
+
+// WriteLimiterFrom returns the write limiter if one is stored in ctx, or nil otherwise.
+func WriteLimiterFrom(ctx context.Context) maxconnections.Limiter {
+	writeLimiter, _ := ctx.Value(writeLimiterKey).(maxconnections.Limiter)
+	return writeLimiter
 }
 
 // withUserClient returns a new Context with the origin's client.

--- a/pkg/dockerregistry/server/maxconnections/counter_test.go
+++ b/pkg/dockerregistry/server/maxconnections/counter_test.go
@@ -1,0 +1,83 @@
+package maxconnections
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+type countM map[interface{}]int
+
+type counter struct {
+	mu sync.Mutex
+	m  countM
+}
+
+func newCounter() *counter {
+	return &counter{
+		m: make(countM),
+	}
+}
+
+func (c *counter) Add(key interface{}, delta int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] += delta
+}
+
+func (c *counter) Values() countM {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m := make(map[interface{}]int)
+	for k, v := range c.m {
+		m[k] = v
+	}
+	return m
+}
+
+func (c *counter) Equal(m countM) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, v := range m {
+		if c.m[k] != v {
+			return false
+		}
+	}
+	for k, v := range c.m {
+		if _, ok := m[k]; !ok && v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCounter(t *testing.T) {
+	c := newCounter()
+	c.Add(100, 1)
+	c.Add(200, 2)
+	c.Add(300, 3)
+	if expected := (countM{100: 1, 200: 2, 300: 3}); !reflect.DeepEqual(c.m, expected) {
+		t.Fatalf("c.m = %v, want %v", c.m, expected)
+	}
+	if expected := (countM{100: 1, 200: 2, 300: 3}); !c.Equal(expected) {
+		t.Fatalf("counter(%v).Equal(%v) is false, want true", c.m, expected)
+	}
+
+	c.Add(200, -2)
+	if expected := (countM{100: 1, 200: 0, 300: 3}); !c.Equal(expected) {
+		t.Fatalf("counter(%v).Equal(%v) is false, want true", c.m, expected)
+	}
+	if expected := (countM{100: 1, 300: 3}); !c.Equal(expected) {
+		t.Fatalf("counter(%v).Equal(%v) is false, want true", c.m, expected)
+	}
+	if expected := (countM{100: 1, 300: 3, 400: 0}); !c.Equal(expected) {
+		t.Fatalf("counter(%v).Equal(%v) is false, want true", c.m, expected)
+	}
+
+	if expected := (countM{100: 1}); c.Equal(expected) {
+		t.Fatalf("counter(%v).Equal(%v) is true, want false", c.m, expected)
+	}
+	if expected := (countM{100: 1, 300: 3, 400: 4}); c.Equal(expected) {
+		t.Fatalf("counter(%v).Equal(%v) is true, want false", c.m, expected)
+	}
+}

--- a/pkg/dockerregistry/server/maxconnections/limiter.go
+++ b/pkg/dockerregistry/server/maxconnections/limiter.go
@@ -1,0 +1,88 @@
+package maxconnections
+
+import (
+	"context"
+	"time"
+)
+
+// A Limiter controls starting of jobs.
+type Limiter interface {
+	// Start decides whether a new job can be started. The decision may be
+	// returned after a delay if the limiter wants to throttle jobs.
+	Start(context.Context) bool
+
+	// Done must be called when a job is finished.
+	Done()
+}
+
+// limiter ensures that there are no more than maxRunning jobs at the same
+// time. It can enqueue up to maxInQueue jobs awaiting to be run, for other
+// jobs Start will return false immediately.
+type limiter struct {
+	// running is a buffered channel. Before starting a job, an empty struct is
+	// sent to the channel. When the job is finished, one element is received
+	// back from the channel. If the channel's buffer is full, the job is
+	// enqueued.
+	running chan struct{}
+
+	// queue is a buffered channel. An empty struct is placed into the channel
+	// while a job is waiting for a spot in the running channel's buffer.
+	// If the queue channel's buffer is full, the job is declined.
+	queue chan struct{}
+
+	// maxWaitInQueue is a maximum wait time in the queue, zero means forever.
+	maxWaitInQueue time.Duration
+
+	// newTimer allows to override the function time.NewTimer for tests.
+	newTimer func(d time.Duration) *time.Timer
+}
+
+// NewLimiter return a limiter that allows no more than maxRunning jobs at the
+// same time. It can enqueue up to maxInQueue jobs awaiting to be run, and a
+// job may wait in the queue no more than maxWaitInQueue.
+func NewLimiter(maxRunning, maxInQueue int, maxWaitInQueue time.Duration) Limiter {
+	return &limiter{
+		running:        make(chan struct{}, maxRunning),
+		queue:          make(chan struct{}, maxInQueue),
+		maxWaitInQueue: maxWaitInQueue,
+		newTimer:       time.NewTimer,
+	}
+}
+
+func (l *limiter) Start(ctx context.Context) bool {
+	select {
+	case l.running <- struct{}{}:
+		return true
+	default:
+	}
+
+	// Slow-path.
+	select {
+	case l.queue <- struct{}{}:
+		defer func() {
+			<-l.queue
+		}()
+	default:
+		return false
+	}
+
+	var timeout <-chan time.Time
+	// if l.maxWaitInQueue is 0, timeout will stay nil which practically means wait forever.
+	if l.maxWaitInQueue > 0 {
+		timer := l.newTimer(l.maxWaitInQueue)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+
+	select {
+	case l.running <- struct{}{}:
+		return true
+	case <-timeout:
+	case <-ctx.Done():
+	}
+	return false
+}
+
+func (l *limiter) Done() {
+	<-l.running
+}

--- a/pkg/dockerregistry/server/maxconnections/limiter_test.go
+++ b/pkg/dockerregistry/server/maxconnections/limiter_test.go
@@ -1,0 +1,193 @@
+package maxconnections
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestLimiter(t *testing.T) {
+	const timeout = 1 * time.Second
+
+	maxRunning := 2
+	maxInQueue := 3
+	maxWaitInQueue := time.Duration(1) // any non-zero value, we redefine newTimer for this test.
+	lim := NewLimiter(maxRunning, maxInQueue, maxWaitInQueue)
+
+	// All clients in the queue will be rejected when the channel deadline is closed.
+	deadline := make(chan time.Time)
+	lim.(*limiter).newTimer = func(d time.Duration) *time.Timer {
+		t := time.NewTimer(d)
+		t.C = deadline
+		return t
+	}
+
+	ctx := context.Background()
+	c := newCounter()
+	jobBarrier := make(chan struct{}, maxRunning+maxInQueue+1)
+	done := make(chan struct{})
+	wait := func(reason string) {
+		select {
+		case <-done:
+		case <-time.After(timeout):
+			t.Fatal(reason)
+		}
+	}
+	for i := 0; i < maxRunning+maxInQueue+1; i++ {
+		go func() {
+			started := lim.Start(ctx)
+			defer func() {
+				c.Add(started, 1)
+				done <- struct{}{}
+			}()
+			if started {
+				<-jobBarrier
+				lim.Done()
+			}
+		}()
+	}
+
+	wait("timeout while waiting one failed job")
+
+	// expected state: 2 running, 3 in queue, 1 failed
+	if expected := (countM{false: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	jobBarrier <- struct{}{}
+	wait("timeout while waiting one succeed job")
+
+	// expected state: 2 running, 2 in queue, 1 failed, 1 succeed
+	if expected := (countM{false: 1, true: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	close(deadline)
+	wait("timeout while waiting the first failed job from the queue")
+	wait("timeout while waiting the second failed job from the queue")
+
+	// expected state: 2 running, 0 in queue, 3 failed, 1 succeed
+	if expected := (countM{false: 3, true: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	jobBarrier <- struct{}{}
+	jobBarrier <- struct{}{}
+	wait("timeout while waiting the first succeed job")
+	wait("timeout while waiting the second succeed job")
+
+	// expected state: 0 running, 0 in queue, 3 failed, 3 succeed
+	if expected := (countM{false: 3, true: 3}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+}
+
+func TestLimiterContext(t *testing.T) {
+	const timeout = 1 * time.Second
+
+	maxRunning := 2
+	maxInQueue := 3
+	maxWaitInQueue := 120 * time.Second
+	lim := NewLimiter(maxRunning, maxInQueue, maxWaitInQueue)
+
+	type job struct {
+		ctx      context.Context
+		cancel   context.CancelFunc
+		finished bool
+	}
+	c := newCounter()
+	jobs := make(chan *job, maxRunning+maxInQueue+1)
+	jobBarrier := make(chan struct{}, maxRunning+maxInQueue+1)
+	done := make(chan struct{})
+	startJobs := func(amount int) {
+		for i := 0; i < amount; i++ {
+			go func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				job := &job{
+					ctx:      ctx,
+					cancel:   cancel,
+					finished: false,
+				}
+				jobs <- job
+
+				started := lim.Start(ctx)
+				defer func() {
+					c.Add(started, 1)
+					job.finished = true
+					done <- struct{}{}
+				}()
+				if started {
+					// if the job is running, it is not cancellable anymore
+					<-jobBarrier
+					lim.Done()
+				}
+			}()
+		}
+	}
+	cancelJobs := func(amount int, desc string) {
+		i := 0
+		for i < amount {
+			select {
+			case job := <-jobs:
+				if job.finished {
+					continue
+				}
+				job.cancel()
+				i++
+			case <-time.After(timeout):
+				t.Fatalf("timeout while cancelling %s (%d of %d)", desc, i+1, amount)
+			}
+		}
+	}
+	finishJobs := func(amount int, desc string) {
+		for i := 0; i < amount; i++ {
+			select {
+			case jobBarrier <- struct{}{}:
+			case <-time.After(timeout):
+				t.Fatalf("timeout while finishing %s (%d of %d)", desc, i+1, amount)
+			}
+		}
+	}
+	waitJobs := func(amount int, desc string) {
+		for i := 0; i < amount; i++ {
+			select {
+			case <-done:
+			case <-time.After(timeout):
+				t.Fatalf("timeout while waiting %s (%d of %d)", desc, i+1, amount)
+			}
+		}
+	}
+
+	startJobs(maxRunning + maxInQueue + 1)
+	waitJobs(1, "the job that doesn't fit in the queue from the first portion")
+
+	// expected state: 2 running, 3 in queue, 1 failed
+	if expected := (countM{false: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	cancelJobs(maxRunning+maxInQueue, "the jobs from the first portion")
+	// The running jobs is not cancellable in this test.
+	waitJobs(maxInQueue, "the cancelled jobs from the queue from the first portion")
+
+	// expected state: 2 running, 0 in queue, 4 failed
+	if expected := (countM{false: 4}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	startJobs(maxInQueue + 1)
+	waitJobs(1, "the job that doesn't fit in the queue from the second portion")
+
+	// expected state: 2 running, 3 in queue, 5 failed
+	if expected := (countM{false: 5}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	finishJobs(maxRunning+maxInQueue, "all running and queued jobs")
+	waitJobs(maxRunning+maxInQueue, "all finished jobs")
+
+	// expected state: 0 running, 0 in queue, 5 failed, 5 succeed
+	if expected := (countM{false: 5, true: 5}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+}

--- a/pkg/dockerregistry/server/maxconnections/maxconnections.go
+++ b/pkg/dockerregistry/server/maxconnections/maxconnections.go
@@ -1,0 +1,37 @@
+package maxconnections
+
+import "net/http"
+
+// See tooManyRequests from k8s.io/apiserver/pkg/server/filters/maxinflight.go
+func defaultOverloadHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Retry-After", "1") // Docker ignores this header, though.
+	http.Error(w, "Too many requests, please try again later.", http.StatusTooManyRequests)
+}
+
+// Handler implements the http.Handler interface.
+type Handler struct {
+	limiter Limiter
+	handler http.Handler
+
+	OverloadHandler http.Handler
+}
+
+// New returns an http.Handler that uses limiter to control h invocation.
+// If limiter prohibits starting a new handler, OverloadHandler will be
+// invoked.
+func New(limiter Limiter, h http.Handler) *Handler {
+	return &Handler{
+		limiter:         limiter,
+		handler:         h,
+		OverloadHandler: http.HandlerFunc(defaultOverloadHandler),
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.limiter.Start(r.Context()) {
+		h.OverloadHandler.ServeHTTP(w, r)
+		return
+	}
+	defer h.limiter.Done()
+	h.handler.ServeHTTP(w, r)
+}

--- a/pkg/dockerregistry/server/maxconnections/maxconnections_test.go
+++ b/pkg/dockerregistry/server/maxconnections/maxconnections_test.go
@@ -1,0 +1,82 @@
+package maxconnections
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestMaxConnections(t *testing.T) {
+	const timeout = 1 * time.Second
+
+	maxRunning := 1
+	maxInQueue := 2
+	maxWaitInQueue := time.Duration(0) // disable timeout
+	lim := NewLimiter(maxRunning, maxInQueue, maxWaitInQueue)
+
+	handlerBarrier := make(chan struct{}, maxRunning+maxInQueue+1)
+	h := New(lim, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-handlerBarrier
+		http.Error(w, "OK", http.StatusOK)
+	}))
+
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+	defer func() {
+		// Finish all pending requests in case of an error.
+		// This prevents ts.Close() from being stuck.
+		close(handlerBarrier)
+	}()
+
+	c := newCounter()
+	done := make(chan struct{})
+	wait := func(reason string) {
+		select {
+		case <-done:
+		case <-time.After(timeout):
+			t.Fatal(reason)
+		}
+	}
+	for i := 0; i < maxRunning+maxInQueue+1; i++ {
+		go func() {
+			res, err := http.Get(ts.URL)
+			if err != nil {
+				t.Errorf("failed to get %s: %s", ts.URL, err)
+			}
+			c.Add(res.StatusCode, 1)
+			done <- struct{}{}
+		}()
+	}
+
+	wait("timeout while waiting one failed client")
+
+	// expected state: 1 running, 2 in queue, 1 failed
+	if expected := (countM{429: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	handlerBarrier <- struct{}{}
+	wait("timeout while waiting the first succeed client")
+
+	// expected state: 1 running, 1 in queue, 1 failed, 1 succeed
+	if expected := (countM{200: 1, 429: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	handlerBarrier <- struct{}{}
+	wait("timeout while waiting the second succeed client")
+
+	// expected state: 1 running, 0 in queue, 1 failed, 2 succeed
+	if expected := (countM{200: 2, 429: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+
+	handlerBarrier <- struct{}{}
+	wait("timeout while waiting the third succeed client")
+
+	// expected state: 0 running, 0 in queue, 1 failed, 3 succeed
+	if expected := (countM{200: 3, 429: 1}); !c.Equal(expected) {
+		t.Errorf("c = %v, want %v", c.Values(), expected)
+	}
+}


### PR DESCRIPTION
The registry might have excessive resource usage under heavy load. To avoid this, we limit the number of concurrent requests. Requests over the MaxRunning limit are enqueued. Requests are rejected if there are MaxInQueue requests in the queue. Request may stay in the queue no more than MaxWaitInQueue.

See also #15448.