### PR TITLE
start the rachet on our API types

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -1,9 +1,171 @@
 [
-   {
-      "baseImportPath" : "pkg/image",
-      "allowedImports" : [
-         "pkg/client",
-         "vendor"
-      ]
-   }
+  {
+    "baseImportPath": "pkg/authorization/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "pkg/user/apis/user/validation",
+      "vendor/k8s.io/apiserver/pkg/authentication/serviceaccount",
+      "vendor/k8s.io/apiserver/pkg/authentication/user",
+      "pkg/authorization/rulevalidation",
+      "vendor/github.com/golang/glog",
+      "test/util/api"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/build/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "pkg/util/namer",
+      "vendor/github.com/golang/glog",
+      "vendor/github.com/openshift/source-to-image/pkg/scm/git",
+      "pkg/build/util",
+      "pkg/image/apis/image",
+      "test/util/api",
+      "pkg/util/labelselector"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/deploy/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "pkg/image/apis/image",
+      "test/util/api",
+      "vendor/github.com/golang/glog"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/image/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "vendor/github.com/golang/glog",
+      "vendor/github.com/fsouza/go-dockerclient",
+      "vendor/github.com/golang/glog",
+      "vendor/github.com/docker/distribution/digest",
+      "vendor/github.com/docker/distribution/manifest/schema1",
+      "vendor/github.com/docker/distribution/manifest/schema2",
+      "vendor/github.com/docker/distribution/reference",
+      "vendor/github.com/blang/semver",
+      "pkg/image/reference",
+      "test/util/api",
+      "pkg/cmd/server/api",
+      "pkg/util/strings"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/oauth/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "test/util/api",
+      "vendor/k8s.io/apiserver/pkg/authentication/serviceaccount",
+      "pkg/user/apis/user/validation",
+      "pkg/authorization/authorizer/scope",
+      "vendor/github.com/golang/glog"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/project/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "test/util/api",
+      "vendor/k8s.io/kubernetes/pkg/registry/core/namespace",
+      "vendor/github.com/golang/glog",
+      "pkg/util/labelselector"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/quota/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "vendor/github.com/golang/glog"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/route/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "vendor/github.com/golang/glog",
+      "test/util/api",
+      "pkg/cmd/util"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/sdn/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "vendor/github.com/golang/glog",
+      "pkg/util/netutils",
+      "test/util/api"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/template/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "test/util/api",
+      "vendor/github.com/golang/glog",
+      "pkg/user/apis/user/validation"
+    ]
+  },
+  {
+    "baseImportPath": "pkg/user/apis",
+    "allowedImports": [
+      "vendor/github.com/google/gofuzz",
+      "vendor/k8s.io/kubernetes/pkg/api",
+      "vendor/k8s.io/kubernetes/pkg/apis",
+      "vendor/k8s.io/apimachinery",
+      "vendor/github.com/gogo/protobuf",
+      "pkg/api",
+      "vendor/github.com/golang/glog",
+      "test/util/api"
+    ]
+  }
 ]

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -6,4 +6,4 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::util::ensure::built_binary_exists 'import-verifier'
 
-import-verifier "${OS_ROOT}/hack/import-restrictions.json" || true
+import-verifier "${OS_ROOT}/hack/import-restrictions.json"


### PR DESCRIPTION
As we start getting ready to create an external client, we need to make sure our types don't pull in anything "weird" that will make vendoring hard.

This is snapshot of what is today and it will prevent dependencies not whitelisted here.  I will start going through and snipping/refactoring links that seem to be odd and I'll try to find good reviewers as I go through.  In general, your types are expected to import other types and that's about it.  I don't that our clients will need the validation packages, so I may either update the verifier and revisit this list.

@openshift/team-project-committers fyi. I think this covers most people reviewing APIs