### PR TITLE
UPSTREAM: 51477: Convert generated obj before printing

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
@@ -395,7 +395,13 @@ func Run(f cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr io
 
 	outputFormat := cmdutil.GetFlagString(cmd, "output")
 	if outputFormat != "" || cmdutil.GetDryRunFlag(cmd) {
-		return f.PrintObject(cmd, false, mapper, obj, cmdOut)
+		// convert to internal version before passing to the printer
+		internalObj, err := mapping.ConvertToVersion(obj, schema.GroupVersion{Group: mapping.GroupVersionKind.Group, Version: runtime.APIVersionInternal})
+		if err != nil {
+			return err
+		}
+
+		return f.PrintObject(cmd, false, mapper, internalObj, cmdOut)
 	}
 	cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
 	return nil


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1455115

Converts a generated object to internalversion before handing it to `cmdutil.Factory#PrintObject`.
Objects are re-converted to external version by the cmdutil.Factory if being printed in a generic format (json, yaml), so this patch does not affect how it was being printed before with a generic printer.

**Before**
```
$ oc run mysql --image=mysql --dry-run
error: unknown type *v1.DeploymentConfig, expected unstructured in map[reflect.Type]
...
```

**After**
```
$ oc run mysql --image=mysql --dry-run
NAME      REVISION   DESIRED   CURRENT   TRIGGERED BY
mysql     0          1         0
```

cc @openshift/cli-review 