### PR TITLE
Allow running a subset of the integration tests

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -206,13 +206,10 @@ test suite.  Testing the API and high level API functions should generally
 not depend on calling into Docker. They are denoted by special test tags and
 should be in their own files so we can selectively build them.
 
-All integration tests are located under `test/integration/*`. All integration
-tests must set the `integration` build tag at the top of their source file,
-and also declare whether they need etcd with the `etcd` build tag and whether
-they need Docker with the `docker` build tag. For special function sets please
-create sub directories like `test/integration/deployimages`.
+All integration tests are located under `test/integration/*`. For special function
+sets please create sub directories like `test/integration/deployimages`.
 
-Run the integration tests with:
+Run all of the integration tests with:
 
     $ hack/test-integration.sh
 
@@ -221,16 +218,11 @@ If you need to execute a subset of integration tests, run:
 
     $ hack/test-integration.sh <regex>
 
-Where `<regex>` is some regular expression that matches the names of all
-of the tests you want to run. The regular expression is passed into `grep -E`,
-so ensure that the syntax or features you use are supported. The default
-regular expression used
-is `Test`, which matches all tests.
+Where `<regex>` is some regular expression that matches the names of all of the
+integration tests you want to run. The regular expression is passed into `go test -run`,
+so ensure that the syntax or features you use are supported.
 
-Each integration function is executed in its own process so that it cleanly
-shuts down any background
-goroutines. You will not be able to run more than a single test within a single
-process.
+Each integration test is executed in parallel using `test/integration/runner`.
 
 There is a CLI integration test suite which covers general non-Docker
 functionality of the CLI tool

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # build the test executable and make sure it's on the path
@@ -8,4 +7,12 @@ if [[ -z "${OPENSHIFT_SKIP_BUILD-}" ]]; then
 fi
 os::util::environment::update_path_var
 
-COVERAGE_SPEC=" " DETECT_RACES=false TMPDIR="${BASETMPDIR}" TIMEOUT=45m GOTESTFLAGS="-sub.timeout=120s" "${OS_ROOT}/hack/test-go.sh" "test/integration/runner"
+gotest_flags="${GOTEST_FLAGS:-}"
+sub_tests="${1:-}"
+
+# Filter to run sub tests and turn up verbosity to show which tests will be run
+if [[ -n "${sub_tests}" ]]; then
+	gotest_flags+=" -run TestIntegration/${sub_tests} -v"
+fi
+
+COVERAGE_SPEC=" " DETECT_RACES=false TMPDIR="${BASETMPDIR}" TIMEOUT=45m GOTEST_FLAGS="${gotest_flags}" "${OS_ROOT}/hack/test-go.sh" "test/integration/runner"

--- a/test/integration/runner/runner_test.go
+++ b/test/integration/runner/runner_test.go
@@ -16,9 +16,10 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
-var timeout = flag.Duration("sub.timeout", 0, "Specify the timeout for each sub test")
+var timeout = flag.Duration("sub.timeout", 5*time.Minute, "Specify the timeout for each sub test")
 
 func TestIntegration(t *testing.T) {
 	executeTests(t, "..", "github.com/openshift/origin/test/integration", 1)


### PR DESCRIPTION
This change restores the previous behavior of running `hack/test-integration.sh <regex>`.  The timeout flag is no longer passed to the integration test runner.  To do so correctly requires using `go test -args` which would add further complexity to `hack/test-go.sh`.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @smarterclayton