### PR TITLE
Modify "sudoer" group and "privileged" SCC to seamlessly work together

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -136,6 +136,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 			},
 			Rules: []rbac.PolicyRule{
 				rbac.NewRule("impersonate").Groups(userGroup, legacyUserGroup).Resources(authorizationapi.SystemUserResource, authorizationapi.UserResource).Names(SystemAdminUsername).RuleOrDie(),
+				rbac.NewRule("impersonate").Groups(userGroup, legacyUserGroup).Resources(authorizationapi.SystemGroupResource, authorizationapi.GroupResource).Names(MastersGroup).RuleOrDie(),
 			},
 		},
 		{

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -285,7 +285,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 // GetBoostrapSCCAccess provides the default set of access that should be passed to GetBootstrapSecurityContextConstraints.
 func GetBoostrapSCCAccess(infraNamespace string) (map[string][]string, map[string][]string) {
 	groups := map[string][]string{
-		SecurityContextConstraintPrivileged: {ClusterAdminGroup, NodesGroup},
+		SecurityContextConstraintPrivileged: {ClusterAdminGroup, NodesGroup, MastersGroup},
 		SecurityContextConstraintsAnyUID:    {ClusterAdminGroup},
 		SecurityContextConstraintRestricted: {AuthenticatedGroup},
 	}
@@ -293,7 +293,7 @@ func GetBoostrapSCCAccess(infraNamespace string) (map[string][]string, map[strin
 	buildControllerUsername := serviceaccount.MakeUsername(infraNamespace, InfraBuildControllerServiceAccountName)
 	pvRecyclerControllerUsername := serviceaccount.MakeUsername(infraNamespace, InfraPersistentVolumeRecyclerControllerServiceAccountName)
 	users := map[string][]string{
-		SecurityContextConstraintPrivileged:         {buildControllerUsername},
+		SecurityContextConstraintPrivileged:         {SystemAdminUsername, buildControllerUsername},
 		SecurityContextConstraintHostMountAndAnyUID: {pvRecyclerControllerUsername},
 	}
 	return groups, users

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -75,7 +75,7 @@ func TestBootstrappedConstraintsWithAddedUser(t *testing.T) {
 
 func getExpectedAccess() (map[string][]string, map[string][]string) {
 	groups := map[string][]string{
-		SecurityContextConstraintPrivileged: {ClusterAdminGroup, NodesGroup},
+		SecurityContextConstraintPrivileged: {ClusterAdminGroup, NodesGroup, MastersGroup},
 		SecurityContextConstraintsAnyUID:    {ClusterAdminGroup},
 		SecurityContextConstraintRestricted: {AuthenticatedGroup},
 	}
@@ -83,7 +83,7 @@ func getExpectedAccess() (map[string][]string, map[string][]string) {
 	buildControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftInfraNamespace, InfraBuildControllerServiceAccountName)
 	pvRecyclerControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftInfraNamespace, InfraPersistentVolumeRecyclerControllerServiceAccountName)
 	users := map[string][]string{
-		SecurityContextConstraintPrivileged:         {buildControllerUsername},
+		SecurityContextConstraintPrivileged:         {SystemAdminUsername, buildControllerUsername},
 		SecurityContextConstraintHostMountAndAnyUID: {pvRecyclerControllerUsername},
 	}
 	return groups, users

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -9,7 +9,10 @@ os::test::junit::declare_suite_start "cmd/policy"
 os::cmd::expect_success_and_text 'oc whoami --as deads' "deads"
 
 os::cmd::expect_success 'oc adm policy add-cluster-role-to-user sudoer wheel'
+os::cmd::try_until_text 'oc policy who-can impersonate users system:admin' "wheel"
+os::cmd::try_until_text 'oc policy who-can impersonate groups system:masters' "wheel"
 os::cmd::try_until_text 'oc policy who-can impersonate systemusers system:admin' "wheel"
+os::cmd::try_until_text 'oc policy who-can impersonate systemgroups system:masters' "wheel"
 os::cmd::expect_success 'oc login -u wheel -p pw'
 os::cmd::expect_success_and_text 'oc whoami' "wheel"
 os::cmd::expect_failure 'oc whoami --as deads'

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -39,6 +39,16 @@ items:
     - users
     verbs:
     - impersonate
+  - apiGroups:
+    - ""
+    - user.openshift.io
+    resourceNames:
+    - system:masters
+    resources:
+    - groups
+    - systemgroups
+    verbs:
+    - impersonate
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
Prior this change, a member of "sudoer" group couldn't create a privileged pod (or perform `oc exec` against it). Also before, a user couldn't impersonate `system:masters` group. Now all of these are became possible.

PTAL @openshift/sig-security 

Fixes #16092 