### PR TITLE
remove usage of legacy client in oc describers

### DIFF
--- a/pkg/cmd/util/clientcmd/factory_object_mapping.go
+++ b/pkg/cmd/util/clientcmd/factory_object_mapping.go
@@ -145,6 +145,10 @@ func (f *ring1Factory) Describer(mapping *meta.RESTMapping) (kprinters.Describer
 		if err != nil {
 			return nil, fmt.Errorf("unable to create client %s: %v", mapping.GroupVersionKind.Kind, err)
 		}
+		clientConfig, err := f.clientAccessFactory.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("unable to create client config %s: %v", mapping.GroupVersionKind.Kind, err)
+		}
 
 		mappingVersion := mapping.GroupVersionKind.GroupVersion()
 		cfg, err := f.clientAccessFactory.ClientConfigForVersion(&mappingVersion)
@@ -152,7 +156,7 @@ func (f *ring1Factory) Describer(mapping *meta.RESTMapping) (kprinters.Describer
 			return nil, fmt.Errorf("unable to load a client %s: %v", mapping.GroupVersionKind.Kind, err)
 		}
 
-		describer, ok := describe.DescriberFor(mapping.GroupVersionKind.GroupKind(), oClient, kClient, cfg.Host)
+		describer, ok := describe.DescriberFor(mapping.GroupVersionKind.GroupKind(), clientConfig, oClient, kClient, cfg.Host)
 		if !ok {
 			return nil, fmt.Errorf("no description has been implemented for %q", mapping.GroupVersionKind.Kind)
 		}

--- a/pkg/oc/cli/describe/describer_test.go
+++ b/pkg/oc/cli/describe/describer_test.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kfake "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
@@ -30,7 +31,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/autoscaling/install"
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
-	kprinters "k8s.io/kubernetes/pkg/printers"
 )
 
 type describeClient struct {
@@ -113,58 +113,9 @@ main:
 		}
 
 		gk := api.SchemeGroupVersion.WithKind(apiType.Name()).GroupKind()
-		_, ok := DescriberFor(gk, c, kfake.NewSimpleClientset(), "")
+		_, ok := DescriberFor(gk, &rest.Config{}, c, kfake.NewSimpleClientset(), "")
 		if !ok {
 			t.Errorf("missing describer for %v.  Check pkg/cmd/cli/describe/describer.go", apiType)
-		}
-	}
-}
-
-func TestDescribers(t *testing.T) {
-	fake := &testclient.Fake{}
-	fakeKube := kfake.NewSimpleClientset()
-	c := &describeClient{T: t, Namespace: "foo", Fake: fake}
-
-	testCases := []struct {
-		d    kprinters.Describer
-		name string
-	}{
-		{&BuildDescriber{c, fakeKube}, "bar"},
-		{&BuildConfigDescriber{c, fakeKube, ""}, "bar"},
-		{&ImageStreamDescriber{c}, "bar"},
-		{&RouteDescriber{c, fakeKube}, "bar"},
-		{&ProjectDescriber{c, fakeKube}, "bar"},
-		{&PolicyDescriber{c}, "bar"},
-		{&PolicyBindingDescriber{c}, "bar"},
-		{&TemplateDescriber{c, nil, nil, nil}, "bar"},
-	}
-
-	for _, test := range testCases {
-		out, err := test.d.Describe("foo", test.name, kprinters.DescriberSettings{})
-		if err != nil {
-			t.Errorf("unexpected error for %v: %v", test.d, err)
-		}
-		if !strings.Contains(out, "Name:") || !strings.Contains(out, "Labels:") {
-			t.Errorf("unexpected out: %s", out)
-		}
-	}
-
-	// omits labels if they are not set to avoid confusing end users
-	testCases = []struct {
-		d    kprinters.Describer
-		name string
-	}{
-		{&ImageDescriber{c}, "bar"},
-		{&ImageStreamTagDescriber{c}, "bar:latest"},
-		{&ImageStreamImageDescriber{c}, "bar@sha256:other"},
-	}
-	for _, test := range testCases {
-		out, err := test.d.Describe("foo", test.name, kprinters.DescriberSettings{})
-		if err != nil {
-			t.Errorf("unexpected error for %v: %v", test.d, err)
-		}
-		if !strings.Contains(out, "Name:") || strings.Contains(out, "Labels:") {
-			t.Errorf("unexpected out: %s", out)
 		}
 	}
 }


### PR DESCRIPTION
This pull will switch describers in oc 3.7 from using /oapi to using the groupified API. This means that normal CRUD will work from oc3.7 to master3.5, but `oc describe` from oc3.7 to master3.5 will not.  `oc describe` from oc3.5 to master3.7 will work fine

`kubectl` only supports one level of skew.  Do we need to update ours to match: https://github.com/openshift/openshift-docs/blob/d5c99ae36b59436459219701c2c19d1bce9bf905/release_notes/index.adoc ?

@fabianofranz @smarterclayton @liggitt 