### PR TITLE
Sharded router based on namespace labels should notice routes immediately

### DIFF
--- a/pkg/router/controller/router_controller.go
+++ b/pkg/router/controller/router_controller.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
@@ -14,14 +16,10 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
+	projectclient "github.com/openshift/origin/pkg/project/generated/internalclientset/typed/project/internalversion"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	"github.com/openshift/origin/pkg/router"
 )
-
-// NamespaceLister returns all the names that should be watched by the client
-type NamespaceLister interface {
-	NamespaceNames() (sets.String, error)
-}
 
 // RouterController abstracts the details of watching resources like Routes, Endpoints, etc.
 // used by the plugin implementation.
@@ -30,13 +28,20 @@ type RouterController struct {
 
 	Plugin router.Plugin
 
-	firstSyncDone       bool
-	filteredByNamespace bool
+	firstSyncDone bool
 
-	Namespaces            NamespaceLister
-	NamespaceSyncInterval time.Duration
-	NamespaceWaitInterval time.Duration
-	NamespaceRetries      int
+	FilteredNamespaceNames sets.String
+	NamespaceLabels        labels.Selector
+	// Holds Namespace --> RouteName --> RouteObject
+	NamespaceRoutes map[string]map[string]*routeapi.Route
+	// Holds Namespace --> EndpointsName --> EndpointsObject
+	NamespaceEndpoints map[string]map[string]*kapi.Endpoints
+
+	ProjectClient       projectclient.ProjectResourceInterface
+	ProjectLabels       labels.Selector
+	ProjectSyncInterval time.Duration
+	ProjectWaitInterval time.Duration
+	ProjectRetries      int
 
 	WatchNodes bool
 
@@ -47,45 +52,149 @@ type RouterController struct {
 // Run begins watching and syncing.
 func (c *RouterController) Run() {
 	glog.V(4).Info("Running router controller")
-	if c.Namespaces != nil {
-		c.HandleNamespaces()
-		go utilwait.Forever(c.HandleNamespaces, c.NamespaceSyncInterval)
+	if c.ProjectLabels != nil {
+		c.HandleProjects()
+		go utilwait.Forever(c.HandleProjects, c.ProjectSyncInterval)
 	}
 	c.handleFirstSync()
 }
 
-func (c *RouterController) HandleNamespaces() {
-	for i := 0; i < c.NamespaceRetries; i++ {
-		namespaces, err := c.Namespaces.NamespaceNames()
+func (c *RouterController) HandleProjects() {
+	for i := 0; i < c.ProjectRetries; i++ {
+		names, err := c.GetFilteredProjectNames()
 		if err == nil {
-
-			// The ingress translator synchronizes access to its cache with a
-			// lock, so calls to it are made outside of the controller lock to
-			// avoid unintended interaction.
-			if c.EnableIngress {
-				c.IngressTranslator.UpdateNamespaces(namespaces)
+			// Return early if there is no new change
+			if names.Equal(c.FilteredNamespaceNames) {
+				return
 			}
-
 			c.lock.Lock()
 			defer c.lock.Unlock()
 
-			glog.V(4).Infof("Updating watched namespaces: %v", namespaces)
-			if err := c.Plugin.HandleNamespaces(namespaces); err != nil {
-				utilruntime.HandleError(err)
-			}
-
-			// Namespace filtering is assumed to be have been
-			// performed so long as the plugin event handler is called
-			// at least once.
-			c.filteredByNamespace = true
+			c.FilteredNamespaceNames = names
+			c.UpdateNamespaces()
 			c.Commit()
-
 			return
 		}
-		utilruntime.HandleError(fmt.Errorf("unable to find namespaces for router: %v", err))
-		time.Sleep(c.NamespaceWaitInterval)
+		utilruntime.HandleError(fmt.Errorf("unable to get filtered projects for router: %v", err))
+		time.Sleep(c.ProjectWaitInterval)
 	}
-	glog.V(4).Infof("Unable to update list of namespaces")
+	glog.V(4).Infof("Unable to update list of filtered projects")
+}
+
+func (c *RouterController) GetFilteredProjectNames() (sets.String, error) {
+	names := sets.String{}
+	all, err := c.ProjectClient.List(v1.ListOptions{LabelSelector: c.ProjectLabels.String()})
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range all.Items {
+		names.Insert(item.Name)
+	}
+	return names, nil
+}
+
+func (c *RouterController) processNamespace(eventType watch.EventType, ns *kapi.Namespace) {
+	before := c.FilteredNamespaceNames.Has(ns.Name)
+	switch eventType {
+	case watch.Added, watch.Modified:
+		if c.NamespaceLabels.Matches(labels.Set(ns.Labels)) {
+			c.FilteredNamespaceNames.Insert(ns.Name)
+		} else {
+			c.FilteredNamespaceNames.Delete(ns.Name)
+		}
+	case watch.Deleted:
+		c.FilteredNamespaceNames.Delete(ns.Name)
+	}
+	after := c.FilteredNamespaceNames.Has(ns.Name)
+
+	// Namespace added or deleted
+	if (!before && after) || (before && !after) {
+		glog.V(5).Infof("Processing matched namespace: %s with labels: %v", ns.Name, ns.Labels)
+
+		c.UpdateNamespaces()
+
+		// New namespace created or router matching labels added to existing namespace
+		// Routes for new namespace will be handled by HandleRoute().
+		// For existing namespace, add corresponding endpoints/routes as watch endpoints
+		// and routes won't be updated till the next resync interval which could be few mins.
+		if !before && after {
+			if epMap, ok := c.NamespaceEndpoints[ns.Name]; ok {
+				for _, ep := range epMap {
+					if err := c.Plugin.HandleEndpoints(watch.Modified, ep); err != nil {
+						utilruntime.HandleError(err)
+					}
+				}
+			}
+
+			if routeMap, ok := c.NamespaceRoutes[ns.Name]; ok {
+				for _, route := range routeMap {
+					c.processRoute(watch.Modified, route)
+				}
+			}
+		}
+	}
+}
+
+func (c *RouterController) UpdateNamespaces() {
+	namespaces := c.FilteredNamespaceNames
+
+	// The ingress translator synchronizes access to its cache with a
+	// lock, so calls to it are made outside of the controller lock to
+	// avoid unintended interaction.
+	if c.EnableIngress {
+		c.IngressTranslator.UpdateNamespaces(namespaces)
+	}
+
+	glog.V(4).Infof("Updating watched namespaces: %v", namespaces)
+	if err := c.Plugin.HandleNamespaces(namespaces); err != nil {
+		utilruntime.HandleError(err)
+	}
+}
+
+func (c *RouterController) RecordNamespaceEndpoints(eventType watch.EventType, ep *kapi.Endpoints) {
+	switch eventType {
+	case watch.Added, watch.Modified:
+		if _, ok := c.NamespaceEndpoints[ep.Namespace]; !ok {
+			c.NamespaceEndpoints[ep.Namespace] = make(map[string]*kapi.Endpoints)
+		}
+		c.NamespaceEndpoints[ep.Namespace][ep.Name] = ep
+	case watch.Deleted:
+		if _, ok := c.NamespaceEndpoints[ep.Namespace]; ok {
+			delete(c.NamespaceEndpoints[ep.Namespace], ep.Name)
+			if len(c.NamespaceEndpoints[ep.Namespace]) == 0 {
+				delete(c.NamespaceEndpoints, ep.Namespace)
+			}
+		}
+	}
+}
+
+func (c *RouterController) RecordNamespaceRoutes(eventType watch.EventType, rt *routeapi.Route) {
+	switch eventType {
+	case watch.Added, watch.Modified:
+		if _, ok := c.NamespaceRoutes[rt.Namespace]; !ok {
+			c.NamespaceRoutes[rt.Namespace] = make(map[string]*routeapi.Route)
+		}
+		c.NamespaceRoutes[rt.Namespace][rt.Name] = rt
+	case watch.Deleted:
+		if _, ok := c.NamespaceRoutes[rt.Namespace]; ok {
+			delete(c.NamespaceRoutes[rt.Namespace], rt.Name)
+			if len(c.NamespaceRoutes[rt.Namespace]) == 0 {
+				delete(c.NamespaceRoutes, rt.Namespace)
+			}
+		}
+	}
+}
+
+func (c *RouterController) HandleNamespace(eventType watch.EventType, obj interface{}) {
+	ns := obj.(*kapi.Namespace)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	glog.V(4).Infof("Processing Namespace: %s", ns.Name)
+	glog.V(4).Infof("           Event: %s", eventType)
+
+	c.processNamespace(eventType, ns)
+	c.Commit()
 }
 
 // HandleNode handles a single Node event and synchronizes the router backend
@@ -94,7 +203,7 @@ func (c *RouterController) HandleNode(eventType watch.EventType, obj interface{}
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	glog.V(4).Infof("Processing Node : %s", node.Name)
+	glog.V(4).Infof("Processing Node: %s", node.Name)
 	glog.V(4).Infof("           Event: %s", eventType)
 
 	if err := c.Plugin.HandleNode(eventType, node); err != nil {
@@ -118,6 +227,7 @@ func (c *RouterController) HandleEndpoints(eventType watch.EventType, obj interf
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	c.RecordNamespaceEndpoints(eventType, endpoints)
 	if err := c.Plugin.HandleEndpoints(eventType, endpoints); err != nil {
 		utilruntime.HandleError(err)
 	}
@@ -156,7 +266,7 @@ func (c *RouterController) HandleSecret(eventType watch.EventType, obj interface
 
 // Commit notifies the plugin that it is safe to commit state.
 func (c *RouterController) Commit() {
-	if !c.isSyncing() {
+	if c.firstSyncDone {
 		if err := c.Plugin.Commit(); err != nil {
 			utilruntime.HandleError(err)
 		}
@@ -170,6 +280,7 @@ func (c *RouterController) processRoute(eventType watch.EventType, route *routea
 	glog.V(4).Infof("           Path: %s", route.Spec.Path)
 	glog.V(4).Infof("           Event: %s", eventType)
 
+	c.RecordNamespaceRoutes(eventType, route)
 	if err := c.Plugin.HandleRoute(eventType, route); err != nil {
 		utilruntime.HandleError(err)
 	}
@@ -178,7 +289,7 @@ func (c *RouterController) processRoute(eventType watch.EventType, route *routea
 // processIngressEvents logs and propagates the route events resulting from an ingress or secret event
 func (c *RouterController) processIngressEvents(events []ingressRouteEvents) {
 	for _, ingressEvent := range events {
-		glog.V(4).Infof("Processing Ingress %s", ingressEvent.ingressKey)
+		glog.V(4).Infof("Processing Ingress: %s", ingressEvent.ingressKey)
 		for _, routeEvent := range ingressEvent.routeEvents {
 			c.processRoute(routeEvent.eventType, routeEvent.route)
 		}
@@ -192,15 +303,4 @@ func (c *RouterController) handleFirstSync() {
 	c.firstSyncDone = true
 	glog.V(4).Infof("Router first sync complete")
 	c.Commit()
-}
-
-func (c *RouterController) isSyncing() bool {
-	syncing := false
-
-	if !c.firstSyncDone {
-		syncing = true
-	} else if c.Namespaces != nil && !c.filteredByNamespace {
-		syncing = true
-	}
-	return syncing
 }

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -314,7 +314,6 @@ func (r *templateRouter) readState() error {
 // Commit applies the changes made to the router configuration - persists
 // the state and refresh the backend. This is all done in the background
 // so that we can rate limit + coalesce multiple changes.
-// Note: If this is changed FakeCommit() in fake.go should also be updated
 func (r *templateRouter) Commit() {
 	r.lock.Lock()
 
@@ -446,6 +445,7 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	glog.V(4).Infof("Applying filtered namespaces: %v", namespaces)
 	if len(namespaces) == 0 {
 		r.state = make(map[string]ServiceAliasConfig)
 		r.serviceUnits = make(map[string]ServiceUnit)

--- a/test/integration/router_without_haproxy_test.go
+++ b/test/integration/router_without_haproxy_test.go
@@ -378,7 +378,7 @@ func launchRateLimitedRouter(t *testing.T, routeclient routeinternalclientset.In
 		plugin = NewDelayPlugin(plugin, maxDelay)
 	}
 
-	factory := controllerfactory.NewDefaultRouterControllerFactory(routeclient, kc)
+	factory := controllerfactory.NewDefaultRouterControllerFactory(routeclient, projectclient.Project().Projects(), kc)
 	ctrl := factory.Create(plugin, false, false)
 	ctrl.Run()
 
@@ -409,11 +409,6 @@ func launchRouter(routeclient routeinternalclientset.Interface, projectclient pr
 	})
 	factory := routerSelection.NewFactory(routeclient, projectclient.Project().Projects(), kc)
 	ctrl := factory.Create(plugin, false, false)
-
-	// Minimize resync latency
-	ctrl.NamespaceSyncInterval = factory.ResyncInterval - 1*time.Second
-	ctrl.NamespaceWaitInterval = 1 * time.Second
-
 	ctrl.Run()
 
 	return templatePlugin


### PR DESCRIPTION
- Currently, sharded router based on namespace labels could take 2 resync
  intervals (10 to 15 mins) to notice new routes which may not be acceptable
  to some customers. This change allows routes to work immediately just like
  the non-sharded router behavior.

- Watching project resource may not guarantee the order of the events,
  so there is no behavior change to shared router based on project labels.

Trello card: https://trello.com/c/Q0puUQOT
Rebased on top of https://github.com/openshift/origin/pull/16315