### PR TITLE
apps: switch to use generated internal clientset

### DIFF
--- a/pkg/cmd/server/origin/controller/apps.go
+++ b/pkg/cmd/server/origin/controller/apps.go
@@ -51,15 +51,11 @@ func (c *DeploymentConfigControllerConfig) RunController(ctx ControllerContext) 
 	if err != nil {
 		return true, err
 	}
-	deprecatedOcDcClient, err := ctx.ClientBuilder.DeprecatedOpenshiftClient(saName)
-	if err != nil {
-		return true, err
-	}
 
 	go deployconfigcontroller.NewDeploymentConfigController(
 		ctx.AppInformers.Apps().InternalVersion().DeploymentConfigs().Informer(),
 		ctx.ExternalKubeInformers.Core().V1().ReplicationControllers(),
-		deprecatedOcDcClient,
+		ctx.ClientBuilder.OpenshiftInternalAppsClientOrDie(saName),
 		kubeClient,
 		c.Codec,
 	).Run(5, ctx.Stop)
@@ -70,16 +66,11 @@ func (c *DeploymentConfigControllerConfig) RunController(ctx ControllerContext) 
 func (c *DeploymentTriggerControllerConfig) RunController(ctx ControllerContext) (bool, error) {
 	saName := bootstrappolicy.InfraDeploymentTriggerControllerServiceAccountName
 
-	deprecatedOcTriggerClient, err := ctx.ClientBuilder.DeprecatedOpenshiftClient(saName)
-	if err != nil {
-		return true, err
-	}
-
 	go triggercontroller.NewDeploymentTriggerController(
 		ctx.AppInformers.Apps().InternalVersion().DeploymentConfigs().Informer(),
 		ctx.ExternalKubeInformers.Core().V1().ReplicationControllers().Informer(),
 		ctx.ImageInformers.Image().InternalVersion().ImageStreams().Informer(),
-		deprecatedOcTriggerClient,
+		ctx.ClientBuilder.OpenshiftInternalAppsClientOrDie(saName),
 		c.Codec,
 	).Run(5, ctx.Stop)
 

--- a/pkg/cmd/server/origin/controller/image.go
+++ b/pkg/cmd/server/origin/controller/image.go
@@ -152,7 +152,7 @@ type ImageImportControllerConfig struct {
 func (c *ImageImportControllerConfig) RunController(ctx ControllerContext) (bool, error) {
 	informer := ctx.ImageInformers.Image().InternalVersion().ImageStreams()
 	controller := imagecontroller.NewImageStreamController(
-		ctx.ClientBuilder.OpenshiftImageClientOrDie(bootstrappolicy.InfraImageImportControllerServiceAccountName),
+		ctx.ClientBuilder.OpenshiftInternalImageClientOrDie(bootstrappolicy.InfraImageImportControllerServiceAccountName),
 		informer,
 	)
 	go controller.Run(5, ctx.Stop)
@@ -162,7 +162,7 @@ func (c *ImageImportControllerConfig) RunController(ctx ControllerContext) (bool
 	}
 
 	scheduledController := imagecontroller.NewScheduledImageStreamController(
-		ctx.ClientBuilder.OpenshiftImageClientOrDie(bootstrappolicy.InfraImageImportControllerServiceAccountName),
+		ctx.ClientBuilder.OpenshiftInternalImageClientOrDie(bootstrappolicy.InfraImageImportControllerServiceAccountName),
 		informer,
 		imagecontroller.ScheduledImageStreamControllerOptions{
 			Resync: time.Duration(c.ScheduledImageImportMinimumIntervalSeconds) * time.Second,

--- a/pkg/cmd/server/origin/controller/template.go
+++ b/pkg/cmd/server/origin/controller/template.go
@@ -17,7 +17,7 @@ func RunTemplateInstanceController(ctx ControllerContext) (bool, error) {
 		restConfig,
 		ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
 		ctx.ClientBuilder.KubeInternalClientOrDie(saName),
-		ctx.ClientBuilder.OpenshiftTemplateClientOrDie(saName),
+		ctx.ClientBuilder.OpenshiftInternalTemplateClientOrDie(saName),
 		ctx.TemplateInformers.Template().InternalVersion().TemplateInstances(),
 	).Run(5, ctx.Stop)
 

--- a/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller.go
+++ b/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/kubernetes/pkg/client/retry"
 	kcontroller "k8s.io/kubernetes/pkg/controller"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	oscache "github.com/openshift/origin/pkg/client/cache"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
+	appsclient "github.com/openshift/origin/pkg/deploy/generated/internalclientset/typed/apps/internalversion"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
@@ -56,7 +56,7 @@ func (e fatalError) Error() string {
 // running deployments.
 type DeploymentConfigController struct {
 	// dn provides access to deploymentconfigs.
-	dn osclient.DeploymentConfigsNamespacer
+	dn appsclient.DeploymentConfigsGetter
 	// rn provides access to replication controllers.
 	rn kcoreclient.ReplicationControllersGetter
 

--- a/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller_test.go
+++ b/pkg/deploy/controller/deploymentconfig/deploymentconfig_controller_test.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 	kinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	_ "github.com/openshift/origin/pkg/deploy/apis/apps/install"
 	deploytest "github.com/openshift/origin/pkg/deploy/apis/apps/test"
 	deployv1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
+	appsfake "github.com/openshift/origin/pkg/deploy/generated/internalclientset/fake"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
@@ -347,7 +347,7 @@ func TestHandleScenarios(t *testing.T) {
 			toStore = append(toStore, deployment)
 		}
 
-		oc := &testclient.Fake{}
+		oc := &appsfake.Clientset{}
 		oc.AddReactor("update", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 			dc := action.(clientgotesting.UpdateAction).GetObject().(*deployapi.DeploymentConfig)
 			updatedConfig = dc
@@ -369,10 +369,10 @@ func TestHandleScenarios(t *testing.T) {
 		dcInformer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return oc.DeploymentConfigs(metav1.NamespaceAll).List(options)
+					return oc.Apps().DeploymentConfigs(metav1.NamespaceAll).List(options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return oc.DeploymentConfigs(metav1.NamespaceAll).Watch(options)
+					return oc.Apps().DeploymentConfigs(metav1.NamespaceAll).Watch(options)
 				},
 			},
 			&deployapi.DeploymentConfig{},

--- a/pkg/deploy/controller/deploymentconfig/factory.go
+++ b/pkg/deploy/controller/deploymentconfig/factory.go
@@ -19,8 +19,8 @@ import (
 	kcoreinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions/core/v1"
 	kcontroller "k8s.io/kubernetes/pkg/controller"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
+	appsclient "github.com/openshift/origin/pkg/deploy/generated/internalclientset"
 )
 
 const (
@@ -34,7 +34,7 @@ const (
 func NewDeploymentConfigController(
 	dcInformer cache.SharedIndexInformer,
 	rcInformer kcoreinformers.ReplicationControllerInformer,
-	oc osclient.Interface,
+	appsClientset appsclient.Interface,
 	kubeClientset kclientset.Interface,
 	codec runtime.Codec,
 ) *DeploymentConfigController {
@@ -43,7 +43,7 @@ func NewDeploymentConfigController(
 	recorder := eventBroadcaster.NewRecorder(kapi.Scheme, kclientv1.EventSource{Component: "deploymentconfig-controller"})
 
 	c := &DeploymentConfigController{
-		dn: oc,
+		dn: appsClientset.Apps(),
 		rn: kubeClientset.Core(),
 
 		queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),

--- a/pkg/deploy/controller/generictrigger/deploy_generictrigger_controller.go
+++ b/pkg/deploy/controller/generictrigger/deploy_generictrigger_controller.go
@@ -7,9 +7,9 @@ import (
 	kcorelister "k8s.io/kubernetes/pkg/client/listers/core/v1"
 
 	"github.com/golang/glog"
-	osclient "github.com/openshift/origin/pkg/client"
 	oscache "github.com/openshift/origin/pkg/client/cache"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
+	appsclient "github.com/openshift/origin/pkg/deploy/generated/internalclientset/typed/apps/internalversion"
 )
 
 const (
@@ -26,7 +26,7 @@ type DeploymentTriggerController struct {
 	triggerFromImages bool
 
 	// dn is used to update deployment configs.
-	dn osclient.DeploymentConfigsNamespacer
+	dn appsclient.DeploymentConfigsGetter
 
 	// queue contains deployment configs that need to be synced.
 	queue workqueue.RateLimitingInterface
@@ -59,7 +59,7 @@ func (c *DeploymentTriggerController) Handle(config *deployapi.DeploymentConfig)
 		request.ExcludeTriggers = []deployapi.DeploymentTriggerType{deployapi.DeploymentTriggerOnImageChange}
 	}
 
-	_, err := c.dn.DeploymentConfigs(config.Namespace).Instantiate(request)
+	_, err := c.dn.DeploymentConfigs(config.Namespace).Instantiate(config.Name, request)
 	return err
 }
 

--- a/pkg/deploy/controller/generictrigger/factory.go
+++ b/pkg/deploy/controller/generictrigger/factory.go
@@ -15,8 +15,8 @@ import (
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/v1"
 	kcontroller "k8s.io/kubernetes/pkg/controller"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
+	appsclient "github.com/openshift/origin/pkg/deploy/generated/internalclientset"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
@@ -29,12 +29,10 @@ const (
 )
 
 // NewDeploymentTriggerController returns a new DeploymentTriggerController.
-func NewDeploymentTriggerController(dcInformer, rcInformer, streamInformer cache.SharedIndexInformer, oc osclient.Interface, codec runtime.Codec) *DeploymentTriggerController {
+func NewDeploymentTriggerController(dcInformer, rcInformer, streamInformer cache.SharedIndexInformer, appsClientset appsclient.Interface, codec runtime.Codec) *DeploymentTriggerController {
 	c := &DeploymentTriggerController{
-		dn: oc,
-
+		dn:    appsClientset.Apps(),
 		queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-
 		codec: codec,
 	}
 

--- a/pkg/deploy/generated/clientset/typed/apps/v1/fake/fake_deploymentconfig.go
+++ b/pkg/deploy/generated/clientset/typed/apps/v1/fake/fake_deploymentconfig.go
@@ -125,7 +125,7 @@ func (c *FakeDeploymentConfigs) Patch(name string, pt types.PatchType, data []by
 // Instantiate takes the representation of a deploymentRequest and creates it.  Returns the server's representation of the deploymentConfig, and an error, if there is any.
 func (c *FakeDeploymentConfigs) Instantiate(deploymentConfigName string, deploymentRequest *apps_v1.DeploymentRequest) (result *apps_v1.DeploymentConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateSubresourceAction(deploymentconfigsResource, deploymentConfigName, "instantiate", c.ns, deploymentRequest), &apps_v1.DeploymentRequest{})
+		Invokes(testing.NewCreateSubresourceAction(deploymentconfigsResource, deploymentConfigName, "instantiate", c.ns, deploymentRequest), &apps_v1.DeploymentConfig{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/deploy/generated/internalclientset/typed/apps/internalversion/fake/fake_deploymentconfig.go
+++ b/pkg/deploy/generated/internalclientset/typed/apps/internalversion/fake/fake_deploymentconfig.go
@@ -125,7 +125,7 @@ func (c *FakeDeploymentConfigs) Patch(name string, pt types.PatchType, data []by
 // Instantiate takes the representation of a deploymentRequest and creates it.  Returns the server's representation of the deploymentConfig, and an error, if there is any.
 func (c *FakeDeploymentConfigs) Instantiate(deploymentConfigName string, deploymentRequest *apps.DeploymentRequest) (result *apps.DeploymentConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateSubresourceAction(deploymentconfigsResource, deploymentConfigName, "instantiate", c.ns, deploymentRequest), &apps.DeploymentRequest{})
+		Invokes(testing.NewCreateSubresourceAction(deploymentconfigsResource, deploymentConfigName, "instantiate", c.ns, deploymentRequest), &apps.DeploymentConfig{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/deploy/registry/deploylog/rest.go
+++ b/pkg/deploy/registry/deploylog/rest.go
@@ -22,9 +22,9 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/registry/core/pod"
 
-	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	"github.com/openshift/origin/pkg/deploy/apis/apps/validation"
+	appsclient "github.com/openshift/origin/pkg/deploy/generated/internalclientset/typed/apps/internalversion"
 	"github.com/openshift/origin/pkg/deploy/registry"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
@@ -53,7 +53,7 @@ func (g *podGetter) Get(ctx apirequest.Context, name string, options *metav1.Get
 
 // REST is an implementation of RESTStorage for the api server.
 type REST struct {
-	dn       client.DeploymentConfigsNamespacer
+	dn       appsclient.DeploymentConfigsGetter
 	rn       kcoreclient.ReplicationControllersGetter
 	pn       kcoreclient.PodsGetter
 	connInfo kubeletclient.ConnectionInfoGetter
@@ -68,7 +68,7 @@ var _ = rest.GetterWithOptions(&REST{})
 // one for deployments (replication controllers) and one for pods to get the necessary
 // attributes to assemble the URL to which the request shall be redirected in order to
 // get the deployment logs.
-func NewREST(dn client.DeploymentConfigsNamespacer, rn kcoreclient.ReplicationControllersGetter, pn kcoreclient.PodsGetter, connectionInfo kubeletclient.ConnectionInfoGetter) *REST {
+func NewREST(dn appsclient.DeploymentConfigsGetter, rn kcoreclient.ReplicationControllersGetter, pn kcoreclient.PodsGetter, connectionInfo kubeletclient.ConnectionInfoGetter) *REST {
 	return &REST{
 		dn:       dn,
 		rn:       rn,

--- a/pkg/deploy/registry/deploylog/rest_test.go
+++ b/pkg/deploy/registry/deploylog/rest_test.go
@@ -18,9 +18,9 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	deploytest "github.com/openshift/origin/pkg/deploy/apis/apps/test"
+	appsfake "github.com/openshift/origin/pkg/deploy/generated/internalclientset/fake"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 
 	// install all APIs
@@ -97,7 +97,7 @@ func (*fakeConnectionInfoGetter) GetConnectionInfo(nodeName types.NodeName) (*ku
 func mockREST(version, desired int64, status deployapi.DeploymentStatus) *REST {
 	// Fake deploymentConfig
 	config := deploytest.OkDeploymentConfig(version)
-	fakeDn := testclient.NewSimpleFake(config)
+	fakeDn := appsfake.NewSimpleClientset(config)
 	fakeDn.PrependReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, config, nil
 	})
@@ -105,7 +105,7 @@ func mockREST(version, desired int64, status deployapi.DeploymentStatus) *REST {
 	// Used for testing validation errors prior to getting replication controllers.
 	if desired > version {
 		return &REST{
-			dn:       fakeDn,
+			dn:       fakeDn.Apps(),
 			connInfo: &fakeConnectionInfoGetter{},
 			timeout:  defaultTimeout,
 		}
@@ -160,7 +160,7 @@ func mockREST(version, desired int64, status deployapi.DeploymentStatus) *REST {
 	}
 
 	return &REST{
-		dn:       fakeDn,
+		dn:       fakeDn.Apps(),
 		rn:       fakeRn.Core(),
 		pn:       fakePn.Core(),
 		connInfo: &fakeConnectionInfoGetter{},

--- a/pkg/deploy/registry/rollback/rest.go
+++ b/pkg/deploy/registry/rollback/rest.go
@@ -12,16 +12,17 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
-	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	"github.com/openshift/origin/pkg/deploy/apis/apps/validation"
+	appsclientinternal "github.com/openshift/origin/pkg/deploy/generated/internalclientset"
+	apps "github.com/openshift/origin/pkg/deploy/generated/internalclientset/typed/apps/internalversion"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
 // REST provides a rollback generation endpoint. Only the Create method is implemented.
 type REST struct {
 	generator RollbackGenerator
-	dn        client.DeploymentConfigsNamespacer
+	dn        apps.DeploymentConfigsGetter
 	rn        kcoreclient.ReplicationControllersGetter
 	codec     runtime.Codec
 }
@@ -29,10 +30,10 @@ type REST struct {
 var _ rest.Creater = &REST{}
 
 // NewREST safely creates a new REST.
-func NewREST(oc client.Interface, kc kclientset.Interface, codec runtime.Codec) *REST {
+func NewREST(appsclient appsclientinternal.Interface, kc kclientset.Interface, codec runtime.Codec) *REST {
 	return &REST{
 		generator: NewRollbackGenerator(),
-		dn:        oc,
+		dn:        appsclient.Apps(),
 		rn:        kc.Core(),
 		codec:     codec,
 	}

--- a/pkg/deploy/registry/rollback/rest_test.go
+++ b/pkg/deploy/registry/rollback/rest_test.go
@@ -12,11 +12,11 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	_ "github.com/openshift/origin/pkg/deploy/apis/apps/install"
 	deploytest "github.com/openshift/origin/pkg/deploy/apis/apps/test"
 	deployv1 "github.com/openshift/origin/pkg/deploy/apis/apps/v1"
+	appsfake "github.com/openshift/origin/pkg/deploy/generated/internalclientset/fake"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 )
 
@@ -57,7 +57,7 @@ func TestCreateInvalid(t *testing.T) {
 }
 
 func TestCreateOk(t *testing.T) {
-	oc := &testclient.Fake{}
+	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, deploytest.OkDeploymentConfig(2), nil
 	})
@@ -88,7 +88,7 @@ func TestCreateOk(t *testing.T) {
 }
 
 func TestCreateRollbackToLatest(t *testing.T) {
-	oc := &testclient.Fake{}
+	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, deploytest.OkDeploymentConfig(2), nil
 	})
@@ -109,7 +109,7 @@ func TestCreateRollbackToLatest(t *testing.T) {
 }
 
 func TestCreateGeneratorError(t *testing.T) {
-	oc := &testclient.Fake{}
+	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, deploytest.OkDeploymentConfig(2), nil
 	})
@@ -121,7 +121,7 @@ func TestCreateGeneratorError(t *testing.T) {
 
 	rest := REST{
 		generator: &terribleGenerator{},
-		dn:        oc,
+		dn:        oc.Apps(),
 		rn:        kc.Core(),
 		codec:     kapi.Codecs.LegacyCodec(deployv1.SchemeGroupVersion),
 	}
@@ -139,7 +139,7 @@ func TestCreateGeneratorError(t *testing.T) {
 }
 
 func TestCreateMissingDeployment(t *testing.T) {
-	oc := &testclient.Fake{}
+	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, deploytest.OkDeploymentConfig(2), nil
 	})
@@ -166,7 +166,7 @@ func TestCreateMissingDeployment(t *testing.T) {
 }
 
 func TestCreateInvalidDeployment(t *testing.T) {
-	oc := &testclient.Fake{}
+	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, deploytest.OkDeploymentConfig(2), nil
 	})
@@ -195,7 +195,7 @@ func TestCreateInvalidDeployment(t *testing.T) {
 }
 
 func TestCreateMissingDeploymentConfig(t *testing.T) {
-	oc := &testclient.Fake{}
+	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		dc := deploytest.OkDeploymentConfig(2)
 		return true, nil, kerrors.NewNotFound(deployapi.Resource("deploymentConfig"), dc.Name)

--- a/pkg/deploy/strategy/recreate/recreate.go
+++ b/pkg/deploy/strategy/recreate/recreate.go
@@ -20,12 +20,12 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/kubectl"
 
-	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	strat "github.com/openshift/origin/pkg/deploy/strategy"
 	stratsupport "github.com/openshift/origin/pkg/deploy/strategy/support"
 	stratutil "github.com/openshift/origin/pkg/deploy/strategy/util"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 )
 
 // RecreateDeploymentStrategy is a simple strategy appropriate as a default.
@@ -51,7 +51,7 @@ type RecreateDeploymentStrategy struct {
 	// scaler is used to scale replication controllers.
 	scaler kubectl.Scaler
 	// tagClient is used to tag images
-	tagClient client.ImageStreamTagsNamespacer
+	tagClient imageclient.ImageStreamTagsGetter
 	// codec is used to decode DeploymentConfigs contained in deployments.
 	decoder runtime.Decoder
 	// hookExecutor can execute a lifecycle hook.
@@ -74,7 +74,7 @@ const (
 
 // NewRecreateDeploymentStrategy makes a RecreateDeploymentStrategy backed by
 // a real HookExecutor and client.
-func NewRecreateDeploymentStrategy(client kclientset.Interface, tagClient client.ImageStreamTagsNamespacer, events record.EventSink, decoder runtime.Decoder, out, errOut io.Writer, until string) *RecreateDeploymentStrategy {
+func NewRecreateDeploymentStrategy(client kclientset.Interface, tagClient imageclient.ImageStreamTagsGetter, events record.EventSink, decoder runtime.Decoder, out, errOut io.Writer, until string) *RecreateDeploymentStrategy {
 	if out == nil {
 		out = ioutil.Discard
 	}

--- a/pkg/deploy/strategy/rolling/rolling.go
+++ b/pkg/deploy/strategy/rolling/rolling.go
@@ -18,12 +18,12 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/kubectl"
 
-	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	strat "github.com/openshift/origin/pkg/deploy/strategy"
 	stratsupport "github.com/openshift/origin/pkg/deploy/strategy/support"
 	stratutil "github.com/openshift/origin/pkg/deploy/strategy/util"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
+	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 )
 
 const (
@@ -64,7 +64,7 @@ type RollingDeploymentStrategy struct {
 	// eventClient is a client to access events
 	eventClient kcoreclient.EventsGetter
 	// tags is a client used to perform tag actions
-	tags client.ImageStreamTagsNamespacer
+	tags imageclient.ImageStreamTagsGetter
 	// rollingUpdate knows how to perform a rolling update.
 	rollingUpdate func(config *kubectl.RollingUpdaterConfig) error
 	// decoder is used to access the encoded config on a deployment.
@@ -90,7 +90,7 @@ type acceptingDeploymentStrategy interface {
 }
 
 // NewRollingDeploymentStrategy makes a new RollingDeploymentStrategy.
-func NewRollingDeploymentStrategy(namespace string, client kclientset.Interface, tags client.ImageStreamTagsNamespacer, events record.EventSink, decoder runtime.Decoder, initialStrategy acceptingDeploymentStrategy, out, errOut io.Writer, until string) *RollingDeploymentStrategy {
+func NewRollingDeploymentStrategy(namespace string, client kclientset.Interface, tags imageclient.ImageStreamTagsGetter, events record.EventSink, decoder runtime.Decoder, initialStrategy acceptingDeploymentStrategy, out, errOut io.Writer, until string) *RollingDeploymentStrategy {
 	if out == nil {
 		out = ioutil.Discard
 	}

--- a/pkg/deploy/strategy/support/lifecycle.go
+++ b/pkg/deploy/strategy/support/lifecycle.go
@@ -19,11 +19,11 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
-	"github.com/openshift/origin/pkg/client"
 	deployapi "github.com/openshift/origin/pkg/deploy/apis/apps"
 	strategyutil "github.com/openshift/origin/pkg/deploy/strategy/util"
 	deployutil "github.com/openshift/origin/pkg/deploy/util"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	"github.com/openshift/origin/pkg/util"
 	namer "github.com/openshift/origin/pkg/util/namer"
 )
@@ -44,7 +44,7 @@ type hookExecutor struct {
 	// pods provides client to pods
 	pods kcoreclient.PodsGetter
 	// tags allows setting image stream tags
-	tags client.ImageStreamTagsNamespacer
+	tags imageclient.ImageStreamTagsGetter
 	// out is where hook pod logs should be written to.
 	out io.Writer
 	// decoder is used for encoding/decoding.
@@ -56,7 +56,7 @@ type hookExecutor struct {
 }
 
 // NewHookExecutor makes a HookExecutor from a client.
-func NewHookExecutor(pods kcoreclient.PodsGetter, tags client.ImageStreamTagsNamespacer, events kcoreclient.EventsGetter, out io.Writer, decoder runtime.Decoder) HookExecutor {
+func NewHookExecutor(pods kcoreclient.PodsGetter, tags imageclient.ImageStreamTagsGetter, events kcoreclient.EventsGetter, out io.Writer, decoder runtime.Decoder) HookExecutor {
 	executor := &hookExecutor{
 		tags:    tags,
 		pods:    pods,

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -15,6 +15,7 @@ import (
 	stratsupport "github.com/openshift/origin/pkg/deploy/strategy/support"
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -405,8 +406,10 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	imageClientset := imageclient.NewForConfigOrDie(testutil.GetClusterAdminClientConfigOrDie(clusterAdminKubeConfig))
+
 	// can tag to a stream that exists
-	exec := stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClientset.Core(), os.Stdout, kapi.Codecs.UniversalDecoder())
+	exec := stratsupport.NewHookExecutor(nil, imageClientset, clusterAdminKubeClientset.Core(), os.Stdout, kapi.Codecs.UniversalDecoder())
 	err = exec.Execute(
 		&deployapi.LifecycleHook{
 			TagImages: []deployapi.TagImageHook{
@@ -444,7 +447,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	}
 
 	// can execute a second time the same tag and it should work
-	exec = stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClientset.Core(), os.Stdout, kapi.Codecs.UniversalDecoder())
+	exec = stratsupport.NewHookExecutor(nil, imageClientset, clusterAdminKubeClientset.Core(), os.Stdout, kapi.Codecs.UniversalDecoder())
 	err = exec.Execute(
 		&deployapi.LifecycleHook{
 			TagImages: []deployapi.TagImageHook{
@@ -476,7 +479,7 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	}
 
 	// can lifecycle tag a new image stream
-	exec = stratsupport.NewHookExecutor(nil, clusterAdminClient, clusterAdminKubeClientset.Core(), os.Stdout, kapi.Codecs.UniversalDecoder())
+	exec = stratsupport.NewHookExecutor(nil, imageClientset, clusterAdminKubeClientset.Core(), os.Stdout, kapi.Codecs.UniversalDecoder())
 	err = exec.Execute(
 		&deployapi.LifecycleHook{
 			TagImages: []deployapi.TagImageHook{

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -64,6 +64,16 @@ func GetClusterAdminClientConfig(adminKubeConfigFile string) (*restclient.Config
 	return conf, nil
 }
 
+// GetClusterAdminClientConfigOrDie returns a REST config for the cluster admin
+// user or panic.
+func GetClusterAdminClientConfigOrDie(adminKubeConfigFile string) *restclient.Config {
+	conf, err := GetClusterAdminClientConfig(adminKubeConfigFile)
+	if err != nil {
+		panic(err)
+	}
+	return conf
+}
+
 func GetClientForUser(clientConfig restclient.Config, username string) (*client.Client, kclientset.Interface, *restclient.Config, error) {
 	token, err := tokencmd.RequestToken(&clientConfig, nil, username, "password")
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -420,8 +420,8 @@ var createSubresourceTemplate = `
 // Create takes the representation of a $.inputType|private$ and creates it.  Returns the server's representation of the $.resultType|private$, and an error, if there is any.
 func (c *Fake$.type|publicPlural$) Create($.type|private$Name string, $.inputType|private$ *$.inputType|raw$) (result *$.resultType|raw$, err error) {
 	obj, err := c.Fake.
-		$if .namespaced$Invokes($.NewCreateSubresourceAction|raw$($.type|allLowercasePlural$Resource, $.type|private$Name, "$.subresourcePath$", c.ns, $.inputType|private$), &$.inputType|raw${})
-		$else$Invokes($.NewRootCreateAction|raw$($.inputType|allLowercasePlural$Resource, $.inputType|private$), &$.inputType|raw${})$end$
+		$if .namespaced$Invokes($.NewCreateSubresourceAction|raw$($.type|allLowercasePlural$Resource, $.type|private$Name, "$.subresourcePath$", c.ns, $.inputType|private$), &$.resultType|raw${})
+		$else$Invokes($.NewRootCreateAction|raw$($.inputType|allLowercasePlural$Resource, $.inputType|private$), &$.resultType|raw${})$end$
 	if obj == nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR  replaces the legacy pkg/client in pkg/deploy. It switches controllers and storage to use the generated internal clientset.