### PR TITLE
GetBootstrapSecurityContextConstraints: change return type to a slice of pointers

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -48,7 +48,7 @@ const (
 // GetBootstrapSecurityContextConstraints returns the slice of default SecurityContextConstraints
 // for system bootstrapping.  This method takes additional users and groups that should be added
 // to the strategies.  Use GetBoostrapSCCAccess to produce the default set of mappings.
-func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string][]string, sccNameToAdditionalUsers map[string][]string) []securityapi.SecurityContextConstraints {
+func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string][]string, sccNameToAdditionalUsers map[string][]string) []*securityapi.SecurityContextConstraints {
 	// define priorities here and reference them below so it is easy to see, at a glance
 	// what we're setting
 	var (
@@ -57,7 +57,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 		securityContextConstraintsAnyUIDPriority = int32(10)
 	)
 
-	constraints := []securityapi.SecurityContextConstraints{
+	constraints := []*securityapi.SecurityContextConstraints{
 		// SecurityContextConstraintPrivileged allows all access for every field
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -42,7 +42,7 @@ func TestBootstrappedConstraints(t *testing.T) {
 		}
 
 		for _, expectedVolume := range expectedVolumes {
-			if !sccutil.SCCAllowsFSType(&constraint, expectedVolume) {
+			if !sccutil.SCCAllowsFSType(constraint, expectedVolume) {
 				t.Errorf("%s does not support %v which is required for all default SCCs", constraint.Name, expectedVolume)
 			}
 		}

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -475,7 +475,7 @@ func (c *OpenshiftAPIConfig) bootstrapSCC(context genericapiserver.PostStartHook
 	bootstrapSCCGroups, bootstrapSCCUsers := bootstrappolicy.GetBoostrapSCCAccess(ns)
 
 	for _, scc := range bootstrappolicy.GetBootstrapSecurityContextConstraints(bootstrapSCCGroups, bootstrapSCCUsers) {
-		_, err := legacyclient.NewFromClient(c.KubeClientInternal.Core().RESTClient()).Create(&scc)
+		_, err := legacyclient.NewFromClient(c.KubeClientInternal.Core().RESTClient()).Create(scc)
 		if kapierror.IsAlreadyExists(err) {
 			continue
 		}

--- a/pkg/oc/admin/policy/reconcile_sccs.go
+++ b/pkg/oc/admin/policy/reconcile_sccs.go
@@ -177,8 +177,7 @@ func (o *ReconcileSCCOptions) ChangedSCCs() ([]*securityapi.SecurityContextConst
 	groups, users := bootstrappolicy.GetBoostrapSCCAccess(o.InfraNamespace)
 	bootstrapSCCs := bootstrappolicy.GetBootstrapSecurityContextConstraints(groups, users)
 
-	for i := range bootstrapSCCs {
-		expectedSCC := &bootstrapSCCs[i]
+	for _, expectedSCC := range bootstrapSCCs {
 		actualSCC, err := o.SCCClient.Get(expectedSCC.Name, metav1.GetOptions{})
 		// if not found it needs to be created
 		if kapierrors.IsNotFound(err) {


### PR DESCRIPTION
Extracted from https://github.com/openshift/origin/pull/15923#discussion_r134748038:

It turned out that in all the places we need `[]*SecurityContextConstraints`. This PR updates `GetBootstrapSecurityContextConstraints` function to return this type. This change simplify our code.

PTAL @pweil- @adelton 
CC @simo5 