### PR TITLE
Add OpenShift's recycler templates to Kubernetes controller config

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/patch.go
@@ -1,7 +1,0 @@
-package volume
-
-import "k8s.io/kubernetes/pkg/api/v1"
-
-// we carry a patch which allows us to reset this function selectively when we run openshift start, but *not*
-// when we run `kube-controller-manager`.  We have it in this separate file to avoid conflicts during a rebase
-var NewPersistentVolumeRecyclerPodTemplate func() *v1.Pod = newPersistentVolumeRecyclerPodTemplate

--- a/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/plugins.go
@@ -560,7 +560,7 @@ func (pm *VolumePluginMgr) FindAttachablePluginByName(name string) (AttachableVo
 //     before failing.  Recommended.  Default is 60 seconds.
 //
 // See HostPath and NFS for working recycler examples
-func newPersistentVolumeRecyclerPodTemplate() *v1.Pod {
+func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
 	timeout := int64(60)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
When user did not specify any recycler template files, create OpenShift one and let Kubernetes use it. The template file is created in /tmp and is deleted after controller initialization (which is safe).

This removes any OpenShift recycler \<carry\> patches in Kubernetes.

/assign @deads2k 