### PR TITLE
make wiring more obvious in TSB

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -95,10 +95,10 @@ func (c *MasterConfig) newOpenshiftNonAPIConfig(kubeAPIServerConfig apiserver.Co
 
 func (c *MasterConfig) newTemplateServiceBrokerConfig(kubeAPIServerConfig apiserver.Config) *openservicebrokerserver.TemplateServiceBrokerConfig {
 	ret := &openservicebrokerserver.TemplateServiceBrokerConfig{
-		GenericConfig:      &kubeAPIServerConfig,
-		KubeClientInternal: c.PrivilegedLoopbackKubernetesClientsetInternal,
-		TemplateInformers:  c.TemplateInformers,
-		TemplateNamespaces: c.Options.TemplateServiceBrokerConfig.TemplateNamespaces,
+		GenericConfig:              &kubeAPIServerConfig,
+		PrivilegedKubeClientConfig: *kubeAPIServerConfig.LoopbackClientConfig,
+		TemplateInformers:          c.TemplateInformers,
+		TemplateNamespaces:         c.Options.TemplateServiceBrokerConfig.TemplateNamespaces,
 	}
 
 	return ret


### PR DESCRIPTION
The TSB currently needs a privileged kube config (not a loopback) and its not obvious that its late binding to hide the cycle it introduced.  This pull makes both more obvious as a starting point for what's next.

The next step will be to take this pull and the new command pull and make a forward building version of this.