### PR TITLE
Prevent wrong line order when printing badly formatted lines

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 bad_files=$(os::util::list_go_src_files | xargs gofmt -s -l)
 if [[ -n "${bad_files}" ]]; then
-	os::log::warning "!!! gofmt needs to be run on the following files: "
+	os::log::warning "!!! gofmt needs to be run on the listed files"
 	echo "${bad_files}"
 	os::log::fatal "Try running 'gofmt -s -d [path]'
 Or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'"


### PR DESCRIPTION
Example of current confusing output:

```
  ./pkg/oc/cli/cmd/importimage.go
  [WARNING] !!! gofmt needs to be run on the following files:
  [FATAL] Try running 'gofmt -s -d [path]'
  [FATAL] Or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'
```