### PR TITLE
UPSTREAM: 49219: Use case-insensitive header keys for --requestheader-…

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -145,7 +145,8 @@ func headerValue(h http.Header, headerNames []string) string {
 func allHeaderValues(h http.Header, headerNames []string) []string {
 	ret := []string{}
 	for _, headerName := range headerNames {
-		values, ok := h[headerName]
+		headerKey := http.CanonicalHeaderKey(headerName)
+		values, ok := h[headerKey]
 		if !ok {
 			continue
 		}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
@@ -111,6 +111,20 @@ func TestRequestHeader(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+		"groups case-insensitive": {
+			nameHeaders:  []string{"X-REMOTE-User"},
+			groupHeaders: []string{"X-REMOTE-Group"},
+			requestHeaders: http.Header{
+				"X-Remote-User":  {"Bob"},
+				"X-Remote-Group": {"Users"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name:   "Bob",
+				Groups: []string{"Users"},
+				Extra:  map[string][]string{},
+			},
+			expectedOk: true,
+		},
 
 		"extra prefix matches case-insensitive": {
 			nameHeaders:        []string{"X-Remote-User"},


### PR DESCRIPTION
…group-headers.

fixes https://github.com/openshift/origin/issues/16185