### PR TITLE
Switch to the advanced audit backend

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -1,6 +1,7 @@
 package origin
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -11,10 +12,13 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 
 	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	auditpolicy "k8s.io/apiserver/pkg/audit/policy"
 	apifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apiserver "k8s.io/apiserver/pkg/server"
 	apiserverfilters "k8s.io/apiserver/pkg/server/filters"
+	auditlog "k8s.io/apiserver/plugin/pkg/audit/log"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
 	kubeapiserver "k8s.io/kubernetes/pkg/master"
 	kcorestorage "k8s.io/kubernetes/pkg/registry/core/rest"
@@ -225,6 +229,14 @@ func (c *MasterConfig) Run(kubeAPIServerConfig *kubeapiserver.Config, assetConfi
 		return err
 	}
 
+	// Start the audit backend before any request comes in. This means we cannot turn it into a
+	// post start hook because without calling Backend.Run the Backend.ProcessEvents call might block.
+	if c.AuditBackend != nil {
+		if err := c.AuditBackend.Run(stopCh); err != nil {
+			return fmt.Errorf("failed to run the audit backend: %v", err)
+		}
+	}
+
 	// add post-start hooks
 	aggregatedAPIServer.GenericAPIServer.AddPostStartHook("user.openshift.io-groupcache",
 		func(context apiserver.PostStartHookContext) error {
@@ -275,7 +287,13 @@ func (c *MasterConfig) buildHandlerChain(assetConfig *AssetConfig) (func(http.Ha
 				// backwards compatible writer to regular log
 				writer = cmdutil.NewGLogWriterV(0)
 			}
-			handler = apifilters.WithLegacyAudit(handler, contextMapper, writer)
+			c.AuditBackend = auditlog.NewBackend(writer)
+			auditPolicyChecker := auditpolicy.NewChecker(&auditinternal.Policy{
+				// This is for backwards compatibility maintaining the old visibility, ie. just
+				// raw overview of the requests comming in.
+				Rules: []auditinternal.PolicyRule{{Level: auditinternal.LevelMetadata}},
+			})
+			handler = apifilters.WithAudit(handler, contextMapper, c.AuditBackend, auditPolicyChecker, kc.LongRunningFunc)
 		}
 		handler = serverhandlers.AuthenticationHandlerFilter(handler, c.Authenticator, contextMapper)
 		handler = namespacingFilter(handler, contextMapper)

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/request/anonymous"
@@ -177,6 +178,8 @@ type MasterConfig struct {
 	// To apply different access control to a system component, create a separate client/config specifically
 	// for that component.
 	PrivilegedLoopbackOpenShiftClient *osclient.Client
+
+	AuditBackend audit.Backend
 
 	// TODO inspect uses to eliminate them
 	InternalKubeInformers  kinternalinformers.SharedInformerFactory


### PR DESCRIPTION
Fixes #15271.

@deads2k || @sttts for wiring
@smarterclayton for api change

There are a few changes when turning on the new audit:

1. one line instead of two (previously we've logged the response on separate line), see [old](https://docs.openshift.org/latest/install_config/master_node_configuration.html#master-node-config-audit-config) and new:
```
AUDIT: id="ac14f7c8-1891-4551-9da4-e5075e9d89c6" stage="ResponseComplete" ip="127.0.0.1" method="list" user="test-admin" groups="\"system:authenticated:oauth\",\"system:authenticated\"" as="<self>" asgroups="<lookup>" namespace="test" uri="/api/v1/namespaces/test/pods" response="200"
```
2. the method changed from HTTP action to actual operation performed
3. there's a new field `stage` showing when the event was generated

I'll open a separate PR enabling other alpha features after I sync with @mpbarrett