### PR TITLE
Wait longer for healthz during integration tests

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -201,7 +201,7 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 		},
 		Webhook: componentconfig.KubeletWebhookAuthentication{
 			Enabled:  true,
-			CacheTTL: metav1.Duration{authnTTL},
+			CacheTTL: metav1.Duration{Duration: authnTTL},
 		},
 		Anonymous: componentconfig.KubeletAnonymousAuthentication{
 			Enabled: true,
@@ -214,8 +214,8 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 	server.Authorization = componentconfig.KubeletAuthorization{
 		Mode: componentconfig.KubeletAuthorizationModeWebhook,
 		Webhook: componentconfig.KubeletWebhookAuthorization{
-			CacheAuthorizedTTL:   metav1.Duration{authzTTL},
-			CacheUnauthorizedTTL: metav1.Duration{authzTTL},
+			CacheAuthorizedTTL:   metav1.Duration{Duration: authzTTL},
+			CacheUnauthorizedTTL: metav1.Duration{Duration: authzTTL},
 		},
 	}
 

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -550,7 +550,7 @@ func (c *OpenshiftAPIConfig) ensureOpenShiftInfraNamespace(context genericapiser
 	// Ensure we have the bootstrap SA for Nodes
 	_, err = c.KubeClientInternal.Core().ServiceAccounts(ns).Create(&kapi.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: bootstrappolicy.InfraNodeBootstrapServiceAccountName}})
 	if err != nil && !kapierror.IsAlreadyExists(err) {
-		glog.Errorf("Error creating service account %s/%s: %v", namespace, bootstrappolicy.InfraNodeBootstrapServiceAccountName, err)
+		glog.Errorf("Error creating service account %s/%s: %v", ns, bootstrappolicy.InfraNodeBootstrapServiceAccountName, err)
 	}
 
 	EnsureNamespaceServiceAccountRoleBindings(c.KubeClientInternal, c.DeprecatedOpenshiftClient, namespace)

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -85,7 +85,7 @@ func (factory *RouterControllerFactory) Create(plugin router.Plugin, watchNodes,
 		field:     factory.Fields,
 		label:     factory.Labels,
 	}
-	cache.NewReflector(&cache.ListWatch{rLW.List, rLW.Watch}, &routeapi.Route{}, routeEventQueue, factory.ResyncInterval).Run()
+	cache.NewReflector(&cache.ListWatch{ListFunc: rLW.List, WatchFunc: rLW.Watch}, &routeapi.Route{}, routeEventQueue, factory.ResyncInterval).Run()
 
 	endpointsEventQueue := oscache.NewEventQueue(routerKeyFn)
 	cache.NewReflector(&endpointsLW{
@@ -223,7 +223,7 @@ func (factory *RouterControllerFactory) CreateNotifier(changed func()) RoutesByH
 		field:     factory.Fields,
 		label:     factory.Labels,
 	}
-	cache.NewReflector(&cache.ListWatch{rLW.List, rLW.Watch}, &routeapi.Route{}, routeEventQueue, factory.ResyncInterval).Run()
+	cache.NewReflector(&cache.ListWatch{ListFunc: rLW.List, WatchFunc: rLW.Watch}, &routeapi.Route{}, routeEventQueue, factory.ResyncInterval).Run()
 
 	endpointStore := cache.NewStore(keyFn)
 	endpointsEventQueue := oscache.NewEventQueueForStore(keyFn, endpointStore)

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -464,7 +464,7 @@ func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig, test
 	}
 
 	var healthzResponse string
-	err = wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+	err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		var healthy bool
 		healthy, healthzResponse, err = IsServerHealthy(*masterURL)
 		if err != nil {


### PR DESCRIPTION
Adding post start hooks makes it take longer for the server to report that it is healthy.  Thus we wait longer to ensure that the server actually failed to start.

Signed-off-by: Monis Khan <mkhan@redhat.com>