### PR TITLE
allow any 3.7 to have the TSB

### DIFF
--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -1047,7 +1047,7 @@ func (c *ClientStartConfig) ShouldInstallTemplateServiceBroker() bool {
 	}
 
 	// the TSB, which requires 3.7
-	serverVersion, _ := c.OpenShiftHelper().ServerPrereleaseVersion()
+	serverVersion, _ := c.OpenShiftHelper().ServerVersion()
 	if serverVersion.LT(openshiftVersion37) {
 		return false
 	}


### PR DESCRIPTION
I think this means "only use the 3.7.x of the version number"