### PR TITLE
enable the TSB storage and controller by default

### DIFF
--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -22,9 +22,6 @@ os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 os::start::configure_server
 
-cp "${SERVER_CONFIG_DIR}/master/master-config.yaml" "${SERVER_CONFIG_DIR}/master/master-config.orig2.yaml"
-openshift ex config patch "${SERVER_CONFIG_DIR}/master/master-config.orig2.yaml" --patch="{\"templateServiceBrokerConfig\": {\"templateNamespaces\": [\"openshift\"]}}"  > "${SERVER_CONFIG_DIR}/master/master-config.yaml"
-
 SWAGGER_SPEC_REL_DIR="${1:-}"
 SWAGGER_SPEC_OUT_DIR="${OS_ROOT}/${SWAGGER_SPEC_REL_DIR}/api/swagger-spec"
 mkdir -p "${SWAGGER_SPEC_OUT_DIR}"

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -216,6 +216,7 @@ func GetOpenshiftBootstrapClusterRoles() []authorizationapi.ClusterRole {
 				authorizationapi.NewRule(read...).Groups(securityGroup, legacySecurityGroup).Resources("securitycontextconstraints").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
+				authorizationapi.NewRule(read...).Groups(templateGroup).Resources("brokertemplateinstances", "templateinstances/status").RuleOrDie(),
 
 				authorizationapi.NewRule(read...).Groups(userGroup, legacyUserGroup).Resources("groups", "identities", "useridentitymappings", "users").RuleOrDie(),
 

--- a/pkg/cmd/server/origin/storage.go
+++ b/pkg/cmd/server/origin/storage.go
@@ -473,20 +473,18 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		"routes/status": routeStatusStorage,
 	}
 
-	if c.EnableTemplateServiceBroker {
-		templateInstanceStorage, templateInstanceStatusStorage, err := templateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.KubeClientInternal)
-		if err != nil {
-			return nil, fmt.Errorf("error building REST storage: %v", err)
-		}
-		brokerTemplateInstanceStorage, err := brokertemplateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-		if err != nil {
-			return nil, fmt.Errorf("error building REST storage: %v", err)
-		}
-
-		storage[templateapiv1.SchemeGroupVersion]["templateinstances"] = templateInstanceStorage
-		storage[templateapiv1.SchemeGroupVersion]["templateinstances/status"] = templateInstanceStatusStorage
-		storage[templateapiv1.SchemeGroupVersion]["brokertemplateinstances"] = brokerTemplateInstanceStorage
+	templateInstanceStorage, templateInstanceStatusStorage, err := templateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.KubeClientInternal)
+	if err != nil {
+		return nil, fmt.Errorf("error building REST storage: %v", err)
 	}
+	brokerTemplateInstanceStorage, err := brokertemplateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, fmt.Errorf("error building REST storage: %v", err)
+	}
+
+	storage[templateapiv1.SchemeGroupVersion]["templateinstances"] = templateInstanceStorage
+	storage[templateapiv1.SchemeGroupVersion]["templateinstances/status"] = templateInstanceStatusStorage
+	storage[templateapiv1.SchemeGroupVersion]["brokertemplateinstances"] = brokerTemplateInstanceStorage
 
 	if c.EnableBuilds {
 		storage[buildapiv1.SchemeGroupVersion] = map[string]rest.Storage{

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -751,9 +751,6 @@ func getExcludedControllers(options configapi.MasterConfig) sets.String {
 		excludedControllers.Insert("openshift.io/build")
 		excludedControllers.Insert("openshift.io/build-config-change")
 	}
-	if options.TemplateServiceBrokerConfig == nil {
-		excludedControllers.Insert("openshift.io/templateinstance")
-	}
 
 	return excludedControllers
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -383,6 +383,16 @@ items:
     - list
     - watch
   - apiGroups:
+    - template.openshift.io
+    attributeRestrictions: null
+    resources:
+    - brokertemplateinstances
+    - templateinstances/status
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
     - user.openshift.io
     - ""
     attributeRestrictions: null


### PR DESCRIPTION
This enables the basic storage and controllers (but not the broker) in the apiserver by default.