### PR TITLE
image: match the integrated registry when using image name in image policy

### DIFF
--- a/pkg/image/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/admission/imagepolicy/imagepolicy.go
@@ -304,7 +304,7 @@ func (c *imageResolutionCache) resolveImageReference(ref imageapi.DockerImageRef
 			return nil, err
 		}
 		c.cache.Add(ref.ID, imageCacheEntry{expires: now.Add(c.expiration), image: image})
-		return &rules.ImagePolicyAttributes{Name: ref, Image: image}, nil
+		return &rules.ImagePolicyAttributes{Name: ref, Image: image, IntegratedRegistry: c.integrated.Matches(ref.Registry)}, nil
 	}
 
 	fullReference := c.integrated.Matches(ref.Registry)


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/15475