### PR TITLE
Mark subjectaccessreview/resourceaccessreview as root-scoped

### DIFF
--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -26891,70 +26891,6 @@
      }
     ]
    },
-   "/apis/authorization.openshift.io/v1/namespaces/{namespace}/resourceaccessreviews": {
-    "post": {
-     "description": "create a ResourceAccessReview",
-     "consumes": [
-      "*/*"
-     ],
-     "produces": [
-      "application/json",
-      "application/yaml",
-      "application/vnd.kubernetes.protobuf"
-     ],
-     "schemes": [
-      "https"
-     ],
-     "tags": [
-      "authorizationOpenshiftIo_v1"
-     ],
-     "operationId": "createAuthorizationOpenshiftIoV1NamespacedResourceAccessReview",
-     "parameters": [
-      {
-       "name": "body",
-       "in": "body",
-       "required": true,
-       "schema": {
-        "$ref": "#/definitions/com.github.openshift.origin.pkg.authorization.apis.authorization.v1.ResourceAccessReview"
-       }
-      }
-     ],
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "$ref": "#/definitions/com.github.openshift.origin.pkg.authorization.apis.authorization.v1.ResourceAccessReview"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      }
-     },
-     "x-kubernetes-action": "post",
-     "x-kubernetes-group-version-kind": {
-      "group": "authorization.openshift.io",
-      "version": "latest",
-      "kind": "ResourceAccessReview"
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "object name and auth scope, such as for teams and projects",
-      "name": "namespace",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "If 'true', then the output is pretty printed.",
-      "name": "pretty",
-      "in": "query"
-     }
-    ]
-   },
    "/apis/authorization.openshift.io/v1/namespaces/{namespace}/rolebindingrestrictions": {
     "get": {
      "description": "list or watch objects of kind RoleBindingRestriction",
@@ -28209,70 +28145,6 @@
      }
     ]
    },
-   "/apis/authorization.openshift.io/v1/namespaces/{namespace}/subjectaccessreviews": {
-    "post": {
-     "description": "create a SubjectAccessReview",
-     "consumes": [
-      "*/*"
-     ],
-     "produces": [
-      "application/json",
-      "application/yaml",
-      "application/vnd.kubernetes.protobuf"
-     ],
-     "schemes": [
-      "https"
-     ],
-     "tags": [
-      "authorizationOpenshiftIo_v1"
-     ],
-     "operationId": "createAuthorizationOpenshiftIoV1NamespacedSubjectAccessReview",
-     "parameters": [
-      {
-       "name": "body",
-       "in": "body",
-       "required": true,
-       "schema": {
-        "$ref": "#/definitions/com.github.openshift.origin.pkg.authorization.apis.authorization.v1.SubjectAccessReview"
-       }
-      }
-     ],
-     "responses": {
-      "200": {
-       "description": "OK",
-       "schema": {
-        "$ref": "#/definitions/com.github.openshift.origin.pkg.authorization.apis.authorization.v1.SubjectAccessReview"
-       }
-      },
-      "401": {
-       "description": "Unauthorized"
-      }
-     },
-     "x-kubernetes-action": "post",
-     "x-kubernetes-group-version-kind": {
-      "group": "authorization.openshift.io",
-      "version": "latest",
-      "kind": "SubjectAccessReview"
-     }
-    },
-    "parameters": [
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "object name and auth scope, such as for teams and projects",
-      "name": "namespace",
-      "in": "path",
-      "required": true
-     },
-     {
-      "uniqueItems": true,
-      "type": "string",
-      "description": "If 'true', then the output is pretty printed.",
-      "name": "pretty",
-      "in": "query"
-     }
-    ]
-   },
    "/apis/authorization.openshift.io/v1/namespaces/{namespace}/subjectrulesreviews": {
     "post": {
      "description": "create a SubjectRulesReview",
@@ -28628,7 +28500,7 @@
      "tags": [
       "authorizationOpenshiftIo_v1"
      ],
-     "operationId": "createAuthorizationOpenshiftIoV1ResourceAccessReviewForAllNamespaces",
+     "operationId": "createAuthorizationOpenshiftIoV1ResourceAccessReview",
      "parameters": [
       {
        "name": "body",
@@ -29151,7 +29023,7 @@
      "tags": [
       "authorizationOpenshiftIo_v1"
      ],
-     "operationId": "createAuthorizationOpenshiftIoV1SubjectAccessReviewForAllNamespaces",
+     "operationId": "createAuthorizationOpenshiftIoV1SubjectAccessReview",
      "parameters": [
       {
        "name": "body",

--- a/pkg/authorization/apis/authorization/install/apigroup.go
+++ b/pkg/authorization/apis/authorization/install/apigroup.go
@@ -23,7 +23,7 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 			VersionPreferenceOrder:     []string{authorizationapiv1.SchemeGroupVersion.Version},
 			ImportPrefix:               importPrefix,
 			AddInternalObjectsToScheme: authorizationapi.AddToScheme,
-			RootScopedKinds:            sets.NewString("ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding"),
+			RootScopedKinds:            sets.NewString("ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding", "SubjectAccessReview", "ResourceAccessReview"),
 		},
 		announced.VersionToSchemeFunc{
 			authorizationapiv1.SchemeGroupVersion.Version: authorizationapiv1.AddToScheme,


### PR DESCRIPTION
When the groupified APIs were formed, these two resources were not marked as root scoped.