### PR TITLE
Do not ignore RBAC during storage migration

### DIFF
--- a/pkg/oc/admin/migrate/storage/storage.go
+++ b/pkg/oc/admin/migrate/storage/storage.go
@@ -86,10 +86,6 @@ func NewCmdMigrateAPIStorage(name, fullName string, f *clientcmd.Factory, in io.
 				{Resource: "replicationcontrollerdummies.extensions"},
 				{Resource: "podtemplates"},
 				{Resource: "selfsubjectaccessreviews", Group: "authorization.k8s.io"}, {Resource: "localsubjectaccessreviews", Group: "authorization.k8s.io"},
-
-				// skip kube RBAC resources for now because no one will have rights to update them yet
-				{Resource: "roles", Group: "rbac.authorization.k8s.io"}, {Resource: "rolebindings", Group: "rbac.authorization.k8s.io"},
-				{Resource: "clusterroles", Group: "rbac.authorization.k8s.io"}, {Resource: "clusterrolebindings", Group: "rbac.authorization.k8s.io"},
 			},
 			// Resources known to share the same storage
 			OverlappingResources: []sets.String{


### PR DESCRIPTION
RBAC permissions are now the same as the origin authorization resources.  Thus they do not need to be skipped during migration.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @deads2k @smarterclayton

@openshift/sig-security