### PR TITLE
Handle the changed --haproxy.scrape-uri argument (- to --)

### DIFF
--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -474,7 +474,7 @@ func generateMetricsExporterContainer(cfg *RouterConfig, env app.Environment) *k
 			Image: "prom/haproxy-exporter:latest",
 			Env:   env.List(),
 			Args: []string{
-				fmt.Sprintf("-haproxy.scrape-uri=http://$(STATS_USERNAME):$(STATS_PASSWORD)@localhost:$(STATS_PORT)/haproxy?stats;csv"),
+				fmt.Sprintf("--haproxy.scrape-uri=http://$(STATS_USERNAME):$(STATS_PASSWORD)@localhost:$(STATS_PORT)/haproxy?stats;csv"),
 			},
 			Ports: []kapi.ContainerPort{
 				{


### PR DESCRIPTION
The argument changed from -haproxy.scrape to --haproxy.scrape.  This
makes 'oc adm --expose-metrics' handle the change.

Fixes bug 1488954 (https://bugzilla.redhat.com/show_bug.cgi?id=1488954)