### PR TITLE
registry: use generated imagestream clientset to retrieve secrets 

### DIFF
--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -48,12 +48,12 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 	// to make other unit tests working
 	defer m.changeUnsetRepository(false)
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, "user", "app", "latest")
 
 	ctx := context.Background()
 	ctx = WithConfiguration(ctx, &srvconfig.Configuration{})
-	ctx = WithRegistryClient(ctx, registryclient.NewFakeRegistryClient(client, imageClient))
+	ctx = WithRegistryClient(ctx, registryclient.NewFakeRegistryClient(imageClient))
 	app := handlers.NewApp(ctx, &configuration.Configuration{
 		Loglevel: "debug",
 		Auth: map[string]configuration.Parameters{

--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -3,6 +3,7 @@ package client
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
@@ -103,8 +104,10 @@ type ImageStreamTagInterface interface {
 	Delete(name string, options *metav1.DeleteOptions) error
 }
 
+var _ ImageStreamSecretInterface = imageclientv1.ImageStreamInterface(nil)
+
 type ImageStreamSecretInterface interface {
-	Secrets(name string, options metav1.ListOptions) (*kapi.SecretList, error)
+	Secrets(name string, options metav1.ListOptions) (*kapiv1.SecretList, error)
 }
 
 var _ LimitRangeInterface = kcoreclient.LimitRangeInterface(nil)

--- a/pkg/dockerregistry/server/client/test.go
+++ b/pkg/dockerregistry/server/client/test.go
@@ -3,29 +3,26 @@ package client
 import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
-	"github.com/openshift/origin/pkg/client"
 	imageclientv1 "github.com/openshift/origin/pkg/image/generated/clientset/typed/image/v1"
 )
 
 type fakeRegistryClient struct {
 	RegistryClient
 
-	client client.Interface
 	images imageclientv1.ImageV1Interface
 }
 
-func NewFakeRegistryClient(c client.Interface, imageclient imageclientv1.ImageV1Interface) RegistryClient {
+func NewFakeRegistryClient(imageclient imageclientv1.ImageV1Interface) RegistryClient {
 	return &fakeRegistryClient{
 		RegistryClient: &registryClient{},
-		client:         c,
 		images:         imageclient,
 	}
 }
 
 func (c *fakeRegistryClient) Client() (Interface, error) {
-	return newAPIClient(c.client, nil, nil, c.images, nil), nil
+	return newAPIClient(nil, nil, c.images, nil), nil
 }
 
-func NewFakeRegistryAPIClient(c client.Interface, kc kcoreclient.CoreInterface, imageclient imageclientv1.ImageV1Interface) Interface {
-	return newAPIClient(c, nil, nil, imageclient, nil)
+func NewFakeRegistryAPIClient(kc kcoreclient.CoreInterface, imageclient imageclientv1.ImageV1Interface) Interface {
+	return newAPIClient(nil, nil, imageclient, nil)
 }

--- a/pkg/dockerregistry/server/manifestservice_test.go
+++ b/pkg/dockerregistry/server/manifestservice_test.go
@@ -19,11 +19,11 @@ func TestManifestServiceExists(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := testutil.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := testutil.NewFakeOpenShiftWithClient()
 	testImage := testutil.AddRandomImage(t, fos, namespace, repo, tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ms := &manifestService{
@@ -51,7 +51,7 @@ func TestManifestServiceGetDoesntChangeDockerImageReference(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := testutil.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := testutil.NewFakeOpenShiftWithClient()
 
 	testImage, err := testutil.CreateRandomImage(namespace, repo)
 	if err != nil {
@@ -77,7 +77,7 @@ func TestManifestServiceGetDoesntChangeDockerImageReference(t *testing.T) {
 	}
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ms := &manifestService{
@@ -113,7 +113,7 @@ func TestManifestServicePut(t *testing.T) {
 	repo := "app"
 	repoName := fmt.Sprintf("%s/%s", namespace, repo)
 
-	_, client, imageClient := testutil.NewFakeOpenShiftWithClient()
+	_, _, imageClient := testutil.NewFakeOpenShiftWithClient()
 
 	bs := newTestBlobStore(map[digest.Digest][]byte{
 		"test:1": []byte("{}"),
@@ -122,7 +122,7 @@ func TestManifestServicePut(t *testing.T) {
 	tms := newTestManifestService(repoName, nil)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 		blobs:  bs,
 	})
 
@@ -146,7 +146,7 @@ func TestManifestServicePut(t *testing.T) {
 		},
 	}
 
-	osclient, err := registryclient.NewFakeRegistryClient(client, imageClient).Client()
+	osclient, err := registryclient.NewFakeRegistryClient(imageClient).Client()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestManifestServicePut(t *testing.T) {
 
 	// recreate repository to reset cached image stream
 	r = newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 		blobs:  bs,
 	})
 

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -46,7 +46,7 @@ func TestPullthroughServeBlob(t *testing.T) {
 	os.Setenv("OPENSHIFT_DEFAULT_REGISTRY", serverURL.Host)
 	testImage.DockerImageReference = fmt.Sprintf("%s/%s@%s", serverURL.Host, repoName, testImage.Name)
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	registrytest.AddImageStream(t, fos, namespace, name, map[string]string{
 		imageapi.InsecureRepositoryAnnotation: "true",
 	})
@@ -137,7 +137,7 @@ func TestPullthroughServeBlob(t *testing.T) {
 
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 		repo := newTestRepository(t, namespace, name, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: true,
 		})
 		ptbs := &pullthroughBlobStore{
@@ -278,7 +278,7 @@ func TestPullthroughServeNotSeekableBlob(t *testing.T) {
 	}
 	testImage.DockerImageReference = fmt.Sprintf("%s/%s@%s", serverURL.Host, repoName, testImage.Name)
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	registrytest.AddImageStream(t, fos, namespace, name, map[string]string{
 		imageapi.InsecureRepositoryAnnotation: "true",
 	})
@@ -288,7 +288,7 @@ func TestPullthroughServeNotSeekableBlob(t *testing.T) {
 
 	ctx := WithTestPassthroughToUpstream(context.Background(), false)
 	repo := newTestRepository(t, namespace, name, testRepositoryOptions{
-		client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 		enablePullThrough: true,
 	})
 	ptbs := &pullthroughBlobStore{
@@ -598,7 +598,7 @@ func TestPullthroughServeBlobInsecure(t *testing.T) {
 			expectedBytesServed:   int64(m1img.DockerImageLayers[0].LayerSize),
 		},
 	} {
-		fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+		fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 		tc.fakeOpenShiftInit(fos)
 
@@ -607,7 +607,7 @@ func TestPullthroughServeBlobInsecure(t *testing.T) {
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 
 		repo := newTestRepository(t, namespace, repo1, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: true,
 		})
 

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -93,7 +93,7 @@ func TestPullthroughManifests(t *testing.T) {
 	image.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", serverURL.Host, namespace, repo, image.Name)
 	image.DockerImageManifest = ""
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	registrytest.AddImageStream(t, fos, namespace, repo, map[string]string{
 		imageapi.InsecureRepositoryAnnotation: "true",
 	})
@@ -136,7 +136,7 @@ func TestPullthroughManifests(t *testing.T) {
 		localManifestService := newTestManifestService(repoName, tc.localData)
 
 		repo := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: true,
 		})
 
@@ -351,7 +351,7 @@ func TestPullthroughManifestInsecure(t *testing.T) {
 			},
 		},
 	} {
-		fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+		fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 		tc.fakeOpenShiftInit(fos)
 
@@ -359,7 +359,7 @@ func TestPullthroughManifestInsecure(t *testing.T) {
 
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 		repo := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: true,
 		})
 		ctx = withRepository(ctx, repo)
@@ -459,7 +459,7 @@ func TestPullthroughManifestDockerReference(t *testing.T) {
 	image2 := *img
 	image2.DockerImageReference = dockerImageReference(server2, "foo/bar")
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	registrytest.AddImageStream(t, fos, namespace, repo1, map[string]string{
 		imageapi.InsecureRepositoryAnnotation: "true",
 	})
@@ -493,7 +493,7 @@ func TestPullthroughManifestDockerReference(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, tc.repoName, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: true,
 		})
 

--- a/pkg/dockerregistry/server/repositorymiddleware_test.go
+++ b/pkg/dockerregistry/server/repositorymiddleware_test.go
@@ -297,7 +297,7 @@ func TestRepositoryBlobStat(t *testing.T) {
 			ctx = withDeferredErrors(ctx, tc.deferredErrors)
 		}
 
-		fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+		fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 		for _, is := range tc.imageStreams {
 			_, err = fos.CreateImageStream(is.Namespace, &is)
@@ -313,7 +313,7 @@ func TestRepositoryBlobStat(t *testing.T) {
 			}
 		}
 
-		reg, err := newTestRegistry(ctx, registryclient.NewFakeRegistryAPIClient(client, nil, imageClient), driver, defaultBlobRepositoryCacheTTL, tc.pullthrough, true)
+		reg, err := newTestRegistry(ctx, registryclient.NewFakeRegistryAPIClient(nil, imageClient), driver, defaultBlobRepositoryCacheTTL, tc.pullthrough, true)
 		if err != nil {
 			t.Errorf("[%s] unexpected error: %v", tc.name, err)
 			continue
@@ -375,11 +375,11 @@ func TestRepositoryBlobStatCacheEviction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	registrytest.AddImageStream(t, fos, "nm", "is", nil)
 	registrytest.AddImage(t, fos, testImage, "nm", "is", "latest")
 
-	reg, err := newTestRegistry(ctx, registryclient.NewFakeRegistryAPIClient(client, nil, imageClient), driver, blobRepoCacheTTL, false, false)
+	reg, err := newTestRegistry(ctx, registryclient.NewFakeRegistryAPIClient(nil, imageClient), driver, blobRepoCacheTTL, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/dockerregistry/server/signaturedispatcher_test.go
+++ b/pkg/dockerregistry/server/signaturedispatcher_test.go
@@ -47,19 +47,19 @@ func TestSignatureGet(t *testing.T) {
 	testImage.DockerImageManifest = ""
 	testImage.Signatures = append(testImage.Signatures, testSignature)
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	registrytest.AddImageStream(t, fos, "user", "app", map[string]string{
 		imageapi.InsecureRepositoryAnnotation: "true",
 	})
 	registrytest.AddImage(t, fos, testImage, "user", "app", "latest")
 
-	osclient, err := registryclient.NewFakeRegistryClient(client, imageClient).Client()
+	osclient, err := registryclient.NewFakeRegistryClient(imageClient).Client()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	ctx := context.Background()
-	ctx = WithRegistryClient(ctx, registryclient.NewFakeRegistryClient(client, imageClient))
+	ctx = WithRegistryClient(ctx, registryclient.NewFakeRegistryClient(imageClient))
 	ctx = WithConfiguration(ctx, &regconfig.Configuration{})
 	ctx = withUserClient(ctx, osclient)
 	registryApp := handlers.NewApp(ctx, &configuration.Configuration{
@@ -162,13 +162,13 @@ func TestSignaturePut(t *testing.T) {
 		return true, sign, nil
 	})
 
-	osclient, err := registryclient.NewFakeRegistryClient(nil, imageClient).Client()
+	osclient, err := registryclient.NewFakeRegistryClient(imageClient).Client()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	ctx := context.Background()
-	ctx = WithRegistryClient(ctx, registryclient.NewFakeRegistryClient(nil, imageClient))
+	ctx = WithRegistryClient(ctx, registryclient.NewFakeRegistryClient(imageClient))
 	ctx = WithConfiguration(ctx, &regconfig.Configuration{})
 	ctx = withUserClient(ctx, osclient)
 	registryApp := handlers.NewApp(ctx, &configuration.Configuration{

--- a/pkg/dockerregistry/server/tagservice_test.go
+++ b/pkg/dockerregistry/server/tagservice_test.go
@@ -18,7 +18,7 @@ func TestTagGet(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -69,7 +69,7 @@ func TestTagGet(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -107,10 +107,10 @@ func TestTagGetWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	_, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	_, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -134,7 +134,7 @@ func TestTagCreation(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -174,7 +174,7 @@ func TestTagCreation(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -192,7 +192,7 @@ func TestTagCreation(t *testing.T) {
 		}
 
 		r = newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -217,11 +217,11 @@ func TestTagCreationWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	anotherImage := registrytest.AddRandomImage(t, fos, namespace, repo+"-another", tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -247,7 +247,7 @@ func TestTagDeletion(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -295,7 +295,7 @@ func TestTagDeletion(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -329,10 +329,10 @@ func TestTagDeletionWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	_, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	_, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -356,7 +356,7 @@ func TestTagGetAll(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -391,7 +391,7 @@ func TestTagGetAll(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -416,10 +416,10 @@ func TestTagGetAllWithoutImageStream(t *testing.T) {
 	namespace := "user"
 	repo := "app"
 
-	_, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	_, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ts := &tagService{
@@ -443,7 +443,7 @@ func TestTagLookup(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	testImage := registrytest.AddRandomImage(t, fos, namespace, repo, tag)
 
 	testcases := []struct {
@@ -489,7 +489,7 @@ func TestTagLookup(t *testing.T) {
 		}
 
 		r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-			client:            registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+			client:            registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 			enablePullThrough: tc.pullthrough,
 		})
 
@@ -522,11 +522,11 @@ func TestTagLookupWithoutImageStream(t *testing.T) {
 	repo := "app"
 	tag := "latest"
 
-	fos, client, imageClient := registrytest.NewFakeOpenShiftWithClient()
+	fos, _, imageClient := registrytest.NewFakeOpenShiftWithClient()
 	anotherImage := registrytest.AddRandomImage(t, fos, namespace, repo+"-another", tag)
 
 	r := newTestRepository(t, namespace, repo, testRepositoryOptions{
-		client: registryclient.NewFakeRegistryAPIClient(client, nil, imageClient),
+		client: registryclient.NewFakeRegistryAPIClient(nil, imageClient),
 	})
 
 	ts := &tagService{

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/dockerregistry/server/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -176,7 +177,7 @@ func getImportContext(
 	secrets, err := osClient.ImageStreamSecrets(namespace).Secrets(name, metav1.ListOptions{})
 	if err != nil {
 		context.GetLogger(ctx).Errorf("error getting secrets for repository %s/%s: %v", namespace, name, err)
-		secrets = &kapi.SecretList{}
+		secrets = &kapiv1.SecretList{}
 	}
 	credentials := importer.NewCredentialsForSecrets(secrets.Items)
 	return importer.NewContext(secureTransport, insecureTransport).WithCredentials(credentials)

--- a/pkg/dockerregistry/testutil/fakeopenshift.go
+++ b/pkg/dockerregistry/testutil/fakeopenshift.go
@@ -39,6 +39,7 @@ func NewFakeOpenShift() *FakeOpenShift {
 // NewFakeOpenShiftWithClient constructs a fake client associated with
 // the stateful fake in-memory OpenShift reactors. The fake OpenShift is
 // available for direct interaction, so you can make buggy states.
+// TODO: remove the FakeOpenshift as the legacy client is not needed anymore
 func NewFakeOpenShiftWithClient() (*FakeOpenShift, *testclient.Fake, *imagefakeclient.FakeImageV1) {
 	fos := NewFakeOpenShift()
 	client := &testclient.Fake{}

--- a/pkg/image/registry/imagestreamimport/rest.go
+++ b/pkg/image/registry/imagestreamimport/rest.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapihelper "k8s.io/kubernetes/pkg/api/helper"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
@@ -147,12 +148,20 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ bool) (runti
 	}
 
 	// only load secrets if we need them
-	credentials := importer.NewLazyCredentialsForSecrets(func() ([]kapi.Secret, error) {
+	credentials := importer.NewLazyCredentialsForSecrets(func() ([]kapiv1.Secret, error) {
 		secrets, err := r.secrets.ImageStreamSecrets(namespace).Secrets(isi.Name, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
-		return secrets.Items, nil
+		secretsv1 := make([]kapiv1.Secret, len(secrets.Items))
+		for i, secret := range secrets.Items {
+			err := kapiv1.Convert_api_Secret_To_v1_Secret(&secret, &secretsv1[i], nil)
+			if err != nil {
+				utilruntime.HandleError(err)
+				continue
+			}
+		}
+		return secretsv1, nil
 	})
 	importCtx := importer.NewContext(r.transport, r.insecureTransport).WithCredentials(credentials)
 	imports := r.importFn(importCtx)


### PR DESCRIPTION
@deads2k this is making registry using purely external client.