### PR TITLE
Add Back node-bootstrapper Service Account creation

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -96,6 +96,8 @@ const (
 	NodeReaderRoleName = "system:node-reader"
 
 	OpenshiftSharedResourceViewRoleName = "shared-resource-viewer"
+
+	NodeBootstrapRoleName = "system:node-bootstrapper"
 )
 
 // RoleBindings

--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -48,6 +48,8 @@ const (
 	// This is a special constant which maps to the service account name used by the underlying
 	// Kubernetes code, so that we can build out the extra policy required to scale OpenShift resources.
 	InfraHorizontalPodAutoscalerControllerServiceAccountName = "horizontal-pod-autoscaler"
+
+	InfraNodeBootstrapServiceAccountName = "node-bootstrapper"
 )
 
 var (

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -993,6 +993,10 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbac.ClusterRoleBinding {
 		newOriginClusterBinding(BuildStrategyJenkinsPipelineRoleBindingName, BuildStrategyJenkinsPipelineRoleName).
 			Groups(AuthenticatedGroup).
 			BindingOrDie(),
+		// Allow node-bootstrapper SA to bootstrap nodes by default.
+		rbac.NewClusterBinding(NodeBootstrapRoleName).
+			SAs(DefaultOpenShiftInfraNamespace, InfraNodeBootstrapServiceAccountName).
+			BindingOrDie(),
 	}
 }
 

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -506,6 +506,12 @@ func (c *OpenshiftAPIConfig) ensureOpenShiftInfraNamespace(context genericapiser
 		return nil
 	}
 
+	// Ensure we have the bootstrap SA for Nodes
+	_, err = c.KubeClientInternal.Core().ServiceAccounts(ns).Create(&kapi.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: bootstrappolicy.InfraNodeBootstrapServiceAccountName}})
+	if err != nil && !kapierror.IsAlreadyExists(err) {
+		glog.Errorf("Error creating service account %s/%s: %v", namespace, bootstrappolicy.InfraNodeBootstrapServiceAccountName, err)
+	}
+
 	EnsureNamespaceServiceAccountRoleBindings(c.KubeClientInternal, c.DeprecatedOpenshiftClient, namespace)
 	return nil
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -245,6 +245,19 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
+    creationTimestamp: null
+    name: system:node-bootstrapper
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:node-bootstrapper
+  subjects:
+  - kind: ServiceAccount
+    name: node-bootstrapper
+    namespace: openshift-infra
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null


### PR DESCRIPTION
This was recently dropped together with some refactoring for Controller
Roles bootstrapping.

Fixes #15869

@simo5's PR #15890 + test fix

@openshift/sig-security 