### PR TITLE
Fix clientset generation script - moderate aggressive delete

### DIFF
--- a/hack/update-generated-clientsets.sh
+++ b/hack/update-generated-clientsets.sh
@@ -40,7 +40,9 @@ verify="${VERIFY:-}"
 if [[ -z "${verify}" ]]; then
   for pkg in "${packages[@]}"; do
     grouppkg=$(realpath --canonicalize-missing --relative-to=$(pwd) ${pkg}/../..)
-    go list -f '{{.Dir}}' "${grouppkg}/generated/clientset/..." "${grouppkg}/generated/internalclientset/..." | xargs rm -rf
+    # delete all generated go files excluding files named *_expansion.go
+    go list -f '{{.Dir}}' "${grouppkg}/generated/clientset" "${grouppkg}/generated/internalclientset" \
+		| xargs -n1 -I{} find {} -type f -not -name "*_expansion.go" -delete
   done
 fi
 


### PR DESCRIPTION
If you include `*_expansion.go` files in the generated clientset packages, the current generation script will remove them.

This change modifies the script so that it deletes all files except those named `*_expansion.go`