### PR TITLE
Add enj to pkg/cmd/OWNERS

### DIFF
--- a/pkg/cmd/OWNERS
+++ b/pkg/cmd/OWNERS
@@ -7,9 +7,11 @@ reviewers:
   - juanvallejo
   - csrwng
   - fabianofranz
+  - enj
 approvers:
   - smarterclayton
   - liggitt
   - mfojtik
   - kargakis
   - fabianofranz
+  - enj


### PR DESCRIPTION
Added as reviewer and approver for the auth / API / etcd related pieces under `pkg/cmd`.

@openshift/sig-security 