### PR TITLE
generate more image clients and fix users clientset

### DIFF
--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -94,6 +94,10 @@ const (
 	ImageSignatureTypeAtomicImageV1 string = "AtomicImageV1"
 )
 
+// +genclient
+// +genclient:onlyVerbs=create,delete
+// +genclient:nonNamespaced
+
 // ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims
 // as long as the signature is trusted. Based on this information it is possible to restrict runnable images
 // to those matching cluster-wide policy.
@@ -351,6 +355,9 @@ type TagEventCondition struct {
 	Generation int64
 }
 
+// +genclient
+// +genclient:onlyVerbs=create
+
 // ImageStreamMapping represents a mapping from a single tag to a Docker image as
 // well as the reference to the Docker image repository the image came from.
 type ImageStreamMapping struct {
@@ -366,6 +373,9 @@ type ImageStreamMapping struct {
 	// A string value this image can be located with inside the repository.
 	Tag string
 }
+
+// +genclient
+// +genclient:onlyVerbs=get,create,update,delete
 
 // ImageStreamTag has a .Name in the format <stream name>:<tag>.
 type ImageStreamTag struct {
@@ -400,6 +410,9 @@ type ImageStreamTagList struct {
 
 	Items []ImageStreamTag
 }
+
+// +genclient
+// +genclient:onlyVerbs=get
 
 // ImageStreamImage represents an Image that is retrieved by image name from an ImageStream.
 type ImageStreamImage struct {

--- a/pkg/image/apis/image/v1/types.go
+++ b/pkg/image/apis/image/v1/types.go
@@ -58,6 +58,10 @@ type ImageLayer struct {
 	MediaType string `json:"mediaType" protobuf:"bytes,3,opt,name=mediaType"`
 }
 
+// +genclient
+// +genclient:onlyVerbs=create,delete
+// +genclient:nonNamespaced
+
 // ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims
 // as long as the signature is trusted. Based on this information it is possible to restrict runnable images
 // to those matching cluster-wide policy.
@@ -300,6 +304,9 @@ type TagEventCondition struct {
 	Generation int64 `json:"generation" protobuf:"varint,6,opt,name=generation"`
 }
 
+// +genclient
+// +genclient:onlyVerbs=create
+
 // ImageStreamMapping represents a mapping from a single tag to a Docker image as
 // well as the reference to the Docker image stream the image came from.
 type ImageStreamMapping struct {
@@ -312,6 +319,9 @@ type ImageStreamMapping struct {
 	// Tag is a string value this image can be located with inside the stream.
 	Tag string `json:"tag" protobuf:"bytes,3,opt,name=tag"`
 }
+
+// +genclient
+// +genclient:onlyVerbs=get,create,update,delete
 
 // ImageStreamTag represents an Image that is retrieved by tag name from an ImageStream.
 type ImageStreamTag struct {
@@ -349,6 +359,9 @@ type ImageStreamTagList struct {
 	// Items is the list of image stream tags
 	Items []ImageStreamTag `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
+
+// +genclient
+// +genclient:onlyVerbs=get
 
 // ImageStreamImage represents an Image that is retrieved by image name from an ImageStream.
 type ImageStreamImage struct {

--- a/pkg/image/generated/clientset/typed/image/v1/fake/fake_image_client.go
+++ b/pkg/image/generated/clientset/typed/image/v1/fake/fake_image_client.go
@@ -14,8 +14,24 @@ func (c *FakeImageV1) Images() v1.ImageResourceInterface {
 	return &FakeImages{c}
 }
 
+func (c *FakeImageV1) ImageSignatures() v1.ImageSignatureInterface {
+	return &FakeImageSignatures{c}
+}
+
 func (c *FakeImageV1) ImageStreams(namespace string) v1.ImageStreamInterface {
 	return &FakeImageStreams{c, namespace}
+}
+
+func (c *FakeImageV1) ImageStreamImages(namespace string) v1.ImageStreamImageInterface {
+	return &FakeImageStreamImages{c, namespace}
+}
+
+func (c *FakeImageV1) ImageStreamMappings(namespace string) v1.ImageStreamMappingInterface {
+	return &FakeImageStreamMappings{c, namespace}
+}
+
+func (c *FakeImageV1) ImageStreamTags(namespace string) v1.ImageStreamTagInterface {
+	return &FakeImageStreamTags{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagesignature.go
+++ b/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagesignature.go
@@ -1,0 +1,34 @@
+package fake
+
+import (
+	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageSignatures implements ImageSignatureInterface
+type FakeImageSignatures struct {
+	Fake *FakeImageV1
+}
+
+var imagesignaturesResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "v1", Resource: "imagesignatures"}
+
+var imagesignaturesKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "v1", Kind: "ImageSignature"}
+
+// Create takes the representation of a imageSignature and creates it.  Returns the server's representation of the imageSignature, and an error, if there is any.
+func (c *FakeImageSignatures) Create(imageSignature *v1.ImageSignature) (result *v1.ImageSignature, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(imagesignaturesResource, imageSignature), &v1.ImageSignature{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ImageSignature), err
+}
+
+// Delete takes name of the imageSignature and deletes it. Returns an error if one occurs.
+func (c *FakeImageSignatures) Delete(name string, options *meta_v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(imagesignaturesResource, name), &v1.ImageSignature{})
+	return err
+}

--- a/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreamimage.go
+++ b/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreamimage.go
@@ -1,0 +1,29 @@
+package fake
+
+import (
+	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageStreamImages implements ImageStreamImageInterface
+type FakeImageStreamImages struct {
+	Fake *FakeImageV1
+	ns   string
+}
+
+var imagestreamimagesResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "v1", Resource: "imagestreamimages"}
+
+var imagestreamimagesKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "v1", Kind: "ImageStreamImage"}
+
+// Get takes name of the imageStreamImage, and returns the corresponding imageStreamImage object, and an error if there is any.
+func (c *FakeImageStreamImages) Get(name string, options v1.GetOptions) (result *image_v1.ImageStreamImage, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(imagestreamimagesResource, c.ns, name), &image_v1.ImageStreamImage{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image_v1.ImageStreamImage), err
+}

--- a/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreammapping.go
+++ b/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreammapping.go
@@ -1,0 +1,28 @@
+package fake
+
+import (
+	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageStreamMappings implements ImageStreamMappingInterface
+type FakeImageStreamMappings struct {
+	Fake *FakeImageV1
+	ns   string
+}
+
+var imagestreammappingsResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "v1", Resource: "imagestreammappings"}
+
+var imagestreammappingsKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "v1", Kind: "ImageStreamMapping"}
+
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
+func (c *FakeImageStreamMappings) Create(imageStreamMapping *v1.ImageStreamMapping) (result *v1.ImageStreamMapping, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(imagestreammappingsResource, c.ns, imageStreamMapping), &v1.ImageStreamMapping{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1.ImageStreamMapping), err
+}

--- a/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreamtag.go
+++ b/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreamtag.go
@@ -1,0 +1,59 @@
+package fake
+
+import (
+	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageStreamTags implements ImageStreamTagInterface
+type FakeImageStreamTags struct {
+	Fake *FakeImageV1
+	ns   string
+}
+
+var imagestreamtagsResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "v1", Resource: "imagestreamtags"}
+
+var imagestreamtagsKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "v1", Kind: "ImageStreamTag"}
+
+// Get takes name of the imageStreamTag, and returns the corresponding imageStreamTag object, and an error if there is any.
+func (c *FakeImageStreamTags) Get(name string, options v1.GetOptions) (result *image_v1.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(imagestreamtagsResource, c.ns, name), &image_v1.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image_v1.ImageStreamTag), err
+}
+
+// Create takes the representation of a imageStreamTag and creates it.  Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *FakeImageStreamTags) Create(imageStreamTag *image_v1.ImageStreamTag) (result *image_v1.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(imagestreamtagsResource, c.ns, imageStreamTag), &image_v1.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image_v1.ImageStreamTag), err
+}
+
+// Update takes the representation of a imageStreamTag and updates it. Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *FakeImageStreamTags) Update(imageStreamTag *image_v1.ImageStreamTag) (result *image_v1.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(imagestreamtagsResource, c.ns, imageStreamTag), &image_v1.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image_v1.ImageStreamTag), err
+}
+
+// Delete takes name of the imageStreamTag and deletes it. Returns an error if one occurs.
+func (c *FakeImageStreamTags) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(imagestreamtagsResource, c.ns, name), &image_v1.ImageStreamTag{})
+
+	return err
+}

--- a/pkg/image/generated/clientset/typed/image/v1/generated_expansion.go
+++ b/pkg/image/generated/clientset/typed/image/v1/generated_expansion.go
@@ -2,4 +2,12 @@ package v1
 
 type ImageResourceExpansion interface{}
 
+type ImageSignatureExpansion interface{}
+
 type ImageStreamExpansion interface{}
+
+type ImageStreamImageExpansion interface{}
+
+type ImageStreamMappingExpansion interface{}
+
+type ImageStreamTagExpansion interface{}

--- a/pkg/image/generated/clientset/typed/image/v1/image_client.go
+++ b/pkg/image/generated/clientset/typed/image/v1/image_client.go
@@ -10,7 +10,11 @@ import (
 type ImageV1Interface interface {
 	RESTClient() rest.Interface
 	ImagesGetter
+	ImageSignaturesGetter
 	ImageStreamsGetter
+	ImageStreamImagesGetter
+	ImageStreamMappingsGetter
+	ImageStreamTagsGetter
 }
 
 // ImageV1Client is used to interact with features provided by the image.openshift.io group.
@@ -22,8 +26,24 @@ func (c *ImageV1Client) Images() ImageResourceInterface {
 	return newImages(c)
 }
 
+func (c *ImageV1Client) ImageSignatures() ImageSignatureInterface {
+	return newImageSignatures(c)
+}
+
 func (c *ImageV1Client) ImageStreams(namespace string) ImageStreamInterface {
 	return newImageStreams(c, namespace)
+}
+
+func (c *ImageV1Client) ImageStreamImages(namespace string) ImageStreamImageInterface {
+	return newImageStreamImages(c, namespace)
+}
+
+func (c *ImageV1Client) ImageStreamMappings(namespace string) ImageStreamMappingInterface {
+	return newImageStreamMappings(c, namespace)
+}
+
+func (c *ImageV1Client) ImageStreamTags(namespace string) ImageStreamTagInterface {
+	return newImageStreamTags(c, namespace)
 }
 
 // NewForConfig creates a new ImageV1Client for the given config.

--- a/pkg/image/generated/clientset/typed/image/v1/imagesignature.go
+++ b/pkg/image/generated/clientset/typed/image/v1/imagesignature.go
@@ -1,0 +1,53 @@
+package v1
+
+import (
+	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageSignaturesGetter has a method to return a ImageSignatureInterface.
+// A group's client should implement this interface.
+type ImageSignaturesGetter interface {
+	ImageSignatures() ImageSignatureInterface
+}
+
+// ImageSignatureInterface has methods to work with ImageSignature resources.
+type ImageSignatureInterface interface {
+	Create(*v1.ImageSignature) (*v1.ImageSignature, error)
+	Delete(name string, options *meta_v1.DeleteOptions) error
+	ImageSignatureExpansion
+}
+
+// imageSignatures implements ImageSignatureInterface
+type imageSignatures struct {
+	client rest.Interface
+}
+
+// newImageSignatures returns a ImageSignatures
+func newImageSignatures(c *ImageV1Client) *imageSignatures {
+	return &imageSignatures{
+		client: c.RESTClient(),
+	}
+}
+
+// Create takes the representation of a imageSignature and creates it.  Returns the server's representation of the imageSignature, and an error, if there is any.
+func (c *imageSignatures) Create(imageSignature *v1.ImageSignature) (result *v1.ImageSignature, err error) {
+	result = &v1.ImageSignature{}
+	err = c.client.Post().
+		Resource("imagesignatures").
+		Body(imageSignature).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the imageSignature and deletes it. Returns an error if one occurs.
+func (c *imageSignatures) Delete(name string, options *meta_v1.DeleteOptions) error {
+	return c.client.Delete().
+		Resource("imagesignatures").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}

--- a/pkg/image/generated/clientset/typed/image/v1/imagestreamimage.go
+++ b/pkg/image/generated/clientset/typed/image/v1/imagestreamimage.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	image_v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	scheme "github.com/openshift/origin/pkg/image/generated/clientset/scheme"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageStreamImagesGetter has a method to return a ImageStreamImageInterface.
+// A group's client should implement this interface.
+type ImageStreamImagesGetter interface {
+	ImageStreamImages(namespace string) ImageStreamImageInterface
+}
+
+// ImageStreamImageInterface has methods to work with ImageStreamImage resources.
+type ImageStreamImageInterface interface {
+	Get(name string, options v1.GetOptions) (*image_v1.ImageStreamImage, error)
+	ImageStreamImageExpansion
+}
+
+// imageStreamImages implements ImageStreamImageInterface
+type imageStreamImages struct {
+	client rest.Interface
+	ns     string
+}
+
+// newImageStreamImages returns a ImageStreamImages
+func newImageStreamImages(c *ImageV1Client, namespace string) *imageStreamImages {
+	return &imageStreamImages{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Get takes name of the imageStreamImage, and returns the corresponding imageStreamImage object, and an error if there is any.
+func (c *imageStreamImages) Get(name string, options v1.GetOptions) (result *image_v1.ImageStreamImage, err error) {
+	result = &image_v1.ImageStreamImage{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreamimages").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/image/generated/clientset/typed/image/v1/imagestreammapping.go
+++ b/pkg/image/generated/clientset/typed/image/v1/imagestreammapping.go
@@ -1,0 +1,44 @@
+package v1
+
+import (
+	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageStreamMappingsGetter has a method to return a ImageStreamMappingInterface.
+// A group's client should implement this interface.
+type ImageStreamMappingsGetter interface {
+	ImageStreamMappings(namespace string) ImageStreamMappingInterface
+}
+
+// ImageStreamMappingInterface has methods to work with ImageStreamMapping resources.
+type ImageStreamMappingInterface interface {
+	Create(*v1.ImageStreamMapping) (*v1.ImageStreamMapping, error)
+	ImageStreamMappingExpansion
+}
+
+// imageStreamMappings implements ImageStreamMappingInterface
+type imageStreamMappings struct {
+	client rest.Interface
+	ns     string
+}
+
+// newImageStreamMappings returns a ImageStreamMappings
+func newImageStreamMappings(c *ImageV1Client, namespace string) *imageStreamMappings {
+	return &imageStreamMappings{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
+func (c *imageStreamMappings) Create(imageStreamMapping *v1.ImageStreamMapping) (result *v1.ImageStreamMapping, err error) {
+	result = &v1.ImageStreamMapping{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("imagestreammappings").
+		Body(imageStreamMapping).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/image/generated/clientset/typed/image/v1/imagestreamtag.go
+++ b/pkg/image/generated/clientset/typed/image/v1/imagestreamtag.go
@@ -1,0 +1,86 @@
+package v1
+
+import (
+	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	scheme "github.com/openshift/origin/pkg/image/generated/clientset/scheme"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageStreamTagsGetter has a method to return a ImageStreamTagInterface.
+// A group's client should implement this interface.
+type ImageStreamTagsGetter interface {
+	ImageStreamTags(namespace string) ImageStreamTagInterface
+}
+
+// ImageStreamTagInterface has methods to work with ImageStreamTag resources.
+type ImageStreamTagInterface interface {
+	Create(*v1.ImageStreamTag) (*v1.ImageStreamTag, error)
+	Update(*v1.ImageStreamTag) (*v1.ImageStreamTag, error)
+	Delete(name string, options *meta_v1.DeleteOptions) error
+	Get(name string, options meta_v1.GetOptions) (*v1.ImageStreamTag, error)
+	ImageStreamTagExpansion
+}
+
+// imageStreamTags implements ImageStreamTagInterface
+type imageStreamTags struct {
+	client rest.Interface
+	ns     string
+}
+
+// newImageStreamTags returns a ImageStreamTags
+func newImageStreamTags(c *ImageV1Client, namespace string) *imageStreamTags {
+	return &imageStreamTags{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Get takes name of the imageStreamTag, and returns the corresponding imageStreamTag object, and an error if there is any.
+func (c *imageStreamTags) Get(name string, options meta_v1.GetOptions) (result *v1.ImageStreamTag, err error) {
+	result = &v1.ImageStreamTag{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Create takes the representation of a imageStreamTag and creates it.  Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *imageStreamTags) Create(imageStreamTag *v1.ImageStreamTag) (result *v1.ImageStreamTag, err error) {
+	result = &v1.ImageStreamTag{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Body(imageStreamTag).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a imageStreamTag and updates it. Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *imageStreamTags) Update(imageStreamTag *v1.ImageStreamTag) (result *v1.ImageStreamTag, err error) {
+	result = &v1.ImageStreamTag{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(imageStreamTag.Name).
+		Body(imageStreamTag).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the imageStreamTag and deletes it. Returns an error if one occurs.
+func (c *imageStreamTags) Delete(name string, options *meta_v1.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_image_client.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_image_client.go
@@ -14,8 +14,24 @@ func (c *FakeImage) Images() internalversion.ImageResourceInterface {
 	return &FakeImages{c}
 }
 
+func (c *FakeImage) ImageSignatures() internalversion.ImageSignatureInterface {
+	return &FakeImageSignatures{c}
+}
+
 func (c *FakeImage) ImageStreams(namespace string) internalversion.ImageStreamInterface {
 	return &FakeImageStreams{c, namespace}
+}
+
+func (c *FakeImage) ImageStreamImages(namespace string) internalversion.ImageStreamImageInterface {
+	return &FakeImageStreamImages{c, namespace}
+}
+
+func (c *FakeImage) ImageStreamMappings(namespace string) internalversion.ImageStreamMappingInterface {
+	return &FakeImageStreamMappings{c, namespace}
+}
+
+func (c *FakeImage) ImageStreamTags(namespace string) internalversion.ImageStreamTagInterface {
+	return &FakeImageStreamTags{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagesignature.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagesignature.go
@@ -1,0 +1,34 @@
+package fake
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageSignatures implements ImageSignatureInterface
+type FakeImageSignatures struct {
+	Fake *FakeImage
+}
+
+var imagesignaturesResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "", Resource: "imagesignatures"}
+
+var imagesignaturesKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "", Kind: "ImageSignature"}
+
+// Create takes the representation of a imageSignature and creates it.  Returns the server's representation of the imageSignature, and an error, if there is any.
+func (c *FakeImageSignatures) Create(imageSignature *image.ImageSignature) (result *image.ImageSignature, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(imagesignaturesResource, imageSignature), &image.ImageSignature{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image.ImageSignature), err
+}
+
+// Delete takes name of the imageSignature and deletes it. Returns an error if one occurs.
+func (c *FakeImageSignatures) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(imagesignaturesResource, name), &image.ImageSignature{})
+	return err
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreamimage.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreamimage.go
@@ -1,0 +1,29 @@
+package fake
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageStreamImages implements ImageStreamImageInterface
+type FakeImageStreamImages struct {
+	Fake *FakeImage
+	ns   string
+}
+
+var imagestreamimagesResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "", Resource: "imagestreamimages"}
+
+var imagestreamimagesKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "", Kind: "ImageStreamImage"}
+
+// Get takes name of the imageStreamImage, and returns the corresponding imageStreamImage object, and an error if there is any.
+func (c *FakeImageStreamImages) Get(name string, options v1.GetOptions) (result *image.ImageStreamImage, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(imagestreamimagesResource, c.ns, name), &image.ImageStreamImage{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image.ImageStreamImage), err
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreammapping.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreammapping.go
@@ -1,0 +1,28 @@
+package fake
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageStreamMappings implements ImageStreamMappingInterface
+type FakeImageStreamMappings struct {
+	Fake *FakeImage
+	ns   string
+}
+
+var imagestreammappingsResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "", Resource: "imagestreammappings"}
+
+var imagestreammappingsKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "", Kind: "ImageStreamMapping"}
+
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
+func (c *FakeImageStreamMappings) Create(imageStreamMapping *image.ImageStreamMapping) (result *image.ImageStreamMapping, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(imagestreammappingsResource, c.ns, imageStreamMapping), &image.ImageStreamMapping{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image.ImageStreamMapping), err
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreamtag.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreamtag.go
@@ -1,0 +1,59 @@
+package fake
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	testing "k8s.io/client-go/testing"
+)
+
+// FakeImageStreamTags implements ImageStreamTagInterface
+type FakeImageStreamTags struct {
+	Fake *FakeImage
+	ns   string
+}
+
+var imagestreamtagsResource = schema.GroupVersionResource{Group: "image.openshift.io", Version: "", Resource: "imagestreamtags"}
+
+var imagestreamtagsKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "", Kind: "ImageStreamTag"}
+
+// Get takes name of the imageStreamTag, and returns the corresponding imageStreamTag object, and an error if there is any.
+func (c *FakeImageStreamTags) Get(name string, options v1.GetOptions) (result *image.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(imagestreamtagsResource, c.ns, name), &image.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image.ImageStreamTag), err
+}
+
+// Create takes the representation of a imageStreamTag and creates it.  Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *FakeImageStreamTags) Create(imageStreamTag *image.ImageStreamTag) (result *image.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(imagestreamtagsResource, c.ns, imageStreamTag), &image.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image.ImageStreamTag), err
+}
+
+// Update takes the representation of a imageStreamTag and updates it. Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *FakeImageStreamTags) Update(imageStreamTag *image.ImageStreamTag) (result *image.ImageStreamTag, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(imagestreamtagsResource, c.ns, imageStreamTag), &image.ImageStreamTag{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*image.ImageStreamTag), err
+}
+
+// Delete takes name of the imageStreamTag and deletes it. Returns an error if one occurs.
+func (c *FakeImageStreamTags) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(imagestreamtagsResource, c.ns, name), &image.ImageStreamTag{})
+
+	return err
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/generated_expansion.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/generated_expansion.go
@@ -2,4 +2,12 @@ package internalversion
 
 type ImageResourceExpansion interface{}
 
+type ImageSignatureExpansion interface{}
+
 type ImageStreamExpansion interface{}
+
+type ImageStreamImageExpansion interface{}
+
+type ImageStreamMappingExpansion interface{}
+
+type ImageStreamTagExpansion interface{}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/image_client.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/image_client.go
@@ -8,7 +8,11 @@ import (
 type ImageInterface interface {
 	RESTClient() rest.Interface
 	ImagesGetter
+	ImageSignaturesGetter
 	ImageStreamsGetter
+	ImageStreamImagesGetter
+	ImageStreamMappingsGetter
+	ImageStreamTagsGetter
 }
 
 // ImageClient is used to interact with features provided by the image.openshift.io group.
@@ -20,8 +24,24 @@ func (c *ImageClient) Images() ImageResourceInterface {
 	return newImages(c)
 }
 
+func (c *ImageClient) ImageSignatures() ImageSignatureInterface {
+	return newImageSignatures(c)
+}
+
 func (c *ImageClient) ImageStreams(namespace string) ImageStreamInterface {
 	return newImageStreams(c, namespace)
+}
+
+func (c *ImageClient) ImageStreamImages(namespace string) ImageStreamImageInterface {
+	return newImageStreamImages(c, namespace)
+}
+
+func (c *ImageClient) ImageStreamMappings(namespace string) ImageStreamMappingInterface {
+	return newImageStreamMappings(c, namespace)
+}
+
+func (c *ImageClient) ImageStreamTags(namespace string) ImageStreamTagInterface {
+	return newImageStreamTags(c, namespace)
 }
 
 // NewForConfig creates a new ImageClient for the given config.

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/imagesignature.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/imagesignature.go
@@ -1,0 +1,53 @@
+package internalversion
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageSignaturesGetter has a method to return a ImageSignatureInterface.
+// A group's client should implement this interface.
+type ImageSignaturesGetter interface {
+	ImageSignatures() ImageSignatureInterface
+}
+
+// ImageSignatureInterface has methods to work with ImageSignature resources.
+type ImageSignatureInterface interface {
+	Create(*image.ImageSignature) (*image.ImageSignature, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	ImageSignatureExpansion
+}
+
+// imageSignatures implements ImageSignatureInterface
+type imageSignatures struct {
+	client rest.Interface
+}
+
+// newImageSignatures returns a ImageSignatures
+func newImageSignatures(c *ImageClient) *imageSignatures {
+	return &imageSignatures{
+		client: c.RESTClient(),
+	}
+}
+
+// Create takes the representation of a imageSignature and creates it.  Returns the server's representation of the imageSignature, and an error, if there is any.
+func (c *imageSignatures) Create(imageSignature *image.ImageSignature) (result *image.ImageSignature, err error) {
+	result = &image.ImageSignature{}
+	err = c.client.Post().
+		Resource("imagesignatures").
+		Body(imageSignature).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the imageSignature and deletes it. Returns an error if one occurs.
+func (c *imageSignatures) Delete(name string, options *v1.DeleteOptions) error {
+	return c.client.Delete().
+		Resource("imagesignatures").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreamimage.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreamimage.go
@@ -1,0 +1,47 @@
+package internalversion
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	scheme "github.com/openshift/origin/pkg/image/generated/internalclientset/scheme"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageStreamImagesGetter has a method to return a ImageStreamImageInterface.
+// A group's client should implement this interface.
+type ImageStreamImagesGetter interface {
+	ImageStreamImages(namespace string) ImageStreamImageInterface
+}
+
+// ImageStreamImageInterface has methods to work with ImageStreamImage resources.
+type ImageStreamImageInterface interface {
+	Get(name string, options v1.GetOptions) (*image.ImageStreamImage, error)
+	ImageStreamImageExpansion
+}
+
+// imageStreamImages implements ImageStreamImageInterface
+type imageStreamImages struct {
+	client rest.Interface
+	ns     string
+}
+
+// newImageStreamImages returns a ImageStreamImages
+func newImageStreamImages(c *ImageClient, namespace string) *imageStreamImages {
+	return &imageStreamImages{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Get takes name of the imageStreamImage, and returns the corresponding imageStreamImage object, and an error if there is any.
+func (c *imageStreamImages) Get(name string, options v1.GetOptions) (result *image.ImageStreamImage, err error) {
+	result = &image.ImageStreamImage{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreamimages").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreammapping.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreammapping.go
@@ -1,0 +1,44 @@
+package internalversion
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageStreamMappingsGetter has a method to return a ImageStreamMappingInterface.
+// A group's client should implement this interface.
+type ImageStreamMappingsGetter interface {
+	ImageStreamMappings(namespace string) ImageStreamMappingInterface
+}
+
+// ImageStreamMappingInterface has methods to work with ImageStreamMapping resources.
+type ImageStreamMappingInterface interface {
+	Create(*image.ImageStreamMapping) (*image.ImageStreamMapping, error)
+	ImageStreamMappingExpansion
+}
+
+// imageStreamMappings implements ImageStreamMappingInterface
+type imageStreamMappings struct {
+	client rest.Interface
+	ns     string
+}
+
+// newImageStreamMappings returns a ImageStreamMappings
+func newImageStreamMappings(c *ImageClient, namespace string) *imageStreamMappings {
+	return &imageStreamMappings{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
+func (c *imageStreamMappings) Create(imageStreamMapping *image.ImageStreamMapping) (result *image.ImageStreamMapping, err error) {
+	result = &image.ImageStreamMapping{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("imagestreammappings").
+		Body(imageStreamMapping).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreamtag.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreamtag.go
@@ -1,0 +1,86 @@
+package internalversion
+
+import (
+	image "github.com/openshift/origin/pkg/image/apis/image"
+	scheme "github.com/openshift/origin/pkg/image/generated/internalclientset/scheme"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rest "k8s.io/client-go/rest"
+)
+
+// ImageStreamTagsGetter has a method to return a ImageStreamTagInterface.
+// A group's client should implement this interface.
+type ImageStreamTagsGetter interface {
+	ImageStreamTags(namespace string) ImageStreamTagInterface
+}
+
+// ImageStreamTagInterface has methods to work with ImageStreamTag resources.
+type ImageStreamTagInterface interface {
+	Create(*image.ImageStreamTag) (*image.ImageStreamTag, error)
+	Update(*image.ImageStreamTag) (*image.ImageStreamTag, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	Get(name string, options v1.GetOptions) (*image.ImageStreamTag, error)
+	ImageStreamTagExpansion
+}
+
+// imageStreamTags implements ImageStreamTagInterface
+type imageStreamTags struct {
+	client rest.Interface
+	ns     string
+}
+
+// newImageStreamTags returns a ImageStreamTags
+func newImageStreamTags(c *ImageClient, namespace string) *imageStreamTags {
+	return &imageStreamTags{
+		client: c.RESTClient(),
+		ns:     namespace,
+	}
+}
+
+// Get takes name of the imageStreamTag, and returns the corresponding imageStreamTag object, and an error if there is any.
+func (c *imageStreamTags) Get(name string, options v1.GetOptions) (result *image.ImageStreamTag, err error) {
+	result = &image.ImageStreamTag{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Create takes the representation of a imageStreamTag and creates it.  Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *imageStreamTags) Create(imageStreamTag *image.ImageStreamTag) (result *image.ImageStreamTag, err error) {
+	result = &image.ImageStreamTag{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Body(imageStreamTag).
+		Do().
+		Into(result)
+	return
+}
+
+// Update takes the representation of a imageStreamTag and updates it. Returns the server's representation of the imageStreamTag, and an error, if there is any.
+func (c *imageStreamTags) Update(imageStreamTag *image.ImageStreamTag) (result *image.ImageStreamTag, err error) {
+	result = &image.ImageStreamTag{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(imageStreamTag.Name).
+		Body(imageStreamTag).
+		Do().
+		Into(result)
+	return
+}
+
+// Delete takes name of the imageStreamTag and deletes it. Returns an error if one occurs.
+func (c *imageStreamTags) Delete(name string, options *v1.DeleteOptions) error {
+	return c.client.Delete().
+		Namespace(c.ns).
+		Resource("imagestreamtags").
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}

--- a/pkg/user/apis/user/types.go
+++ b/pkg/user/apis/user/types.go
@@ -9,6 +9,7 @@ import (
 // POST to UserIdentityMapping, get back error or a filled out UserIdentityMapping object
 
 // +genclient
+// +genclient:nonNamespaced
 
 type User struct {
 	metav1.TypeMeta

--- a/pkg/user/apis/user/v1/types.go
+++ b/pkg/user/apis/user/v1/types.go
@@ -8,6 +8,7 @@ import (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 
 // Upon log in, every user of the system receives a User and Identity resource. Administrators
 // may directly manipulate the attributes of the users for their own tracking, or set groups

--- a/pkg/user/generated/clientset/typed/user/v1/fake/fake_user_client.go
+++ b/pkg/user/generated/clientset/typed/user/v1/fake/fake_user_client.go
@@ -10,8 +10,8 @@ type FakeUserV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeUserV1) Users(namespace string) v1.UserResourceInterface {
-	return &FakeUsers{c, namespace}
+func (c *FakeUserV1) Users() v1.UserResourceInterface {
+	return &FakeUsers{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/user/generated/clientset/typed/user/v1/fake/fake_userresource.go
+++ b/pkg/user/generated/clientset/typed/user/v1/fake/fake_userresource.go
@@ -13,7 +13,6 @@ import (
 // FakeUsers implements UserResourceInterface
 type FakeUsers struct {
 	Fake *FakeUserV1
-	ns   string
 }
 
 var usersResource = schema.GroupVersionResource{Group: "user.openshift.io", Version: "v1", Resource: "users"}
@@ -23,8 +22,7 @@ var usersKind = schema.GroupVersionKind{Group: "user.openshift.io", Version: "v1
 // Get takes name of the userResource, and returns the corresponding userResource object, and an error if there is any.
 func (c *FakeUsers) Get(name string, options v1.GetOptions) (result *user_v1.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(usersResource, c.ns, name), &user_v1.User{})
-
+		Invokes(testing.NewRootGetAction(usersResource, name), &user_v1.User{})
 	if obj == nil {
 		return nil, err
 	}
@@ -34,8 +32,7 @@ func (c *FakeUsers) Get(name string, options v1.GetOptions) (result *user_v1.Use
 // List takes label and field selectors, and returns the list of Users that match those selectors.
 func (c *FakeUsers) List(opts v1.ListOptions) (result *user_v1.UserList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(usersResource, usersKind, c.ns, opts), &user_v1.UserList{})
-
+		Invokes(testing.NewRootListAction(usersResource, usersKind, opts), &user_v1.UserList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -56,15 +53,13 @@ func (c *FakeUsers) List(opts v1.ListOptions) (result *user_v1.UserList, err err
 // Watch returns a watch.Interface that watches the requested users.
 func (c *FakeUsers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(usersResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(usersResource, opts))
 }
 
 // Create takes the representation of a userResource and creates it.  Returns the server's representation of the userResource, and an error, if there is any.
 func (c *FakeUsers) Create(userResource *user_v1.User) (result *user_v1.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(usersResource, c.ns, userResource), &user_v1.User{})
-
+		Invokes(testing.NewRootCreateAction(usersResource, userResource), &user_v1.User{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,8 +69,7 @@ func (c *FakeUsers) Create(userResource *user_v1.User) (result *user_v1.User, er
 // Update takes the representation of a userResource and updates it. Returns the server's representation of the userResource, and an error, if there is any.
 func (c *FakeUsers) Update(userResource *user_v1.User) (result *user_v1.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(usersResource, c.ns, userResource), &user_v1.User{})
-
+		Invokes(testing.NewRootUpdateAction(usersResource, userResource), &user_v1.User{})
 	if obj == nil {
 		return nil, err
 	}
@@ -85,14 +79,13 @@ func (c *FakeUsers) Update(userResource *user_v1.User) (result *user_v1.User, er
 // Delete takes name of the userResource and deletes it. Returns an error if one occurs.
 func (c *FakeUsers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(usersResource, c.ns, name), &user_v1.User{})
-
+		Invokes(testing.NewRootDeleteAction(usersResource, name), &user_v1.User{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeUsers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(usersResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(usersResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &user_v1.UserList{})
 	return err
@@ -101,8 +94,7 @@ func (c *FakeUsers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 // Patch applies the patch and returns the patched userResource.
 func (c *FakeUsers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *user_v1.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(usersResource, c.ns, name, data, subresources...), &user_v1.User{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(usersResource, name, data, subresources...), &user_v1.User{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/user/generated/clientset/typed/user/v1/user_client.go
+++ b/pkg/user/generated/clientset/typed/user/v1/user_client.go
@@ -17,8 +17,8 @@ type UserV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *UserV1Client) Users(namespace string) UserResourceInterface {
-	return newUsers(c, namespace)
+func (c *UserV1Client) Users() UserResourceInterface {
+	return newUsers(c)
 }
 
 // NewForConfig creates a new UserV1Client for the given config.

--- a/pkg/user/generated/clientset/typed/user/v1/userresource.go
+++ b/pkg/user/generated/clientset/typed/user/v1/userresource.go
@@ -12,7 +12,7 @@ import (
 // UsersGetter has a method to return a UserResourceInterface.
 // A group's client should implement this interface.
 type UsersGetter interface {
-	Users(namespace string) UserResourceInterface
+	Users() UserResourceInterface
 }
 
 // UserResourceInterface has methods to work with UserResource resources.
@@ -31,14 +31,12 @@ type UserResourceInterface interface {
 // users implements UserResourceInterface
 type users struct {
 	client rest.Interface
-	ns     string
 }
 
 // newUsers returns a Users
-func newUsers(c *UserV1Client, namespace string) *users {
+func newUsers(c *UserV1Client) *users {
 	return &users{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -46,7 +44,6 @@ func newUsers(c *UserV1Client, namespace string) *users {
 func (c *users) Get(name string, options meta_v1.GetOptions) (result *v1.User, err error) {
 	result = &v1.User{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("users").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -59,7 +56,6 @@ func (c *users) Get(name string, options meta_v1.GetOptions) (result *v1.User, e
 func (c *users) List(opts meta_v1.ListOptions) (result *v1.UserList, err error) {
 	result = &v1.UserList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("users").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -71,7 +67,6 @@ func (c *users) List(opts meta_v1.ListOptions) (result *v1.UserList, err error) 
 func (c *users) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("users").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -81,7 +76,6 @@ func (c *users) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
 func (c *users) Create(userResource *v1.User) (result *v1.User, err error) {
 	result = &v1.User{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("users").
 		Body(userResource).
 		Do().
@@ -93,7 +87,6 @@ func (c *users) Create(userResource *v1.User) (result *v1.User, err error) {
 func (c *users) Update(userResource *v1.User) (result *v1.User, err error) {
 	result = &v1.User{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("users").
 		Name(userResource.Name).
 		Body(userResource).
@@ -105,7 +98,6 @@ func (c *users) Update(userResource *v1.User) (result *v1.User, err error) {
 // Delete takes name of the userResource and deletes it. Returns an error if one occurs.
 func (c *users) Delete(name string, options *meta_v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("users").
 		Name(name).
 		Body(options).
@@ -116,7 +108,6 @@ func (c *users) Delete(name string, options *meta_v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *users) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("users").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -128,7 +119,6 @@ func (c *users) DeleteCollection(options *meta_v1.DeleteOptions, listOptions met
 func (c *users) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.User, err error) {
 	result = &v1.User{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("users").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/user/generated/informers/externalversions/user/v1/user.go
+++ b/pkg/user/generated/informers/externalversions/user/v1/user.go
@@ -29,10 +29,10 @@ func newUserInformer(client clientset.Interface, resyncPeriod time.Duration) cac
 	sharedIndexInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.UserV1().Users(meta_v1.NamespaceAll).List(options)
+				return client.UserV1().Users().List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.UserV1().Users(meta_v1.NamespaceAll).Watch(options)
+				return client.UserV1().Users().Watch(options)
 			},
 		},
 		&user_v1.User{},

--- a/pkg/user/generated/informers/internalversion/user/internalversion/user.go
+++ b/pkg/user/generated/informers/internalversion/user/internalversion/user.go
@@ -29,10 +29,10 @@ func newUserInformer(client internalclientset.Interface, resyncPeriod time.Durat
 	sharedIndexInformer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.User().Users(v1.NamespaceAll).List(options)
+				return client.User().Users().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.User().Users(v1.NamespaceAll).Watch(options)
+				return client.User().Users().Watch(options)
 			},
 		},
 		&user.User{},

--- a/pkg/user/generated/internalclientset/typed/user/internalversion/fake/fake_user_client.go
+++ b/pkg/user/generated/internalclientset/typed/user/internalversion/fake/fake_user_client.go
@@ -14,8 +14,8 @@ func (c *FakeUser) Groups(namespace string) internalversion.GroupInterface {
 	return &FakeGroups{c, namespace}
 }
 
-func (c *FakeUser) Users(namespace string) internalversion.UserResourceInterface {
-	return &FakeUsers{c, namespace}
+func (c *FakeUser) Users() internalversion.UserResourceInterface {
+	return &FakeUsers{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/user/generated/internalclientset/typed/user/internalversion/fake/fake_userresource.go
+++ b/pkg/user/generated/internalclientset/typed/user/internalversion/fake/fake_userresource.go
@@ -13,7 +13,6 @@ import (
 // FakeUsers implements UserResourceInterface
 type FakeUsers struct {
 	Fake *FakeUser
-	ns   string
 }
 
 var usersResource = schema.GroupVersionResource{Group: "user.openshift.io", Version: "", Resource: "users"}
@@ -23,8 +22,7 @@ var usersKind = schema.GroupVersionKind{Group: "user.openshift.io", Version: "",
 // Get takes name of the userResource, and returns the corresponding userResource object, and an error if there is any.
 func (c *FakeUsers) Get(name string, options v1.GetOptions) (result *user.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(usersResource, c.ns, name), &user.User{})
-
+		Invokes(testing.NewRootGetAction(usersResource, name), &user.User{})
 	if obj == nil {
 		return nil, err
 	}
@@ -34,8 +32,7 @@ func (c *FakeUsers) Get(name string, options v1.GetOptions) (result *user.User, 
 // List takes label and field selectors, and returns the list of Users that match those selectors.
 func (c *FakeUsers) List(opts v1.ListOptions) (result *user.UserList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(usersResource, usersKind, c.ns, opts), &user.UserList{})
-
+		Invokes(testing.NewRootListAction(usersResource, usersKind, opts), &user.UserList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -56,15 +53,13 @@ func (c *FakeUsers) List(opts v1.ListOptions) (result *user.UserList, err error)
 // Watch returns a watch.Interface that watches the requested users.
 func (c *FakeUsers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(usersResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(usersResource, opts))
 }
 
 // Create takes the representation of a userResource and creates it.  Returns the server's representation of the userResource, and an error, if there is any.
 func (c *FakeUsers) Create(userResource *user.User) (result *user.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(usersResource, c.ns, userResource), &user.User{})
-
+		Invokes(testing.NewRootCreateAction(usersResource, userResource), &user.User{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,8 +69,7 @@ func (c *FakeUsers) Create(userResource *user.User) (result *user.User, err erro
 // Update takes the representation of a userResource and updates it. Returns the server's representation of the userResource, and an error, if there is any.
 func (c *FakeUsers) Update(userResource *user.User) (result *user.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(usersResource, c.ns, userResource), &user.User{})
-
+		Invokes(testing.NewRootUpdateAction(usersResource, userResource), &user.User{})
 	if obj == nil {
 		return nil, err
 	}
@@ -85,14 +79,13 @@ func (c *FakeUsers) Update(userResource *user.User) (result *user.User, err erro
 // Delete takes name of the userResource and deletes it. Returns an error if one occurs.
 func (c *FakeUsers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(usersResource, c.ns, name), &user.User{})
-
+		Invokes(testing.NewRootDeleteAction(usersResource, name), &user.User{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeUsers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(usersResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(usersResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &user.UserList{})
 	return err
@@ -101,8 +94,7 @@ func (c *FakeUsers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 // Patch applies the patch and returns the patched userResource.
 func (c *FakeUsers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *user.User, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(usersResource, c.ns, name, data, subresources...), &user.User{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(usersResource, name, data, subresources...), &user.User{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/user/generated/internalclientset/typed/user/internalversion/user_client.go
+++ b/pkg/user/generated/internalclientset/typed/user/internalversion/user_client.go
@@ -20,8 +20,8 @@ func (c *UserClient) Groups(namespace string) GroupInterface {
 	return newGroups(c, namespace)
 }
 
-func (c *UserClient) Users(namespace string) UserResourceInterface {
-	return newUsers(c, namespace)
+func (c *UserClient) Users() UserResourceInterface {
+	return newUsers(c)
 }
 
 // NewForConfig creates a new UserClient for the given config.

--- a/pkg/user/generated/internalclientset/typed/user/internalversion/userresource.go
+++ b/pkg/user/generated/internalclientset/typed/user/internalversion/userresource.go
@@ -12,7 +12,7 @@ import (
 // UsersGetter has a method to return a UserResourceInterface.
 // A group's client should implement this interface.
 type UsersGetter interface {
-	Users(namespace string) UserResourceInterface
+	Users() UserResourceInterface
 }
 
 // UserResourceInterface has methods to work with UserResource resources.
@@ -31,14 +31,12 @@ type UserResourceInterface interface {
 // users implements UserResourceInterface
 type users struct {
 	client rest.Interface
-	ns     string
 }
 
 // newUsers returns a Users
-func newUsers(c *UserClient, namespace string) *users {
+func newUsers(c *UserClient) *users {
 	return &users{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -46,7 +44,6 @@ func newUsers(c *UserClient, namespace string) *users {
 func (c *users) Get(name string, options v1.GetOptions) (result *user.User, err error) {
 	result = &user.User{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("users").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -59,7 +56,6 @@ func (c *users) Get(name string, options v1.GetOptions) (result *user.User, err 
 func (c *users) List(opts v1.ListOptions) (result *user.UserList, err error) {
 	result = &user.UserList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("users").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -71,7 +67,6 @@ func (c *users) List(opts v1.ListOptions) (result *user.UserList, err error) {
 func (c *users) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("users").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -81,7 +76,6 @@ func (c *users) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *users) Create(userResource *user.User) (result *user.User, err error) {
 	result = &user.User{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("users").
 		Body(userResource).
 		Do().
@@ -93,7 +87,6 @@ func (c *users) Create(userResource *user.User) (result *user.User, err error) {
 func (c *users) Update(userResource *user.User) (result *user.User, err error) {
 	result = &user.User{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("users").
 		Name(userResource.Name).
 		Body(userResource).
@@ -105,7 +98,6 @@ func (c *users) Update(userResource *user.User) (result *user.User, err error) {
 // Delete takes name of the userResource and deletes it. Returns an error if one occurs.
 func (c *users) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("users").
 		Name(name).
 		Body(options).
@@ -116,7 +108,6 @@ func (c *users) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *users) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("users").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -128,7 +119,6 @@ func (c *users) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 func (c *users) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *user.User, err error) {
 	result = &user.User{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("users").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/user/generated/listers/user/v1/expansion_generated.go
+++ b/pkg/user/generated/listers/user/v1/expansion_generated.go
@@ -5,7 +5,3 @@ package v1
 // UserListerExpansion allows custom methods to be added to
 // UserLister.
 type UserListerExpansion interface{}
-
-// UserNamespaceListerExpansion allows custom methods to be added to
-// UserNamespaceLister.
-type UserNamespaceListerExpansion interface{}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/packages.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/packages.go
@@ -162,7 +162,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
 			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
-			if !tags.GenerateClient || tags.NoVerbs {
+			if !tags.GenerateClient || tags.NoVerbs || !tags.HasVerb("list") || !tags.HasVerb("watch") {
 				continue
 			}
 
@@ -290,7 +290,8 @@ func groupPackage(basePackage string, groupVersions clientgentypes.GroupVersions
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
+			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+			return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("watch")
 		},
 	}
 }
@@ -330,7 +331,8 @@ func versionPackage(basePackage string, gv clientgentypes.GroupVersion, boilerpl
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
+			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+			return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("watch")
 		},
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
@@ -118,10 +118,14 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
-			if !util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient {
+			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+			if !tags.GenerateClient || !tags.HasVerb("list") || !tags.HasVerb("get") {
 				continue
 			}
 			typesToGenerate = append(typesToGenerate, t)
+		}
+		if len(typesToGenerate) == 0 {
+			continue
 		}
 		orderer := namer.Orderer{Namer: namer.NewPrivateNamer(0)}
 		typesToGenerate = orderer.OrderTypes(typesToGenerate)
@@ -156,7 +160,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				return generators
 			},
 			FilterFunc: func(c *generator.Context, t *types.Type) bool {
-				return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
+				tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+				return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("get")
 			},
 		})
 	}


### PR DESCRIPTION
Add clients for ImageStreamImage, ImageSignatures and ImageStreamMappings.
Fixes Users() to be non-namespaced.