### PR TITLE
Adjust NetworkPolicy OVS flows for compatibility with (as-yet-unreleased) OVS 2.8

### DIFF
--- a/pkg/sdn/plugin/ovscontroller.go
+++ b/pkg/sdn/plugin/ovscontroller.go
@@ -130,7 +130,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR, serviceNetworkCIDR, localS
 	otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:60", serviceNetworkCIDR)
 	if oc.useConnTrack {
-		otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, ct_state=+rpl, actions=ct(nat),goto_table:70", localSubnetCIDR)
+		otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, ct_state=+rpl, actions=ct(nat,table=70)", localSubnetCIDR)
 	}
 	otx.AddFlow("table=30, priority=200, ip, nw_dst=%s, actions=goto_table:70", localSubnetCIDR)
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:90", clusterNetworkCIDR)


### PR DESCRIPTION
A (proposed) upcoming change to OVS 2.8 changes the behavior of flows using `ct()`, and we'll need this patch to remain compatible.

Specifically, without this change, the later flow `"table=80, priority=200, ip, ct_state=+rpl, actions=output:NXM_NX_REG2[]"` will never match, because the `ct_state` will have been cleared in the current context by the call to `ct(nat)`. With the change, processing of the packet after the table 30 rule continues in a context where `ct_state` is still set. (In OVS 2.7, the patch is basically a no-op; `ct_state` is set in both contexts.)