### PR TITLE
UPSTREAM: 51215: preserve specified dest path

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
@@ -131,6 +131,13 @@ func runCopy(f cmdutil.Factory, cmd *cobra.Command, out, cmderr io.Writer, args 
 
 func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, src, dest fileSpec) error {
 	reader, writer := io.Pipe()
+
+	// if destination path ends in a "/", assume destination is a directory
+	// and copy source path inside destination directory
+	if string(dest.File[len(dest.File)-1]) == "/" {
+		dest.File = dest.File + path.Base(src.File)
+	}
+
 	go func() {
 		defer writer.Close()
 		err := makeTar(src.File, dest.File, writer)


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1469411
Also addresses BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1470962

**Before**
```
$ oc cp foo_dir pod_name:/tmp/bar_dir
$ oc rsh pod_name
sh-4.2$
sh-4.2$ ls /tmp
sh-4.2$ foo_dir
```

**After**
```
$ oc cp foo_dir pod_name:/tmp/bar_dir
$ oc rsh pod_name
sh-4.2$
sh-4.2$ ls /tmp
sh-4.2$ bar_dir
```

**Expected Command Behaviors After This Patch**
- **[ unchanged ]:** Copying a file `foo` to pod as `mypod:/tmp/` (trailing "/")
  - Will keep existing behavior of copying the file as `foo` with absolute path being `/tmp/foo` in the remote pod.
- **[ unchanged ]:** Copying a directory `foo_dir` to pod as `mypod:/tmp/` (trailing "/")
  - Will keep existing behavior of copying the directory as `foo_dir` with absolute path being `/tmp/foo_dir` in the remote pod.
- **[&nbsp;&nbsp;&nbsp;changed&nbsp;&nbsp;&nbsp;]:** Copying a file `foo` from local machine to pod as `mypod:/tmp/bar`
  - Will now honor `bar` as the final copied file's name, rather than always defaulting the file's name to `foo`
- **[&nbsp;&nbsp;&nbsp;changed&nbsp;&nbsp;&nbsp;]:** Copying a directory `foo_dir` to pod as `mypod:/tmp/bar_dir`
  - Will now honor `bar_dir` as the final copied directory's name, rather than always defaulting the directory's name to `foo_dir`.
- **[&nbsp;&nbsp;&nbsp;changed&nbsp;&nbsp;&nbsp;]:** Copying a directory `foo_dir` to pod as `mypod:/tmp` (no trailing slash)
  - Will now copy the *contents* of `foo_dir` into the `/tmp` directory (but will not copy the directory itself).
  - Before this patch, the user would receive a "permission denied" error instead; since it would attempt to create the directory under "/". Now, without the trailing slash after ":/tmp", it treats `/tmp` as the final directory's name - and if a directory by that name already exists, it merges the contents of both.
- **[&nbsp;&nbsp;&nbsp;changed&nbsp;&nbsp;&nbsp;]:** (Slightly changed) Copying a file `foo` to pod as `mypod:/tmp` (no trailing slash)
  - Will now return an error `tar: tmp: Cannot open: File exists` (it will try to honor `tmp` as copied file name, rather than old behavior of always using original file name)
  - Before this patch, returned the error `tar: can't open 'test': Permission denied`

cc @openshift/cli-review 