### PR TITLE
avoid mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil) invocations

### DIFF
--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -43,7 +43,7 @@ const (
 )
 
 func TestInstantiate(t *testing.T) {
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	_, err := generator.Instantiate(apirequest.NewDefaultContext(), &buildapi.BuildRequest{})
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -51,7 +51,7 @@ func TestInstantiate(t *testing.T) {
 }
 
 func TestInstantiateBinary(t *testing.T) {
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	build, err := generator.Instantiate(apirequest.NewDefaultContext(), &buildapi.BuildRequest{Binary: &buildapi.BinaryBuildSource{}})
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -161,7 +161,7 @@ func TestInstantiateDeletingError(t *testing.T) {
 // that has a binary source value, the resulting build does not have a binary source value
 // (because the request did not include one)
 func TestInstantiateBinaryRemoved(t *testing.T) {
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	client := generator.Client.(TestingClient)
 	client.GetBuildConfigFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 		bc := &buildapi.BuildConfig{
@@ -361,7 +361,10 @@ func TestInstantiateWithImageTrigger(t *testing.T) {
 				Triggers: tc.triggers,
 			},
 		}
-		imageStreamTagFunc := func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
+		generator := mockBuildGenerator()
+
+		client := generator.Client.(TestingClient)
+		client.GetImageStreamTagFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
 			return &imageapi.ImageStreamTag{
 				Image: imageapi.Image{
 					ObjectMeta:           metav1.ObjectMeta{Name: imageRepoName + ":" + newTag},
@@ -369,9 +372,6 @@ func TestInstantiateWithImageTrigger(t *testing.T) {
 				},
 			}, nil
 		}
-
-		generator := mockBuildGenerator(nil, nil, nil, nil, nil, imageStreamTagFunc, nil)
-		client := generator.Client.(TestingClient)
 		client.GetBuildConfigFunc =
 			func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 				return bc, nil
@@ -526,7 +526,7 @@ func TestInstantiateWithBuildRequestEnvs(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+		generator := mockBuildGenerator()
 		client := generator.Client.(TestingClient)
 		client.GetBuildConfigFunc = tc.bcfunc
 		generator.Client = client
@@ -575,7 +575,7 @@ func TestInstantiateWithBuildRequestEnvs(t *testing.T) {
 }
 
 func TestInstantiateWithLastVersion(t *testing.T) {
-	g := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	g := mockBuildGenerator()
 	c := g.Client.(TestingClient)
 	c.GetBuildConfigFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 		bc := mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput())
@@ -606,7 +606,7 @@ func TestInstantiateWithLastVersion(t *testing.T) {
 }
 
 func TestInstantiateWithMissingImageStream(t *testing.T) {
-	g := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	g := mockBuildGenerator()
 	c := g.Client.(TestingClient)
 	c.GetImageStreamFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
 		return nil, errors.NewNotFound(imageapi.Resource("imagestreams"), "testRepo")
@@ -630,7 +630,7 @@ func TestInstantiateWithMissingImageStream(t *testing.T) {
 }
 
 func TestInstantiateWithLabelsAndAnnotations(t *testing.T) {
-	g := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	g := mockBuildGenerator()
 	c := g.Client.(TestingClient)
 	c.GetBuildConfigFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 		bc := mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput())
@@ -867,7 +867,7 @@ func TestCreateBuildNamespaceError(t *testing.T) {
 			Name: "test-build",
 		},
 	}
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 
 	_, err := generator.createBuild(apirequest.NewContext(), build)
 	if err == nil || !strings.Contains(err.Error(), "Build.Namespace") {
@@ -928,7 +928,7 @@ func TestGenerateBuildFromConfig(t *testing.T) {
 			Commit: "abcd",
 		},
 	}
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 
 	build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, revision, nil)
 	if err != nil {
@@ -1381,7 +1381,7 @@ func TestSubstituteImageCustomAllMatch(t *testing.T) {
 	strategy := mockCustomStrategyForDockerImage(originalImage, &metav1.GetOptions{})
 	output := mocks.MockOutput()
 	bc := mocks.MockBuildConfig(source, strategy, output)
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
@@ -1415,7 +1415,7 @@ func TestSubstituteImageCustomAllMismatch(t *testing.T) {
 	strategy := mockCustomStrategyForDockerImage(originalImage, &metav1.GetOptions{})
 	output := mocks.MockOutput()
 	bc := mocks.MockBuildConfig(source, strategy, output)
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
@@ -1434,7 +1434,7 @@ func TestSubstituteImageCustomBaseMatchEnvMismatch(t *testing.T) {
 	strategy := mockCustomStrategyForImageRepository()
 	output := mocks.MockOutput()
 	bc := mocks.MockBuildConfig(source, strategy, output)
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
@@ -1462,7 +1462,7 @@ func TestSubstituteImageCustomBaseMatchEnvMissing(t *testing.T) {
 	strategy := mockCustomStrategyForImageRepository()
 	output := mocks.MockOutput()
 	bc := mocks.MockBuildConfig(source, strategy, output)
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
@@ -1490,7 +1490,7 @@ func TestSubstituteImageCustomBaseMatchEnvNil(t *testing.T) {
 	strategy := mockCustomStrategyForImageRepository()
 	output := mocks.MockOutput()
 	bc := mocks.MockBuildConfig(source, strategy, output)
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
@@ -1591,7 +1591,7 @@ func TestResolveImageStreamRef(t *testing.T) {
 		expectedSuccess   bool
 		expectedDockerRef string
 	}
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 
 	tests := []resolveTest{
 		{
@@ -1730,130 +1730,74 @@ func mockBuild(source buildapi.BuildSource, strategy buildapi.BuildStrategy, out
 	}
 }
 
-func getBuildConfigFunc(buildConfigFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error)) func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
-	if buildConfigFunc == nil {
-		return func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
-			return mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput()), nil
-		}
-	}
-	return buildConfigFunc
-}
-
-func getUpdateBuildConfigFunc(updateBuildConfigFunc func(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error) func(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error {
-	if updateBuildConfigFunc == nil {
-		return func(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error {
-			return nil
-		}
-	}
-	return updateBuildConfigFunc
-}
-
-func getCreateBuildFunc(createBuildConfigFunc func(ctx apirequest.Context, build *buildapi.Build) error, b *buildapi.Build) func(ctx apirequest.Context, build *buildapi.Build) error {
-	if createBuildConfigFunc == nil {
-		return func(ctx apirequest.Context, build *buildapi.Build) error {
-			*b = *build
-			return nil
-		}
-	}
-	return createBuildConfigFunc
-}
-
-func getGetBuildFunc(getBuildFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error), b *buildapi.Build) func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error) {
-	if getBuildFunc == nil {
-		return func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error) {
-			if b == nil {
-				return &buildapi.Build{}, nil
-			}
-			return b, nil
-		}
-	}
-	return getBuildFunc
-}
-
-func getGetImageStreamFunc(getImageStreamFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error)) func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
-	if getImageStreamFunc == nil {
-		return func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
-			if name != imageRepoName {
-				return &imageapi.ImageStream{}, nil
-			}
-			return &imageapi.ImageStream{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      imageRepoName,
-					Namespace: imageRepoNamespace,
-				},
-				Status: imageapi.ImageStreamStatus{
-					DockerImageRepository: "repo/namespace/image",
-					Tags: map[string]imageapi.TagEventList{
-						tagName: {
-							Items: []imageapi.TagEvent{
-								{DockerImageReference: dockerReference},
-							},
-						},
-						imageapi.DefaultImageTag: {
-							Items: []imageapi.TagEvent{
-								{DockerImageReference: latestDockerReference, Image: "myid"},
-							},
-						},
-					},
-				},
-			}, nil
-		}
-	}
-	return getImageStreamFunc
-}
-
-func getGetImageStreamTagFunc(getImageStreamTagFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error)) func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
-	if getImageStreamTagFunc == nil {
-		return func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
-			return &imageapi.ImageStreamTag{
-				Image: imageapi.Image{
-					ObjectMeta:           metav1.ObjectMeta{Name: imageRepoName + ":" + newTag},
-					DockerImageReference: latestDockerReference,
-				},
-			}, nil
-		}
-	}
-	return getImageStreamTagFunc
-}
-
-func getGetImageStreamImageFunc(getImageStreamImageFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error)) func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error) {
-	if getImageStreamImageFunc == nil {
-		return func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error) {
-			return &imageapi.ImageStreamImage{
-				Image: imageapi.Image{
-					ObjectMeta:           metav1.ObjectMeta{Name: imageRepoName + ":@id"},
-					DockerImageReference: latestDockerReference,
-				},
-			}, nil
-		}
-	}
-	return getImageStreamImageFunc
-}
-
-func mockBuildGenerator(buildConfigFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error),
-	updateBuildConfigFunc func(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error,
-	createBuildFunc func(ctx apirequest.Context, build *buildapi.Build) error,
-	getBuildFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error),
-	getImageStreamFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error),
-	getImageStreamTagFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error),
-	getImageStreamImageFunc func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error),
-) *BuildGenerator {
+func mockBuildGenerator() *BuildGenerator {
 	fakeSecrets := []runtime.Object{}
 	for _, s := range mocks.MockBuilderSecrets() {
 		fakeSecrets = append(fakeSecrets, s)
 	}
-	b := buildapi.Build{}
+	var b *buildapi.Build
 	return &BuildGenerator{
 		Secrets:         fake.NewSimpleClientset(fakeSecrets...).Core(),
 		ServiceAccounts: mocks.MockBuilderServiceAccount(mocks.MockBuilderSecrets()),
 		Client: TestingClient{
-			GetBuildConfigFunc:      getBuildConfigFunc(buildConfigFunc),
-			UpdateBuildConfigFunc:   getUpdateBuildConfigFunc(updateBuildConfigFunc),
-			CreateBuildFunc:         getCreateBuildFunc(createBuildFunc, &b),
-			GetBuildFunc:            getGetBuildFunc(getBuildFunc, &b),
-			GetImageStreamFunc:      getGetImageStreamFunc(getImageStreamFunc),
-			GetImageStreamTagFunc:   getGetImageStreamTagFunc(getImageStreamTagFunc),
-			GetImageStreamImageFunc: getGetImageStreamImageFunc(getImageStreamImageFunc),
+			GetBuildConfigFunc: func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
+				return mocks.MockBuildConfig(mocks.MockSource(), mocks.MockSourceStrategyForImageRepository(), mocks.MockOutput()), nil
+			},
+			UpdateBuildConfigFunc: func(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error {
+				return nil
+			},
+			CreateBuildFunc: func(ctx apirequest.Context, build *buildapi.Build) error {
+				b = build
+				return nil
+			},
+			GetBuildFunc: func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error) {
+				if b == nil {
+					return &buildapi.Build{}, nil
+				}
+				return b, nil
+			},
+			GetImageStreamFunc: func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
+				if name != imageRepoName {
+					return &imageapi.ImageStream{}, nil
+				}
+				return &imageapi.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      imageRepoName,
+						Namespace: imageRepoNamespace,
+					},
+					Status: imageapi.ImageStreamStatus{
+						DockerImageRepository: "repo/namespace/image",
+						Tags: map[string]imageapi.TagEventList{
+							tagName: {
+								Items: []imageapi.TagEvent{
+									{DockerImageReference: dockerReference},
+								},
+							},
+							imageapi.DefaultImageTag: {
+								Items: []imageapi.TagEvent{
+									{DockerImageReference: latestDockerReference, Image: "myid"},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			GetImageStreamTagFunc: func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
+				return &imageapi.ImageStreamTag{
+					Image: imageapi.Image{
+						ObjectMeta:           metav1.ObjectMeta{Name: imageRepoName + ":" + newTag},
+						DockerImageReference: latestDockerReference,
+					},
+				}, nil
+			},
+			GetImageStreamImageFunc: func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error) {
+				return &imageapi.ImageStreamImage{
+					Image: imageapi.Image{
+						ObjectMeta:           metav1.ObjectMeta{Name: imageRepoName + ":@id"},
+						DockerImageReference: latestDockerReference,
+					},
+				}, nil
+			},
 		}}
 }
 
@@ -1876,7 +1820,7 @@ func TestGenerateBuildFromConfigWithSecrets(t *testing.T) {
 		// Setup the BuildGenerator
 		strategy := mockDockerStrategyForDockerImage(imageName, &metav1.GetOptions{})
 		output := mockOutputWithImageName(imageName, &metav1.GetOptions{})
-		generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+		generator := mockBuildGenerator()
 		bc := mocks.MockBuildConfig(source, strategy, output)
 		build, err := generator.generateBuildFromConfig(apirequest.NewContext(), bc, revision, nil)
 
@@ -1904,7 +1848,7 @@ func TestInstantiateBuildTriggerCauseConfigChange(t *testing.T) {
 			},
 		),
 	}
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	buildObject, err := generator.Instantiate(apirequest.NewDefaultContext(), buildRequest)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %v", err)
@@ -1939,7 +1883,7 @@ func TestInstantiateBuildTriggerCauseImageChange(t *testing.T) {
 		),
 	}
 
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	buildObject, err := generator.Instantiate(apirequest.NewDefaultContext(), buildRequest)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %v", err)
@@ -1987,7 +1931,7 @@ func TestInstantiateBuildTriggerCauseGenericWebHook(t *testing.T) {
 		),
 	}
 
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	buildObject, err := generator.Instantiate(apirequest.NewDefaultContext(), buildRequest)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %v", err)
@@ -2032,7 +1976,7 @@ func TestInstantiateBuildTriggerCauseGitHubWebHook(t *testing.T) {
 		),
 	}
 
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	buildObject, err := generator.Instantiate(apirequest.NewDefaultContext(), buildRequest)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %v", err)
@@ -2079,7 +2023,7 @@ func TestInstantiateBuildTriggerCauseGitLabWebHook(t *testing.T) {
 		),
 	}
 
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	buildObject, err := generator.Instantiate(apirequest.NewDefaultContext(), buildRequest)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %v", err)
@@ -2126,7 +2070,7 @@ func TestInstantiateBuildTriggerCauseBitbucketWebHook(t *testing.T) {
 		),
 	}
 
-	generator := mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil)
+	generator := mockBuildGenerator()
 	buildObject, err := generator.Instantiate(apirequest.NewDefaultContext(), buildRequest)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got %v", err)
@@ -2145,7 +2089,9 @@ func TestInstantiateBuildTriggerCauseBitbucketWebHook(t *testing.T) {
 }
 
 func TestOverrideDockerStrategyNoCacheOption(t *testing.T) {
-	buildConfigFunc := func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
+	g := mockBuildGenerator()
+	client := g.Client.(TestingClient)
+	client.GetBuildConfigFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 		return &buildapi.BuildConfig{
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: buildapi.BuildConfigSpec{
@@ -2165,8 +2111,8 @@ func TestOverrideDockerStrategyNoCacheOption(t *testing.T) {
 			},
 		}, nil
 	}
+	g.Client = client
 
-	g := mockBuildGenerator(buildConfigFunc, nil, nil, nil, nil, nil, nil)
 	build, err := g.Instantiate(apirequest.NewDefaultContext(), &buildapi.BuildRequest{})
 	if err != nil {
 		t.Errorf("Unexpected error encountered:  %v", err)
@@ -2178,7 +2124,10 @@ func TestOverrideDockerStrategyNoCacheOption(t *testing.T) {
 
 func TestOverrideSourceStrategyIncrementalOption(t *testing.T) {
 	myTrue := true
-	buildConfigFunc := func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
+
+	g := mockBuildGenerator()
+	client := g.Client.(TestingClient)
+	client.GetBuildConfigFunc = func(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 		return &buildapi.BuildConfig{
 			ObjectMeta: metav1.ObjectMeta{},
 			Spec: buildapi.BuildConfigSpec{
@@ -2203,8 +2152,8 @@ func TestOverrideSourceStrategyIncrementalOption(t *testing.T) {
 			},
 		}, nil
 	}
+	g.Client = client
 
-	g := mockBuildGenerator(buildConfigFunc, nil, nil, nil, nil, nil, nil)
 	build, err := g.Instantiate(apirequest.NewDefaultContext(), &buildapi.BuildRequest{})
 	if err != nil {
 		t.Errorf("Unexpected error encountered:  %v", err)

--- a/pkg/build/generator/testing_client.go
+++ b/pkg/build/generator/testing_client.go
@@ -21,41 +21,41 @@ type TestingClient struct {
 }
 
 // GetBuildConfig retrieves a named build config
-func (c TestingClient) GetBuildConfig(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
+func (c *TestingClient) GetBuildConfig(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.BuildConfig, error) {
 	return c.GetBuildConfigFunc(ctx, name, options)
 }
 
 // UpdateBuildConfig updates a named build config
-func (c TestingClient) UpdateBuildConfig(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error {
+func (c *TestingClient) UpdateBuildConfig(ctx apirequest.Context, buildConfig *buildapi.BuildConfig) error {
 	return c.UpdateBuildConfigFunc(ctx, buildConfig)
 }
 
 // GetBuild retrieves a build
-func (c TestingClient) GetBuild(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error) {
+func (c *TestingClient) GetBuild(ctx apirequest.Context, name string, options *metav1.GetOptions) (*buildapi.Build, error) {
 	return c.GetBuildFunc(ctx, name, options)
 }
 
 // CreateBuild creates a new build
-func (c TestingClient) CreateBuild(ctx apirequest.Context, build *buildapi.Build) error {
+func (c *TestingClient) CreateBuild(ctx apirequest.Context, build *buildapi.Build) error {
 	return c.CreateBuildFunc(ctx, build)
 }
 
 // UpdateBuild updates a build
-func (c TestingClient) UpdateBuild(ctx apirequest.Context, build *buildapi.Build) error {
+func (c *TestingClient) UpdateBuild(ctx apirequest.Context, build *buildapi.Build) error {
 	return c.UpdateBuildFunc(ctx, build)
 }
 
 // GetImageStream retrieves a named image stream
-func (c TestingClient) GetImageStream(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
+func (c *TestingClient) GetImageStream(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
 	return c.GetImageStreamFunc(ctx, name, options)
 }
 
 // GetImageStreamImage retrieves an image stream image
-func (c TestingClient) GetImageStreamImage(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error) {
+func (c *TestingClient) GetImageStreamImage(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamImage, error) {
 	return c.GetImageStreamImageFunc(ctx, name, options)
 }
 
 // GetImageStreamTag retrieves and image stream tag
-func (c TestingClient) GetImageStreamTag(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
+func (c *TestingClient) GetImageStreamTag(ctx apirequest.Context, name string, options *metav1.GetOptions) (*imageapi.ImageStreamTag, error) {
 	return c.GetImageStreamTagFunc(ctx, name, options)
 }


### PR DESCRIPTION
Suggested follow-up to #16014, avoiding mockBuildGenerator(nil, nil, nil, nil, nil, nil, nil) invocations.  I think the move to functors made the code (even) less clear, especially since half the code is still patching function pointers anyway.  I suggest we keep patching function pointers throughout for homogeneity.

@coreydaley ptal
