### PR TITLE
Fix all-caps consts in pkg/sdn

### DIFF
--- a/pkg/diagnostics/networkpod/util/log.go
+++ b/pkg/diagnostics/networkpod/util/log.go
@@ -26,8 +26,8 @@ func (l *LogInterface) LogNode(kubeClient kclientset.Interface) {
 
 	l.Run("brctl show", "bridges")
 	l.Run("docker ps -a", "docker-ps")
-	l.Run(fmt.Sprintf("ovs-ofctl -O OpenFlow13 dump-flows %s", sdnplugin.BR), "flows")
-	l.Run(fmt.Sprintf("ovs-ofctl -O OpenFlow13 show %s", sdnplugin.BR), "ovs-show")
+	l.Run(fmt.Sprintf("ovs-ofctl -O OpenFlow13 dump-flows %s", sdnplugin.Br0), "flows")
+	l.Run(fmt.Sprintf("ovs-ofctl -O OpenFlow13 show %s", sdnplugin.Br0), "ovs-show")
 	l.Run("tc qdisc show", "tc-qdisc")
 	l.Run("tc class show", "tc-class")
 	l.Run("tc filter show", "tc-filter")

--- a/pkg/sdn/plugin/dns.go
+++ b/pkg/sdn/plugin/dns.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DIG = "dig"
+	dig = "dig"
 
 	defaultTTL = 30 * time.Minute
 )
@@ -40,8 +40,8 @@ type DNS struct {
 }
 
 func CheckDNSResolver() error {
-	if _, err := exec.LookPath(DIG); err != nil {
-		return fmt.Errorf("%s is not installed", DIG)
+	if _, err := exec.LookPath(dig); err != nil {
+		return fmt.Errorf("%s is not installed", dig)
 	}
 	return nil
 }
@@ -109,7 +109,7 @@ func (d *DNS) updateOne(dns string) (error, bool) {
 	// Due to lack of any go bindings for dns resolver that actually provides TTL value, we are relying on 'dig' shell command.
 	// Output Format:
 	// <domain-name>.		<<ttl from authoritative ns>	IN	A	<IP addr>
-	out, err := d.execer.Command(DIG, "+nocmd", "+noall", "+answer", "+ttlid", "a", dns).CombinedOutput()
+	out, err := d.execer.Command(dig, "+nocmd", "+noall", "+answer", "+ttlid", "a", dns).CombinedOutput()
 	if err != nil || len(out) == 0 {
 		return fmt.Errorf("Failed to fetch IP addr and TTL value for domain: %q, err: %v", dns, err), false
 	}

--- a/pkg/sdn/plugin/master.go
+++ b/pkg/sdn/plugin/master.go
@@ -136,7 +136,7 @@ func StartMaster(networkConfig osconfigapi.MasterNetworkConfig, osClient *osclie
 }
 
 func (master *OsdnMaster) checkClusterNetworkAgainstLocalNetworks() error {
-	hostIPNets, _, err := netutils.GetHostIPNetworks([]string{TUN})
+	hostIPNets, _, err := netutils.GetHostIPNetworks([]string{Tun0})
 	if err != nil {
 		return err
 	}

--- a/pkg/sdn/plugin/node.go
+++ b/pkg/sdn/plugin/node.go
@@ -164,7 +164,7 @@ func NewNodePlugin(c *OsdnNodeConfig) (*OsdnNode, error) {
 		return nil, fmt.Errorf("%q plugin is not compatible with proxy-mode %q", c.PluginName, c.ProxyMode)
 	}
 
-	ovsif, err := ovs.New(kexec.New(), BR, minOvsVersion)
+	ovsif, err := ovs.New(kexec.New(), Br0, minOvsVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("failed to get network information: %v", err)
 	}
 
-	hostIPNets, _, err := netutils.GetHostIPNetworks([]string{TUN})
+	hostIPNets, _, err := netutils.GetHostIPNetworks([]string{Tun0})
 	if err != nil {
 		return fmt.Errorf("failed to get host network information: %v", err)
 	}

--- a/pkg/sdn/plugin/node_iptables.go
+++ b/pkg/sdn/plugin/node_iptables.go
@@ -134,7 +134,7 @@ func (n *NodeIPTables) syncIPTableRules() error {
 	return nil
 }
 
-const VXLAN_PORT = "4789"
+const vxlanPort = "4789"
 
 func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 	var masqRule []string
@@ -160,8 +160,8 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 			srcChain: "INPUT",
 			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
 			rules: [][]string{
-				{"-p", "udp", "--dport", VXLAN_PORT, "-m", "comment", "--comment", "VXLAN incoming", "-j", "ACCEPT"},
-				{"-i", TUN, "-m", "comment", "--comment", "from SDN to localhost", "-j", "ACCEPT"},
+				{"-p", "udp", "--dport", vxlanPort, "-m", "comment", "--comment", "VXLAN incoming", "-j", "ACCEPT"},
+				{"-i", Tun0, "-m", "comment", "--comment", "from SDN to localhost", "-j", "ACCEPT"},
 				{"-i", "docker0", "-m", "comment", "--comment", "from docker to localhost", "-j", "ACCEPT"},
 			},
 		},
@@ -180,7 +180,7 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 			table:    "filter",
 			name:     "OPENSHIFT-ADMIN-OUTPUT-RULES",
 			srcChain: "FORWARD",
-			srcRule:  []string{"-i", TUN, "!", "-o", TUN, "-m", "comment", "--comment", "administrator overrides"},
+			srcRule:  []string{"-i", Tun0, "!", "-o", Tun0, "-m", "comment", "--comment", "administrator overrides"},
 			rules:    nil,
 		},
 	}

--- a/pkg/sdn/plugin/ovscontroller_test.go
+++ b/pkg/sdn/plugin/ovscontroller_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func setup(t *testing.T) (ovs.Interface, *ovsController, []string) {
-	ovsif := ovs.NewFake(BR)
+	ovsif := ovs.NewFake(Br0)
 	oc := NewOVSController(ovsif, 0, true)
 	err := oc.SetupOVS("10.128.0.0/14", "172.30.0.0/16", "10.128.0.0/23", "10.128.0.1", "172.17.0.4")
 	if err != nil {
@@ -973,7 +973,7 @@ func TestAlreadySetUp(t *testing.T) {
 	}
 
 	for i, tc := range testcases {
-		ovsif := ovs.NewFake(BR)
+		ovsif := ovs.NewFake(Br0)
 		if err := ovsif.AddBridge("fail-mode=secure", "protocols=OpenFlow13"); err != nil {
 			t.Fatalf("(%d) unexpected error from AddBridge: %v", i, err)
 		}

--- a/pkg/sdn/plugin/pod_linux.go
+++ b/pkg/sdn/plugin/pod_linux.go
@@ -253,7 +253,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 	defer func() {
 		if !success {
 			m.ipamDel(req.SandboxID)
-			if err := m.hostportSyncer.SyncHostports(TUN, m.getRunningPods()); err != nil {
+			if err := m.hostportSyncer.SyncHostports(Tun0, m.getRunningPods()); err != nil {
 				glog.Warningf("failed syncing hostports: %v", err)
 			}
 		}
@@ -265,7 +265,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 		return nil, nil, err
 	}
 	podPortMapping := hostport.ConstructPodPortMapping(&v1Pod, podIP)
-	if err := m.hostportSyncer.OpenPodHostportsAndSync(podPortMapping, TUN, m.getRunningPods()); err != nil {
+	if err := m.hostportSyncer.OpenPodHostportsAndSync(podPortMapping, Tun0, m.getRunningPods()); err != nil {
 		return nil, nil, err
 	}
 
@@ -386,7 +386,7 @@ func (m *podManager) teardown(req *cniserver.PodRequest) error {
 		errList = append(errList, err)
 	}
 
-	if err := m.hostportSyncer.SyncHostports(TUN, m.getRunningPods()); err != nil {
+	if err := m.hostportSyncer.SyncHostports(Tun0, m.getRunningPods()); err != nil {
 		errList = append(errList, err)
 	}
 

--- a/pkg/sdn/plugin/sdn_controller.go
+++ b/pkg/sdn/plugin/sdn_controller.go
@@ -56,7 +56,7 @@ func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR, clusterNetworkCIDR 
 	var found bool
 
 	exec := kexec.New()
-	itx := ipcmd.NewTransaction(exec, TUN)
+	itx := ipcmd.NewTransaction(exec, Tun0)
 	addrs, err := itx.GetAddresses()
 	itx.EndTransaction()
 	if err != nil {
@@ -73,7 +73,7 @@ func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR, clusterNetworkCIDR 
 		return false
 	}
 
-	itx = ipcmd.NewTransaction(exec, TUN)
+	itx = ipcmd.NewTransaction(exec, Tun0)
 	routes, err := itx.GetRoutes()
 	itx.EndTransaction()
 	if err != nil {
@@ -160,9 +160,9 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 		return false, err
 	}
 
-	itx := ipcmd.NewTransaction(exec, TUN)
+	itx := ipcmd.NewTransaction(exec, Tun0)
 	itx.AddAddress(gwCIDR)
-	defer deleteLocalSubnetRoute(TUN, localSubnetCIDR)
+	defer deleteLocalSubnetRoute(Tun0, localSubnetCIDR)
 	itx.SetLink("mtu", fmt.Sprint(plugin.mtu))
 	itx.SetLink("up")
 	itx.AddRoute(clusterNetworkCIDR, "proto", "kernel", "scope", "link")


### PR DESCRIPTION
golang style does not use all-caps for constants (and in particular this results in package-local constants accidentally being exported publicly when we didn't intent for them to). The rest of the tree is mostly right about this. This fixes pkg/sdn.

@openshift/networking PTAL