### PR TITLE
UPSTREAM: <carry>: Fix to avoid REST API calls at log level 2.

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -146,7 +146,7 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 // Log is intended to be called once at the end of your request handler, via defer
 func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
-	if glog.V(2) {
+	if glog.V(3) {
 		if !rl.hijacked {
 			glog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) %v%v%v [%s %s]", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo, rl.req.Header["User-Agent"], rl.req.RemoteAddr))
 		} else {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1484095. Its a regression in origin master (3.7). @sjenning 

This PR is carry because the previous PR to 3.6 was carry too (https://github.com/openshift/origin/pull/13844) due to uncertainty around upstream PR (https://github.com/kubernetes/kubernetes/pull/40933).

@stevekuznetsov @deads2k  Also is something broken in the rebase process or any related scripts that previous carry PR (https://github.com/openshift/origin/pull/13844) was dropped? Not to blame anyone, just informing as I am wondering if there are other carry PRs that got dropped and we are not aware causing regressions in future, so that if something is broken (process or script), can be fixed. 