### PR TITLE
registry: add Oleg and Michal as approvers for registry

### DIFF
--- a/pkg/dockerregistry/OWNERS
+++ b/pkg/dockerregistry/OWNERS
@@ -12,3 +12,5 @@ approvers:
   - legionus
   - liggitt
   - soltysh
+  - dmage
+  - miminar


### PR DESCRIPTION
@smarterclayton @bparees these two should be approvers for registry as they effectively owns that component. 