### PR TITLE
Distinguish SCCs that AllowHostNetwork and AllowHostPorts from those that do not, in the score calculation.

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -16,11 +16,11 @@ func TestBootstrappedConstraints(t *testing.T) {
 	// ordering of expectedConstraintNames is important, we check it against scc.ByPriority
 	expectedConstraintNames := []string{
 		SecurityContextConstraintsAnyUID,
-		SecurityContextConstraintsHostNetwork,
 		SecurityContextConstraintRestricted,
 		SecurityContextConstraintNonRoot,
-		SecurityContextConstraintHostNS,
 		SecurityContextConstraintHostMountAndAnyUID,
+		SecurityContextConstraintsHostNetwork,
+		SecurityContextConstraintHostNS,
 		SecurityContextConstraintPrivileged,
 	}
 	expectedGroups, expectedUsers := getExpectedAccess()

--- a/pkg/security/securitycontextconstraints/byrestrictions.go
+++ b/pkg/security/securitycontextconstraints/byrestrictions.go
@@ -28,7 +28,10 @@ func (s ByRestrictions) Less(i, j int) bool {
 type points int
 
 const (
-	privilegedPoints points = 200000
+	privilegedPoints points = 1000000
+
+	hostNetworkPoints points = 200000
+	hostPortsPoints   points = 400000
 
 	hostVolumePoints       points = 100000
 	nonTrivialVolumePoints points = 50000
@@ -61,6 +64,13 @@ func pointValue(constraint *securityapi.SecurityContextConstraints) points {
 
 	// add points based on volume requests
 	totalPoints += volumePointValue(constraint)
+
+	if constraint.AllowHostNetwork {
+		totalPoints += hostNetworkPoints
+	}
+	if constraint.AllowHostPorts {
+		totalPoints += hostPortsPoints
+	}
 
 	// add points based on capabilities
 	totalPoints += capabilitiesPointValue(constraint)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15933.