### PR TITLE
Fix filter namespaces in template router

### DIFF
--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -460,7 +460,7 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	}
 
 	for k := range r.state {
-		ns := strings.SplitN(k, "_", 2)[0]
+		ns := strings.SplitN(k, ":", 2)[0]
 		if namespaces.Has(ns) {
 			continue
 		}


### PR DESCRIPTION
Colon instead of underscore is used to uniquely identify ServiceAliasConfig(route for a service).