### PR TITLE
Updating docker --build-arg test due to docker code change

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -308,14 +308,14 @@ var _ = g.Describe("[builds][Slow] starting a build using CLI", func() {
 			g.By("verifying the build output contains the changes.")
 			o.Expect(buildLog).To(o.ContainSubstring("bar"))
 		})
-		g.It("Should fail on non-existent build-arg", func() {
+		g.It("Should complete with a warning on non-existent build-arg", func() {
 			g.By("starting the build with --build-arg flag")
 			br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=bar=foo")
-			br.AssertFailure()
+			br.AssertSuccess()
 			buildLog, err := br.Logs()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			g.By("verifying the build failed due to Docker.")
-			o.Expect(buildLog).To(o.ContainSubstring("One or more build-args [bar] were not consumed, failing build"))
+			g.By("verifying the build completed with a warning.")
+			o.Expect(buildLog).To(o.ContainSubstring("One or more build-args [bar] were not consumed"))
 		})
 	})
 


### PR DESCRIPTION
Docker changed the error for a non-existent --build-arg to a warning
and changed the text of the message slightly, breaking one of our tests.
Docker change: https://github.com/moby/moby/commit/f150f42009dddb4f9b8d4ceef8763af701b0d0f9

Fixes: #16197