### PR TITLE
Use groupUIDNameMapping for LDAP sync/prune with Openshift groups

### DIFF
--- a/pkg/cmd/server/api/validation/ldap.go
+++ b/pkg/cmd/server/api/validation/ldap.go
@@ -19,6 +19,12 @@ func ValidateLDAPSyncConfig(config *api.LDAPSyncConfig) ValidationResults {
 	bindPassword, _ := api.ResolveStringValue(config.BindPassword)
 	validationResults.Append(ValidateLDAPClientConfig(config.URL, config.BindDN, bindPassword, config.CA, config.Insecure, nil))
 
+	for ldapGroupUID, openShiftGroupName := range config.LDAPGroupUIDToOpenShiftGroupNameMapping {
+		if len(ldapGroupUID) == 0 || len(openShiftGroupName) == 0 {
+			validationResults.AddErrors(field.Invalid(field.NewPath("groupUIDNameMapping").Key(ldapGroupUID), openShiftGroupName, "has empty key or value"))
+		}
+	}
+
 	schemaConfigsFound := []string{}
 
 	if config.RFC2307Config != nil {

--- a/pkg/oc/admin/groups/sync/cli/prune.go
+++ b/pkg/oc/admin/groups/sync/cli/prune.go
@@ -132,17 +132,18 @@ func NewCmdPrune(name, fullName string, f *clientcmd.Factory, out io.Writer) *co
 
 func (o *PruneOptions) Complete(whitelistFile, blacklistFile, configFile string, args []string, f *clientcmd.Factory) error {
 	var err error
-	o.Whitelist, err = buildOpenShiftGroupNameList(args, whitelistFile)
-	if err != nil {
-		return err
-	}
-
-	o.Blacklist, err = buildOpenShiftGroupNameList([]string{}, blacklistFile)
-	if err != nil {
-		return err
-	}
 
 	o.Config, err = decodeSyncConfigFromFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	o.Whitelist, err = buildOpenShiftGroupNameList(args, whitelistFile, o.Config.LDAPGroupUIDToOpenShiftGroupNameMapping)
+	if err != nil {
+		return err
+	}
+
+	o.Blacklist, err = buildOpenShiftGroupNameList([]string{}, blacklistFile, o.Config.LDAPGroupUIDToOpenShiftGroupNameMapping)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When syncing LDAP groups with --type=openshift or when pruning groups, the `LDAPGroupUIDToOpenShiftGroupNameMapping` should be taken into consideration since:

1. The system of truth in both flows is openshift groups
2. The mapping was probably used to name said openshift groups

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1484831

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-security @stevekuznetsov