### PR TITLE
openshift always serves securely, so disallow non-tls serving info

### DIFF
--- a/pkg/cmd/server/api/helpers.go
+++ b/pkg/cmd/server/api/helpers.go
@@ -429,10 +429,6 @@ func DefaultClientTransport(rt http.RoundTripper) http.RoundTripper {
 	return transport
 }
 
-func UseTLS(servingInfo ServingInfo) bool {
-	return len(servingInfo.ServerCert.CertFile) > 0
-}
-
 // GetAPIClientCertCAPool returns the cert pool used to validate client certificates to the API server
 func GetAPIClientCertCAPool(options MasterConfig) (*x509.CertPool, error) {
 	return cmdutil.CertPoolFromFile(options.ServingInfo.ClientCA)
@@ -484,10 +480,6 @@ func GetClientCertCAPool(options MasterConfig) (*x509.CertPool, error) {
 }
 
 func GetOAuthClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
-	if !UseTLS(options.ServingInfo.ServingInfo) {
-		return nil, nil
-	}
-
 	allCerts := []*x509.Certificate{}
 
 	if options.OAuthConfig != nil {
@@ -512,9 +504,6 @@ func GetOAuthClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
 }
 
 func GetRequestHeaderClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
-	if !UseTLS(options.ServingInfo.ServingInfo) {
-		return nil, nil
-	}
 	if options.AuthConfig.RequestHeader == nil {
 		return nil, nil
 	}
@@ -527,10 +516,6 @@ func GetRequestHeaderClientCertCAs(options MasterConfig) ([]*x509.Certificate, e
 }
 
 func getAPIClientCertCAs(options MasterConfig) ([]*x509.Certificate, error) {
-	if !UseTLS(options.ServingInfo.ServingInfo) {
-		return nil, nil
-	}
-
 	return cmdutil.CertificatesFromFile(options.ServingInfo.ClientCA)
 }
 

--- a/pkg/cmd/server/api/validation/etcd.go
+++ b/pkg/cmd/server/api/validation/etcd.go
@@ -32,12 +32,7 @@ func ValidateEtcdConnectionInfo(config api.EtcdConnectionInfo, server *api.EtcdC
 
 	// If we have server config info, make sure the client connection info will work with it
 	if server != nil {
-		var builtInAddress string
-		if api.UseTLS(server.ServingInfo) {
-			builtInAddress = fmt.Sprintf("https://%s", server.Address)
-		} else {
-			builtInAddress = fmt.Sprintf("http://%s", server.Address)
-		}
+		var builtInAddress = fmt.Sprintf("https://%s", server.Address)
 
 		// Require a client cert to connect to an etcd that requires client certs
 		if len(server.ServingInfo.ClientCA) > 0 {

--- a/pkg/cmd/server/api/validation/validation.go
+++ b/pkg/cmd/server/api/validation/validation.go
@@ -109,7 +109,7 @@ func ValidateServingInfo(info api.ServingInfo, fldPath *field.Path) ValidationRe
 	validationResults := ValidationResults{}
 
 	validationResults.AddErrors(ValidateHostPort(info.BindAddress, fldPath.Child("bindAddress"))...)
-	validationResults.AddErrors(ValidateCertInfo(info.ServerCert, false, fldPath)...)
+	validationResults.AddErrors(ValidateCertInfo(info.ServerCert, true, fldPath)...)
 
 	if len(info.NamedCertificates) > 0 && len(info.ServerCert.CertFile) == 0 {
 		validationResults.AddErrors(field.Invalid(fldPath.Child("namedCertificates"), "", "a default certificate and key is required in certFile/keyFile in order to use namedCertificates"))

--- a/pkg/cmd/server/api/validation/validation_test.go
+++ b/pkg/cmd/server/api/validation/validation_test.go
@@ -36,6 +36,10 @@ func TestValidateServingInfo(t *testing.T) {
 				BindAddress: "0.0.0.0:1234",
 				BindNetwork: "tcp",
 			},
+			ExpectedErrors: []string{
+				"certFile: Required value: The certificate file must be provided",
+				"keyFile: Required value: The certificate key must be provided",
+			},
 		},
 		"missing key": {
 			ServingInfo: api.ServingInfo{
@@ -46,6 +50,7 @@ func TestValidateServingInfo(t *testing.T) {
 				},
 			},
 			ExpectedErrors: []string{
+				"keyFile: Required value: The certificate key must be provided",
 				"certFile: Required value: Both the certificate file and the certificate key must be provided together or not at all",
 				"keyFile: Required value: Both the certificate file and the certificate key must be provided together or not at all",
 			},
@@ -91,7 +96,11 @@ func TestValidateServingInfo(t *testing.T) {
 					{Names: []string{"example.com"}, CertInfo: api.CertInfo{CertFile: certFileName, KeyFile: keyFileName}},
 				},
 			},
-			ExpectedErrors: []string{"namedCertificates: Invalid value"},
+			ExpectedErrors: []string{
+				"certFile: Required value: The certificate file must be provided",
+				"keyFile: Required value: The certificate key must be provided",
+				"namedCertificates: Invalid value",
+			},
 		},
 
 		"namedCertificates with missing names": {

--- a/pkg/cmd/server/etcd/etcdserver/run.go
+++ b/pkg/cmd/server/etcd/etcdserver/run.go
@@ -23,26 +23,22 @@ func RunEtcd(etcdServerConfig *configapi.EtcdConfig) {
 	cfg.Name = defaultName
 	cfg.Dir = etcdServerConfig.StorageDir
 
-	clientTLS := configapi.UseTLS(etcdServerConfig.ServingInfo)
-	if clientTLS {
-		cfg.ClientTLSInfo.CAFile = etcdServerConfig.ServingInfo.ClientCA
-		cfg.ClientTLSInfo.CertFile = etcdServerConfig.ServingInfo.ServerCert.CertFile
-		cfg.ClientTLSInfo.KeyFile = etcdServerConfig.ServingInfo.ServerCert.KeyFile
-		cfg.ClientTLSInfo.ClientCertAuth = len(cfg.ClientTLSInfo.CAFile) > 0
-	}
+	clientTLS := true
+	cfg.ClientTLSInfo.CAFile = etcdServerConfig.ServingInfo.ClientCA
+	cfg.ClientTLSInfo.CertFile = etcdServerConfig.ServingInfo.ServerCert.CertFile
+	cfg.ClientTLSInfo.KeyFile = etcdServerConfig.ServingInfo.ServerCert.KeyFile
+	cfg.ClientTLSInfo.ClientCertAuth = len(cfg.ClientTLSInfo.CAFile) > 0
 	u, err := types.NewURLs(addressToURLs(etcdServerConfig.ServingInfo.BindAddress, clientTLS))
 	if err != nil {
 		glog.Fatalf("Unable to build etcd peer URLs: %v", err)
 	}
 	cfg.LCUrls = []url.URL(u)
 
-	peerTLS := configapi.UseTLS(etcdServerConfig.PeerServingInfo)
-	if peerTLS {
-		cfg.PeerTLSInfo.CAFile = etcdServerConfig.PeerServingInfo.ClientCA
-		cfg.PeerTLSInfo.CertFile = etcdServerConfig.PeerServingInfo.ServerCert.CertFile
-		cfg.PeerTLSInfo.KeyFile = etcdServerConfig.PeerServingInfo.ServerCert.KeyFile
-		cfg.PeerTLSInfo.ClientCertAuth = len(cfg.PeerTLSInfo.CAFile) > 0
-	}
+	peerTLS := true
+	cfg.PeerTLSInfo.CAFile = etcdServerConfig.PeerServingInfo.ClientCA
+	cfg.PeerTLSInfo.CertFile = etcdServerConfig.PeerServingInfo.ServerCert.CertFile
+	cfg.PeerTLSInfo.KeyFile = etcdServerConfig.PeerServingInfo.ServerCert.KeyFile
+	cfg.PeerTLSInfo.ClientCertAuth = len(cfg.PeerTLSInfo.CAFile) > 0
 	u, err = types.NewURLs(addressToURLs(etcdServerConfig.PeerServingInfo.BindAddress, peerTLS))
 	if err != nil {
 		glog.Fatalf("Unable to build etcd peer URLs: %v", err)

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -672,10 +672,6 @@ func DefaultOpenAPIConfig(config configapi.MasterConfig) *openapicommon.Config {
 			},
 		}
 	}
-	if configapi.UseTLS(config.ServingInfo.ServingInfo) {
-		// No support in Swagger's OpenAPI sepc v.2 ¯\_(ツ)_/¯
-		// TODO: Add x509 specification once available
-	}
 	defNamer := apiserverendpointsopenapi.NewDefinitionNamer(kapi.Scheme)
 	return &openapicommon.Config{
 		ProtocolList:      []string{"https"},

--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -282,29 +282,25 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	}
 
 	// TODO: could be cleaner
-	if configapi.UseTLS(options.ServingInfo) {
-		extraCerts, err := configapi.GetNamedCertificateMap(options.ServingInfo.NamedCertificates)
-		if err != nil {
-			return nil, err
-		}
-		deps.TLSOptions = &kubeletserver.TLSOptions{
-			Config: crypto.SecureTLSConfig(&tls.Config{
-				// RequestClientCert lets us request certs, but allow requests without client certs
-				// Verification is done by the authn layer
-				ClientAuth: tls.RequestClientCert,
-				ClientCAs:  clientCAs,
-				// Set SNI certificate func
-				// Do not use NameToCertificate, since that requires certificates be included in the server's tlsConfig.Certificates list,
-				// which we do not control when running with http.Server#ListenAndServeTLS
-				GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
-				MinVersion:     crypto.TLSVersionOrDie(options.ServingInfo.MinTLSVersion),
-				CipherSuites:   crypto.CipherSuitesOrDie(options.ServingInfo.CipherSuites),
-			}),
-			CertFile: options.ServingInfo.ServerCert.CertFile,
-			KeyFile:  options.ServingInfo.ServerCert.KeyFile,
-		}
-	} else {
-		deps.TLSOptions = nil
+	extraCerts, err := configapi.GetNamedCertificateMap(options.ServingInfo.NamedCertificates)
+	if err != nil {
+		return nil, err
+	}
+	deps.TLSOptions = &kubeletserver.TLSOptions{
+		Config: crypto.SecureTLSConfig(&tls.Config{
+			// RequestClientCert lets us request certs, but allow requests without client certs
+			// Verification is done by the authn layer
+			ClientAuth: tls.RequestClientCert,
+			ClientCAs:  clientCAs,
+			// Set SNI certificate func
+			// Do not use NameToCertificate, since that requires certificates be included in the server's tlsConfig.Certificates list,
+			// which we do not control when running with http.Server#ListenAndServeTLS
+			GetCertificate: cmdutil.GetCertificateFunc(extraCerts),
+			MinVersion:     crypto.TLSVersionOrDie(options.ServingInfo.MinTLSVersion),
+			CipherSuites:   crypto.CipherSuitesOrDie(options.ServingInfo.CipherSuites),
+		}),
+		CertFile: options.ServingInfo.ServerCert.CertFile,
+		KeyFile:  options.ServingInfo.ServerCert.KeyFile,
 	}
 
 	sdnProxy, err := sdnplugin.NewProxyPlugin(options.NetworkConfig.NetworkPluginName, originClient, kubeClient)

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -136,8 +136,6 @@ type MasterConfig struct {
 	// of both the origin config AND the kube config, so this spot makes more sense.
 	KubeAdmissionControl admission.Interface
 
-	TLS bool
-
 	// ImageFor is a function that returns the appropriate image to use for a named component
 	ImageFor func(component string) string
 	// RegistryNameFn retrieves the name of the integrated registry, or false if no such registry
@@ -358,8 +356,6 @@ func BuildMasterConfig(options configapi.MasterConfig, informers InformerAccess)
 
 		AdmissionControl:     originAdmission,
 		KubeAdmissionControl: kubeAdmission,
-
-		TLS: configapi.UseTLS(options.ServingInfo.ServingInfo),
 
 		ImageFor:       imageTemplate.ExpandOrDie,
 		RegistryNameFn: imageapi.DefaultRegistryFunc(defaultRegistryFunc),
@@ -951,15 +947,13 @@ func newAuthenticator(config configapi.MasterConfig, restOptionsGetter restoptio
 		authenticators = append(authenticators, union.New(tokenAuthenticators...))
 	}
 
-	if configapi.UseTLS(config.ServingInfo.ServingInfo) {
-		// build cert authenticator
-		// TODO: add "system:" prefix in authenticator, limit cert to username
-		// TODO: add "system:" prefix to groups in authenticator, limit cert to group name
-		opts := x509request.DefaultVerifyOptions()
-		opts.Roots = apiClientCAs
-		certauth := x509request.New(opts, x509request.CommonNameUserConversion)
-		authenticators = append(authenticators, certauth)
-	}
+	// build cert authenticator
+	// TODO: add "system:" prefix in authenticator, limit cert to username
+	// TODO: add "system:" prefix to groups in authenticator, limit cert to group name
+	opts := x509request.DefaultVerifyOptions()
+	opts.Roots = apiClientCAs
+	certauth := x509request.New(opts, x509request.CommonNameUserConversion)
+	authenticators = append(authenticators, certauth)
 
 	resultingAuthenticator := union.NewFailOnError(authenticators...)
 

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -292,29 +292,27 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		},
 	}
 
-	if args.ListenArg.UseTLS() {
-		config.ServingInfo.ServerCert = admin.DefaultMasterServingCertInfo(args.ConfigDir.Value())
-		config.ServingInfo.ClientCA = admin.DefaultAPIClientCAFile(args.ConfigDir.Value())
+	config.ServingInfo.ServerCert = admin.DefaultMasterServingCertInfo(args.ConfigDir.Value())
+	config.ServingInfo.ClientCA = admin.DefaultAPIClientCAFile(args.ConfigDir.Value())
 
-		config.AssetConfig.ServingInfo.ServerCert = admin.DefaultAssetServingCertInfo(args.ConfigDir.Value())
+	config.AssetConfig.ServingInfo.ServerCert = admin.DefaultAssetServingCertInfo(args.ConfigDir.Value())
 
-		if oauthConfig != nil {
-			s := admin.DefaultCABundleFile(args.ConfigDir.Value())
-			oauthConfig.MasterCA = &s
-		}
+	if oauthConfig != nil {
+		s := admin.DefaultCABundleFile(args.ConfigDir.Value())
+		oauthConfig.MasterCA = &s
+	}
 
-		// Only set up ca/cert info for kubelet connections if we're self-hosting Kubernetes
-		if builtInKubernetes {
-			config.KubeletClientInfo.CA = admin.DefaultRootCAFile(args.ConfigDir.Value())
-			config.KubeletClientInfo.ClientCert = kubeletClientInfo.CertLocation
-			config.ServiceAccountConfig.MasterCA = admin.DefaultCABundleFile(args.ConfigDir.Value())
-		}
+	// Only set up ca/cert info for kubelet connections if we're self-hosting Kubernetes
+	if builtInKubernetes {
+		config.KubeletClientInfo.CA = admin.DefaultRootCAFile(args.ConfigDir.Value())
+		config.KubeletClientInfo.ClientCert = kubeletClientInfo.CertLocation
+		config.ServiceAccountConfig.MasterCA = admin.DefaultCABundleFile(args.ConfigDir.Value())
+	}
 
-		// Only set up ca/cert info for etcd connections if we're self-hosting etcd
-		if builtInEtcd {
-			config.EtcdClientInfo.CA = admin.DefaultRootCAFile(args.ConfigDir.Value())
-			config.EtcdClientInfo.ClientCert = etcdClientInfo.CertLocation
-		}
+	// Only set up ca/cert info for etcd connections if we're self-hosting etcd
+	if builtInEtcd {
+		config.EtcdClientInfo.CA = admin.DefaultRootCAFile(args.ConfigDir.Value())
+		config.EtcdClientInfo.ClientCert = etcdClientInfo.CertLocation
 	}
 
 	if builtInKubernetes {

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -118,12 +118,11 @@ func TestNodeAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	nodeTLS := configapi.UseTLS(nodeConfig.ServingInfo)
 
 	kubeletClientConfig := func(config *restclient.Config) *kubeletclient.KubeletClientConfig {
 		return &kubeletclient.KubeletClientConfig{
 			Port:            uint(nodePortInt),
-			EnableHttps:     nodeTLS,
+			EnableHttps:     true,
 			TLSClientConfig: config.TLSClientConfig,
 			BearerToken:     config.BearerToken,
 		}

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -399,14 +399,13 @@ func StartConfiguredNode(nodeConfig *configapi.NodeConfig, components *utilflags
 	if err != nil {
 		return err
 	}
-	nodeTLS := configapi.UseTLS(nodeConfig.ServingInfo)
 
 	if err := start.StartNode(*nodeConfig, components); err != nil {
 		return err
 	}
 
 	// wait for the server to come up for 30 seconds (average time on desktop is 2 seconds, but Jenkins timed out at 10 seconds)
-	if err := cmdutil.WaitForSuccessfulDial(nodeTLS, "tcp", net.JoinHostPort(nodeConfig.NodeName, nodePort), 100*time.Millisecond, 1*time.Second, 30); err != nil {
+	if err := cmdutil.WaitForSuccessfulDial(true, "tcp", net.JoinHostPort(nodeConfig.NodeName, nodePort), 100*time.Millisecond, 1*time.Second, 30); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
OpenShift shipped 3.0 with the intent to always serve securely.  Our authentication story doesn't even work without it since we bootstrap with client certs.  Any insecure option that appeared to work was coincidence.

This updates validation to fail and removes the option.

@liggitt @openshift/sig-security 