### PR TITLE
Router - A/B weights properly distributed

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -386,8 +386,9 @@ backend be_secure:{{$cfgIdx}}
   {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
     {{- if ne $weight 0 }}
       {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+      {{- with $serviceEndpoints := index $cfg.ServiceEndpoints $serviceUnitName }}
         {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{calcWeight $weight $serviceEndpoints $idx}}
           {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
             {{- end }}
@@ -407,6 +408,7 @@ backend be_secure:{{$cfgIdx}}
 
           {{- end }}{{/* end if cg.TLSTermination */}}
         {{- end }}{{/* end range processEndpointsForAlias */}}
+      {{- end }}{{/* end get serviceEndpoints from its name */}}
       {{- end }}{{/* end get serviceUnit from its name */}}
   {{- end }}{{/* end range over serviceUnitNames */}}
 
@@ -453,11 +455,13 @@ backend be_tcp:{{$cfgIdx}}
     {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
       {{- if ne $weight 0 }}
         {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+        {{- with $serviceEndpoints := index $cfg.ServiceEndpoints $serviceUnitName }}
           {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{calcWeight $weight $serviceEndpoints $idx}}
             {{- if not $endpoint.NoHealthCheck }} check inter {{firstMatch $timeSpecRE (index $cfg.Annotations "router.openshift.io/haproxy.health.check.interval") (env "ROUTER_BACKEND_CHECK_INTERVAL") "5000ms"}}
             {{- end }}{{/* end else no health check */}}
           {{- end }}{{/* end range processEndpointsForAlias */}}
+        {{- end }}{{/* end get ServiceEndpoints from serviceUnitName */}}
         {{- end }}{{/* end get ServiceUnit from serviceUnitName */}}
       {{- end }}{{/* end if weight != 0 */}}
     {{- end }}{{/* end iterate over services*/}}

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -174,11 +174,13 @@ func (r *TestRouter) DeleteEndpoints(id string) {
 // AddRoute adds a ServiceAliasConfig and associated ServiceUnits for the route
 func (r *TestRouter) AddRoute(route *routeapi.Route) {
 	routeKey := r.routeKey(route)
+	serviceUnitNames, serviceEndpoints := getServiceUnits(r.numberOfEndpoints, route)
 
 	config := ServiceAliasConfig{
 		Host:             route.Spec.Host,
 		Path:             route.Spec.Path,
-		ServiceUnitNames: getServiceUnits(r.numberOfEndpoints, route),
+		ServiceUnitNames: serviceUnitNames,
+		ServiceEndpoints: serviceEndpoints,
 	}
 
 	for key := range config.ServiceUnitNames {

--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -297,3 +297,71 @@ func TestMatchPattern(t *testing.T) {
 		}
 	}
 }
+
+func TestCalcWeight(t *testing.T) {
+	testCases := []struct {
+		name   string
+		weight int32
+		eps    int32
+		idx    int
+		result int32
+	}{
+		// Test various situations
+		{
+			name: "weight 100 over 2 eps, idx 0",
+			weight: 100,
+			eps:	2,
+			idx:	0,
+			result: 50,
+		},
+		{
+			name: "weight 100 over 2 eps, idx 1",
+			weight: 100,
+			eps:	2,
+			idx:	1,
+			result: 50,
+		},
+		{
+			name: "weight 1 over 2 eps, idx 0",
+			weight: 1,
+			eps:	2,
+			idx:	0,
+			result: 1,
+		},
+		{
+			name: "weight 1 over 2 eps, idx 1",
+			weight: 1,
+			eps:	2,
+			idx:	1,
+			result: 0,
+		},
+		{
+			name: "weight 17 over 2 eps, idx 0",
+			weight: 17,
+			eps:	2,
+			idx:	0,
+			result: 9,
+		},
+		{
+			name: "weight 17 over 2 eps, idx 1",
+			weight: 17,
+			eps:	2,
+			idx:	1,
+			result: 8,
+		},
+		{
+			name: "no endpoints",
+			weight: 100,
+			eps:	0,
+			idx:	0,
+			result: 0,
+		},
+	}
+
+	for _, tt := range testCases {
+		weight := calcWeight(tt.weight, tt.eps, tt.idx)
+		if weight != tt.result {
+			t.Errorf("%s: weight %d, %d endpoints at index %d expected %d but got %d", tt.name, tt.weight, tt.eps, tt.idx, tt.result, weight)
+		}
+	}
+}

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -57,6 +57,10 @@ type ServiceAliasConfig struct {
 	// and valued on the weight attached to it with respect to other entries in the map
 	ServiceUnitNames map[string]int32
 
+	// ServiceEndpoints is the number of endpoints for each of the services, keyed by
+	// service name, that support this route.
+	ServiceEndpoints map[string]int32
+
 	// ActiveServiceUnits is a count of the service units with a non-zero weight
 	ActiveServiceUnits int
 }


### PR DESCRIPTION
[WIP][DO NOT MERGE]

Service weight is roughly distributed among the endpoints. The
service can end up with more or less weight than desired.

This change distributes the exact service weight among the endpoints.

There are two cases that are of interest:
1) The weight doesn't divide by the number of endpoints.
For example the weight is 17 and there are 3 endpoints.
endpoints 0 and 1 will end up with 6 and endpoints 2 will have 5.
2) The weigth is 3 and there are 5 endpoints.
The minimum weight is 1, so endpoints 0, 1, and 2 will get 1 and
endpoints 3 and 4 will get 0.

Added test case for calcWeight.

bug: 1477685
https://bugzilla.redhat.com/show_bug.cgi?id=1477685

Trello: BhWCH3vu
https://trello.com/c/BhWCH3vu/543-3-fix-problem-in-a-b-weight-algorithm