### PR TITLE
Consider openshift/origin-base a part of a release for pushing

### DIFF
--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -35,11 +35,11 @@ if [[ -z "${source_tag}" ]]; then
 fi
 
 base_images=(
-  openshift/origin-base
   openshift/origin-release
 )
 images=(
   openshift/origin
+  openshift/origin-base
   openshift/origin-pod
   openshift/origin-deployer
   openshift/origin-docker-builder


### PR DESCRIPTION
We are now depending on openshift/origin-base directly because of the
new manner in which we are building images. We need to be pushing the
base image as well as the component images to the hub.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton 