### PR TITLE
Remove extensions.jobs

### DIFF
--- a/pkg/api/meta/pods.go
+++ b/pkg/api/meta/pods.go
@@ -57,13 +57,11 @@ var resourcesToCheck = map[schema.GroupResource]schema.GroupKind{
 	batch.Resource("jobtemplates"):          batch.Kind("JobTemplate"),
 
 	// TODO do we still need this or is cronjob sufficient?
-	batch.Resource("scheduledjobs"):     batch.Kind("ScheduledJob"),
-	batch.Resource("cronjobs"):          batch.Kind("CronJob"),
-	extensions.Resource("deployments"):  extensions.Kind("Deployment"),
-	extensions.Resource("replicasets"):  extensions.Kind("ReplicaSet"),
-	extensions.Resource("jobs"):         extensions.Kind("Job"),
-	extensions.Resource("jobtemplates"): extensions.Kind("JobTemplate"),
-	apps.Resource("statefulsets"):       apps.Kind("StatefulSet"),
+	batch.Resource("scheduledjobs"):    batch.Kind("ScheduledJob"),
+	batch.Resource("cronjobs"):         batch.Kind("CronJob"),
+	extensions.Resource("deployments"): extensions.Kind("Deployment"),
+	extensions.Resource("replicasets"): extensions.Kind("ReplicaSet"),
+	apps.Resource("statefulsets"):      apps.Kind("StatefulSet"),
 
 	deployapi.Resource("deploymentconfigs"):                           deployapi.Kind("DeploymentConfig"),
 	deployapi.LegacyResource("deploymentconfigs"):                     deployapi.LegacyKind("DeploymentConfig"),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -332,7 +332,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs", "scheduledjobs", "cronjobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("horizontalpodautoscalers", "replicationcontrollers/scale",
 					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback", "networkpolicies").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
@@ -400,7 +400,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(readWrite...).Groups(batchGroup).Resources("jobs", "scheduledjobs", "cronjobs").RuleOrDie(),
 
-				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicationcontrollers/scale",
+				authorizationapi.NewRule(readWrite...).Groups(extensionsGroup).Resources("horizontalpodautoscalers", "replicationcontrollers/scale",
 					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
@@ -457,7 +457,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 
 				authorizationapi.NewRule(read...).Groups(batchGroup).Resources("jobs", "scheduledjobs", "cronjobs").RuleOrDie(),
 
-				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("jobs", "horizontalpodautoscalers", "replicasets", "replicasets/scale",
+				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("horizontalpodautoscalers", "replicasets", "replicasets/scale",
 					"deployments", "deployments/scale").RuleOrDie(),
 				authorizationapi.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -210,7 +210,6 @@ func BuildStorageFactory(masterConfig configapi.MasterConfig, server *kapiserver
 	}
 
 	// the order here is important, it defines which version will be used for storage
-	storageFactory.AddCohabitatingResources(batch.Resource("jobs"), extensions.Resource("jobs"))
 	// keep HPAs in the autoscaling apigroup (as in upstream 1.6), but keep extension cohabitation around until origin 3.7.
 	storageFactory.AddCohabitatingResources(autoscaling.Resource("horizontalpodautoscalers"), extensions.Resource("horizontalpodautoscalers"))
 	// keep Deployments in extensions for backwards compatibility, we'll have to migrate at some point, eventually

--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -327,17 +327,6 @@ func (f *Factory) PodForResource(resource string, timeout time.Duration) (string
 			return "", err
 		}
 		return pod.Name, nil
-	case extensions.Resource("jobs"):
-		kc, err := f.ClientSet()
-		if err != nil {
-			return "", err
-		}
-		// TODO/REBASE kc.Extensions() doesn't exist any more. Is this ok?
-		job, err := kc.Batch().Jobs(namespace).Get(name, metav1.GetOptions{})
-		if err != nil {
-			return "", err
-		}
-		return podNameForJob(job, kc, timeout, sortBy)
 	case batch.Resource("jobs"):
 		kc, err := f.ClientSet()
 		if err != nil {

--- a/pkg/image/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/admission/imagepolicy/imagepolicy.go
@@ -442,8 +442,7 @@ func (config resolutionConfig) FailOnResolutionFailure(gr schema.GroupResource) 
 
 var skipImageRewriteOnUpdate = map[schema.GroupResource]struct{}{
 	// Job template specs are immutable, they cannot be updated.
-	{Group: "extensions", Resource: "jobs"}: {},
-	{Group: "batch", Resource: "jobs"}:      {},
+	{Group: "batch", Resource: "jobs"}: {},
 	// Build specs are immutable, they cannot be updated.
 	{Group: "", Resource: "builds"}:                   {},
 	{Group: "build.openshift.io", Resource: "builds"}: {},

--- a/pkg/image/admission/imagepolicy/imagepolicy_test.go
+++ b/pkg/image/admission/imagepolicy/imagepolicy_test.go
@@ -1049,10 +1049,10 @@ func TestResolutionConfig(t *testing.T) {
 			config: &api.ImagePolicyConfig{
 				ResolveImages: api.DoNotAttempt,
 				ResolutionRules: []api.ImageResolutionPolicyRule{
-					{LocalNames: true, TargetResource: metav1.GroupResource{Group: "extensions", Resource: "jobs"}},
+					{LocalNames: true, TargetResource: metav1.GroupResource{Group: "batch", Resource: "jobs"}},
 				},
 			},
-			resource: schema.GroupResource{Group: "extensions", Resource: "jobs"},
+			resource: schema.GroupResource{Group: "batch", Resource: "jobs"},
 			update:   true,
 			resolve:  true,
 			rewrite:  false,
@@ -1063,10 +1063,10 @@ func TestResolutionConfig(t *testing.T) {
 			config: &api.ImagePolicyConfig{
 				ResolveImages: api.DoNotAttempt,
 				ResolutionRules: []api.ImageResolutionPolicyRule{
-					{LocalNames: true, TargetResource: metav1.GroupResource{Group: "extensions", Resource: "jobs"}},
+					{LocalNames: true, TargetResource: metav1.GroupResource{Group: "batch", Resource: "jobs"}},
 				},
 			},
-			resource: schema.GroupResource{Group: "extensions", Resource: "jobs"},
+			resource: schema.GroupResource{Group: "batch", Resource: "jobs"},
 			update:   false,
 			resolve:  true,
 			rewrite:  true,

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -190,12 +190,6 @@ func TestPodNodeConstraintsResources(t *testing.T) {
 		},
 		{
 			resource:      job,
-			kind:          extensions.Kind("Job"),
-			groupresource: extensions.Resource("jobs"),
-			prefix:        "Job",
-		},
-		{
-			resource:      job,
 			kind:          batch.Kind("Job"),
 			groupresource: batch.Resource("jobs"),
 			prefix:        "Job",

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -716,7 +716,6 @@ items:
     - deployments/rollback
     - deployments/scale
     - horizontalpodautoscalers
-    - jobs
     - networkpolicies
     - replicasets
     - replicasets/scale
@@ -1174,7 +1173,6 @@ items:
     - deployments/rollback
     - deployments/scale
     - horizontalpodautoscalers
-    - jobs
     - replicasets
     - replicasets/scale
     - replicationcontrollers/scale
@@ -1512,7 +1510,6 @@ items:
     - deployments
     - deployments/scale
     - horizontalpodautoscalers
-    - jobs
     - replicasets
     - replicasets/scale
     verbs:


### PR DESCRIPTION
@deads2k || @liggitt we've dropped support for `extensions.Jobs` in 3.6 so I think it's safe to remove it entirely from our code base. ptal