### PR TITLE
Properly handle errors in policy listing

### DIFF
--- a/pkg/authorization/registry/clusterpolicy/registry.go
+++ b/pkg/authorization/registry/clusterpolicy/registry.go
@@ -100,6 +100,9 @@ func NewSimulatedRegistry(clusterRegistry Registry) policy.Registry {
 
 func (s *simulatedStorage) ListPolicies(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.PolicyList, error) {
 	ret, err := s.clusterRegistry.ListClusterPolicies(ctx, options)
+	if err != nil {
+		return nil, err
+	}
 	return authorizationapi.ToPolicyList(ret), err
 }
 
@@ -113,6 +116,9 @@ func (s *simulatedStorage) UpdatePolicy(ctx apirequest.Context, policy *authoriz
 
 func (s *simulatedStorage) GetPolicy(ctx apirequest.Context, name string, options *metav1.GetOptions) (*authorizationapi.Policy, error) {
 	ret, err := s.clusterRegistry.GetClusterPolicy(ctx, name, options)
+	if err != nil {
+		return nil, err
+	}
 	return authorizationapi.ToPolicy(ret), err
 }
 

--- a/pkg/authorization/registry/clusterpolicybinding/registry.go
+++ b/pkg/authorization/registry/clusterpolicybinding/registry.go
@@ -100,6 +100,9 @@ func NewSimulatedRegistry(clusterRegistry Registry) policybinding.Registry {
 
 func (s *simulatedStorage) ListPolicyBindings(ctx apirequest.Context, options *metainternal.ListOptions) (*authorizationapi.PolicyBindingList, error) {
 	ret, err := s.clusterRegistry.ListClusterPolicyBindings(ctx, options)
+	if err != nil {
+		return nil, err
+	}
 	return authorizationapi.ToPolicyBindingList(ret), err
 }
 
@@ -113,6 +116,9 @@ func (s *simulatedStorage) UpdatePolicyBinding(ctx apirequest.Context, policyBin
 
 func (s *simulatedStorage) GetPolicyBinding(ctx apirequest.Context, name string, options *metav1.GetOptions) (*authorizationapi.PolicyBinding, error) {
 	ret, err := s.clusterRegistry.GetClusterPolicyBinding(ctx, name, options)
+	if err != nil {
+		return nil, err
+	}
 	return authorizationapi.ToPolicyBinding(ret), err
 }
 


### PR DESCRIPTION
In some policy{binding} function a conversion is performed after listing,
but error checking is not properly performed on the previous listing
function return.
This can cause panics on errors.

Fixes #15747
