### PR TITLE
remove trailing newline from oc-get-users

### DIFF
--- a/pkg/oc/cli/describe/printer.go
+++ b/pkg/oc/cli/describe/printer.go
@@ -954,7 +954,7 @@ func printOAuthAuthorizeTokenList(list *oauthapi.OAuthAuthorizeTokenList, w io.W
 
 func printUser(user *userapi.User, w io.Writer, opts kprinters.PrintOptions) error {
 	name := formatResourceName(opts.Kind, user.Name, opts.WithKind)
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, user.UID, user.FullName, strings.Join(user.Identities, ", ")); err != nil {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s", name, user.UID, user.FullName, strings.Join(user.Identities, ", ")); err != nil {
 		return err
 	}
 	if err := appendItemLabels(user.Labels, w, opts.ColumnLabels, opts.ShowLabels); err != nil {


### PR DESCRIPTION
Related BZ comment: https://bugzilla.redhat.com/show_bug.cgi?id=1486501#c4

**Before**
```
$ oc get users
NAME        UID                                    FULL NAME   IDENTITIES
developer   b3aec42c-93d5-11e7-a160-507b9dac96e1               anypassword:developer

$
```

**After**
```
$ oc get users
NAME        UID                                    FULL NAME   IDENTITIES
developer   b3aec42c-93d5-11e7-a160-507b9dac96e1               anypassword:developer
$
```

cc @openshift/cli-review 