### PR TITLE
build controller: use client lister to get builds for policy

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -174,6 +174,7 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 
 	buildClient := buildclient.NewOSClientBuildClient(params.OpenshiftClient)
 	buildLister := params.BuildInformer.Lister()
+	clientBuildLister := buildclient.NewOSClientBuildLister(params.OpenshiftClient)
 	buildConfigGetter := params.BuildConfigInformer.Lister()
 	c := &BuildController{
 		buildPatcher:      buildClient,
@@ -200,7 +201,7 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 		imageStreamQueue: newResourceTriggerQueue(),
 
 		recorder:    eventBroadcaster.NewRecorder(kapi.Scheme, clientv1.EventSource{Component: "build-controller"}),
-		runPolicies: policy.GetAllRunPolicies(buildLister, buildClient),
+		runPolicies: policy.GetAllRunPolicies(clientBuildLister, buildClient),
 	}
 
 	c.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
Switches to using the client to list builds for the build policy which determines which build to run next. The issue is that we only ask the policy to determine what the next build is going to be when we are transitioning a build to complete state. If the policy object is using the cache, then it will still see the just updated build as still running until the cache catches up.

Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1484763