### PR TITLE
switch user group to a separate apiserver

### DIFF
--- a/pkg/cmd/server/origin/storage.go
+++ b/pkg/cmd/server/origin/storage.go
@@ -68,12 +68,6 @@ import (
 	hostsubnetetcd "github.com/openshift/origin/pkg/sdn/registry/hostsubnet/etcd"
 	netnamespaceetcd "github.com/openshift/origin/pkg/sdn/registry/netnamespace/etcd"
 	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
-	userapiv1 "github.com/openshift/origin/pkg/user/apis/user/v1"
-	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
-	groupetcd "github.com/openshift/origin/pkg/user/registry/group/etcd"
-	identityetcd "github.com/openshift/origin/pkg/user/registry/identity/etcd"
-	useretcd "github.com/openshift/origin/pkg/user/registry/user/etcd"
-	"github.com/openshift/origin/pkg/user/registry/useridentitymapping"
 
 	"github.com/openshift/origin/pkg/build/registry/buildclone"
 	"github.com/openshift/origin/pkg/build/registry/buildconfiginstantiate"
@@ -175,27 +169,8 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		return nil, fmt.Errorf("error building REST storage: %v", err)
 	}
 
-	userClient, err := userclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
-	userStorage, err := useretcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-	identityStorage, err := identityetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-	userIdentityMappingStorage := useridentitymapping.NewREST(userClient.Users(), userClient.Identities())
-	groupStorage, err := groupetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-
 	selfSubjectRulesReviewStorage := selfsubjectrulesreview.NewREST(c.RuleResolver, c.KubeInternalInformers.Rbac().InternalVersion().ClusterRoles().Lister())
 	subjectRulesReviewStorage := subjectrulesreview.NewREST(c.RuleResolver, c.KubeInternalInformers.Rbac().InternalVersion().ClusterRoles().Lister())
-
 	subjectAccessReviewStorage := subjectaccessreview.NewREST(c.GenericConfig.Authorizer)
 	subjectAccessReviewRegistry := subjectaccessreview.NewRegistry(subjectAccessReviewStorage)
 	localSubjectAccessReviewStorage := localsubjectaccessreview.NewREST(subjectAccessReviewRegistry)
@@ -380,13 +355,6 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		"netNamespaces":         netNamespaceStorage,
 		"clusterNetworks":       clusterNetworkStorage,
 		"egressNetworkPolicies": egressNetworkPolicyStorage,
-	}
-
-	storage[userapiv1.SchemeGroupVersion] = map[string]rest.Storage{
-		"users":                userStorage,
-		"groups":               groupStorage,
-		"identities":           identityStorage,
-		"userIdentityMappings": userIdentityMappingStorage,
 	}
 
 	storage[oauthapiv1.SchemeGroupVersion] = map[string]rest.Storage{

--- a/pkg/template/apiserver/apiserver.go
+++ b/pkg/template/apiserver/apiserver.go
@@ -1,8 +1,6 @@
 package apiserver
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,15 +66,14 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		GenericAPIServer: genericServer,
 	}
 
-	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(templateapiv1.GroupName, c.Registry, c.Scheme, metav1.ParameterCodec, c.Codecs)
-	apiGroupInfo.GroupMeta.GroupVersion = templateapiv1.SchemeGroupVersion
-
 	v1Storage, err := c.V1RESTStorage()
 	if err != nil {
 		return nil, err
 	}
-	apiGroupInfo.VersionedResourcesStorageMap[templateapiv1.SchemeGroupVersion.Version] = v1Storage
 
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(templateapiv1.GroupName, c.Registry, c.Scheme, metav1.ParameterCodec, c.Codecs)
+	apiGroupInfo.GroupMeta.GroupVersion = templateapiv1.SchemeGroupVersion
+	apiGroupInfo.VersionedResourcesStorageMap[templateapiv1.SchemeGroupVersion.Version] = v1Storage
 	if err := s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
 		return nil, err
 	}
@@ -86,28 +83,31 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 
 func (c *TemplateConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 	c.makeV1Storage.Do(func() {
-		templateStorage, err := templateetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-		if err != nil {
-			c.v1StorageErr = fmt.Errorf("error building REST storage: %v", err)
-			return
-		}
-		templateInstanceStorage, templateInstanceStatusStorage, err := templateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.AuthorizationClient)
-		if err != nil {
-			c.v1StorageErr = fmt.Errorf("error building REST storage: %v", err)
-			return
-		}
-		brokerTemplateInstanceStorage, err := brokertemplateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-		if err != nil {
-			c.v1StorageErr = fmt.Errorf("error building REST storage: %v", err)
-			return
-		}
-		c.v1Storage = map[string]rest.Storage{}
-		c.v1Storage["processedTemplates"] = templateregistry.NewREST()
-		c.v1Storage["templates"] = templateStorage
-		c.v1Storage["templateinstances"] = templateInstanceStorage
-		c.v1Storage["templateinstances/status"] = templateInstanceStatusStorage
-		c.v1Storage["brokertemplateinstances"] = brokerTemplateInstanceStorage
+		c.v1Storage, c.v1StorageErr = c.newV1RESTStorage()
 	})
 
 	return c.v1Storage, c.v1StorageErr
+}
+
+func (c *TemplateConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
+	templateStorage, err := templateetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, err
+	}
+	templateInstanceStorage, templateInstanceStatusStorage, err := templateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.AuthorizationClient)
+	if err != nil {
+		return nil, err
+	}
+	brokerTemplateInstanceStorage, err := brokertemplateinstanceetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, err
+	}
+
+	v1Storage := map[string]rest.Storage{}
+	v1Storage["processedTemplates"] = templateregistry.NewREST()
+	v1Storage["templates"] = templateStorage
+	v1Storage["templateinstances"] = templateInstanceStorage
+	v1Storage["templateinstances/status"] = templateInstanceStatusStorage
+	v1Storage["brokertemplateinstances"] = brokerTemplateInstanceStorage
+	return v1Storage, nil
 }

--- a/pkg/user/apiserver/apiserver.go
+++ b/pkg/user/apiserver/apiserver.go
@@ -1,0 +1,113 @@
+package apiserver
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+
+	userapiv1 "github.com/openshift/origin/pkg/user/apis/user/v1"
+	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
+	groupetcd "github.com/openshift/origin/pkg/user/registry/group/etcd"
+	identityetcd "github.com/openshift/origin/pkg/user/registry/identity/etcd"
+	useretcd "github.com/openshift/origin/pkg/user/registry/user/etcd"
+	"github.com/openshift/origin/pkg/user/registry/useridentitymapping"
+)
+
+type UserConfig struct {
+	GenericConfig *genericapiserver.Config
+
+	// TODO these should all become local eventually
+	Scheme   *runtime.Scheme
+	Registry *registered.APIRegistrationManager
+	Codecs   serializer.CodecFactory
+
+	makeV1Storage sync.Once
+	v1Storage     map[string]rest.Storage
+	v1StorageErr  error
+}
+
+type UserServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+}
+
+type completedConfig struct {
+	*UserConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *UserConfig) Complete() completedConfig {
+	c.GenericConfig.Complete()
+
+	return completedConfig{c}
+}
+
+// SkipComplete provides a way to construct a server instance without config completion.
+func (c *UserConfig) SkipComplete() completedConfig {
+	return completedConfig{c}
+}
+
+// New returns a new instance of UserServer from the given config.
+func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*UserServer, error) {
+	genericServer, err := c.UserConfig.GenericConfig.SkipComplete().New("user.openshift.io-apiserver", delegationTarget) // completion is done in Complete, no need for a second time
+	if err != nil {
+		return nil, err
+	}
+
+	s := &UserServer{
+		GenericAPIServer: genericServer,
+	}
+
+	v1Storage, err := c.V1RESTStorage()
+	if err != nil {
+		return nil, err
+	}
+
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(userapiv1.GroupName, c.Registry, c.Scheme, metav1.ParameterCodec, c.Codecs)
+	apiGroupInfo.GroupMeta.GroupVersion = userapiv1.SchemeGroupVersion
+	apiGroupInfo.VersionedResourcesStorageMap[userapiv1.SchemeGroupVersion.Version] = v1Storage
+	if err := s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (c *UserConfig) V1RESTStorage() (map[string]rest.Storage, error) {
+	c.makeV1Storage.Do(func() {
+		c.v1Storage, c.v1StorageErr = c.newV1RESTStorage()
+	})
+
+	return c.v1Storage, c.v1StorageErr
+}
+
+func (c *UserConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
+	userClient, err := userclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	userStorage, err := useretcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, err
+	}
+	identityStorage, err := identityetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, err
+	}
+	userIdentityMappingStorage := useridentitymapping.NewREST(userClient.Users(), userClient.Identities())
+	groupStorage, err := groupetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, err
+	}
+
+	v1Storage := map[string]rest.Storage{}
+	v1Storage["users"] = userStorage
+	v1Storage["groups"] = groupStorage
+	v1Storage["identities"] = identityStorage
+	v1Storage["userIdentityMappings"] = userIdentityMappingStorage
+	return v1Storage, nil
+}


### PR DESCRIPTION
This moves the user api group storage to its logical group.  Turns out that no storage is simple, they're all special snowflakes, so I may end up with one pull each.

@openshift/sig-security 