### PR TITLE
move oauth storage to server

### DIFF
--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -40,6 +40,7 @@ import (
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	networkapiserver "github.com/openshift/origin/pkg/network/apiserver"
+	oauthapiserver "github.com/openshift/origin/pkg/oauth/apiserver"
 	"github.com/openshift/origin/pkg/oc/admin/policy"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
@@ -100,6 +101,7 @@ type OpenshiftAPIConfig struct {
 
 	EnableBuilds bool
 
+	// oauth API server
 	ServiceAccountMethod configapi.GrantHandlerType
 
 	ClusterQuotaMappingController *clusterquotamapping.ClusterQuotaMappingController
@@ -288,6 +290,28 @@ func (c *completedConfig) withNetworkAPIServer(delegateAPIServer genericapiserve
 	return server.GenericAPIServer, &legacyStorageVersionMutator{version: networkapiv1.SchemeGroupVersion, storage: storage}, nil
 }
 
+func (c *completedConfig) withOAuthAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, legacyStorageMutator, error) {
+	config := &oauthapiserver.OAuthAPIServerConfig{
+		GenericConfig:             c.GenericConfig,
+		CoreAPIServerClientConfig: c.GenericConfig.LoopbackClientConfig,
+		ServiceAccountMethod:      c.ServiceAccountMethod,
+		Codecs:                    kapi.Codecs,
+		Registry:                  kapi.Registry,
+		Scheme:                    kapi.Scheme,
+	}
+	server, err := config.Complete().New(delegateAPIServer)
+	if err != nil {
+		return nil, nil, err
+	}
+	storage, err := config.V1RESTStorage()
+	if err != nil {
+		return nil, nil, err
+	}
+	server.GenericAPIServer.PrepareRun() // this triggers openapi construction
+
+	return server.GenericAPIServer, &legacyStorageVersionMutator{version: oauthapiv1.SchemeGroupVersion, storage: storage}, nil
+}
+
 func (c *completedConfig) withTemplateAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, legacyStorageMutator, error) {
 	config := &templateapiserver.TemplateConfig{
 		GenericConfig:       c.GenericConfig,
@@ -348,6 +372,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withAppsAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withBuildAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withNetworkAPIServer)
+	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withOAuthAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withTemplateAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withUserAPIServer)
 
@@ -520,7 +545,6 @@ var apiGroupsVersions = []apiGroupInfo{
 	{PreferredVersion: "v1", Versions: []schema.GroupVersion{routeapiv1.SchemeGroupVersion}},
 	{PreferredVersion: "v1", Versions: []schema.GroupVersion{imageapiv1.SchemeGroupVersion}},
 	{PreferredVersion: "v1", Versions: []schema.GroupVersion{authzapiv1.SchemeGroupVersion}},
-	{PreferredVersion: "v1", Versions: []schema.GroupVersion{oauthapiv1.SchemeGroupVersion}},
 }
 
 // isPreferredGroupVersion returns true if the given GroupVersion is preferred version in

--- a/pkg/cmd/server/origin/storage.go
+++ b/pkg/cmd/server/origin/storage.go
@@ -26,19 +26,11 @@ import (
 	"github.com/openshift/origin/pkg/image/registry/imagestreamimport"
 	"github.com/openshift/origin/pkg/image/registry/imagestreammapping"
 	"github.com/openshift/origin/pkg/image/registry/imagestreamtag"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthapiv1 "github.com/openshift/origin/pkg/oauth/apis/oauth/v1"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
-	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
-	authorizetokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken/etcd"
-	clientetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclient/etcd"
-	clientauthetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization/etcd"
 	projectapiv1 "github.com/openshift/origin/pkg/project/apis/project/v1"
 	projectproxy "github.com/openshift/origin/pkg/project/registry/project/proxy"
 	projectrequeststorage "github.com/openshift/origin/pkg/project/registry/projectrequest/delegated"
 	routeapiv1 "github.com/openshift/origin/pkg/route/apis/route/v1"
 	routeetcd "github.com/openshift/origin/pkg/route/registry/route/etcd"
-	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
 
 	quotaapiv1 "github.com/openshift/origin/pkg/quota/apis/quota/v1"
 	appliedclusterresourcequotaregistry "github.com/openshift/origin/pkg/quota/registry/appliedclusterresourcequota"
@@ -171,36 +163,6 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 		c.KubeInternalInformers.Rbac().InternalVersion().RoleBindings().Lister(),
 	)
 
-	clientStorage, err := clientetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-
-	// If OAuth is disabled, set the strategy to Deny
-	saAccountGrantMethod := oauthapi.GrantHandlerDeny
-	if len(c.ServiceAccountMethod) > 0 {
-		// Otherwise, take the value provided in master-config.yaml
-		saAccountGrantMethod = oauthapi.GrantHandlerType(c.ServiceAccountMethod)
-	}
-
-	oauthClient, err := oauthclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
-	if err != nil {
-		return nil, err
-	}
-	combinedOAuthClientGetter := saoauth.NewServiceAccountOAuthClientGetter(c.KubeClientInternal.Core(), c.KubeClientInternal.Core(), c.DeprecatedOpenshiftClient, oauthClient.OAuthClients(), saAccountGrantMethod)
-	authorizeTokenStorage, err := authorizetokenetcd.NewREST(c.GenericConfig.RESTOptionsGetter, combinedOAuthClientGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-	accessTokenStorage, err := accesstokenetcd.NewREST(c.GenericConfig.RESTOptionsGetter, combinedOAuthClientGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-	clientAuthorizationStorage, err := clientauthetcd.NewREST(c.GenericConfig.RESTOptionsGetter, combinedOAuthClientGetter)
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
-
 	clusterResourceQuotaStorage, clusterResourceQuotaStatusStorage, err := clusterresourcequotaetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
 	if err != nil {
 		return nil, fmt.Errorf("error building REST storage: %v", err)
@@ -220,13 +182,6 @@ func (c OpenshiftAPIConfig) GetRestStorage() (map[schema.GroupVersion]map[string
 			c.QuotaInformers.Quota().InternalVersion().ClusterResourceQuotas().Lister(),
 			c.KubeInternalInformers.Core().InternalVersion().Namespaces().Lister(),
 		),
-	}
-
-	storage[oauthapiv1.SchemeGroupVersion] = map[string]rest.Storage{
-		"oAuthAuthorizeTokens":      authorizeTokenStorage,
-		"oAuthAccessTokens":         accessTokenStorage,
-		"oAuthClients":              clientStorage,
-		"oAuthClientAuthorizations": clientAuthorizationStorage,
 	}
 
 	storage[authzapiv1.SchemeGroupVersion] = map[string]rest.Storage{

--- a/pkg/oauth/apiserver/apiserver.go
+++ b/pkg/oauth/apiserver/apiserver.go
@@ -1,0 +1,145 @@
+package apiserver
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	restclient "k8s.io/client-go/rest"
+	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapiv1 "github.com/openshift/origin/pkg/oauth/apis/oauth/v1"
+	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
+	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
+	authorizetokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken/etcd"
+	clientetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclient/etcd"
+	clientauthetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization/etcd"
+	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type OAuthAPIServerConfig struct {
+	GenericConfig *genericapiserver.Config
+
+	CoreAPIServerClientConfig *restclient.Config
+	ServiceAccountMethod      configapi.GrantHandlerType
+
+	// TODO these should all become local eventually
+	Scheme   *runtime.Scheme
+	Registry *registered.APIRegistrationManager
+	Codecs   serializer.CodecFactory
+
+	makeV1Storage sync.Once
+	v1Storage     map[string]rest.Storage
+	v1StorageErr  error
+}
+
+type OAuthAPIServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+}
+
+type completedConfig struct {
+	*OAuthAPIServerConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *OAuthAPIServerConfig) Complete() completedConfig {
+	c.GenericConfig.Complete()
+
+	return completedConfig{c}
+}
+
+// SkipComplete provides a way to construct a server instance without config completion.
+func (c *OAuthAPIServerConfig) SkipComplete() completedConfig {
+	return completedConfig{c}
+}
+
+// New returns a new instance of OAuthAPIServer from the given config.
+func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*OAuthAPIServer, error) {
+	genericServer, err := c.OAuthAPIServerConfig.GenericConfig.SkipComplete().New("oauth.openshift.io-apiserver", delegationTarget) // completion is done in Complete, no need for a second time
+	if err != nil {
+		return nil, err
+	}
+
+	s := &OAuthAPIServer{
+		GenericAPIServer: genericServer,
+	}
+
+	v1Storage, err := c.V1RESTStorage()
+	if err != nil {
+		return nil, err
+	}
+
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(oauthapiv1.GroupName, c.Registry, c.Scheme, metav1.ParameterCodec, c.Codecs)
+	apiGroupInfo.GroupMeta.GroupVersion = oauthapiv1.SchemeGroupVersion
+	apiGroupInfo.VersionedResourcesStorageMap[oauthapiv1.SchemeGroupVersion.Version] = v1Storage
+	if err := s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (c *OAuthAPIServerConfig) V1RESTStorage() (map[string]rest.Storage, error) {
+	c.makeV1Storage.Do(func() {
+		c.v1Storage, c.v1StorageErr = c.newV1RESTStorage()
+	})
+
+	return c.v1Storage, c.v1StorageErr
+}
+
+func (c *OAuthAPIServerConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
+
+	clientStorage, err := clientetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	if err != nil {
+		return nil, fmt.Errorf("error building REST storage: %v", err)
+	}
+
+	// If OAuth is disabled, set the strategy to Deny
+	saAccountGrantMethod := oauthapi.GrantHandlerDeny
+	if len(c.ServiceAccountMethod) > 0 {
+		// Otherwise, take the value provided in master-config.yaml
+		saAccountGrantMethod = oauthapi.GrantHandlerType(c.ServiceAccountMethod)
+	}
+
+	oauthClient, err := oauthclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	coreClient, err := coreclient.NewForConfig(c.CoreAPIServerClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	deprecatedClient, err := osclient.New(c.CoreAPIServerClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	combinedOAuthClientGetter := saoauth.NewServiceAccountOAuthClientGetter(coreClient, coreClient, deprecatedClient, oauthClient.OAuthClients(), saAccountGrantMethod)
+	authorizeTokenStorage, err := authorizetokenetcd.NewREST(c.GenericConfig.RESTOptionsGetter, combinedOAuthClientGetter)
+	if err != nil {
+		return nil, fmt.Errorf("error building REST storage: %v", err)
+	}
+	accessTokenStorage, err := accesstokenetcd.NewREST(c.GenericConfig.RESTOptionsGetter, combinedOAuthClientGetter)
+	if err != nil {
+		return nil, fmt.Errorf("error building REST storage: %v", err)
+	}
+	clientAuthorizationStorage, err := clientauthetcd.NewREST(c.GenericConfig.RESTOptionsGetter, combinedOAuthClientGetter)
+	if err != nil {
+		return nil, fmt.Errorf("error building REST storage: %v", err)
+	}
+
+	v1Storage := map[string]rest.Storage{}
+	v1Storage["oAuthAuthorizeTokens"] = authorizeTokenStorage
+	v1Storage["oAuthAccessTokens"] = accessTokenStorage
+	v1Storage["oAuthClients"] = clientStorage
+	v1Storage["oAuthClientAuthorizations"] = clientAuthorizationStorage
+	return v1Storage, nil
+}


### PR DESCRIPTION
Moves the oauth storage into its own API server.  What do you know, we do have one that doesn't suck to move.