### PR TITLE
Only start the SDN controller if an openshift network plugin is configured

### DIFF
--- a/pkg/cmd/server/origin/controller/network_linux.go
+++ b/pkg/cmd/server/origin/controller/network_linux.go
@@ -8,6 +8,7 @@ import (
 	osclient "github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/network"
 	sdnmaster "github.com/openshift/origin/pkg/network/master"
 )
 
@@ -16,6 +17,10 @@ type SDNControllerConfig struct {
 }
 
 func (c *SDNControllerConfig) RunController(ctx ControllerContext) (bool, error) {
+	if !network.IsOpenShiftNetworkPlugin(c.NetworkConfig.NetworkPluginName) {
+		return false, nil
+	}
+
 	// TODO: Switch SDN to use client.Interface
 	clientConfig, err := ctx.ClientBuilder.Config(bootstrappolicy.InfraSDNControllerServiceAccountName)
 	if err != nil {

--- a/pkg/cmd/server/origin/controller/network_unsupported.go
+++ b/pkg/cmd/server/origin/controller/network_unsupported.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/network"
 )
 
 type SDNControllerConfig struct {
@@ -13,5 +14,9 @@ type SDNControllerConfig struct {
 }
 
 func (c *SDNControllerConfig) RunController(ctx ControllerContext) (bool, error) {
+	if !network.IsOpenShiftNetworkPlugin(c.NetworkConfig.NetworkPluginName) {
+		return false, nil
+	}
+
 	return false, fmt.Errorf("SDN not supported on this platform")
 }


### PR DESCRIPTION
Returning an error causes a process exit. This logs and skips instead.