### PR TITLE
Fix NodePort test

### DIFF
--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -16,7 +16,7 @@ export SHELLOPTS
 #
 # The EmptyDir test is a canary; it will fail if mount propagation is
 # not properly configured on the host.
-NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Feature:OSNetworkPolicy|EmptyDir volumes should support \(root,0644,tmpfs\)}"
+NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services should be able to create a functioning NodePort service|Feature:OSNetworkPolicy|EmptyDir volumes should support \(root,0644,tmpfs\)}"
 NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
 
 DEFAULT_SKIP_LIST=(

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -298,9 +298,6 @@ var (
 		`validates resource limits of pods that are allowed to run`, // SchedulerPredicates
 		`should idle the service and DeploymentConfig properly`,     // idling with a single service and DeploymentConfig [Conformance]
 
-		// fails without a cloud provider
-		"should be able to create a functioning NodePort service",
-
 		// TODO undisable:
 		"should be schedule to node that don't match the PodAntiAffinity terms",
 		"should perfer to scheduled to nodes pod can tolerate",

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/service_util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/service_util.go
@@ -281,6 +281,10 @@ func GetNodePublicIps(c clientset.Interface) ([]string, error) {
 	nodes := GetReadySchedulableNodesOrDie(c)
 
 	ips := CollectAddresses(nodes, v1.NodeExternalIP)
+	if len(ips) == 0 {
+		// If ExternalIP isn't set, assume the test programs can reach the InternalIP
+		ips = CollectAddresses(nodes, v1.NodeInternalIP)
+	}
 	return ips, nil
 }
 

--- a/vendor/k8s.io/kubernetes/test/e2e/service.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/service.go
@@ -460,7 +460,7 @@ var _ = framework.KubeDescribe("Services", func() {
 		hostExec := framework.LaunchHostExecPod(f.ClientSet, f.Namespace.Name, "hostexec")
 		// Even if the node-ip:node-port check above passed, this hostexec pod
 		// might fall on a node with a laggy kube-proxy.
-		cmd := fmt.Sprintf(`for i in $(seq 1 300); do if ss -ant46 'sport = :%d' | grep ^LISTEN; then exit 0; fi; sleep 1; done; exit 1`, nodePort)
+		cmd := fmt.Sprintf(`for i in $(seq 1 300); do if ss -ant46 'sport = :%d' | grep ^LISTEN; then exit 0; fi; sleep 1; done; ss -ant46; ip a; exit 1`, nodePort)
 		stdout, err := framework.RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
 		if err != nil {
 			framework.Failf("expected node port %d to be in use, stdout: %v. err: %v", nodePort, stdout, err)


### PR DESCRIPTION
Pulls in the k8s test utils fix from https://github.com/kubernetes/kubernetes/pull/49025 to make the NodePort test work on non-cloud installs again.

Fixes #15253
