### PR TITLE
UPSTREAM: google/cadvisor: 1722: Skip subcontainer update on v2 calls

### DIFF
--- a/vendor/github.com/google/cadvisor/manager/container.go
+++ b/vendor/github.com/google/cadvisor/manager/container.go
@@ -113,16 +113,18 @@ func (c *containerData) allowErrorLogging() bool {
 	return false
 }
 
-func (c *containerData) GetInfo() (*containerInfo, error) {
+func (c *containerData) GetInfo(shouldUpdateSubcontainers bool) (*containerInfo, error) {
 	// Get spec and subcontainers.
 	if time.Since(c.lastUpdatedTime) > 5*time.Second {
 		err := c.updateSpec()
 		if err != nil {
 			return nil, err
 		}
-		err = c.updateSubcontainers()
-		if err != nil {
-			return nil, err
+		if shouldUpdateSubcontainers {
+			err = c.updateSubcontainers()
+			if err != nil {
+				return nil, err
+			}
 		}
 		c.lastUpdatedTime = time.Now()
 	}

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -400,7 +400,7 @@ func (self *manager) GetContainerSpec(containerName string, options v2.RequestOp
 	var errs partialFailure
 	specs := make(map[string]v2.ContainerSpec)
 	for name, cont := range conts {
-		cinfo, err := cont.GetInfo()
+		cinfo, err := cont.GetInfo(false)
 		if err != nil {
 			errs.append(name, "GetInfo", err)
 		}
@@ -449,7 +449,7 @@ func (self *manager) GetContainerInfoV2(containerName string, options v2.Request
 	infos := make(map[string]v2.ContainerInfo, len(containers))
 	for name, container := range containers {
 		result := v2.ContainerInfo{}
-		cinfo, err := container.GetInfo()
+		cinfo, err := container.GetInfo(false)
 		if err != nil {
 			errs.append(name, "GetInfo", err)
 			infos[name] = result
@@ -473,7 +473,7 @@ func (self *manager) GetContainerInfoV2(containerName string, options v2.Request
 
 func (self *manager) containerDataToContainerInfo(cont *containerData, query *info.ContainerInfoRequest) (*info.ContainerInfo, error) {
 	// Get the info from the container.
-	cinfo, err := cont.GetInfo()
+	cinfo, err := cont.GetInfo(true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
3.6 pick of https://github.com/openshift/origin/pull/15873

xref google/cadvisor#1722

@derekwaynecarr @eparis @smarterclayton 