### PR TITLE
Make focus and skip a lot easier to use in extended tests

### DIFF
--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -17,7 +17,7 @@ variable `FOCUS='regex'` where 'regex' is a regular expression matching the
 description of the test you want to run.  For example one of the s2i tests
 (s2i_incremental.go) defines:
 
-	var _ = g.Describe("[builds][Slow] incremental s2i build", func() {
+	var _ = g.Describe("[Feature:Builds][Slow] incremental s2i build", func() {
 
 So you can write a focus regex that includes this test by setting
 `FOCUS='\[builds\]'` or `FOCUS='incremental s2i'`.

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -18,7 +18,7 @@ import (
 // These build pruning tests create 4 builds and check that 2-3 of them are left after pruning.
 // This variation in the number of builds that could be left is caused by the HandleBuildPruning
 // function using cached information from the buildLister.
-var _ = g.Describe("[builds][pruning] prune builds based on settings in the buildconfig", func() {
+var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in the buildconfig", func() {
 	var (
 		buildPruningBaseDir   = exutil.FixturePath("testdata", "build-pruning")
 		isFixture             = filepath.Join(buildPruningBaseDir, "imagestream.yaml")

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -26,7 +26,7 @@ func verifyStages(stages []buildapi.StageInfo, expectedStages map[string][]strin
 	}
 }
 
-var _ = g.Describe("[builds][timing] capture build stages and durations", func() {
+var _ = g.Describe("[Feature:Builds][timing] capture build stages and durations", func() {
 	var (
 		buildTimingBaseDir    = exutil.FixturePath("testdata", "build-timing")
 		isFixture             = filepath.Join(buildTimingBaseDir, "test-is.json")

--- a/test/extended/builds/buildconfigsecretinjector.go
+++ b/test/extended/builds/buildconfigsecretinjector.go
@@ -7,7 +7,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds] buildconfig secret injector", func() {
+var _ = g.Describe("[Feature:Builds] buildconfig secret injector", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/builds/completiondeadlineseconds.go
+++ b/test/extended/builds/completiondeadlineseconds.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] builds should have deadlines", func() {
+var _ = g.Describe("[Feature:Builds][Slow] builds should have deadlines", func() {
 	defer g.GinkgoRecover()
 	var (
 		sourceFixture = exutil.FixturePath("testdata", "test-cds-sourcebuild.json")

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -14,7 +14,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] builds with a context directory", func() {
+var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", func() {
 	defer g.GinkgoRecover()
 	var (
 		appFixture            = exutil.FixturePath("testdata", "test-context-build.json")

--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -9,7 +9,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] completed builds should have digest of the image in their status", func() {
+var _ = g.Describe("[Feature:Builds][Slow] completed builds should have digest of the image in their status", func() {
 	defer g.GinkgoRecover()
 	var (
 		imageStreamFixture = exutil.FixturePath("..", "integration", "testdata", "test-image-stream.json")

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -9,7 +9,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][pullsecret][Conformance] docker build using a pull secret", func() {
+var _ = g.Describe("[Feature:Builds][pullsecret][Conformance] docker build using a pull secret", func() {
 	defer g.GinkgoRecover()
 	const (
 		buildTestPod     = "build-test-pod"

--- a/test/extended/builds/docker_quota.go
+++ b/test/extended/builds/docker_quota.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][quota][Slow] docker build with a quota", func() {
+var _ = g.Describe("[Feature:Builds][quota][Slow] docker build with a quota", func() {
 	defer g.GinkgoRecover()
 	const (
 		buildTestPod     = "build-test-pod"

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -9,7 +9,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] build can have Dockerfile input", func() {
+var _ = g.Describe("[Feature:Builds][Slow] build can have Dockerfile input", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc             = exutil.NewCLI("build-dockerfile-env", exutil.KubeConfigPath())

--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -16,7 +16,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] update failure status", func() {
+var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/builds/forcepull.go
+++ b/test/extended/builds/forcepull.go
@@ -69,7 +69,7 @@ while this test is running and compare results.  Restarting your docker daemon, 
 be a quick fix.
 */
 
-var _ = g.Describe("[builds] forcePull should affect pulling builder images", func() {
+var _ = g.Describe("[Feature:Builds] forcePull should affect pulling builder images", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("forcepull", exutil.KubeConfigPath())
 

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -22,7 +22,7 @@ func hostname(hostport string) (string, error) {
 	return host, err
 }
 
-var _ = g.Describe("[builds][Slow] can use private repositories as build input", func() {
+var _ = g.Describe("[Feature:Builds][Slow] can use private repositories as build input", func() {
 	defer g.GinkgoRecover()
 
 	const (

--- a/test/extended/builds/hooks.go
+++ b/test/extended/builds/hooks.go
@@ -7,7 +7,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] testing build configuration hooks", func() {
+var _ = g.Describe("[Feature:Builds][Slow] testing build configuration hooks", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "test-build-postcommit.json")

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] build can have Docker image source", func() {
+var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture     = exutil.FixturePath("testdata", "test-imagesource-build.yaml")

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -10,7 +10,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] result image should have proper labels set", func() {
+var _ = g.Describe("[Feature:Builds][Slow] result image should have proper labels set", func() {
 	defer g.GinkgoRecover()
 	var (
 		imageStreamFixture = exutil.FixturePath("..", "integration", "testdata", "test-image-stream.json")

--- a/test/extended/builds/long_names.go
+++ b/test/extended/builds/long_names.go
@@ -8,7 +8,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] extremely long build/bc names are not problematic", func() {
+var _ = g.Describe("[Feature:Builds][Slow] extremely long build/bc names are not problematic", func() {
 	defer g.GinkgoRecover()
 	var (
 		testDataBaseDir  = exutil.FixturePath("testdata", "long_names")

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -13,7 +13,7 @@ const (
 	a59 = "a2345678901234567890123456789012345678901234567890123456789"
 )
 
-var _ = g.Describe("[builds][Conformance] oc new-app", func() {
+var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 	// Previously, the maximum length of app names creatable by new-app has
 	// inadvertently been decreased, e.g. by creating an annotation somewhere
 	// whose name itself includes the app name.  Ensure we can create and fully

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -9,7 +9,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Conformance] build without output image", func() {
+var _ = g.Describe("[Feature:Builds][Conformance] build without output image", func() {
 	defer g.GinkgoRecover()
 	var (
 		dockerImageFixture = exutil.FixturePath("testdata", "test-docker-no-outputname.json")

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds] build with empty source", func() {
+var _ = g.Describe("[Feature:Builds] build with empty source", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "test-nosrc-build.json")

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -14,7 +14,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds] Optimized image builds", func() {
+var _ = g.Describe("[Feature:Builds] Optimized image builds", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc             = exutil.NewCLI("build-dockerfile-env", exutil.KubeConfigPath())

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -50,7 +50,7 @@ func debugAnyJenkinsFailure(br *exutil.BuildResult, name string, oc *exutil.CLI,
 	}
 }
 
-var _ = g.Describe("[builds][Slow] openshift pipeline build", func() {
+var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 	defer g.GinkgoRecover()
 	var (
 		jenkinsTemplatePath    = exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json")

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] the s2i build should support proxies", func() {
+var _ = g.Describe("[Feature:Builds][Slow] the s2i build should support proxies", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "test-build-proxy.yaml")

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Conformance] remove all builds when build configuration is removed", func() {
+var _ = g.Describe("[Feature:Builds][Conformance] remove all builds when build configuration is removed", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "test-build.json")

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds] build have source revision metadata", func() {
+var _ = g.Describe("[Feature:Builds] build have source revision metadata", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture = exutil.FixturePath("testdata", "test-build-revision.json")

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -17,7 +17,7 @@ import (
 )
 
 // this test is very latency sensitive so run it by itself (serially).
-var _ = g.Describe("[builds][Slow][Serial] using build configuration runPolicy", func() {
+var _ = g.Describe("[Feature:Builds][Slow][Serial] using build configuration runPolicy", func() {
 	defer g.GinkgoRecover()
 	var (
 		// Use invalid source here as we don't care about the result

--- a/test/extended/builds/s2i_dropcaps.go
+++ b/test/extended/builds/s2i_dropcaps.go
@@ -9,7 +9,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] Capabilities should be dropped for s2i builders", func() {
+var _ = g.Describe("[Feature:Builds][Slow] Capabilities should be dropped for s2i builders", func() {
 	defer g.GinkgoRecover()
 	var (
 		s2ibuilderFixture      = exutil.FixturePath("testdata", "s2i-dropcaps", "rootable-ruby")

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -12,7 +12,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] s2i build with environment file in sources", func() {
+var _ = g.Describe("[Feature:Builds][Slow] s2i build with environment file in sources", func() {
 	defer g.GinkgoRecover()
 	const (
 		buildTestPod     = "build-test-pod"

--- a/test/extended/builds/s2i_extended_build.go
+++ b/test/extended/builds/s2i_extended_build.go
@@ -9,7 +9,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[builds][Slow] s2i extended build", func() {
+var _ = g.Describe("[Feature:Builds][Slow] s2i extended build", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -12,7 +12,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] incremental s2i build", func() {
+var _ = g.Describe("[Feature:Builds][Slow] incremental s2i build", func() {
 	defer g.GinkgoRecover()
 
 	const (

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -12,7 +12,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Conformance] s2i build with a quota", func() {
+var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func() {
 	defer g.GinkgoRecover()
 	const (
 		buildTestPod     = "build-test-pod"

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -10,7 +10,7 @@ import (
 	s2istatus "github.com/openshift/source-to-image/pkg/util/status"
 )
 
-var _ = g.Describe("[builds][Conformance] s2i build with a root user image", func() {
+var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a root user image", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -11,7 +11,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] can use build secrets", func() {
+var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildSecretBaseDir    = exutil.FixturePath("testdata", "build-secrets")

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -17,7 +17,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Slow] starting a build using CLI", func() {
+var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 	defer g.GinkgoRecover()
 	var (
 		buildFixture      = exutil.FixturePath("testdata", "test-build.json")

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -10,7 +10,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[builds][Conformance][valueFrom] process valueFrom in build strategy environment variables", func() {
+var _ = g.Describe("[Feature:Builds][Conformance][valueFrom] process valueFrom in build strategy environment variables", func() {
 	var (
 		valueFromBaseDir               = exutil.FixturePath("testdata", "valuefrom")
 		testImageStreamFixture         = filepath.Join(valueFromBaseDir, "test-is.json")

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -28,7 +28,7 @@ import (
 const deploymentRunTimeout = 5 * time.Minute
 const deploymentChangeTimeout = 30 * time.Second
 
-var _ = g.Describe("deploymentconfigs", func() {
+var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                              = exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[networking] network isolation", func() {
+var _ = Describe("[Area:Networking] network isolation", func() {
 	InSingleTenantContext(func() {
 		f1 := e2e.NewDefaultFramework("net-isolation1")
 		f2 := e2e.NewDefaultFramework("net-isolation2")

--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[networking] multicast", func() {
+var _ = Describe("[Area:Networking] multicast", func() {
 	InSingleTenantContext(func() {
 		oc := testexutil.NewCLI("multicast", testexutil.KubeConfigPath())
 		f := oc.KubeFramework()

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[networking] services", func() {
+var _ = Describe("[Area:Networking] services", func() {
 	Context("basic functionality", func() {
 		f1 := e2e.NewDefaultFramework("net-services1")
 

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -17,7 +17,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Feature:Prometheus][builds] Prometheus", func() {
+var _ = g.Describe("[Feature:Prometheus][Feature:Builds] Prometheus", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLI("prometheus", exutil.KubeConfigPath())

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -18,7 +18,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Conformance][networking][router] router headers", func() {
+var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] router headers", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "router-http-echo-server.yaml")

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -23,7 +23,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Conformance][networking][router] openshift router metrics", func() {
+var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] openshift router metrics", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLI("router-metrics", exutil.KubeConfigPath())

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -14,7 +14,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Conformance][networking][router]", func() {
+var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "reencrypt-serving-cert.yaml")

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -20,7 +20,7 @@ import (
 
 const changeTimeoutSeconds = 3 * 60
 
-var _ = g.Describe("[Conformance][networking][router] openshift routers", func() {
+var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] openshift routers", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "scoped-router.yaml")

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Conformance][networking][router] weighted openshift router", func() {
+var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] weighted openshift router", func() {
 	defer g.GinkgoRecover()
 	var (
 		configPath = exutil.FixturePath("testdata", "weighted-router.yaml")

--- a/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -188,6 +188,10 @@ type Benchmarker interface {
 	RecordValueWithPrecision(name string, value float64, units string, precision int, info ...interface{})
 }
 
+func WalkTests(fn func(name string, node types.TestNode)) {
+	globalSuite.WalkTests(fn)
+}
+
 //RunSpecs is the entry point for the Ginkgo test runner.
 //You must call this within a Golang testing TestX(t *testing.T) function.
 //

--- a/vendor/github.com/onsi/ginkgo/internal/leafnodes/it_node.go
+++ b/vendor/github.com/onsi/ginkgo/internal/leafnodes/it_node.go
@@ -33,8 +33,16 @@ func (node *ItNode) Text() string {
 	return node.text
 }
 
+func (node *ItNode) SetText(text string) {
+	node.text = text
+}
+
 func (node *ItNode) Flag() types.FlagType {
 	return node.flag
+}
+
+func (node *ItNode) SetFlag(flag types.FlagType) {
+	node.flag = flag
 }
 
 func (node *ItNode) CodeLocation() types.CodeLocation {

--- a/vendor/github.com/onsi/ginkgo/internal/suite/suite.go
+++ b/vendor/github.com/onsi/ginkgo/internal/suite/suite.go
@@ -181,3 +181,14 @@ func (suite *Suite) PushAfterEachNode(body interface{}, codeLocation types.CodeL
 	}
 	suite.currentContainer.PushSetupNode(leafnodes.NewAfterEachNode(body, codeLocation, timeout, suite.failer, suite.containerIndex))
 }
+
+func (suite *Suite) WalkTests(fn func(testName string, test types.TestNode)) {
+	suite.topLevelContainer.BackPropagateProgrammaticFocus()
+	for _, collatedNodes := range suite.topLevelContainer.Collate() {
+		itNode, ok := collatedNodes.Subject.(*leafnodes.ItNode)
+		if !ok {
+			continue
+		}
+		fn(spec.New(collatedNodes.Subject, collatedNodes.Containers, false).ConcatenatedString(), itNode)
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/types/types.go
+++ b/vendor/github.com/onsi/ginkgo/types/types.go
@@ -171,3 +171,13 @@ const (
 	FlagTypeFocused
 	FlagTypePending
 )
+
+type TestNode interface {
+	Type() SpecComponentType
+	CodeLocation() CodeLocation
+
+	Text() string
+	SetText(text string)
+	Flag() FlagType
+	SetFlag(flag FlagType)
+}


### PR DESCRIPTION
Generates synthetic suites more effectively by actually modifying the test name based on the filter.  This means that `ginkgo -focus -dryRun` only prints the tests it will actually run.

Now:

    ginkgo ... -focus=Suite:openshift/conformance/parallel
    ginkgo ... -focus=Suite:openshift/conformance/serial

Both

    ginkgo ... -focus=Suite:openshift/conformance

OpenShift

    ginkgo ... -focus=Suite:openshift

Kubernetes

    ginkgo ... -focus=Suite:k8s

@stevekuznetsov @bparees I think this is easier to reason about