### PR TITLE
Remove getAPIGroupLegacy() from scope conversion

### DIFF
--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -443,7 +443,7 @@ func removeEscalatingResources(in rbac.PolicyRule) rbac.PolicyRule {
 	var ruleCopy *rbac.PolicyRule
 
 	for _, resource := range escalatingScopeResources {
-		if !(has(getAPIGroupLegacy(in), resource.Group) && has(in.Resources, resource.Resource)) {
+		if !(has(in.APIGroups, resource.Group) && has(in.Resources, resource.Resource)) {
 			continue
 		}
 
@@ -462,14 +462,6 @@ func removeEscalatingResources(in rbac.PolicyRule) rbac.PolicyRule {
 	}
 
 	return in
-}
-
-func getAPIGroupLegacy(rule rbac.PolicyRule) []string {
-	if len(rule.APIGroups) == 0 {
-		// this was done for backwards compatibility in the authorizer
-		return []string{""}
-	}
-	return rule.APIGroups
 }
 
 func ValidateScopeRestrictions(client *oauthapi.OAuthClient, scopes ...string) error {

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -226,14 +226,14 @@ func TestEscalationProtection(t *testing.T) {
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
 		{
-			name: "match old group secrets",
+			name: "no longer match old group secrets",
 			clusterRoles: []rbac.ClusterRole{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "admin"},
 					Rules:      []rbac.PolicyRule{{APIGroups: []string{}, Resources: []string{"pods", "secrets"}}},
 				},
 			},
-			expectedRules: []rbac.PolicyRule{authorizationapi.RbacDiscoveryRule, {APIGroups: []string{}, Resources: []string{"pods"}}},
+			expectedRules: []rbac.PolicyRule{authorizationapi.RbacDiscoveryRule, {APIGroups: []string{}, Resources: []string{"pods", "secrets"}}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
 		{


### PR DESCRIPTION
Use of this helper function is no longer needed after the RBAC conversion.
Fixes #15824 
@enj @simo5 