### PR TITLE
build controller: use a buildconfig queue to track which buildconfigs to kick

### DIFF
--- a/pkg/build/controller/common/util.go
+++ b/pkg/build/controller/common/util.go
@@ -6,7 +6,6 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -15,30 +14,12 @@ import (
 	buildadmission "github.com/openshift/origin/pkg/build/admission"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildclient "github.com/openshift/origin/pkg/build/client"
-	"github.com/openshift/origin/pkg/build/controller/policy"
 	buildlister "github.com/openshift/origin/pkg/build/generated/listers/build/internalversion"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	envresolve "github.com/openshift/origin/pkg/pod/envresolve"
 
 	"github.com/golang/glog"
 )
-
-func HandleBuildCompletion(build *buildapi.Build, buildLister buildlister.BuildLister, buildConfigGetter buildlister.BuildConfigLister, buildDeleter buildclient.BuildDeleter, runPolicies []policy.RunPolicy) {
-	if !buildutil.IsBuildComplete(build) {
-		return
-	}
-	runPolicy := policy.ForBuild(build, runPolicies)
-	if runPolicy == nil {
-		utilruntime.HandleError(fmt.Errorf("unable to determine build scheduler for %s/%s", build.Namespace, build.Name))
-		return
-	}
-	if err := runPolicy.OnComplete(build); err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to run policy on completed build %s/%s: %v", build.Namespace, build.Name, err))
-	}
-	if err := HandleBuildPruning(buildutil.ConfigNameForBuild(build), build.Namespace, buildLister, buildConfigGetter, buildDeleter); err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to prune old builds %s/%s: %v", build.Namespace, build.Name, err))
-	}
-}
 
 type ByCreationTimestamp []*buildapi.Build
 

--- a/pkg/build/controller/policy/parallel.go
+++ b/pkg/build/controller/policy/parallel.go
@@ -27,11 +27,6 @@ func (s *ParallelPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
 	return !hasRunningSerialBuild(s.BuildLister, build.Namespace, bcName), nil
 }
 
-// OnComplete implements the RunPolicy interface.
-func (s *ParallelPolicy) OnComplete(build *buildapi.Build) error {
-	return handleComplete(s.BuildLister, s.BuildUpdater, build)
-}
-
 // Handles returns true for the build run parallel policy
 func (s *ParallelPolicy) Handles(policy buildapi.BuildRunPolicy) bool {
 	return policy == buildapi.BuildRunPolicyParallel

--- a/pkg/build/controller/policy/serial.go
+++ b/pkg/build/controller/policy/serial.go
@@ -30,11 +30,6 @@ func (s *SerialPolicy) IsRunnable(build *buildapi.Build) (bool, error) {
 	return len(nextBuilds) == 1 && nextBuilds[0].Name == build.Name, err
 }
 
-// OnComplete implements the RunPolicy interface.
-func (s *SerialPolicy) OnComplete(build *buildapi.Build) error {
-	return handleComplete(s.BuildLister, s.BuildUpdater, build)
-}
-
 // Handles returns true for the build run serial policy
 func (s *SerialPolicy) Handles(policy buildapi.BuildRunPolicy) bool {
 	return policy == buildapi.BuildRunPolicySerial

--- a/pkg/build/controller/policy/serial_latest_only.go
+++ b/pkg/build/controller/policy/serial_latest_only.go
@@ -45,11 +45,6 @@ func (s *SerialLatestOnlyPolicy) IsRunnable(build *buildapi.Build) (bool, error)
 	return len(nextBuilds) == 1 && nextBuilds[0].Name == build.Name, err
 }
 
-// IsRunnable implements the Scheduler interface.
-func (s *SerialLatestOnlyPolicy) OnComplete(build *buildapi.Build) error {
-	return handleComplete(s.BuildLister, s.BuildUpdater, build)
-}
-
 // Handles returns true for the build run serial latest only policy
 func (s *SerialLatestOnlyPolicy) Handles(policy buildapi.BuildRunPolicy) bool {
 	return policy == buildapi.BuildRunPolicySerialLatestOnly

--- a/pkg/build/controller/policy/serial_latest_only_test.go
+++ b/pkg/build/controller/policy/serial_latest_only_test.go
@@ -107,14 +107,4 @@ func TestSerialLatestOnlyIsRunnableBuildsWithErrors(t *testing.T) {
 	if _, err := policy.IsRunnable(&builds[1]); err == nil {
 		t.Errorf("expected error for build-2")
 	}
-
-	err = policy.OnComplete(&builds[0])
-	if err != nil {
-		t.Errorf("expected no error, got %v", err)
-	}
-
-	// No type-check as this error is returned as kerrors.aggregate
-	if err := policy.OnComplete(&builds[1]); err == nil {
-		t.Errorf("expected error for build-2")
-	}
 }


### PR DESCRIPTION
Reverts to using the cache lister to determine which builds to run next.
Adds a new queue to the build controller to keep track of which build configs to poke when a build has completed. 
Removes the OnComplete handler for policy, given that they all end up calling the same code.
Removes code that updates an annotation on a build to add to the queue and instead adds the build(s) directly to the queue.

Fixes https://github.com/openshift/origin/issues/16081