### PR TITLE
Replace legacy client in Docker Registry with external clientset

### DIFF
--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -47,6 +47,7 @@ import (
 	"github.com/openshift/origin/pkg/dockerregistry/server"
 	"github.com/openshift/origin/pkg/dockerregistry/server/api"
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 	registryconfig "github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 	"github.com/openshift/origin/pkg/dockerregistry/server/maxconnections"
 	"github.com/openshift/origin/pkg/dockerregistry/server/prune"
@@ -94,7 +95,7 @@ func ExecutePruner(configFile io.Reader, dryRun bool) {
 	}
 	log.WithFields(versionFields()).Info(startPrune)
 
-	registryClient := server.NewRegistryClient(clientcmd.NewConfig().BindToFile())
+	registryClient := client.NewRegistryClient(clientcmd.NewConfig().BindToFile())
 
 	storageDriver, err := factory.Create(config.Storage.Type(), config.Storage.Parameters())
 	if err != nil {
@@ -153,7 +154,7 @@ func Execute(configFile io.Reader) {
 		log.Fatalf("error configuring logger: %v", err)
 	}
 
-	registryClient := server.NewRegistryClient(clientcmd.NewConfig().BindToFile())
+	registryClient := client.NewRegistryClient(clientcmd.NewConfig().BindToFile())
 	ctx = server.WithRegistryClient(ctx, registryClient)
 
 	readLimiter := newLimiter(extraConfig.Requests.Read)
@@ -171,8 +172,8 @@ func Execute(configFile io.Reader) {
 			dockerConfig.Auth[server.OpenShiftAuth] = make(configuration.Parameters)
 		}
 		dockerConfig.Auth[server.OpenShiftAuth][server.AccessControllerOptionParams] = server.AccessControllerParams{
-			Logger:           context.GetLogger(ctx),
-			SafeClientConfig: registryClient.SafeClientConfig(),
+			Logger:         context.GetLogger(ctx),
+			RegistryClient: registryClient,
 		}
 	}
 

--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -450,7 +450,7 @@ func verifyOpenShiftUser(ctx context.Context, c client.UsersInterfacer) (string,
 	return userInfo.GetName(), string(userInfo.GetUID()), nil
 }
 
-func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, c client.SubjectAccessReviews) error {
+func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, c client.SelfSubjectAccessReviewsNamespacer) error {
 	sar := authorizationapi.SelfSubjectAccessReview{
 		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationapi.ResourceAttributes{
@@ -462,7 +462,7 @@ func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, 
 			},
 		},
 	}
-	response, err := c.SubjectAccessReviews().Create(&sar)
+	response, err := c.SelfSubjectAccessReviews().Create(&sar)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("OpenShift client error: %s", err)
 		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
@@ -479,15 +479,15 @@ func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, 
 	return nil
 }
 
-func verifyImageStreamAccess(ctx context.Context, namespace, imageRepo, verb string, c client.SubjectAccessReviews) error {
+func verifyImageStreamAccess(ctx context.Context, namespace, imageRepo, verb string, c client.SelfSubjectAccessReviewsNamespacer) error {
 	return verifyWithSAR(ctx, "imagestreams/layers", namespace, imageRepo, verb, c)
 }
 
-func verifyImageSignatureAccess(ctx context.Context, namespace, imageRepo string, c client.SubjectAccessReviews) error {
+func verifyImageSignatureAccess(ctx context.Context, namespace, imageRepo string, c client.SelfSubjectAccessReviewsNamespacer) error {
 	return verifyWithSAR(ctx, "imagesignatures", namespace, imageRepo, "create", c)
 }
 
-func verifyPruneAccess(ctx context.Context, c client.SubjectAccessReviews) error {
+func verifyPruneAccess(ctx context.Context, c client.SelfSubjectAccessReviewsNamespacer) error {
 	sar := authorizationapi.SelfSubjectAccessReview{
 		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationapi.ResourceAttributes{
@@ -497,7 +497,7 @@ func verifyPruneAccess(ctx context.Context, c client.SubjectAccessReviews) error
 			},
 		},
 	}
-	response, err := c.SubjectAccessReviews().Create(&sar)
+	response, err := c.SelfSubjectAccessReviews().Create(&sar)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("OpenShift client error: %s", err)
 		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {

--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -12,16 +12,13 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	restclient "k8s.io/client-go/rest"
-	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization/v1"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/util/httprequest"
 
 	"github.com/openshift/origin/pkg/dockerregistry/server/audit"
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 )
 
 type deferredErrors map[string]error
@@ -51,40 +48,6 @@ const (
 	AccessControllerOptionParams = "_params"
 )
 
-// RegistryClient encapsulates getting access to the OpenShift API.
-type RegistryClient interface {
-	// Clients return the authenticated clients to use with the server.
-	Clients() (client.Interface, kcoreclient.CoreInterface, error)
-	// SafeClientConfig returns a client config without authentication info.
-	SafeClientConfig() restclient.Config
-}
-
-// registryClient implements RegistryClient
-type registryClient struct {
-	config *clientcmd.Config
-}
-
-var _ RegistryClient = &registryClient{}
-
-// NewRegistryClient creates a registry client.
-func NewRegistryClient(config *clientcmd.Config) RegistryClient {
-	return &registryClient{config: config}
-}
-
-// Client returns the authenticated client to use with the server.
-func (r *registryClient) Clients() (client.Interface, kcoreclient.CoreInterface, error) {
-	oc, kc, err := r.config.Clients()
-	if err != nil {
-		return nil, nil, err
-	}
-	return oc, kc.Core(), err
-}
-
-// SafeClientConfig returns a client config without authentication info.
-func (r *registryClient) SafeClientConfig() restclient.Config {
-	return clientcmd.AnonymousClientConfig(r.config.OpenShiftConfig())
-}
-
 func init() {
 	registryauth.Register(OpenShiftAuth, registryauth.InitFunc(newAccessController))
 }
@@ -102,10 +65,10 @@ func WithUserInfoLogger(ctx context.Context, username, userid string) context.Co
 }
 
 type AccessController struct {
-	realm      string
-	tokenRealm *url.URL
-	config     restclient.Config
-	auditLog   bool
+	realm          string
+	tokenRealm     *url.URL
+	registryClient client.RegistryClient
+	auditLog       bool
 }
 
 var _ registryauth.AccessController = &AccessController{}
@@ -170,8 +133,8 @@ func TokenRealm(options map[string]interface{}) (*url.URL, error) {
 
 // AccessControllerParams is the parameters for newAccessController
 type AccessControllerParams struct {
-	Logger           context.Logger
-	SafeClientConfig restclient.Config
+	Logger         context.Logger
+	RegistryClient client.RegistryClient
 }
 
 func newAccessController(options map[string]interface{}) (registryauth.AccessController, error) {
@@ -193,9 +156,9 @@ func newAccessController(options map[string]interface{}) (registryauth.AccessCon
 	}
 
 	ac := &AccessController{
-		realm:      realm,
-		tokenRealm: tokenRealm,
-		config:     params.SafeClientConfig,
+		realm:          realm,
+		tokenRealm:     tokenRealm,
+		registryClient: params.RegistryClient,
 	}
 
 	if audit, ok := options["audit"]; ok {
@@ -305,9 +268,7 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 		return nil, ac.wrapErr(ctx, err)
 	}
 
-	copied := ac.config
-	copied.BearerToken = bearerToken
-	osClient, err := client.New(&copied)
+	osClient, err := ac.registryClient.ClientFromToken(bearerToken)
 	if err != nil {
 		return nil, ac.wrapErr(ctx, err)
 	}
@@ -476,8 +437,8 @@ func getOpenShiftAPIToken(ctx context.Context, req *http.Request) (string, error
 	return token, nil
 }
 
-func verifyOpenShiftUser(ctx context.Context, client client.UsersInterface) (string, string, error) {
-	userInfo, err := client.Users().Get("~", metav1.GetOptions{})
+func verifyOpenShiftUser(ctx context.Context, c client.UsersInterfacer) (string, string, error) {
+	userInfo, err := c.Users().Get("~", metav1.GetOptions{})
 	if err != nil {
 		context.GetLogger(ctx).Errorf("Get user failed with error: %s", err)
 		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
@@ -489,17 +450,19 @@ func verifyOpenShiftUser(ctx context.Context, client client.UsersInterface) (str
 	return userInfo.GetName(), string(userInfo.GetUID()), nil
 }
 
-func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, client client.LocalSubjectAccessReviewsNamespacer) error {
-	sar := authorizationapi.LocalSubjectAccessReview{
-		Action: authorizationapi.Action{
-			Verb:         verb,
-			Group:        imageapi.GroupName,
-			Resource:     resource,
-			ResourceName: name,
+func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, c client.SubjectAccessReviews) error {
+	sar := authorizationapi.SelfSubjectAccessReview{
+		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      verb,
+				Group:     imageapi.GroupName,
+				Resource:  resource,
+				Name:      name,
+			},
 		},
 	}
-	response, err := client.LocalSubjectAccessReviews(namespace).Create(&sar)
-
+	response, err := c.SubjectAccessReviews().Create(&sar)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("OpenShift client error: %s", err)
 		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
@@ -508,31 +471,33 @@ func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, 
 		return err
 	}
 
-	if !response.Allowed {
-		context.GetLogger(ctx).Errorf("OpenShift access denied: %s", response.Reason)
+	if !response.Status.Allowed {
+		context.GetLogger(ctx).Errorf("OpenShift access denied: %s", response.Status.Reason)
 		return ErrOpenShiftAccessDenied
 	}
 
 	return nil
 }
 
-func verifyImageStreamAccess(ctx context.Context, namespace, imageRepo, verb string, client client.LocalSubjectAccessReviewsNamespacer) error {
-	return verifyWithSAR(ctx, "imagestreams/layers", namespace, imageRepo, verb, client)
+func verifyImageStreamAccess(ctx context.Context, namespace, imageRepo, verb string, c client.SubjectAccessReviews) error {
+	return verifyWithSAR(ctx, "imagestreams/layers", namespace, imageRepo, verb, c)
 }
 
-func verifyImageSignatureAccess(ctx context.Context, namespace, imageRepo string, client client.LocalSubjectAccessReviewsNamespacer) error {
-	return verifyWithSAR(ctx, "imagesignatures", namespace, imageRepo, "create", client)
+func verifyImageSignatureAccess(ctx context.Context, namespace, imageRepo string, c client.SubjectAccessReviews) error {
+	return verifyWithSAR(ctx, "imagesignatures", namespace, imageRepo, "create", c)
 }
 
-func verifyPruneAccess(ctx context.Context, client client.SubjectAccessReviews) error {
-	sar := authorizationapi.SubjectAccessReview{
-		Action: authorizationapi.Action{
-			Verb:     "delete",
-			Group:    imageapi.GroupName,
-			Resource: "images",
+func verifyPruneAccess(ctx context.Context, c client.SubjectAccessReviews) error {
+	sar := authorizationapi.SelfSubjectAccessReview{
+		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Verb:     "delete",
+				Group:    imageapi.GroupName,
+				Resource: "images",
+			},
 		},
 	}
-	response, err := client.SubjectAccessReviews().Create(&sar)
+	response, err := c.SubjectAccessReviews().Create(&sar)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("OpenShift client error: %s", err)
 		if kerrors.IsUnauthorized(err) || kerrors.IsForbidden(err) {
@@ -540,8 +505,8 @@ func verifyPruneAccess(ctx context.Context, client client.SubjectAccessReviews) 
 		}
 		return err
 	}
-	if !response.Allowed {
-		context.GetLogger(ctx).Errorf("OpenShift access denied: %s", response.Reason)
+	if !response.Status.Allowed {
+		context.GetLogger(ctx).Errorf("OpenShift access denied: %s", response.Status.Reason)
 		return ErrOpenShiftAccessDenied
 	}
 	return nil

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -19,15 +19,25 @@ import (
 
 	"github.com/docker/distribution/context"
 	"github.com/openshift/origin/pkg/api/latest"
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization/v1"
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
-	"github.com/openshift/origin/pkg/client"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 )
+
+func sarResponse(ns string, allowed bool, reason string) *authorizationapi.SelfSubjectAccessReview {
+	resp := &authorizationapi.SelfSubjectAccessReview{}
+	if len(ns) > 0 {
+		resp.Namespace = ns
+	}
+	resp.Status = authorizationapi.SubjectAccessReviewStatus{Allowed: allowed, Reason: reason}
+	return resp
+}
 
 // TestVerifyImageStreamAccess mocks openshift http request/response and
 // tests invalid/valid/scoped openshift tokens.
@@ -45,11 +55,7 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 			// Test valid openshift bearer token but token *not* scoped for create operation
 			openshiftResponse: response{
 				200,
-				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{
-					Namespace: "foo",
-					Allowed:   false,
-					Reason:    "not authorized!",
-				}),
+				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("foo", false, "not authorized!")),
 			},
 			expectedError: ErrOpenShiftAccessDenied,
 		},
@@ -57,11 +63,7 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 			// Test valid openshift bearer token and token scoped for create operation
 			openshiftResponse: response{
 				200,
-				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{
-					Namespace: "foo",
-					Allowed:   true,
-					Reason:    "authorized!",
-				}),
+				runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("foo", true, "authorized!")),
 			},
 			expectedError: nil,
 		},
@@ -69,11 +71,19 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 	for _, test := range tests {
 		ctx := context.Background()
 		server, _ := simulateOpenShiftMaster([]response{test.openshiftResponse})
-		client, err := client.New(&restclient.Config{BearerToken: "magic bearer token", Host: server.URL})
+
+		cfg := clientcmd.NewConfig()
+		cfg.SkipEnv = true
+		cfg.KubernetesAddr.Set(server.URL)
+		cfg.CommonConfig = restclient.Config{
+			BearerToken: "magic bearer token",
+			Host:        server.URL,
+		}
+		osclient, err := client.NewRegistryClient(cfg).Client()
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = verifyImageStreamAccess(ctx, "foo", "bar", "create", client)
+		err = verifyImageStreamAccess(ctx, "foo", "bar", "create", osclient)
 		if err == nil || test.expectedError == nil {
 			if err != test.expectedError {
 				t.Fatalf("verifyImageStreamAccess did not get expected error - got %s - expected %s", err, test.expectedError)
@@ -154,24 +164,24 @@ func TestAccessController(t *testing.T) {
 			}},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
 			},
 			expectedError:     ErrNamespaceRequired,
 			expectedChallenge: false,
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
 			},
 		},
 		"registry token but does not involve any repository operation": {
 			access:     []auth.Access{{}},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
 			},
 			expectedError:     ErrUnsupportedResource,
 			expectedChallenge: false,
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
 			},
 		},
 		"registry token but does not involve any known action": {
@@ -184,12 +194,12 @@ func TestAccessController(t *testing.T) {
 			}},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
 			},
 			expectedError:     ErrUnsupportedAction,
 			expectedChallenge: false,
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
 			},
 		},
 		"docker login with invalid openshift creds": {
@@ -198,16 +208,16 @@ func TestAccessController(t *testing.T) {
 			expectedError:      ErrOpenShiftAccessDenied,
 			expectedChallenge:  true,
 			expectedHeaders:    http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`}},
-			expectedActions:    []string{"GET /oapi/v1/users/~ (Authorization=Bearer awesome)"},
+			expectedActions:    []string{"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)"},
 		},
 		"docker login with valid openshift creds": {
 			basicToken: "dXNyMTphd2Vzb21l",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
-			expectedActions:   []string{"GET /oapi/v1/users/~ (Authorization=Bearer awesome)"},
+			expectedActions:   []string{"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)"},
 		},
 		"error running subject access review": {
 			access: []auth.Access{{
@@ -219,14 +229,14 @@ func TestAccessController(t *testing.T) {
 			}},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
 				{500, "Uh oh"},
 			},
-			expectedError:     errors.New("an error on the server (\"unknown\") has prevented the request from succeeding (post localSubjectAccessReviews)"),
+			expectedError:     errors.New("an error on the server (\"unknown\") has prevented the request from succeeding (post selfsubjectaccessreviews.authorization.k8s.io)"),
 			expectedChallenge: false,
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
 			},
 		},
 		"valid openshift token but token not scoped for the given repo operation": {
@@ -239,15 +249,15 @@ func TestAccessController(t *testing.T) {
 			}},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: false, Reason: "unauthorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("foo", false, "not"))},
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
 			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`}},
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
 			},
 		},
 		"partially valid openshift token": {
@@ -260,21 +270,21 @@ func TestAccessController(t *testing.T) {
 			},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "bar", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "baz", Allowed: false, Reason: "no!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("foo", true, "authorized!"))},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("bar", true, "authorized!"))},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("", true, "authorized!"))},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("baz", false, "no!"))},
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
 			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`}},
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/bar/localsubjectaccessreviews (Authorization=Bearer awesome)",
-				"POST /oapi/v1/subjectaccessreviews (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/baz/localsubjectaccessreviews (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
 			},
 		},
 		"deferred cross-mount error": {
@@ -288,19 +298,19 @@ func TestAccessController(t *testing.T) {
 			},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "pushrepo", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "pushrepo", Allowed: true, Reason: "authorized!"})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "fromrepo", Allowed: false, Reason: "no!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("pushrepo", true, "authorized!"))},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("pushrepo", true, "authorized!"))},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("fromrepo", false, "no!"))},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
 			expectedRepoErr:   "fromrepo/bbb",
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/pushrepo/localsubjectaccessreviews (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/pushrepo/localsubjectaccessreviews (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/fromrepo/localsubjectaccessreviews (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
 			},
 		},
 		"valid openshift token": {
@@ -313,14 +323,14 @@ func TestAccessController(t *testing.T) {
 			}},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("", true, "authorized!"))},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
-				"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
 			},
 		},
 		"valid anonymous token": {
@@ -333,11 +343,13 @@ func TestAccessController(t *testing.T) {
 			}},
 			bearerToken: "anonymous",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Namespace: "foo", Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("foo", true, "authorized!"))},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
-			expectedActions:   []string{"POST /oapi/v1/namespaces/foo/localsubjectaccessreviews (Authorization=)"},
+			expectedActions: []string{
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=)",
+			},
 		},
 		"pruning": {
 			access: []auth.Access{
@@ -357,14 +369,14 @@ func TestAccessController(t *testing.T) {
 			},
 			basicToken: "b3BlbnNoaWZ0OmF3ZXNvbWU=",
 			openshiftResponses: []response{
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
-				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]), &authorizationapi.SubjectAccessReviewResponse{Allowed: true, Reason: "authorized!"})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(userapi.GroupName).GroupVersions[0]), &userapi.User{ObjectMeta: metav1.ObjectMeta{Name: "usr1"}})},
+				{200, runtime.EncodeOrDie(kapi.Codecs.LegacyCodec(kapi.Registry.GroupOrDie(authorizationapi.GroupName).GroupVersions[0]), sarResponse("", true, "authorized!"))},
 			},
 			expectedError:     nil,
 			expectedChallenge: false,
 			expectedActions: []string{
-				"GET /oapi/v1/users/~ (Authorization=Bearer awesome)",
-				"POST /oapi/v1/subjectaccessreviews (Authorization=Bearer awesome)",
+				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
+				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
 			},
 		},
 	}
@@ -394,12 +406,16 @@ func TestAccessController(t *testing.T) {
 		}
 
 		server, actions := simulateOpenShiftMaster(test.openshiftResponses)
+		cfg := clientcmd.NewConfig()
+		cfg.SkipEnv = true
+		cfg.KubernetesAddr.Set(server.URL)
+		cfg.CommonConfig = restclient.Config{
+			Host:            server.URL,
+			TLSClientConfig: restclient.TLSClientConfig{Insecure: true},
+		}
 		options[AccessControllerOptionParams] = AccessControllerParams{
-			Logger: context.GetLogger(context.Background()),
-			SafeClientConfig: restclient.Config{
-				Host:            server.URL,
-				TLSClientConfig: restclient.TLSClientConfig{Insecure: true},
-			},
+			Logger:         context.GetLogger(context.Background()),
+			RegistryClient: client.NewRegistryClient(cfg),
 		}
 		accessController, err := newAccessController(options)
 		if err != nil {
@@ -416,13 +432,13 @@ func TestAccessController(t *testing.T) {
 			expectedActions = []string{}
 		}
 		if !reflect.DeepEqual(actions, &expectedActions) {
-			t.Errorf("%s: expected\n\t%#v\ngot\n\t%#v", k, &expectedActions, actions)
+			t.Errorf("\n%s:\n expected:\n\t%#v\ngot:\n\t%#v", k, &expectedActions, actions)
 			continue
 		}
 
 		if err == nil || test.expectedError == nil {
 			if err != test.expectedError {
-				t.Errorf("%s: accessController did not get expected error - got %v - expected %v", k, err, test.expectedError)
+				t.Errorf("%s: accessController did not get expected error - got %+#v - expected %v", k, err, test.expectedError)
 				continue
 			}
 			if authCtx == nil {
@@ -461,7 +477,7 @@ func TestAccessController(t *testing.T) {
 			}
 
 			if err.Error() != test.expectedError.Error() {
-				t.Errorf("%s: accessController did not get expected error - got %s - expected %s", k, err, test.expectedError)
+				t.Errorf("%s: accessController did not get expected error - got %+v - expected %s", k, err, test.expectedError)
 				continue
 			}
 			if authCtx != nil {

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -32,9 +32,7 @@ import (
 
 func sarResponse(ns string, allowed bool, reason string) *authorizationapi.SelfSubjectAccessReview {
 	resp := &authorizationapi.SelfSubjectAccessReview{}
-	if len(ns) > 0 {
-		resp.Namespace = ns
-	}
+	resp.Namespace = ns
 	resp.Status = authorizationapi.SubjectAccessReviewStatus{Allowed: allowed, Reason: reason}
 	return resp
 }

--- a/pkg/dockerregistry/server/client/client.go
+++ b/pkg/dockerregistry/server/client/client.go
@@ -1,0 +1,162 @@
+package client
+
+import (
+	restclient "k8s.io/client-go/rest"
+	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+
+	authclientv1 "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/authorization/v1"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+
+	"github.com/openshift/origin/pkg/client"
+
+	imageclientv1 "github.com/openshift/origin/pkg/image/generated/clientset/typed/image/v1"
+	userclientv1 "github.com/openshift/origin/pkg/user/generated/clientset/typed/user/v1"
+)
+
+// RegistryClient provides Origin and Kubernetes clients to Docker Registry.
+type RegistryClient interface {
+	// Client returns the authenticated client to use with the server.
+	Client() (Interface, error)
+	// ClientFromToken returns a client based on the user bearer token.
+	ClientFromToken(token string) (Interface, error)
+}
+
+// Interface contains client methods that registry use to communicate with
+// Origin or Kubernetes API.
+type Interface interface {
+	ImageSignaturesInterfacer
+	ImagesInterfacer
+	ImageStreamImagesNamespacer
+	ImageStreamMappingsNamespacer
+	ImageStreamSecretsNamespacer
+	ImageStreamsNamespacer
+	ImageStreamTagsNamespacer
+	LimitRangesGetter
+	LocalSubjectAccessReviewsNamespacer
+	SubjectAccessReviews
+	UsersInterfacer
+}
+
+type apiClient struct {
+	oc    client.Interface
+	kube  kcoreclient.CoreInterface
+	auth  authclientv1.AuthorizationV1Interface
+	image imageclientv1.ImageV1Interface
+	user  userclientv1.UserV1Interface
+}
+
+func newAPIClient(
+	c client.Interface,
+	kc kcoreclient.CoreInterface,
+	authClient authclientv1.AuthorizationV1Interface,
+	imageClient imageclientv1.ImageV1Interface,
+	userClient userclientv1.UserV1Interface,
+) Interface {
+	return &apiClient{
+		oc:    c,
+		kube:  kc,
+		auth:  authClient,
+		image: imageClient,
+		user:  userClient,
+	}
+}
+
+func (c *apiClient) Users() UserInterface {
+	return c.user.Users()
+}
+
+func (c *apiClient) Images() ImageInterface {
+	return c.image.Images()
+}
+
+func (c *apiClient) ImageSignatures() ImageSignatureInterface {
+	return c.image.ImageSignatures()
+}
+
+func (c *apiClient) ImageStreams(namespace string) ImageStreamInterface {
+	return c.image.ImageStreams(namespace)
+}
+
+func (c *apiClient) ImageStreamImages(namespace string) ImageStreamImageInterface {
+	return c.image.ImageStreamImages(namespace)
+}
+
+func (c *apiClient) ImageStreamMappings(namespace string) ImageStreamMappingInterface {
+	return c.image.ImageStreamMappings(namespace)
+}
+
+func (c *apiClient) ImageStreamTags(namespace string) ImageStreamTagInterface {
+	return c.image.ImageStreamTags(namespace)
+}
+
+func (c *apiClient) ImageStreamSecrets(namespace string) ImageStreamSecretInterface {
+	return c.oc.ImageStreamSecrets(namespace)
+}
+
+func (c *apiClient) LimitRanges(namespace string) LimitRangeInterface {
+	return c.kube.LimitRanges(namespace)
+}
+
+func (c *apiClient) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface {
+	return c.auth.LocalSubjectAccessReviews(namespace)
+}
+
+func (c *apiClient) SubjectAccessReviews() SubjectAccessReviewInterface {
+	return c.auth.SelfSubjectAccessReviews()
+}
+
+type registryClient struct {
+	config *clientcmd.Config
+}
+
+func NewRegistryClient(config *clientcmd.Config) RegistryClient {
+	return &registryClient{config: config}
+}
+
+// Client returns the authenticated client to use with the server.
+func (c *registryClient) Client() (Interface, error) {
+	oc, kc, err := c.config.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	return newAPIClient(
+		oc,
+		kc.Core(),
+		authclientv1.NewForConfigOrDie(c.config.KubeConfig()),
+		imageclientv1.NewForConfigOrDie(c.config.KubeConfig()),
+		userclientv1.NewForConfigOrDie(c.config.KubeConfig()),
+	), nil
+}
+
+func (c *registryClient) ClientFromToken(token string) (Interface, error) {
+	_, kc, err := c.config.Clients()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := c.safeClientConfig()
+	cfg.BearerToken = token
+
+	oc, err := client.New(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfig := c.config.KubeConfig()
+	kubeConfig.BearerToken = token
+
+	return newAPIClient(
+		oc,
+		kc.Core(),
+		authclientv1.NewForConfigOrDie(kubeConfig),
+		imageclientv1.NewForConfigOrDie(kubeConfig),
+		userclientv1.NewForConfigOrDie(kubeConfig),
+	), nil
+}
+
+// safeClientConfig returns a client config without authentication info.
+func (с *registryClient) safeClientConfig() restclient.Config {
+	return clientcmd.AnonymousClientConfig(с.config.OpenShiftConfig())
+}

--- a/pkg/dockerregistry/server/client/doc.go
+++ b/pkg/dockerregistry/server/client/doc.go
@@ -1,0 +1,2 @@
+// Package client provides functions to make requests to external APIs.
+package client

--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	userapiv1 "github.com/openshift/origin/pkg/user/apis/user/v1"
+	authapiv1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
+)
+
+type UsersInterfacer interface {
+	Users() UserInterface
+}
+
+type ImagesInterfacer interface {
+	Images() ImageInterface
+}
+
+type ImageSignaturesInterfacer interface {
+	ImageSignatures() ImageSignatureInterface
+}
+
+type ImageStreamImagesNamespacer interface {
+	ImageStreamImages(namespace string) ImageStreamImageInterface
+}
+
+type ImageStreamsNamespacer interface {
+	ImageStreams(namespace string) ImageStreamInterface
+}
+
+type ImageStreamMappingsNamespacer interface {
+	ImageStreamMappings(namespace string) ImageStreamMappingInterface
+}
+
+type ImageStreamSecretsNamespacer interface {
+	ImageStreamSecrets(namespace string) ImageStreamSecretInterface
+}
+
+type ImageStreamTagsNamespacer interface {
+	ImageStreamTags(namespace string) ImageStreamTagInterface
+}
+
+type LimitRangesGetter interface {
+	LimitRanges(namespace string) LimitRangeInterface
+}
+
+type LocalSubjectAccessReviewsNamespacer interface {
+	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface
+}
+
+type SubjectAccessReviews interface {
+	SubjectAccessReviews() SubjectAccessReviewInterface
+}
+
+type ImageSignatureInterface interface {
+	Create(signature *imageapiv1.ImageSignature) (*imageapiv1.ImageSignature, error)
+}
+
+type ImageStreamImageInterface interface {
+	Get(name string, options metav1.GetOptions) (*imageapiv1.ImageStreamImage, error)
+}
+
+type UserInterface interface {
+	Get(name string, options metav1.GetOptions) (*userapiv1.User, error)
+}
+
+type ImageInterface interface {
+	Get(name string, options metav1.GetOptions) (*imageapiv1.Image, error)
+	Update(image *imageapiv1.Image) (*imageapiv1.Image, error)
+	List(opts metav1.ListOptions) (*imageapiv1.ImageList, error)
+}
+
+type ImageStreamInterface interface {
+	Get(name string, options metav1.GetOptions) (*imageapiv1.ImageStream, error)
+	Create(stream *imageapiv1.ImageStream) (*imageapiv1.ImageStream, error)
+}
+
+type ImageStreamMappingInterface interface {
+	Create(mapping *imageapiv1.ImageStreamMapping) (*imageapiv1.ImageStreamMapping, error)
+}
+
+type ImageStreamSecretInterface interface {
+	Secrets(name string, options metav1.ListOptions) (*kapi.SecretList, error)
+}
+
+type ImageStreamTagInterface interface {
+	Delete(name string, options *metav1.DeleteOptions) error
+}
+
+type LimitRangeInterface interface {
+	List(opts metav1.ListOptions) (*kapi.LimitRangeList, error)
+}
+
+type LocalSubjectAccessReviewInterface interface {
+	Create(policy *authapiv1.LocalSubjectAccessReview) (*authapiv1.LocalSubjectAccessReview, error)
+}
+
+type SubjectAccessReviewInterface interface {
+	Create(policy *authapiv1.SelfSubjectAccessReview) (*authapiv1.SelfSubjectAccessReview, error)
+}

--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -3,10 +3,15 @@ package client
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	userapiv1 "github.com/openshift/origin/pkg/user/apis/user/v1"
 	authapiv1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
+
+	imageclientv1 "github.com/openshift/origin/pkg/image/generated/clientset/typed/image/v1"
+	userclientv1 "github.com/openshift/origin/pkg/user/generated/clientset/typed/user/v1"
+	authclientv1 "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/authorization/v1"
 )
 
 type UsersInterfacer interface {
@@ -49,21 +54,29 @@ type LocalSubjectAccessReviewsNamespacer interface {
 	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewInterface
 }
 
-type SubjectAccessReviews interface {
-	SubjectAccessReviews() SubjectAccessReviewInterface
+type SelfSubjectAccessReviewsNamespacer interface {
+	SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface
 }
+
+var _ ImageSignatureInterface = imageclientv1.ImageSignatureInterface(nil)
 
 type ImageSignatureInterface interface {
 	Create(signature *imageapiv1.ImageSignature) (*imageapiv1.ImageSignature, error)
 }
 
+var _ ImageStreamImageInterface = imageclientv1.ImageStreamImageInterface(nil)
+
 type ImageStreamImageInterface interface {
 	Get(name string, options metav1.GetOptions) (*imageapiv1.ImageStreamImage, error)
 }
 
+var _ UserInterface = userclientv1.UserResourceInterface(nil)
+
 type UserInterface interface {
 	Get(name string, options metav1.GetOptions) (*userapiv1.User, error)
 }
+
+var _ ImageInterface = imageclientv1.ImageResourceInterface(nil)
 
 type ImageInterface interface {
 	Get(name string, options metav1.GetOptions) (*imageapiv1.Image, error)
@@ -71,31 +84,43 @@ type ImageInterface interface {
 	List(opts metav1.ListOptions) (*imageapiv1.ImageList, error)
 }
 
+var _ ImageStreamInterface = imageclientv1.ImageStreamInterface(nil)
+
 type ImageStreamInterface interface {
 	Get(name string, options metav1.GetOptions) (*imageapiv1.ImageStream, error)
 	Create(stream *imageapiv1.ImageStream) (*imageapiv1.ImageStream, error)
 }
 
+var _ ImageStreamMappingInterface = imageclientv1.ImageStreamMappingInterface(nil)
+
 type ImageStreamMappingInterface interface {
 	Create(mapping *imageapiv1.ImageStreamMapping) (*imageapiv1.ImageStreamMapping, error)
+}
+
+var _ ImageStreamTagInterface = imageclientv1.ImageStreamTagInterface(nil)
+
+type ImageStreamTagInterface interface {
+	Delete(name string, options *metav1.DeleteOptions) error
 }
 
 type ImageStreamSecretInterface interface {
 	Secrets(name string, options metav1.ListOptions) (*kapi.SecretList, error)
 }
 
-type ImageStreamTagInterface interface {
-	Delete(name string, options *metav1.DeleteOptions) error
-}
+var _ LimitRangeInterface = kcoreclient.LimitRangeInterface(nil)
 
 type LimitRangeInterface interface {
 	List(opts metav1.ListOptions) (*kapi.LimitRangeList, error)
 }
 
+var _ LocalSubjectAccessReviewInterface = authclientv1.LocalSubjectAccessReviewInterface(nil)
+
 type LocalSubjectAccessReviewInterface interface {
 	Create(policy *authapiv1.LocalSubjectAccessReview) (*authapiv1.LocalSubjectAccessReview, error)
 }
 
-type SubjectAccessReviewInterface interface {
+var _ SelfSubjectAccessReviewInterface = authclientv1.SelfSubjectAccessReviewInterface(nil)
+
+type SelfSubjectAccessReviewInterface interface {
 	Create(policy *authapiv1.SelfSubjectAccessReview) (*authapiv1.SelfSubjectAccessReview, error)
 }

--- a/pkg/dockerregistry/server/client/test.go
+++ b/pkg/dockerregistry/server/client/test.go
@@ -16,7 +16,7 @@ type fakeRegistryClient struct {
 
 func NewFakeRegistryClient(c client.Interface, imageclient imageclientv1.ImageV1Interface) RegistryClient {
 	return &fakeRegistryClient{
-		RegistryClient: NewRegistryClient(nil),
+		RegistryClient: &registryClient{},
 		client:         c,
 		images:         imageclient,
 	}

--- a/pkg/dockerregistry/server/client/test.go
+++ b/pkg/dockerregistry/server/client/test.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+
+	"github.com/openshift/origin/pkg/client"
+	imageclientv1 "github.com/openshift/origin/pkg/image/generated/clientset/typed/image/v1"
+)
+
+type fakeRegistryClient struct {
+	RegistryClient
+
+	client client.Interface
+	images imageclientv1.ImageV1Interface
+}
+
+func NewFakeRegistryClient(c client.Interface, imageclient imageclientv1.ImageV1Interface) RegistryClient {
+	return &fakeRegistryClient{
+		RegistryClient: NewRegistryClient(nil),
+		client:         c,
+		images:         imageclient,
+	}
+}
+
+func (c *fakeRegistryClient) Client() (Interface, error) {
+	return newAPIClient(c.client, nil, nil, c.images, nil), nil
+}
+
+func NewFakeRegistryAPIClient(c client.Interface, kc kcoreclient.CoreInterface, imageclient imageclientv1.ImageV1Interface) Interface {
+	return newAPIClient(c, nil, nil, imageclient, nil)
+}

--- a/pkg/dockerregistry/server/context.go
+++ b/pkg/dockerregistry/server/context.go
@@ -3,7 +3,7 @@ package server
 import (
 	"github.com/docker/distribution/context"
 
-	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 	"github.com/openshift/origin/pkg/dockerregistry/server/configuration"
 	"github.com/openshift/origin/pkg/dockerregistry/server/maxconnections"
 )
@@ -65,14 +65,14 @@ func remoteBlobAccessCheckEnabledFrom(ctx context.Context) bool {
 }
 
 // WithRegistryClient returns a new Context with provided registry client.
-func WithRegistryClient(ctx context.Context, client RegistryClient) context.Context {
+func WithRegistryClient(ctx context.Context, client client.RegistryClient) context.Context {
 	return context.WithValue(ctx, registryClientKey, client)
 }
 
 // RegistryClientFrom returns the registry client stored in ctx if present.
 // It will panic otherwise.
-func RegistryClientFrom(ctx context.Context) RegistryClient {
-	return ctx.Value(registryClientKey).(RegistryClient)
+func RegistryClientFrom(ctx context.Context) client.RegistryClient {
+	return ctx.Value(registryClientKey).(client.RegistryClient)
 }
 
 // WithWriteLimiter returns a new Context with a write limiter.

--- a/pkg/dockerregistry/server/manifesthandler.go
+++ b/pkg/dockerregistry/server/manifesthandler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 // A ManifestHandler defines a common set of operations on all versions of manifest schema.
@@ -18,7 +18,7 @@ type ManifestHandler interface {
 	// with blob sizes. Newer Docker client versions don't set layer sizes in the manifest schema 1 at all.
 	// Origin master needs correct layer sizes for proper image quota support. That's why we need to fill the
 	// metadata in the registry.
-	FillImageMetadata(ctx context.Context, image *imageapi.Image) error
+	FillImageMetadata(ctx context.Context, image *imageapiv1.Image) error
 
 	// Manifest returns a deserialized manifest object.
 	Manifest() distribution.Manifest
@@ -47,7 +47,7 @@ func NewManifestHandler(repo *repository, manifest distribution.Manifest) (Manif
 }
 
 // NewManifestHandlerFromImage creates a new manifest handler for a manifest stored in the given image.
-func NewManifestHandlerFromImage(repo *repository, image *imageapi.Image) (ManifestHandler, error) {
+func NewManifestHandlerFromImage(repo *repository, image *imageapiv1.Image) (ManifestHandler, error) {
 	var (
 		manifest distribution.Manifest
 		err      error

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 )
 
@@ -127,12 +128,12 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 	dgst := digest.FromBytes(canonical)
 
 	// Upload to openshift
-	ism := imageapi.ImageStreamMapping{
+	ism := imageapiv1.ImageStreamMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: m.repo.namespace,
 			Name:      m.repo.name,
 		},
-		Image: imageapi.Image{
+		Image: imageapiv1.Image{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: dgst.String(),
 				Annotations: map[string]string{
@@ -160,7 +161,7 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 	ism.Image.DockerImageManifest = ""
 	ism.Image.DockerImageConfig = ""
 
-	if err = m.repo.registryOSClient.ImageStreamMappings(m.repo.namespace).Create(&ism); err != nil {
+	if _, err = m.repo.registryOSClient.ImageStreamMappings(m.repo.namespace).Create(&ism); err != nil {
 		// if the error was that the image stream wasn't found, try to auto provision it
 		statusErr, ok := err.(*kerrors.StatusError)
 		if !ok {
@@ -190,7 +191,7 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 		}
 
 		// try to create the ISM again
-		if err := m.repo.registryOSClient.ImageStreamMappings(m.repo.namespace).Create(&ism); err != nil {
+		if _, err := m.repo.registryOSClient.ImageStreamMappings(m.repo.namespace).Create(&ism); err != nil {
 			if quotautil.IsErrorQuotaExceeded(err) {
 				context.GetLogger(ctx).Errorf("denied a creation of ImageStreamMapping: %v", err)
 				return "", distribution.ErrAccessDenied
@@ -217,7 +218,7 @@ var manifestInflight = make(map[digest.Digest]struct{})
 // manifestInflightSync protects manifestInflight
 var manifestInflightSync sync.Mutex
 
-func (m *manifestService) migrateManifest(ctx context.Context, image *imageapi.Image, dgst digest.Digest, manifest distribution.Manifest, isLocalStored bool) {
+func (m *manifestService) migrateManifest(ctx context.Context, image *imageapiv1.Image, dgst digest.Digest, manifest distribution.Manifest, isLocalStored bool) {
 	// Everything in its place and nothing to do.
 	if isLocalStored && len(image.DockerImageManifest) == 0 {
 		return
@@ -233,7 +234,7 @@ func (m *manifestService) migrateManifest(ctx context.Context, image *imageapi.I
 	go m.storeManifestLocally(ctx, image, dgst, manifest, isLocalStored)
 }
 
-func (m *manifestService) storeManifestLocally(ctx context.Context, image *imageapi.Image, dgst digest.Digest, manifest distribution.Manifest, isLocalStored bool) {
+func (m *manifestService) storeManifestLocally(ctx context.Context, image *imageapiv1.Image, dgst digest.Digest, manifest distribution.Manifest, isLocalStored bool) {
 	defer func() {
 		manifestInflightSync.Lock()
 		delete(manifestInflight, dgst)

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/distribution/digest"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 // pullthroughManifestService wraps a distribution.ManifestService
@@ -92,7 +93,7 @@ func (m *pullthroughManifestService) getRemoteRepositoryClient(ctx context.Conte
 			return nil, err // this is impossible
 		}
 		// if the client pulled by digest, find the corresponding tag in the image stream
-		tag, _ = imageapi.LatestImageTagEvent(is, dgst.String())
+		tag, _ = imageapiv1.LatestImageTagEvent(is, dgst.String())
 	}
 	insecure := pullInsecureByDefault(m.repo.imageStreamGetter.get, tag)
 

--- a/pkg/dockerregistry/server/quotarestrictedblobstore.go
+++ b/pkg/dockerregistry/server/quotarestrictedblobstore.go
@@ -20,8 +20,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 )
 
@@ -134,7 +134,7 @@ func (bw *quotaRestrictedBlobWriter) Commit(ctx context.Context, provisional dis
 }
 
 // getLimitRangeList returns list of limit ranges for repo.
-func getLimitRangeList(ctx context.Context, limitClient kcoreclient.LimitRangesGetter, namespace string) (*kapi.LimitRangeList, error) {
+func getLimitRangeList(ctx context.Context, limitClient client.LimitRangesGetter, namespace string) (*kapi.LimitRangeList, error) {
 	if quotaEnforcing.limitRanges != nil {
 		obj, exists, _ := quotaEnforcing.limitRanges.get(namespace)
 		if exists {
@@ -167,7 +167,7 @@ func admitBlobWrite(ctx context.Context, repo *repository, size int64) error {
 		return nil
 	}
 
-	lrs, err := getLimitRangeList(ctx, repo.limitClient, repo.namespace)
+	lrs, err := getLimitRangeList(ctx, repo.registryOSClient, repo.namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/dockerregistry/server/repository_test.go
+++ b/pkg/dockerregistry/server/repository_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
 
-	"github.com/openshift/origin/pkg/client/testclient"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 type testRepository struct {
@@ -29,7 +29,7 @@ func (r *testRepository) Blobs(ctx context.Context) distribution.BlobStore {
 }
 
 type testRepositoryOptions struct {
-	client            *testclient.Fake
+	client            client.Interface
 	enablePullThrough bool
 	blobs             distribution.BlobStore
 }
@@ -72,7 +72,7 @@ func newTestRepository(
 		cachedLayers:      cachedLayers,
 		registryOSClient:  opts.client,
 		imageStreamGetter: isGetter,
-		cachedImages:      make(map[digest.Digest]*imageapi.Image),
+		cachedImages:      make(map[digest.Digest]*imageapiv1.Image),
 	}
 
 	if opts.enablePullThrough {

--- a/pkg/dockerregistry/server/signaturedispatcher.go
+++ b/pkg/dockerregistry/server/signaturedispatcher.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ctxu "github.com/docker/distribution/context"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/docker/distribution/registry/handlers"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 
 	gorillahandlers "github.com/gorilla/handlers"
 )
@@ -104,7 +106,7 @@ func (s *signatureHandler) Put(w http.ResponseWriter, r *http.Request) {
 		s.handleError(s.ctx, ErrorCodeSignatureInvalid.WithDetail(errors.New("only schemaVersion=2 is currently supported")), w)
 		return
 	}
-	newSig := &imageapi.ImageSignature{Content: sig.Content, Type: sig.Type}
+	newSig := &imageapiv1.ImageSignature{Content: sig.Content, Type: sig.Type}
 	newSig.Name = sig.Name
 
 	_, err = client.ImageSignatures().Create(newSig)
@@ -151,7 +153,7 @@ func (s *signatureHandler) Get(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	image, err := client.ImageStreamImages(s.reference.Namespace).Get(s.reference.Name, s.reference.ID)
+	image, err := client.ImageStreamImages(s.reference.Namespace).Get(imageapi.MakeImageStreamImageName(s.reference.Name, s.reference.ID), metav1.GetOptions{})
 	switch {
 	case err == nil:
 	case kapierrors.IsUnauthorized(err):

--- a/pkg/dockerregistry/server/tagservice.go
+++ b/pkg/dockerregistry/server/tagservice.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 )
 
@@ -24,7 +25,7 @@ func (t tagService) Get(ctx context.Context, tag string) (distribution.Descripto
 		return distribution.Descriptor{}, distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
 	}
 
-	te := imageapi.LatestTaggedImage(imageStream, tag)
+	te := imageapiv1.LatestTaggedImage(imageStream, tag)
 	if te == nil {
 		return distribution.Descriptor{}, distribution.ErrTagUnknown{Tag: tag}
 	}
@@ -58,10 +59,11 @@ func (t tagService) All(ctx context.Context) ([]string, error) {
 
 	managedImages := make(map[string]bool)
 
-	for tag, history := range imageStream.Status.Tags {
+	for _, history := range imageStream.Status.Tags {
 		if len(history.Items) == 0 {
 			continue
 		}
+		tag := history.Tag
 
 		if t.repo.pullthrough {
 			tags = append(tags, tag)
@@ -105,10 +107,11 @@ func (t tagService) Lookup(ctx context.Context, desc distribution.Descriptor) ([
 
 	managedImages := make(map[string]bool)
 
-	for tag, history := range imageStream.Status.Tags {
+	for _, history := range imageStream.Status.Tags {
 		if len(history.Items) == 0 {
 			continue
 		}
+		tag := history.Tag
 
 		dgst, err := digest.ParseDigest(history.Items[0].Image)
 		if err != nil {
@@ -164,7 +167,7 @@ func (t tagService) Tag(ctx context.Context, tag string, dgst distribution.Descr
 		return distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
 	}
 
-	ism := imageapi.ImageStreamMapping{
+	ism := imageapiv1.ImageStreamMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: imageStream.Namespace,
 			Name:      imageStream.Name,
@@ -173,7 +176,7 @@ func (t tagService) Tag(ctx context.Context, tag string, dgst distribution.Descr
 		Image: *image,
 	}
 
-	err = t.repo.registryOSClient.ImageStreamMappings(imageStream.Namespace).Create(&ism)
+	_, err = t.repo.registryOSClient.ImageStreamMappings(imageStream.Namespace).Create(&ism)
 	if quotautil.IsErrorQuotaExceeded(err) {
 		context.GetLogger(ctx).Errorf("denied creating ImageStreamMapping: %v", err)
 		return distribution.ErrAccessDenied
@@ -189,7 +192,7 @@ func (t tagService) Untag(ctx context.Context, tag string) error {
 		return distribution.ErrRepositoryUnknown{Name: t.repo.Named().Name()}
 	}
 
-	te := imageapi.LatestTaggedImage(imageStream, tag)
+	te := imageapiv1.LatestTaggedImage(imageStream, tag)
 	if te == nil {
 		return distribution.ErrTagUnknown{Tag: tag}
 	}
@@ -210,5 +213,5 @@ func (t tagService) Untag(ctx context.Context, tag string) error {
 		}
 	}
 
-	return t.repo.registryOSClient.ImageStreamTags(imageStream.Namespace).Delete(imageStream.Name, tag)
+	return t.repo.registryOSClient.ImageStreamTags(imageStream.Namespace).Delete(imageapi.JoinImageStreamTag(imageStream.Name, tag), &metav1.DeleteOptions{})
 }

--- a/pkg/dockerregistry/server/tagservice_test.go
+++ b/pkg/dockerregistry/server/tagservice_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 
+	registryclient "github.com/openshift/origin/pkg/dockerregistry/server/client"
 	registrytest "github.com/openshift/origin/pkg/dockerregistry/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
@@ -17,7 +18,7 @@ func TestTagGet(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -68,7 +69,7 @@ func TestTagGet(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -106,10 +107,10 @@ func TestTagGetWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	_, client := registrytest.NewFakeOpenShiftWithClient()
+	_, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -133,7 +134,7 @@ func TestTagCreation(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -173,7 +174,7 @@ func TestTagCreation(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -188,6 +189,16 @@ func TestTagCreation(t *testing.T) {
 				t.Fatalf("[%s] error expected", tc.title)
 			}
 			continue
+		}
+
+		r = newTestRepository(t, namespace, repo, testRepositoryOptions{
+			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			enablePullThrough: tc.pullthrough,
+		})
+
+		ts = &tagService{
+			TagService: newTestTagService(nil),
+			repo:       r,
 		}
 
 		tag, err := ts.Get(context.Background(), tc.tagName)
@@ -206,11 +217,11 @@ func TestTagCreationWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	anotherImage := registrytest.AddRandomImage(t, fos, namespace, repo+"-another", tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -236,7 +247,7 @@ func TestTagDeletion(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -284,7 +295,7 @@ func TestTagDeletion(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -318,10 +329,10 @@ func TestTagDeletionWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	_, client := registrytest.NewFakeOpenShiftWithClient()
+	_, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -345,7 +356,7 @@ func TestTagGetAll(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -380,7 +391,7 @@ func TestTagGetAll(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -405,10 +416,10 @@ func TestTagGetAllWithoutImageStream(t *testing.T) {
 	namespace := "user"
 	repo := "app"
 
-	_, client := registrytest.NewFakeOpenShiftWithClient()
+	_, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -432,7 +443,7 @@ func TestTagLookup(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -478,7 +489,7 @@ func TestTagLookup(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            client,
+			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -511,11 +522,11 @@ func TestTagLookupWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client := registrytest.NewFakeOpenShiftWithClient()
+	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	anotherImage := registrytest.AddRandomImage(t, fos, namespace, repo+"-another", tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: client,
+		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
 	})
 
 	ts := &tagService{

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -9,16 +10,22 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/api/errcode"
 	disterrors "github.com/docker/distribution/registry/api/v2"
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	"github.com/openshift/origin/pkg/image/importer"
 )
 
@@ -132,7 +139,7 @@ func effectiveCreateOptions(options []distribution.BlobCreateOption) (*distribut
 	return opts, nil
 }
 
-func isImageManaged(image *imageapi.Image) bool {
+func isImageManaged(image *imageapiv1.Image) bool {
 	managed, ok := image.ObjectMeta.Annotations[imageapi.ManagedByOpenShiftAnnotation]
 	return ok && managed == "true"
 }
@@ -163,7 +170,7 @@ func wrapKStatusErrorOnGetImage(repoName string, dgst digest.Digest, err error) 
 // to remote repositories.
 func getImportContext(
 	ctx context.Context,
-	osClient osclient.ImageStreamSecretsNamespacer,
+	osClient client.ImageStreamSecretsNamespacer,
 	namespace, name string,
 ) importer.RepositoryRetriever {
 	secrets, err := osClient.ImageStreamSecrets(namespace).Secrets(name, metav1.ListOptions{})
@@ -180,11 +187,11 @@ type cachedImageStreamGetter struct {
 	ctx               context.Context
 	namespace         string
 	name              string
-	isNamespacer      osclient.ImageStreamsNamespacer
-	cachedImageStream *imageapi.ImageStream
+	isNamespacer      client.ImageStreamsNamespacer
+	cachedImageStream *imageapiv1.ImageStream
 }
 
-func (g *cachedImageStreamGetter) get() (*imageapi.ImageStream, error) {
+func (g *cachedImageStreamGetter) get() (*imageapiv1.ImageStream, error) {
 	if g.cachedImageStream != nil {
 		context.GetLogger(g.ctx).Debugf("(*cachedImageStreamGetter).getImageStream: returning cached copy")
 		return g.cachedImageStream, nil
@@ -207,7 +214,176 @@ func (g *cachedImageStreamGetter) get() (*imageapi.ImageStream, error) {
 	return is, nil
 }
 
-func (g *cachedImageStreamGetter) cacheImageStream(is *imageapi.ImageStream) {
+func (g *cachedImageStreamGetter) cacheImageStream(is *imageapiv1.ImageStream) {
 	context.GetLogger(g.ctx).Debugf("(*cachedImageStreamGetter).cacheImageStream: got image stream %s/%s", is.Namespace, is.Name)
 	g.cachedImageStream = is
+}
+
+// imageMetadataFromManifest is used only when creating the image stream mapping
+// in registry. In that case the image stream mapping contains image with the
+// manifest and we have to pupulate the the docker image metadata field.
+func imageMetadataFromManifest(image *imageapiv1.Image) error {
+	// Manifest must be set in order for this function to work as we extracting
+	// all metadata from the manifest.
+	if len(image.DockerImageManifest) == 0 {
+		return nil
+	}
+
+	// If we already have metadata don't mutate existing metadata.
+	meta, ok := image.DockerImageMetadata.Object.(*imageapi.DockerImage)
+	hasMetadata := ok && meta.Size > 0
+	if len(image.DockerImageLayers) > 0 && hasMetadata && len(image.DockerImageManifestMediaType) > 0 {
+		return nil
+	}
+
+	manifestData := image.DockerImageManifest
+
+	manifest := imageapi.DockerImageManifest{}
+	if err := json.Unmarshal([]byte(manifestData), &manifest); err != nil {
+		return err
+	}
+
+	switch manifest.SchemaVersion {
+	case 0:
+		// legacy config object
+	case 1:
+		image.DockerImageManifestMediaType = schema1.MediaTypeManifest
+
+		if len(manifest.History) == 0 {
+			// should never have an empty history, but just in case...
+			return nil
+		}
+
+		v1Metadata := imageapi.DockerV1CompatibilityImage{}
+		if err := json.Unmarshal([]byte(manifest.History[0].DockerV1Compatibility), &v1Metadata); err != nil {
+			return err
+		}
+
+		image.DockerImageLayers = make([]imageapiv1.ImageLayer, len(manifest.FSLayers))
+		for i, layer := range manifest.FSLayers {
+			image.DockerImageLayers[i].MediaType = schema1.MediaTypeManifestLayer
+			image.DockerImageLayers[i].Name = layer.DockerBlobSum
+		}
+		if len(manifest.History) == len(image.DockerImageLayers) {
+			// This code does not work for images converted from v2 to v1, since V1Compatibility does not
+			// contain size information in this case.
+			image.DockerImageLayers[0].LayerSize = v1Metadata.Size
+			var size = imageapi.DockerV1CompatibilityImageSize{}
+			for i, obj := range manifest.History[1:] {
+				size.Size = 0
+				if err := json.Unmarshal([]byte(obj.DockerV1Compatibility), &size); err != nil {
+					continue
+				}
+				image.DockerImageLayers[i+1].LayerSize = size.Size
+			}
+		}
+		// reverse order of the layers for v1 (lowest = 0, highest = i)
+		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
+			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
+		}
+
+		dockerImage := &imageapi.DockerImage{}
+
+		dockerImage.ID = v1Metadata.ID
+		dockerImage.Parent = v1Metadata.Parent
+		dockerImage.Comment = v1Metadata.Comment
+		dockerImage.Created = v1Metadata.Created
+		dockerImage.Container = v1Metadata.Container
+		dockerImage.ContainerConfig = v1Metadata.ContainerConfig
+		dockerImage.DockerVersion = v1Metadata.DockerVersion
+		dockerImage.Author = v1Metadata.Author
+		dockerImage.Config = v1Metadata.Config
+		dockerImage.Architecture = v1Metadata.Architecture
+		if len(image.DockerImageLayers) > 0 {
+			size := int64(0)
+			layerSet := sets.NewString()
+			for _, layer := range image.DockerImageLayers {
+				if layerSet.Has(layer.Name) {
+					continue
+				}
+				layerSet.Insert(layer.Name)
+				size += layer.LayerSize
+			}
+			dockerImage.Size = size
+		} else {
+			dockerImage.Size = v1Metadata.Size
+		}
+
+		image.DockerImageMetadata.Object = dockerImage
+	case 2:
+		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
+
+		if len(image.DockerImageConfig) == 0 {
+			return fmt.Errorf("dockerImageConfig must not be empty for manifest schema 2")
+		}
+		config := imageapi.DockerImageConfig{}
+		if err := json.Unmarshal([]byte(image.DockerImageConfig), &config); err != nil {
+			return fmt.Errorf("failed to parse dockerImageConfig: %v", err)
+		}
+
+		image.DockerImageLayers = make([]imageapiv1.ImageLayer, len(manifest.Layers))
+		for i, layer := range manifest.Layers {
+			image.DockerImageLayers[i].Name = layer.Digest
+			image.DockerImageLayers[i].LayerSize = layer.Size
+			image.DockerImageLayers[i].MediaType = layer.MediaType
+		}
+		// reverse order of the layers for v1 (lowest = 0, highest = i)
+		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
+			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
+		}
+		dockerImage := &imageapi.DockerImage{}
+
+		dockerImage.ID = manifest.Config.Digest
+		dockerImage.Parent = config.Parent
+		dockerImage.Comment = config.Comment
+		dockerImage.Created = config.Created
+		dockerImage.Container = config.Container
+		dockerImage.ContainerConfig = config.ContainerConfig
+		dockerImage.DockerVersion = config.DockerVersion
+		dockerImage.Author = config.Author
+		dockerImage.Config = config.Config
+		dockerImage.Architecture = config.Architecture
+		dockerImage.Size = int64(len(image.DockerImageConfig))
+
+		layerSet := sets.NewString(dockerImage.ID)
+		if len(image.DockerImageLayers) > 0 {
+			for _, layer := range image.DockerImageLayers {
+				if layerSet.Has(layer.Name) {
+					continue
+				}
+				layerSet.Insert(layer.Name)
+				dockerImage.Size += layer.LayerSize
+			}
+		}
+		image.DockerImageMetadata.Object = dockerImage
+	default:
+		return fmt.Errorf("unrecognized Docker image manifest schema %d for %q (%s)", manifest.SchemaVersion, image.Name, image.DockerImageReference)
+	}
+
+	if image.DockerImageMetadata.Object != nil && len(image.DockerImageMetadata.Raw) == 0 {
+		meta, ok := image.DockerImageMetadata.Object.(*imageapi.DockerImage)
+		if !ok {
+			return fmt.Errorf("docker image metadata object is not docker image")
+		}
+		gvString := image.DockerImageMetadataVersion
+		if len(gvString) == 0 {
+			gvString = "1.0"
+		}
+		if !strings.Contains(gvString, "/") {
+			gvString = "/" + gvString
+		}
+
+		version, err := schema.ParseGroupVersion(gvString)
+		if err != nil {
+			return err
+		}
+		data, err := runtime.Encode(kapi.Codecs.LegacyCodec(version), meta)
+		if err != nil {
+			return err
+		}
+		image.DockerImageMetadata.Raw = data
+		image.DockerImageMetadataVersion = version.Version
+	}
+
+	return nil
 }

--- a/pkg/dockerregistry/testutil/fakeopenshiftutil.go
+++ b/pkg/dockerregistry/testutil/fakeopenshiftutil.go
@@ -7,11 +7,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 // AddImageStream creates a new image stream with annotations.
-func AddImageStream(t *testing.T, fos *FakeOpenShift, namespace, name string, annotations map[string]string) *imageapi.ImageStream {
-	is := &imageapi.ImageStream{}
+func AddImageStream(t *testing.T, fos *FakeOpenShift, namespace, name string, annotations map[string]string) *imageapiv1.ImageStream {
+	is := &imageapiv1.ImageStream{}
 	is.Name = name
 	is.Annotations = annotations
 
@@ -23,7 +24,7 @@ func AddImageStream(t *testing.T, fos *FakeOpenShift, namespace, name string, an
 }
 
 // AddUntaggedImage creates image in fos.
-func AddUntaggedImage(t *testing.T, fos *FakeOpenShift, image *imageapi.Image) {
+func AddUntaggedImage(t *testing.T, fos *FakeOpenShift, image *imageapiv1.Image) {
 	_, err := fos.CreateImage(image)
 	if err != nil {
 		t.Fatal(err)
@@ -31,8 +32,8 @@ func AddUntaggedImage(t *testing.T, fos *FakeOpenShift, image *imageapi.Image) {
 }
 
 // AddImage tags image into the image stream namespace/name.
-func AddImage(t *testing.T, fos *FakeOpenShift, image *imageapi.Image, namespace, name, tag string) {
-	_, err := fos.CreateImageStreamMapping(namespace, &imageapi.ImageStreamMapping{
+func AddImage(t *testing.T, fos *FakeOpenShift, image *imageapiv1.Image, namespace, name, tag string) {
+	_, err := fos.CreateImageStreamMapping(namespace, &imageapiv1.ImageStreamMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -48,7 +49,7 @@ func AddImage(t *testing.T, fos *FakeOpenShift, image *imageapi.Image, namespace
 // AddRandomImage creates a new image with a random content and tags it into
 // the image stream namespace/name. If the image stream doesn't exists, it
 // will be created.
-func AddRandomImage(t *testing.T, fos *FakeOpenShift, namespace, name, tag string) *imageapi.Image {
+func AddRandomImage(t *testing.T, fos *FakeOpenShift, namespace, name, tag string) *imageapiv1.Image {
 	image, err := CreateRandomImage(namespace, name)
 	if err != nil {
 		t.Fatal(err)
@@ -67,8 +68,8 @@ func AddRandomImage(t *testing.T, fos *FakeOpenShift, namespace, name, tag strin
 }
 
 // AddImageStreamTag creates an image stream tag.
-func AddImageStreamTag(t *testing.T, fos *FakeOpenShift, image *imageapi.Image, namespace, name string, tag *imageapi.TagReference) *imageapi.ImageStreamTag {
-	istag, err := fos.CreateImageStreamTag(namespace, &imageapi.ImageStreamTag{
+func AddImageStreamTag(t *testing.T, fos *FakeOpenShift, image *imageapiv1.Image, namespace, name string, tag *imageapiv1.TagReference) *imageapiv1.ImageStreamTag {
+	istag, err := fos.CreateImageStreamTag(namespace, &imageapiv1.ImageStreamTag{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s:%s", name, tag.Name),
 		},

--- a/pkg/dockerregistry/testutil/manifests.go
+++ b/pkg/dockerregistry/testutil/manifests.go
@@ -22,8 +22,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
+	kapi "k8s.io/kubernetes/pkg/api"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 type ManifestSchemaVersion int
@@ -316,7 +318,7 @@ func AssertManifestsEqual(t *testing.T, description string, ma distribution.Mani
 
 // NewImageManifest creates a new Image object for the given manifest string. Note that the manifest must
 // contain signatures if it is of schema 1.
-func NewImageForManifest(repoName string, rawManifest string, manifestConfig string, managedByOpenShift bool) (*imageapi.Image, error) {
+func NewImageForManifest(repoName string, rawManifest string, manifestConfig string, managedByOpenShift bool) (*imageapiv1.Image, error) {
 	var versioned manifest.Versioned
 	if err := json.Unmarshal([]byte(rawManifest), &versioned); err != nil {
 		return nil, err
@@ -332,7 +334,7 @@ func NewImageForManifest(repoName string, rawManifest string, manifestConfig str
 		annotations[imageapi.ManagedByOpenShiftAnnotation] = "true"
 	}
 
-	img := &imageapi.Image{
+	img := imageapi.Image{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        desc.Digest.String(),
 			Annotations: annotations,
@@ -341,10 +343,17 @@ func NewImageForManifest(repoName string, rawManifest string, manifestConfig str
 		DockerImageManifest:  rawManifest,
 		DockerImageConfig:    manifestConfig,
 	}
+	if err := imageapi.ImageWithMetadata(&img); err != nil {
+		return nil, err
+	}
+	newImage := imageapiv1.Image{}
+	if err := kapi.Scheme.Converter().Convert(&img, &newImage, 0, nil); err != nil {
+		return nil, err
+	}
 
-	if err := imageapi.ImageWithMetadata(img); err != nil {
+	if err := imageapiv1.ImageWithMetadata(&newImage); err != nil {
 		return nil, fmt.Errorf("failed to fill image with metadata: %v", err)
 	}
 
-	return img, nil
+	return &newImage, nil
 }

--- a/pkg/dockerregistry/testutil/util.go
+++ b/pkg/dockerregistry/testutil/util.go
@@ -18,8 +18,7 @@ import (
 	distclient "github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
-
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 // UploadBlob uploads a blob with payload to the registry server located at
@@ -137,7 +136,7 @@ func CreateRandomTarFile() ([]byte, error) {
 }
 
 // CreateRandomImage creates an image with a random content.
-func CreateRandomImage(namespace, name string) (*imageapi.Image, error) {
+func CreateRandomImage(namespace, name string) (*imageapiv1.Image, error) {
 	_, manifest, _, err := CreateRandomManifest(ManifestSchema1, 3)
 	if err != nil {
 		return nil, err

--- a/pkg/image/apis/image/helper.go
+++ b/pkg/image/apis/image/helper.go
@@ -580,7 +580,7 @@ func LatestImageTagEvent(stream *ImageStream, imageID string) (string, *TagEvent
 			continue
 		}
 		for i, event := range events.Items {
-			if digestOrImageMatch(event.Image, imageID) &&
+			if DigestOrImageMatch(event.Image, imageID) &&
 				(latestTagEvent == nil || latestTagEvent != nil && event.Created.After(latestTagEvent.Created.Time)) {
 				latestTagEvent = &events.Items[i]
 				latestTag = tag
@@ -878,7 +878,8 @@ func UpdateTrackingTags(stream *ImageStream, updatedTag string, updatedImage Tag
 	return updated
 }
 
-func digestOrImageMatch(image, imageID string) bool {
+// DigestOrImageMatch matches the digest in the image name.
+func DigestOrImageMatch(image, imageID string) bool {
 	if d, err := digest.ParseDigest(image); err == nil {
 		return strings.HasPrefix(d.Hex(), imageID) || strings.HasPrefix(image, imageID)
 	}
@@ -893,7 +894,7 @@ func ResolveImageID(stream *ImageStream, imageID string) (*TagEvent, error) {
 	for _, history := range stream.Status.Tags {
 		for i := range history.Items {
 			tagging := &history.Items[i]
-			if digestOrImageMatch(tagging.Image, imageID) {
+			if DigestOrImageMatch(tagging.Image, imageID) {
 				event = tagging
 				set.Insert(tagging.Image)
 			}

--- a/pkg/image/apis/image/v1/helpers.go
+++ b/pkg/image/apis/image/v1/helpers.go
@@ -1,16 +1,15 @@
 package v1
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	api "k8s.io/kubernetes/pkg/api"
 
-	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/manifest/schema2"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
@@ -90,140 +89,22 @@ func LatestTaggedImage(stream *ImageStream, tag string) *TagEvent {
 // ImageWithMetadata mutates the given image. It parses raw DockerImageManifest data stored in the image and
 // fills its DockerImageMetadata and other fields.
 func ImageWithMetadata(image *Image) error {
-	if len(image.DockerImageManifest) == 0 {
+	// Check if the metadata are already filled in for this image.
+	meta, hasMetadata := image.DockerImageMetadata.Object.(*imageapi.DockerImage)
+	if hasMetadata && meta.Size > 0 {
 		return nil
 	}
 
-	if len(image.DockerImageLayers) > 0 && len(image.DockerImageManifestMediaType) > 0 {
-		if meta, ok := image.DockerImageMetadata.Object.(*imageapi.DockerImage); ok && meta.Size > 0 {
-			// don't update image already filled
-			return nil
-		}
+	version := image.DockerImageMetadataVersion
+	if len(version) == 0 {
+		version = "1.0"
 	}
 
-	manifestData := image.DockerImageManifest
-
-	manifest := imageapi.DockerImageManifest{}
-	if err := json.Unmarshal([]byte(manifestData), &manifest); err != nil {
+	obj := &imageapi.DockerImage{}
+	if err := runtime.DecodeInto(api.Codecs.UniversalDecoder(), image.DockerImageMetadata.Raw, obj); err != nil {
 		return err
 	}
-
-	switch manifest.SchemaVersion {
-	case 0:
-		// legacy config object
-	case 1:
-		image.DockerImageManifestMediaType = schema1.MediaTypeManifest
-
-		if len(manifest.History) == 0 {
-			// should never have an empty history, but just in case...
-			return nil
-		}
-
-		v1Metadata := imageapi.DockerV1CompatibilityImage{}
-		if err := json.Unmarshal([]byte(manifest.History[0].DockerV1Compatibility), &v1Metadata); err != nil {
-			return err
-		}
-
-		image.DockerImageLayers = make([]ImageLayer, len(manifest.FSLayers))
-		for i, layer := range manifest.FSLayers {
-			image.DockerImageLayers[i].MediaType = schema1.MediaTypeManifestLayer
-			image.DockerImageLayers[i].Name = layer.DockerBlobSum
-		}
-		if len(manifest.History) == len(image.DockerImageLayers) {
-			// This code does not work for images converted from v2 to v1, since V1Compatibility does not
-			// contain size information in this case.
-			image.DockerImageLayers[0].LayerSize = v1Metadata.Size
-			var size = imageapi.DockerV1CompatibilityImageSize{}
-			for i, obj := range manifest.History[1:] {
-				size.Size = 0
-				if err := json.Unmarshal([]byte(obj.DockerV1Compatibility), &size); err != nil {
-					continue
-				}
-				image.DockerImageLayers[i+1].LayerSize = size.Size
-			}
-		}
-		// reverse order of the layers for v1 (lowest = 0, highest = i)
-		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
-			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
-		}
-
-		dockerImage := &imageapi.DockerImage{}
-
-		dockerImage.ID = v1Metadata.ID
-		dockerImage.Parent = v1Metadata.Parent
-		dockerImage.Comment = v1Metadata.Comment
-		dockerImage.Created = v1Metadata.Created
-		dockerImage.Container = v1Metadata.Container
-		dockerImage.ContainerConfig = v1Metadata.ContainerConfig
-		dockerImage.DockerVersion = v1Metadata.DockerVersion
-		dockerImage.Author = v1Metadata.Author
-		dockerImage.Config = v1Metadata.Config
-		dockerImage.Architecture = v1Metadata.Architecture
-		if len(image.DockerImageLayers) > 0 {
-			size := int64(0)
-			layerSet := sets.NewString()
-			for _, layer := range image.DockerImageLayers {
-				if layerSet.Has(layer.Name) {
-					continue
-				}
-				layerSet.Insert(layer.Name)
-				size += layer.LayerSize
-			}
-			dockerImage.Size = size
-		} else {
-			dockerImage.Size = v1Metadata.Size
-		}
-
-		image.DockerImageMetadata.Object = dockerImage
-	case 2:
-		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
-
-		if len(image.DockerImageConfig) == 0 {
-			return fmt.Errorf("dockerImageConfig must not be empty for manifest schema 2")
-		}
-		config := imageapi.DockerImageConfig{}
-		if err := json.Unmarshal([]byte(image.DockerImageConfig), &config); err != nil {
-			return fmt.Errorf("failed to parse dockerImageConfig: %v", err)
-		}
-
-		image.DockerImageLayers = make([]ImageLayer, len(manifest.Layers))
-		for i, layer := range manifest.Layers {
-			image.DockerImageLayers[i].Name = layer.Digest
-			image.DockerImageLayers[i].LayerSize = layer.Size
-			image.DockerImageLayers[i].MediaType = layer.MediaType
-		}
-		// reverse order of the layers for v1 (lowest = 0, highest = i)
-		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
-			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
-		}
-		dockerImage := &imageapi.DockerImage{}
-
-		dockerImage.ID = manifest.Config.Digest
-		dockerImage.Parent = config.Parent
-		dockerImage.Comment = config.Comment
-		dockerImage.Created = config.Created
-		dockerImage.Container = config.Container
-		dockerImage.ContainerConfig = config.ContainerConfig
-		dockerImage.DockerVersion = config.DockerVersion
-		dockerImage.Author = config.Author
-		dockerImage.Config = config.Config
-		dockerImage.Architecture = config.Architecture
-		dockerImage.Size = int64(len(image.DockerImageConfig))
-
-		layerSet := sets.NewString(dockerImage.ID)
-		if len(image.DockerImageLayers) > 0 {
-			for _, layer := range image.DockerImageLayers {
-				if layerSet.Has(layer.Name) {
-					continue
-				}
-				layerSet.Insert(layer.Name)
-				dockerImage.Size += layer.LayerSize
-			}
-		}
-		image.DockerImageMetadata.Object = dockerImage
-	default:
-		return fmt.Errorf("unrecognized Docker image manifest schema %d for %q (%s)", manifest.SchemaVersion, image.Name, image.DockerImageReference)
-	}
-
+	image.DockerImageMetadata.Object = obj
+	image.DockerImageMetadataVersion = version
 	return nil
 }

--- a/pkg/image/apis/image/v1/helpers.go
+++ b/pkg/image/apis/image/v1/helpers.go
@@ -1,0 +1,229 @@
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+)
+
+// ResolveImageID returns latest TagEvent for specified imageID and an error if
+// there's more than one image matching the ID or when one does not exist.
+func ResolveImageID(stream *ImageStream, imageID string) (*TagEvent, error) {
+	var event *TagEvent
+	set := sets.NewString()
+	for _, history := range stream.Status.Tags {
+		for i := range history.Items {
+			tagging := &history.Items[i]
+			if imageapi.DigestOrImageMatch(tagging.Image, imageID) {
+				event = tagging
+				set.Insert(tagging.Image)
+			}
+		}
+	}
+	switch len(set) {
+	case 1:
+		return &TagEvent{
+			Created:              metav1.Now(),
+			DockerImageReference: event.DockerImageReference,
+			Image:                event.Image,
+		}, nil
+	case 0:
+		return nil, errors.NewNotFound(Resource("imagestreamimage"), imageID)
+	default:
+		return nil, errors.NewConflict(Resource("imagestreamimage"), imageID, fmt.Errorf("multiple images match the prefix %q: %s", imageID, strings.Join(set.List(), ", ")))
+	}
+}
+
+// LatestImageTagEvent returns the most recent TagEvent and the tag for the specified
+// image.
+func LatestImageTagEvent(stream *ImageStream, imageID string) (string, *TagEvent) {
+	var (
+		latestTagEvent *TagEvent
+		latestTag      string
+	)
+	for _, events := range stream.Status.Tags {
+		if len(events.Items) == 0 {
+			continue
+		}
+		tag := events.Tag
+		for i, event := range events.Items {
+			if imageapi.DigestOrImageMatch(event.Image, imageID) &&
+				(latestTagEvent == nil || latestTagEvent != nil && event.Created.After(latestTagEvent.Created.Time)) {
+				latestTagEvent = &events.Items[i]
+				latestTag = tag
+			}
+		}
+	}
+	return latestTag, latestTagEvent
+}
+
+// LatestTaggedImage returns the most recent TagEvent for the specified image
+// repository and tag. Will resolve lookups for the empty tag. Returns nil
+// if tag isn't present in stream.status.tags.
+func LatestTaggedImage(stream *ImageStream, tag string) *TagEvent {
+	if len(tag) == 0 {
+		tag = imageapi.DefaultImageTag
+	}
+	// find the most recent tag event with an image reference
+	if stream.Status.Tags != nil {
+		for _, t := range stream.Status.Tags {
+			if t.Tag == tag {
+				if len(t.Items) == 0 {
+					return nil
+				}
+				return &t.Items[0]
+			}
+		}
+	}
+
+	return nil
+}
+
+// ImageWithMetadata mutates the given image. It parses raw DockerImageManifest data stored in the image and
+// fills its DockerImageMetadata and other fields.
+func ImageWithMetadata(image *Image) error {
+	if len(image.DockerImageManifest) == 0 {
+		return nil
+	}
+
+	if len(image.DockerImageLayers) > 0 && len(image.DockerImageManifestMediaType) > 0 {
+		if meta, ok := image.DockerImageMetadata.Object.(*imageapi.DockerImage); ok && meta.Size > 0 {
+			// don't update image already filled
+			return nil
+		}
+	}
+
+	manifestData := image.DockerImageManifest
+
+	manifest := imageapi.DockerImageManifest{}
+	if err := json.Unmarshal([]byte(manifestData), &manifest); err != nil {
+		return err
+	}
+
+	switch manifest.SchemaVersion {
+	case 0:
+		// legacy config object
+	case 1:
+		image.DockerImageManifestMediaType = schema1.MediaTypeManifest
+
+		if len(manifest.History) == 0 {
+			// should never have an empty history, but just in case...
+			return nil
+		}
+
+		v1Metadata := imageapi.DockerV1CompatibilityImage{}
+		if err := json.Unmarshal([]byte(manifest.History[0].DockerV1Compatibility), &v1Metadata); err != nil {
+			return err
+		}
+
+		image.DockerImageLayers = make([]ImageLayer, len(manifest.FSLayers))
+		for i, layer := range manifest.FSLayers {
+			image.DockerImageLayers[i].MediaType = schema1.MediaTypeManifestLayer
+			image.DockerImageLayers[i].Name = layer.DockerBlobSum
+		}
+		if len(manifest.History) == len(image.DockerImageLayers) {
+			// This code does not work for images converted from v2 to v1, since V1Compatibility does not
+			// contain size information in this case.
+			image.DockerImageLayers[0].LayerSize = v1Metadata.Size
+			var size = imageapi.DockerV1CompatibilityImageSize{}
+			for i, obj := range manifest.History[1:] {
+				size.Size = 0
+				if err := json.Unmarshal([]byte(obj.DockerV1Compatibility), &size); err != nil {
+					continue
+				}
+				image.DockerImageLayers[i+1].LayerSize = size.Size
+			}
+		}
+		// reverse order of the layers for v1 (lowest = 0, highest = i)
+		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
+			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
+		}
+
+		dockerImage := &imageapi.DockerImage{}
+
+		dockerImage.ID = v1Metadata.ID
+		dockerImage.Parent = v1Metadata.Parent
+		dockerImage.Comment = v1Metadata.Comment
+		dockerImage.Created = v1Metadata.Created
+		dockerImage.Container = v1Metadata.Container
+		dockerImage.ContainerConfig = v1Metadata.ContainerConfig
+		dockerImage.DockerVersion = v1Metadata.DockerVersion
+		dockerImage.Author = v1Metadata.Author
+		dockerImage.Config = v1Metadata.Config
+		dockerImage.Architecture = v1Metadata.Architecture
+		if len(image.DockerImageLayers) > 0 {
+			size := int64(0)
+			layerSet := sets.NewString()
+			for _, layer := range image.DockerImageLayers {
+				if layerSet.Has(layer.Name) {
+					continue
+				}
+				layerSet.Insert(layer.Name)
+				size += layer.LayerSize
+			}
+			dockerImage.Size = size
+		} else {
+			dockerImage.Size = v1Metadata.Size
+		}
+
+		image.DockerImageMetadata.Object = dockerImage
+	case 2:
+		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
+
+		if len(image.DockerImageConfig) == 0 {
+			return fmt.Errorf("dockerImageConfig must not be empty for manifest schema 2")
+		}
+		config := imageapi.DockerImageConfig{}
+		if err := json.Unmarshal([]byte(image.DockerImageConfig), &config); err != nil {
+			return fmt.Errorf("failed to parse dockerImageConfig: %v", err)
+		}
+
+		image.DockerImageLayers = make([]ImageLayer, len(manifest.Layers))
+		for i, layer := range manifest.Layers {
+			image.DockerImageLayers[i].Name = layer.Digest
+			image.DockerImageLayers[i].LayerSize = layer.Size
+			image.DockerImageLayers[i].MediaType = layer.MediaType
+		}
+		// reverse order of the layers for v1 (lowest = 0, highest = i)
+		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
+			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
+		}
+		dockerImage := &imageapi.DockerImage{}
+
+		dockerImage.ID = manifest.Config.Digest
+		dockerImage.Parent = config.Parent
+		dockerImage.Comment = config.Comment
+		dockerImage.Created = config.Created
+		dockerImage.Container = config.Container
+		dockerImage.ContainerConfig = config.ContainerConfig
+		dockerImage.DockerVersion = config.DockerVersion
+		dockerImage.Author = config.Author
+		dockerImage.Config = config.Config
+		dockerImage.Architecture = config.Architecture
+		dockerImage.Size = int64(len(image.DockerImageConfig))
+
+		layerSet := sets.NewString(dockerImage.ID)
+		if len(image.DockerImageLayers) > 0 {
+			for _, layer := range image.DockerImageLayers {
+				if layerSet.Has(layer.Name) {
+					continue
+				}
+				layerSet.Insert(layer.Name)
+				dockerImage.Size += layer.LayerSize
+			}
+		}
+		image.DockerImageMetadata.Object = dockerImage
+	default:
+		return fmt.Errorf("unrecognized Docker image manifest schema %d for %q (%s)", manifest.SchemaVersion, image.Name, image.DockerImageReference)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This use the recent changes to codegen to provide missing clients for some of the image.openshift.io group resouces and then replace clients in registry with external clientsets.

In order to pickup external clients I had to rework the registry code in some places to deal with external types. I failed to do that in some places and fall-backed to conversions, which I hate but it will require more plumbing in the origin code to get this right.

Also I failed to use the external clientset for ImageSecrets as it is implemented as not-standard client returning `[]Secret` instead of `ImageSecretList` (so we can't generate client for that). 

Part of fixing: https://github.com/openshift/origin/issues/15272