### PR TITLE
RBAC Migration Followup #4: Use upstream subject locator directly

### DIFF
--- a/pkg/authorization/apiserver/apiserver.go
+++ b/pkg/authorization/apiserver/apiserver.go
@@ -14,9 +14,9 @@ import (
 	rbacclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
-	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/authorization/registry/clusterrole"
 	"github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding"
 	"github.com/openshift/origin/pkg/authorization/registry/localresourceaccessreview"
@@ -36,7 +36,7 @@ type AuthorizationAPIServerConfig struct {
 	CoreAPIServerClientConfig *restclient.Config
 	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 	RuleResolver              rbacregistryvalidation.AuthorizationRuleResolver
-	SubjectLocator            authorizer.SubjectLocator
+	SubjectLocator            authorizerrbac.SubjectLocator
 
 	// TODO these should all become local eventually
 	Scheme   *runtime.Scheme

--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -3,28 +3,17 @@ package authorizer
 import (
 	"errors"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/kubernetes/pkg/apis/rbac"
-	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
+	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 type openshiftAuthorizer struct {
-	delegate              authorizer.Authorizer
+	delegate              kauthorizer.Authorizer
 	forbiddenMessageMaker ForbiddenMessageMaker
 }
 
-type openshiftSubjectLocator struct {
-	delegate authorizerrbac.SubjectLocator
-}
-
-func NewAuthorizer(delegate authorizer.Authorizer, forbiddenMessageMaker ForbiddenMessageMaker) authorizer.Authorizer {
+func NewAuthorizer(delegate kauthorizer.Authorizer, forbiddenMessageMaker ForbiddenMessageMaker) authorizer.Authorizer {
 	return &openshiftAuthorizer{delegate: delegate, forbiddenMessageMaker: forbiddenMessageMaker}
-}
-
-func NewSubjectLocator(delegate authorizerrbac.SubjectLocator) SubjectLocator {
-	return &openshiftSubjectLocator{delegate: delegate}
 }
 
 func (a *openshiftAuthorizer) Authorize(attributes authorizer.Attributes) (bool, string, error) {
@@ -49,41 +38,6 @@ func (a *openshiftAuthorizer) Authorize(attributes authorizer.Attributes) (bool,
 	}
 
 	return false, denyReason, nil
-}
-
-// GetAllowedSubjects returns the subjects it knows can perform the action.
-// If we got an error, then the list of subjects may not be complete, but it does not contain any incorrect names.
-// This is done because policy rules are purely additive and policy determinations
-// can be made on the basis of those rules that are found.
-func (a *openshiftSubjectLocator) GetAllowedSubjects(attributes authorizer.Attributes) (sets.String, sets.String, error) {
-	users := sets.String{}
-	groups := sets.String{}
-	namespace := attributes.GetNamespace()
-	subjects, err := a.delegate.AllowedSubjects(attributes)
-	for _, subject := range subjects {
-		switch subject.Kind {
-		case rbac.UserKind:
-			users.Insert(subject.Name)
-		case rbac.GroupKind:
-			groups.Insert(subject.Name)
-		case rbac.ServiceAccountKind:
-			// default the namespace to namespace we're working in if
-			// it's available. This allows rolebindings that reference
-			// SAs in the local namespace to avoid having to qualify
-			// them.
-			ns := namespace
-			if len(subject.Namespace) > 0 {
-				ns = subject.Namespace
-			}
-			if len(ns) >= 0 {
-				name := serviceaccount.MakeUsername(ns, subject.Name)
-				users.Insert(name)
-			}
-		default:
-			continue // TODO, should this add errs?
-		}
-	}
-	return users, groups, err
 }
 
 func reason(attributes authorizer.Attributes) string {

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -1,13 +1,8 @@
 package authorizer
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
-
-type SubjectLocator interface {
-	GetAllowedSubjects(attributes authorizer.Attributes) (sets.String, sets.String, error)
-}
 
 // ForbiddenMessageMaker creates a forbidden message from Attributes
 type ForbiddenMessageMaker interface {

--- a/pkg/authorization/registry/localresourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest_test.go
@@ -10,10 +10,12 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
+	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 )
 
 type resourceAccessTest struct {
@@ -37,12 +39,11 @@ func (a *testAuthorizer) Authorize(attributes kauthorizer.Attributes) (allowed b
 
 	return false, "", errors.New("Unsupported")
 }
-func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attributes) (sets.String, sets.String, error) {
+
+func (a *testAuthorizer) AllowedSubjects(passedAttributes kauthorizer.Attributes) ([]rbac.Subject, error) {
 	a.actualAttributes = passedAttributes
-	if len(a.err) == 0 {
-		return a.users, a.groups, nil
-	}
-	return a.users, a.groups, errors.New(a.err)
+	subjects := authorizationutil.BuildRBACSubjects(a.users.List(), a.groups.List())
+	return subjects, errors.New(a.err)
 }
 
 func TestNoNamespace(t *testing.T) {

--- a/pkg/authorization/registry/resourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest_test.go
@@ -11,9 +11,11 @@ import (
 	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
+	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 )
 
 type resourceAccessTest struct {
@@ -42,12 +44,11 @@ func (a *testAuthorizer) Authorize(attributes kauthorizer.Attributes) (allowed b
 
 	return false, "", errors.New("unsupported")
 }
-func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attributes) (sets.String, sets.String, error) {
+
+func (a *testAuthorizer) AllowedSubjects(passedAttributes kauthorizer.Attributes) ([]rbac.Subject, error) {
 	a.actualAttributes = passedAttributes
-	if len(a.err) == 0 {
-		return a.users, a.groups, nil
-	}
-	return a.users, a.groups, errors.New(a.err)
+	subjects := authorizationutil.BuildRBACSubjects(a.users.List(), a.groups.List())
+	return subjects, errors.New(a.err)
 }
 
 func TestDeniedNamespace(t *testing.T) {

--- a/pkg/authorization/util/subject.go
+++ b/pkg/authorization/util/subject.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 )
@@ -22,4 +24,36 @@ func BuildRBACSubjects(users, groups []string) []rbac.Subject {
 	}
 
 	return subjects
+}
+
+func ExpandSubjects(namespace string, subjects []rbac.Subject) (sets.String, sets.String, []error) {
+	var errs []error
+	users := sets.String{}
+	groups := sets.String{}
+	for _, subject := range subjects {
+		switch subject.Kind {
+		case rbac.UserKind:
+			users.Insert(subject.Name)
+		case rbac.GroupKind:
+			groups.Insert(subject.Name)
+		case rbac.ServiceAccountKind:
+			// default the namespace to namespace we're working in if
+			// it's available. This allows rolebindings that reference
+			// SAs in the local namespace to avoid having to qualify
+			// them.
+			ns := namespace
+			if len(subject.Namespace) > 0 {
+				ns = subject.Namespace
+			}
+			if len(ns) >= 0 {
+				name := serviceaccount.MakeUsername(ns, subject.Name)
+				users.Insert(name)
+			}
+		default:
+			errs = append(errs, fmt.Errorf("Unrecognized kinds for subjects: %s. "+
+				"Only UserKind, GroupKind and ServiceAccountKind are supported.", subject.Kind))
+		}
+
+	}
+	return users, groups, errs
 }

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -23,8 +23,8 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	kubeapiserver "k8s.io/kubernetes/pkg/master"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
-	"github.com/openshift/origin/pkg/authorization/authorizer"
 	authorizationinformer "github.com/openshift/origin/pkg/authorization/generated/informers/internalversion"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	kubernetes "github.com/openshift/origin/pkg/cmd/server/kubernetes/master"
@@ -55,7 +55,7 @@ type MasterConfig struct {
 	RESTOptionsGetter restoptions.Getter
 
 	RuleResolver   rbacregistryvalidation.AuthorizationRuleResolver
-	SubjectLocator authorizer.SubjectLocator
+	SubjectLocator authorizerrbac.SubjectLocator
 
 	ProjectAuthorizationCache     *projectauth.AuthorizationCache
 	ProjectCache                  *projectcache.ProjectCache
@@ -243,7 +243,7 @@ func newProjectCache(informers InformerAccess, privilegedLoopbackConfig *restcli
 		defaultNodeSelector), nil
 }
 
-func newProjectAuthorizationCache(subjectLocator authorizer.SubjectLocator, namespaces cache.SharedIndexInformer, internalRBACInformers rbacinformers.Interface) *projectauth.AuthorizationCache {
+func newProjectAuthorizationCache(subjectLocator authorizerrbac.SubjectLocator, namespaces cache.SharedIndexInformer, internalRBACInformers rbacinformers.Interface) *projectauth.AuthorizationCache {
 	return projectauth.NewAuthorizationCache(
 		namespaces,
 		projectauth.NewAuthorizerReviewer(subjectLocator),

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -28,13 +28,13 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	"github.com/openshift/origin/pkg/api"
 	"github.com/openshift/origin/pkg/api/v1"
 	oappsapiv1 "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 	oappsapiserver "github.com/openshift/origin/pkg/apps/apiserver"
 	authorizationapiserver "github.com/openshift/origin/pkg/authorization/apiserver"
-	"github.com/openshift/origin/pkg/authorization/authorizer"
 	buildapiserver "github.com/openshift/origin/pkg/build/apiserver"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -87,7 +87,7 @@ type OpenshiftAPIConfig struct {
 
 	// these are all required to build our storage
 	RuleResolver   rbacregistryvalidation.AuthorizationRuleResolver
-	SubjectLocator authorizer.SubjectLocator
+	SubjectLocator authorizerrbac.SubjectLocator
 
 	// for Images
 	LimitVerifier imageadmission.LimitVerifier


### PR DESCRIPTION
This PR attempts to fix the [follow up #4](https://github.com/openshift/origin/issues/15816) from RBAC migration.

Remaining task:

- [x] Merge my changes with @tiran's code to convert []rbac.Subject -> users, groups
[]string