### PR TITLE
Template test fixes

### DIFF
--- a/examples/templateservicebroker/templateservicebroker-template.yaml
+++ b/examples/templateservicebroker/templateservicebroker-template.yaml
@@ -55,6 +55,11 @@ objects:
             name: serving-cert
           - mountPath: /var/apiserver-config
             name: apiserver-config
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
         volumes:
         - name: serving-cert
           secret:

--- a/hack/update-generated-bindata.sh
+++ b/hack/update-generated-bindata.sh
@@ -59,7 +59,7 @@ pushd "${OS_ROOT}" > /dev/null
 popd > /dev/null
 
 # If you hit this, please reduce other tests instead of importing more
-if [[ "$( cat "${OUTPUT_PARENT}/test/extended/testdata/bindata.go" | wc -c )" -gt 920000 ]]; then
+if [[ "$( cat "${OUTPUT_PARENT}/test/extended/testdata/bindata.go" | wc -c )" -gt 950000 ]]; then
     echo "error: extended bindata is $( cat "${OUTPUT_PARENT}/test/extended/testdata/bindata.go" | wc -c ) bytes, reduce the size of the import" 1>&2
     exit 1
 fi

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13945,6 +13945,11 @@ objects:
             name: serving-cert
           - mountPath: /var/apiserver-config
             name: apiserver-config
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
         volumes:
         - name: serving-cert
           secret:

--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -155,7 +155,7 @@ func (c *TemplateInstanceController) sync(key string) error {
 	}
 
 	if !templateInstance.HasCondition(templateapi.TemplateInstanceInstantiateFailure, kapi.ConditionTrue) {
-		ready, err := c.checkReadiness(templateInstance)
+		ready, err := c.checkReadiness(templateInstance, time.Now())
 		if err != nil {
 			glog.V(4).Infof("TemplateInstance controller: checkReadiness %s returned %v", key, err)
 
@@ -205,8 +205,8 @@ func (c *TemplateInstanceController) sync(key string) error {
 	return nil
 }
 
-func (c *TemplateInstanceController) checkReadiness(templateInstance *templateapi.TemplateInstance) (bool, error) {
-	if time.Now().After(templateInstance.CreationTimestamp.Add(readinessTimeout)) {
+func (c *TemplateInstanceController) checkReadiness(templateInstance *templateapi.TemplateInstance, now time.Time) (bool, error) {
+	if now.After(templateInstance.CreationTimestamp.Add(readinessTimeout)) {
 		return false, fmt.Errorf("Timeout")
 	}
 

--- a/pkg/template/controller/templateinstance_controller_test.go
+++ b/pkg/template/controller/templateinstance_controller_test.go
@@ -1,0 +1,121 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	clientgotesting "k8s.io/client-go/testing"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/authorization"
+	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+
+	"github.com/openshift/origin/pkg/client"
+	templateapi "github.com/openshift/origin/pkg/template/apis/template"
+)
+
+type roundtripper func(*http.Request) (*http.Response, error)
+
+func (rt roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+// TestControllerCheckReadiness verifies the basic behaviour of
+// TemplateInstanceController.checkReadiness(): that it can return ready, not
+// ready and timed out correctly.
+func TestControllerCheckReadiness(t *testing.T) {
+	job := batchv1.Job{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				templateapi.WaitForReadyAnnotation: "true",
+			},
+		},
+	}
+
+	// fake generic API server, responds to any HTTP req with the above job
+	// object
+	fakerestconfig := &rest.Config{
+		WrapTransport: func(http.RoundTripper) http.RoundTripper {
+			return roundtripper(func(req *http.Request) (*http.Response, error) {
+				b, err := json.Marshal(job)
+				if err != nil {
+					panic(err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewBuffer(b)),
+				}, nil
+			})
+		},
+	}
+
+	// fakeclient, respond "allowed" to any subjectaccessreview
+	fakeclientset := &fake.Clientset{}
+	c := &TemplateInstanceController{
+		restmapper: client.DefaultMultiRESTMapper(),
+		kc:         fakeclientset,
+		config:     fakerestconfig,
+	}
+	fakeclientset.AddReactor("create", "subjectaccessreviews", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &authorization.SubjectAccessReview{Status: authorization.SubjectAccessReviewStatus{Allowed: true}}, nil
+	})
+
+	now := time.Now()
+	templateInstance := &templateapi.TemplateInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: now},
+		},
+		Spec: templateapi.TemplateInstanceSpec{
+			Requester: &templateapi.TemplateInstanceRequester{},
+		},
+		Status: templateapi.TemplateInstanceStatus{
+			Objects: []templateapi.TemplateInstanceObject{
+				{
+					Ref: kapi.ObjectReference{
+						APIVersion: "batch/v1",
+						Kind:       "Job",
+						Namespace:  "namespace",
+						Name:       "name",
+					},
+				},
+			},
+		},
+	}
+
+	// should report not ready yet
+	ready, err := c.checkReadiness(templateInstance, now)
+	if ready || err != nil {
+		t.Error(ready, err)
+	}
+
+	// should report timed out
+	ready, err = c.checkReadiness(templateInstance, now.Add(readinessTimeout+1))
+	if ready || err == nil || err.Error() != "Timeout" {
+		t.Error(ready, err)
+	}
+
+	// should report ready
+	job.Status.CompletionTime = &metav1.Time{Time: now}
+	ready, err = c.checkReadiness(templateInstance, now)
+	if !ready || err != nil {
+		t.Error(ready, err)
+	}
+
+	// should report failed
+	job.Status.Failed = int32(1)
+	ready, err = c.checkReadiness(templateInstance, now)
+	if ready || err == nil || err.Error() != "Readiness failed on Job namespace/name" {
+		t.Error(ready, err)
+	}
+}

--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -12,15 +12,15 @@ From the top-level origin directory, run
 
 Where \<some_script\>.sh is one of the bucket scripts such as "core.sh".
 
-You can further narrow the set of tests being run by passing
-`--ginkgo.focus='regex'` where 'regex' is a regular expression matching the
+You can further narrow the set of tests being run by setting the environment
+variable `FOCUS='regex'` where 'regex' is a regular expression matching the
 description of the test you want to run.  For example one of the s2i tests
 (s2i_incremental.go) defines:
 
 	var _ = g.Describe("[builds][Slow] incremental s2i build", func() {
 
-So you can write a focus regex that includes this test by passing
-`--ginkgo.focus='\[builds\]'` or `--ginkgo.focus='incremental s2i'`.
+So you can write a focus regex that includes this test by setting
+`FOCUS='\[builds\]'` or `FOCUS='incremental s2i'`.
 
 Prerequisites
 -------------
@@ -53,18 +53,18 @@ $ export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
 Then, for example:
 ```console
 $ make build-extended-test
-$ TEST_ONLY=1 test/extended/core.sh --ginkgo.focus='\[builds\]'
+$ FOCUS='\[builds\]' TEST_ONLY=1 test/extended/core.sh
 ```
 
 By default the Kubernetes test framework will remove the project associated with
 your test spec when it completes, regardless of whether it fails or not.
-Origin's wrapper scripts may also do clean-up.  This can be inconvenient when
-debugging.  To stop this behaviour, set the `SKIP_TEARDOWN` environment variable
-and add the argument `--delete-namespace=false`:
+Origin's wrapper scripts may also do clean-up.  Running tests in parallel can
+also hinder debugging.  To stop these behaviours, set the `SKIP_TEARDOWN`
+environment variable, set `DELETE_NAMESPACE=false`, and set `PARALLEL_NODES=1`:
 
 ```console
 $ make build-extended-test
-$ SKIP_TEARDOWN=1 TEST_ONLY=1 test/extended/core.sh --delete-namespace=false --ginkgo.focus='\[builds\]'
+$ FOCUS='\[builds\]' TEST_ONLY=1 SKIP_TEARDOWN=1 DELETE_NAMESPACE=false PARALLEL_NODES=1 test/extended/core.sh
 ```
 
 Test labels

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -1,36 +1,30 @@
 package templates
 
 import (
+	"bufio"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/pkg/apis/extensions"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
-	kexternalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
-	intframework "k8s.io/kubernetes/test/integration/framework"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	osbclient "github.com/openshift/origin/pkg/openservicebroker/client"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	exutil "github.com/openshift/origin/test/extended/util"
-)
-
-const (
-	tsbNS   = "openshift-template-service-broker"
-	tsbHost = "apiserver." + tsbNS + ".svc"
 )
 
 func createUser(cli *exutil.CLI, name, role string) *userapi.User {
@@ -79,109 +73,64 @@ func setUser(cli *exutil.CLI, user *userapi.User) {
 	}
 }
 
-// EnsureTSB makes sure the TSB is present where expected and returns a client to speak to it and
-// and a close method which provides the proxy.  The caller must call the close method, usually done in AfterEach
+// EnsureTSB makes sure a TSB is present where expected and returns a client to
+// speak to it and a close method which provides the proxy.  The caller must
+// call the close method, usually done in AfterEach
 func EnsureTSB(tsbOC *exutil.CLI) (osbclient.Client, func() error) {
-	exists := true
-	if _, err := tsbOC.AdminKubeClient().Extensions().DaemonSets(tsbNS).Get("apiserver", metav1.GetOptions{}); err != nil {
-		if !kerrors.IsNotFound(err) {
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
-		exists = false
-	}
+	configPath := exutil.FixturePath("..", "..", "examples", "templateservicebroker", "templateservicebroker-template.yaml")
 
-	if !exists {
-		e2e.Logf("Installing TSB onto the cluster for testing")
-		_, _, err := tsbOC.AsAdmin().WithoutNamespace().Run("create", "namespace").Args(tsbNS).Outputs()
-		// If template tests run in parallel this could be created twice, we don't really care.
+	err := tsbOC.AsAdmin().Run("new-app").Args(configPath, "-p", "LOGLEVEL=4", "-p", "NAMESPACE="+tsbOC.Namespace()).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	var pod *kapiv1.Pod
+	err = wait.Poll(e2e.Poll, 10*time.Minute, func() (bool, error) {
+		pods, err := tsbOC.KubeClient().CoreV1().Pods(tsbOC.Namespace()).List(metav1.ListOptions{})
 		if err != nil {
-			e2e.Logf("Error creating TSB namespace %s: %v \n", tsbNS, err)
+			return false, err
 		}
-		configPath := exutil.FixturePath("..", "..", "examples", "templateservicebroker", "templateservicebroker-template.yaml")
-		stdout, _, err := tsbOC.WithoutNamespace().Run("process").Args("-f", configPath).Outputs()
-		if err != nil {
-			e2e.Logf("Error processing TSB template at %s: %v \n", configPath, err)
+		pod = nil
+		for _, p := range pods.Items {
+			if strings.HasPrefix(p.Name, "apiserver-") {
+				pod = &p
+				break
+			}
 		}
-		err = tsbOC.WithoutNamespace().AsAdmin().Run("create").Args("-f", "-").InputString(stdout).Execute()
-		if err != nil {
-			// If template tests run in parallel this could be created twice, we don't really care.
-			e2e.Logf("Error creating TSB resources: %v \n", err)
+		if pod == nil {
+			return false, nil
 		}
-	}
-	err := WaitForDaemonSetStatus(tsbOC.AdminKubeClient(), &extensions.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: tsbNS}})
+		for _, c := range pod.Status.Conditions {
+			if c.Type == kapiv1.PodReady && c.Status == kapiv1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	// we're trying to test the TSB, not the service.  We're outside all the normal networks.  Run a portforward to a particular
 	// pod and test that
-	pods, err := tsbOC.AdminKubeClient().Core().Pods(tsbNS).List(metav1.ListOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	var pod *kapiv1.Pod
-	for i := range pods.Items {
-		currPod := pods.Items[i]
-		for _, cond := range currPod.Status.Conditions {
-			if cond.Type == kapiv1.PodReady && cond.Status == kapiv1.ConditionTrue {
-				pod = &currPod
-				break
-			} else {
-				out, _ := json.Marshal(currPod.Status)
-				e2e.Logf("%v %v", currPod.Name, string(out))
-			}
-		}
-	}
-	if pod == nil {
-		e2e.Failf("no ready pod found")
-	}
-	port, err := intframework.FindFreeLocalPort()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	portForwardCmd, _, _, err := tsbOC.AsAdmin().WithoutNamespace().Run("port-forward").Args("-n="+tsbNS, pod.Name, fmt.Sprintf("%d:8443", port)).Background()
+	portForwardCmd, stdout, err := tsbOC.Run("port-forward").Args(pod.Name, ":8443").BackgroundRC()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	svc, err := tsbOC.AdminKubeClient().Core().Services(tsbNS).Get("apiserver", metav1.GetOptions{})
+	// read in the local address the port-forwarder is listening on
+	br := bufio.NewReader(stdout)
+	portline, err := br.ReadString('\n')
 	o.Expect(err).NotTo(o.HaveOccurred())
-	tsbclient := osbclient.NewClient(&http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}, fmt.Sprintf("https://localhost:%d%s", port, templateapi.ServiceBrokerRoot))
 
-	// wait to get back healthy from the tsb
-	healthResponse := ""
-	err = wait.Poll(e2e.Poll, 2*time.Minute, func() (bool, error) {
-		resp, err := tsbclient.Client().Get("https://" + svc.Spec.ClusterIP + "/healthz")
-		if err != nil {
-			return false, err
-		}
-		defer resp.Body.Close()
-		content, _ := ioutil.ReadAll(resp.Body)
-		healthResponse = string(content)
-		if resp.StatusCode == http.StatusOK {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		o.Expect(fmt.Errorf("error waiting for the TSB to be healthy: %v: %v", healthResponse, err)).NotTo(o.HaveOccurred())
-	}
+	s := regexp.MustCompile(`Forwarding from (.*) ->`).FindStringSubmatch(portline)
+	o.Expect(s).To(o.HaveLen(2))
+
+	go io.Copy(ioutil.Discard, br)
+
+	tsbclient := osbclient.NewClient(&http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}, "https://"+s[1]+templateapi.ServiceBrokerRoot)
 
 	return tsbclient, func() error {
-		err := portForwardCmd.Process.Kill()
-		portForwardOutput, _ := portForwardCmd.CombinedOutput()
-		e2e.Logf("PortForward output:\n%v", string(portForwardOutput))
-		return err
+		return portForwardCmd.Process.Kill()
 	}
-}
-
-// Waits for the daemonset to have at least one ready pod
-func WaitForDaemonSetStatus(c kexternalclientset.Interface, d *extensions.DaemonSet) error {
-	err := wait.Poll(e2e.Poll, 5*time.Minute, func() (bool, error) {
-		var err error
-		ds, err := c.Extensions().DaemonSets(d.Namespace).Get(d.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		if ds.Status.NumberReady > 0 {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("error waiting for ds %q status to match expectation: %v", d.Name, err)
-	}
-	return nil
 }

--- a/test/extended/templates/templateinstance_cross_namespace.go
+++ b/test/extended/templates/templateinstance_cross_namespace.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[templates] templateinstance cross-namespace test", func() {
+var _ = g.Describe("[Conformance][templates] templateinstance cross-namespace test", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -22,7 +22,7 @@ import (
 // or can impersonate, the requester.
 // 2. Check that templateinstancespecs, particularly including
 // requester.username, are immutable.
-var _ = g.Describe("[templates] templateinstance impersonation tests", func() {
+var _ = g.Describe("[Conformance][templates] templateinstance impersonation tests", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateinstance_objectkinds.go
+++ b/test/extended/templates/templateinstance_objectkinds.go
@@ -16,7 +16,7 @@ import (
 
 // ensure that we can instantiate Kubernetes and OpenShift objects, legacy and
 // non-legacy, from a range of API groups.
-var _ = g.Describe("[templates] templateinstance object kinds test", func() {
+var _ = g.Describe("[Conformance][templates] templateinstance object kinds test", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
@@ -20,7 +21,7 @@ import (
 )
 
 // ensure that template instantiation waits for annotated objects
-var _ = g.Describe("[templates] templateinstance readiness test", func() {
+var _ = g.Describe("[Conformance][templates] templateinstance readiness test", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -97,6 +98,8 @@ var _ = g.Describe("[templates] templateinstance readiness test", func() {
 	}
 
 	g.BeforeEach(func() {
+		framework.SkipIfProviderIs("gce")
+
 		err := cli.Run("create").Args("-f", templatefixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_security.go
+++ b/test/extended/templates/templateinstance_security.go
@@ -26,7 +26,7 @@ import (
 
 // Check that objects created through the TemplateInstance mechanism are done
 // impersonating the requester, and that privilege escalation is not possible.
-var _ = g.Describe("[templates] templateinstance security tests", func() {
+var _ = g.Describe("[Conformance][templates] templateinstance security tests", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 	defer g.GinkgoRecover()
 
 	var (
-		tsbOC               = exutil.NewCLI(tsbNS, exutil.KubeConfigPath())
+		tsbOC               = exutil.NewCLI("openshift-template-service-broker", exutil.KubeConfigPath())
 		portForwardCmdClose func() error
 
 		cli                = exutil.NewCLI("templates", exutil.KubeConfigPath())

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 		var err error
 
 		// should have been created before the extended test runs
-		template, err = cli.TemplateClient().Template().Templates("openshift").Get("cakephp-mysql-persistent", metav1.GetOptions{})
+		template, err = cli.TemplateClient().Template().Templates("openshift").Get("cakephp-mysql-example", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		processedtemplate, err = cli.AdminClient().TemplateConfigs("openshift").Create(template)
@@ -196,7 +196,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 			"DATABASE_USER": []byte("test"),
 		}))
 
-		examplesecret, err := cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Get("cakephp-mysql-persistent", metav1.GetOptions{})
+		examplesecret, err := cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Get("cakephp-mysql-example", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		o.Expect(examplesecret.Labels[templateapi.TemplateInstanceLabel]).To(o.Equal(instanceID))

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -24,7 +24,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[templates] templateservicebroker end-to-end test", func() {
+var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end test", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker security test
 
 		var err error
 
-		template, err = cli.Client().Templates("openshift").Get("cakephp-mysql-persistent", metav1.GetOptions{})
+		template, err = cli.Client().Templates("openshift").Get("cakephp-mysql-example", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		clusterrolebinding, err = cli.AdminClient().ClusterRoleBindings().Create(&authorizationapi.ClusterRoleBinding{

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[templates] templateservicebroker security test", func() {
+var _ = g.Describe("[Conformance][templates] templateservicebroker security test", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker security test
 	defer g.GinkgoRecover()
 
 	var (
-		tsbOC               = exutil.NewCLI(tsbNS, exutil.KubeConfigPath())
+		tsbOC               = exutil.NewCLI("openshift-template-service-broker", exutil.KubeConfigPath())
 		portForwardCmdClose func() error
 
 		cli                = exutil.NewCLI("templates", exutil.KubeConfigPath())

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -27807,6 +27807,11 @@ objects:
             name: serving-cert
           - mountPath: /var/apiserver-config
             name: apiserver-config
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
         volumes:
         - name: serving-cert
           secret:


### PR DESCRIPTION
- add all template tests to Conformance
- don't use persistent templates for templateservicebroker tests
- additional template instance controller readiness checking testing
- increase tsb loglevel in extended tests

fixes https://github.com/openshift/origin/issues/15912
fixes https://github.com/openshift/origin/issues/15961
