### PR TITLE
Convert subjectchecker to use rbac.Subject

### DIFF
--- a/pkg/authorization/admission/restrictusers/restrictusers.go
+++ b/pkg/authorization/admission/restrictusers/restrictusers.go
@@ -11,11 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/admission"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	kadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	oclient "github.com/openshift/origin/pkg/client"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
@@ -71,8 +69,7 @@ func (q *restrictUsersAdmission) SetUserInformer(userInformers userinformer.Shar
 
 // subjectsDelta returns the relative complement of elementsToIgnore in
 // elements (i.e., elements∖elementsToIgnore).
-// TODO return []rbac.Subject{} once we convert subjectchecker to RBAC types
-func subjectsDelta(elementsToIgnore, elements []rbac.Subject) ([]kapi.ObjectReference, error) {
+func subjectsDelta(elementsToIgnore, elements []rbac.Subject) []rbac.Subject {
 	result := []rbac.Subject{}
 
 	for _, el := range elements {
@@ -88,7 +85,7 @@ func subjectsDelta(elementsToIgnore, elements []rbac.Subject) ([]kapi.ObjectRefe
 		}
 	}
 
-	return authorizationapi.Convert_rbac_Subjects_To_authorization_Subjects(result)
+	return result
 }
 
 // Admit makes admission decisions that enforce restrictions on adding
@@ -140,11 +137,7 @@ func (q *restrictUsersAdmission) Admit(a admission.Attributes) (err error) {
 	glog.V(4).Infof("Handling rolebinding %s/%s",
 		rolebinding.Namespace, rolebinding.Name)
 
-	newSubjects, err := subjectsDelta(oldSubjects, rolebinding.Subjects)
-	if err != nil {
-		return admission.NewForbidden(a,
-			fmt.Errorf("failed to select Subjects: %v", err))
-	}
+	newSubjects := subjectsDelta(oldSubjects, rolebinding.Subjects)
 	if len(newSubjects) == 0 {
 		glog.V(4).Infof("No new subjects; admitting")
 		return nil

--- a/pkg/authorization/admission/restrictusers/subjectchecker_test.go
+++ b/pkg/authorization/admission/restrictusers/subjectchecker_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
@@ -25,30 +26,22 @@ func mustNewSubjectChecker(t *testing.T, spec *authorizationapi.RoleBindingRestr
 
 func TestSubjectCheckers(t *testing.T) {
 	var (
-		userBobRef = kapi.ObjectReference{
-			Kind: authorizationapi.UserKind,
+		userBobRef = rbac.Subject{
+			Kind: rbac.UserKind,
 			Name: "Bob",
 		}
-		userAliceRef = kapi.ObjectReference{
-			Kind: authorizationapi.UserKind,
+		userAliceRef = rbac.Subject{
+			Kind: rbac.UserKind,
 			Name: "Alice",
 		}
-		groupRef = kapi.ObjectReference{
-			Kind: authorizationapi.GroupKind,
+		groupRef = rbac.Subject{
+			Kind: rbac.GroupKind,
 			Name: "group",
 		}
-		serviceaccountRef = kapi.ObjectReference{
-			Kind:      authorizationapi.ServiceAccountKind,
+		serviceaccountRef = rbac.Subject{
+			Kind:      rbac.ServiceAccountKind,
 			Namespace: "namespace",
 			Name:      "serviceaccount",
-		}
-		systemuserRef = kapi.ObjectReference{
-			Kind: authorizationapi.SystemUserKind,
-			Name: "system user",
-		}
-		systemgroupRef = kapi.ObjectReference{
-			Kind: authorizationapi.SystemGroupKind,
-			Name: "system group",
 		}
 		group = userapi.Group{
 			ObjectMeta: metav1.ObjectMeta{
@@ -82,31 +75,9 @@ func TestSubjectCheckers(t *testing.T) {
 	testCases := []struct {
 		name        string
 		checker     SubjectChecker
-		subject     kapi.ObjectReference
+		subject     rbac.Subject
 		shouldAllow bool
 	}{
-		{
-			name: "allow system user by literal name match",
-			checker: mustNewSubjectChecker(t,
-				&authorizationapi.RoleBindingRestrictionSpec{
-					UserRestriction: &authorizationapi.UserRestriction{
-						Users: []string{systemuserRef.Name},
-					},
-				}),
-			subject:     systemuserRef,
-			shouldAllow: true,
-		},
-		{
-			name: "allow system group by literal name match",
-			checker: mustNewSubjectChecker(t,
-				&authorizationapi.RoleBindingRestrictionSpec{
-					GroupRestriction: &authorizationapi.GroupRestriction{
-						Groups: []string{systemgroupRef.Name},
-					},
-				}),
-			subject:     systemgroupRef,
-			shouldAllow: true,
-		},
 		{
 			name: "allow regular user by literal name match",
 			checker: mustNewSubjectChecker(t,
@@ -232,8 +203,8 @@ func TestSubjectCheckers(t *testing.T) {
 						},
 					},
 				}),
-			subject: kapi.ObjectReference{
-				Kind:      authorizationapi.ServiceAccountKind,
+			subject: rbac.Subject{
+				Kind:      rbac.ServiceAccountKind,
 				Namespace: "othernamespace",
 				Name:      serviceaccountRef.Name,
 			},
@@ -249,8 +220,8 @@ func TestSubjectCheckers(t *testing.T) {
 						},
 					},
 				}),
-			subject: kapi.ObjectReference{
-				Kind:      authorizationapi.ServiceAccountKind,
+			subject: rbac.Subject{
+				Kind:      rbac.ServiceAccountKind,
 				Namespace: "othernamespace",
 				Name:      serviceaccountRef.Name,
 			},
@@ -269,8 +240,8 @@ func TestSubjectCheckers(t *testing.T) {
 						},
 					},
 				}),
-			subject: kapi.ObjectReference{
-				Kind: authorizationapi.ServiceAccountKind,
+			subject: rbac.Subject{
+				Kind: rbac.ServiceAccountKind,
 				Name: serviceaccountRef.Name,
 			},
 			shouldAllow: true,
@@ -285,8 +256,8 @@ func TestSubjectCheckers(t *testing.T) {
 						},
 					},
 				}),
-			subject: kapi.ObjectReference{
-				Kind: authorizationapi.ServiceAccountKind,
+			subject: rbac.Subject{
+				Kind: rbac.ServiceAccountKind,
 				Name: serviceaccountRef.Name,
 			},
 			shouldAllow: true,
@@ -304,8 +275,8 @@ func TestSubjectCheckers(t *testing.T) {
 						},
 					},
 				}),
-			subject: kapi.ObjectReference{
-				Kind: authorizationapi.ServiceAccountKind,
+			subject: rbac.Subject{
+				Kind: rbac.ServiceAccountKind,
 				Name: serviceaccountRef.Name,
 			},
 			shouldAllow: false,

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -170,4 +170,59 @@ func TestRestrictUsers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// Creating rolebindings that also contains "system non existing" users should
+	// not fail.
+	allowWithNonExisting := &authorizationapi.RoleBindingRestriction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "match-users-eve-and-non-existing",
+			Namespace: "namespace",
+		},
+		Spec: authorizationapi.RoleBindingRestrictionSpec{
+			UserRestriction: &authorizationapi.UserRestriction{
+				Users: []string{"eve", "system:non-existing"},
+			},
+		},
+	}
+
+	if _, err := clusterAdminClient.RoleBindingRestrictions("namespace").Create(allowWithNonExisting); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rolebindingEve := &authorizationapi.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      "rolebinding4",
+		},
+		Subjects: []kapi.ObjectReference{
+			{
+				Kind:      authorizationapi.UserKind,
+				Namespace: "namespace",
+				Name:      "eve",
+			},
+		},
+		RoleRef: kapi.ObjectReference{Name: "role", Namespace: "namespace"},
+	}
+
+	if _, err := clusterAdminClient.RoleBindings("namespace").Create(rolebindingEve); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rolebindingNonExisting := &authorizationapi.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      "rolebinding5",
+		},
+		Subjects: []kapi.ObjectReference{
+			{
+				Kind:      authorizationapi.UserKind,
+				Namespace: "namespace",
+				Name:      "system:non-existing",
+			},
+		},
+		RoleRef: kapi.ObjectReference{Name: "role", Namespace: "namespace"},
+	}
+
+	if _, err := clusterAdminClient.RoleBindings("namespace").Create(rolebindingNonExisting); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }


### PR DESCRIPTION
This also removes any distinction between System and regular User/Groups, as that distinction is gone with RBAC RoleBindings.

Fixes #16032
Fixes #16259