### PR TITLE
Add myself as an OWNER under the root

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,5 +12,6 @@ approvers:
   - liggitt
   - bparees
   - mfojtik
-  - eparis 
+  - eparis
   - derekwaynecarr
+  - stevekuznetsov # for build and tooling changes


### PR DESCRIPTION
I originally used top 5 committers with merge rights to bootstrap this ... I'm at 6

```
$ git log --pretty=%ae | sort | uniq -c | sort -nr | grep -v openshiftbot | head -n 6 | tail -n 1
    394 skuznets@redhat.com
```

And enough of my  PRs end up resolving to root OWNERS by touching something like the Makefile that this seems reasonable to me.

/cc @smarterclayton 

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>