### PR TITLE
Enable Scaleio volume

### DIFF
--- a/pkg/cmd/server/kubernetes/master/controller/volumes.go
+++ b/pkg/cmd/server/kubernetes/master/controller/volumes.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/host_path"
 	"k8s.io/kubernetes/pkg/volume/nfs"
 	"k8s.io/kubernetes/pkg/volume/rbd"
+	"k8s.io/kubernetes/pkg/volume/scaleio"
 	"k8s.io/kubernetes/pkg/volume/vsphere_volume"
 )
 
@@ -121,6 +122,7 @@ func probeRecyclableVolumePlugins(config componentconfig.VolumeConfiguration, re
 	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, rbd.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, azure_dd.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, scaleio.ProbeVolumePlugins()...)
 
 	return allPlugins, nil
 }


### PR DESCRIPTION
Switch-on ScaleIO volume plugin that was newly added into Kubernetes 1.6.

Fix https://bugzilla.redhat.com/show_bug.cgi?id=1482274