### PR TITLE
Remove unnecessary requires from dependent packages

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -107,7 +107,6 @@ Obsoletes:      openshift-master < %{package_refector_version}
 
 %package tests
 Summary: %{product_name} Test Suite
-Requires:       %{name} = %{version}-%{release}
 
 %description tests
 %{summary}
@@ -159,7 +158,6 @@ BuildRequires:  goversioninfo
 
 %package dockerregistry
 Summary:        Docker Registry v2 for %{product_name}
-Requires:       %{name} = %{version}-%{release}
 
 %description dockerregistry
 %{summary}
@@ -186,20 +184,17 @@ Obsoletes:        openshift-sdn-ovs < %{package_refector_version}
 
 %package federation-services
 Summary:        %{produce_name} Federation Services
-Requires:       %{name} = %{version}-%{release}
 
 %description federation-services
 
 %package service-catalog
 Summary:        %{product_name} Service Catalog
-Requires:       %{name} = %{version}-%{release}
 
 %description service-catalog
 %{summary}
 
 %package cluster-capacity
 Summary:        %{product_name} Cluster Capacity Analysis Tool
-Requires:       %{name} = %{version}-%{release}
 
 %description cluster-capacity
 %{summary}


### PR DESCRIPTION
They do not require OpenShift packages.

Fixes #15576

@sdodson