### PR TITLE
WIP - Create a proxy that intercepts native docker build calls 

### DIFF
--- a/pkg/build/proxy/dockerproxy/LICENSE
+++ b/pkg/build/proxy/dockerproxy/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014-2016 Weaveworks Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/build/proxy/dockerproxy/chunked.go
+++ b/pkg/build/proxy/dockerproxy/chunked.go
@@ -1,0 +1,123 @@
+// Based on net/http/internal
+package dockerproxy
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strconv"
+)
+
+var (
+	ErrLineTooLong        = errors.New("header line too long")
+	ErrInvalidChunkLength = errors.New("invalid byte in chunk length")
+)
+
+// Unlike net/http/internal.chunkedReader, this has an interface where we can
+// handle individual chunks. The interface is based on database/sql.Rows.
+func NewChunkedReader(r io.Reader) *ChunkedReader {
+	br, ok := r.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(r)
+	}
+	return &ChunkedReader{r: br}
+}
+
+type ChunkedReader struct {
+	r     *bufio.Reader
+	chunk *io.LimitedReader
+	err   error
+	buf   [2]byte
+}
+
+// Next prepares the next chunk for reading. It returns true on success, or
+// false if there is no next chunk or an error happened while preparing
+// it. Err should be consulted to distinguish between the two cases.
+//
+// Every call to Chunk, even the first one, must be preceded by a call to Next.
+//
+// Calls to Next will discard any unread bytes in the current Chunk.
+func (cr *ChunkedReader) Next() bool {
+	if cr.err != nil {
+		return false
+	}
+
+	// Check the termination of the previous chunk
+	if cr.chunk != nil {
+		// Make sure the remainder is drained, in case the user of this quit
+		// reading early.
+		if _, cr.err = io.Copy(ioutil.Discard, cr.chunk); cr.err != nil {
+			return false
+		}
+
+		// Check the next two bytes after the chunk are \r\n
+		if _, cr.err = io.ReadFull(cr.r, cr.buf[:2]); cr.err != nil {
+			return false
+		}
+		if cr.buf[0] != '\r' || cr.buf[1] != '\n' {
+			cr.err = errors.New("malformed chunked encoding")
+			return false
+		}
+	} else {
+		cr.chunk = &io.LimitedReader{R: cr.r}
+	}
+
+	// Setup the next chunk
+	if n := cr.beginChunk(); n > 0 {
+		cr.chunk.N = int64(n)
+	} else if cr.err == nil {
+		cr.err = io.EOF
+	}
+	return cr.err == nil
+}
+
+// Chunk returns the io.Reader of the current chunk. On each call, this returns
+// the same io.Reader for a given chunk.
+func (cr *ChunkedReader) Chunk() io.Reader {
+	return cr.chunk
+}
+
+// Err returns the error, if any, that was encountered during iteration.
+func (cr *ChunkedReader) Err() error {
+	if cr.err == io.EOF {
+		return nil
+	}
+	return cr.err
+}
+
+func (cr *ChunkedReader) beginChunk() uint64 {
+	var (
+		line []byte
+		n    uint64
+	)
+	// chunk-size CRLF
+	line, cr.err = readLine(cr.r)
+	if cr.err != nil {
+		return 0
+	}
+	n, cr.err = strconv.ParseUint(string(line), 16, 64)
+	if cr.err != nil {
+		cr.err = ErrInvalidChunkLength
+	}
+	return n
+}
+
+// Read a line of bytes (up to \n) from b.
+// Give up if the line exceeds the buffer size.
+// The returned bytes are a pointer into storage in
+// the bufio, so they are only valid until the next bufio read.
+func readLine(b *bufio.Reader) (p []byte, err error) {
+	if p, err = b.ReadSlice('\n'); err != nil {
+		// We always know when EOF is coming.
+		// If the caller asked for a line, there should be a line.
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		} else if err == bufio.ErrBufferFull {
+			err = ErrLineTooLong
+		}
+		return nil, err
+	}
+	return bytes.TrimRight(p, " \t\n\r"), nil
+}

--- a/pkg/build/proxy/dockerproxy/chunked_test.go
+++ b/pkg/build/proxy/dockerproxy/chunked_test.go
@@ -1,0 +1,174 @@
+// Based on net/http/internal
+package dockerproxy
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestChunk(t *testing.T) {
+	r := NewChunkedReader(bytes.NewBufferString(
+		"7\r\nhello, \r\n17\r\nworld! 0123456789abcdef\r\n0\r\n",
+	))
+
+	assertNextChunk(t, r, "hello, ")
+	assertNextChunk(t, r, "world! 0123456789abcdef")
+	assertNoMoreChunks(t, r)
+}
+
+func TestIncompleteReadOfChunk(t *testing.T) {
+	r := NewChunkedReader(bytes.NewBufferString(
+		"7\r\nhello, \r\n17\r\nworld! 0123456789abcdef\r\n0\r\n",
+	))
+
+	// Incomplete read of first chunk
+	{
+		if !r.Next() {
+			t.Fatalf("Expected chunk, but ran out early: %v", r.Err())
+		}
+		if r.Err() != nil {
+			t.Fatalf("Error reading chunk: %q", r.Err())
+		}
+		// Read just 2 bytes
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(r.Chunk(), buf[:2]); err != nil {
+			t.Fatalf("Error reading first bytes of chunk: %q", err)
+		}
+		if buf[0] != 'h' || buf[1] != 'e' {
+			t.Fatalf("Unexpected first 2 bytes of chunk: %q", buf)
+		}
+	}
+
+	assertNextChunk(t, r, "world! 0123456789abcdef")
+	assertNoMoreChunks(t, r)
+}
+
+func TestMalformedChunks(t *testing.T) {
+	r := NewChunkedReader(bytes.NewBufferString(
+		"7\r\nhello, GARBAGEBYTES17\r\nworld! 0123456789abcdef\r\n0\r\n",
+	))
+
+	assertNextChunk(t, r, "hello, ")
+	assertError(t, r, "malformed chunked encoding")
+}
+
+type charReader byte
+
+// Read an infinite sequence of some char
+func (r *charReader) Read(p []byte) (int, error) {
+	b := byte(*r)
+	for i := range p {
+		p[i] = b
+	}
+	return len(p), nil
+}
+
+func TestLargeChunks(t *testing.T) {
+	var expected int64 = 1024 * 1024
+	chars := charReader('a')
+	r := NewChunkedReader(io.MultiReader(
+		strings.NewReader(strconv.FormatInt(expected, 16)+"\r\n"),
+		&io.LimitedReader{N: expected, R: &chars},
+		strings.NewReader("\r\n0\r\n"),
+	))
+
+	if !r.Next() {
+		t.Fatalf("Expected chunk, but ran out early: %v", r.Err())
+	}
+	if r.Err() != nil {
+		t.Fatalf("Error reading chunk: %q", r.Err())
+	}
+	n, err := io.Copy(ioutil.Discard, r.Chunk())
+	if n != expected {
+		t.Errorf("chunk reader read %q; want %q", n, expected)
+	}
+	if err != nil {
+		t.Fatalf("reading chunk: %v", err)
+	}
+	assertNoMoreChunks(t, r)
+}
+
+func TestInvalidChunkSize(t *testing.T) {
+	r := NewChunkedReader(bytes.NewBufferString(
+		"foobar\r\nhello, \r\n0\r\n",
+	))
+
+	assertError(t, r, "invalid byte in chunk length")
+}
+
+func TestChunkSizeLineTooLong(t *testing.T) {
+	var (
+		maxLineLength = 4096
+		chunkSize     string
+	)
+	for i := 0; i < maxLineLength; i++ {
+		chunkSize = chunkSize + "0"
+	}
+	chunkSize = chunkSize + "7"
+
+	r := NewChunkedReader(bytes.NewBufferString(
+		chunkSize + "\r\nhello, \r\n0\r\n",
+	))
+
+	assertError(t, r, "header line too long")
+}
+
+func TestBytesAfterLastChunkAreIgnored(t *testing.T) {
+	r := NewChunkedReader(bytes.NewBufferString(
+		"7\r\nhello, \r\n0\r\nGARBAGEBYTES",
+	))
+
+	assertNextChunk(t, r, "hello, ")
+	assertNoMoreChunks(t, r)
+}
+
+func assertNextChunk(t *testing.T, r *ChunkedReader, expected string) {
+	if !r.Next() {
+		t.Fatalf("Expected chunk, but ran out early: %v", r.Err())
+	}
+	if r.Err() != nil {
+		t.Fatalf("Error reading chunk: %q", r.Err())
+	}
+	data, err := ioutil.ReadAll(r.Chunk())
+	if string(data) != expected {
+		t.Errorf("chunk reader read %q; want %q", data, expected)
+	}
+	if err != nil {
+		t.Logf(`data: %q`, data)
+		t.Fatalf("reading chunk: %v", err)
+	}
+}
+
+func assertError(t *testing.T, r *ChunkedReader, e string) {
+	if r.Next() {
+		t.Errorf("Expected failure when reading chunks, but got one")
+	}
+	if r.Err() == nil || r.Err().Error() != e {
+		t.Errorf("chunk reader errored %q; want %q", r.Err(), e)
+	}
+	data, err := ioutil.ReadAll(r.Chunk())
+	if len(data) != 0 {
+		t.Errorf("chunk should have been empty. got %q", data)
+	}
+	if err != nil {
+		t.Logf(`data: %q`, data)
+		t.Errorf("reading chunk: %v", err)
+	}
+
+	if r.Next() {
+		t.Errorf("Expected no more chunks, but found too many")
+	}
+}
+
+func assertNoMoreChunks(t *testing.T, r *ChunkedReader) {
+	if r.Next() {
+		t.Errorf("Expected no more chunks, but found too many")
+	}
+	if r.Err() != nil {
+		t.Errorf("Expected no error, but found: %q", r.Err())
+	}
+}

--- a/pkg/build/proxy/dockerproxy/common.go
+++ b/pkg/build/proxy/dockerproxy/common.go
@@ -1,0 +1,66 @@
+package dockerproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+func unmarshalRequestBody(r *http.Request, target interface{}) error {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	glog.V(6).Infof("->requestBody: %s", body)
+	if err := r.Body.Close(); err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+
+	d := json.NewDecoder(bytes.NewReader(body))
+	d.UseNumber() // don't want large numbers in scientific format
+	return d.Decode(&target)
+}
+
+func marshalRequestBody(r *http.Request, body interface{}) error {
+	newBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	glog.V(6).Infof("<-requestBody: %s", newBody)
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+	return nil
+}
+
+func unmarshalResponseBody(r *http.Response, target interface{}) error {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	glog.V(6).Infof("->responseBody: %s", body)
+	if err := r.Body.Close(); err != nil {
+		return err
+	}
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
+
+	d := json.NewDecoder(bytes.NewReader(body))
+	d.UseNumber() // don't want large numbers in scientific format
+	return d.Decode(&target)
+}
+
+func marshalResponseBody(r *http.Response, body interface{}) error {
+	newBody, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	glog.V(6).Infof("<-responseBody: %s", newBody)
+	r.Body = ioutil.NopCloser(bytes.NewReader(newBody))
+	r.ContentLength = int64(len(newBody))
+	// Stop it being chunked, because that hangs
+	r.TransferEncoding = nil
+	return nil
+}

--- a/pkg/build/proxy/dockerproxy/doc.go
+++ b/pkg/build/proxy/dockerproxy/doc.go
@@ -1,0 +1,3 @@
+// package dockerproxy implements a lightweight Docker API interceptor
+// Inspired by https://github.com/weaveworks/weave and the proxy package
+package dockerproxy

--- a/pkg/build/proxy/dockerproxy/interceptor.go
+++ b/pkg/build/proxy/dockerproxy/interceptor.go
@@ -1,0 +1,17 @@
+package dockerproxy
+
+import (
+	"net/http"
+)
+
+type Interceptor interface {
+	InterceptRequest(*http.Request) error
+	InterceptResponse(*http.Response) error
+}
+
+var Allow Interceptor = allow{}
+
+type allow struct{}
+
+func (allow) InterceptRequest(*http.Request) error   { return nil }
+func (allow) InterceptResponse(*http.Response) error { return nil }

--- a/pkg/build/proxy/dockerproxy/json.go
+++ b/pkg/build/proxy/dockerproxy/json.go
@@ -1,0 +1,92 @@
+package dockerproxy
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type UnmarshalWrongTypeError struct {
+	Field, Expected string
+	Got             interface{}
+}
+
+func (e *UnmarshalWrongTypeError) Error() string {
+	return fmt.Sprintf("Wrong type for %s field, expected %s, but got %T", e.Field, e.Expected, e.Got)
+}
+
+type jsonObject map[string]interface{}
+
+func (j jsonObject) Object(key string) (jsonObject, error) {
+	iface, ok := j[key]
+	if !ok || iface == nil {
+		result := jsonObject{}
+		j[key] = result
+		return result, nil
+	}
+
+	result, ok := iface.(map[string]interface{})
+	if !ok {
+		return nil, &UnmarshalWrongTypeError{key, "object", iface}
+	}
+
+	return jsonObject(result), nil
+}
+
+func (j jsonObject) String(key string) (string, error) {
+	iface, ok := j[key]
+	if !ok || iface == nil {
+		return "", nil
+	}
+
+	result, ok := iface.(string)
+	if !ok {
+		return "", &UnmarshalWrongTypeError{key, "string", iface}
+	}
+
+	return result, nil
+}
+
+func (j jsonObject) Int(key string) (int, error) {
+	iface, ok := j[key]
+	if !ok || iface == nil {
+		return 0, nil
+	}
+
+	result, ok := iface.(json.Number)
+	if !ok {
+		return 0, &UnmarshalWrongTypeError{key, "json.Number", iface}
+	}
+
+	i64, err := result.Int64()
+	if err != nil {
+		return 0, err
+	}
+
+	return int(i64), nil
+}
+
+func (j jsonObject) StringArray(key string) ([]string, error) {
+	iface, ok := j[key]
+	if !ok || iface == nil {
+		return nil, nil
+	}
+
+	switch o := iface.(type) {
+	case string:
+		return []string{o}, nil
+	case []string:
+		return o, nil
+	case []interface{}:
+		result := []string{}
+		for _, s := range o {
+			if s, ok := s.(string); ok {
+				result = append(result, s)
+			} else {
+				return nil, &UnmarshalWrongTypeError{key, "string or array of strings", iface}
+			}
+		}
+		return result, nil
+	}
+
+	return nil, &UnmarshalWrongTypeError{key, "string or array of strings", iface}
+}

--- a/pkg/build/proxy/dockerproxy/json_test.go
+++ b/pkg/build/proxy/dockerproxy/json_test.go
@@ -1,0 +1,116 @@
+package dockerproxy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupObject(t *testing.T) {
+	tests := []struct {
+		root   jsonObject
+		key    string
+		result jsonObject
+		err    error
+	}{
+		{
+			jsonObject{},
+			"a",
+			jsonObject{},
+			nil,
+		},
+		{
+			jsonObject{"a": map[string]interface{}{"b": int(1)}},
+			"a",
+			jsonObject{"b": int(1)},
+			nil,
+		},
+		{
+			jsonObject{"nonObject": int(1)},
+			"nonObject",
+			nil,
+			&UnmarshalWrongTypeError{Field: "nonObject", Expected: "object", Got: 1},
+		},
+	}
+	for _, test := range tests {
+		gotResult, gotErr := test.root.Object(test.key)
+		msg := fmt.Sprintf("%q.Object(%q) => %q, %q", test.root, test.key, gotResult, gotErr)
+		assert.Equal(t, test.result, gotResult, msg)
+		assert.Equal(t, test.err, gotErr, msg)
+	}
+}
+
+func TestLookupString(t *testing.T) {
+	tests := []struct {
+		root   jsonObject
+		key    string
+		result string
+		err    error
+	}{
+		{
+			jsonObject{},
+			"a",
+			"",
+			nil,
+		},
+		{
+			jsonObject{"nonString": int(1)},
+			"nonString",
+			"",
+			&UnmarshalWrongTypeError{Field: "nonString", Expected: "string", Got: 1},
+		},
+	}
+	for _, test := range tests {
+		gotResult, gotErr := test.root.String(test.key)
+		msg := fmt.Sprintf("%q.String(%q) => %q, %q", test.root, test.key, gotResult, gotErr)
+		assert.Equal(t, test.result, gotResult, msg)
+		assert.Equal(t, test.err, gotErr, msg)
+	}
+}
+
+func TestLookupStringArray(t *testing.T) {
+	tests := []struct {
+		root   jsonObject
+		key    string
+		result []string
+		err    error
+	}{
+		{
+			jsonObject{},
+			"a",
+			nil,
+			nil,
+		},
+		{
+			jsonObject{"a": []string{"foo"}},
+			"a",
+			[]string{"foo"},
+			nil,
+		},
+		{
+			jsonObject{"a": []string{}},
+			"a",
+			[]string{},
+			nil,
+		},
+		{
+			jsonObject{"a": "foo"},
+			"a",
+			[]string{"foo"},
+			nil,
+		},
+		{
+			jsonObject{"int": 5},
+			"int",
+			nil,
+			&UnmarshalWrongTypeError{Field: "int", Expected: "string or array of strings", Got: 5},
+		},
+	}
+	for _, test := range tests {
+		gotResult, gotErr := test.root.StringArray(test.key)
+		msg := fmt.Sprintf("%q.String(%q) => %q, %q", test.root, test.key, gotResult, gotErr)
+		assert.Equal(t, test.result, gotResult, msg)
+		assert.Equal(t, test.err, gotErr, msg)
+	}
+}

--- a/pkg/build/proxy/dockerproxy/proxy.go
+++ b/pkg/build/proxy/dockerproxy/proxy.go
@@ -1,0 +1,229 @@
+package dockerproxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+)
+
+const (
+	defaultCaFile   = "ca.pem"
+	defaultKeyFile  = "key.pem"
+	defaultCertFile = "cert.pem"
+
+	initialInterval = 2 * time.Second
+	maxInterval     = 1 * time.Minute
+)
+
+type Config struct {
+	Client      *docker.Client
+	ListenAddrs []string
+
+	HostnameFromLabel   string
+	HostnameMatch       string
+	HostnameReplacement string
+	Image               string
+	Version             string
+}
+
+type wait struct {
+	ident string
+	ch    chan error
+	done  bool
+}
+
+type Proxy struct {
+	sync.Mutex
+	config              Config
+	hostnameMatchRegexp *regexp.Regexp
+	normalisedAddrs     []string
+	quit                chan struct{}
+}
+
+func StubProxy(c Config) (*Proxy, error) {
+	if c.Client == nil {
+		client, err := docker.NewClientFromEnv()
+		if err != nil {
+			return nil, err
+		}
+		c.Client = client
+	}
+	p := &Proxy{
+		config: c,
+		quit:   make(chan struct{}),
+	}
+	return p, nil
+}
+
+func NewProxy(c Config) (*Proxy, error) {
+	p, err := StubProxy(c)
+	if err != nil {
+		return nil, err
+	}
+
+	p.hostnameMatchRegexp, err = regexp.Compile(c.HostnameMatch)
+	if err != nil {
+		return nil, fmt.Errorf("Incorrect hostname match '%s': %s", c.HostnameMatch, err.Error())
+	}
+
+	return p, nil
+}
+
+func (proxy *Proxy) Dial() (net.Conn, error) {
+	proto := "tcp"
+	addr := proxy.config.Client.Endpoint()
+	switch {
+	case strings.HasPrefix(addr, "unix://"):
+		proto = "unix"
+		addr = strings.TrimPrefix(addr, "unix://")
+	case strings.HasPrefix(addr, "tcp://"):
+		addr = strings.TrimPrefix(addr, "tcp://")
+	}
+	return net.Dial(proto, addr)
+}
+
+func (proxy *Proxy) Listen() []net.Listener {
+	listeners := []net.Listener{}
+	proxy.normalisedAddrs = []string{}
+	unixAddrs := []string{}
+	for _, addr := range proxy.config.ListenAddrs {
+		if strings.HasPrefix(addr, "unix://") || strings.HasPrefix(addr, "/") {
+			unixAddrs = append(unixAddrs, addr)
+			continue
+		}
+		listener, normalisedAddr, err := proxy.listen(addr)
+		if err != nil {
+			glog.Fatalf("Unable to listen: %s", err)
+		}
+		listeners = append(listeners, listener)
+		proxy.normalisedAddrs = append(proxy.normalisedAddrs, normalisedAddr)
+	}
+
+	if len(unixAddrs) > 0 {
+		for _, unixAddr := range unixAddrs {
+			listener, _, err := proxy.listen(unixAddr)
+			if err != nil {
+				glog.Fatalf("Unable to listen: %s", err)
+			}
+			listeners = append(listeners, listener)
+			proxy.normalisedAddrs = append(proxy.normalisedAddrs, unixAddr)
+		}
+	}
+
+	for _, addr := range proxy.normalisedAddrs {
+		glog.Infof("Docker proxy listening on %s", addr)
+	}
+
+	return listeners
+}
+
+// ServeWithReady starts a server on each provided listener, invoking ready when all listeners
+// have been spawned, and exits with a fatal error if any listener closes.
+// TODO: parameterize the http.Server here.
+func ServeWithReady(handler http.Handler, listeners []net.Listener, ready func()) {
+	errs := make(chan error)
+	for _, listener := range listeners {
+		go func(listener net.Listener) {
+			errs <- (&http.Server{Handler: handler}).Serve(listener)
+		}(listener)
+	}
+	// It would be better if we could delay calling Done() until all
+	// the listeners are ready, but it doesn't seem to be possible to
+	// hook the right point in http.Server
+	ready()
+	for range listeners {
+		err := <-errs
+		if err != nil {
+			glog.Fatalf("Serve failed: %s", err)
+		}
+	}
+}
+
+func (proxy *Proxy) StatusHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, addr := range proxy.normalisedAddrs {
+		fmt.Fprintln(w, addr)
+	}
+}
+
+func copyOwnerAndPermissions(from, to string) error {
+	stat, err := os.Stat(from)
+	if err != nil {
+		return err
+	}
+	if err = os.Chmod(to, stat.Mode()); err != nil {
+		return err
+	}
+
+	moreStat, ok := stat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+
+	if err = os.Chown(to, int(moreStat.Uid), int(moreStat.Gid)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (proxy *Proxy) listen(protoAndAddr string) (net.Listener, string, error) {
+	var (
+		listener    net.Listener
+		err         error
+		proto, addr string
+	)
+
+	if protoAddrParts := strings.SplitN(protoAndAddr, "://", 2); len(protoAddrParts) == 2 {
+		proto, addr = protoAddrParts[0], protoAddrParts[1]
+	} else if strings.HasPrefix(protoAndAddr, "/") {
+		proto, addr = "unix", protoAndAddr
+	} else {
+		proto, addr = "tcp", protoAndAddr
+	}
+
+	switch proto {
+	case "tcp":
+		listener, err = net.Listen(proto, addr)
+		if err != nil {
+			return nil, "", err
+		}
+		if proxy.config.Client.TLSConfig != nil {
+			listener = tls.NewListener(listener, proxy.config.Client.TLSConfig)
+		}
+
+	case "unix":
+		// remove socket from last invocation
+		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
+			return nil, "", err
+		}
+		listener, err = net.Listen(proto, addr)
+		if err != nil {
+			return nil, "", err
+		}
+		dockerEndpoint := proxy.config.Client.Endpoint()
+		if strings.HasPrefix(dockerEndpoint, "unix://") {
+			if err = copyOwnerAndPermissions(strings.TrimPrefix(dockerEndpoint, "unix://"), addr); err != nil {
+				return nil, "", err
+			}
+		}
+
+	default:
+		return nil, "", fmt.Errorf("invalid protocol format %q for %q", proto, protoAndAddr)
+	}
+
+	return listener, fmt.Sprintf("%s://%s", proto, addr), nil
+}
+
+func (proxy *Proxy) Stop() {
+	close(proxy.quit)
+}

--- a/pkg/build/proxy/dockerproxy/proxy_intercept.go
+++ b/pkg/build/proxy/dockerproxy/proxy_intercept.go
@@ -1,0 +1,189 @@
+package dockerproxy
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/build/proxy/interceptor"
+)
+
+func (proxy *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	proxy.Intercept(Allow, w, r)
+}
+
+func (proxy *Proxy) Intercept(i interceptor.Interface, w http.ResponseWriter, r *http.Request) {
+	if err := i.InterceptRequest(r); err != nil {
+		glog.V(4).Infof("%s %s rejected with error: %v", r.Method, r.URL, err)
+		switch err {
+		case docker.ErrNoSuchImage:
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		switch t := err.(type) {
+		case http.Handler:
+			t.ServeHTTP(w, r)
+		case *docker.NoSuchContainer:
+			http.Error(w, err.Error(), http.StatusNotFound)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			glog.Warning("Error intercepting request: ", err)
+		}
+		return
+	}
+
+	glog.V(4).Infof("%s %s dispatch", r.Method, r.URL)
+
+	conn, err := proxy.Dial()
+	if err != nil {
+		http.Error(w, "Could not connect to target", http.StatusInternalServerError)
+		glog.Warning(err)
+		return
+	}
+	client := httputil.NewClientConn(conn, nil)
+	defer client.Close()
+
+	resp, err := client.Do(r)
+	if err != nil && err != httputil.ErrPersistEOF {
+		http.Error(w, fmt.Sprintf("Could not make request to target: %v", err), http.StatusInternalServerError)
+		glog.Warning("Error forwarding request: ", err)
+		return
+	}
+
+	glog.V(4).Infof("%s %s response: %s %v", r.Method, r.URL, resp.Status, w.Header())
+
+	err = i.InterceptResponse(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		glog.Warning("Error intercepting response: ", err)
+		return
+	}
+
+	hdr := w.Header()
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			hdr.Add(k, v)
+		}
+	}
+
+	glog.V(4).Infof("%s %s intercept: %s %v", r.Method, r.URL, resp.Status, w.Header())
+
+	if resp.Header.Get("Content-Type") == "application/vnd.docker.raw-stream" {
+		doRawStream(w, resp, client)
+	} else if resp.TransferEncoding != nil && resp.TransferEncoding[0] == "chunked" {
+		doChunkedResponse(w, resp, client)
+	} else {
+		w.WriteHeader(resp.StatusCode)
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			glog.Warning(err)
+		}
+	}
+}
+
+func doRawStream(w http.ResponseWriter, resp *http.Response, client *httputil.ClientConn) {
+	down, downBuf, up, remaining, err := hijack(w, client)
+	if err != nil {
+		http.Error(w, "Unable to hijack connection for raw stream mode", http.StatusInternalServerError)
+		return
+	}
+	defer down.Close()
+	defer up.Close()
+	defer func() {
+		if err != nil {
+			glog.Warning(err)
+		}
+	}()
+
+	if _, err = downBuf.Write([]byte("HTTP/1.1 " + resp.Status + "\n")); err != nil {
+		return
+	}
+	if err = resp.Header.Write(downBuf); err != nil {
+		return
+	}
+	if _, err = downBuf.Write([]byte("\n")); err != nil {
+		return
+	}
+	if err = downBuf.Flush(); err != nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go copyStream(down, io.MultiReader(remaining, up), &wg)
+	go copyStream(up, downBuf, &wg)
+	wg.Wait()
+}
+
+type closeWriter interface {
+	CloseWrite() error
+}
+
+func copyStream(dst io.WriteCloser, src io.Reader, wg *sync.WaitGroup) {
+	defer wg.Done()
+	if _, err := io.Copy(dst, src); err != nil {
+		glog.Warning(err)
+	}
+	var err error
+	if c, ok := dst.(closeWriter); ok {
+		err = c.CloseWrite()
+	} else {
+		err = dst.Close()
+	}
+	if err != nil {
+		glog.Warningf("Error closing connection: %s", err)
+	}
+}
+
+type writeFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+func doChunkedResponse(w http.ResponseWriter, resp *http.Response, client *httputil.ClientConn) {
+	wf, ok := w.(writeFlusher)
+	if !ok {
+		http.Error(w, "Error forwarding chunked response body: flush not available", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	wf.Flush()
+
+	up, remaining := client.Hijack()
+	defer up.Close()
+
+	var err error
+	chunks := NewChunkedReader(io.MultiReader(remaining, up))
+	for chunks.Next() && err == nil {
+		_, err = io.Copy(wf, chunks.Chunk())
+		wf.Flush()
+	}
+	if err == nil {
+		err = chunks.Err()
+	}
+	if err != nil {
+		glog.Errorf("Error forwarding chunked response body: %s", err)
+	}
+}
+
+func hijack(w http.ResponseWriter, client *httputil.ClientConn) (down net.Conn, downBuf *bufio.ReadWriter, up net.Conn, remaining io.Reader, err error) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		err = errors.New("Unable to cast to Hijack")
+		return
+	}
+	down, downBuf, err = hj.Hijack()
+	if err != nil {
+		return
+	}
+	up, remaining = client.Hijack()
+	return
+}

--- a/pkg/build/proxy/dockerproxy/status.go
+++ b/pkg/build/proxy/dockerproxy/status.go
@@ -1,0 +1,15 @@
+package dockerproxy
+
+type Status struct {
+	Addresses []string
+}
+
+func NewStatus(proxy *Proxy) *Status {
+	if proxy == nil {
+		return nil
+	}
+	status := &Status{
+		Addresses: proxy.normalisedAddrs,
+	}
+	return status
+}

--- a/pkg/build/proxy/dockerproxy/tls.go
+++ b/pkg/build/proxy/dockerproxy/tls.go
@@ -1,0 +1,78 @@
+package dockerproxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/homedir"
+)
+
+type TLSConfig struct {
+	Enabled, Verify   bool
+	Cert, Key, CACert string
+	*tls.Config
+}
+
+// IsEnabled returns true if TLS is enable, according to the config.
+func (c *TLSConfig) IsEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.Enabled || c.Verify
+}
+
+// LoadCerts loads the certificates into c.Config, if TLS is enabled.
+func (c *TLSConfig) LoadCerts() error {
+	if !c.IsEnabled() {
+		return nil
+	}
+
+	dockerCertPath := os.Getenv("DOCKER_CERT_PATH")
+	if dockerCertPath == "" {
+		dockerCertPath = filepath.Join(homedir.Get(), ".docker")
+	}
+
+	if c.CACert == "" {
+		c.CACert = filepath.Join(dockerCertPath, defaultCaFile)
+	}
+	if c.Cert == "" {
+		c.Cert = filepath.Join(dockerCertPath, defaultCertFile)
+	}
+	if c.Key == "" {
+		c.Key = filepath.Join(dockerCertPath, defaultKeyFile)
+	}
+
+	tlsConfig := &tls.Config{
+		NextProtos: []string{"http/1.1"},
+		// Avoid fallback on insecure SSL protocols
+		MinVersion: tls.VersionTLS10,
+	}
+
+	if c.Verify {
+		certPool := x509.NewCertPool()
+		file, err := ioutil.ReadFile(c.CACert)
+		if err != nil {
+			return fmt.Errorf("Couldn't read CA certificate: %v", err)
+		}
+		certPool.AppendCertsFromPEM(file)
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.ClientCAs = certPool
+	}
+
+	_, errCert := os.Stat(c.Cert)
+	_, errKey := os.Stat(c.Key)
+	if errCert == nil && errKey == nil {
+		cert, err := tls.LoadX509KeyPair(c.Cert, c.Key)
+		if err != nil {
+			return fmt.Errorf("Couldn't load X509 key pair: %q. Make sure the key is encrypted", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	c.Config = tlsConfig
+	return nil
+}

--- a/pkg/build/proxy/handler.go
+++ b/pkg/build/proxy/handler.go
@@ -1,0 +1,362 @@
+package proxy
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/builder/dockerfile/parser"
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/build/proxy/interceptor"
+	"github.com/openshift/origin/pkg/build/proxy/interceptor/archive"
+)
+
+// NewAuthorizingDockerAPIFilter allows a subset of the Docker API to be invoked on the nested handler and only
+// after the provided authorizer validates/transforms the provided request.
+func NewAuthorizingDockerAPIFilter(h http.Handler, allowHost string, authorizer interceptor.BuildAuthorizer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == "GET" && interceptor.IsPingEndpoint(req.URL.Path):
+			h.ServeHTTP(w, req)
+
+		// The interceptor allows the /auth endpoint to be hit to provide a convenience for local testing.
+		// If the incoming server address matches the fake builder, we return 204 to let docker use those
+		// credentials. Otherwise, we reject the call
+		case req.Method == "POST" && interceptor.IsAuthEndpoint(req.URL.Path):
+			info, err := interceptor.ParseAuthorizationRequest(req, 50*1024)
+			if err != nil {
+				interceptor.NewForbiddenError(err).ServeHTTP(w, req)
+				return
+			}
+			if info.ServerAddress == allowHost {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				fmt.Fprintln(w, `{"Status":"Login succeeded"}`)
+				return
+			}
+			glog.V(2).Infof("%s %s forbidden: not required host", req.Method, req.URL)
+			interceptor.NewForbiddenError(fmt.Errorf("only build or ping requests are allowed")).ServeHTTP(w, req)
+
+		case req.Method == "POST" && interceptor.IsBuildImageEndpoint(req.URL.Path):
+			if err := filterBuildImageRequest(w, req, allowHost, authorizer); err != nil {
+				glog.V(2).Infof("%s %s forbidden: %v", req.Method, req.URL, err)
+				err.ServeHTTP(w, req)
+				return
+			}
+
+			h.ServeHTTP(w, req)
+
+		case req.Method == "POST" && interceptor.IsPushImageEndpoint(req.URL.Path):
+			if err := filterPushImageRequest(req, allowHost); err != nil {
+				glog.V(2).Infof("%s %s forbidden: %v", req.Method, req.URL, err)
+				err.ServeHTTP(w, req)
+				return
+			}
+
+			h.ServeHTTP(w, req)
+
+		case req.Method == "POST" && interceptor.IsTagImageEndpoint(req.URL.Path):
+			if err := filterTagImageRequest(req, allowHost); err != nil {
+				glog.V(2).Infof("%s %s forbidden: %v", req.Method, req.URL, err)
+				err.ServeHTTP(w, req)
+				return
+			}
+
+			h.ServeHTTP(w, req)
+
+		case req.Method == "DELETE" && interceptor.IsRemoveImageEndpoint(req.URL.Path):
+			if err := filterRemoveImageRequest(req, allowHost); err != nil {
+				glog.V(2).Infof("%s %s forbidden: %v", req.Method, req.URL, err)
+				err.ServeHTTP(w, req)
+				return
+			}
+
+			h.ServeHTTP(w, req)
+
+		default:
+			glog.V(2).Infof("%s %s forbidden", req.Method, req.URL)
+			interceptor.NewForbiddenError(fmt.Errorf("only build or ping requests are allowed")).ServeHTTP(w, req)
+		}
+	})
+}
+
+// filterBuildImageRequest applies the necessary authorization to an incoming build request based on authorizer.
+// Authorizer may mutate the build request, which will then be applied back to the passed request URLs for
+// continuing the action.
+func filterBuildImageRequest(w http.ResponseWriter, req *http.Request, allowHost string, authorizer interceptor.BuildAuthorizer) interceptor.ErrorHandler {
+	info, err := interceptor.ParseBuildAuthorization(req, allowHost)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+
+	build := &interceptor.BuildImageOptions{}
+	if err := interceptor.StrictDecodeFromQuery(build, req.URL.Query()); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build request rejected because of an unrecogized query param: %v", err))
+	}
+
+	if len(build.Names) > 1 {
+		return interceptor.NewForbiddenError(fmt.Errorf("build request rejected because more than one tag was specified"))
+	}
+	names, err := tagNameValidation(allowHost+"/", build.Names...)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+	build.Names = names
+
+	authCtx, _ := context.WithDeadline(req.Context(), time.Now().Add(10*time.Second))
+	updatedBuild, err := authorizer.AuthorizeBuildRequest(authCtx, build, info)
+	if err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build request could not be authorized: %v", err))
+	}
+
+	// transform the incoming request into the authorized form
+	updateRequest(req, req.URL.Path, interceptor.EncodeToQuery(updatedBuild).Encode())
+	// wrap the request body to ensure the dockerfile is safe
+	// req.Body = filterBuildArchive(req.Body, updatedBuild)
+
+	glog.V(4).Infof("Authorized %s to build %#v", info.Username, updatedBuild)
+	return nil
+}
+
+func filterBuildArchive(in io.Reader, options *interceptor.BuildImageOptions) io.ReadCloser {
+	dockerfilePath := options.Dockerfile
+	if len(dockerfilePath) == 0 {
+		dockerfilePath = "Dockerfile"
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		err := archive.FilterArchive(in, pw, func(h *tar.Header, in io.Reader) ([]byte, bool, error) {
+			if h.Name != dockerfilePath {
+				return nil, false, nil
+			}
+			glog.Infof("Intercepted %s: %#v", dockerfilePath, h)
+			if h.Size > 100*1024 {
+				return nil, false, fmt.Errorf("Dockerfile in uploaded build context too large, %d bytes", h.Size)
+			}
+			data, err := ioutil.ReadAll(in)
+			if err != nil {
+				return nil, false, err
+			}
+			directive := &parser.Directive{}
+			if err := parser.SetEscapeToken(parser.DefaultEscapeToken, directive); err != nil {
+				return nil, false, fmt.Errorf("invalid Dockerfile parser: %v", err)
+			}
+			root, err := parser.Parse(bytes.NewBuffer(data), directive)
+			if err != nil {
+				return nil, false, fmt.Errorf("unable to parse %s in archive: %v", h.Name, err)
+			}
+			// for _, child := range root.Children {
+			// }
+			glog.Infof("Found dockerfile:\n%s", root.Dump())
+			return data, true, nil
+		})
+		pw.CloseWithError(err)
+	}()
+	return pr
+}
+
+// filterPushImageRequest applies the necessary authorization to an incoming push request.
+func filterPushImageRequest(req *http.Request, allowHost string) interceptor.ErrorHandler {
+	push := &interceptor.PushImageOptions{}
+	if err := interceptor.StrictDecodeFromQuery(push, req.URL.Query()); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("push request rejected because of an unrecogized query param: %v", err))
+	}
+	name, ok := interceptor.PushImageEndpointParameters(req.URL.Path)
+	if !ok || len(name) == 0 {
+		return interceptor.NewForbiddenError(fmt.Errorf("push request rejected: unable to find endpoint path"))
+	}
+	names, err := tagNameValidation(allowHost+"/", name)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+
+	if len(push.Tag) == 0 {
+		tag := findTag(name)
+		if len(tag) == 0 {
+			tag = "latest"
+		}
+		push.Tag = tag
+	}
+	push.Name = names[0]
+
+	// transform the incoming request into the authorized form
+	newPath, ok := interceptor.ReplacePushImageEndpointParameters(req.URL.Path, push.Name)
+	if !ok {
+		return interceptor.NewForbiddenError(fmt.Errorf("push request rejected: unable to generate new endpoint path"))
+	}
+	updateRequest(req, newPath, interceptor.EncodeToQuery(push).Encode())
+
+	glog.V(4).Infof("Authorized to push %#v", push)
+	return nil
+}
+
+// filterRemoveImageRequest applies the necessary authorization to an incoming image removal.
+func filterRemoveImageRequest(req *http.Request, allowHost string) interceptor.ErrorHandler {
+	removeImage := &interceptor.RemoveImageOptions{}
+	if err := interceptor.StrictDecodeFromQuery(removeImage, req.URL.Query()); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("remove image request rejected because of an unrecogized query param: %v", err))
+	}
+	name, ok := interceptor.RemoveImageEndpointParameters(req.URL.Path)
+	if !ok || len(name) == 0 {
+		return interceptor.NewForbiddenError(fmt.Errorf("remove image rejected: unable to find endpoint path"))
+	}
+	names, err := tagNameValidation(allowHost+"/", name)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+
+	removeImage = &interceptor.RemoveImageOptions{
+		Name: names[0],
+		// prevent users from leaving unused content
+		Force:   true,
+		NoPrune: false,
+	}
+
+	// transform the incoming request into the authorized form
+	newPath, ok := interceptor.ReplaceRemoveImageEndpointParameters(req.URL.Path, removeImage.Name)
+	if !ok {
+		return interceptor.NewForbiddenError(fmt.Errorf("remove image request rejected: unable to generate new endpoint path"))
+	}
+	updateRequest(req, newPath, interceptor.EncodeToQuery(removeImage).Encode())
+
+	glog.V(4).Infof("Authorized to remove %#v", removeImage)
+	return nil
+}
+
+// filterTagImageRequest applies the necessary authorization checks to an incoming tag image request.
+func filterTagImageRequest(req *http.Request, allowHost string) interceptor.ErrorHandler {
+	imageTag := &interceptor.ImageTagOptions{}
+	if err := interceptor.StrictDecodeFromQuery(imageTag, req.URL.Query()); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("tag request rejected because of an unrecogized query param: %v", err))
+	}
+	if len(imageTag.Repo) == 0 {
+		return interceptor.NewForbiddenError(fmt.Errorf("tag request rejected, no destination repository parameter provided"))
+	}
+	if len(imageTag.Tag) == 0 {
+		imageTag.Tag = "latest"
+	}
+
+	name, ok := interceptor.TagImageEndpointParameters(req.URL.Path)
+	if !ok || len(name) == 0 {
+		return interceptor.NewForbiddenError(fmt.Errorf("tag request rejected: unable to find endpoint path"))
+	}
+	repoName := imageTag.Repo + ":" + imageTag.Tag
+
+	names, err := tagNameValidation(allowHost+"/", name)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+	repoNames, err := tagNameValidation(allowHost+"/", repoName)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+	imageTag = &interceptor.ImageTagOptions{
+		Name: names[0],
+		Tag:  findTag(repoNames[0]),
+		Repo: removeTagOrDigest(repoNames[0]),
+	}
+
+	// transform the incoming request into the authorized form
+	newPath, ok := interceptor.ReplaceTagImageEndpointParameters(req.URL.Path, imageTag.Name)
+	if !ok {
+		return interceptor.NewForbiddenError(fmt.Errorf("push request rejected: unable to generate new push endpoint path"))
+	}
+	updateRequest(req, newPath, interceptor.EncodeToQuery(imageTag).Encode())
+
+	glog.V(4).Infof("Authorized to tag %#v", imageTag)
+	return nil
+}
+
+func tagNameValidation(requiredPrefix string, names ...string) ([]string, error) {
+	var internalNames []string
+	for _, name := range names {
+		if len(name) == 0 {
+			return nil, fmt.Errorf("tag names may not be empty and must start with %q", requiredPrefix)
+		}
+		if !strings.HasPrefix(name, requiredPrefix) {
+			return nil, fmt.Errorf("tag names must start with %q", requiredPrefix)
+		}
+		remaining := strings.TrimPrefix(name, requiredPrefix)
+
+		i := strings.Index(remaining, "/")
+		if i == -1 {
+			return nil, fmt.Errorf("tag names must start with %q and have a random prefix segment that cannot be guessed", requiredPrefix)
+		}
+
+		// TODO: verify that the segment is a hash of the password?
+
+		remaining = remaining[i+1:]
+		remaining = removeTagOrDigest(remaining)
+		hash := sha256.New()
+		if _, err := hash.Write([]byte(name)); err != nil {
+			return nil, fmt.Errorf("unable to encode tag")
+		}
+		sum := base64.RawURLEncoding.EncodeToString(hash.Sum(nil))
+
+		internalNames = append(internalNames, remaining+":internal-"+sum)
+	}
+	return internalNames, nil
+}
+
+func updateRequest(req *http.Request, path, rawQuery string) {
+	copiedURL := *req.URL
+	copiedURL.Path = path
+	copiedURL.RawQuery = rawQuery
+	req.URL = &copiedURL
+	req.RequestURI = copiedURL.Path
+	if len(copiedURL.RawQuery) > 0 {
+		req.RequestURI = "?" + copiedURL.RawQuery
+	}
+}
+
+func contains(values []string, value string) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func cookieToMappedTags(cookie map[interface{}]interface{}) (map[string][]string, error) {
+	result := make(map[string][]string)
+	for keyObj, valueObj := range cookie {
+		key, ok := keyObj.(string)
+		if !ok {
+			continue
+		}
+		values, ok := valueObj.([]string)
+		if !ok {
+			continue
+		}
+		for _, value := range values {
+			result[value] = append(result[value], key)
+		}
+	}
+	return result, nil
+}
+
+func removeTagOrDigest(value string) string {
+	last := strings.LastIndex(value, "/")
+	if suffix := strings.LastIndexAny(value, "@:"); suffix != -1 && last < suffix {
+		value = value[:suffix]
+	}
+	return value
+}
+
+func findTag(value string) string {
+	last := strings.LastIndex(value, "/")
+	if suffix := strings.LastIndexAny(value, ":"); suffix != -1 && last < suffix {
+		return value[suffix+1:]
+	}
+	return ""
+}

--- a/pkg/build/proxy/imagebuilder/imagebuilder.go
+++ b/pkg/build/proxy/imagebuilder/imagebuilder.go
@@ -1,0 +1,168 @@
+package imagebuilder
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/archive"
+	dockertypes "github.com/docker/engine-api/types"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+	"github.com/openshift/imagebuilder"
+	"github.com/openshift/imagebuilder/dockerclient"
+
+	"github.com/openshift/origin/pkg/build/proxy/interceptor"
+)
+
+type Server struct {
+	Handler http.Handler
+	Client  *docker.Client
+}
+
+func (s Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	switch path := req.URL.Path; {
+	case req.Method == "POST" && interceptor.IsBuildImageEndpoint(path):
+		if err := handleBuildImageRequest(s.Client, w, req); err != nil {
+			glog.V(2).Infof("%s %s forbidden: %v", req.Method, req.URL, err)
+			err.ServeHTTP(w, req)
+		}
+		return
+	}
+
+	s.Handler.ServeHTTP(w, req)
+}
+
+// handleBuildImageRequest applies the necessary authorization to an incoming build request based on authorizer.
+// Authorizer may mutate the build request, which will then be applied back to the passed request URLs for
+// continuing the action.
+func handleBuildImageRequest(client *docker.Client, w http.ResponseWriter, req *http.Request) interceptor.ErrorHandler {
+	var auth docker.AuthConfigurations
+	if header := req.Header.Get("X-Registry-Config"); len(header) > 0 {
+		data, err := base64.StdEncoding.DecodeString(header)
+		if err != nil {
+			return interceptor.NewForbiddenError(fmt.Errorf("build request rejected because X-Registry-Config header not valid base64: %v", err))
+		}
+		if err := json.Unmarshal(data, &auth.Configs); err != nil {
+			return interceptor.NewForbiddenError(fmt.Errorf("build request rejected because X-Registry-Config header not parseable: %v", err))
+		}
+	}
+
+	options := &interceptor.BuildImageOptions{}
+	if err := interceptor.StrictDecodeFromQuery(options, req.URL.Query()); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build request rejected because of an unrecogized query param: %v", err))
+	}
+
+	dockerfilePath := options.Dockerfile
+	if len(dockerfilePath) == 0 {
+		dockerfilePath = "Dockerfile"
+	}
+	dockerfilePath = path.Clean(dockerfilePath)
+	arguments := make(map[string]string)
+	for _, arg := range options.BuildArgs {
+		arguments[arg.Name] = arg.Value
+	}
+
+	in, err := archive.DecompressStream(req.Body)
+	if err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build context be decompressed: %v", err))
+	}
+
+	// TODO: save archive to disk, then stream from archive into image rather than unpacking
+	//   to preserve file info
+	dir, err := ioutil.TempDir("", "imagebuilder-")
+	if err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build context be extracted: %v", err))
+	}
+	defer func() { os.RemoveAll(dir) }()
+	if err := archive.Untar(in, dir, &archive.TarOptions{NoLchown: true}); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build context be extracted: %v", err))
+	}
+	dockerfilePath = filepath.Join(dir, dockerfilePath)
+
+	e := dockerclient.NewClientExecutor(client)
+	e.AuthFn = func(name string) ([]dockertypes.AuthConfig, bool) {
+		cfg, ok := auth.Configs[name]
+		return []dockertypes.AuthConfig{
+			{Username: cfg.Username, Password: cfg.Password, Email: cfg.Email, ServerAddress: cfg.ServerAddress},
+		}, ok
+	}
+	e.AllowPull = options.Pull
+	e.HostConfig = &docker.HostConfig{
+		NetworkMode:  options.NetworkMode,
+		CgroupParent: options.CgroupParent,
+	}
+	if len(options.Names) > 0 {
+		e.Tag = options.Names[0]
+		e.AdditionalTags = options.Names[1:]
+	}
+
+	for _, name := range options.Names {
+		if err := client.RemoveImage(name); err != nil {
+			if err != docker.ErrNoSuchImage {
+				glog.V(4).Infof("Unable to remove previously tagged image %s", name)
+			}
+		}
+	}
+
+	// TODO: handle signals
+	defer func() {
+		for _, err := range e.Release() {
+			glog.V(2).Infof("Unable to clean up build: %v\n", err)
+		}
+	}()
+
+	b, node, err := imagebuilder.NewBuilderForFile(dockerfilePath, arguments)
+	if err != nil {
+		return interceptor.NewForbiddenError(err)
+	}
+
+	out := &streamWriter{encoder: json.NewEncoder(w)}
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	e.LogFn = func(format string, args ...interface{}) {
+		fmt.Fprintf(out, "--> "+format+"\n", args...)
+	}
+	e.Out = out
+	e.ErrOut = out
+
+	if err := e.Prepare(b, node, ""); err != nil {
+		fmt.Fprintf(out, "error: %v", err)
+		return nil
+	}
+	if err := e.Execute(b, node); err != nil {
+		fmt.Fprintf(out, "error: %v", err)
+		return nil
+	}
+	if len(options.Names) > 0 {
+		if err := e.Commit(b); err != nil {
+			fmt.Fprintf(out, "error: %v", err)
+			return nil
+		}
+	}
+	return nil
+}
+
+type streamWriter struct {
+	encoder *json.Encoder
+	r       streamResponse
+}
+
+type streamResponse struct {
+	Stream string `json:"stream"`
+}
+
+func (w *streamWriter) Write(data []byte) (n int, err error) {
+	w.r.Stream = string(data)
+	if err := w.encoder.Encode(&w.r); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}

--- a/pkg/build/proxy/interceptor/archive/archive.go
+++ b/pkg/build/proxy/interceptor/archive/archive.go
@@ -1,0 +1,54 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+
+	"github.com/docker/docker/pkg/archive"
+)
+
+// TransformFileFunc is given a chance to transform an arbitrary input file.
+type TransformFileFunc func(h *tar.Header, r io.Reader) ([]byte, bool, error)
+
+// FilterArchive transforms the provided input archive (compressed) to a
+// compressed archive, giving the fn a chance to transform arbitrary files.
+func FilterArchive(r io.Reader, w io.Writer, fn TransformFileFunc) error {
+	in, err := archive.DecompressStream(r)
+	if err != nil {
+		return err
+	}
+	tr := tar.NewReader(in)
+	tw := tar.NewWriter(w)
+	out, err := archive.CompressStream(tw, archive.Gzip)
+	if err != nil {
+		return err
+	}
+
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			return out.Close()
+		}
+		if err != nil {
+			return err
+		}
+
+		var body io.Reader = tr
+		data, ok, err := fn(h, tr)
+		if err != nil {
+			return err
+		}
+		if ok {
+			h.Size = int64(len(data))
+			body = bytes.NewBuffer(data)
+		}
+
+		if err := tw.WriteHeader(h); err != nil {
+			return err
+		}
+		if _, err := io.Copy(tw, body); err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/build/proxy/interceptor/auth.go
+++ b/pkg/build/proxy/interceptor/auth.go
@@ -1,0 +1,46 @@
+package interceptor
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func ParseAuthorizationRequest(req *http.Request, maxLength int64) (*AuthRequest, error) {
+	data, err := ioutil.ReadAll(io.LimitReader(req.Body, maxLength))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse authorization request, may be too large: %v", err)
+	}
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	auth := &AuthRequest{}
+	if err := json.Unmarshal(data, auth); err != nil {
+		return nil, fmt.Errorf("authorization request rejected because body was not parseable to JSON: %v", err)
+	}
+	return auth, nil
+}
+
+func ParseBuildAuthorization(req *http.Request, host string) (*AuthOptions, error) {
+	var config map[string]AuthOptions
+	auth := req.Header.Get("X-Registry-Config")
+	if len(auth) > 0 {
+		data, err := base64.StdEncoding.DecodeString(auth)
+		if err != nil {
+			return nil, fmt.Errorf("build request rejected because X-Registry-Config header not valid base64: %v", err)
+		}
+		if err := json.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("build request rejected because X-Registry-Config header not parseable: %v", err)
+		}
+	}
+	local, ok := config[host]
+	if !ok {
+		return nil, fmt.Errorf("build request rejected because no credentials for %q were provided", host)
+	}
+	if len(local.Username) == 0 || len(local.Password) == 0 {
+		return nil, fmt.Errorf("build request rejected because username and password were not set for %q", host)
+	}
+	return &local, nil
+}

--- a/pkg/build/proxy/interceptor/context.go
+++ b/pkg/build/proxy/interceptor/context.go
@@ -1,0 +1,9 @@
+package interceptor
+
+import (
+	"context"
+)
+
+func WithAuthorizationContext(ctx context.Context) context.Context {
+	return ctx
+}

--- a/pkg/build/proxy/interceptor/doc.go
+++ b/pkg/build/proxy/interceptor/doc.go
@@ -1,0 +1,3 @@
+// package interceptor provides Docker specific interceptor logic for verifying that
+// requested docker operations are safe.
+package interceptor

--- a/pkg/build/proxy/interceptor/docker.go
+++ b/pkg/build/proxy/interceptor/docker.go
@@ -1,0 +1,135 @@
+package interceptor
+
+import (
+	"fmt"
+	"regexp"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+var (
+	pingRegexp        = dockerAPIEndpoint("_ping")
+	authRegexp        = dockerAPIEndpoint("auth")
+	buildImageRegexp  = dockerAPIEndpoint("build")
+	pushImageRegexp   = dockerAPIEndpoint("images/([\\w\\-/\\:\\.]+?)/push")
+	tagImageRegexp    = dockerAPIEndpoint("images/([\\w\\-/\\:\\.]+?)/tag")
+	removeImageRegexp = dockerAPIEndpoint("images/([\\w\\-/\\:\\.]+?)")
+)
+
+func dockerAPIEndpoint(endpoint string) *regexp.Regexp {
+	return regexp.MustCompile("^(/v[0-9\\.]*)?/" + endpoint + "$")
+}
+
+func IsPingEndpoint(path string) bool        { return pingRegexp.MatchString(path) }
+func IsAuthEndpoint(path string) bool        { return authRegexp.MatchString(path) }
+func IsBuildImageEndpoint(path string) bool  { return buildImageRegexp.MatchString(path) }
+func IsPushImageEndpoint(path string) bool   { return pushImageRegexp.MatchString(path) }
+func IsTagImageEndpoint(path string) bool    { return tagImageRegexp.MatchString(path) }
+func IsRemoveImageEndpoint(path string) bool { return removeImageRegexp.MatchString(path) }
+
+func PushImageEndpointParameters(path string) (string, bool) {
+	matches := pushImageRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return matches[2], true
+}
+
+func TagImageEndpointParameters(path string) (string, bool) {
+	matches := tagImageRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return matches[2], true
+}
+
+func RemoveImageEndpointParameters(path string) (string, bool) {
+	matches := removeImageRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return matches[2], true
+}
+
+func ReplacePushImageEndpointParameters(path, name string) (string, bool) {
+	matches := pushImageRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("%s/images/%s/push", matches[1], name), true
+}
+
+func ReplaceTagImageEndpointParameters(path, name string) (string, bool) {
+	matches := tagImageRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("%s/images/%s/tag", matches[1], name), true
+}
+
+func ReplaceRemoveImageEndpointParameters(path, name string) (string, bool) {
+	matches := removeImageRegexp.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("%s/images/%s", matches[1], name), true
+}
+
+type BuildImageOptions struct {
+	Names               []string          `qs:"t"`
+	Dockerfile          string            `qs:"dockerfile"`
+	NoCache             bool              `qs:"nocache"`
+	SuppressOutput      bool              `qs:"q"`
+	Pull                bool              `qs:"pull"`
+	RmTmpContainer      bool              `qs:"rm"`
+	ForceRmTmpContainer bool              `qs:"forcerm"`
+	Memory              int64             `qs:"memory"`
+	Memswap             int64             `qs:"memswap"`
+	CPUShares           int64             `qs:"cpushares"`
+	CPUQuota            int64             `qs:"cpuquota"`
+	CPUPeriod           int64             `qs:"cpuperiod"`
+	CPUSetCPUs          string            `qs:"cpusetcpus"`
+	Labels              map[string]string `qs:"labels"`
+	Remote              string            `qs:"remote"`
+	ContextDir          string            `qs:"-"`
+	Ulimits             []docker.ULimit   `qs:"ulimits"`
+	BuildArgs           []docker.BuildArg `qs:"buildargs"`
+	NetworkMode         string            `qs:"networkmode"`
+	CgroupParent        string            `qs:"cgroupparent"`
+
+	// parameters that are not in go-dockerclient yet
+	ExtraHosts string   `qs:"extrahosts"`
+	CPUSetMems string   `qs:"cpusetmems"`
+	CacheFrom  []string `qs:"cachefrom"`
+	ShmSize    int64    `qs:"shmsize"`
+	Squash     bool     `qs:"squash"`
+	Isolation  string   `qs:"isolation"`
+}
+
+type PushImageOptions struct {
+	Name string `qs:"-"`
+	Tag  string `qs:"tag"`
+}
+
+type ImageTagOptions struct {
+	Name string `qs:"-"`
+	Repo string `qs:"repo"`
+	Tag  string `qs:"tag"`
+}
+
+type RemoveImageOptions struct {
+	Name    string `qs:"-"`
+	NoPrune bool   `qs:"noprune"`
+	Force   bool   `qs:"force"`
+}
+
+type AuthOptions struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type AuthRequest struct {
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	ServerAddress string `json:"serveraddress"`
+}

--- a/pkg/build/proxy/interceptor/docker_test.go
+++ b/pkg/build/proxy/interceptor/docker_test.go
@@ -1,0 +1,26 @@
+package interceptor
+
+import (
+	"testing"
+)
+
+func TestIsPushImageEndpoint(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "with dashes", args: args{path: "/v1.24/images/openshift-built-image-kpoe6a7h3p5md6vjlh3s32d5tm1qe4mb/push"}, want: true},
+		{name: "with slashes", args: args{path: "/v1.24/images/openshift/built/image/kpoe6a7h3p5md6vjlh3s32d5tm1qe4mb/push"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPushImageEndpoint(tt.args.path); got != tt.want {
+				t.Errorf("IsPushImageEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/build/proxy/interceptor/interface.go
+++ b/pkg/build/proxy/interceptor/interface.go
@@ -1,0 +1,55 @@
+package interceptor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type BuildAuthorizer interface {
+	AuthorizeBuildRequest(ctx context.Context, build *BuildImageOptions, auth *AuthOptions) (*BuildImageOptions, error)
+}
+
+type Interface interface {
+	InterceptRequest(*http.Request) error
+	InterceptResponse(*http.Response) error
+}
+
+type Proxy interface {
+	Intercept(Interface, http.ResponseWriter, *http.Request)
+}
+
+var Allow Interface = allow{}
+
+type allow struct{}
+
+func (allow) InterceptRequest(r *http.Request) error   { return nil }
+func (allow) InterceptResponse(r *http.Response) error { return nil }
+
+type ErrorHandler interface {
+	error
+	http.Handler
+}
+
+func NewForbiddenError(err error) ErrorHandler {
+	return forbiddenError{err: err}
+}
+
+type forbiddenError struct {
+	err error
+}
+
+func (e forbiddenError) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return "forbidden"
+}
+
+func (e forbiddenError) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if e.err != nil {
+		http.Error(w, fmt.Sprintf("This call is forbidden: %v", e.err), http.StatusForbidden)
+	} else {
+		http.Error(w, "This call is forbidden", http.StatusForbidden)
+	}
+}

--- a/pkg/build/proxy/interceptor/query.go
+++ b/pkg/build/proxy/interceptor/query.go
@@ -1,0 +1,213 @@
+package interceptor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// StrictDecodeFromQuery parses query values into a struct. It returns an error if unrecognized
+// query parameters are present, if the provided value does not correctly serialize to
+// the matching field type, or if the provided object is not a pointer to a struct.
+// This method is intentionally strict to prevent new security critical fields from being
+// passed unknowningly to a backend.
+func StrictDecodeFromQuery(obj interface{}, values url.Values) error {
+	return decodeQueryString(obj, values)
+}
+
+func decodeQueryString(obj interface{}, values url.Values) error {
+	if obj == nil {
+		return nil
+	}
+	value := reflect.ValueOf(obj)
+	if value.Kind() != reflect.Ptr {
+		return fmt.Errorf("options must be a pointer to a struct %T", obj)
+	}
+	value = value.Elem()
+	if value.Kind() != reflect.Struct {
+		return fmt.Errorf("options must be a pointer to a struct %T", obj)
+	}
+	keys := make(map[string]struct{})
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Type().Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		key := field.Tag.Get("qs")
+		if key == "" {
+			key = strings.ToLower(field.Name)
+		}
+		if key == "-" {
+			continue
+		}
+		keys[key] = struct{}{}
+		if err := setQueryStringValue(values[key], key, value.Field(i)); err != nil {
+			return err
+		}
+	}
+	for key := range values {
+		if _, ok := keys[key]; !ok {
+			return fmt.Errorf("key %q is not recognized", key)
+		}
+	}
+	return nil
+}
+
+func setQueryStringValue(values []string, key string, v reflect.Value) error {
+	if len(values) == 0 {
+		v.Set(reflect.Zero(v.Type()))
+		return nil
+	}
+	last := values[len(values)-1]
+	switch v.Kind() {
+	case reflect.Bool:
+		if last == "1" {
+			v.SetBool(true)
+		}
+	case reflect.Int8:
+		i, err := strconv.ParseInt(last, 10, 8)
+		if err != nil {
+			return err
+		}
+		v.SetInt(i)
+	case reflect.Int16:
+		i, err := strconv.ParseInt(last, 10, 16)
+		if err != nil {
+			return err
+		}
+		v.SetInt(i)
+	case reflect.Int32:
+		i, err := strconv.ParseInt(last, 10, 32)
+		if err != nil {
+			return err
+		}
+		v.SetInt(i)
+	case reflect.Int64, reflect.Int:
+		i, err := strconv.ParseInt(last, 10, 64)
+		if err != nil {
+			return err
+		}
+		v.SetInt(i)
+	case reflect.Float32:
+		f, err := strconv.ParseFloat(last, 32)
+		if err != nil {
+			return err
+		}
+		v.SetFloat(f)
+	case reflect.Float64:
+		f, err := strconv.ParseFloat(last, 32)
+		if err != nil {
+			return err
+		}
+		v.SetFloat(f)
+	case reflect.String:
+		v.SetString(last)
+	// case reflect.Ptr:
+	// 	if !v.IsNil() {
+	// 		if b, err := json.Marshal(v.Interface()); err == nil {
+	// 			items.Add(key, string(b))
+	// 		}
+	// 	}
+	case reflect.Map:
+		if v.Type().Key().Kind() != reflect.String || v.Type().Elem().Kind() != reflect.String {
+			return fmt.Errorf("map of type %s is not supported for key %s", v.Type(), key)
+		}
+		keys := make(map[string]string)
+		if err := json.Unmarshal([]byte(last), &keys); err != nil {
+			return fmt.Errorf("JSON string map for key %s could not be parsed: %v", key, err)
+		}
+		v.Set(reflect.ValueOf(keys))
+	case reflect.Array, reflect.Slice:
+		if v.Type().Elem().Kind() == reflect.String {
+			v.Set(reflect.ValueOf(values))
+		} else {
+			// special case, historical empty value?
+			if last == "{}" {
+				v.Set(reflect.Zero(v.Type()))
+				return nil
+			}
+			if !v.CanAddr() {
+				return fmt.Errorf("cannot decode value for key %s because it cannot take an address", key)
+			}
+			obj := v.Addr().Interface()
+			if err := json.Unmarshal([]byte(last), obj); err != nil {
+				return fmt.Errorf("JSON array for key %s could not be parsed into %T: %v", key, obj, err)
+			}
+			v.Set(reflect.ValueOf(obj).Elem())
+		}
+	default:
+		return fmt.Errorf("unrecognized value type %s for key %s", v.Type(), key)
+	}
+	return nil
+}
+
+func EncodeToQuery(opts interface{}) url.Values {
+	if opts == nil {
+		return nil
+	}
+	value := reflect.ValueOf(opts)
+	if value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return nil
+	}
+	items := url.Values(map[string][]string{})
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Type().Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		key := field.Tag.Get("qs")
+		if key == "" {
+			key = strings.ToLower(field.Name)
+		} else if key == "-" {
+			continue
+		}
+		addQueryStringValue(items, key, value.Field(i))
+	}
+	return items
+}
+
+func addQueryStringValue(items url.Values, key string, v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Bool:
+		if v.Bool() {
+			items.Add(key, "1")
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Int() > 0 {
+			items.Add(key, strconv.FormatInt(v.Int(), 10))
+		}
+	case reflect.Float32, reflect.Float64:
+		if v.Float() > 0 {
+			items.Add(key, strconv.FormatFloat(v.Float(), 'f', -1, 64))
+		}
+	case reflect.String:
+		if v.String() != "" {
+			items.Add(key, v.String())
+		}
+	case reflect.Ptr:
+		if !v.IsNil() {
+			if b, err := json.Marshal(v.Interface()); err == nil {
+				items.Add(key, string(b))
+			}
+		}
+	case reflect.Map:
+		if len(v.MapKeys()) > 0 {
+			if b, err := json.Marshal(v.Interface()); err == nil {
+				items.Add(key, string(b))
+			}
+		}
+	case reflect.Array, reflect.Slice:
+		vLen := v.Len()
+		if vLen > 0 {
+			for i := 0; i < vLen; i++ {
+				addQueryStringValue(items, key, v.Index(i))
+			}
+		}
+	}
+}

--- a/pkg/build/proxy/passthrough/authorizer.go
+++ b/pkg/build/proxy/passthrough/authorizer.go
@@ -1,0 +1,190 @@
+package passthrough
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+
+	"github.com/openshift/origin/pkg/build/proxy/interceptor"
+)
+
+// DefaultAuthorizer allows a local client to authorize a build by writing a file
+// to the local filesystem, and then passing a cgroup parent to the build that points
+// to the correct cgroup container.
+// TODO: support normal systemd cgroups.
+type DefaultAuthorizer struct {
+	Client *docker.Client
+	File   string
+}
+
+var _ interceptor.BuildAuthorizer = &DefaultAuthorizer{}
+
+var (
+	validPodSlice = regexp.MustCompile(
+		`^` +
+			`/kubepods\.slice/kubepods-(burstable|besteffort|guaranteed)\.slice` +
+			`/kubepods-(\w+)-pod(\w+)\.slice` +
+			`/docker-(\w+).scope` +
+			`$`,
+	)
+)
+
+func (a *DefaultAuthorizer) AuthorizeBuildRequest(ctx context.Context, build *interceptor.BuildImageOptions, auth *interceptor.AuthOptions) (*interceptor.BuildImageOptions, error) {
+	safeBuild, err := copySafe(build)
+	if err != nil {
+		return nil, err
+	}
+
+	switch parent := build.CgroupParent; {
+	case strings.HasPrefix(parent, "/kubepods.slice/"):
+		podUID, containerID, parent, err := parseKubeCgroupParent(parent)
+		if err != nil {
+			return nil, err
+		}
+
+		container, err := a.Client.InspectContainer(containerID)
+		if err != nil {
+			return nil, fmt.Errorf("could not verify cgroup parent container exists: %v", err)
+		}
+		if container.Config.Labels["io.kubernetes.pod.uid"] != podUID {
+			return nil, fmt.Errorf("requested container by cgroup is not in the correct pod")
+		}
+		if container.HostConfig.CgroupParent != parent {
+			return nil, fmt.Errorf("the container cgroup parent does not match the expected cgroup parent")
+		}
+		if len(container.HostConfig.NetworkMode) == 0 {
+			return nil, fmt.Errorf("the container does not have a limiting network mode and is not a valid build target")
+		}
+
+		token, err := retrieveContainerCredentials(ctx, a.Client, containerID, a.File)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get contents of the file %s in the requested container: %v", a.File, err)
+		}
+		if token != auth.Password {
+			return nil, fmt.Errorf("container file %s contents do not match provided password", a.File)
+		}
+
+		safeBuild.NetworkMode = container.HostConfig.NetworkMode
+		safeBuild.CgroupParent = parent
+		safeBuild.Names = build.Names
+
+	default:
+		return nil, fmt.Errorf("only requests within a cgroup parented pod are allowed (/kubepods.slice/...)")
+	}
+
+	return safeBuild, nil
+}
+
+// parseKubeCgroupParent expects to receive a valid Kubernetes cgroup hierarchy containing the pod UID and
+// the docker container ID. It returns an error if it cannot find a matching value.
+// Returns pod UID, container ID, and the parent cgroup if no error is found.
+func parseKubeCgroupParent(parent string) (podUID string, containerID string, parentCgroup string, err error) {
+	matches := validPodSlice.FindStringSubmatch(parent)
+	if len(matches) == 0 {
+		return "", "", "", fmt.Errorf("cgroup parent value did not match the expected format for a Kubernetes container (%s)", validPodSlice)
+	}
+	if matches[1] != matches[2] {
+		return "", "", "", fmt.Errorf("cgroup parent value did not match the expected format for a Kubernetes container: pod slice does not have the same QoS value")
+	}
+
+	podUIDString := strings.Replace(matches[3], "_", "-", -1)
+	container := matches[4]
+
+	// the parent cgroup is the name of the next highest level
+	parent = path.Base(path.Dir(parent))
+
+	return podUIDString, container, parent, nil
+}
+
+// copySafe returns only the options that have no security impact. All other fields must be explicitly copied.
+func copySafe(build *interceptor.BuildImageOptions) (*interceptor.BuildImageOptions, error) {
+	return &interceptor.BuildImageOptions{
+		// Names
+		Dockerfile:          build.Dockerfile,
+		NoCache:             build.NoCache,
+		SuppressOutput:      build.SuppressOutput,
+		Pull:                build.Pull,
+		RmTmpContainer:      build.RmTmpContainer,
+		ForceRmTmpContainer: build.ForceRmTmpContainer,
+		//Memory
+		//Memswap
+		//CPUShares
+		//CPUQuota
+		//CPUPeriod
+		//CPUSetCPUs
+		Labels:     build.Labels,
+		Remote:     build.Remote,
+		ContextDir: build.ContextDir,
+		// Ulimits
+		BuildArgs: build.BuildArgs,
+		// NetworkMode
+		// CgroupParent
+
+		// parameters that are not in go-dockerclient yet
+		ExtraHosts: build.ExtraHosts,
+		// CPUSetMems
+		// CacheFrom
+		// ShmSize
+		Squash: build.Squash,
+		// Isolation
+	}, nil
+}
+
+// retrieveContainerCredentials attempts to read a single file from the filesystem of the specified container.
+func retrieveContainerCredentials(ctx context.Context, client *docker.Client, containerID, file string) (string, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, 50*1024))
+	if err := client.DownloadFromContainer(containerID, docker.DownloadFromContainerOptions{
+		Context:           ctx,
+		Path:              file,
+		OutputStream:      buf,
+		InactivityTimeout: 3 * time.Second,
+	}); err != nil {
+		return "", err
+	}
+
+	r := tar.NewReader(buf)
+	h, err := r.Next()
+	if err != nil {
+		return "", fmt.Errorf("unable to read first credentials entry: %v", err)
+	}
+	if h.FileInfo().IsDir() {
+		return "", fmt.Errorf("%s must not be a directory", file)
+	}
+	if h.Name != path.Base(file) {
+		return "", fmt.Errorf("unexpected credentials tar entry: %v", err)
+	}
+	buf = &bytes.Buffer{}
+	if _, err := buf.ReadFrom(r); err != nil {
+		return "", fmt.Errorf("unable to read from credentials archive: %v", err)
+	}
+	return buf.String(), nil
+}
+
+// imageSafeCharacters are characters allowed to be part of a Docker image name.
+const imageSafeCharacters = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// randSeq returns a sequence of random characters drawn from source. It returns
+// an error if cryptographic randomness is not available or source is more than 255
+// characters.
+func randSeq(source string, n int) (string, error) {
+	if len(source) > 255 {
+		return "", fmt.Errorf("source must be less than 256 bytes long")
+	}
+	random := make([]byte, n)
+	if _, err := io.ReadFull(rand.Reader, random); err != nil {
+		return "", err
+	}
+	for i := range random {
+		random[i] = source[random[i]%byte(len(source))]
+	}
+	return string(random), nil
+}

--- a/pkg/build/proxy/passthrough/authorizer_test.go
+++ b/pkg/build/proxy/passthrough/authorizer_test.go
@@ -1,0 +1,64 @@
+package passthrough
+
+import "testing"
+
+func Test_parseKubeCgroupParent(t *testing.T) {
+	type args struct {
+		parent string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		podUID       string
+		containerID  string
+		parentCgroup string
+		wantErr      bool
+	}{
+		{
+			name:         "parse valid Kubernetes slice",
+			args:         args{parent: "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podcea81ac2_7d63_11e7_96cd_080027893417.slice/docker-0d9ba9436cdf7136eb3217baac1e6a41c1e0d15a10b5f51a3f8b3a53ea5e5e03.scope"},
+			podUID:       "cea81ac2-7d63-11e7-96cd-080027893417",
+			containerID:  "0d9ba9436cdf7136eb3217baac1e6a41c1e0d15a10b5f51a3f8b3a53ea5e5e03",
+			parentCgroup: "kubepods-burstable-podcea81ac2_7d63_11e7_96cd_080027893417.slice",
+			wantErr:      false,
+		},
+		{
+			name:    "invalid QoS value",
+			args:    args{parent: "/kubepods.slice/kubepods-.slice/kubepods--podcea81ac2_7d63_11e7_96cd_080027893417.slice/docker-0d9ba9436cdf7136eb3217baac1e6a41c1e0d15a10b5f51a3f8b3a53ea5e5e03.scope"},
+			wantErr: true,
+		},
+		{
+			name:    "missing pod UID",
+			args:    args{parent: "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod.slice/docker-0d9ba9436cdf7136eb3217baac1e6a41c1e0d15a10b5f51a3f8b3a53ea5e5e03.scope"},
+			wantErr: true,
+		},
+		{
+			name:    "missing container ID",
+			args:    args{parent: "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podcea81ac2_7d63_11e7_96cd_080027893417.slice/docker-.scope"},
+			wantErr: true,
+		},
+		{
+			name:    "slice QoS tiers mismatch",
+			args:    args{parent: "/kubepods.slice/kubepods-burstable.slice/kubepods-besteffort-podcea81ac2_7d63_11e7_96cd_080027893417.slice/docker-0d9ba9436cdf7136eb3217baac1e6a41c1e0d15a10b5f51a3f8b3a53ea5e5e03.scope"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podUID, containerID, parentCgroup, err := parseKubeCgroupParent(tt.args.parent)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseKubeCgroupParent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if podUID != tt.podUID {
+				t.Errorf("parseKubeCgroupParent() got = %v, want %v", podUID, tt.podUID)
+			}
+			if containerID != tt.containerID {
+				t.Errorf("parseKubeCgroupParent() got1 = %v, want %v", containerID, tt.containerID)
+			}
+			if parentCgroup != tt.parentCgroup {
+				t.Errorf("parseKubeCgroupParent() got2 = %v, want %v", parentCgroup, tt.parentCgroup)
+			}
+		})
+	}
+}

--- a/pkg/build/proxy/passthrough/passthrough.go
+++ b/pkg/build/proxy/passthrough/passthrough.go
@@ -1,0 +1,42 @@
+package passthrough
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/build/proxy/interceptor"
+)
+
+type Server struct {
+	Proxy interceptor.Proxy
+}
+
+func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var i interceptor.Interface = interceptor.Allow
+
+	switch path := r.URL.Path; {
+	case r.Method == "POST" && interceptor.IsBuildImageEndpoint(path):
+		i = &buildInterceptor{}
+	}
+
+	s.Proxy.Intercept(i, w, r)
+}
+
+type buildInterceptor struct {
+}
+
+func (i *buildInterceptor) InterceptRequest(req *http.Request) error {
+	options := &interceptor.BuildImageOptions{}
+	if err := interceptor.StrictDecodeFromQuery(options, req.URL.Query()); err != nil {
+		return interceptor.NewForbiddenError(fmt.Errorf("build request rejected because of an unrecogized query param: %v", err))
+	}
+	glog.V(4).Infof("Build request found: %#v", options)
+
+	return nil
+}
+
+func (i *buildInterceptor) InterceptResponse(r *http.Response) error {
+	return nil
+}

--- a/pkg/build/proxy/proxy.go
+++ b/pkg/build/proxy/proxy.go
@@ -1,0 +1,79 @@
+package proxy
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+	gorillacontext "github.com/gorilla/context"
+
+	"github.com/openshift/origin/pkg/build/proxy/dockerproxy"
+	"github.com/openshift/origin/pkg/build/proxy/imagebuilder"
+	"github.com/openshift/origin/pkg/build/proxy/passthrough"
+	"github.com/openshift/origin/pkg/version"
+)
+
+type Server struct {
+	ListenAddrs []string
+	Mode        string
+	Client      *docker.Client
+
+	AllowHost string
+}
+
+func (s *Server) Start() error {
+	if len(s.ListenAddrs) == 0 {
+		return fmt.Errorf("must specify one or more addresses to listen on")
+	}
+
+	client := s.Client
+	if client == nil {
+		c, err := docker.NewClientFromEnv()
+		if err != nil {
+			return err
+		}
+		client = c
+	}
+
+	allowHost := s.AllowHost
+	if len(allowHost) == 0 {
+		allowHost = fmt.Sprintf("%d.openshift-build-proxy.local:1000", rand.Int31())
+	}
+
+	authorizer := &passthrough.DefaultAuthorizer{
+		Client: client,
+		File:   "/tmp/build-proxy-openshift-token",
+	}
+
+	p, err := dockerproxy.NewProxy(dockerproxy.Config{
+		Client:      client,
+		ListenAddrs: s.ListenAddrs,
+	})
+	if err != nil {
+		return err
+	}
+
+	var server http.Handler
+	switch s.Mode {
+	case "passthrough":
+		server = passthrough.Server{
+			Proxy: p,
+		}
+	case "imagebuilder":
+		server = imagebuilder.Server{
+			Handler: p,
+			Client:  client,
+		}
+	default:
+		return fmt.Errorf("unrecognized proxy mode %q", s.Mode)
+	}
+	server = NewAuthorizingDockerAPIFilter(server, allowHost, authorizer)
+	server = gorillacontext.ClearHandler(server)
+
+	dockerproxy.ServeWithReady(server, p.Listen(), func() {
+		glog.Infof("Proxy (version: %s) is accepting requests for %s", version.Get().String(), allowHost)
+	})
+	return nil
+}

--- a/pkg/cmd/infra/buildproxy/buildproxy.go
+++ b/pkg/cmd/infra/buildproxy/buildproxy.go
@@ -1,0 +1,39 @@
+package buildproxy
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"github.com/openshift/origin/pkg/build/proxy"
+)
+
+var (
+	buildProxyLong = templates.LongDesc(`
+		Start a Docker build proxy
+
+		This command launches a proxy that handles the Docker build API and enforces authorization 
+		checks from the client.`)
+)
+
+// NewCommandBuildProxy provides a command that runs a Docker build proxy
+func NewCommandBuildProxy(name string) *cobra.Command {
+	server := &proxy.Server{
+		ListenAddrs: []string{"unix:///var/run/openshift-build-proxy"},
+		Mode:        "passthrough",
+	}
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Start a build proxy",
+		Long:  buildProxyLong,
+		Run: func(c *cobra.Command, args []string) {
+			err := server.Start()
+			kcmdutil.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringSliceVar(&server.ListenAddrs, "listen", server.ListenAddrs, "One or more unix:// or tcp:// sockets to listen on for build connections.")
+	cmd.Flags().StringVar(&server.AllowHost, "hostname", server.AllowHost, "The Docker authorization config to accept authentication requests on. Defaults to a random value.")
+	cmd.Flags().StringVar(&server.Mode, "mode", server.Mode, "The backend build implementation to use. Accepts 'imagebuilder' or 'passthrough'.")
+	return cmd
+}

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
 	"github.com/openshift/origin/pkg/cmd/infra/builder"
+	"github.com/openshift/origin/pkg/cmd/infra/buildproxy"
 	"github.com/openshift/origin/pkg/cmd/infra/deployer"
 	irouter "github.com/openshift/origin/pkg/cmd/infra/router"
 	"github.com/openshift/origin/pkg/cmd/recycle"
@@ -136,6 +137,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 		deployer.NewCommandDeployer("deploy"),
 		recycle.NewCommandRecycle("recycle", out),
 		builder.NewCommandS2IBuilder("sti-build"),
+		buildproxy.NewCommandBuildProxy("build-proxy"),
 		builder.NewCommandDockerBuilder("docker-build"),
 		diagnostics.NewCommandPodDiagnostics("diagnostic-pod", out),
 		diagnostics.NewCommandNetworkPodDiagnostics("network-diagnostic-pod", out),


### PR DESCRIPTION
Begin work towards a per node proxy that can authenticate and authorize specific docker build operations, removing the build pod from having privileged access to a node. By emulating the docker api we ensure that we can support existing clients while adding a framework for providing additional backends that may not rely on a docker socket.

This uses a variant of the weave proxy to provide a simple intercepting proxy to docker that can be layered with other logic.  A layer in front of that proxy (or other future additions like buildah or imagebuilder) defines a set of allowed calls and performs authentication and limits the set of actions that can be taken.

Authentication is required for image build operations.  The docker client pushes a set of registry credentials to the build image endpoint so that pulls are possible - we leverage that and require that a special host entry be present that has a username and password.  The host entry is arbitrary and settable per proxy.  The proxy then determines the container to target based on the cgroup parent (although it could be the username).  A file inside that running container must have contents that match the password provided by the client.  This prevents any user except one with write access inside a container from spoofing an action.  Other build parameters are explicitly forced to match the parent container's pod information.

Because image references themselves may collide, a special scheme is chosen.  The external pull spec must match the following form for any operation dealing with an image:

    <SPECIAL_HOST>/<UNIQUE_VALUE>/<pull_spec>

where `SPECIAL_HOST` is the same as the entry described above, `UNIQUE_VALUE` is an end user defined value that cannot be guessed by other users, and `pull_spec` is the normal image pull spec.  The server takes a SHA256 sum of the entire pull spec, then strips the first two segments and stores the value as:

    <pull_spec>:<SHA256_OF_FULL_REF>

For an attacker to steal another user's image, they must find a sha256 collision with another user's value.

The push, tag, and remove image endpoints are currently adapted as above, with some limitations.

TODO:

- [ ] quota / rate-limit per container - prevent filling up disk
- [ ] prevent arbitrary internet clients from being able to retry large swathes of actions
- [ ] better test cases and logging
- [ ] have a master mode that switches to this proxy
- [ ] move the proxy out of the main repo