### PR TITLE
cmd test flake: 0-length response instead of expected timeout

### DIFF
--- a/test/cmd/timeout.sh
+++ b/test/cmd/timeout.sh
@@ -16,7 +16,7 @@ os::cmd::expect_success_and_text 'oc new-app node' 'Success'
 os::cmd::expect_success_and_text 'oc get dc node -w --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1s' 'node'
 os::cmd::expect_success_and_text 'oc get dc node --request-timeout=1' 'node'
-os::cmd::expect_failure_and_text 'oc login -u testuser -p test --request-timeout=1ns' 'Timeout exceeded while awaiting headers'
+os::cmd::expect_success_and_text 'oc get pods --watch --request-timeout=1s 2>&1' 'Timeout exceeded while reading body'
 
 echo "request-timeout: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
It looks like this issue is related with HEAD request that we do. By
changing it to send HTTP GET requests to our /healthz endpoint seems
to fix the issue.

Signed-off-by: Bruno Oliveira <bruno@abstractj.org>

@juanvallejo @fabianofranz it seems to fix the issue https://github.com/openshift/origin/issues/15453