### PR TITLE
catalog: add update permission for bindings/finalizers

### DIFF
--- a/examples/service-catalog/service-catalog.yaml
+++ b/examples/service-catalog/service-catalog.yaml
@@ -119,6 +119,7 @@ objects:
     - brokers/status
     - instances/status
     - bindings/status
+    - bindings/finalizers
     verbs:
     - update
   - apiGroups:

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13598,6 +13598,7 @@ objects:
     - brokers/status
     - instances/status
     - bindings/status
+    - bindings/finalizers
     verbs:
     - update
   - apiGroups:


### PR DESCRIPTION
Fixes this error:
secrets "mongodb-persistent-c6ztb-credentials-vp2y8" is forbidden:
cannot set blockOwnerDeletion if an ownerReference refers to a resource
you can't set finalizers on: User
"system:serviceaccount:kube-service-catalog:service-catalog-controller"
cannot update bindings/finalizers.servicecatalog.k8s.io in project
"meproject"

(#16141)