### PR TITLE
Check that the endpoints doesn't exceed the size of the ARP cache

### DIFF
--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -132,10 +132,19 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 		data, err := ioutil.ReadFile("/proc/sys/net/ipv4/neigh/default/gc_thresh3")
 		if err != nil {
 			glog.Warningf("Error reading ARP neighbour information: %s", err)
+			return
 		}
-		endpoints, _ := factory.KClient.Endpoints(factory.Namespace).List(metav1.ListOptions{})
+		endpoints, err := factory.KClient.Endpoints(factory.Namespace).List(metav1.ListOptions{})
+		if err != nil {
+			glog.Warningf("Error getting endpoint list: %s", err)
+			return
+		}
 		items := len(endpoints.Items)
-		arpcache, _ := strconv.Atoi(string(data[:len(data)-1]))
+		arpcache, err := strconv.Atoi(string(data[:len(data)-1]))
+		if err != nil {
+			glog.Warningf("Error: %s", err)
+			return
+		}
 		arpthreshold := float64(arpcache) * 0.9
 		if items > int(arpthreshold) {
 			glog.Warningf("Number of endpoints: %d is exceeding size of ARP neighbour cache threshold: %d", items, int(arpthreshold))

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -140,7 +140,7 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 		if items > int(arpthreshold) {
 			glog.Warningf("Number of endpoints: %d is exceeding size of ARP neighbour cache threshold: %d", items, int(arpthreshold))
 		}
-	}, time.Second*600) //run every 10 minutes
+	}, time.Minute*10) //run every 10 minutes
 
 	return &routercontroller.RouterController{
 		Plugin: plugin,

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -131,7 +131,7 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 	go utilwait.Forever(func() {
 		data, err := ioutil.ReadFile("/proc/sys/net/ipv4/neigh/default/gc_thresh3")
 		if err != nil {
-			glog.Warning("Error reading ARP neighbour information")
+			glog.Warningf("Error reading ARP neighbour information: %s", err)
 		}
 		endpoints, _ := factory.KClient.Endpoints(factory.Namespace).List(metav1.ListOptions{})
 		items := len(endpoints.Items)

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -2,7 +2,10 @@ package factory
 
 import (
 	"fmt"
+	"github.com/golang/glog"
+	"io/ioutil"
 	"sort"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -123,6 +126,21 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 			label:     labels.Everything(),
 		}, &kapi.Secret{}, secretEventQueue, factory.ResyncInterval).Run()
 	}
+
+	// Check ARP Cache and endpoint list
+	go utilwait.Forever(func() {
+		data, err := ioutil.ReadFile("/proc/sys/net/ipv4/neigh/default/gc_thresh3")
+		if err != nil {
+			glog.Warning("Error reading ARP neighbour information")
+		}
+		endpoints, _ := factory.KClient.Endpoints(factory.Namespace).List(metav1.ListOptions{})
+		items := len(endpoints.Items)
+		arpcache, _ := strconv.Atoi(string(data[:len(data)-1]))
+		arpthreshold := float64(arpcache) * 0.9
+		if items > int(arpthreshold) {
+			glog.Warningf("Number of endpoints: %d is exceeding size of ARP neighbour cache threshold: %d", items, int(arpthreshold))
+		}
+	}, time.Second*600) //run every 10 minutes
 
 	return &routercontroller.RouterController{
 		Plugin: plugin,

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -103,6 +103,10 @@ type templateRouter struct {
 	metricReload prometheus.Summary
 	// metricWriteConfig tracks writing config
 	metricWriteConfig prometheus.Summary
+	//ARP cache readability status
+	arpCacheReadable bool
+	//true if number of endpoints reches the threshold limit of the ARP cache
+	arpCacheWarn bool
 }
 
 // templateRouterCfg holds all configuration items required to initialize the template router
@@ -205,6 +209,9 @@ func newTemplateRouter(cfg templateRouterCfg) (*templateRouter, error) {
 
 		metricReload:      metricsReload,
 		metricWriteConfig: metricWriteConfig,
+
+		arpCacheWarn:     false,
+		arpCacheReadable: true,
 
 		rateLimitedCommitFunction:    nil,
 		rateLimitedCommitStopChannel: make(chan struct{}),
@@ -511,26 +518,15 @@ func (r *templateRouter) writeConfig() error {
 		cfg.Status = ServiceAliasConfigStatusSaved
 		r.state[k] = cfg
 	}
-
-	data, err := ioutil.ReadFile("/proc/sys/net/ipv4/neigh/default/gc_thresh3")
-	if err != nil {
-		glog.Warningf("Error reading ARP neighbour information: %s", err)
+	if !r.arpCacheWarn && r.arpCacheReadable {
+		if err := r.checkEndpointCount(); err != nil {
+			glog.Warningf("Error checking endpoint neighbour availability: %s", err)
+		}
 	}
-	arpcache, err := strconv.Atoi(string(data[:len(data)-1]))
-	if err != nil {
-		glog.Warningf("Error: %s", err)
-	}
-	arpthreshold := float64(arpcache) * 0.9
-
 	for path, template := range r.templates {
 		file, err := os.Create(path)
 		if err != nil {
 			return fmt.Errorf("error creating config file %s: %v", path, err)
-		}
-
-		items := len(r.serviceUnits)
-		if items > int(arpthreshold) {
-			glog.Warningf("Number of endpoints: %d is exceeding size of ARP neighbour cache threshold: %d", items, int(arpthreshold))
 		}
 
 		data := templateData{
@@ -553,6 +549,30 @@ func (r *templateRouter) writeConfig() error {
 	}
 
 	return nil
+}
+
+// Check that the number of endpoints don't exceed the ARP cache limit
+func (r *templateRouter) checkEndpointCount() error {
+	data, err := ioutil.ReadFile("/proc/sys/net/ipv4/neigh/default/gc_thresh3")
+	if err != nil {
+		glog.Warningf("Error reading ARP neighbour information: %s", err)
+		r.arpCacheReadable = false
+		return err
+	} else {
+		arpCache, err := strconv.Atoi(string(data[:len(data)-1]))
+		if err != nil {
+			glog.Warningf("Error: %s", err)
+			return err
+		}
+		r.arpCacheReadable = true
+		arpThreshold := float64(arpCache) * 0.9
+		items := len(r.serviceUnits)
+		if items > int(arpThreshold) {
+			glog.Warningf("The number of distinct endpoints (%d) is close to the size of the ARP neighbour cache (%d). Please increase the ARP neighbour cache size.", items, arpCache)
+			r.arpCacheWarn = true
+		}
+	}
+	return nil //no error
 }
 
 // writeCertificates attempts to write certificates only if the cfg requires it see shouldWriteCerts


### PR DESCRIPTION
The router should check that the number of endpoints handled is not
greater than the size of the neighbour cache. If the number of
endpoints is bigger than the ARP cache it will issue a warning to
the log file.

Trello: https://trello.com/c/qI628QaP/339-3-router-should-check-that-the-number-of-endpoints-handled-doesnt-exceed-the-size-of-the-neighbors-arp-cache-scalesupportability