### PR TITLE
hack/lib: dedup os::util::host_platform and os::build::host_platform

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -137,7 +137,7 @@ $ hack/env make release
 In order to make use of the binaries from your shell, add the build output
 directory to the `$PATH`:
 ----
-$ export PATH="${PATH}:$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::util::host_platform )/" )"
+$ export PATH="${PATH}:$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::build::host_platform )/" )"
 ----
 
 See more information in https://github.com/openshift/origin/blob/master/HACKING.md#building-on-non-linux-systems[`HACKING.md`]

--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -292,7 +292,7 @@ readonly -f os::cleanup::find_cache_alterations
 function os::cleanup::dump_pprof_output() {
 	if go tool -n pprof >/dev/null 2>&1 && [[ -s cpu.pprof ]]; then
 		os::log::info "[CLEANUP] \`pprof\` output logged to $( os::util::repository_relative_path "${LOG_DIR}/pprof.out" )"
-		go tool pprof -text "./_output/local/bin/$(os::util::host_platform)/openshift" cpu.pprof >"${LOG_DIR}/pprof.out" 2>&1
+		go tool pprof -text "./_output/local/bin/$(os::build::host_platform)/openshift" cpu.pprof >"${LOG_DIR}/pprof.out" 2>&1
 	fi
 }
 readonly -f os::cleanup::dump_pprof_output

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -104,7 +104,7 @@ readonly -f os::util::environment::setup_all_server_vars
 function os::util::environment::update_path_var() {
     local prefix
     if os::util::find::system_binary 'go' >/dev/null 2>&1; then
-        prefix+="${OS_OUTPUT_BINPATH}/$(os::util::host_platform):"
+        prefix+="${OS_OUTPUT_BINPATH}/$(os::build::host_platform):"
     fi
     if [[ -n "${GOPATH:-}" ]]; then
         prefix+="${GOPATH}/bin:"

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -190,21 +190,6 @@ function os::util::curl_etcd() {
 	fi
 }
 
-# os::util::host_platform determines what the host OS and architecture
-# are, as Golang sees it. The go tool chain does some slightly different
-# things when the target platform matches the host platform.
-#
-# Globals:
-#  None
-# Arguments:
-#  None
-# Returns:
-#  None
-function os::util::host_platform() {
-	echo "$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
-}
-readonly -f os::util::host_platform
-
 # os::util::list_go_src_files lists files we consider part of our project
 # source code, useful for tools that iterate over source to provide vet-
 # ting or linting, etc.


### PR DESCRIPTION
Currently we have `os::util::host_platform` and `os::build::host_platform` that provide the same functionality, to better enable testing for alternative architectures, there is need to also add additional platform and arch helpers.

Since `os::build::host_platform` is more widely used currently than `os::util::host_platform`, it seemed like removing `os::util::host_platform` in favor of `os::build::host_platform` made the most sense, but if it is preferred to move the other platform and arch helpers to `os::util` instead then I'll be happy to do that instead.

I'll be creating followup PRs to https://github.com/openshift/cluster-capacity and https://github.com/openshift/service-catalog to mirror this change as well.