### PR TITLE
Update test alert metadata

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -245,9 +245,18 @@ objects:
         - alert: Node Down
           expr: up{job="kubernetes-nodes"} == 0
           annotations:
-            miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
+        #
+        # Example alert with annotations needed for ManageIQ alert collection.
+        #
+        #- alert: "ManageIQ test alert"
+        #  expr: up{job="kubernetes-nodes"} == 0
+        #  annotations:
+        #    miqTarget: "ContainerNode"
+        #    severity: "HIGH"
+        #    url: "https://www.example.com/fixing_instructions"
+        #    message: "Alerts configured correctly! ContainerNode {{$labels.instance}} is up"
     prometheus.yml: |
       rule_files:
         - 'prometheus.rules'

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13214,9 +13214,18 @@ objects:
         - alert: Node Down
           expr: up{job="kubernetes-nodes"} == 0
           annotations:
-            miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
+        #
+        # Example alert with annotations needed for ManageIQ alert collection.
+        #
+        #- alert: "ManageIQ test alert"
+        #  expr: up{job="kubernetes-nodes"} == 0
+        #  annotations:
+        #    miqTarget: "ContainerNode"
+        #    severity: "HIGH"
+        #    url: "https://www.example.com/fixing_instructions"
+        #    message: "Alerts configured correctly! ContainerNode {{$labels.instance}} is up"
     prometheus.yml: |
       rule_files:
         - 'prometheus.rules'

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -24544,9 +24544,18 @@ objects:
         - alert: Node Down
           expr: up{job="kubernetes-nodes"} == 0
           annotations:
-            miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
+        #
+        # Example alert with annotations needed for ManageIQ alert collection.
+        #
+        #- alert: "ManageIQ test alert"
+        #  expr: up{job="kubernetes-nodes"} == 0
+        #  annotations:
+        #    miqTarget: "ContainerNode"
+        #    severity: "HIGH"
+        #    url: "https://www.example.com/fixing_instructions"
+        #    message: "Alerts configured correctly! ContainerNode {{$labels.instance}} is up"
     prometheus.yml: |
       rule_files:
         - 'prometheus.rules'


### PR DESCRIPTION
The purpose of this test alert is to see that alerts are configured correctly for going into ManageIQ.
This will make it easier to see alerts are working properly straight away