### PR TITLE
stop running the TSB in the main apiserver

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -240,13 +240,10 @@
     ],
     "allowedImportPackages": [
       "vendor/github.com/golang/glog",
-      "vendor/k8s.io/kubernetes/pkg/api",
       "vendor/github.com/emicklei/go-restful",
       "vendor/github.com/lestrrat/go-jsschema",
-      "vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
       "vendor/k8s.io/kubernetes/pkg/controller",
       "github.com/openshift/origin/pkg/api",
-      "github.com/openshift/origin/pkg/cmd/server/bootstrappolicy",
       "github.com/openshift/origin/pkg/template/apis/template",
       "github.com/openshift/origin/pkg/template/servicebroker"
     ]

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -99,8 +99,6 @@ type OpenshiftAPIConfig struct {
 
 	ServiceAccountMethod configapi.GrantHandlerType
 
-	EnableTemplateServiceBroker bool
-
 	ClusterQuotaMappingController *clusterquotamapping.ClusterQuotaMappingController
 
 	// SCCStorage is actually created with a kubernetes restmapper options to have the correct prefix,

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -11,10 +11,8 @@ import (
 	restclient "k8s.io/client-go/rest"
 	extapi "k8s.io/kubernetes/pkg/apis/extensions"
 	kclientsetexternal "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
-	fakeexternal "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	fakeinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
-	kinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
@@ -86,26 +84,6 @@ func TestValidationRegistration(t *testing.T) {
 	}
 }
 
-// fakeMasterConfig creates a new fake master config with an empty kubelet config and dummy storage.
-func fakeMasterConfig() *MasterConfig {
-	internalKubeInformerFactory := kinternalinformers.NewSharedInformerFactory(fakeinternal.NewSimpleClientset(), 1*time.Second)
-	externalKubeInformerFactory := kinformers.NewSharedInformerFactory(fakeexternal.NewSimpleClientset(), 1*time.Second)
-	authorizationInformerFactory := authorizationinformer.NewSharedInformerFactory(authorizationclientfake.NewSimpleClientset(), 0)
-	quotaInformerFactory := quotainformer.NewSharedInformerFactory(quotaclientfake.NewSimpleClientset(), 0)
-
-	return &MasterConfig{
-		KubeletClientConfig:                           &kubeletclient.KubeletClientConfig{},
-		RESTOptionsGetter:                             restoptions.NewSimpleGetter(&storagebackend.Config{ServerList: []string{"localhost"}}),
-		ExternalKubeInformers:                         externalKubeInformerFactory,
-		InternalKubeInformers:                         internalKubeInformerFactory,
-		AuthorizationInformers:                        authorizationInformerFactory,
-		QuotaInformers:                                quotaInformerFactory,
-		ClusterQuotaMappingController:                 clusterquotamapping.NewClusterQuotaMappingControllerInternal(internalKubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformerFactory.Quota().InternalVersion().ClusterResourceQuotas()),
-		PrivilegedLoopbackKubernetesClientsetInternal: &kclientsetinternal.Clientset{},
-		PrivilegedLoopbackKubernetesClientsetExternal: &kclientsetexternal.Clientset{},
-	}
-}
-
 func fakeOpenshiftAPIServerConfig() *OpenshiftAPIConfig {
 	internalkubeInformerFactory := kinternalinformers.NewSharedInformerFactory(fakeinternal.NewSimpleClientset(), 1*time.Second)
 	authorizationInformerFactory := authorizationinformer.NewSharedInformerFactory(authorizationclientfake.NewSimpleClientset(), 0)
@@ -129,7 +107,6 @@ func fakeOpenshiftAPIServerConfig() *OpenshiftAPIConfig {
 		SecurityInformers:             securityInformerFactory,
 		SCCStorage:                    sccStorage,
 		EnableBuilds:                  true,
-		EnableTemplateServiceBroker:   false,
 		ClusterQuotaMappingController: clusterquotamapping.NewClusterQuotaMappingControllerInternal(internalkubeInformerFactory.Core().InternalVersion().Namespaces(), quotaInformerFactory.Quota().InternalVersion().ClusterResourceQuotas()),
 	}
 	return ret

--- a/pkg/openservicebroker/server/apiserver.go
+++ b/pkg/openservicebroker/server/apiserver.go
@@ -4,23 +4,17 @@ import (
 	"fmt"
 	"time"
 
-	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/pkg/api"
-	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/controller"
 
-	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
 	templateinternalclientset "github.com/openshift/origin/pkg/template/generated/internalclientset"
@@ -52,11 +46,6 @@ var (
 type TemplateServiceBrokerConfig struct {
 	GenericConfig *genericapiserver.Config
 
-	// PrivilegedKubeClientConfig is *not* a loopback config, since it needs to point to the kube apiserver
-	// TODO remove this and use the SA that start us instead of trying to cyclically find an SA token
-	PrivilegedKubeClientConfig *restclient.Config
-
-	TemplateInformers  templateinformer.SharedInformerFactory
 	TemplateNamespaces []string
 }
 
@@ -90,91 +79,43 @@ func (c completedTemplateServiceBrokerConfig) New(delegationTarget genericapiser
 		GenericAPIServer: genericServer,
 	}
 
-	inCluster := false
-	var broker *templateservicebroker.Broker
-	// TODO, this block drops out after the server is moved.
-	if c.PrivilegedKubeClientConfig != nil {
-		broker = templateservicebroker.DeprecatedNewBrokerInsideAPIServer(
-			*c.PrivilegedKubeClientConfig,
-			c.TemplateInformers.Template().InternalVersion().Templates(),
-			c.TemplateNamespaces,
-		)
-		// make sure no one else uses it
-		c.TemplateInformers = nil
-
-	} else {
-		// we're running in cluster
-		// in this case we actually want to construct our own template informer
-		// eventually the config value drops out as it isn't supported server side
-		inCluster = true
-		clientConfig, err := restclient.InClusterConfig()
-		if err != nil {
-			return nil, err
-		}
-		templateClient, err := templateinternalclientset.NewForConfig(clientConfig)
-		if err != nil {
-			return nil, err
-		}
-		templateInformers := templateinformer.NewSharedInformerFactory(templateClient, 5*time.Minute)
-		templateInformers.Template().InternalVersion().Templates().Informer().AddIndexers(cache.Indexers{
-			templateapi.TemplateUIDIndex: func(obj interface{}) ([]string, error) {
-				return []string{string(obj.(*templateapi.Template).UID)}, nil
-			},
-		})
-
-		broker, err = templateservicebroker.NewBroker(
-			clientConfig,
-			templateInformers.Template().InternalVersion().Templates(),
-			c.TemplateNamespaces,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		s.GenericAPIServer.AddPostStartHook("template-service-broker-synctemplates", func(context genericapiserver.PostStartHookContext) error {
-			templateInformers.Start(context.StopCh)
-			if !controller.WaitForCacheSync("tsb", context.StopCh, templateInformers.Template().InternalVersion().Templates().Informer().HasSynced) {
-				return fmt.Errorf("unable to sync caches")
-			}
-			return nil
-		})
+	clientConfig, err := restclient.InClusterConfig()
+	if err != nil {
+		return nil, err
 	}
+	templateClient, err := templateinternalclientset.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	templateInformers := templateinformer.NewSharedInformerFactory(templateClient, 5*time.Minute)
+	templateInformers.Template().InternalVersion().Templates().Informer().AddIndexers(cache.Indexers{
+		templateapi.TemplateUIDIndex: func(obj interface{}) ([]string, error) {
+			return []string{string(obj.(*templateapi.Template).UID)}, nil
+		},
+	})
+
+	broker, err := templateservicebroker.NewBroker(
+		clientConfig,
+		templateInformers.Template().InternalVersion().Templates(),
+		c.TemplateNamespaces,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	s.GenericAPIServer.AddPostStartHook("template-service-broker-synctemplates", func(context genericapiserver.PostStartHookContext) error {
+		templateInformers.Start(context.StopCh)
+		if !controller.WaitForCacheSync("tsb", context.StopCh, templateInformers.Template().InternalVersion().Templates().Informer().HasSynced) {
+			return fmt.Errorf("unable to sync caches")
+		}
+		return nil
+	})
 
 	Route(
 		s.GenericAPIServer.Handler.GoRestfulContainer,
 		templateapi.ServiceBrokerRoot,
 		broker,
 	)
-
-	// TODO, when the TSB becomes a separate entity, this should stop creating the SA and use its container pod SA identity instead
-	if !inCluster {
-		s.GenericAPIServer.AddPostStartHook("template-service-broker-ensure-service-account", func(context genericapiserver.PostStartHookContext) error {
-			kc, err := kclientsetinternal.NewForConfig(context.LoopbackClientConfig)
-			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("template service broker: failed to get client: %v", err))
-				return err
-			}
-
-			err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
-				kc.Namespaces().Create(&api.Namespace{ObjectMeta: metav1.ObjectMeta{Name: bootstrappolicy.DefaultOpenShiftInfraNamespace}})
-
-				_, err = kc.ServiceAccounts(bootstrappolicy.DefaultOpenShiftInfraNamespace).Create(&api.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: bootstrappolicy.InfraTemplateServiceBrokerServiceAccountName}})
-				switch {
-				case err == nil || kapierrors.IsAlreadyExists(err):
-					done, err = true, nil
-				case kapierrors.IsNotFound(err):
-					err = nil
-				}
-
-				return
-			})
-
-			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("creation of template-service-broker SA failed: %v", err))
-			}
-			return err
-		})
-	}
 
 	return s, nil
 }

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -891,7 +891,6 @@ func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, gett
 	masterConfig.AdmissionConfig.PluginConfig["ServiceAccount"] = serverapi.AdmissionPluginConfig{
 		Configuration: &serverapi.DefaultAdmissionConfig{Disable: true},
 	}
-	masterConfig.TemplateServiceBrokerConfig = &serverapi.TemplateServiceBrokerConfig{}
 	if etcdServer.V3Client == nil {
 		masterConfig.KubernetesMasterConfig.APIServerArguments["storage-backend"] = []string{"etcd2"}
 	}


### PR DESCRIPTION
The last commit here stops serving the TSB from the apiserver.  I'm expecting failures, so this is flushing them out for me.

I've left the types to do separately in case it breaks the patch command used elsewhere to add this to the config.