### PR TITLE
Remove ncdc from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - liggitt
   - bparees
   - stevekuznetsov
-  - ncdc
   - soltysh
 approvers:
   - smarterclayton
@@ -12,5 +11,5 @@ approvers:
   - liggitt
   - bparees
   - mfojtik
-  - eparis 
+  - eparis
   - derekwaynecarr

--- a/cmd/dockerregistry/OWNERS
+++ b/cmd/dockerregistry/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - smarterclayton
   - miminar
   - liggitt
-  - ncdc
 approvers:
   - pweil-
   - ironcladlou

--- a/examples/statefulsets/OWNERS
+++ b/examples/statefulsets/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
   - soltysh
-  - ncdc
 approvers:
   - soltysh

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - stevekuznetsov
   - liggitt
   - bparees
-  - ncdc
   - soltysh
 approvers:
   - smarterclayton

--- a/images/deployer/OWNERS
+++ b/images/deployer/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - kargakis
   - mfojtik
   - smarterclayton
-  - ncdc
 approvers:
   - tdawson
   - stevekuznetsov

--- a/images/dockerregistry/OWNERS
+++ b/images/dockerregistry/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - miminar
   - smarterclayton
-  - ncdc
   - legionus
   - tdawson
   - kargakis

--- a/images/release/OWNERS
+++ b/images/release/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - mfojtik
   - tdawson
   - fabianofranz
-  - ncdc
   - liggitt
   - jhadvig
 approvers:

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -6,7 +6,6 @@ reviewers:
   - mfojtik
   - csrwng
   - jwforres
-  - ncdc
 approvers:
   - smarterclayton
   - liggitt

--- a/pkg/api/OWNERS
+++ b/pkg/api/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - kargakis
   - mfojtik
   - liggitt
-  - ncdc
   - soltysh
   - gabemontero
   - bparees

--- a/pkg/authorization/OWNERS
+++ b/pkg/authorization/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - smarterclayton
   - liggitt
   - enj
-  - ncdc
   - soltysh
   - csrwng
   - stevekuznetsov

--- a/pkg/build/OWNERS
+++ b/pkg/build/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - mfojtik
   - soltysh
   - csrwng
-  - ncdc
   - gabemontero
 approvers:
   - bparees

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - deads2k
   - smarterclayton
-  - ncdc
   - kargakis
   - soltysh
   - liggitt

--- a/pkg/cmd/OWNERS
+++ b/pkg/cmd/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - liggitt
   - mfojtik
   - kargakis
-  - ncdc
   - soltysh
   - juanvallejo
   - csrwng

--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - smarterclayton
   - deads2k
-  - ncdc
   - kargakis
   - soltysh
   - bparees

--- a/pkg/deploy/OWNERS
+++ b/pkg/deploy/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - kargakis
   - smarterclayton
   - mfojtik
-  - ncdc
   - soltysh
   - abhgupta
 approvers:

--- a/pkg/diagnostics/OWNERS
+++ b/pkg/diagnostics/OWNERS
@@ -6,7 +6,6 @@ reviewers:
   - soltysh
   - jcantrill
   - dgoodwin
-  - ncdc
   - stevekuznetsov
 approvers:
   - pravisankar

--- a/pkg/dns/OWNERS
+++ b/pkg/dns/OWNERS
@@ -1,6 +1,5 @@
 reviewers:
   - smarterclayton
-  - ncdc
   - liggitt
   - soltysh
   - pweil-

--- a/pkg/dockerregistry/OWNERS
+++ b/pkg/dockerregistry/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - miminar
   - smarterclayton
-  - ncdc
   - legionus
   - liggitt
   - dmage

--- a/pkg/generate/OWNERS
+++ b/pkg/generate/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - gabemontero
   - mfojtik
   - jim-minter
-  - ncdc
 approvers:
   - smarterclayton
   - csrwng

--- a/pkg/gitserver/OWNERS
+++ b/pkg/gitserver/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - smarterclayton
   - csrwng
   - liggitt
-  - ncdc
   - jim-minter
   - bparees
 approvers:

--- a/pkg/image/OWNERS
+++ b/pkg/image/OWNERS
@@ -1,6 +1,5 @@
 reviewers:
   - smarterclayton
-  - ncdc
   - soltysh
   - miminar
   - mfojtik

--- a/pkg/ingress/OWNERS
+++ b/pkg/ingress/OWNERS
@@ -1,6 +1,5 @@
 reviewers:
   - JacobTanenbaum
   - smarterclayton
-  - ncdc
 approvers:
   - smarterclayton

--- a/pkg/ipfailover/OWNERS
+++ b/pkg/ipfailover/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - pecameron
   - stevekuznetsov
   - liggitt
-  - ncdc
 approvers:
   - smarterclayton
   - stevekuznetsov

--- a/pkg/oauth/OWNERS
+++ b/pkg/oauth/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - smarterclayton
   - deads2k
   - liggitt
-  - ncdc
   - soltysh
   - enj
   - stevekuznetsov

--- a/pkg/openservicebroker/OWNERS
+++ b/pkg/openservicebroker/OWNERS
@@ -1,4 +1,3 @@
 reviewers:
   - jim-minter
-  - ncdc
 approvers:

--- a/pkg/project/OWNERS
+++ b/pkg/project/OWNERS
@@ -5,7 +5,6 @@ reviewers:
   - derekwaynecarr
   - mfojtik
   - soltysh
-  - ncdc
   - pweil-
   - csrwng
   - enj

--- a/pkg/proxy/OWNERS
+++ b/pkg/proxy/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - DirectXMan12
   - knobunc
-  - ncdc
   - soltysh
   - dcbw
 approvers:

--- a/pkg/quota/OWNERS
+++ b/pkg/quota/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - deads2k
   - smarterclayton
-  - ncdc
   - miminar
   - liggitt
   - soltysh

--- a/pkg/route/OWNERS
+++ b/pkg/route/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - smarterclayton
   - pweil-
   - soltysh
-  - ncdc
   - liggitt
   - imcsk8
   - knobunc

--- a/pkg/sdn/OWNERS
+++ b/pkg/sdn/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - pravisankar
   - dcbw
   - smarterclayton
-  - ncdc
   - rajatchopra
   - soltysh
   - danwinship

--- a/pkg/security/OWNERS
+++ b/pkg/security/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - smarterclayton
   - pweil-
   - soltysh
-  - ncdc
   - liggitt
   - php-coder
   - enj

--- a/pkg/service/OWNERS
+++ b/pkg/service/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - smarterclayton
   - soltysh
-  - ncdc
   - mfojtik
   - pravisankar
   - pweil-

--- a/pkg/serviceaccounts/OWNERS
+++ b/pkg/serviceaccounts/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - liggitt
   - smarterclayton
   - mfojtik
-  - ncdc
   - pweil-
   - sgallagher
   - enj

--- a/pkg/template/OWNERS
+++ b/pkg/template/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - jim-minter
   - bparees
   - soltysh
-  - ncdc
 approvers:
   - smarterclayton
   - mfojtik

--- a/pkg/unidling/OWNERS
+++ b/pkg/unidling/OWNERS
@@ -1,6 +1,5 @@
 reviewers:
   - DirectXMan12
-  - ncdc
   - soltysh
   - juanvallejo
   - liggitt

--- a/pkg/user/OWNERS
+++ b/pkg/user/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - liggitt
   - mfojtik
   - soltysh
-  - ncdc
   - pweil-
   - stevekuznetsov
   - enj

--- a/pkg/volume/OWNERS
+++ b/pkg/volume/OWNERS
@@ -1,6 +1,5 @@
 reviewers:
   - dgoodwin
-  - ncdc
   - danmcp
   - smarterclayton
 approvers:

--- a/test/common/OWNERS
+++ b/test/common/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - csrwng
   - bparees
-  - ncdc
   - soltysh
   - deads2k
 approvers:

--- a/test/integration/OWNERS
+++ b/test/integration/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - liggitt
   - mfojtik
   - csrwng
-  - ncdc
   - soltysh
   - bparees
   - kargakis

--- a/test/testdata/OWNERS
+++ b/test/testdata/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - mfojtik
   - enj
   - liggitt
-  - ncdc
   - soltysh
   - jim-minter
   - knobunc

--- a/test/util/OWNERS
+++ b/test/util/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - liggitt
   - deads2k
   - mfojtik
-  - ncdc
   - miminar
   - soltysh
   - sosiouxme

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - stevekuznetsov
   - deads2k
   - soltysh
-  - ncdc
   - liggitt
   - juanvallejo
 approvers:

--- a/tools/genconversion/OWNERS
+++ b/tools/genconversion/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - smarterclayton
   - deads2k
-  - ncdc
   - stevekuznetsov
   - pweil-
   - mfojtik

--- a/tools/gendeepcopy/OWNERS
+++ b/tools/gendeepcopy/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - deads2k
   - smarterclayton
   - soltysh
-  - ncdc
   - stevekuznetsov
   - pweil-
 approvers:

--- a/tools/gendefaults/OWNERS
+++ b/tools/gendefaults/OWNERS
@@ -1,3 +1,2 @@
 reviewers:
-  - ncdc
 approvers:

--- a/tools/genlisters/OWNERS
+++ b/tools/genlisters/OWNERS
@@ -1,3 +1,2 @@
 reviewers:
-  - ncdc
 approvers:

--- a/tools/genopenapi/OWNERS
+++ b/tools/genopenapi/OWNERS
@@ -1,3 +1,2 @@
 reviewers:
-  - ncdc
 approvers:

--- a/tools/genprotobuf/OWNERS
+++ b/tools/genprotobuf/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - ncdc
   - deads2k
   - soltysh
   - smarterclayton

--- a/tools/genswaggerdoc/OWNERS
+++ b/tools/genswaggerdoc/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
   - stevekuznetsov
-  - ncdc
 approvers:
   - stevekuznetsov

--- a/tools/rebasehelpers/OWNERS
+++ b/tools/rebasehelpers/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - stevekuznetsov
   - liggitt
   - soltysh
-  - ncdc
   - jpeeler
   - deads2k
   - smarterclayton


### PR DESCRIPTION
As a courtesy since Andy does not work at Red Hat anymore.

Signed-off-by: Monis Khan <mkhan@redhat.com>