### PR TITLE
Treat the missing binary message as an info not warning

### DIFF
--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -55,7 +55,7 @@ function os::util::ensure::built_binary_exists() {
 		fi
 
 		if [[ -n "${target}" ]]; then
-			os::log::warning "No compiled \`${binary}\` binary was found. Attempting to build one using:
+			os::log::info "No compiled \`${binary}\` binary was found. Attempting to build one using:
   $ hack/build-go.sh ${target}"
 			"${OS_ROOT}/hack/build-go.sh" "${target}"
 		else


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @deads2k 