### PR TITLE
update node_config test to be arch agnostic

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config_test.go
+++ b/pkg/cmd/server/kubernetes/node/node_config_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"io"
 	"reflect"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func TestKubeletDefaults(t *testing.T) {
 				DockerEndpoint:            "unix:///var/run/docker.sock",
 				ImagePullProgressDeadline: metav1.Duration{Duration: 1 * time.Minute},
 				RktAPIEndpoint:            rkt.DefaultRktAPIServiceEndpoint,
-				PodSandboxImage:           "gcr.io/google_containers/pause-amd64:3.0", // overridden
+				PodSandboxImage:           "gcr.io/google_containers/pause-" + goruntime.GOARCH + ":3.0", // overridden
 			},
 		},
 


### PR DESCRIPTION
This PR updates the node_config test to use arch specific images rather than hardcode the amd64 image.