### PR TITLE
image: set error when we receive unknown schema for the image

### DIFF
--- a/pkg/image/importer/importer.go
+++ b/pkg/image/importer/importer.go
@@ -490,8 +490,10 @@ func (isi *ImageStreamImporter) importRepositoryFromDocker(ctx gocontext.Context
 
 			importDigest.Image, err = schema2ToImage(deserializedManifest, imageConfig, d)
 		} else {
+			// TODO: Current this error means the imported received the manifest list
+			// which we don't support yet.
+			err = fmt.Errorf("unsupported image manifest schema: %T", manifest)
 			glog.V(5).Infof("unsupported manifest type: %T", manifest)
-			continue
 		}
 
 		if err != nil {
@@ -548,8 +550,10 @@ func (isi *ImageStreamImporter) importRepositoryFromDocker(ctx gocontext.Context
 			}
 			importTag.Image, err = schema2ToImage(deserializedManifest, imageConfig, "")
 		} else {
+			// TODO: Current this error means the imported received the manifest list
+			// which we don't support yet.
+			err = fmt.Errorf("unsupported image manifest schema: %T", manifest)
 			glog.V(5).Infof("unsupported manifest type: %T", manifest)
-			continue
 		}
 
 		if err != nil {

--- a/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
+++ b/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
@@ -21,6 +21,12 @@ var SchemaVersion = manifest.Versioned{
 }
 
 func init() {
+	// FIXME: Do not registry the manifest list schema as the manifest lists are
+	// not supported by OpenShift and fetching the manifest list will result in
+	// the import failure. If we return here, it means the docker client will ask
+	// for the schema2 instead.
+	return
+
 	manifestListFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
 		m := new(DeserializedManifestList)
 		err := m.UnmarshalJSON(b)


### PR DESCRIPTION
@dmage @soltysh 

The error we get is:

```console
I0913 06:32:59.350152   24974 importer.go:551] unsupported manifest type: *manifestlist.DeserializedManifestList
```

This will result into the .Image field to be nil which we then later panic on. I'm not sure how this was not broken before or if something changed in DockerHub. The mongo and redis images in DockerHub both have manifest lists, but we should be converting them to schema2 automatically?

This PR just propagate that error to image stream status instead of panicking the importer. We should investigate further.