### PR TITLE
update cmdconfig.MergeConfig; use --context option in `oc login` if one is provided

### DIFF
--- a/pkg/oc/cli/cmd/login/login.go
+++ b/pkg/oc/cli/cmd/login/login.go
@@ -117,6 +117,11 @@ func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args
 		o.CommandName = "oc"
 	}
 
+	context := kcmdutil.GetFlagString(cmd, "context")
+	if len(context) > 0 {
+		o.StartingKubeConfig.CurrentContext = context
+	}
+
 	parsedDefaultClusterURL, err := url.Parse(defaultClusterURL)
 	if err != nil {
 		return err


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1471160

Right now, `oc login` does not acknowledge a `--context` value passed by a user.
Reading the value of this flag would allow users to edit their `kubeconfig` file with a custom name for a current context, and re-use that edited context in future login attempts.

This patch also updates the `MergeConfig` helper, which now looks at existing contexts to see if any contain a matching `authInfo` and `cluster` (regardless of names) before creating a new one.

**Before**
```
$ oc login -u dev -p test --context friendlycontextname
# this would try to use the default context "/hostname:port/dev", despite the user providing a context name to use
Server [https://hostname:port]:
```

**After**
```
$ oc login -u dev -p test --context friendlycontextname
Login successful.
...
```

cc @openshift/cli-review 