### PR TITLE
bootstrap policy: replace panic with error

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/all.go
+++ b/pkg/cmd/server/bootstrappolicy/all.go
@@ -25,42 +25,29 @@ func Policy() *rbacrest.PolicyData {
 	}
 }
 
-func ConvertToOriginClusterRolesOrDie(in []rbac.ClusterRole) []authorizationapi.ClusterRole {
+func ConvertToOriginClusterRoles(in []rbac.ClusterRole) ([]authorizationapi.ClusterRole, error) {
 	out := []authorizationapi.ClusterRole{}
-	errs := []error{}
 
 	for i := range in {
 		newRole := &authorizationapi.ClusterRole{}
 		if err := kapi.Scheme.Convert(&in[i], newRole, nil); err != nil {
-			errs = append(errs, fmt.Errorf("error converting %q: %v", in[i].Name, err))
-			continue
+			return nil, fmt.Errorf("error converting %q: %v", in[i].Name, err)
 		}
 		out = append(out, *newRole)
 	}
-
-	if len(errs) > 0 {
-		panic(errs)
-	}
-
-	return out
+	return out, nil
 }
 
-func ConvertToOriginClusterRoleBindingsOrDie(in []rbac.ClusterRoleBinding) []authorizationapi.ClusterRoleBinding {
+func ConvertToOriginClusterRoleBindings(in []rbac.ClusterRoleBinding) ([]authorizationapi.ClusterRoleBinding, error) {
 	out := []authorizationapi.ClusterRoleBinding{}
-	errs := []error{}
 
 	for i := range in {
 		newRoleBinding := &authorizationapi.ClusterRoleBinding{}
 		if err := kapi.Scheme.Convert(&in[i], newRoleBinding, nil); err != nil {
-			errs = append(errs, fmt.Errorf("error converting %q: %v", in[i].Name, err))
-			continue
+			return nil, fmt.Errorf("error converting %q: %v", in[i].Name, err)
 		}
 		out = append(out, *newRoleBinding)
 	}
 
-	if len(errs) > 0 {
-		panic(errs)
-	}
-
-	return out
+	return out, nil
 }

--- a/pkg/oc/admin/policy/reconcile_clusterrolebindings.go
+++ b/pkg/oc/admin/policy/reconcile_clusterrolebindings.go
@@ -208,7 +208,10 @@ func (o *ReconcileClusterRoleBindingsOptions) ChangedClusterRoleBindings() ([]*a
 
 	rolesToReconcile := sets.NewString(o.RolesToReconcile...)
 	rolesNotFound := sets.NewString(o.RolesToReconcile...)
-	bootstrapClusterRoleBindings := bootstrappolicy.ConvertToOriginClusterRoleBindingsOrDie(bootstrappolicy.GetBootstrapClusterRoleBindings())
+	bootstrapClusterRoleBindings, err := bootstrappolicy.ConvertToOriginClusterRoleBindings(bootstrappolicy.GetBootstrapClusterRoleBindings())
+	if err != nil {
+		return nil, nil, err
+	}
 	for i := range bootstrapClusterRoleBindings {
 		expectedClusterRoleBinding := &bootstrapClusterRoleBindings[i]
 		if (len(rolesToReconcile) > 0) && !rolesToReconcile.Has(expectedClusterRoleBinding.RoleRef.Name) {

--- a/pkg/oc/admin/policy/reconcile_clusterroles.go
+++ b/pkg/oc/admin/policy/reconcile_clusterroles.go
@@ -191,7 +191,10 @@ func (o *ReconcileClusterRolesOptions) ChangedClusterRoles() ([]*authorizationap
 	rolesToReconcile := sets.NewString(o.RolesToReconcile...)
 	rolesNotFound := sets.NewString(o.RolesToReconcile...)
 	//TODO: nuke convert from orbit
-	bootstrapClusterRoles := bootstrappolicy.ConvertToOriginClusterRolesOrDie(bootstrappolicy.GetBootstrapClusterRoles())
+	bootstrapClusterRoles, err := bootstrappolicy.ConvertToOriginClusterRoles(bootstrappolicy.GetBootstrapClusterRoles())
+	if err != nil {
+		return nil, nil, err
+	}
 	for i := range bootstrapClusterRoles {
 		expectedClusterRole := &bootstrapClusterRoles[i]
 		if (len(rolesToReconcile) > 0) && !rolesToReconcile.Has(expectedClusterRole.Name) {


### PR DESCRIPTION
Replace panic() call in ConvertToOriginClusterRolesOrDie() and
ConvertToOriginClusterRoleBindingsOrDie() with error return value.
Callers take care of proper error handling.

@openshift/sig-security 

See: #15827
Signed-off-by: Christian Heimes <cheimes@redhat.com>