### PR TITLE
Router tests should not panic when router has no endpoints

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -59,6 +59,10 @@ var _ = g.Describe("[Conformance][networking][router] openshift router metrics",
 
 		epts, err := oc.AdminKubeClient().CoreV1().Endpoints("default").Get("router", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(epts.Subsets) == 0 || len(epts.Subsets[0].Addresses) == 0 {
+			e2e.Failf("Unable to run HAProxy router tests, the router reports no endpoints: %#v", epts)
+			return
+		}
 		host = epts.Subsets[0].Addresses[0].IP
 
 		ns = oc.KubeFramework().Namespace.Name


### PR DESCRIPTION
Fail the test instead so we can debug