### PR TITLE
Improve build-images workflow for newcomers

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -124,7 +124,12 @@ $ git clone git://github.com/<forkid>/origin  # Replace <forkid> with the your g
 $ cd origin
 $ git remote add upstream git://github.com/openshift/origin
 ----
-4.  You are now ready to edit the source, build and restart OpenShift to
+4. You will need the imagebuilder binary in order to build OpenShift images:
++
+----
+$ go get -u github.com/openshift/imagebuilder/cmd/imagebuilder
+----
+5.  You are now ready to edit the source, build and restart OpenShift to
     test your changes.
 
 ==== Building Origin Binaries, RPMs and Images

--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -8,7 +8,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 # determine the correct tag prefix
 tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 
-os::util::ensure::gopath_binary_exists imagebuilder
+os::util::ensure::gopath_binary_exists imagebuilder "github.com/openshift/imagebuilder/cmd/imagebuilder"
 
 # Build the base image without the default image args
 os::build::image "${tag_prefix}-source" "${OS_ROOT}/images/source"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -15,7 +15,9 @@ function cleanup() {
 }
 trap "cleanup" EXIT
 
-os::util::ensure::gopath_binary_exists imagebuilder
+os::util::ensure::gopath_binary_exists imagebuilder "github.com/openshift/imagebuilder/cmd/imagebuilder"
+# image builds require base images to have been built
+os::build::image::check_for_base_images
 # image builds require RPMs to have been built
 os::build::release::check_for_rpms
 # OS_RELEASE_COMMIT is required by image-build

--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -2,6 +2,27 @@
 
 # This library holds utility functions for building container images.
 
+# os::build::check_for_base_images checks for the base images
+# needed to build container images
+#
+# Returns:
+#  None
+function os::build::image::check_for_base_images() {
+    local tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
+    local base_images="${tag_prefix}-source ${tag_prefix}-base"
+    local inspect
+
+    for base_image in ${base_images}; do
+        inspect=$(docker inspect "${base_image}") || {
+            os::log::fatal "Base image ${base_image} has not been built!
+Base images are necessary to build container images.
+Build them with:
+  $ hack/build-base-images.sh"
+        }
+    done
+}
+readonly -f os::build::image::check_for_base_images
+
 # os::build::image builds an image from a directory, to a tag or tags The default
 # behavior is to use the imagebuilder binary if it is available on the path with
 # fallback to docker build if it is not available.


### PR DESCRIPTION
The user facing documentation, primarily CONTRIBUTING.adoc, encourage
you to build the container images for openshift origin. This commit
helps newcommers by pointing out some of the early pitfalls and how to
fix them.