### PR TITLE
don't special case / in handler chain

### DIFF
--- a/pkg/authorization/apis/authorization/types.go
+++ b/pkg/authorization/apis/authorization/types.go
@@ -52,6 +52,9 @@ var DiscoveryRule = PolicyRule{
 		"/swaggerapi", "/swaggerapi/*", "/swagger.json",
 		"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
 		"/.well-known", "/.well-known/*",
+
+		// we intentionally allow all to here
+		"/",
 	),
 }
 

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -245,9 +245,6 @@ func (c *MasterConfig) buildHandlerChain(assetConfig *AssetConfig) (func(http.Ha
 			glog.Fatalf("Failed to setup serving of assets: %v", err)
 		}
 
-		// skip authz/n for the index handler
-		handler = WithPatternsHandler(handler, apiHandler, "/", "")
-
 		if c.WebConsoleEnabled() {
 			handler = WithAssetServerRedirect(handler, c.Options.AssetConfig.PublicURL)
 		}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1810,6 +1810,7 @@ items:
   - apiGroups: null
     attributeRestrictions: null
     nonResourceURLs:
+    - /
     - /.well-known
     - /.well-known/*
     - /api
@@ -2534,6 +2535,7 @@ items:
   - apiGroups: null
     attributeRestrictions: null
     nonResourceURLs:
+    - /
     - /.well-known
     - /.well-known/*
     - /api


### PR DESCRIPTION
I found this looking at our handler chain.  Rather than skip half the handler chain (makes it hard to reason about and maintain), this just grants the permission we need.

@openshift/security 