### PR TITLE
UPSTREAM: 46236: Support sandbox images from private registries

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package dockershim
 
 import (
+	"encoding/base64"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/blang/semver"
@@ -266,13 +270,33 @@ func TestGetSecurityOptSeparator(t *testing.T) {
 	}
 }
 
+// writeDockerConfig will write a config file into a temporary dir, and return that dir.
+// Caller is responsible for deleting the dir and its contents.
+func writeDockerConfig(cfg string) (string, error) {
+	tmpdir, err := ioutil.TempDir("", "dockershim=helpers_test.go=")
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(tmpdir, ".docker")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		return "", err
+	}
+	return tmpdir, ioutil.WriteFile(filepath.Join(dir, "config.json"), []byte(cfg), 0644)
+}
+
 func TestEnsureSandboxImageExists(t *testing.T) {
 	sandboxImage := "gcr.io/test/image"
+	registryHost := "https://gcr.io/"
+	authConfig := dockertypes.AuthConfig{Username: "user", Password: "pass"}
+	authB64 := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", authConfig.Username, authConfig.Password)))
+	authJSON := fmt.Sprintf("{\"auths\": {\"%s\": {\"auth\": \"%s\"} } }", registryHost, authB64)
 	for desc, test := range map[string]struct {
-		injectImage bool
-		injectErr   error
-		calls       []string
-		err         bool
+		injectImage  bool
+		imgNeedsAuth bool
+		injectErr    error
+		calls        []string
+		err          bool
+		configJSON   string
 	}{
 		"should not pull image when it already exists": {
 			injectImage: true,
@@ -290,14 +314,42 @@ func TestEnsureSandboxImageExists(t *testing.T) {
 			calls:       []string{"inspect_image"},
 			err:         true,
 		},
+		"should return error when image pull needs private auth, but none provided": {
+			injectImage:  true,
+			imgNeedsAuth: true,
+			injectErr:    dockertools.ImageNotFoundError{ID: "image_id"},
+			calls:        []string{"inspect_image", "pull"},
+			err:          true,
+		},
+		"should pull private image using dockerauth if image doesn't exist": {
+			injectImage:  true,
+			imgNeedsAuth: true,
+			injectErr:    dockertools.ImageNotFoundError{ID: "image_id"},
+			calls:        []string{"inspect_image", "pull"},
+			configJSON:   authJSON,
+			err:          false,
+		},
 	} {
 		t.Logf("TestCase: %q", desc)
 		_, fakeDocker, _ := newTestDockerService()
 		if test.injectImage {
-			fakeDocker.InjectImages([]dockertypes.Image{{ID: sandboxImage}})
+			images := []dockertypes.Image{{ID: sandboxImage}}
+			fakeDocker.InjectImages(images)
+			if test.imgNeedsAuth {
+				fakeDocker.MakeImagesPrivate(images, authConfig)
+			}
 		}
 		fakeDocker.InjectError("inspect_image", test.injectErr)
-		err := ensureSandboxImageExists(fakeDocker, sandboxImage)
+
+		var dockerCfgSearchPath []string
+		if test.configJSON != "" {
+			tmpdir, err := writeDockerConfig(test.configJSON)
+			require.NoError(t, err, "could not create a temp docker config file")
+			dockerCfgSearchPath = append(dockerCfgSearchPath, filepath.Join(tmpdir, ".docker"))
+			defer os.RemoveAll(tmpdir)
+		}
+
+		err := ensureSandboxImageExistsDockerCfg(fakeDocker, sandboxImage, dockerCfgSearchPath)
 		assert.NoError(t, fakeDocker.AssertCalls(test.calls))
 		assert.Equal(t, test.err, err != nil)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockertools/fake_docker_client.go
@@ -55,6 +55,7 @@ type FakeDockerClient struct {
 	ContainerMap         map[string]*dockertypes.ContainerJSON
 	ImageInspects        map[string]*dockertypes.ImageInspect
 	Images               []dockertypes.Image
+	ImageIDsNeedingAuth  map[string]dockertypes.AuthConfig
 	Errors               map[string]error
 	called               []calledDetail
 	pulled               []string
@@ -91,8 +92,9 @@ func NewFakeDockerClient() *FakeDockerClient {
 		ContainerMap: make(map[string]*dockertypes.ContainerJSON),
 		Clock:        clock.RealClock{},
 		// default this to true, so that we trace calls, image pulls and container lifecycle
-		EnableTrace:   true,
-		ImageInspects: make(map[string]*dockertypes.ImageInspect),
+		EnableTrace:         true,
+		ImageInspects:       make(map[string]*dockertypes.ImageInspect),
+		ImageIDsNeedingAuth: make(map[string]dockertypes.AuthConfig),
 	}
 }
 
@@ -624,6 +626,14 @@ func (f *FakeDockerClient) Logs(id string, opts dockertypes.ContainerLogsOptions
 	return f.popError("logs")
 }
 
+func (f *FakeDockerClient) isAuthorizedForImage(image string, auth dockertypes.AuthConfig) bool {
+	if reqd, exists := f.ImageIDsNeedingAuth[image]; !exists {
+		return true // no auth needed
+	} else {
+		return auth.Username == reqd.Username && auth.Password == reqd.Password
+	}
+}
+
 // PullImage is a test-spy implementation of DockerInterface.PullImage.
 // It adds an entry "pull" to the internal method call record.
 func (f *FakeDockerClient) PullImage(image string, auth dockertypes.AuthConfig, opts dockertypes.ImagePullOptions) error {
@@ -632,6 +642,10 @@ func (f *FakeDockerClient) PullImage(image string, auth dockertypes.AuthConfig, 
 	f.appendCalled(calledDetail{name: "pull"})
 	err := f.popError("pull")
 	if err == nil {
+		if !f.isAuthorizedForImage(image, auth) {
+			return ImageNotFoundError{ID: image}
+		}
+
 		authJson, _ := json.Marshal(auth)
 		inspect := createImageInspectFromRef(image)
 		f.ImageInspects[image] = inspect
@@ -712,11 +726,20 @@ func (f *FakeDockerClient) InjectImages(images []dockertypes.Image) {
 	}
 }
 
+func (f *FakeDockerClient) MakeImagesPrivate(images []dockertypes.Image, auth dockertypes.AuthConfig) {
+	f.Lock()
+	defer f.Unlock()
+	for _, i := range images {
+		f.ImageIDsNeedingAuth[i.ID] = auth
+	}
+}
+
 func (f *FakeDockerClient) ResetImages() {
 	f.Lock()
 	defer f.Unlock()
 	f.Images = []dockertypes.Image{}
 	f.ImageInspects = make(map[string]*dockertypes.ImageInspect)
+	f.ImageIDsNeedingAuth = make(map[string]dockertypes.AuthConfig)
 }
 
 func (f *FakeDockerClient) InjectImageInspects(inspects []dockertypes.ImageInspect) {


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/46236

xref https://bugzilla.redhat.com/show_bug.cgi?id=1316341

This is a regression vs origin 1.5.  When using the dockershim+CRI, the new default in kube 1.6, the client no longer uses `.docker/config.json` for pull credentials for infra pods.

This upstream commit went into kube 1.7  but was not cherry-picked to kube 1.6.

This PR is the pick for origin 1.6 and should try to go into 1.6.1

Reviewer note:
Upstream refactored `dockertools` to `libdocker` so the patch doesn't match exactly.

@sdodson @michaelgugino @derekwaynecarr @eparis 