### PR TITLE
remove more special cases from the controller init path

### DIFF
--- a/pkg/cmd/server/kubernetes/master/controller/config.go
+++ b/pkg/cmd/server/kubernetes/master/controller/config.go
@@ -32,12 +32,6 @@ type KubeControllerConfig struct {
 func (c KubeControllerConfig) GetControllerInitializers() (map[string]kubecontroller.InitFunc, error) {
 	ret := kubecontroller.NewControllerInitializers()
 
-	// Remove the "normal" resource quota, because we run it as an openshift controller to cover all types
-	// TODO split openshift separately so we get upstream initialization here
-	delete(ret, "resourcequota")
-	// "serviceaccount-token" is used to create SA tokens for everyone else.  We special case this one.
-	delete(ret, "serviceaccount-token")
-
 	// overrides the Kube HPA controller config, so that we can point it at an HTTPS Heapster
 	// in openshift-infra, and pass it a scale client that knows how to scale DCs
 	ret["horizontalpodautoscaling"] = c.HorizontalPodAutoscalerControllerConfig.RunController

--- a/pkg/cmd/server/origin/controller/config.go
+++ b/pkg/cmd/server/origin/controller/config.go
@@ -40,7 +40,6 @@ func getOpenShiftClientEnvVars(options configapi.MasterConfig) ([]kapi.EnvVar, e
 type OpenshiftControllerConfig struct {
 	ServiceAccountTokenControllerOptions ServiceAccountTokenControllerOptions
 
-	// TODO, this should only hold the delta on names and we run two controllers, upstream and ours
 	ServiceAccountControllerOptions ServiceAccountControllerOptions
 
 	BuildControllerConfig BuildControllerConfig
@@ -64,8 +63,7 @@ type OpenshiftControllerConfig struct {
 func (c *OpenshiftControllerConfig) GetControllerInitializers() (map[string]InitFunc, error) {
 	ret := map[string]InitFunc{}
 
-	// TODO, this should only hold the delta on names and we run two controllers, upstream and ours
-	ret["serviceaccount"] = c.ServiceAccountControllerOptions.RunController
+	ret["openshift.io/serviceaccount"] = c.ServiceAccountControllerOptions.RunController
 
 	ret["openshift.io/serviceaccount-pull-secrets"] = RunServiceAccountPullSecretsController
 	ret["openshift.io/origin-namespace"] = RunOriginNamespaceController
@@ -87,8 +85,7 @@ func (c *OpenshiftControllerConfig) GetControllerInitializers() (map[string]Init
 	ret["openshift.io/unidling"] = c.UnidlingControllerConfig.RunController
 	ret["openshift.io/ingress-ip"] = c.IngressIPControllerConfig.RunController
 
-	// Overrides the upstream "resourcequota" controller
-	ret["resourcequota"] = RunResourceQuotaManager
+	ret["openshift.io/resourcequota"] = RunResourceQuotaManager
 	ret["openshift.io/cluster-quota-reconciliation"] = c.ClusterQuotaReconciliationControllerConfig.RunController
 
 	return ret, nil

--- a/pkg/cmd/server/origin/controller/quota.go
+++ b/pkg/cmd/server/origin/controller/quota.go
@@ -20,11 +20,9 @@ func RunResourceQuotaManager(ctx ControllerContext) (bool, error) {
 	replenishmentSyncPeriodFunc := calculateResyncPeriod(ctx.KubeControllerContext.Options.MinResyncPeriod.Duration)
 	saName := "resourcequota-controller"
 
-	resourceQuotaRegistry := quota.NewAllResourceQuotaRegistry(
-		ctx.ExternalKubeInformers,
+	resourceQuotaRegistry := quota.NewOriginQuotaRegistry(
 		ctx.ImageInformers.Image().InternalVersion().ImageStreams(),
 		ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
-		ctx.ClientBuilder.ClientOrDie(saName),
 	)
 
 	resourceQuotaControllerOptions := &kresourcequota.ResourceQuotaControllerOptions{

--- a/pkg/cmd/server/origin/controller/serviceaccount.go
+++ b/pkg/cmd/server/origin/controller/serviceaccount.go
@@ -26,6 +26,10 @@ func (c *ServiceAccountControllerOptions) RunController(ctx ControllerContext) (
 	options.ServiceAccounts = []kapiv1.ServiceAccount{}
 
 	for _, saName := range c.ManagedNames {
+		// the upstream controller does this one, so we don't have to
+		if saName == "default" {
+			continue
+		}
 		sa := kapiv1.ServiceAccount{}
 		sa.Name = saName
 


### PR DESCRIPTION
Trying to remove more special cases from the controller init path.

@mfojtik this is needed to avoid slips as controller initialization changes in kube from release to release.