### PR TITLE
enforce package import restrictions on TSB

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -26,7 +26,7 @@
       "github.com/openshift/origin/test/util/api"
     ]
   },
-  
+
   {
     "checkedPackages": [
       "github.com/openshift/origin/pkg/build/apis/build",
@@ -223,6 +223,32 @@
       "github.com/openshift/origin/pkg/api",
       "github.com/openshift/origin/pkg/api/install",
       "github.com/openshift/origin/test/util/api"
+    ]
+  },
+
+  {
+    "checkedPackageRoots": [
+      "github.com/openshift/origin/pkg/openservicebroker"
+    ],
+    "allowedImportPackageRoots": [
+      "vendor/k8s.io/apimachinery",
+      "vendor/k8s.io/apiserver",
+      "vendor/k8s.io/client-go",
+      "vendor/github.com/spf13/cobra",
+      "vendor/golang.org",
+      "github.com/openshift/origin/pkg/template/generated"
+    ],
+    "allowedImportPackages": [
+      "vendor/github.com/golang/glog",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/github.com/emicklei/go-restful",
+      "vendor/github.com/lestrrat/go-jsschema",
+      "vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+      "vendor/k8s.io/kubernetes/pkg/controller",
+      "github.com/openshift/origin/pkg/api",
+      "github.com/openshift/origin/pkg/cmd/server/bootstrappolicy",
+      "github.com/openshift/origin/pkg/template/apis/template",
+      "github.com/openshift/origin/pkg/template/servicebroker"
     ]
   }
 ]


### PR DESCRIPTION
We need to ensure good behavior for logically external components.  This isn't a perfect start, but its close, so we'll start here and turn the ratchet later.

@bparees @jim-minter the idea is to limit the import tree so that this can built without vendoring openshift.  If you look at the dependency chain, this looks really close.  I'll work on snipping links on a separate thread, but this keeps it from getting worse.  The general rule is that you can depend on any time and any client, but nothing specific to the apiserver.  `pkg/api` and `pkg/cmd/server/bootstrappolicy` are targets for removal.

Also, because this is tightening a verify script, it must be tested during merge.