### PR TITLE
UPSTREAM: 52127: Fix deployment timeout reporting

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/deployment/util/deployment_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/deployment/util/deployment_util.go
@@ -862,6 +862,20 @@ func DeploymentTimedOut(deployment *extensions.Deployment, newStatus *extensions
 	if condition == nil {
 		return false
 	}
+	// If the previous condition has been a successful rollout then we shouldn't try to
+	// estimate any progress. Scenario:
+	//
+	// * progressDeadlineSeconds is smaller than the difference between now and the time
+	//   the last rollout finished in the past.
+	// * the creation of a new ReplicaSet triggers a resync of the Deployment prior to the
+	//   cached copy of the Deployment getting updated with the status.condition that indicates
+	//   the creation of the new ReplicaSet.
+	//
+	// The Deployment will be resynced and eventually its Progressing condition will catch
+	// up with the state of the world.
+	if condition.Reason == NewRSAvailableReason {
+		return false
+	}
 	if condition.Reason == TimedOutReason {
 		return true
 	}


### PR DESCRIPTION
If the previous condition has been a successful rollout then we
shouldn't try to estimate any progress. Scenario:

* progressDeadlineSeconds is smaller than the difference between
  now and the time the last rollout finished in the past.
* the creation of a new ReplicaSet triggers a resync of the
  Deployment prior to the cached copy of the Deployment getting
  updated with the status.condition that indicates the creation
   of the new ReplicaSet.

The Deployment will be resynced and eventually its Progressing
condition will catch up with the state of the world.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>

Cherry-pick of https://github.com/kubernetes/kubernetes/pull/52127
/assign @mfojtik @tnozicka 
/area apps
/kind bug