### PR TITLE
get resource version on dc scale err

### DIFF
--- a/pkg/deploy/cmd/scale.go
+++ b/pkg/deploy/cmd/scale.go
@@ -68,7 +68,12 @@ func (scaler *DeploymentConfigScaler) ScaleSimple(namespace, name string, precon
 	scale.Spec.Replicas = int32(newSize)
 	updated, err := scaler.dcClient.DeploymentConfigs(namespace).UpdateScale(scale)
 	if err != nil {
-		return "", kubectl.ScaleError{FailureType: kubectl.ScaleUpdateFailure, ResourceVersion: "Unknown", ActualError: err}
+		resourceVersion := "Unknown"
+		dc, dcErr := scaler.dcClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+		if dcErr == nil {
+			resourceVersion = dc.ResourceVersion
+		}
+		return "", kubectl.ScaleError{FailureType: kubectl.ScaleUpdateFailure, ResourceVersion: resourceVersion, ActualError: err}
 	}
 	return updated.ResourceVersion, nil
 }

--- a/pkg/deploy/cmd/scale.go
+++ b/pkg/deploy/cmd/scale.go
@@ -68,7 +68,7 @@ func (scaler *DeploymentConfigScaler) ScaleSimple(namespace, name string, precon
 	scale.Spec.Replicas = int32(newSize)
 	updated, err := scaler.dcClient.DeploymentConfigs(namespace).UpdateScale(scale)
 	if err != nil {
-		resourceVersion := "Unknown"
+		resourceVersion := ""
 		dc, dcErr := scaler.dcClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 		if dcErr == nil {
 			resourceVersion = dc.ResourceVersion

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/scale.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/scale.go
@@ -104,9 +104,11 @@ type ScaleError struct {
 }
 
 func (c ScaleError) Error() string {
-	return fmt.Sprintf(
-		"Scaling the resource failed with: %v; Current resource version %s",
-		c.ActualError, c.ResourceVersion)
+	msg := fmt.Sprintf("Scaling the resource failed with: %v", c.ActualError)
+	if len(c.ResourceVersion) > 0 {
+		msg += fmt.Sprintf("; Current resource version %s", c.ResourceVersion)
+	}
+	return msg
 }
 
 // RetryParams encapsulates the retry parameters used by kubectl's scaler.


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/16056

When scaling a deploymentconfig, we default the resource version to `Unknown` on a scalerError.
This patch attempts to GET the resource version to include as part of the error, or fall back to Unknown otherwise.

cc @openshift/cli-review @stevekuznetsov 