### PR TITLE
Correctly validate identity provider username

### DIFF
--- a/pkg/user/apis/user/validation/validation.go
+++ b/pkg/user/apis/user/validation/validation.go
@@ -139,7 +139,7 @@ func ValidateIdentity(identity *userapi.Identity) field.ErrorList {
 
 	if len(identity.ProviderUserName) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("providerUserName"), ""))
-	} else if reasons := ValidateIdentityProviderName(identity.ProviderUserName); len(reasons) != 0 {
+	} else if reasons := ValidateIdentityProviderUserName(identity.ProviderUserName); len(reasons) != 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("providerUserName"), identity.ProviderUserName, strings.Join(reasons, ", ")))
 	}
 


### PR DESCRIPTION
`ValidateIdentityProviderUserName` should be used to validate the provider username, not `ValidateIdentityProviderName`.  This makes it so that `~` cannot be used as a provider username.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @liggitt

@openshift/sig-security