### PR TITLE
create a template group apiserver

### DIFF
--- a/pkg/cmd/server/origin/storage.go
+++ b/pkg/cmd/server/origin/storage.go
@@ -69,11 +69,6 @@ import (
 	hostsubnetetcd "github.com/openshift/origin/pkg/sdn/registry/hostsubnet/etcd"
 	netnamespaceetcd "github.com/openshift/origin/pkg/sdn/registry/netnamespace/etcd"
 	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
-	templateapiv1 "github.com/openshift/origin/pkg/template/apis/template/v1"
-	brokertemplateinstanceetcd "github.com/openshift/origin/pkg/template/registry/brokertemplateinstance/etcd"
-	templateregistry "github.com/openshift/origin/pkg/template/registry/template"
-	templateetcd "github.com/openshift/origin/pkg/template/registry/template/etcd"
-	templateinstanceetcd "github.com/openshift/origin/pkg/template/registry/templateinstance/etcd"
 	userapiv1 "github.com/openshift/origin/pkg/user/apis/user/v1"
 	groupetcd "github.com/openshift/origin/pkg/user/registry/group/etcd"
 	identityregistry "github.com/openshift/origin/pkg/user/registry/identity"
@@ -357,11 +352,6 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		return nil, fmt.Errorf("error building REST storage: %v", err)
 	}
 
-	templateStorage, err := templateetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-
 	clusterResourceQuotaStorage, clusterResourceQuotaStatusStorage, err := clusterresourcequotaetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
 	if err != nil {
 		return nil, fmt.Errorf("error building REST storage: %v", err)
@@ -451,11 +441,6 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		"deploymentConfigs/instantiate": dcInstantiateStorage,
 	}
 
-	storage[templateapiv1.SchemeGroupVersion] = map[string]rest.Storage{
-		"processedTemplates": templateregistry.NewREST(),
-		"templates":          templateStorage,
-	}
-
 	storage[imageapiv1.SchemeGroupVersion] = map[string]rest.Storage{
 		"images":               imageStorage,
 		"imagesignatures":      imageSignatureStorage,
@@ -472,19 +457,6 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		"routes":        routeStorage,
 		"routes/status": routeStatusStorage,
 	}
-
-	templateInstanceStorage, templateInstanceStatusStorage, err := templateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.KubeClientInternal.Authorization())
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-	brokerTemplateInstanceStorage, err := brokertemplateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-
-	storage[templateapiv1.SchemeGroupVersion]["templateinstances"] = templateInstanceStorage
-	storage[templateapiv1.SchemeGroupVersion]["templateinstances/status"] = templateInstanceStatusStorage
-	storage[templateapiv1.SchemeGroupVersion]["brokertemplateinstances"] = brokerTemplateInstanceStorage
 
 	if c.EnableBuilds {
 		storage[buildapiv1.SchemeGroupVersion] = map[string]rest.Storage{

--- a/pkg/template/apiserver/apiserver.go
+++ b/pkg/template/apiserver/apiserver.go
@@ -1,0 +1,113 @@
+package apiserver
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	authorizationinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
+
+	"sync"
+
+	templateapiv1 "github.com/openshift/origin/pkg/template/apis/template/v1"
+	brokertemplateinstanceetcd "github.com/openshift/origin/pkg/template/registry/brokertemplateinstance/etcd"
+	templateregistry "github.com/openshift/origin/pkg/template/registry/template"
+	templateetcd "github.com/openshift/origin/pkg/template/registry/template/etcd"
+	templateinstanceetcd "github.com/openshift/origin/pkg/template/registry/templateinstance/etcd"
+)
+
+type TemplateConfig struct {
+	GenericConfig *genericapiserver.Config
+
+	// AuthorizationClient is used to run SAR checks.  It should point to the master.
+	AuthorizationClient authorizationinternalversion.AuthorizationInterface
+
+	// TODO these should all become local eventually
+	Scheme   *runtime.Scheme
+	Registry *registered.APIRegistrationManager
+	Codecs   serializer.CodecFactory
+
+	makeV1Storage sync.Once
+	v1Storage     map[string]rest.Storage
+	v1StorageErr  error
+}
+
+// TemplateServer contains state for a Kubernetes cluster master/api server.
+type TemplateServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+}
+
+type completedConfig struct {
+	*TemplateConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *TemplateConfig) Complete() completedConfig {
+	c.GenericConfig.Complete()
+
+	return completedConfig{c}
+}
+
+// SkipComplete provides a way to construct a server instance without config completion.
+func (c *TemplateConfig) SkipComplete() completedConfig {
+	return completedConfig{c}
+}
+
+// New returns a new instance of TemplateServer from the given config.
+func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*TemplateServer, error) {
+	genericServer, err := c.TemplateConfig.GenericConfig.SkipComplete().New("template.openshift.io-apiserver", delegationTarget) // completion is done in Complete, no need for a second time
+	if err != nil {
+		return nil, err
+	}
+
+	s := &TemplateServer{
+		GenericAPIServer: genericServer,
+	}
+
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(templateapiv1.GroupName, c.Registry, c.Scheme, metav1.ParameterCodec, c.Codecs)
+	apiGroupInfo.GroupMeta.GroupVersion = templateapiv1.SchemeGroupVersion
+
+	v1Storage, err := c.V1RESTStorage()
+	if err != nil {
+		return nil, err
+	}
+	apiGroupInfo.VersionedResourcesStorageMap[templateapiv1.SchemeGroupVersion.Version] = v1Storage
+
+	if err := s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (c *TemplateConfig) V1RESTStorage() (map[string]rest.Storage, error) {
+	c.makeV1Storage.Do(func() {
+		templateStorage, err := templateetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+		if err != nil {
+			c.v1StorageErr = fmt.Errorf("error building REST storage: %v", err)
+			return
+		}
+		templateInstanceStorage, templateInstanceStatusStorage, err := templateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.AuthorizationClient)
+		if err != nil {
+			c.v1StorageErr = fmt.Errorf("error building REST storage: %v", err)
+			return
+		}
+		brokerTemplateInstanceStorage, err := brokertemplateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+		if err != nil {
+			c.v1StorageErr = fmt.Errorf("error building REST storage: %v", err)
+			return
+		}
+		c.v1Storage = map[string]rest.Storage{}
+		c.v1Storage["processedTemplates"] = templateregistry.NewREST()
+		c.v1Storage["templates"] = templateStorage
+		c.v1Storage["templateinstances"] = templateInstanceStorage
+		c.v1Storage["templateinstances/status"] = templateInstanceStatusStorage
+		c.v1Storage["brokertemplateinstances"] = brokerTemplateInstanceStorage
+	})
+
+	return c.v1Storage, c.v1StorageErr
+}


### PR DESCRIPTION
This separates the template API group into a separate server that is aggregated in and shows how we could still have the legacy api group keep working on a subset of endpoints.

We gain some boilerplate (need to figure out how to deal with that), but the giant `storage.go` finally gets broken apart and we don't risk all storage to be able to add something new.

OpenAPI aggregation break again @sttts  :( .