### PR TITLE
switch route extra auth check to SAR client

### DIFF
--- a/pkg/cmd/server/origin/storage.go
+++ b/pkg/cmd/server/origin/storage.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
+	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	authzapiv1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 	"github.com/openshift/origin/pkg/dockerregistry"
@@ -176,7 +177,11 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		c.DeprecatedOpenshiftClient.SubjectAccessReviews())
 	imageStreamImageStorage := imagestreamimage.NewREST(imageRegistry, imageStreamRegistry)
 
-	routeStorage, routeStatusStorage, err := routeetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.RouteAllocator, subjectAccessReviewRegistry)
+	authorizationClient, err := authorizationclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	routeStorage, routeStatusStorage, err := routeetcd.NewREST(c.GenericConfig.RESTOptionsGetter, c.RouteAllocator, authorizationClient.SubjectAccessReviews())
 	if err != nil {
 		return nil, fmt.Errorf("error building REST storage: %v", err)
 	}

--- a/pkg/route/registry/route/etcd/etcd_test.go
+++ b/pkg/route/registry/route/etcd/etcd_test.go
@@ -9,9 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	routetypes "github.com/openshift/origin/pkg/route"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	_ "github.com/openshift/origin/pkg/route/apis/route/install"
@@ -41,9 +41,13 @@ type testSAR struct {
 	sar   *authorizationapi.SubjectAccessReview
 }
 
-func (t *testSAR) CreateSubjectAccessReview(ctx apirequest.Context, subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+func (t *testSAR) Create(subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReview, error) {
 	t.sar = subjectAccessReview
-	return &authorizationapi.SubjectAccessReviewResponse{Allowed: t.allow}, t.err
+	return &authorizationapi.SubjectAccessReview{
+		Status: authorizationapi.SubjectAccessReviewStatus{
+			Allowed: t.allow,
+		},
+	}, t.err
 }
 
 func newStorage(t *testing.T, allocator routetypes.RouteAllocator) (*REST, *etcdtesting.EtcdTestServer) {

--- a/pkg/route/registry/route/strategy_test.go
+++ b/pkg/route/registry/route/strategy_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	kapi "k8s.io/kubernetes/pkg/api"
+	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 )
 
@@ -31,9 +31,13 @@ type testSAR struct {
 	sar   *authorizationapi.SubjectAccessReview
 }
 
-func (t *testSAR) CreateSubjectAccessReview(ctx apirequest.Context, subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReviewResponse, error) {
+func (t *testSAR) Create(subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReview, error) {
 	t.sar = subjectAccessReview
-	return &authorizationapi.SubjectAccessReviewResponse{Allowed: t.allow}, t.err
+	return &authorizationapi.SubjectAccessReview{
+		Status: authorizationapi.SubjectAccessReviewStatus{
+			Allowed: t.allow,
+		},
+	}, t.err
 }
 
 func TestEmptyHostDefaulting(t *testing.T) {


### PR DESCRIPTION
Switches the route authz check to use a client.

@soltysh @mfojtik this is on the path to splitting the route storage