### PR TITLE
move the oauth server out of the main API server for structure

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -38,6 +38,12 @@ import (
 	"github.com/openshift/origin/pkg/user/cache"
 )
 
+const (
+	openShiftOAuthAPIPrefix      = "/oauth"
+	openShiftLoginPrefix         = "/login"
+	openShiftOAuthCallbackPrefix = "/oauth2callback"
+)
+
 func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Config) (*OpenshiftAPIConfig, error) {
 	// sccStorage must use the upstream RESTOptionsGetter to be in the correct location
 	// this probably creates a duplicate cache, but there are not very many SCCs, so live with it to avoid further linkage
@@ -199,6 +205,22 @@ func (c *MasterConfig) newAssetServerHandler() (http.Handler, error) {
 	return assetServer.GenericAPIServer.PrepareRun().GenericAPIServer.Handler.FullHandlerChain, nil
 }
 
+func (c *MasterConfig) newOAuthServerHandler() (http.Handler, error) {
+	if c.Options.OAuthConfig == nil {
+		return http.NotFoundHandler(), nil
+	}
+
+	config, err := NewOAuthServerConfigFromMasterConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	oauthServer, err := config.Complete().New(apiserver.EmptyDelegate)
+	if err != nil {
+		return nil, err
+	}
+	return oauthServer.GenericAPIServer.PrepareRun().GenericAPIServer.Handler.FullHandlerChain, nil
+}
+
 func (c *MasterConfig) withAggregator(delegateAPIServer apiserver.DelegationTarget, kubeAPIServerConfig apiserver.Config, apiExtensionsInformers apiextensionsinformers.SharedInformerFactory) (*aggregatorapiserver.APIAggregator, error) {
 	aggregatorConfig, err := c.createAggregatorConfig(kubeAPIServerConfig)
 	if err != nil {
@@ -220,11 +242,10 @@ func (c *MasterConfig) Run(kubeAPIServerConfig *kubeapiserver.Config, controller
 	var apiExtensionsInformers apiextensionsinformers.SharedInformerFactory
 	var delegateAPIServer apiserver.DelegationTarget
 
-	assetHandler, err := c.newAssetServerHandler()
+	kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, err = c.buildHandlerChain()
 	if err != nil {
 		return err
 	}
-	kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc = c.buildHandlerChain(assetHandler)
 
 	delegateAPIServer = apiserver.EmptyDelegate
 	delegateAPIServer, err = c.withTemplateServiceBroker(delegateAPIServer, *kubeAPIServerConfig.GenericConfig)
@@ -266,24 +287,29 @@ func (c *MasterConfig) Run(kubeAPIServerConfig *kubeapiserver.Config, controller
 
 	go aggregatedAPIServer.GenericAPIServer.PrepareRun().Run(stopCh)
 
-	// TODO find a better home for this output
-	if c.Options.OAuthConfig != nil {
-		glog.Infof("Starting OAuth2 API at %s", oauthutil.OpenShiftOAuthAPIPrefix)
-	}
-	if c.WebConsoleEnabled() && !c.WebConsoleStandalone() {
-		glog.Infof("Starting Web Console %s", c.Options.AssetConfig.PublicURL)
-	}
-
 	// Attempt to verify the server came up for 20 seconds (100 tries * 100ms, 100ms timeout per try)
 	return cmdutil.WaitForSuccessfulDial(true, aggregatedAPIServer.GenericAPIServer.SecureServingInfo.BindNetwork, aggregatedAPIServer.GenericAPIServer.SecureServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
 }
 
-func (c *MasterConfig) buildHandlerChain(assetServerHandler http.Handler) func(apiHandler http.Handler, kc *apiserver.Config) http.Handler {
+func (c *MasterConfig) buildHandlerChain() (func(apiHandler http.Handler, kc *apiserver.Config) http.Handler, error) {
+	assetServerHandler, err := c.newAssetServerHandler()
+	if err != nil {
+		return nil, err
+	}
+	oauthServerHandler, err := c.newOAuthServerHandler()
+	if err != nil {
+		return nil, err
+	}
+
 	return func(apiHandler http.Handler, genericConfig *apiserver.Config) http.Handler {
+		// these are after the kube handler
 		handler := c.versionSkewFilter(apiHandler, genericConfig.RequestContextMapper)
+		handler = namespacingFilter(handler, genericConfig.RequestContextMapper)
+
+		// these are all equivalent to the kube handler chain
+		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		handler = serverhandlers.AuthorizationFilter(handler, c.Authorizer, c.AuthorizationAttributeBuilder, genericConfig.RequestContextMapper)
 		handler = serverhandlers.ImpersonationFilter(handler, c.Authorizer, cache.NewGroupCache(c.UserInformers.User().InternalVersion().Groups()), genericConfig.RequestContextMapper)
-
 		// audit handler must comes before the impersonationFilter to read the original user
 		if c.Options.AuditConfig.Enabled {
 			var writer io.Writer
@@ -307,20 +333,6 @@ func (c *MasterConfig) buildHandlerChain(assetServerHandler http.Handler) func(a
 			handler = apifilters.WithAudit(handler, genericConfig.RequestContextMapper, c.AuditBackend, auditPolicyChecker, genericConfig.LongRunningFunc)
 		}
 		handler = serverhandlers.AuthenticationHandlerFilter(handler, c.Authenticator, genericConfig.RequestContextMapper)
-		handler = namespacingFilter(handler, genericConfig.RequestContextMapper)
-		handler = cacheControlFilter(handler, "no-store") // protected endpoints should not be cached
-
-		if c.Options.OAuthConfig != nil {
-			authConfig, err := BuildAuthConfig(c)
-			if err != nil {
-				glog.Fatalf("Failed to setup OAuth2: %v", err)
-			}
-			handler, err = authConfig.WithOAuth(handler)
-			if err != nil {
-				glog.Fatalf("Failed to setup OAuth2: %v", err)
-			}
-		}
-
 		handler = apiserverfilters.WithCORS(handler, c.Options.CORSAllowedOrigins, nil, nil, nil, "true")
 		handler = apiserverfilters.WithTimeoutForNonLongRunningRequests(handler, genericConfig.RequestContextMapper, genericConfig.LongRunningFunc)
 		// TODO: MaxRequestsInFlight should be subdivided by intent, type of behavior, and speed of
@@ -330,6 +342,10 @@ func (c *MasterConfig) buildHandlerChain(assetServerHandler http.Handler) func(a
 		handler = apifilters.WithRequestInfo(handler, apiserver.NewRequestInfoResolver(genericConfig), genericConfig.RequestContextMapper)
 		handler = apirequest.WithRequestContext(handler, genericConfig.RequestContextMapper)
 		handler = apiserverfilters.WithPanicRecovery(handler)
+		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		// these handlers are all before the normal kube chain
+		handler = cacheControlFilter(handler, "no-store") // protected endpoints should not be cached
 
 		if c.WebConsoleEnabled() {
 			handler = assetapiserver.WithAssetServerRedirect(handler, c.Options.AssetConfig.PublicURL)
@@ -337,9 +353,10 @@ func (c *MasterConfig) buildHandlerChain(assetServerHandler http.Handler) func(a
 		// these handlers are actually separate API servers which have their own handler chains.
 		// our server embeds these
 		handler = c.withConsoleRedirection(handler, assetServerHandler, c.Options.AssetConfig)
+		handler = c.withOAuthRedirection(handler, oauthServerHandler)
 
 		return handler
-	}
+	}, nil
 }
 
 func (c *MasterConfig) withConsoleRedirection(handler, assetServerHandler http.Handler, assetConfig *configapi.AssetConfig) http.Handler {
@@ -361,7 +378,18 @@ func (c *MasterConfig) withConsoleRedirection(handler, assetServerHandler http.H
 	if publicURL.Path[lastIndex] == '/' {
 		prefix = publicURL.Path[0:lastIndex]
 	}
+
+	glog.Infof("Starting Web Console %s", assetConfig.PublicURL)
 	return WithPatternPrefixHandler(handler, assetServerHandler, prefix)
+}
+
+func (c *MasterConfig) withOAuthRedirection(handler, oauthServerHandler http.Handler) http.Handler {
+	if c.Options.OAuthConfig == nil {
+		return handler
+	}
+
+	glog.Infof("Starting OAuth2 API at %s", oauthutil.OpenShiftOAuthAPIPrefix)
+	return WithPatternPrefixHandler(handler, oauthServerHandler, openShiftOAuthAPIPrefix, openShiftLoginPrefix, openShiftOAuthCallbackPrefix)
 }
 
 // RouteAllocator returns a route allocation controller.

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -1053,12 +1053,6 @@ func (c *MasterConfig) KubeClientsetExternal() kclientsetexternal.Interface {
 	return c.PrivilegedLoopbackKubernetesClientsetExternal
 }
 
-// OAuthServerClients returns the openshift and kubernetes OAuth server client objects
-// The returned clients are privileged
-func (c *MasterConfig) OAuthServerClients() (*osclient.Client, kclientsetinternal.Interface) {
-	return c.PrivilegedLoopbackOpenShiftClient, c.PrivilegedLoopbackKubernetesClientsetInternal
-}
-
 // ServiceAccountRoleBindingClient returns the client object used to bind roles to service accounts
 // It must have the following capabilities:
 //  get, list, update, create policyBindings and clusterPolicyBindings in all namespaces

--- a/pkg/cmd/server/origin/oauth_apiserver_adapter.go
+++ b/pkg/cmd/server/origin/oauth_apiserver_adapter.go
@@ -1,0 +1,68 @@
+package origin
+
+import (
+	"net"
+	"strconv"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
+	oauthapiserver "github.com/openshift/origin/pkg/oauth/apiserver"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
+)
+
+// TODO this is taking a very large config for a small piece of it.  The information must be broken up at some point so that
+// we can run this in a pod.  This is an indication of leaky abstraction because it spent too much time in openshift start
+func NewOAuthServerConfigFromMasterConfig(masterConfig *MasterConfig) (*oauthapiserver.OAuthServerConfig, error) {
+	options := masterConfig.Options
+	servingConfig := options.ServingInfo
+	oauthConfig := masterConfig.Options.OAuthConfig
+
+	oauthServerConfig, err := oauthapiserver.NewOAuthServerConfig(*oauthConfig, &masterConfig.PrivilegedLoopbackClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	oauthServerConfig.GenericConfig.CorsAllowedOriginList = options.CORSAllowedOrigins
+
+	// TODO pull this out into a function
+	_, portString, err := net.SplitHostPort(servingConfig.BindAddress)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		return nil, err
+	}
+	secureServingOptions := apiserveroptions.SecureServingOptions{}
+	secureServingOptions.BindPort = port
+	secureServingOptions.ServerCert.CertKey.CertFile = servingConfig.ServerCert.CertFile
+	secureServingOptions.ServerCert.CertKey.KeyFile = servingConfig.ServerCert.KeyFile
+	for _, nc := range servingConfig.NamedCertificates {
+		sniCert := utilflag.NamedCertKey{
+			CertFile: nc.CertFile,
+			KeyFile:  nc.KeyFile,
+			Names:    nc.Names,
+		}
+		secureServingOptions.SNICertKeys = append(secureServingOptions.SNICertKeys, sniCert)
+	}
+	if err := secureServingOptions.ApplyTo(oauthServerConfig.GenericConfig); err != nil {
+		return nil, err
+	}
+	oauthServerConfig.GenericConfig.SecureServingInfo.BindAddress = servingConfig.BindAddress
+	oauthServerConfig.GenericConfig.SecureServingInfo.BindNetwork = servingConfig.BindNetwork
+	oauthServerConfig.GenericConfig.SecureServingInfo.MinTLSVersion = crypto.TLSVersionOrDie(servingConfig.MinTLSVersion)
+	oauthServerConfig.GenericConfig.SecureServingInfo.CipherSuites = crypto.CipherSuitesOrDie(servingConfig.CipherSuites)
+
+	oauthServerConfig.RESTOptionsGetter = masterConfig.RESTOptionsGetter
+	// TODO pass a privileged client config through during construction.  It is NOT a loopback client.
+	oauthServerConfig.OpenShiftClient = masterConfig.PrivilegedLoopbackOpenShiftClient
+	oauthServerConfig.KubeClient = masterConfig.PrivilegedLoopbackKubernetesClientsetInternal
+
+	// Build the list of valid redirect_uri prefixes for a login using the openshift-web-console client to redirect to
+	if !options.DisabledFeatures.Has(configapi.FeatureWebConsole) {
+		oauthServerConfig.AssetPublicAddresses = []string{oauthConfig.AssetPublicURL}
+	}
+
+	return oauthServerConfig, nil
+}

--- a/pkg/oauth/apiserver/handler_wrapper.go
+++ b/pkg/oauth/apiserver/handler_wrapper.go
@@ -1,4 +1,4 @@
-package origin
+package apiserver
 
 import (
 	"net/http"

--- a/pkg/oauth/apiserver/oauth_apiserver_test.go
+++ b/pkg/oauth/apiserver/oauth_apiserver_test.go
@@ -1,4 +1,4 @@
-package origin
+package apiserver
 
 import (
 	"io/ioutil"

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	"github.com/openshift/origin/pkg/cmd/server/origin"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapiserver "github.com/openshift/origin/pkg/oauth/apiserver"
 	"github.com/openshift/origin/pkg/oc/admin/policy"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -80,7 +80,7 @@ func TestNodeAuth(t *testing.T) {
 	}
 	whoamiOnlyBobToken := &oauthapi.OAuthAccessToken{
 		ObjectMeta: metav1.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
-		ClientName: origin.OpenShiftCLIClientID,
+		ClientName: oauthapiserver.OpenShiftCLIClientID,
 		ExpiresIn:  200,
 		Scopes:     []string{scope.UserInfo},
 		UserName:   bobUser.Name,

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/cmd/server/origin"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapiserver "github.com/openshift/origin/pkg/oauth/apiserver"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -56,7 +56,7 @@ func TestScopedTokens(t *testing.T) {
 
 	whoamiOnlyToken := &oauthapi.OAuthAccessToken{
 		ObjectMeta: metav1.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
-		ClientName: origin.OpenShiftCLIClientID,
+		ClientName: oauthapiserver.OpenShiftCLIClientID,
 		ExpiresIn:  200,
 		Scopes:     []string{scope.UserInfo},
 		UserName:   userName,
@@ -176,7 +176,7 @@ func TestScopeEscalations(t *testing.T) {
 
 	nonEscalatingEditToken := &oauthapi.OAuthAccessToken{
 		ObjectMeta: metav1.ObjectMeta{Name: "non-escalating-edit-plus-some-padding-here-to-make-the-limit"},
-		ClientName: origin.OpenShiftCLIClientID,
+		ClientName: oauthapiserver.OpenShiftCLIClientID,
 		ExpiresIn:  200,
 		Scopes:     []string{scope.ClusterRoleIndicator + "edit:*"},
 		UserName:   userName,
@@ -199,7 +199,7 @@ func TestScopeEscalations(t *testing.T) {
 
 	escalatingEditToken := &oauthapi.OAuthAccessToken{
 		ObjectMeta: metav1.ObjectMeta{Name: "escalating-edit-plus-some-padding-here-to-make-the-limit"},
-		ClientName: origin.OpenShiftCLIClientID,
+		ClientName: oauthapiserver.OpenShiftCLIClientID,
 		ExpiresIn:  200,
 		Scopes:     []string{scope.ClusterRoleIndicator + "edit:*:!"},
 		UserName:   userName,

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -194,7 +194,7 @@ func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
 	linkRegexps := make([]string, 0)
 
 	// Verify that the plain /login URI is unavailable when multiple IDPs are in use.
-	urlMap["/login"] = urlResults{http.StatusForbidden, ""}
+	urlMap["/login"] = urlResults{http.StatusNotFound, ""}
 
 	// Create the common base URLs
 	escapedPublicURL := url.QueryEscape(masterOptions.OAuthConfig.AssetPublicURL)


### PR DESCRIPTION
@openshift/sig-security fyi

This moves the oauth API server to its own package to make it a little more obvious where pieces come from.  It does not restructure the oauth server.

Doing this enables us to organize our handler chain into before and after the standard upstream chain.