### PR TITLE
Deployment extended test can fail due to cancel

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -80,10 +80,10 @@ var _ = g.Describe("deploymentconfigs", func() {
 					e2e.Logf("%02d: cancelling deployment", i)
 					if out, err := oc.Run("rollout").Args("cancel", "dc/deployment-simple").Output(); err != nil {
 						// TODO: we should fix this
-						if !strings.Contains(out, "the object has been modified") {
+						if !strings.Contains(out, "the object has been modified") && !strings.Contains(out, "there have been no replication controllers") {
 							o.Expect(err).NotTo(o.HaveOccurred())
 						}
-						e2e.Logf("rollout cancel deployment failed due to conflict: %v", err)
+						e2e.Logf("rollout cancel deployment failed due to known safe error: %v", err)
 					}
 
 				case n < 0.0:


### PR DESCRIPTION
If we race the deployment controller, cancel may fail because the deployment hasn't started yet. Ignore the error like we ignore conflicts, since we are only testing that the controller converges.

Fixes #13575

https://ci.openshift.redhat.com/jenkins/job/test_pull_request_origin_extended_conformance_gce/6326/testReport/junit/(root)/Extended/deploymentconfigs_when_run_iteratively__Conformance__should_only_deploy_the_last_deployment/

```
Stacktrace

/tmp/openshift/build-rpm-release/tito/rpmbuild-originFxMtUq/BUILD/origin-3.7.0/_output/local/go/src/github.com/openshift/origin/test/extended/deployments/deployments.go:143
Expected error:
    <*util.ExitError | 0xc420638f00>: {
        Cmd: "oc rollout --config=/tmp/extended-test-cli-deployment-3fvlh-g2tnb-user.kubeconfig --namespace=extended-test-cli-deployment-3fvlh-g2tnb cancel dc/deployment-simple",
        StdErr: "error: there have been no replication controllers for extended-test-cli-deployment-3fvlh-g2tnb/deployment-simple",
        ExitError: {
            ProcessState: {
                pid: 9105,
                status: 256,
                rusage: {
                    Utime: {Sec: 0, Usec: 201730},
                    Stime: {Sec: 0, Usec: 20173},
                    Maxrss: 49016,
                    Ixrss: 0,
                    Idrss: 0,
                    Isrss: 0,
                    Minflt: 13361,
                    Majflt: 0,
                    Nswap: 0,
                    Inblock: 0,
                    Oublock: 0,
                    Msgsnd: 0,
                    Msgrcv: 0,
                    Nsignals: 0,
                    Nvcsw: 921,
                    Nivcsw: 3,
                },
            },
            Stderr: nil,
        },
    }
    exit status 1
not to have occurred
/tmp/openshift/build-rpm-release/tito/rpmbuild-originFxMtUq/BUILD/origin-3.7.0/_output/local/go/src/github.com/openshift/origin/test/extended/deployments/deployments.go:84
Standard Output

[BeforeEach] [Top Level]
  /tmp/openshift/build-rpm-release/tito/rpmbuild-originFxMtUq/BUILD/origin-3.7.0/_output/local/go/src/github.com/openshift/origin/test/extended/util/test.go:52
[BeforeEach] deploymentconfigs
  /tmp/openshift/build-rpm-release/tito/rpmbuild-originFxMtUq/BUILD/origin-3.7.0/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:130
STEP: Creating a kubernetes client
Aug 22 10:25:21.802: INFO: >>> kubeConfig: /tmp/cluster-admin.kubeconfig
STEP: Building a namespace api object
Aug 22 10:25:22.574: INFO: configPath is now "/tmp/extended-test-cli-deployment-3fvlh-g2tnb-user.kubeconfig"
Aug 22 10:25:22.574: INFO: The user is now "extended-test-cli-deployment-3fvlh-g2tnb-user"
Aug 22 10:25:22.574: INFO: Creating project "extended-test-cli-deployment-3fvlh-g2tnb"
STEP: Waiting for a default service account to be provisioned in namespace
[It] should only deploy the last deployment
  /tmp/openshift/build-rpm-release/tito/rpmbuild-originFxMtUq/BUILD/origin-3.7.0/_output/local/go/src/github.com/openshift/origin/test/extended/deployments/deployments.go:143
Aug 22 10:25:24.022: INFO: Running 'oc create --config=/tmp/extended-test-cli-deployment-3fvlh-g2tnb-user.kubeconfig --namespace=extended-test-cli-deployment-3fvlh-g2tnb -f /tmp/fixture-testdata-dir908196698/test/extended/testdata/deployments/deployment-simple.yaml'
Aug 22 10:25:25.003: INFO: 00: cancelling deployment
Aug 22 10:25:25.003: INFO: Running 'oc rollout --config=/tmp/extended-test-cli-deployment-3fvlh-g2tnb-user.kubeconfig --namespace=extended-test-cli-deployment-3fvlh-g2tnb cancel dc/deployment-simple'
Aug 22 10:25:25.933: INFO: Error running &{/data/src/github.com/openshift/origin/_output/local/bin/linux/amd64/oc [oc rollout --config=/tmp/extended-test-cli-deployment-3fvlh-g2tnb-user.kubeconfig --namespace=extended-test-cli-deployment-3fvlh-g2tnb cancel dc/deployment-simple] []   error: there have been no replication controllers for extended-test-cli-deployment-3fvlh-g2tnb/deployment-simple
 error: there have been no replication controllers for extended-test-cli-deployment-3fvlh-g2tnb/deployment-simple
 [] <nil> 0xc421afa180 exit status 1 <nil> <nil> true [0xc4211feb38 0xc4211feb60 0xc4211feb60] [0xc4211feb38 0xc4211feb60] [0xc4211feb40 0xc4211feb58] [0x18191b0 0x18192b0] 0xc4215684e0 <nil>}:
error: there have been no replication controllers for extended-test-cli-deployment-3fvlh-g2tnb/deployment-simple
[AfterEach] when run iteratively [Conformance]
  /tmp/openshift/build-rpm-release/tito/rpmbuild-originFxMtUq/BUILD/origin-3.7.0/_output/local/go/src/github.com/openshift/origin/test/extended/deployments/deployments.go:58
Aug 22 10:25:25.934: INFO: Running 'oc get --config=/tmp/extended-test-cli-deployment-3fvlh-g2tnb-user.kubeconfig --namespace=extended-test-cli-deployment-3fvlh-g2tnb dc/deployment-simple -o yaml'
```