### PR TITLE
Append user labels when --show-labels is passed

### DIFF
--- a/pkg/oc/cli/describe/printer.go
+++ b/pkg/oc/cli/describe/printer.go
@@ -954,8 +954,13 @@ func printOAuthAuthorizeTokenList(list *oauthapi.OAuthAuthorizeTokenList, w io.W
 
 func printUser(user *userapi.User, w io.Writer, opts kprinters.PrintOptions) error {
 	name := formatResourceName(opts.Kind, user.Name, opts.WithKind)
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, user.UID, user.FullName, strings.Join(user.Identities, ", "))
-	return err
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, user.UID, user.FullName, strings.Join(user.Identities, ", ")); err != nil {
+		return err
+	}
+	if err := appendItemLabels(user.Labels, w, opts.ColumnLabels, opts.ShowLabels); err != nil {
+		return err
+	}
+	return nil
 }
 
 func printUserList(list *userapi.UserList, w io.Writer, opts kprinters.PrintOptions) error {

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -29,5 +29,10 @@ os::cmd::expect_success_and_not_text 'oc get svc/testsvc1 svc/testsvc2' "svc/tes
 os::cmd::expect_success_and_text 'oc get svc/testsvc1 is/testimg1' "svc/testsvc1"
 # specific resources should not have their kind prefixed
 os::cmd::expect_success_and_text 'oc get svc' "testsvc1"
+# test --show-labels displays labels for users
+os::cmd::expect_success 'oc create user test-user-1'
+os::cmd::expect_success 'oc label user/test-user-1 customlabel=true'
+os::cmd::expect_success_and_text 'oc get users test-user-1 --show-labels' "customlabel=true"
+os::cmd::expect_success_and_not_text 'oc get users test-user-1' "customlabel=true"
 echo "oc get all: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Addresses BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1486501

`--show-labels` was not being honored when printing users with `$oc get ...`

cc @openshift/cli-review 