### PR TITLE
Remove use of legacy decoder in NewApp templates

### DIFF
--- a/pkg/oc/cli/cmd/newapp.go
+++ b/pkg/oc/cli/cmd/newapp.go
@@ -157,11 +157,21 @@ func (o *ObjectGeneratorOptions) Complete(baseName, commandName string, f *clien
 	if err != nil {
 		return err
 	}
+
 	mapper, typer := f.Object()
+	dynamicMapper, dynamicTyper, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
 	// ignore errors.   We use this to make a best guess at preferred seralizations, but the command might run without a server
 	discoveryClient, _ := f.DiscoveryClient()
 
 	o.Action.Out, o.Action.ErrOut = out, o.ErrOut
+	o.Action.Bulk.DynamicMapper = &resource.Mapper{
+		RESTMapper:   dynamicMapper,
+		ObjectTyper:  dynamicTyper,
+		ClientMapper: resource.ClientMapperFunc(f.UnstructuredClientForMapping),
+	}
 	o.Action.Bulk.Mapper = &resource.Mapper{
 		RESTMapper:   mapper,
 		ObjectTyper:  typer,


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15996

Use of the legacy codec was unable to decode `servicecatalog.k8s.io/Broker` objects, resulting in errors in newapp when attempting to access annotations and extract type info.

**Before**
```
$ oc new-app -f broker.yaml -p NAMESPACE=sample
--> Deploying template "myproject/broker" for "broker.yaml" to project myproject

     * With parameters:
        * NAMESPACE=sample

error: failed to add annotation to object of type "servicecatalog.k8s.io/v1alpha1, Kind=Broker", this resource type is probably unsupported by your client version.
```

**After**
```
$ oc new-app -f broker.yaml -p NAMESPACE=sample
--> Deploying template "myproject/broker" for "broker.yaml" to project myproject

     * With parameters:
        * NAMESPACE=sample

--> Creating resources ...
    broker "ansible-service-broker" created
--> Success
    Run 'oc status' to view your app.
```

cc @openshift/cli-review @bparees 