### PR TITLE
Add hack/build-base-image.sh as dependency for build-images target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,8 +297,13 @@ build-rpms-redistributable:
 # Example:
 #   make build-images
 build-images: build-rpms
+	build-base-images
 	hack/build-images.sh
 .PHONY: build-images
+
+build-base-images:
+	hack/build-base-images.sh
+.PHONY: build-base-images
 
 # Vendor the Origin Web Console
 #

--- a/Makefile
+++ b/Makefile
@@ -290,20 +290,19 @@ build-rpms-redistributable:
 	hack/build-rpm-release.sh
 .PHONY: build-rpms-redistributable
 
+build-base-images:
+	hack/build-base-images.sh
+.PHONY: build-base-images
+
 # Build images from the official RPMs
 # 
 # Args:
 #
 # Example:
 #   make build-images
-build-images: build-rpms
-	build-base-images
+build-images:  build-rpms build-base-images
 	hack/build-images.sh
 .PHONY: build-images
-
-build-base-images:
-	hack/build-base-images.sh
-.PHONY: build-base-images
 
 # Vendor the Origin Web Console
 #


### PR DESCRIPTION
Fixes #16304

Without a call to `hack/build-base-images.sh`, `hack/build-images.sh` fails because many images depend on base images that don't exist in registries. This PR fixes the issue by adding a `build-base-images` target to the `Makefile` that calls `hack/build-base-images.sh` and adding it as a dependency of `buid-images`