### PR TITLE
UPSTREAM: revert: c502d10: <carry>: match kube rbac setup in e2es wit…

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/examples.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/examples.go
@@ -72,7 +72,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 
 		// this test wants powerful permissions.  Since the namespace names are unique, we can leave this
 		// lying around so we don't have to race any caches
-		framework.BindClusterRoleInNamespace(c.RbacV1beta1(), f.ClientPool, "edit", f.Namespace.Name,
+		framework.BindClusterRoleInNamespace(c.Rbac(), "edit", f.Namespace.Name,
 			rbacv1beta1.Subject{Kind: rbacv1beta1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
 
 		err := framework.WaitForAuthorizationUpdate(c.AuthorizationV1beta1(),

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/authorizer_util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/authorizer_util.go
@@ -22,20 +22,12 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	unstructuredconversion "k8s.io/apimachinery/pkg/conversion/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/kubernetes/pkg/api"
 	authorizationv1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
-	rbacinternal "k8s.io/kubernetes/pkg/apis/rbac"
 	rbacv1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 	v1beta1authorization "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/authorization/v1beta1"
 	v1beta1rbac "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1"
-
-	openshiftauthzinternal "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	openshiftauthzexternal "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 )
 
 const (
@@ -78,9 +70,9 @@ func WaitForAuthorizationUpdate(c v1beta1authorization.SubjectAccessReviewsGette
 }
 
 // BindClusterRole binds the cluster role at the cluster scope
-func BindClusterRole(c v1beta1rbac.ClusterRoleBindingsGetter, clientPool dynamic.ClientPool, clusterRole, ns string, subjects ...rbacv1beta1.Subject) {
+func BindClusterRole(c v1beta1rbac.ClusterRoleBindingsGetter, clusterRole, ns string, subjects ...rbacv1beta1.Subject) {
 	// Since the namespace names are unique, we can leave this lying around so we don't have to race any caches
-	clusterRoleBinding := &rbacv1beta1.ClusterRoleBinding{
+	_, err := c.ClusterRoleBindings().Create(&rbacv1beta1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns + "--" + clusterRole,
 		},
@@ -90,58 +82,18 @@ func BindClusterRole(c v1beta1rbac.ClusterRoleBindingsGetter, clientPool dynamic
 			Name:     clusterRole,
 		},
 		Subjects: subjects,
-	}
-	_, err := c.ClusterRoleBindings().Create(clusterRoleBinding)
+	})
 
 	// if we failed, don't fail the entire test because it may still work. RBAC may simply be disabled.
 	if err != nil {
 		fmt.Printf("Error binding clusterrole/%s for %q for %v\n", clusterRole, ns, subjects)
 	}
-
-	// CARRY: also do this for OpenShift
-	internalClusterRoleBinding := &rbacinternal.ClusterRoleBinding{}
-	if err := api.Scheme.Convert(clusterRoleBinding, internalClusterRoleBinding, nil); err != nil {
-		fmt.Printf("Error converting v1beta1 ClusterRoleBinding to internal: %v\n", err)
-		return
-	}
-
-	openShiftInternal := &openshiftauthzinternal.ClusterRoleBinding{}
-	if err := api.Scheme.Convert(internalClusterRoleBinding, openShiftInternal, nil); err != nil {
-		fmt.Printf("Error converting kube ClusterRoleBinding to openshift internal: %v\n", err)
-		return
-	}
-
-	openShiftExternal := &openshiftauthzexternal.ClusterRoleBinding{}
-	if err := api.Scheme.Convert(openShiftInternal, openShiftExternal, nil); err != nil {
-		fmt.Printf("Error converting openshift internal ClusterRoleBinding to external: %v\n", err)
-		return
-	}
-
-	gvkClient, err := clientPool.ClientForGroupVersionKind(openshiftauthzexternal.SchemeGroupVersion.WithKind("ClusterRoleBinding"))
-	if err != nil {
-		fmt.Printf("Error creating dynamic client: %v", err)
-		return
-	}
-
-	oc := gvkClient.Resource(&metav1.APIResource{Name: "clusterrolebindings"}, "")
-
-	unstructured := metav1unstructured.Unstructured{
-		Object: make(map[string]interface{}),
-	}
-	if err := unstructuredconversion.DefaultConverter.ToUnstructured(openShiftExternal, &unstructured.Object); err != nil {
-		fmt.Printf("Error converting to unstructured: %v", err)
-		return
-	}
-
-	if _, err := oc.Create(&unstructured); err != nil {
-		fmt.Printf("Error binding OpenShift clusterrole/%s for %q for %v: %v\n", clusterRole, ns, subjects, err)
-	}
 }
 
 // BindClusterRoleInNamespace binds the cluster role at the namespace scope
-func BindClusterRoleInNamespace(c v1beta1rbac.RoleBindingsGetter, clientPool dynamic.ClientPool, clusterRole, ns string, subjects ...rbacv1beta1.Subject) {
+func BindClusterRoleInNamespace(c v1beta1rbac.RoleBindingsGetter, clusterRole, ns string, subjects ...rbacv1beta1.Subject) {
 	// Since the namespace names are unique, we can leave this lying around so we don't have to race any caches
-	roleBinding := &rbacv1beta1.RoleBinding{
+	_, err := c.RoleBindings(ns).Create(&rbacv1beta1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns + "--" + clusterRole,
 		},
@@ -151,51 +103,10 @@ func BindClusterRoleInNamespace(c v1beta1rbac.RoleBindingsGetter, clientPool dyn
 			Name:     clusterRole,
 		},
 		Subjects: subjects,
-	}
-
-	_, err := c.RoleBindings(ns).Create(roleBinding)
+	})
 
 	// if we failed, don't fail the entire test because it may still work. RBAC may simply be disabled.
 	if err != nil {
 		fmt.Printf("Error binding clusterrole/%s into %q for %v\n", clusterRole, ns, subjects)
-	}
-
-	// CARRY: also do this for OpenShift
-	internalRoleBinding := &rbacinternal.RoleBinding{}
-	if err := api.Scheme.Convert(roleBinding, internalRoleBinding, nil); err != nil {
-		fmt.Printf("Error converting v1beta1 RoleBinding to internal: %v\n", err)
-		return
-	}
-
-	openShiftInternal := &openshiftauthzinternal.RoleBinding{}
-	if err := api.Scheme.Convert(internalRoleBinding, openShiftInternal, nil); err != nil {
-		fmt.Printf("Error converting kube RoleBinding to openshift internal: %v\n", err)
-		return
-	}
-
-	openShiftExternal := &openshiftauthzexternal.RoleBinding{}
-	if err := api.Scheme.Convert(openShiftInternal, openShiftExternal, nil); err != nil {
-		fmt.Printf("Error converting openshift internal RoleBinding to external: %v\n", err)
-		return
-	}
-
-	gvkClient, err := clientPool.ClientForGroupVersionKind(openshiftauthzexternal.SchemeGroupVersion.WithKind("RoleBinding"))
-	if err != nil {
-		fmt.Printf("Error creating dynamic client: %v", err)
-		return
-	}
-
-	oc := gvkClient.Resource(&metav1.APIResource{Name: "rolebindings"}, "")
-
-	unstructured := metav1unstructured.Unstructured{
-		Object: make(map[string]interface{}),
-	}
-	if err := unstructuredconversion.DefaultConverter.ToUnstructured(openShiftExternal, &unstructured.Object); err != nil {
-		fmt.Printf("Error converting to unstructured: %v", err)
-		return
-	}
-
-	if _, err := oc.Create(&unstructured); err != nil {
-		fmt.Printf("Error binding OpenShift clusterrole/%s for %q for %v: %v\n", clusterRole, ns, subjects, err)
 	}
 }

--- a/vendor/k8s.io/kubernetes/test/e2e/ingress.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/ingress.go
@@ -46,7 +46,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 
 		// this test wants powerful permissions.  Since the namespace names are unique, we can leave this
 		// lying around so we don't have to race any caches
-		framework.BindClusterRole(jig.Client.RbacV1beta1(), f.ClientPool, "cluster-admin", f.Namespace.Name,
+		framework.BindClusterRole(jig.Client.Rbac(), "cluster-admin", f.Namespace.Name,
 			rbacv1beta1.Subject{Kind: rbacv1beta1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
 
 		err := framework.WaitForAuthorizationUpdate(jig.Client.AuthorizationV1beta1(),

--- a/vendor/k8s.io/kubernetes/test/e2e/kubectl.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/kubectl.go
@@ -583,7 +583,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		It("should handle in-cluster config", func() {
 			By("adding rbac permissions")
 			// grant the view permission widely to allow inspection of the `invalid` namespace and the default namespace
-			framework.BindClusterRole(f.ClientSet.Rbac(), f.ClientPool, "view", f.Namespace.Name,
+			framework.BindClusterRole(f.ClientSet.Rbac(), "view", f.Namespace.Name,
 				rbacv1beta1.Subject{Kind: rbacv1beta1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
 
 			err := framework.WaitForAuthorizationUpdate(f.ClientSet.AuthorizationV1beta1(),

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
@@ -521,7 +521,7 @@ var _ = framework.KubeDescribe("Dynamic Provisioning", func() {
 		It("should let an external dynamic provisioner create and delete persistent volumes [Slow] [Volume]", func() {
 			// external dynamic provisioner pods need additional permissions provided by the
 			// persistent-volume-provisioner role
-			framework.BindClusterRole(c.Rbac(), f.ClientPool, "system:persistent-volume-provisioner", ns,
+			framework.BindClusterRole(c.Rbac(), "system:persistent-volume-provisioner", ns,
 				rbacv1beta1.Subject{Kind: rbacv1beta1.ServiceAccountKind, Namespace: ns, Name: "default"})
 
 			err := framework.WaitForAuthorizationUpdate(c.AuthorizationV1beta1(),


### PR DESCRIPTION
…h openshift kinds

fixes https://github.com/openshift/origin/issues/15258

reverts a carry for openshift kinds in e2e tests since we now support RBAC directly.

@openshift/sig-security 