### PR TITLE
Add forwardfor option for passthrough routes

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -466,6 +466,7 @@ backend be_secure:{{$cfgIdx}}
 
 # Secure backend, pass through
 backend be_tcp:{{$cfgIdx}}
+  option forwardfor
 {{- if ne (env "ROUTER_SYSLOG_ADDRESS" "") ""}}
   option tcplog
 {{- end }}


### PR DESCRIPTION
Made X-Forwarded-For a default option for pass through routes in the haproxy-config.template file


