### PR TITLE
Enable IngressConfiguredRouter test

### DIFF
--- a/test/end-to-end/router_test.go
+++ b/test/end-to-end/router_test.go
@@ -1884,7 +1884,6 @@ func ingressConfiguredRouter(t *testing.T, fakeMasterAndPod *tr.TestHttpService)
 
 // TestRouterIngress validates that an ingress resource can configure a router to expose a tls route.
 func TestIngressConfiguredRouter(t *testing.T) {
-	t.Skip()
 	enableIngress := true
 	// Enable namespace filtering to allow validation of compatibility with ingress.
 	namespaceNames := []string{defaultNamespace}


### PR DESCRIPTION
We are no longer trying to run these tests inside of a container, so the
test disable that was added previously in 4af99ae4cf00197b2299c660ff1f8996047664b2
is no longer valid.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>