### PR TITLE
Update etcd stores to use DefaultQualifiedResource

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicy/etcd/etcd.go
@@ -18,10 +18,10 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterPolicy.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &authorizationapi.ClusterPolicy{} },
-		NewListFunc:       func() runtime.Object { return &authorizationapi.ClusterPolicyList{} },
-		QualifiedResource: authorizationapi.Resource("clusterpolicies"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &authorizationapi.ClusterPolicy{} },
+		NewListFunc:              func() runtime.Object { return &authorizationapi.ClusterPolicyList{} },
+		DefaultQualifiedResource: authorizationapi.Resource("clusterpolicies"),
 
 		CreateStrategy: clusterpolicy.Strategy,
 		UpdateStrategy: clusterpolicy.Strategy,

--- a/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/clusterpolicybinding/etcd/etcd.go
@@ -18,10 +18,10 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterPolicyBinding.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &authorizationapi.ClusterPolicyBinding{} },
-		NewListFunc:       func() runtime.Object { return &authorizationapi.ClusterPolicyBindingList{} },
-		QualifiedResource: authorizationapi.Resource("clusterpolicybindings"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &authorizationapi.ClusterPolicyBinding{} },
+		NewListFunc:              func() runtime.Object { return &authorizationapi.ClusterPolicyBindingList{} },
+		DefaultQualifiedResource: authorizationapi.Resource("clusterpolicybindings"),
 
 		CreateStrategy: clusterpolicybinding.Strategy,
 		UpdateStrategy: clusterpolicybinding.Strategy,

--- a/pkg/authorization/registry/policy/etcd/etcd.go
+++ b/pkg/authorization/registry/policy/etcd/etcd.go
@@ -18,10 +18,10 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Policy objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &authorizationapi.Policy{} },
-		NewListFunc:       func() runtime.Object { return &authorizationapi.PolicyList{} },
-		QualifiedResource: authorizationapi.Resource("policies"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &authorizationapi.Policy{} },
+		NewListFunc:              func() runtime.Object { return &authorizationapi.PolicyList{} },
+		DefaultQualifiedResource: authorizationapi.Resource("policies"),
 
 		CreateStrategy: policy.Strategy,
 		UpdateStrategy: policy.Strategy,

--- a/pkg/authorization/registry/policybinding/etcd/etcd.go
+++ b/pkg/authorization/registry/policybinding/etcd/etcd.go
@@ -22,10 +22,10 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against PolicyBinding objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &authorizationapi.PolicyBinding{} },
-		NewListFunc:       func() runtime.Object { return &authorizationapi.PolicyBindingList{} },
-		QualifiedResource: authorizationapi.Resource("policybindings"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &authorizationapi.PolicyBinding{} },
+		NewListFunc:              func() runtime.Object { return &authorizationapi.PolicyBindingList{} },
+		DefaultQualifiedResource: authorizationapi.Resource("policybindings"),
 
 		CreateStrategy: policybinding.Strategy,
 		UpdateStrategy: policybinding.Strategy,

--- a/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
+++ b/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
@@ -21,11 +21,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against nodes.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &authorizationapi.RoleBindingRestriction{} },
-		NewListFunc:       func() runtime.Object { return &authorizationapi.RoleBindingRestrictionList{} },
-		QualifiedResource: authorizationapi.Resource("rolebindingrestrictions"),
-		PredicateFunc:     rolebindingrestriction.Matcher,
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &authorizationapi.RoleBindingRestriction{} },
+		NewListFunc:              func() runtime.Object { return &authorizationapi.RoleBindingRestrictionList{} },
+		DefaultQualifiedResource: authorizationapi.Resource("rolebindingrestrictions"),
+		PredicateFunc:            rolebindingrestriction.Matcher,
 
 		CreateStrategy: rolebindingrestriction.Strategy,
 		UpdateStrategy: rolebindingrestriction.Strategy,

--- a/pkg/build/registry/build/etcd/etcd.go
+++ b/pkg/build/registry/build/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against Build objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, *DetailsREST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &buildapi.Build{} },
-		NewListFunc:       func() runtime.Object { return &buildapi.BuildList{} },
-		PredicateFunc:     build.Matcher,
-		QualifiedResource: buildapi.Resource("builds"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &buildapi.Build{} },
+		NewListFunc:              func() runtime.Object { return &buildapi.BuildList{} },
+		PredicateFunc:            build.Matcher,
+		DefaultQualifiedResource: buildapi.Resource("builds"),
 
 		CreateStrategy: build.Strategy,
 		UpdateStrategy: build.Strategy,

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -21,11 +21,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against BuildConfig.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &buildapi.BuildConfig{} },
-		NewListFunc:       func() runtime.Object { return &buildapi.BuildConfigList{} },
-		QualifiedResource: buildapi.Resource("buildconfigs"),
-		PredicateFunc:     buildconfig.Matcher,
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &buildapi.BuildConfig{} },
+		NewListFunc:              func() runtime.Object { return &buildapi.BuildConfigList{} },
+		DefaultQualifiedResource: buildapi.Resource("buildconfigs"),
+		PredicateFunc:            buildconfig.Matcher,
 
 		CreateStrategy: buildconfig.GroupStrategy,
 		UpdateStrategy: buildconfig.GroupStrategy,

--- a/pkg/deploy/registry/deployconfig/etcd/etcd.go
+++ b/pkg/deploy/registry/deployconfig/etcd/etcd.go
@@ -31,11 +31,11 @@ var _ rest.StandardStorage = &REST{}
 // and a scaleREST containing the REST storage for the Scale subresources of DeploymentConfigs.
 func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, *ScaleREST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &deployapi.DeploymentConfig{} },
-		NewListFunc:       func() runtime.Object { return &deployapi.DeploymentConfigList{} },
-		PredicateFunc:     deployconfig.Matcher,
-		QualifiedResource: deployapi.Resource("deploymentconfigs"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &deployapi.DeploymentConfig{} },
+		NewListFunc:              func() runtime.Object { return &deployapi.DeploymentConfigList{} },
+		PredicateFunc:            deployconfig.Matcher,
+		DefaultQualifiedResource: deployapi.Resource("deploymentconfigs"),
 
 		CreateStrategy: deployconfig.Strategy,
 		UpdateStrategy: deployconfig.Strategy,

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -174,9 +174,9 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 		}
 
 		status := statusErr.ErrStatus
-		if status.Code != http.StatusNotFound ||
-			(strings.ToLower(status.Details.Kind) != "imagestream" /*pre-1.2*/ && strings.ToLower(status.Details.Kind) != "imagestreams") ||
-			status.Details.Name != m.repo.name {
+		kind := strings.ToLower(status.Details.Kind)
+		isValidKind := kind == "imagestream" /*pre-1.2*/ || kind == "imagestreams" /*1.2 to 1.6*/ || kind == "imagestreammappings" /*1.7+*/
+		if !isValidKind || status.Code != http.StatusNotFound || status.Details.Name != m.repo.name {
 			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping: %s", err)
 			return "", err
 		}

--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a new REST.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &imageapi.Image{} },
-		NewListFunc:       func() runtime.Object { return &imageapi.ImageList{} },
-		PredicateFunc:     image.Matcher,
-		QualifiedResource: imageapi.Resource("images"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &imageapi.Image{} },
+		NewListFunc:              func() runtime.Object { return &imageapi.ImageList{} },
+		PredicateFunc:            image.Matcher,
+		DefaultQualifiedResource: imageapi.Resource("images"),
 
 		CreateStrategy: image.Strategy,
 		UpdateStrategy: image.Strategy,

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -27,11 +27,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a new REST.
 func NewREST(optsGetter restoptions.Getter, defaultRegistry imageapi.DefaultRegistry, subjectAccessReviewRegistry subjectaccessreview.Registry, limitVerifier imageadmission.LimitVerifier) (*REST, *StatusREST, *InternalREST, error) {
 	store := registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &imageapi.ImageStream{} },
-		NewListFunc:       func() runtime.Object { return &imageapi.ImageStreamList{} },
-		PredicateFunc:     imagestream.Matcher,
-		QualifiedResource: imageapi.Resource("imagestreams"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &imageapi.ImageStream{} },
+		NewListFunc:              func() runtime.Object { return &imageapi.ImageStreamList{} },
+		PredicateFunc:            imagestream.Matcher,
+		DefaultQualifiedResource: imageapi.Resource("imagestreams"),
 	}
 
 	rest := &REST{

--- a/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
@@ -28,11 +28,11 @@ var _ rest.StandardStorage = &REST{}
 func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter, backends ...storage.Interface) (*REST, error) {
 	strategy := oauthaccesstoken.NewStrategy(clientGetter)
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &oauthapi.OAuthAccessToken{} },
-		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthAccessTokenList{} },
-		PredicateFunc:     oauthaccesstoken.Matcher,
-		QualifiedResource: oauthapi.Resource("oauthaccesstokens"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthAccessToken{} },
+		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthAccessTokenList{} },
+		PredicateFunc:            oauthaccesstoken.Matcher,
+		DefaultQualifiedResource: oauthapi.Resource("oauthaccesstokens"),
 
 		TTLFunc: func(obj runtime.Object, existing uint64, update bool) (uint64, error) {
 			token := obj.(*oauthapi.OAuthAccessToken)

--- a/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
@@ -24,11 +24,11 @@ var _ rest.StandardStorage = &REST{}
 func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*REST, error) {
 	strategy := oauthauthorizetoken.NewStrategy(clientGetter)
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &oauthapi.OAuthAuthorizeToken{} },
-		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthAuthorizeTokenList{} },
-		PredicateFunc:     oauthauthorizetoken.Matcher,
-		QualifiedResource: oauthapi.Resource("oauthauthorizetokens"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthAuthorizeToken{} },
+		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthAuthorizeTokenList{} },
+		PredicateFunc:            oauthauthorizetoken.Matcher,
+		DefaultQualifiedResource: oauthapi.Resource("oauthauthorizetokens"),
 
 		TTLFunc: func(obj runtime.Object, existing uint64, update bool) (uint64, error) {
 			token := obj.(*oauthapi.OAuthAuthorizeToken)

--- a/pkg/oauth/registry/oauthclient/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclient/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against oauth clients
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &oauthapi.OAuthClient{} },
-		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthClientList{} },
-		PredicateFunc:     oauthclient.Matcher,
-		QualifiedResource: oauthapi.Resource("oauthclients"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthClient{} },
+		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthClientList{} },
+		PredicateFunc:            oauthclient.Matcher,
+		DefaultQualifiedResource: oauthapi.Resource("oauthclients"),
 
 		CreateStrategy: oauthclient.Strategy,
 		UpdateStrategy: oauthclient.Strategy,

--- a/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
@@ -25,11 +25,11 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 	strategy := oauthclientauthorization.NewStrategy(clientGetter)
 
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &oauthapi.OAuthClientAuthorization{} },
-		NewListFunc:       func() runtime.Object { return &oauthapi.OAuthClientAuthorizationList{} },
-		PredicateFunc:     oauthclientauthorization.Matcher,
-		QualifiedResource: oauthapi.Resource("oauthclientauthorizations"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthClientAuthorization{} },
+		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthClientAuthorizationList{} },
+		PredicateFunc:            oauthclientauthorization.Matcher,
+		DefaultQualifiedResource: oauthapi.Resource("oauthclientauthorizations"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
@@ -23,11 +23,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against ClusterResourceQuota objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &quotaapi.ClusterResourceQuota{} },
-		NewListFunc:       func() runtime.Object { return &quotaapi.ClusterResourceQuotaList{} },
-		PredicateFunc:     clusterresourcequota.Matcher,
-		QualifiedResource: quotaapi.Resource("clusterresourcequotas"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &quotaapi.ClusterResourceQuota{} },
+		NewListFunc:              func() runtime.Object { return &quotaapi.ClusterResourceQuotaList{} },
+		PredicateFunc:            clusterresourcequota.Matcher,
+		DefaultQualifiedResource: quotaapi.Resource("clusterresourcequotas"),
 
 		CreateStrategy: clusterresourcequota.Strategy,
 		UpdateStrategy: clusterresourcequota.Strategy,

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -27,11 +27,11 @@ func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarC
 	strategy := routeregistry.NewStrategy(allocator, sarClient)
 
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &routeapi.Route{} },
-		NewListFunc:       func() runtime.Object { return &routeapi.RouteList{} },
-		PredicateFunc:     routeregistry.Matcher,
-		QualifiedResource: routeapi.Resource("routes"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &routeapi.Route{} },
+		NewListFunc:              func() runtime.Object { return &routeapi.RouteList{} },
+		PredicateFunc:            routeregistry.Matcher,
+		DefaultQualifiedResource: routeapi.Resource("routes"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/sdn/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/sdn/registry/clusternetwork/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against subnets
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &sdnapi.ClusterNetwork{} },
-		NewListFunc:       func() runtime.Object { return &sdnapi.ClusterNetworkList{} },
-		PredicateFunc:     clusternetwork.Matcher,
-		QualifiedResource: sdnapi.Resource("clusternetworks"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &sdnapi.ClusterNetwork{} },
+		NewListFunc:              func() runtime.Object { return &sdnapi.ClusterNetworkList{} },
+		PredicateFunc:            clusternetwork.Matcher,
+		DefaultQualifiedResource: sdnapi.Resource("clusternetworks"),
 
 		CreateStrategy: clusternetwork.Strategy,
 		UpdateStrategy: clusternetwork.Strategy,

--- a/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
+++ b/pkg/sdn/registry/egressnetworkpolicy/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against egress network policy
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &sdnapi.EgressNetworkPolicy{} },
-		NewListFunc:       func() runtime.Object { return &sdnapi.EgressNetworkPolicyList{} },
-		PredicateFunc:     egressnetworkpolicy.Matcher,
-		QualifiedResource: sdnapi.Resource("egressnetworkpolicies"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &sdnapi.EgressNetworkPolicy{} },
+		NewListFunc:              func() runtime.Object { return &sdnapi.EgressNetworkPolicyList{} },
+		PredicateFunc:            egressnetworkpolicy.Matcher,
+		DefaultQualifiedResource: sdnapi.Resource("egressnetworkpolicies"),
 
 		CreateStrategy: egressnetworkpolicy.Strategy,
 		UpdateStrategy: egressnetworkpolicy.Strategy,

--- a/pkg/sdn/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/sdn/registry/hostsubnet/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against subnets
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &sdnapi.HostSubnet{} },
-		NewListFunc:       func() runtime.Object { return &sdnapi.HostSubnetList{} },
-		PredicateFunc:     hostsubnet.Matcher,
-		QualifiedResource: sdnapi.Resource("hostsubnets"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &sdnapi.HostSubnet{} },
+		NewListFunc:              func() runtime.Object { return &sdnapi.HostSubnetList{} },
+		PredicateFunc:            hostsubnet.Matcher,
+		DefaultQualifiedResource: sdnapi.Resource("hostsubnets"),
 
 		CreateStrategy: hostsubnet.Strategy,
 		UpdateStrategy: hostsubnet.Strategy,

--- a/pkg/sdn/registry/netnamespace/etcd/etcd.go
+++ b/pkg/sdn/registry/netnamespace/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against netnamespaces
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &sdnapi.NetNamespace{} },
-		NewListFunc:       func() runtime.Object { return &sdnapi.NetNamespaceList{} },
-		PredicateFunc:     netnamespace.Matcher,
-		QualifiedResource: sdnapi.Resource("netnamespaces"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &sdnapi.NetNamespace{} },
+		NewListFunc:              func() runtime.Object { return &sdnapi.NetNamespaceList{} },
+		PredicateFunc:            netnamespace.Matcher,
+		DefaultQualifiedResource: sdnapi.Resource("netnamespaces"),
 
 		CreateStrategy: netnamespace.Strategy,
 		UpdateStrategy: netnamespace.Strategy,

--- a/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
+++ b/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
@@ -28,9 +28,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*securityapi.SecurityContextConstraints).Name, nil
 		},
-		PredicateFunc:     securitycontextconstraints.Matcher,
-		QualifiedResource: securityapi.Resource("securitycontextconstraints"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("securitycontextconstraints"),
+		PredicateFunc:            securitycontextconstraints.Matcher,
+		DefaultQualifiedResource: securityapi.Resource("securitycontextconstraints"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("securitycontextconstraints"),
 
 		CreateStrategy:      securitycontextconstraints.Strategy,
 		UpdateStrategy:      securitycontextconstraints.Strategy,

--- a/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
+++ b/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against brokertemplateinstances.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &templateapi.BrokerTemplateInstance{} },
-		NewListFunc:       func() runtime.Object { return &templateapi.BrokerTemplateInstanceList{} },
-		PredicateFunc:     brokertemplateinstance.Matcher,
-		QualifiedResource: templateapi.Resource("brokertemplateinstances"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &templateapi.BrokerTemplateInstance{} },
+		NewListFunc:              func() runtime.Object { return &templateapi.BrokerTemplateInstanceList{} },
+		PredicateFunc:            brokertemplateinstance.Matcher,
+		DefaultQualifiedResource: templateapi.Resource("brokertemplateinstances"),
 
 		CreateStrategy: brokertemplateinstance.Strategy,
 		UpdateStrategy: brokertemplateinstance.Strategy,

--- a/pkg/template/registry/template/etcd/etcd.go
+++ b/pkg/template/registry/template/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against templates.
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &templateapi.Template{} },
-		NewListFunc:       func() runtime.Object { return &templateapi.TemplateList{} },
-		PredicateFunc:     template.Matcher,
-		QualifiedResource: templateapi.Resource("templates"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &templateapi.Template{} },
+		NewListFunc:              func() runtime.Object { return &templateapi.TemplateList{} },
+		PredicateFunc:            template.Matcher,
+		DefaultQualifiedResource: templateapi.Resource("templates"),
 
 		CreateStrategy: template.Strategy,
 		UpdateStrategy: template.Strategy,

--- a/pkg/template/registry/templateinstance/etcd/etcd.go
+++ b/pkg/template/registry/templateinstance/etcd/etcd.go
@@ -27,11 +27,11 @@ func NewREST(optsGetter restoptions.Getter, kc kclientset.Interface) (*REST, *St
 	strategy := templateinstance.NewStrategy(kc)
 
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &templateapi.TemplateInstance{} },
-		NewListFunc:       func() runtime.Object { return &templateapi.TemplateInstanceList{} },
-		PredicateFunc:     templateinstance.Matcher,
-		QualifiedResource: templateapi.Resource("templateinstances"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &templateapi.TemplateInstance{} },
+		NewListFunc:              func() runtime.Object { return &templateapi.TemplateInstanceList{} },
+		PredicateFunc:            templateinstance.Matcher,
+		DefaultQualifiedResource: templateapi.Resource("templateinstances"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/user/registry/group/etcd/etcd.go
+++ b/pkg/user/registry/group/etcd/etcd.go
@@ -19,11 +19,11 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against groups
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &userapi.Group{} },
-		NewListFunc:       func() runtime.Object { return &userapi.GroupList{} },
-		PredicateFunc:     group.Matcher,
-		QualifiedResource: userapi.Resource("groups"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &userapi.Group{} },
+		NewListFunc:              func() runtime.Object { return &userapi.GroupList{} },
+		PredicateFunc:            group.Matcher,
+		DefaultQualifiedResource: userapi.Resource("groups"),
 
 		CreateStrategy: group.Strategy,
 		UpdateStrategy: group.Strategy,

--- a/pkg/user/registry/identity/etcd/etcd.go
+++ b/pkg/user/registry/identity/etcd/etcd.go
@@ -22,11 +22,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against identites
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &userapi.Identity{} },
-		NewListFunc:       func() runtime.Object { return &userapi.IdentityList{} },
-		PredicateFunc:     identity.Matcher,
-		QualifiedResource: userapi.Resource("identities"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &userapi.Identity{} },
+		NewListFunc:              func() runtime.Object { return &userapi.IdentityList{} },
+		PredicateFunc:            identity.Matcher,
+		DefaultQualifiedResource: userapi.Resource("identities"),
 
 		CreateStrategy: identity.Strategy,
 		UpdateStrategy: identity.Strategy,

--- a/pkg/user/registry/user/etcd/etcd.go
+++ b/pkg/user/registry/user/etcd/etcd.go
@@ -32,11 +32,11 @@ var _ rest.StandardStorage = &REST{}
 // NewREST returns a RESTStorage object that will work against users
 func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
-		Copier:            kapi.Scheme,
-		NewFunc:           func() runtime.Object { return &userapi.User{} },
-		NewListFunc:       func() runtime.Object { return &userapi.UserList{} },
-		PredicateFunc:     user.Matcher,
-		QualifiedResource: userapi.Resource("users"),
+		Copier:                   kapi.Scheme,
+		NewFunc:                  func() runtime.Object { return &userapi.User{} },
+		NewListFunc:              func() runtime.Object { return &userapi.UserList{} },
+		PredicateFunc:            user.Matcher,
+		DefaultQualifiedResource: userapi.Resource("users"),
 
 		CreateStrategy: user.Strategy,
 		UpdateStrategy: user.Strategy,

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -116,9 +116,9 @@ os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/admin/groups"
 os::cmd::expect_success_and_text 'oadm groups new shortoutputgroup -o name' 'groups/shortoutputgroup'
-os::cmd::expect_failure_and_text 'oadm groups new shortoutputgroup' 'groups.user.openshift.io "shortoutputgroup" already exists'
+os::cmd::expect_failure_and_text 'oadm groups new shortoutputgroup' 'groups "shortoutputgroup" already exists'
 os::cmd::expect_failure_and_text 'oadm groups new errorgroup -o blah' 'error: output format "blah" not recognized'
-os::cmd::expect_failure_and_text 'oc get groups/errorgroup' 'groups.user.openshift.io "errorgroup" not found'
+os::cmd::expect_failure_and_text 'oc get groups/errorgroup' 'groups "errorgroup" not found'
 os::cmd::expect_success_and_text 'oadm groups new group1 foo bar' 'group1.*foo, bar'
 os::cmd::expect_success_and_text 'oc get groups/group1 --no-headers' 'foo, bar'
 os::cmd::expect_success 'oadm groups add-users group1 baz'

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -153,7 +153,7 @@ os::test::junit::declare_suite_start "cmd/deployments/setdeploymenthook"
 arg="-f test/integration/testdata/test-deployment-config.yaml"
 os::cmd::expect_failure_and_text "oc set deployment-hook" "error: one or more deployment configs"
 os::cmd::expect_failure_and_text "oc set deployment-hook ${arg}" "error: you must specify one of --pre, --mid, or --post"
-os::cmd::expect_failure_and_text "oc set deployment-hook ${arg} -o yaml --pre -- mycmd" 'deploymentconfigs.apps.openshift.io "test-deployment-config" not found'
+os::cmd::expect_failure_and_text "oc set deployment-hook ${arg} -o yaml --pre -- mycmd" 'deploymentconfigs "test-deployment-config" not found'
 os::cmd::expect_success_and_text "oc set deployment-hook ${arg} --local -o yaml --post -- mycmd" 'mycmd'
 os::cmd::expect_success_and_not_text "oc set deployment-hook ${arg} --local -o yaml --post -- mycmd | oc set deployment-hook -f - --local -o yaml --post --remove" 'mycmd'
 os::cmd::expect_success "oc create ${arg}"

--- a/vendor/k8s.io/kubernetes/federation/registry/cluster/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/federation/registry/cluster/etcd/etcd.go
@@ -48,12 +48,12 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 // NewREST returns a RESTStorage object that will work against clusters.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &federation.Cluster{} },
-		NewListFunc:       func() runtime.Object { return &federation.ClusterList{} },
-		PredicateFunc:     cluster.MatchCluster,
-		QualifiedResource: federation.Resource("clusters"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusters"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &federation.Cluster{} },
+		NewListFunc:              func() runtime.Object { return &federation.ClusterList{} },
+		PredicateFunc:            cluster.MatchCluster,
+		DefaultQualifiedResource: federation.Resource("clusters"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusters"),
 
 		CreateStrategy:      cluster.Strategy,
 		UpdateStrategy:      cluster.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage.go
@@ -40,9 +40,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*admissionregistration.ExternalAdmissionHookConfiguration).Name, nil
 		},
-		PredicateFunc:     externaladmissionhookconfiguration.MatchExternalAdmissionHookConfiguration,
-		QualifiedResource: admissionregistration.Resource("externaladmissionhookconfigurations"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("externaladmissionhookconfigurations"),
+		PredicateFunc:            externaladmissionhookconfiguration.MatchExternalAdmissionHookConfiguration,
+		DefaultQualifiedResource: admissionregistration.Resource("externaladmissionhookconfigurations"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("externaladmissionhookconfigurations"),
 
 		CreateStrategy: externaladmissionhookconfiguration.Strategy,
 		UpdateStrategy: externaladmissionhookconfiguration.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/admissionregistration/initializerconfiguration/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/admissionregistration/initializerconfiguration/storage/storage.go
@@ -40,9 +40,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*admissionregistration.InitializerConfiguration).Name, nil
 		},
-		PredicateFunc:     initializerconfiguration.MatchInitializerConfiguration,
-		QualifiedResource: admissionregistration.Resource("initializerconfigurations"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("initializerconfigurations"),
+		PredicateFunc:            initializerconfiguration.MatchInitializerConfiguration,
+		DefaultQualifiedResource: admissionregistration.Resource("initializerconfigurations"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("initializerconfigurations"),
 
 		CreateStrategy: initializerconfiguration.Strategy,
 		UpdateStrategy: initializerconfiguration.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/apps/controllerrevision/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/apps/controllerrevision/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work with ControllerRevision objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &apps.ControllerRevision{} },
-		NewListFunc:       func() runtime.Object { return &apps.ControllerRevisionList{} },
-		PredicateFunc:     controllerrevision.MatchControllerRevision,
-		QualifiedResource: apps.Resource("controllerrevisions"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("controllerrevisions"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &apps.ControllerRevision{} },
+		NewListFunc:              func() runtime.Object { return &apps.ControllerRevisionList{} },
+		PredicateFunc:            controllerrevision.MatchControllerRevision,
+		DefaultQualifiedResource: apps.Resource("controllerrevisions"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("controllerrevisions"),
 
 		CreateStrategy: controllerrevision.Strategy,
 		UpdateStrategy: controllerrevision.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/apps/statefulset/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/apps/statefulset/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &appsapi.StatefulSet{} },
-		NewListFunc:       func() runtime.Object { return &appsapi.StatefulSetList{} },
-		PredicateFunc:     statefulset.MatchStatefulSet,
-		QualifiedResource: appsapi.Resource("statefulsets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("statefulsets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &appsapi.StatefulSet{} },
+		NewListFunc:              func() runtime.Object { return &appsapi.StatefulSetList{} },
+		PredicateFunc:            statefulset.MatchStatefulSet,
+		DefaultQualifiedResource: appsapi.Resource("statefulsets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("statefulsets"),
 
 		CreateStrategy: statefulset.Strategy,
 		UpdateStrategy: statefulset.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -36,12 +36,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
-		NewListFunc:       func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
-		PredicateFunc:     horizontalpodautoscaler.MatchAutoscaler,
-		QualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("horizontalpodautoscalers"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
+		NewListFunc:              func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
+		PredicateFunc:            horizontalpodautoscaler.MatchAutoscaler,
+		DefaultQualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("horizontalpodautoscalers"),
 
 		CreateStrategy: horizontalpodautoscaler.Strategy,
 		UpdateStrategy: horizontalpodautoscaler.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/batch/cronjob/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/batch/cronjob/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against CronJobs.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &batch.CronJob{} },
-		NewListFunc:       func() runtime.Object { return &batch.CronJobList{} },
-		PredicateFunc:     cronjob.MatchCronJob,
-		QualifiedResource: batch.Resource("cronjobs"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("cronjobs"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &batch.CronJob{} },
+		NewListFunc:              func() runtime.Object { return &batch.CronJobList{} },
+		PredicateFunc:            cronjob.MatchCronJob,
+		DefaultQualifiedResource: batch.Resource("cronjobs"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("cronjobs"),
 
 		CreateStrategy: cronjob.Strategy,
 		UpdateStrategy: cronjob.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/batch/job/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/batch/job/storage/storage.go
@@ -52,12 +52,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Jobs.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &batch.Job{} },
-		NewListFunc:       func() runtime.Object { return &batch.JobList{} },
-		PredicateFunc:     job.MatchJob,
-		QualifiedResource: batch.Resource("jobs"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("jobs"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &batch.Job{} },
+		NewListFunc:              func() runtime.Object { return &batch.JobList{} },
+		PredicateFunc:            job.MatchJob,
+		DefaultQualifiedResource: batch.Resource("jobs"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("jobs"),
 
 		CreateStrategy: job.Strategy,
 		UpdateStrategy: job.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/certificates/certificates/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/certificates/certificates/storage/storage.go
@@ -36,12 +36,12 @@ type REST struct {
 // NewREST returns a registry which will store CertificateSigningRequest in the given helper
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *ApprovalREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &certificates.CertificateSigningRequest{} },
-		NewListFunc:       func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
-		PredicateFunc:     csrregistry.Matcher,
-		QualifiedResource: certificates.Resource("certificatesigningrequests"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("certificatesigningrequests"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &certificates.CertificateSigningRequest{} },
+		NewListFunc:              func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
+		PredicateFunc:            csrregistry.Matcher,
+		DefaultQualifiedResource: certificates.Resource("certificatesigningrequests"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("certificatesigningrequests"),
 
 		CreateStrategy: csrregistry.Strategy,
 		UpdateStrategy: csrregistry.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/configmap/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/configmap/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work with ConfigMap objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ConfigMap{} },
-		NewListFunc:       func() runtime.Object { return &api.ConfigMapList{} },
-		PredicateFunc:     configmap.MatchConfigMap,
-		QualifiedResource: api.Resource("configmaps"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("configmaps"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ConfigMap{} },
+		NewListFunc:              func() runtime.Object { return &api.ConfigMapList{} },
+		PredicateFunc:            configmap.MatchConfigMap,
+		DefaultQualifiedResource: api.Resource("configmaps"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("configmaps"),
 
 		CreateStrategy: configmap.Strategy,
 		UpdateStrategy: configmap.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/endpoint/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/endpoint/storage/storage.go
@@ -33,12 +33,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against endpoints.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Endpoints{} },
-		NewListFunc:       func() runtime.Object { return &api.EndpointsList{} },
-		PredicateFunc:     endpoint.MatchEndpoints,
-		QualifiedResource: api.Resource("endpoints"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("endpoints"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Endpoints{} },
+		NewListFunc:              func() runtime.Object { return &api.EndpointsList{} },
+		PredicateFunc:            endpoint.MatchEndpoints,
+		DefaultQualifiedResource: api.Resource("endpoints"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("endpoints"),
 
 		CreateStrategy: endpoint.Strategy,
 		UpdateStrategy: endpoint.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/event/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/event/storage/storage.go
@@ -50,8 +50,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 		TTLFunc: func(runtime.Object, uint64, bool) (uint64, error) {
 			return ttl, nil
 		},
-		QualifiedResource: resource,
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource(resource.Resource),
+		DefaultQualifiedResource: resource,
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource(resource.Resource),
 
 		CreateStrategy: event.Strategy,
 		UpdateStrategy: event.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/limitrange/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/limitrange/storage/storage.go
@@ -33,12 +33,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.LimitRange{} },
-		NewListFunc:       func() runtime.Object { return &api.LimitRangeList{} },
-		PredicateFunc:     limitrange.MatchLimitRange,
-		QualifiedResource: api.Resource("limitranges"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("limitranges"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.LimitRange{} },
+		NewListFunc:              func() runtime.Object { return &api.LimitRangeList{} },
+		PredicateFunc:            limitrange.MatchLimitRange,
+		DefaultQualifiedResource: api.Resource("limitranges"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("limitranges"),
 
 		CreateStrategy: limitrange.Strategy,
 		UpdateStrategy: limitrange.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/namespace/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/namespace/storage/storage.go
@@ -54,12 +54,12 @@ type FinalizeREST struct {
 // NewREST returns a RESTStorage object that will work against namespaces.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *FinalizeREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Namespace{} },
-		NewListFunc:       func() runtime.Object { return &api.NamespaceList{} },
-		PredicateFunc:     namespace.MatchNamespace,
-		QualifiedResource: api.Resource("namespaces"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("namespaces"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Namespace{} },
+		NewListFunc:              func() runtime.Object { return &api.NamespaceList{} },
+		PredicateFunc:            namespace.MatchNamespace,
+		DefaultQualifiedResource: api.Resource("namespaces"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("namespaces"),
 
 		CreateStrategy:      namespace.Strategy,
 		UpdateStrategy:      namespace.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/node/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/node/storage/storage.go
@@ -72,12 +72,12 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 // NewStorage returns a NodeStorage object that will work against nodes.
 func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client.KubeletClientConfig, proxyTransport http.RoundTripper) (*NodeStorage, error) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Node{} },
-		NewListFunc:       func() runtime.Object { return &api.NodeList{} },
-		PredicateFunc:     node.MatchNode,
-		QualifiedResource: api.Resource("nodes"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("nodes"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Node{} },
+		NewListFunc:              func() runtime.Object { return &api.NodeList{} },
+		PredicateFunc:            node.MatchNode,
+		DefaultQualifiedResource: api.Resource("nodes"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("nodes"),
 
 		CreateStrategy: node.Strategy,
 		UpdateStrategy: node.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/persistentvolume/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.PersistentVolume{} },
-		NewListFunc:       func() runtime.Object { return &api.PersistentVolumeList{} },
-		PredicateFunc:     persistentvolume.MatchPersistentVolumes,
-		QualifiedResource: api.Resource("persistentvolumes"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("persistentvolumes"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.PersistentVolume{} },
+		NewListFunc:              func() runtime.Object { return &api.PersistentVolumeList{} },
+		PredicateFunc:            persistentvolume.MatchPersistentVolumes,
+		DefaultQualifiedResource: api.Resource("persistentvolumes"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("persistentvolumes"),
 
 		CreateStrategy:      persistentvolume.Strategy,
 		UpdateStrategy:      persistentvolume.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.PersistentVolumeClaim{} },
-		NewListFunc:       func() runtime.Object { return &api.PersistentVolumeClaimList{} },
-		PredicateFunc:     persistentvolumeclaim.MatchPersistentVolumeClaim,
-		QualifiedResource: api.Resource("persistentvolumeclaims"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("persistentvolumeclaims"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.PersistentVolumeClaim{} },
+		NewListFunc:              func() runtime.Object { return &api.PersistentVolumeClaimList{} },
+		PredicateFunc:            persistentvolumeclaim.MatchPersistentVolumeClaim,
+		DefaultQualifiedResource: api.Resource("persistentvolumeclaims"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("persistentvolumeclaims"),
 
 		CreateStrategy:      persistentvolumeclaim.Strategy,
 		UpdateStrategy:      persistentvolumeclaim.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/storage/storage.go
@@ -66,12 +66,12 @@ type REST struct {
 func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper, podDisruptionBudgetClient policyclient.PodDisruptionBudgetsGetter) PodStorage {
 
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Pod{} },
-		NewListFunc:       func() runtime.Object { return &api.PodList{} },
-		PredicateFunc:     pod.MatchPod,
-		QualifiedResource: api.Resource("pods"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("pods"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Pod{} },
+		NewListFunc:              func() runtime.Object { return &api.PodList{} },
+		PredicateFunc:            pod.MatchPod,
+		DefaultQualifiedResource: api.Resource("pods"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("pods"),
 
 		CreateStrategy:      pod.Strategy,
 		UpdateStrategy:      pod.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/podtemplate/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/podtemplate/storage/storage.go
@@ -32,12 +32,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.PodTemplate{} },
-		NewListFunc:       func() runtime.Object { return &api.PodTemplateList{} },
-		PredicateFunc:     podtemplate.MatchPodTemplate,
-		QualifiedResource: api.Resource("podtemplates"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podtemplates"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.PodTemplate{} },
+		NewListFunc:              func() runtime.Object { return &api.PodTemplateList{} },
+		PredicateFunc:            podtemplate.MatchPodTemplate,
+		DefaultQualifiedResource: api.Resource("podtemplates"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podtemplates"),
 
 		CreateStrategy: podtemplate.Strategy,
 		UpdateStrategy: podtemplate.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -61,12 +61,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ReplicationController{} },
-		NewListFunc:       func() runtime.Object { return &api.ReplicationControllerList{} },
-		PredicateFunc:     replicationcontroller.MatchController,
-		QualifiedResource: api.Resource("replicationcontrollers"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("replicationcontrollers"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ReplicationController{} },
+		NewListFunc:              func() runtime.Object { return &api.ReplicationControllerList{} },
+		PredicateFunc:            replicationcontroller.MatchController,
+		DefaultQualifiedResource: api.Resource("replicationcontrollers"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("replicationcontrollers"),
 
 		CreateStrategy: replicationcontroller.Strategy,
 		UpdateStrategy: replicationcontroller.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/resourcequota/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/resourcequota/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against resource quotas.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ResourceQuota{} },
-		NewListFunc:       func() runtime.Object { return &api.ResourceQuotaList{} },
-		PredicateFunc:     resourcequota.MatchResourceQuota,
-		QualifiedResource: api.Resource("resourcequotas"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("resourcequotas"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ResourceQuota{} },
+		NewListFunc:              func() runtime.Object { return &api.ResourceQuotaList{} },
+		PredicateFunc:            resourcequota.MatchResourceQuota,
+		DefaultQualifiedResource: api.Resource("resourcequotas"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("resourcequotas"),
 
 		CreateStrategy:      resourcequota.Strategy,
 		UpdateStrategy:      resourcequota.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/secret/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/secret/storage/storage.go
@@ -32,12 +32,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against secrets.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Secret{} },
-		NewListFunc:       func() runtime.Object { return &api.SecretList{} },
-		PredicateFunc:     secret.Matcher,
-		QualifiedResource: api.Resource("secrets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("secrets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Secret{} },
+		NewListFunc:              func() runtime.Object { return &api.SecretList{} },
+		PredicateFunc:            secret.Matcher,
+		DefaultQualifiedResource: api.Resource("secrets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("secrets"),
 
 		CreateStrategy: secret.Strategy,
 		UpdateStrategy: secret.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against services.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Service{} },
-		NewListFunc:       func() runtime.Object { return &api.ServiceList{} },
-		PredicateFunc:     service.MatchServices,
-		QualifiedResource: api.Resource("services"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("services"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Service{} },
+		NewListFunc:              func() runtime.Object { return &api.ServiceList{} },
+		PredicateFunc:            service.MatchServices,
+		DefaultQualifiedResource: api.Resource("services"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("services"),
 
 		CreateStrategy: service.Strategy,
 		UpdateStrategy: service.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/serviceaccount/storage/storage.go
@@ -33,12 +33,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against service accounts.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ServiceAccount{} },
-		NewListFunc:       func() runtime.Object { return &api.ServiceAccountList{} },
-		PredicateFunc:     serviceaccount.Matcher,
-		QualifiedResource: api.Resource("serviceaccounts"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("serviceaccounts"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ServiceAccount{} },
+		NewListFunc:              func() runtime.Object { return &api.ServiceAccountList{} },
+		PredicateFunc:            serviceaccount.Matcher,
+		DefaultQualifiedResource: api.Resource("serviceaccounts"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("serviceaccounts"),
 
 		CreateStrategy:      serviceaccount.Strategy,
 		UpdateStrategy:      serviceaccount.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/daemonset/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against DaemonSets.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.DaemonSet{} },
-		NewListFunc:       func() runtime.Object { return &extensions.DaemonSetList{} },
-		PredicateFunc:     daemonset.MatchDaemonSet,
-		QualifiedResource: extensions.Resource("daemonsets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("daemonsets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.DaemonSet{} },
+		NewListFunc:              func() runtime.Object { return &extensions.DaemonSetList{} },
+		PredicateFunc:            daemonset.MatchDaemonSet,
+		DefaultQualifiedResource: extensions.Resource("daemonsets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("daemonsets"),
 
 		CreateStrategy: daemonset.Strategy,
 		UpdateStrategy: daemonset.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/deployment/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/deployment/storage/storage.go
@@ -63,12 +63,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against deployments.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *RollbackREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.Deployment{} },
-		NewListFunc:       func() runtime.Object { return &extensions.DeploymentList{} },
-		PredicateFunc:     deployment.MatchDeployment,
-		QualifiedResource: extensions.Resource("deployments"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("deployments"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.Deployment{} },
+		NewListFunc:              func() runtime.Object { return &extensions.DeploymentList{} },
+		PredicateFunc:            deployment.MatchDeployment,
+		DefaultQualifiedResource: extensions.Resource("deployments"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("deployments"),
 
 		CreateStrategy: deployment.Strategy,
 		UpdateStrategy: deployment.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/ingress/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/ingress/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.Ingress{} },
-		NewListFunc:       func() runtime.Object { return &extensions.IngressList{} },
-		PredicateFunc:     ingress.MatchIngress,
-		QualifiedResource: extensions.Resource("ingresses"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("ingresses"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.Ingress{} },
+		NewListFunc:              func() runtime.Object { return &extensions.IngressList{} },
+		PredicateFunc:            ingress.MatchIngress,
+		DefaultQualifiedResource: extensions.Resource("ingresses"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("ingresses"),
 
 		CreateStrategy: ingress.Strategy,
 		UpdateStrategy: ingress.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/networkpolicy/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/networkpolicy/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against network policies.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensionsapi.NetworkPolicy{} },
-		NewListFunc:       func() runtime.Object { return &extensionsapi.NetworkPolicyList{} },
-		PredicateFunc:     networkpolicy.MatchNetworkPolicy,
-		QualifiedResource: extensionsapi.Resource("networkpolicies"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("networkpolicies"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensionsapi.NetworkPolicy{} },
+		NewListFunc:              func() runtime.Object { return &extensionsapi.NetworkPolicyList{} },
+		PredicateFunc:            networkpolicy.MatchNetworkPolicy,
+		DefaultQualifiedResource: extensionsapi.Resource("networkpolicies"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("networkpolicies"),
 
 		CreateStrategy: networkpolicy.Strategy,
 		UpdateStrategy: networkpolicy.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against PodSecurityPolicy objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.PodSecurityPolicy{} },
-		NewListFunc:       func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
-		PredicateFunc:     podsecuritypolicy.MatchPodSecurityPolicy,
-		QualifiedResource: extensions.Resource("podsecuritypolicies"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podsecuritypolicies"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.PodSecurityPolicy{} },
+		NewListFunc:              func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
+		PredicateFunc:            podsecuritypolicy.MatchPodSecurityPolicy,
+		DefaultQualifiedResource: extensions.Resource("podsecuritypolicies"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podsecuritypolicies"),
 
 		CreateStrategy:      podsecuritypolicy.Strategy,
 		UpdateStrategy:      podsecuritypolicy.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/replicaset/storage/storage.go
@@ -60,12 +60,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.ReplicaSet{} },
-		NewListFunc:       func() runtime.Object { return &extensions.ReplicaSetList{} },
-		PredicateFunc:     replicaset.MatchReplicaSet,
-		QualifiedResource: extensions.Resource("replicasets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("replicasets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.ReplicaSet{} },
+		NewListFunc:              func() runtime.Object { return &extensions.ReplicaSetList{} },
+		PredicateFunc:            replicaset.MatchReplicaSet,
+		DefaultQualifiedResource: extensions.Resource("replicasets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("replicasets"),
 
 		CreateStrategy: replicaset.Strategy,
 		UpdateStrategy: replicaset.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresource/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresource/storage/storage.go
@@ -43,12 +43,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	opts.Decorator = generic.UndecoratedStorage
 
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.ThirdPartyResource{} },
-		NewListFunc:       func() runtime.Object { return &extensions.ThirdPartyResourceList{} },
-		PredicateFunc:     thirdpartyresource.Matcher,
-		QualifiedResource: resource,
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource(resource.Resource),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.ThirdPartyResource{} },
+		NewListFunc:              func() runtime.Object { return &extensions.ThirdPartyResourceList{} },
+		PredicateFunc:            thirdpartyresource.Matcher,
+		DefaultQualifiedResource: resource,
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource(resource.Resource),
 
 		CreateStrategy: thirdpartyresource.Strategy,
 		UpdateStrategy: thirdpartyresource.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresourcedata/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresourcedata/storage/storage.go
@@ -99,12 +99,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter, group, kind string) *REST {
 	opts.ResourcePrefix = "/ThirdPartyResourceData/" + group + "/" + strings.ToLower(kind) + "s"
 
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.ThirdPartyResourceData{} },
-		NewListFunc:       func() runtime.Object { return &extensions.ThirdPartyResourceDataList{} },
-		PredicateFunc:     thirdpartyresourcedata.Matcher,
-		QualifiedResource: resource,
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource(resource.Resource),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.ThirdPartyResourceData{} },
+		NewListFunc:              func() runtime.Object { return &extensions.ThirdPartyResourceDataList{} },
+		PredicateFunc:            thirdpartyresourcedata.Matcher,
+		DefaultQualifiedResource: resource,
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource(resource.Resource),
 
 		CreateStrategy: thirdpartyresourcedata.Strategy,
 		UpdateStrategy: thirdpartyresourcedata.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against NetworkPolicies
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &networkingapi.NetworkPolicy{} },
-		NewListFunc:       func() runtime.Object { return &networkingapi.NetworkPolicyList{} },
-		PredicateFunc:     networkpolicy.Matcher,
-		QualifiedResource: networkingapi.Resource("networkpolicies"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("networkpolicies"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &networkingapi.NetworkPolicy{} },
+		NewListFunc:              func() runtime.Object { return &networkingapi.NetworkPolicyList{} },
+		PredicateFunc:            networkpolicy.Matcher,
+		DefaultQualifiedResource: networkingapi.Resource("networkpolicies"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("networkpolicies"),
 
 		CreateStrategy: networkpolicy.Strategy,
 		UpdateStrategy: networkpolicy.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against pod disruption budgets.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
-		NewListFunc:       func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
-		PredicateFunc:     poddisruptionbudget.MatchPodDisruptionBudget,
-		QualifiedResource: policyapi.Resource("poddisruptionbudgets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("poddisruptionbudgets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
+		NewListFunc:              func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
+		PredicateFunc:            poddisruptionbudget.MatchPodDisruptionBudget,
+		DefaultQualifiedResource: policyapi.Resource("poddisruptionbudgets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("poddisruptionbudgets"),
 
 		CreateStrategy: poddisruptionbudget.Strategy,
 		UpdateStrategy: poddisruptionbudget.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.ClusterRole{} },
-		NewListFunc:       func() runtime.Object { return &rbac.ClusterRoleList{} },
-		PredicateFunc:     clusterrole.Matcher,
-		QualifiedResource: rbac.Resource("clusterroles"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusterroles"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.ClusterRole{} },
+		NewListFunc:              func() runtime.Object { return &rbac.ClusterRoleList{} },
+		PredicateFunc:            clusterrole.Matcher,
+		DefaultQualifiedResource: rbac.Resource("clusterroles"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusterroles"),
 
 		CreateStrategy: clusterrole.Strategy,
 		UpdateStrategy: clusterrole.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.ClusterRoleBinding{} },
-		NewListFunc:       func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
-		PredicateFunc:     clusterrolebinding.Matcher,
-		QualifiedResource: rbac.Resource("clusterrolebindings"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusterrolebindings"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.ClusterRoleBinding{} },
+		NewListFunc:              func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
+		PredicateFunc:            clusterrolebinding.Matcher,
+		DefaultQualifiedResource: rbac.Resource("clusterrolebindings"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusterrolebindings"),
 
 		CreateStrategy: clusterrolebinding.Strategy,
 		UpdateStrategy: clusterrolebinding.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/role/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/role/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Role objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.Role{} },
-		NewListFunc:       func() runtime.Object { return &rbac.RoleList{} },
-		PredicateFunc:     role.Matcher,
-		QualifiedResource: rbac.Resource("roles"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("roles"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.Role{} },
+		NewListFunc:              func() runtime.Object { return &rbac.RoleList{} },
+		PredicateFunc:            role.Matcher,
+		DefaultQualifiedResource: rbac.Resource("roles"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("roles"),
 
 		CreateStrategy: role.Strategy,
 		UpdateStrategy: role.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.RoleBinding{} },
-		NewListFunc:       func() runtime.Object { return &rbac.RoleBindingList{} },
-		PredicateFunc:     rolebinding.Matcher,
-		QualifiedResource: rbac.Resource("rolebindings"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("rolebindings"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.RoleBinding{} },
+		NewListFunc:              func() runtime.Object { return &rbac.RoleBindingList{} },
+		PredicateFunc:            rolebinding.Matcher,
+		DefaultQualifiedResource: rbac.Resource("rolebindings"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("rolebindings"),
 
 		CreateStrategy: rolebinding.Strategy,
 		UpdateStrategy: rolebinding.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/settings/podpreset/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/settings/podpreset/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &settingsapi.PodPreset{} },
-		NewListFunc:       func() runtime.Object { return &settingsapi.PodPresetList{} },
-		PredicateFunc:     podpreset.Matcher,
-		QualifiedResource: settingsapi.Resource("podpresets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podpresets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &settingsapi.PodPreset{} },
+		NewListFunc:              func() runtime.Object { return &settingsapi.PodPresetList{} },
+		PredicateFunc:            podpreset.Matcher,
+		DefaultQualifiedResource: settingsapi.Resource("podpresets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podpresets"),
 
 		CreateStrategy: podpreset.Strategy,
 		UpdateStrategy: podpreset.Strategy,

--- a/vendor/k8s.io/kubernetes/pkg/registry/storage/storageclass/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/storage/storageclass/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &storageapi.StorageClass{} },
-		NewListFunc:       func() runtime.Object { return &storageapi.StorageClassList{} },
-		PredicateFunc:     storageclass.MatchStorageClasses,
-		QualifiedResource: storageapi.Resource("storageclasses"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("storageclass"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &storageapi.StorageClass{} },
+		NewListFunc:              func() runtime.Object { return &storageapi.StorageClassList{} },
+		PredicateFunc:            storageclass.MatchStorageClasses,
+		DefaultQualifiedResource: storageapi.Resource("storageclasses"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("storageclass"),
 
 		CreateStrategy:      storageclass.Strategy,
 		UpdateStrategy:      storageclass.Strategy,

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -40,8 +40,8 @@ func NewREST(resource schema.GroupResource, listKind schema.GroupVersionKind, co
 			ret.SetGroupVersionKind(listKind)
 			return ret
 		},
-		PredicateFunc:     strategy.MatchCustomResourceDefinitionStorage,
-		QualifiedResource: resource,
+		PredicateFunc:            strategy.MatchCustomResourceDefinitionStorage,
+		DefaultQualifiedResource: resource,
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -41,11 +41,11 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &apiextensions.CustomResourceDefinition{} },
-		NewListFunc:       func() runtime.Object { return &apiextensions.CustomResourceDefinitionList{} },
-		PredicateFunc:     MatchCustomResourceDefinition,
-		QualifiedResource: apiextensions.Resource("customresourcedefinitions"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &apiextensions.CustomResourceDefinition{} },
+		NewListFunc:              func() runtime.Object { return &apiextensions.CustomResourceDefinitionList{} },
+		PredicateFunc:            MatchCustomResourceDefinition,
+		DefaultQualifiedResource: apiextensions.Resource("customresourcedefinitions"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -82,8 +83,10 @@ type Store struct {
 	// curl GET /apis/group/version/namespaces/my-ns/myresource
 	NewListFunc func() runtime.Object
 
-	// QualifiedResource is the pluralized name of the resource.
-	QualifiedResource schema.GroupResource
+	// DefaultQualifiedResource is the pluralized name of the resource.
+	// This field is used if there is no request info present in the context.
+	// See qualifiedResourceFromContext for details.
+	DefaultQualifiedResource schema.GroupResource
 
 	// KeyRootFunc returns the root etcd key for this resource; should not
 	// include trailing "/".  This is used for operations that work on the
@@ -262,16 +265,17 @@ func (e *Store) ListPredicate(ctx genericapirequest.Context, p storage.Selection
 	}
 	p.IncludeUninitialized = options.IncludeUninitialized
 	list := e.NewListFunc()
+	qualifiedResource := e.qualifiedResourceFromContext(ctx)
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
 			err := e.Storage.GetToList(ctx, key, options.ResourceVersion, p, list)
-			return list, storeerr.InterpretListError(err, e.QualifiedResource)
+			return list, storeerr.InterpretListError(err, qualifiedResource)
 		}
 		// if we cannot extract a key based on the current context, the optimization is skipped
 	}
 
 	err := e.Storage.List(ctx, e.KeyRootFunc(ctx), options.ResourceVersion, p, list)
-	return list, storeerr.InterpretListError(err, e.QualifiedResource)
+	return list, storeerr.InterpretListError(err, qualifiedResource)
 }
 
 // Create inserts a new item according to the unique key from the object.
@@ -287,13 +291,14 @@ func (e *Store) Create(ctx genericapirequest.Context, obj runtime.Object, includ
 	if err != nil {
 		return nil, err
 	}
+	qualifiedResource := e.qualifiedResourceFromContext(ctx)
 	ttl, err := e.calculateTTL(obj, 0, false)
 	if err != nil {
 		return nil, err
 	}
 	out := e.NewFunc()
 	if err := e.Storage.Create(ctx, key, obj, out, ttl); err != nil {
-		err = storeerr.InterpretCreateError(err, e.QualifiedResource, name)
+		err = storeerr.InterpretCreateError(err, qualifiedResource, name)
 		err = rest.CheckGeneratedNameError(e.CreateStrategy, err, obj)
 		if !kubeerr.IsAlreadyExists(err) {
 			return nil, err
@@ -327,6 +332,8 @@ func (e *Store) Create(ctx genericapirequest.Context, obj runtime.Object, includ
 	return out, nil
 }
 
+// WaitForInitialized holds until the object is initialized, or returns an error if the default limit expires.
+// This method is exposed publicly for consumers of generic rest tooling.
 func (e *Store) WaitForInitialized(ctx genericapirequest.Context, obj runtime.Object) (runtime.Object, error) {
 	// return early if we don't have initializers, or if they've completed already
 	accessor, err := meta.Accessor(obj)
@@ -345,6 +352,7 @@ func (e *Store) WaitForInitialized(ctx genericapirequest.Context, obj runtime.Ob
 	if err != nil {
 		return nil, err
 	}
+	qualifiedResource := e.qualifiedResourceFromContext(ctx)
 	w, err := e.Storage.Watch(ctx, key, accessor.GetResourceVersion(), storage.SelectionPredicate{
 		Label: labels.Everything(),
 		Field: fields.Everything(),
@@ -362,8 +370,9 @@ func (e *Store) WaitForInitialized(ctx genericapirequest.Context, obj runtime.Ob
 		select {
 		case event, ok := <-ch:
 			if !ok {
-				// TODO: should we just expose the partially initialized object?
-				return nil, kubeerr.NewServerTimeout(e.QualifiedResource, "create", 0)
+				msg := fmt.Sprintf("server has timed out waiting for the initialization of %s %s",
+					qualifiedResource.String(), accessor.GetName())
+				return nil, kubeerr.NewTimeoutError(msg, 0)
 			}
 			switch event.Type {
 			case watch.Deleted:
@@ -447,15 +456,15 @@ func (e *Store) deleteWithoutFinalizers(ctx genericapirequest.Context, name, key
 		// requests to remove all finalizers from the object, so we
 		// ignore the NotFound error.
 		if storage.IsNotFound(err) {
-			_, err := e.finalizeDelete(obj, true)
+			_, err := e.finalizeDelete(ctx, obj, true)
 			// clients are expecting an updated object if a PUT succeeded,
 			// but finalizeDelete returns a metav1.Status, so return
 			// the object in the request instead.
 			return obj, false, err
 		}
-		return nil, false, storeerr.InterpretDeleteError(err, e.QualifiedResource, name)
+		return nil, false, storeerr.InterpretDeleteError(err, e.qualifiedResourceFromContext(ctx), name)
 	}
-	_, err := e.finalizeDelete(out, true)
+	_, err := e.finalizeDelete(ctx, out, true)
 	// clients are expecting an updated object if a PUT succeeded, but
 	// finalizeDelete returns a metav1.Status, so return the object in
 	// the request instead.
@@ -476,6 +485,7 @@ func (e *Store) Update(ctx genericapirequest.Context, name string, objInfo rest.
 		creating    = false
 	)
 
+	qualifiedResource := e.qualifiedResourceFromContext(ctx)
 	storagePreconditions := &storage.Preconditions{}
 	if preconditions := objInfo.Preconditions(); preconditions != nil {
 		storagePreconditions.UID = preconditions.UID
@@ -507,7 +517,7 @@ func (e *Store) Update(ctx genericapirequest.Context, name string, objInfo rest.
 		}
 		if version == 0 {
 			if !e.UpdateStrategy.AllowCreateOnUpdate() {
-				return nil, nil, kubeerr.NewNotFound(e.QualifiedResource, name)
+				return nil, nil, kubeerr.NewNotFound(qualifiedResource, name)
 			}
 			creating = true
 			creatingObj = obj
@@ -541,12 +551,12 @@ func (e *Store) Update(ctx genericapirequest.Context, name string, objInfo rest.
 				// TODO: The Invalid error should have a field for Resource.
 				// After that field is added, we should fill the Resource and
 				// leave the Kind field empty. See the discussion in #18526.
-				qualifiedKind := schema.GroupKind{Group: e.QualifiedResource.Group, Kind: e.QualifiedResource.Resource}
+				qualifiedKind := schema.GroupKind{Group: qualifiedResource.Group, Kind: qualifiedResource.Resource}
 				fieldErrList := field.ErrorList{field.Invalid(field.NewPath("metadata").Child("resourceVersion"), newVersion, "must be specified for an update")}
 				return nil, nil, kubeerr.NewInvalid(qualifiedKind, name, fieldErrList)
 			}
 			if newVersion != version {
-				return nil, nil, kubeerr.NewConflict(e.QualifiedResource, name, fmt.Errorf(OptimisticLockErrorMsg))
+				return nil, nil, kubeerr.NewConflict(qualifiedResource, name, fmt.Errorf(OptimisticLockErrorMsg))
 			}
 		}
 		if err := rest.BeforeUpdate(e.UpdateStrategy, ctx, obj, existing); err != nil {
@@ -572,10 +582,10 @@ func (e *Store) Update(ctx genericapirequest.Context, name string, objInfo rest.
 			return e.deleteWithoutFinalizers(ctx, name, key, deleteObj, storagePreconditions)
 		}
 		if creating {
-			err = storeerr.InterpretCreateError(err, e.QualifiedResource, name)
+			err = storeerr.InterpretCreateError(err, qualifiedResource, name)
 			err = rest.CheckGeneratedNameError(e.CreateStrategy, err, creatingObj)
 		} else {
-			err = storeerr.InterpretUpdateError(err, e.QualifiedResource, name)
+			err = storeerr.InterpretUpdateError(err, qualifiedResource, name)
 		}
 		return nil, false, err
 	}
@@ -613,7 +623,7 @@ func (e *Store) Get(ctx genericapirequest.Context, name string, options *metav1.
 		return nil, err
 	}
 	if err := e.Storage.Get(ctx, key, options.ResourceVersion, obj, false); err != nil {
-		return nil, storeerr.InterpretGetError(err, e.QualifiedResource, name)
+		return nil, storeerr.InterpretGetError(err, e.qualifiedResourceFromContext(ctx), name)
 	}
 	if e.Decorator != nil {
 		if err := e.Decorator(obj); err != nil {
@@ -621,6 +631,16 @@ func (e *Store) Get(ctx genericapirequest.Context, name string, options *metav1.
 		}
 	}
 	return obj, nil
+}
+
+// qualifiedResourceFromContext attempts to retrieve a GroupResource from the context's request info.
+// If the context has no request info, DefaultQualifiedResource is used.
+func (e *Store) qualifiedResourceFromContext(ctx genericapirequest.Context) schema.GroupResource {
+	if info, ok := request.RequestInfoFrom(ctx); ok {
+		return schema.GroupResource{Group: info.APIGroup, Resource: info.Resource}
+	}
+	// some implementations access storage directly and thus the context has no RequestInfo
+	return e.DefaultQualifiedResource
 }
 
 var (
@@ -826,10 +846,10 @@ func (e *Store) updateForGracefulDeletion(ctx genericapirequest.Context, name, k
 		// we should fall through and truly delete the object.
 		return nil, false, true, out, lastExisting
 	case errAlreadyDeleting:
-		out, err = e.finalizeDelete(in, true)
+		out, err = e.finalizeDelete(ctx, in, true)
 		return err, false, false, out, lastExisting
 	default:
-		return storeerr.InterpretUpdateError(err, e.QualifiedResource, name), false, false, out, lastExisting
+		return storeerr.InterpretUpdateError(err, e.qualifiedResourceFromContext(ctx), name), false, false, out, lastExisting
 	}
 }
 
@@ -917,10 +937,10 @@ func (e *Store) updateForGracefulDeletionAndFinalizers(ctx genericapirequest.Con
 		// we should fall through and truly delete the object.
 		return nil, false, true, out, lastExisting
 	case errAlreadyDeleting:
-		out, err = e.finalizeDelete(in, true)
+		out, err = e.finalizeDelete(ctx, in, true)
 		return err, false, false, out, lastExisting
 	default:
-		return storeerr.InterpretUpdateError(err, e.QualifiedResource, name), false, false, out, lastExisting
+		return storeerr.InterpretUpdateError(err, e.qualifiedResourceFromContext(ctx), name), false, false, out, lastExisting
 	}
 }
 
@@ -930,10 +950,10 @@ func (e *Store) Delete(ctx genericapirequest.Context, name string, options *meta
 	if err != nil {
 		return nil, false, err
 	}
-
 	obj := e.NewFunc()
+	qualifiedResource := e.qualifiedResourceFromContext(ctx)
 	if err := e.Storage.Get(ctx, key, "", obj, false); err != nil {
-		return nil, false, storeerr.InterpretDeleteError(err, e.QualifiedResource, name)
+		return nil, false, storeerr.InterpretDeleteError(err, qualifiedResource, name)
 	}
 	// support older consumers of delete by treating "nil" as delete immediately
 	if options == nil {
@@ -949,7 +969,7 @@ func (e *Store) Delete(ctx genericapirequest.Context, name string, options *meta
 	}
 	// this means finalizers cannot be updated via DeleteOptions if a deletion is already pending
 	if pendingGraceful {
-		out, err := e.finalizeDelete(obj, false)
+		out, err := e.finalizeDelete(ctx, obj, false)
 		return out, false, err
 	}
 	// check if obj has pending finalizers
@@ -990,12 +1010,12 @@ func (e *Store) Delete(ctx genericapirequest.Context, name string, options *meta
 		if storage.IsNotFound(err) && ignoreNotFound && lastExisting != nil {
 			// The lastExisting object may not be the last state of the object
 			// before its deletion, but it's the best approximation.
-			out, err := e.finalizeDelete(lastExisting, true)
+			out, err := e.finalizeDelete(ctx, lastExisting, true)
 			return out, true, err
 		}
-		return nil, false, storeerr.InterpretDeleteError(err, e.QualifiedResource, name)
+		return nil, false, storeerr.InterpretDeleteError(err, qualifiedResource, name)
 	}
-	out, err = e.finalizeDelete(out, true)
+	out, err = e.finalizeDelete(ctx, out, true)
 	return out, true, err
 }
 
@@ -1097,7 +1117,7 @@ func (e *Store) DeleteCollection(ctx genericapirequest.Context, options *metav1.
 
 // finalizeDelete runs the Store's AfterDelete hook if runHooks is set and
 // returns the decorated deleted object if appropriate.
-func (e *Store) finalizeDelete(obj runtime.Object, runHooks bool) (runtime.Object, error) {
+func (e *Store) finalizeDelete(ctx genericapirequest.Context, obj runtime.Object, runHooks bool) (runtime.Object, error) {
 	if runHooks && e.AfterDelete != nil {
 		if err := e.AfterDelete(obj); err != nil {
 			return nil, err
@@ -1117,10 +1137,11 @@ func (e *Store) finalizeDelete(obj runtime.Object, runHooks bool) (runtime.Objec
 	if err != nil {
 		return nil, err
 	}
+	qualifiedResource := e.qualifiedResourceFromContext(ctx)
 	details := &metav1.StatusDetails{
 		Name:  accessor.GetName(),
-		Group: e.QualifiedResource.Group,
-		Kind:  e.QualifiedResource.Resource, // Yes we set Kind field to resource.
+		Group: qualifiedResource.Group,
+		Kind:  qualifiedResource.Resource, // Yes we set Kind field to resource.
 		UID:   accessor.GetUID(),
 	}
 	status := &metav1.Status{Status: metav1.StatusSuccess, Details: details}
@@ -1150,7 +1171,7 @@ func (e *Store) Watch(ctx genericapirequest.Context, options *metainternalversio
 	return e.WatchPredicate(ctx, predicate, resourceVersion)
 }
 
-// WatchPredicate starts a watch for the items that m matches.
+// WatchPredicate starts a watch for the items that matches.
 func (e *Store) WatchPredicate(ctx genericapirequest.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
@@ -1237,17 +1258,17 @@ func (e *Store) Export(ctx genericapirequest.Context, name string, opts metav1.E
 // CompleteWithOptions updates the store with the provided options and
 // defaults common fields.
 func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
-	if e.QualifiedResource.Empty() {
+	if e.DefaultQualifiedResource.Empty() {
 		return fmt.Errorf("store %#v must have a non-empty qualified resource", e)
 	}
 	if e.NewFunc == nil {
-		return fmt.Errorf("store for %s must have NewFunc set", e.QualifiedResource.String())
+		return fmt.Errorf("store for %s must have NewFunc set", e.DefaultQualifiedResource.String())
 	}
 	if e.NewListFunc == nil {
-		return fmt.Errorf("store for %s must have NewListFunc set", e.QualifiedResource.String())
+		return fmt.Errorf("store for %s must have NewListFunc set", e.DefaultQualifiedResource.String())
 	}
 	if (e.KeyRootFunc == nil) != (e.KeyFunc == nil) {
-		return fmt.Errorf("store for %s must set both KeyRootFunc and KeyFunc or neither", e.QualifiedResource.String())
+		return fmt.Errorf("store for %s must set both KeyRootFunc and KeyFunc or neither", e.DefaultQualifiedResource.String())
 	}
 
 	var isNamespaced bool
@@ -1257,15 +1278,15 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 	case e.UpdateStrategy != nil:
 		isNamespaced = e.UpdateStrategy.NamespaceScoped()
 	default:
-		return fmt.Errorf("store for %s must have CreateStrategy or UpdateStrategy set", e.QualifiedResource.String())
+		return fmt.Errorf("store for %s must have CreateStrategy or UpdateStrategy set", e.DefaultQualifiedResource.String())
 	}
 
 	if e.DeleteStrategy == nil {
-		return fmt.Errorf("store for %s must have DeleteStrategy set", e.QualifiedResource.String())
+		return fmt.Errorf("store for %s must have DeleteStrategy set", e.DefaultQualifiedResource.String())
 	}
 
 	if options.RESTOptions == nil {
-		return fmt.Errorf("options for %s must have RESTOptions set", e.QualifiedResource.String())
+		return fmt.Errorf("options for %s must have RESTOptions set", e.DefaultQualifiedResource.String())
 	}
 
 	attrFunc := options.AttrFunc
@@ -1286,18 +1307,18 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		}
 	}
 
-	opts, err := options.RESTOptions.GetRESTOptions(e.QualifiedResource)
+	opts, err := options.RESTOptions.GetRESTOptions(e.DefaultQualifiedResource)
 	if err != nil {
 		return err
 	}
 
-	// Resource prefix must come from the underlying factory
+	// ResourcePrefix must come from the underlying factory
 	prefix := opts.ResourcePrefix
 	if !strings.HasPrefix(prefix, "/") {
 		prefix = "/" + prefix
 	}
 	if prefix == "/" {
-		return fmt.Errorf("store for %s has an invalid prefix %q", e.QualifiedResource.String(), opts.ResourcePrefix)
+		return fmt.Errorf("store for %s has an invalid prefix %q", e.DefaultQualifiedResource.String(), opts.ResourcePrefix)
 	}
 
 	// Set the default behavior for storage key generation
@@ -1376,5 +1397,5 @@ func (e *Store) ConvertToTable(ctx genericapirequest.Context, object runtime.Obj
 	if e.TableConvertor != nil {
 		return e.TableConvertor.ConvertToTable(ctx, object, tableOptions)
 	}
-	return rest.NewDefaultTableConvertor(e.QualifiedResource).ConvertToTable(ctx, object, tableOptions)
+	return rest.NewDefaultTableConvertor(e.qualifiedResourceFromContext(ctx)).ConvertToTable(ctx, object, tableOptions)
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -35,11 +35,11 @@ type REST struct {
 func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST {
 	strategy := apiservice.NewStrategy(scheme)
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &apiregistration.APIService{} },
-		NewListFunc:       func() runtime.Object { return &apiregistration.APIServiceList{} },
-		PredicateFunc:     apiservice.MatchAPIService,
-		QualifiedResource: apiregistration.Resource("apiservices"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &apiregistration.APIService{} },
+		NewListFunc:              func() runtime.Object { return &apiregistration.APIServiceList{} },
+		PredicateFunc:            apiservice.MatchAPIService,
+		DefaultQualifiedResource: apiregistration.Resource("apiservices"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/etcd.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/etcd.go
@@ -33,11 +33,11 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &wardle.Flunder{} },
-		NewListFunc:       func() runtime.Object { return &wardle.FlunderList{} },
-		PredicateFunc:     MatchFlunder,
-		QualifiedResource: wardle.Resource("flunders"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &wardle.Flunder{} },
+		NewListFunc:              func() runtime.Object { return &wardle.FlunderList{} },
+		PredicateFunc:            MatchFlunder,
+		DefaultQualifiedResource: wardle.Resource("flunders"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,


### PR DESCRIPTION
This field replaces QualifiedResource and serves as the default group resource info when the request does not provide that data.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: #15213 #15006 kubernetes/kubernetes/pull/49868