### PR TITLE
[WIP] add oc msi installer for build-cross.sh 

### DIFF
--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -78,6 +78,7 @@ readonly OC_BINARY_COPY=(
 )
 readonly OS_BINARY_RELEASE_CLIENT_WINDOWS=(
   oc.exe
+  oc.msi
   README.md
   ./LICENSE
 )


### PR DESCRIPTION
This pr add windows msi installer for oc.exe, it used a tool named msitools(https://wiki.gnome.org/msitools) which also rely on wixtoolset(http://wixtoolset.org). 

The command `wixl` read a `.wxs` xml file to decide which attributes the msi installer should have, I just use a minimal configuration now. for now the installer may looks a little simple and crude.

<img width="542" alt="1" src="https://user-images.githubusercontent.com/6284003/29116809-a4b6b460-7d2e-11e7-8206-02d217399b85.png">
<img width="654" alt="2" src="https://user-images.githubusercontent.com/6284003/29116816-aad8f6c8-7d2e-11e7-9ee6-a488f6ce80ee.png">


the oc.exe is install in `C:\Program Files (x86)\OpenShift`, I'm not sure if this is ok, probably we need add this to %PATH% so user can directly input oc in cmd ?  

@stevekuznetsov @fabianofranz @brenton any suggestions ?
also we should add dependency in ci : https://github.com/openshift/origin-ci-tool/pull/134