### PR TITLE
Drop double conversion in boostrap policy

### DIFF
--- a/pkg/authorization/util/subject.go
+++ b/pkg/authorization/util/subject.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+func BuildRBACSubjects(users, groups []string) []rbac.Subject {
+	subjects := []rbac.Subject{}
+
+	for _, user := range users {
+		saNamespace, saName, err := serviceaccount.SplitUsername(user)
+		if err == nil {
+			subjects = append(subjects, rbac.Subject{Kind: rbac.ServiceAccountKind, Namespace: saNamespace, Name: saName})
+		} else {
+			subjects = append(subjects, rbac.Subject{Kind: rbac.UserKind, APIGroup: rbac.GroupName, Name: user})
+		}
+	}
+
+	for _, group := range groups {
+		subjects = append(subjects, rbac.Subject{Kind: rbac.GroupKind, APIGroup: rbac.GroupName, Name: group})
+	}
+
+	return subjects
+}

--- a/pkg/cmd/server/bootstrappolicy/all.go
+++ b/pkg/cmd/server/bootstrappolicy/all.go
@@ -1,16 +1,9 @@
 package bootstrappolicy
 
 import (
-	"fmt"
-
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
-
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
-
-// TODO: this needs some work since we are double converting
 
 func Policy() *rbacrest.PolicyData {
 	return &rbacrest.PolicyData{
@@ -23,44 +16,4 @@ func Policy() *rbacrest.PolicyData {
 			DefaultOpenShiftSharedResourcesNamespace: GetBootstrapOpenshiftRoleBindings(DefaultOpenShiftSharedResourcesNamespace),
 		},
 	}
-}
-
-func ConvertToOriginClusterRolesOrDie(in []rbac.ClusterRole) []authorizationapi.ClusterRole {
-	out := []authorizationapi.ClusterRole{}
-	errs := []error{}
-
-	for i := range in {
-		newRole := &authorizationapi.ClusterRole{}
-		if err := kapi.Scheme.Convert(&in[i], newRole, nil); err != nil {
-			errs = append(errs, fmt.Errorf("error converting %q: %v", in[i].Name, err))
-			continue
-		}
-		out = append(out, *newRole)
-	}
-
-	if len(errs) > 0 {
-		panic(errs)
-	}
-
-	return out
-}
-
-func ConvertToOriginClusterRoleBindingsOrDie(in []rbac.ClusterRoleBinding) []authorizationapi.ClusterRoleBinding {
-	out := []authorizationapi.ClusterRoleBinding{}
-	errs := []error{}
-
-	for i := range in {
-		newRoleBinding := &authorizationapi.ClusterRoleBinding{}
-		if err := kapi.Scheme.Convert(&in[i], newRoleBinding, nil); err != nil {
-			errs = append(errs, fmt.Errorf("error converting %q: %v", in[i].Name, err))
-			continue
-		}
-		out = append(out, *newRoleBinding)
-	}
-
-	if len(errs) > 0 {
-		panic(errs)
-	}
-
-	return out
 }


### PR DESCRIPTION
Drop ``ConvertToOriginClusterRolesOrDie`` and ``ConvertToOriginClusterRoleBindingsOrDie``. Additional conversion like ``ClusterRoleBindingFromRBAC`` and ``ClusterRoleBindingToRBAC`` will be replaced once ``rbac.ClusterRoleInterface`` client is available.

@openshift/sig-security 

Closes: #15827
Signed-off-by: Christian Heimes <cheimes@redhat.com>