### PR TITLE
dind: add support for ovn-kubernetes network plugin

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -435,17 +435,22 @@ function get-network-plugin() {
   local ovn_plugin="ovn"
   local default_plugin="${multitenant_plugin}"
 
-  if [[ "${plugin}" != "${subnet_plugin}" &&
-          "${plugin}" != "${multitenant_plugin}" &&
-          "${plugin}" != "${networkpolicy_plugin}" &&
-          "${plugin}" != "${ovn_plugin}" &&
-          "${plugin}" != "cni" ]]; then
-    if [[ -n "${plugin}" ]]; then
-      >&2 echo "Invalid network plugin: ${plugin}"
-    fi
-    plugin="${default_plugin}"
+  if [[ "${plugin}" = "subnet" || "${plugin}" = "${subnet_plugin}" ]]; then
+    echo "${subnet_plugin}"
+  elif [[ "${plugin}" = "multitenant" || "${plugin}" = "${multitenant_plugin}" ]]; then
+    echo "${multitenant_plugin}"
+  elif [[ "${plugin}" = "networkpolicy" || "${plugin}" = "${networkpolicy_plugin}" ]]; then
+    echo "${networkpolicy_plugin}"
+  elif [[ "${plugin}" = "ovn" ]]; then
+    echo "${ovn_plugin}"
+  elif [[ "${plugin}" = "cni" ]]; then
+    echo "cni"
+  elif [[ -n "${plugin}" ]]; then
+    >&2 echo "Invalid network plugin: ${plugin}"
+    exit 1
+  else
+    echo "${default_plugin}"
   fi
-  echo "${plugin}"
 }
 
 function get-docker-ip() {

--- a/images/dind/master/Dockerfile
+++ b/images/dind/master/Dockerfile
@@ -27,3 +27,12 @@ RUN systemctl enable openshift-master.service
 
 RUN mkdir -p /etc/systemd/system/openshift-node.service.d
 COPY master-node.conf /etc/systemd/system/openshift-node.service.d/
+
+COPY ovn-kubernetes-master-setup.service /etc/systemd/system/
+COPY ovn-kubernetes-master-setup.sh /usr/local/bin/
+RUN systemctl enable ovn-kubernetes-master-setup.service
+
+COPY ovn-kubernetes-master.service /etc/systemd/system/
+COPY ovn-kubernetes-master.sh /usr/local/bin/
+RUN systemctl enable ovn-kubernetes-master.service
+

--- a/images/dind/master/ovn-kubernetes-master-setup.service
+++ b/images/dind/master/ovn-kubernetes-master-setup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup for ovn-kubernetes master network plugin
+Requires=openshift-master.service
+After=openshift-master.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ovn-kubernetes-master-setup.sh
+
+[Install]
+WantedBy=openshift-master.service

--- a/images/dind/master/ovn-kubernetes-master-setup.sh
+++ b/images/dind/master/ovn-kubernetes-master-setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+source /data/network-plugin
+source /data/ovn-kubernetes
+
+function is-api-running() {
+  local config=$1
+
+  /usr/local/bin/oc --config="${kube_config}" get --raw /healthz/ready &> /dev/null
+}
+
+function ovn-kubernetes-master-setup() {
+  local config_dir=$1
+  local kube_config="${config_dir}/admin.kubeconfig"
+
+  local msg="apiserver to become alive"
+  os::util::wait-for-condition "${msg}" "is-api-running ${kube_config}"
+
+  systemctl enable ovn-northd
+  systemctl start ovn-northd
+
+  ln -sf /data/ovnkube /usr/local/bin/
+  ln -sf /data/ovn-kube-util /usr/local/bin/
+  ln -sf /data/ovn-k8s-cni-overlay /usr/local/bin/
+  ln -sf /data/ovn-k8s-gateway-helper /usr/local/bin/
+  ln -sf /data/ovn-k8s-overlay /usr/local/bin
+  ln -sf /data/ovn-k8s-util /usr/local/bin/
+  ln -sf /data/ovn-k8s-watcher /usr/local/bin/
+  mkdir -p /usr/lib/python2.7/site-packages
+  ln -sf /data/ovn_k8s /usr/lib/python2.7/site-packages/
+
+  # Create the service account for OVN stuff
+  if ! /usr/local/bin/oc --config="${kube_config}" get serviceaccount ovn >/dev/null 2>&1; then
+    /usr/local/bin/oc --config="${kube_config}" create serviceaccount ovn
+    /usr/local/bin/oadm --config="${kube_config}" policy add-cluster-role-to-user cluster-admin -z ovn
+    # rhbz#1383707: need to add ovn SA to anyuid SCC to allow pod annotation updates
+    /usr/local/bin/oadm --config="${kube_config}" policy add-scc-to-user anyuid -z ovn
+  fi
+
+  /usr/local/bin/oc --config="${kube_config}" sa get-token ovn > ${config_dir}/ovn.token
+}
+
+if [[ -n "${OPENSHIFT_OVN_KUBERNETES}" ]]; then
+  ovn-kubernetes-master-setup /data/openshift.local.config/master
+fi

--- a/images/dind/master/ovn-kubernetes-master.service
+++ b/images/dind/master/ovn-kubernetes-master.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Setup for ovn-kubernetes master
+Requires=openshift-master.service
+After=openshift-master.service
+After=ovn-kubernetes-master-setup.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ovn-kubernetes-master.sh
+
+[Install]
+WantedBy=openshift-master.service
+WantedBy=ovn-kubernetes-master-setup.service
+

--- a/images/dind/master/ovn-kubernetes-master.sh
+++ b/images/dind/master/ovn-kubernetes-master.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+source /data/network-plugin
+source /data/ovn-kubernetes
+
+function ovn-kubernetes-master() {
+  local config_dir=$1
+  local kube_config="${config_dir}/admin.kubeconfig"
+
+  token=$(cat ${config_dir}/ovn.token)
+
+  local master_config="${config_dir}/master-config.yaml"
+  cluster_cidr=$(python -c "import yaml; stream = file('${master_config}', 'r'); y = yaml.load(stream); print y['networkConfig']['clusterNetworkCIDR']")
+  apiserver=$(oc --config="${kube_config}" config view -o custom-columns=server:clusters[0].cluster.server | grep http)
+  ovn_master_ip=$(echo -n ${apiserver} | cut -d "/" -f 3 | cut -d ":" -f 1)
+
+  echo "Enabling and start ovn-kubernetes master services"
+  /usr/local/bin/ovnkube \
+	--apiserver "${apiserver}" \
+	--ca-cert "${config_dir}/ca.crt" \
+	--token "${token}" \
+	--cluster-subnet "${cluster_cidr}" \
+	--ovn-north-db "tcp://${ovn_master_ip}:6641" \
+	--ovn-south-db "tcp://${ovn_master_ip}:6642" \
+	--init-master `hostname` \
+	--net-controller
+}
+
+if [[ -n "${OPENSHIFT_OVN_KUBERNETES}" ]]; then
+  ovn-kubernetes-master /data/openshift.local.config/master
+fi

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -21,12 +21,19 @@ RUN dnf -y update && dnf -y install\
  bridge-utils\
  ethtool\
  iptables-services\
- openvswitch
+ openvswitch\
+ python-netaddr\
+ python2-pyroute2\
+ python2-requests\
+ PyYAML
 
-# Upgrade to a newer OVS. (This can go away when the base image is upgraded to F26.)
+# Upgrade to a newer OVS and install OVN packages that are only available
+# with the newer release. (This can go away when the base image is upgraded to
+# OVS 2.8 prerelease or release versions and include OVN sub-packages)
 RUN dnf -y install dnf-plugins-core &&\
- dnf -y copr enable danw/origin-dind-ovs &&\
- dnf -y update openvswitch
+ dnf -y copr enable leifmadsen/ovs-master &&\
+ dnf -y update openvswitch &&\
+ dnf -y install openvswitch-ovn-*
 
 # A default deny firewall (either iptables or firewalld) is
 # installed by default on non-cloud fedora and rhel, so all
@@ -75,3 +82,11 @@ RUN ln -sf /data/openshift /usr/local/bin/ && \
     ln -sf /data/loopback      /opt/cni/bin/
 
 ENV KUBECONFIG /data/openshift.local.config/master/admin.kubeconfig
+
+COPY ovn-kubernetes-node-setup.service /etc/systemd/system/
+COPY ovn-kubernetes-node-setup.sh /usr/local/bin/
+RUN systemctl enable ovn-kubernetes-node-setup.service
+
+COPY ovn-kubernetes-node.service /etc/systemd/system/
+COPY ovn-kubernetes-node.sh /usr/local/bin/
+RUN systemctl enable ovn-kubernetes-node.service

--- a/images/dind/node/ovn-kubernetes-node-setup.service
+++ b/images/dind/node/ovn-kubernetes-node-setup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup for ovn-kubernetes node network plugin
+Requires=openshift-node.service
+After=openshift-node.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ovn-kubernetes-node-setup.sh
+
+[Install]
+WantedBy=openshift-node.service

--- a/images/dind/node/ovn-kubernetes-node-setup.sh
+++ b/images/dind/node/ovn-kubernetes-node-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+source /data/network-plugin
+source /data/ovn-kubernetes
+
+function is-api-running() {
+  local config=$1
+
+  /usr/local/bin/oc --config="${kube_config}" get --raw /healthz/ready &> /dev/null
+}
+
+function ovn-kubernetes-node-setup() {
+  local config_dir=$1
+  local kube_config="${config_dir}/node.kubeconfig"
+
+  local msg="apiserver to become alive"
+  os::util::wait-for-condition "${msg}" "is-api-running ${kube_config}"
+
+  ln -sf /data/ovnkube /usr/local/bin/
+  ln -sf /data/ovn-kube-util /usr/local/bin/
+  ln -sf /data/ovn-k8s-cni-overlay /usr/local/bin/
+  ln -sf /data/ovn-k8s-gateway-helper /usr/local/bin/
+  ln -sf /data/ovn-k8s-overlay /usr/local/bin
+  ln -sf /data/ovn-k8s-util /usr/local/bin/
+  ln -sf /data/ovn-k8s-watcher /usr/local/bin/
+  mkdir -p /usr/lib/python2.7/site-packages
+  ln -sf /data/ovn_k8s /usr/lib/python2.7/site-packages/
+}
+
+if [[ -n "${OPENSHIFT_OVN_KUBERNETES}" ]]; then
+  ovn-kubernetes-node-setup /var/lib/origin/openshift.local.config/node/
+fi

--- a/images/dind/node/ovn-kubernetes-node.service
+++ b/images/dind/node/ovn-kubernetes-node.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Setup for ovn-kubernetes node
+Requires=openshift-node.service
+After=openshift-node.service
+After=ovn-kubernetes-node-setup.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ovn-kubernetes-node.sh
+
+[Install]
+WantedBy=openshift-node.service
+WantedBy=ovn-kubernetes-node-setup.service
+

--- a/images/dind/node/ovn-kubernetes-node.sh
+++ b/images/dind/node/ovn-kubernetes-node.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /usr/local/bin/openshift-dind-lib.sh
+source /data/network-plugin
+source /data/ovn-kubernetes
+
+function is-northd-running() {
+  local northd_ip=$1
+
+  ovn-nbctl --timeout=2 "--db=tcp:${northd_ip}:6641" ls-list
+}
+
+function have-token() {
+  local master_dir=$1
+
+  cat ${master_dir}/ovn.token > /dev/null
+}
+
+function ovn-kubernetes-node() {
+  local config_dir=$1
+  local master_dir=$2
+  local kube_config="${config_dir}/node.kubeconfig"
+
+  os::util::wait-for-condition "kubernetes token" "have-token ${master_dir}" "120"
+
+  token=$(cat ${master_dir}/ovn.token)
+
+  cat >"/etc/openvswitch/ovn_k8s.conf" <<EOF
+[default]
+k8s_ca_certificate=${config_dir}/ca.crt
+EOF
+
+  local host
+  host="$(hostname)"
+  if os::util::is-master; then
+    host="${host}-node"
+  fi
+
+  local node_config="${config_dir}/node-config.yaml"
+  local master_config="${master_dir}/master-config.yaml"
+  cluster_cidr=$(python -c "import yaml; stream = file('${master_config}', 'r'); y = yaml.load(stream); print y['networkConfig']['clusterNetworkCIDR']")
+  apiserver=$(grep server ${kube_config} | cut -f 6 -d' ')
+  ovn_master_ip=$(echo -n ${apiserver} | cut -d "/" -f 3 | cut -d ":" -f 1)
+
+  os::util::wait-for-condition "ovn-northd" "is-northd-running ${ovn_master_ip}" "120"
+
+  echo "Enabling and start ovn-kubernetes node services"
+  /usr/local/bin/ovnkube \
+	--apiserver "${apiserver}" \
+	--ca-cert "${config_dir}/ca.crt" \
+	--token "${token}" \
+	--cluster-subnet "${cluster_cidr}" \
+	--ovn-north-db "tcp://${ovn_master_ip}:6641" \
+	--ovn-south-db "tcp://${ovn_master_ip}:6642" \
+	--init-node ${host}
+}
+
+if [[ -n "${OPENSHIFT_OVN_KUBERNETES}" ]]; then
+  ovn-kubernetes-node /var/lib/origin/openshift.local.config/node /data/openshift.local.config/master
+fi


### PR DESCRIPTION
@rajatchopra here's the Origin part...

Operation:
1) get a git checkout of ovn-kubernetes with my changes: https://github.com/openvswitch/ovn-kubernetes/pull/141
2) rebuild your DIND images `hack/dind-cluster.sh build-images`
3) `OVN_ROOT=/path/to/ovn-kubernetes hack/dind-cluster.sh start -o`
