### PR TITLE
Add Back node-bootstrapper Service Account creation

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -28,6 +28,8 @@ const (
 	// This should remain in the default role bindings for the NodeAdmin role
 	LegacyMasterKubeletAdminClientUsername = "system:master"
 	MasterKubeletAdminClientUsername       = "system:openshift-node-admin"
+
+	InfraNodeBootstrapServiceAccountName = "system:" + NodeBootstrapRoleName
 )
 
 // groups
@@ -96,6 +98,8 @@ const (
 	NodeReaderRoleName = "system:node-reader"
 
 	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
+
+	NodeBootstrapRoleName = "node-bootstrapper"
 )
 
 // RoleBindings
@@ -131,4 +135,6 @@ const (
 	BuildStrategyJenkinsPipelineRoleBindingName = BuildStrategyJenkinsPipelineRoleName + "-binding"
 
 	OpenshiftSharedResourceViewRoleBindingName = OpenshiftSharedResourceViewRoleName + "s"
+
+	NodeBootstrapRoleBindingName = NodeBootstrapRoleName + "s"
 )

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -993,6 +993,9 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbac.ClusterRoleBinding {
 		newOriginClusterBinding(BuildStrategyJenkinsPipelineRoleBindingName, BuildStrategyJenkinsPipelineRoleName).
 			Groups(AuthenticatedGroup).
 			BindingOrDie(),
+		newOriginClusterBinding(NodeBootstrapRoleBindingName, NodeBootstrapRoleName).
+			SAs(DefaultOpenShiftInfraNamespace, InfraNodeBootstrapServiceAccountName).
+			BindingOrDie(),
 	}
 }
 

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -506,6 +506,12 @@ func (c *OpenshiftAPIConfig) ensureOpenShiftInfraNamespace(context genericapiser
 		return nil
 	}
 
+	// Ensure we have the bootstrap SA for Nodes
+	_, err = c.KubeClientInternal.Core().ServiceAccounts(ns).Create(&kapi.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: bootstrappolicy.InfraNodeBootstrapServiceAccountName}})
+	if err != nil && !kapierror.IsAlreadyExists(err) {
+		glog.Errorf("Error creating service account %s/%s: %v", namespace, bootstrappolicy.InfraNodeBootstrapServiceAccountName, err)
+	}
+
 	EnsureNamespaceServiceAccountRoleBindings(c.KubeClientInternal, c.DeprecatedOpenshiftClient, namespace)
 	return nil
 }


### PR DESCRIPTION
This was recently dropped together with some refactoring for Controller
Roles bootstrapping.

Fixes #15869 