### PR TITLE
Correct missing sizes for manifest schema 1 images

### DIFF
--- a/pkg/dockerregistry/server/manifesthandler.go
+++ b/pkg/dockerregistry/server/manifesthandler.go
@@ -14,11 +14,12 @@ import (
 
 // A ManifestHandler defines a common set of operations on all versions of manifest schema.
 type ManifestHandler interface {
-	// FillImageMetadata fills a given image with metadata parsed from manifest. It also corrects layer sizes
-	// with blob sizes. Newer Docker client versions don't set layer sizes in the manifest schema 1 at all.
-	// Origin master needs correct layer sizes for proper image quota support. That's why we need to fill the
-	// metadata in the registry.
-	FillImageMetadata(ctx context.Context, image *imageapiv1.Image) error
+	// Config returns a blob with image configuration associated with the manifest. This applies only to
+	// manifet schema 2.
+	Config(ctx context.Context) ([]byte, error)
+
+	// Digest returns manifest's digest.
+	Digest() (manifestDigest digest.Digest, err error)
 
 	// Manifest returns a deserialized manifest object.
 	Manifest() distribution.Manifest
@@ -29,9 +30,6 @@ type ManifestHandler interface {
 
 	// Verify returns an error if the contained manifest is not valid or has missing dependencies.
 	Verify(ctx context.Context, skipDependencyVerification bool) error
-
-	// Digest returns manifest's digest
-	Digest() (manifestDigest digest.Digest, err error)
 }
 
 // NewManifestHandler creates a manifest handler for the given manifest.

--- a/pkg/dockerregistry/server/manifestschema1handler_test.go
+++ b/pkg/dockerregistry/server/manifestschema1handler_test.go
@@ -1,0 +1,375 @@
+package server
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema1"
+)
+
+func TestUnmarshalManifestSchema1(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		manifestString         string
+		signatures             [][]byte
+		expectedName           string
+		expectedTag            string
+		expectedReferences     []distribution.Descriptor
+		expectedSignatures     [][]byte
+		expectedErrorSubstring string
+	}{
+		{
+			name:           "valid manifest with sizes",
+			manifestString: manifestSchema1,
+			expectedName:   "library/busybox",
+			expectedTag:    "1.23",
+			expectedReferences: []distribution.Descriptor{
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[0])},
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[1])},
+			},
+			expectedSignatures: [][]byte{[]byte(manifestSchema1Signature)},
+		},
+
+		{
+			name:           "valid manifest with missing sizes",
+			manifestString: manifestSchema1WithoutSize,
+			expectedName:   "library/busybox",
+			expectedTag:    "1.23",
+			expectedReferences: []distribution.Descriptor{
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[0])},
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[1])},
+			},
+			expectedSignatures: [][]byte{[]byte(manifestSchema1WithoutSizeSignature)},
+		},
+
+		{
+			name:           "having shorter history",
+			manifestString: manifestSchema1ShortHistory,
+			expectedName:   "library/busybox",
+			expectedTag:    "1.23",
+			expectedReferences: []distribution.Descriptor{
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[0])},
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[1])},
+			},
+			expectedSignatures: [][]byte{[]byte(manifestSchema1ShortHistorySignature)},
+		},
+
+		{
+			name:           "having shorter fs layers",
+			manifestString: manifestSchema1ShortFSLayers,
+			expectedName:   "library/busybox",
+			expectedTag:    "1.23",
+			expectedReferences: []distribution.Descriptor{
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[0])},
+			},
+			expectedSignatures: [][]byte{[]byte(manifestSchema1ShortFSLayersSignature)},
+		},
+
+		{
+			name:           "additional signatures",
+			manifestString: manifestSchema1,
+			signatures:     [][]byte{[]byte("my signature")},
+			expectedName:   "library/busybox",
+			expectedTag:    "1.23",
+			expectedReferences: []distribution.Descriptor{
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[0])},
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[1])},
+			},
+			// the additional signature is ignored
+			expectedSignatures: [][]byte{[]byte(manifestSchema1Signature)},
+		},
+
+		{
+			name:                   "manifest missing signatures",
+			manifestString:         manifestSchema1MissingSignatures,
+			expectedErrorSubstring: "no signatures",
+		},
+
+		{
+			name:           "just external signatures",
+			manifestString: manifestSchema1MissingSignatures,
+			signatures:     manifestSchema1ExternalSignatures,
+			expectedName:   "library/busybox",
+			expectedTag:    "1.23",
+			expectedReferences: []distribution.Descriptor{
+				{MediaType: schema1.MediaTypeManifestLayer, Digest: digest.Digest(manifestSchema1Layers[0])},
+			},
+			expectedSignatures: manifestSchema1ExternalSignaturesCompact,
+		},
+
+		{
+			name:                   "invalid manifest",
+			manifestString:         manifestSchema1Invalid,
+			expectedErrorSubstring: "invalid character",
+		},
+
+		{
+			name:           "manifest schema 2",
+			manifestString: manifestSchema2,
+			// FIXME: this could report some better error
+			expectedErrorSubstring: "no signatures",
+		},
+	} {
+
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, err := unmarshalManifestSchema1([]byte(tc.manifestString), tc.signatures)
+			if err != nil {
+				if len(tc.expectedErrorSubstring) == 0 {
+					t.Fatalf("got unexpected error: (%T) %v", err, err)
+				}
+				if !strings.Contains(err.Error(), tc.expectedErrorSubstring) {
+					t.Fatalf("expected error with string %q, instead got: %v", tc.expectedErrorSubstring, err)
+				}
+				return
+			}
+			if err == nil && len(tc.expectedErrorSubstring) > 0 {
+				t.Fatalf("got non-error while expecting: %s", tc.expectedErrorSubstring)
+			}
+
+			sm, ok := manifest.(*schema1.SignedManifest)
+			if !ok {
+				t.Fatalf("got unexpected manifest schema: %T", sm)
+			}
+
+			if sm.Name != tc.expectedName {
+				t.Errorf("got unexpected image name: %s", diff.ObjectGoPrintDiff(sm.Name, tc.expectedName))
+			}
+			if sm.Tag != tc.expectedTag {
+				t.Errorf("got unexpected image tag: %s", diff.ObjectGoPrintDiff(sm.Tag, tc.expectedTag))
+			}
+
+			refs := manifest.References()
+			if !reflect.DeepEqual(refs, tc.expectedReferences) {
+				t.Errorf("got unexpected image references: %s", diff.ObjectGoPrintDiff(refs, tc.expectedReferences))
+			}
+
+			signatures, err := sm.Signatures()
+			if err != nil {
+				t.Fatalf("failed to get manifest signatures: %v", err)
+			}
+			if !reflect.DeepEqual(signatures, tc.expectedSignatures) {
+				t.Errorf("got unexpected image signatures: %s", diff.ObjectGoPrintDiff(signatures, tc.expectedSignatures))
+				for i, sig := range signatures {
+					t.Logf("signature #%d: %#v", i, string(sig))
+
+				}
+				for i, sig := range tc.expectedSignatures {
+					t.Logf("expected signature #%d: %#v", i, string(sig))
+				}
+			}
+		})
+	}
+}
+
+const manifestSchema1Signature = "{\"header\":{\"jwk\":{\"crv\":\"P-256\",\"kid\":\"QKEZ:N7ZA:BUSY:KPSH:PARP:NU4K:POHK:VLWF:EW22:4JFB:MKYJ:ZYSE\",\"kty\":\"EC\",\"x\":\"ppU7aXPngzHYJUswWcpDDL50hYkHWanmcrs_0X8L8Pc\",\"y\":\"dRpAggds8FfHRZsOms_g13XBOMnuqkP1fEWisGwvXso\"},\"alg\":\"ES256\"},\"signature\":\"KixitWkKYsVqNL0mkSxVSZMXQ61tzgXTlTlyeLHz4I2dZNXdDwHJZmYeoMGnYKM_HQKDcQHQeYSoxlu8AMTLOQ\",\"protected\":\"eyJmb3JtYXRMZW5ndGgiOjMyMTAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xNVQwOTo0MzowNFoifQ\"}"
+
+var manifestSchema1Layers = []string{
+	digestSHA256GzippedEmptyTar.String(),
+	"sha256:9d7588d3c0635b53bd9a7dcd40bdf5d2d32cd3fb919c3a29ec2febbc2449eb19",
+}
+
+// imported from docker.io/busybox:1.23
+const manifestSchema1 = `{
+   "schemaVersion": 1,
+   "name": "library/busybox",
+   "tag": "1.23",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:9d7588d3c0635b53bd9a7dcd40bdf5d2d32cd3fb919c3a29ec2febbc2449eb19"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"d7057cb020844f245031d27b76cb18af05db1cc3a96a29fa7777af75f5ac91a3\",\"parent\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.866196515Z\",\"container\":\"7f652467f9e6d1b3bf51172868b9b0c2fa1c711b112f4e987029b1624dd6295f\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":0}\n"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.433616227Z\",\"container\":\"5f8e0e129ff1e03bbb50a8b6ba7636fa5503c695125b1c392490d8aa113e8cf6\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:6cccb5f0a3b3947116a0c0f55d071980d94427ba0d6dad17bc68ead832cc0a8f in /\"],\"Image\":\"\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":1095501}\n"
+      }
+   ],
+   "signatures": [
+      {
+         "header": {
+            "jwk": {
+               "crv": "P-256",
+               "kid": "QKEZ:N7ZA:BUSY:KPSH:PARP:NU4K:POHK:VLWF:EW22:4JFB:MKYJ:ZYSE",
+               "kty": "EC",
+               "x": "ppU7aXPngzHYJUswWcpDDL50hYkHWanmcrs_0X8L8Pc",
+               "y": "dRpAggds8FfHRZsOms_g13XBOMnuqkP1fEWisGwvXso"
+            },
+            "alg": "ES256"
+         },
+         "signature": "KixitWkKYsVqNL0mkSxVSZMXQ61tzgXTlTlyeLHz4I2dZNXdDwHJZmYeoMGnYKM_HQKDcQHQeYSoxlu8AMTLOQ",
+         "protected": "eyJmb3JtYXRMZW5ndGgiOjMyMTAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xNVQwOTo0MzowNFoifQ"
+      }
+   ]
+}`
+
+const manifestSchema1WithoutSizeSignature = `{"header":{"jwk":{"crv":"P-256","kid":"IA3H:ZTL6:ZE5F:YBJU:TV2M:NSYK:W7ON:3D2K:5R3T:B7ZR:7J6X:IY4F","kty":"EC","x":"hM0pR9f7IIqWoKsD62bL_9tMmi1l04YRsVcCV_Q8ePw","y":"Lw1BZJLmNnII5Zt0Uk3nfqbDSDvqbZ5_ay4CM89AUTc"},"alg":"ES256"},"signature":"xlqhy7h3GLoiG_Z4sTwuvjA7t7pv9Jmc74kKkv8cozxvEPGvNOVgpnFDXtRkcfPIUNZAB8LJ6zMQWGkB5akSZA","protected":"eyJmb3JtYXRMZW5ndGgiOjMxOTMsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xOFQxMzozNDowNFoifQ"}`
+const manifestSchema1WithoutSize = `{
+   "schemaVersion": 1,
+   "name": "library/busybox",
+   "tag": "1.23",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:9d7588d3c0635b53bd9a7dcd40bdf5d2d32cd3fb919c3a29ec2febbc2449eb19"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"d7057cb020844f245031d27b76cb18af05db1cc3a96a29fa7777af75f5ac91a3\",\"parent\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.866196515Z\",\"container\":\"7f652467f9e6d1b3bf51172868b9b0c2fa1c711b112f4e987029b1624dd6295f\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":0}\n"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.433616227Z\",\"container\":\"5f8e0e129ff1e03bbb50a8b6ba7636fa5503c695125b1c392490d8aa113e8cf6\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:6cccb5f0a3b3947116a0c0f55d071980d94427ba0d6dad17bc68ead832cc0a8f in /\"],\"Image\":\"\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\"}\n"
+      }
+   ],
+   "signatures": [
+     {
+        "header": {
+           "jwk": {
+              "crv": "P-256",
+              "kid": "IA3H:ZTL6:ZE5F:YBJU:TV2M:NSYK:W7ON:3D2K:5R3T:B7ZR:7J6X:IY4F",
+              "kty": "EC",
+              "x": "hM0pR9f7IIqWoKsD62bL_9tMmi1l04YRsVcCV_Q8ePw",
+              "y": "Lw1BZJLmNnII5Zt0Uk3nfqbDSDvqbZ5_ay4CM89AUTc"
+           },
+           "alg": "ES256"
+        },
+        "signature": "xlqhy7h3GLoiG_Z4sTwuvjA7t7pv9Jmc74kKkv8cozxvEPGvNOVgpnFDXtRkcfPIUNZAB8LJ6zMQWGkB5akSZA",
+        "protected": "eyJmb3JtYXRMZW5ndGgiOjMxOTMsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xOFQxMzozNDowNFoifQ"
+     }
+  ]
+}`
+
+const manifestSchema1ShortHistorySignature = `{"header":{"jwk":{"crv":"P-256","kid":"BMQ5:5OIV:TJXC:IJQE:BYCE:7UBD:SWFQ:HFBN:STVV:XDNE:VJRG:KUUA","kty":"EC","x":"rZo1KLwKH0ZfiTzGFxTTQxbarJZ7gE4fWuPrucpZwjo","y":"QkoUQ3HauBjMythY94qevDCKzMEiLYJse3cVSqrSO4k"},"alg":"ES256"},"signature":"Fn_Diinka9s_cYTBvHoSklrBm3oM8rYe7PNZwEg_hAB-g0SOvTmiCqFjC9QahvhFtUZYT3cpZpJLFzRVAU32Tg","protected":"eyJmb3JtYXRMZW5ndGgiOjE4NTksImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xOFQxNDozMzo0MFoifQ"}`
+const manifestSchema1ShortHistory = `{
+   "schemaVersion": 1,
+   "name": "library/busybox",
+   "tag": "1.23",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:9d7588d3c0635b53bd9a7dcd40bdf5d2d32cd3fb919c3a29ec2febbc2449eb19"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"d7057cb020844f245031d27b76cb18af05db1cc3a96a29fa7777af75f5ac91a3\",\"parent\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.866196515Z\",\"container\":\"7f652467f9e6d1b3bf51172868b9b0c2fa1c711b112f4e987029b1624dd6295f\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":0}\n"
+      }
+   ],
+   "signatures": [
+      {
+         "header": {
+            "jwk": {
+               "crv": "P-256",
+               "kid": "BMQ5:5OIV:TJXC:IJQE:BYCE:7UBD:SWFQ:HFBN:STVV:XDNE:VJRG:KUUA",
+               "kty": "EC",
+               "x": "rZo1KLwKH0ZfiTzGFxTTQxbarJZ7gE4fWuPrucpZwjo",
+               "y": "QkoUQ3HauBjMythY94qevDCKzMEiLYJse3cVSqrSO4k"
+            },
+            "alg": "ES256"
+         },
+         "signature": "Fn_Diinka9s_cYTBvHoSklrBm3oM8rYe7PNZwEg_hAB-g0SOvTmiCqFjC9QahvhFtUZYT3cpZpJLFzRVAU32Tg",
+         "protected": "eyJmb3JtYXRMZW5ndGgiOjE4NTksImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xOFQxNDozMzo0MFoifQ"
+      }
+   ]
+}`
+
+const manifestSchema1ShortFSLayersSignature = `{"header":{"jwk":{"crv":"P-256","kid":"JV5N:BVLF:L6WC:TVCF:7QJS:FB63:DGAS:IVJV:QQ2U:P77G:SVUF:TJPL","kty":"EC","x":"6cbmNJxXJi09n1hM1Yw5_vWeueCDjHGKXTyzQkH6KkM","y":"XSoPqwZ9pL8mQZkKAJb_SuUhtHsBN1_MP0sB6Bz4RN4"},"alg":"ES256"},"signature":"sdJzNKAlPrIeV4ftAwoSGBO3SP0p3ciqsSaj19Q-zDpgrU6R5L4uGp2OiP7yt5gz8w5kQScbjACrrfS-hcZTkA","protected":"eyJmb3JtYXRMZW5ndGgiOjMwODIsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xOFQxNTowNDowMFoifQ"}`
+const manifestSchema1ShortFSLayers = `{
+   "schemaVersion": 1,
+   "name": "library/busybox",
+   "tag": "1.23",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"d7057cb020844f245031d27b76cb18af05db1cc3a96a29fa7777af75f5ac91a3\",\"parent\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.866196515Z\",\"container\":\"7f652467f9e6d1b3bf51172868b9b0c2fa1c711b112f4e987029b1624dd6295f\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":5}\n"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.433616227Z\",\"container\":\"5f8e0e129ff1e03bbb50a8b6ba7636fa5503c695125b1c392490d8aa113e8cf6\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:6cccb5f0a3b3947116a0c0f55d071980d94427ba0d6dad17bc68ead832cc0a8f in /\"],\"Image\":\"\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\"}\n"
+      }
+   ],
+   "signatures": [
+      {
+         "header": {
+            "jwk": {
+               "crv": "P-256",
+               "kid": "JV5N:BVLF:L6WC:TVCF:7QJS:FB63:DGAS:IVJV:QQ2U:P77G:SVUF:TJPL",
+               "kty": "EC",
+               "x": "6cbmNJxXJi09n1hM1Yw5_vWeueCDjHGKXTyzQkH6KkM",
+               "y": "XSoPqwZ9pL8mQZkKAJb_SuUhtHsBN1_MP0sB6Bz4RN4"
+            },
+            "alg": "ES256"
+         },
+         "signature": "sdJzNKAlPrIeV4ftAwoSGBO3SP0p3ciqsSaj19Q-zDpgrU6R5L4uGp2OiP7yt5gz8w5kQScbjACrrfS-hcZTkA",
+         "protected": "eyJmb3JtYXRMZW5ndGgiOjMwODIsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0xOFQxNTowNDowMFoifQ"
+      }
+   ]
+}`
+
+var manifestSchema1ExternalSignatures = [][]byte{[]byte(`{
+   "header": {
+  	"jwk": {
+  	   "crv": "P-256",
+  	   "kid": "QGG7:JZ2V:PFXZ:NKUP:XDPM:V3GS:KRRG:NB27:D4RF:2FQY:ISZV:TYUB",
+  	   "kty": "EC",
+  	   "x": "9itRpQlCqD-vlbSvGH9laJIuM9PfDOU7-mJ42zkFu7E",
+  	   "y": "zGP4n85_A2XgzZ770E3IWAijI0W5kbmv0FrgDPEcFMM"
+  	},
+  	"alg": "ES256"
+   },
+   "signature": "HbWKBd8wRh20G0HAO7qfFgviW2AI8a5woKM48fhTcPuJXr0qA9CyMoEdfrHFk_vwplv4w8CZImizfHbZ3UxzoQ",
+   "protected": "eyJmb3JtYXRMZW5ndGgiOjE3NDgsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0yMFQxMzoxNDozOVoifQ"
+}`)}
+var manifestSchema1ExternalSignaturesCompact = [][]byte{[]byte("{\"header\":{\"jwk\":{\"crv\":\"P-256\",\"kid\":\"QGG7:JZ2V:PFXZ:NKUP:XDPM:V3GS:KRRG:NB27:D4RF:2FQY:ISZV:TYUB\",\"kty\":\"EC\",\"x\":\"9itRpQlCqD-vlbSvGH9laJIuM9PfDOU7-mJ42zkFu7E\",\"y\":\"zGP4n85_A2XgzZ770E3IWAijI0W5kbmv0FrgDPEcFMM\"},\"alg\":\"ES256\"},\"signature\":\"HbWKBd8wRh20G0HAO7qfFgviW2AI8a5woKM48fhTcPuJXr0qA9CyMoEdfrHFk_vwplv4w8CZImizfHbZ3UxzoQ\",\"protected\":\"eyJmb3JtYXRMZW5ndGgiOjE3NDgsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNy0wOS0yMFQxMzoxNDozOVoifQ\"}")}
+
+const manifestSchema1MissingSignatures = `{
+   "schemaVersion": 1,
+   "name": "library/busybox",
+   "tag": "1.23",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"d7057cb020844f245031d27b76cb18af05db1cc3a96a29fa7777af75f5ac91a3\",\"parent\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"created\":\"2015-09-21T20:15:47.866196515Z\",\"container\":\"7f652467f9e6d1b3bf51172868b9b0c2fa1c711b112f4e987029b1624dd6295f\",\"container_config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.2\",\"config\":{\"Hostname\":\"5f8e0e129ff1\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"ExposedPorts\":null,\"PublishService\":\"\",\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"cfa753dfea5e68a24366dfba16e6edf573daa447abf65bc11619c1a98a3aff54\",\"Volumes\":null,\"VolumeDriver\":\"\",\"WorkingDir\":\"\",\"Entrypoint\":null,\"NetworkDisabled\":false,\"MacAddress\":\"\",\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":5}\n"
+      }
+   ]
+}`
+
+const manifestSchema1Invalid = `{
+   "schemaVersion": 1,
+   "name": "library/busybox",
+   "tag": "1.23",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+   ],
+   "history": [],
+   "signatures": [],
+}`

--- a/pkg/dockerregistry/server/manifestschema2handler_test.go
+++ b/pkg/dockerregistry/server/manifestschema2handler_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema2"
+)
+
+func TestUnmarshalManifestSchema2(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		manifestString         string
+		expectedConfig         distribution.Descriptor
+		expectedReferences     []distribution.Descriptor
+		expectedErrorSubstring string
+	}{
+		{
+			name:           "valid nginx image with sizes in manifest",
+			manifestString: manifestSchema2,
+			expectedConfig: manifestSchema2ConfigDescriptor,
+			expectedReferences: []distribution.Descriptor{
+				manifestSchema2ConfigDescriptor,
+				manifestSchema2LayerDescriptors[0],
+				manifestSchema2LayerDescriptors[1],
+				manifestSchema2LayerDescriptors[2],
+			},
+		},
+
+		{
+			name:                   "invalid schema2 image",
+			manifestString:         manifestSchema2Invalid,
+			expectedErrorSubstring: "invalid character",
+		},
+
+		{
+			name:                   "manifest schema1 image",
+			manifestString:         manifestSchema1,
+			expectedErrorSubstring: "unexpected manifest schema version",
+		},
+	} {
+
+		t.Run(tc.name, func(t *testing.T) {
+			manifest, err := unmarshalManifestSchema2([]byte(tc.manifestString))
+			if err != nil {
+				if len(tc.expectedErrorSubstring) == 0 {
+					t.Fatalf("got unexpected error: (%T) %v", err, err)
+				}
+				if !strings.Contains(err.Error(), tc.expectedErrorSubstring) {
+					t.Fatalf("expected error with string %q, instead got: %v", tc.expectedErrorSubstring, err)
+				}
+				return
+			}
+			if err == nil && len(tc.expectedErrorSubstring) > 0 {
+				t.Fatalf("got non-error while expecting: %s", tc.expectedErrorSubstring)
+			}
+
+			dm, ok := manifest.(*schema2.DeserializedManifest)
+			if !ok {
+				t.Fatalf("got unexpected manifest schema: %T", manifest)
+			}
+
+			if !reflect.DeepEqual(dm.Config, tc.expectedConfig) {
+				t.Errorf("got unexpected image config descriptor: %s", diff.ObjectGoPrintDiff(dm.Config, tc.expectedConfig))
+			}
+
+			refs := dm.References()
+			if !reflect.DeepEqual(refs, tc.expectedReferences) {
+				t.Errorf("got unexpected image references: %s", diff.ObjectGoPrintDiff(refs, tc.expectedReferences))
+			}
+		})
+	}
+}
+
+var manifestSchema2LayerDescriptors = []distribution.Descriptor{
+	{
+		MediaType: schema2.MediaTypeLayer,
+		Digest:    digest.Digest("sha256:afeb2bfd31c0760573e7262de6ae67a84da0e0a1c3e8157bbddd41a501b18a5c"),
+		Size:      22488057,
+	},
+	{
+		MediaType: schema2.MediaTypeLayer,
+		Digest:    digest.Digest("sha256:7ff5d10493db2cdfc1b7238434c503cc0664d48d0f7154ea9472e734b28a72dd"),
+		Size:      21869700,
+	},
+	{
+		MediaType: schema2.MediaTypeLayer,
+		Digest:    digest.Digest("sha256:d2562f1ae1d0593a26c54006ad0a6211c35fdc8b4067485d7208000d83477de2"),
+		Size:      201,
+	},
+}
+
+const manifestSchema2ConfigDigest = `sha256:da5939581ac835614e3cf6c765e7489e6d0fc602a44e98c07013f1c938f49675`
+
+var manifestSchema2ConfigDescriptor = distribution.Descriptor{
+	Digest:    digest.Digest(manifestSchema2ConfigDigest),
+	Size:      5838,
+	MediaType: schema2.MediaTypeConfig,
+}
+
+const manifestSchema2 = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {
+      "mediaType": "application/vnd.docker.container.image.v1+json",
+      "size": 5838,
+      "digest": "sha256:da5939581ac835614e3cf6c765e7489e6d0fc602a44e98c07013f1c938f49675"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 22488057,
+         "digest": "sha256:afeb2bfd31c0760573e7262de6ae67a84da0e0a1c3e8157bbddd41a501b18a5c"
+      },
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 21869700,
+         "digest": "sha256:7ff5d10493db2cdfc1b7238434c503cc0664d48d0f7154ea9472e734b28a72dd"
+      },
+      {
+         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+         "size": 201,
+         "digest": "sha256:d2562f1ae1d0593a26c54006ad0a6211c35fdc8b4067485d7208000d83477de2"
+      }
+   ]
+}`
+
+const manifestSchema2Invalid = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "config": {},
+   []
+}`

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -133,7 +133,7 @@ func TestPullthroughServeBlob(t *testing.T) {
 			expectedLocalCalls: map[string]int{"Stat": 1},
 		},
 	} {
-		localBlobStore := newTestBlobStore(tc.localBlobs)
+		localBlobStore := newTestBlobStore(nil, tc.localBlobs)
 
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 		repo := newTestRepository(t, namespace, name, testRepositoryOptions{
@@ -284,7 +284,7 @@ func TestPullthroughServeNotSeekableBlob(t *testing.T) {
 	})
 	registrytest.AddImage(t, fos, testImage, namespace, name, "latest")
 
-	localBlobStore := newTestBlobStore(nil)
+	localBlobStore := newTestBlobStore(nil, nil)
 
 	ctx := WithTestPassthroughToUpstream(context.Background(), false)
 	repo := newTestRepository(t, namespace, name, testRepositoryOptions{
@@ -602,7 +602,7 @@ func TestPullthroughServeBlobInsecure(t *testing.T) {
 
 		tc.fakeOpenShiftInit(fos)
 
-		localBlobStore := newTestBlobStore(tc.localBlobs)
+		localBlobStore := newTestBlobStore(nil, tc.localBlobs)
 
 		ctx := WithTestPassthroughToUpstream(context.Background(), false)
 
@@ -680,9 +680,13 @@ func makeDigestFromBytes(data []byte) digest.Digest {
 	return digest.Digest(fmt.Sprintf("sha256:%x", sha256.Sum256(data)))
 }
 
+type blobContents map[digest.Digest][]byte
+type blobDescriptors map[digest.Digest]distribution.Descriptor
+
 type testBlobStore struct {
+	blobDescriptors blobDescriptors
 	// blob digest mapped to content
-	blobs map[digest.Digest][]byte
+	blobs blobContents
 	// method name mapped to number of invocations
 	calls       map[string]int
 	bytesServed int64
@@ -690,19 +694,29 @@ type testBlobStore struct {
 
 var _ distribution.BlobStore = &testBlobStore{}
 
-func newTestBlobStore(blobs map[digest.Digest][]byte) *testBlobStore {
-	b := make(map[digest.Digest][]byte)
+func newTestBlobStore(blobDescriptors blobDescriptors, blobs blobContents) *testBlobStore {
+	bs := make(map[digest.Digest][]byte)
 	for d, content := range blobs {
-		b[d] = content
+		bs[d] = content
+	}
+	bds := make(map[digest.Digest]distribution.Descriptor)
+	for d, desc := range blobDescriptors {
+		bds[d] = desc
 	}
 	return &testBlobStore{
-		blobs: b,
-		calls: make(map[string]int),
+		blobDescriptors: bds,
+		blobs:           bs,
+		calls:           make(map[string]int),
 	}
 }
 
 func (t *testBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
 	t.calls["Stat"]++
+	desc, exists := t.blobDescriptors[dgst]
+	if exists {
+		return desc, nil
+	}
+
 	content, exists := t.blobs[dgst]
 	if !exists {
 		return distribution.Descriptor{}, distribution.ErrBlobUnknown

--- a/pkg/dockerregistry/server/util.go
+++ b/pkg/dockerregistry/server/util.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -10,18 +9,12 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/api/errcode"
 	disterrors "github.com/docker/distribution/registry/api/v2"
 	quotautil "github.com/openshift/origin/pkg/quota/util"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
-	kapi "k8s.io/kubernetes/pkg/api"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	"github.com/openshift/origin/pkg/dockerregistry/server/client"
@@ -218,173 +211,4 @@ func (g *cachedImageStreamGetter) get() (*imageapiv1.ImageStream, error) {
 func (g *cachedImageStreamGetter) cacheImageStream(is *imageapiv1.ImageStream) {
 	context.GetLogger(g.ctx).Debugf("(*cachedImageStreamGetter).cacheImageStream: got image stream %s/%s", is.Namespace, is.Name)
 	g.cachedImageStream = is
-}
-
-// imageMetadataFromManifest is used only when creating the image stream mapping
-// in registry. In that case the image stream mapping contains image with the
-// manifest and we have to pupulate the the docker image metadata field.
-func imageMetadataFromManifest(image *imageapiv1.Image) error {
-	// Manifest must be set in order for this function to work as we extracting
-	// all metadata from the manifest.
-	if len(image.DockerImageManifest) == 0 {
-		return nil
-	}
-
-	// If we already have metadata don't mutate existing metadata.
-	meta, ok := image.DockerImageMetadata.Object.(*imageapi.DockerImage)
-	hasMetadata := ok && meta.Size > 0
-	if len(image.DockerImageLayers) > 0 && hasMetadata && len(image.DockerImageManifestMediaType) > 0 {
-		return nil
-	}
-
-	manifestData := image.DockerImageManifest
-
-	manifest := imageapi.DockerImageManifest{}
-	if err := json.Unmarshal([]byte(manifestData), &manifest); err != nil {
-		return err
-	}
-
-	switch manifest.SchemaVersion {
-	case 0:
-		// legacy config object
-	case 1:
-		image.DockerImageManifestMediaType = schema1.MediaTypeManifest
-
-		if len(manifest.History) == 0 {
-			// should never have an empty history, but just in case...
-			return nil
-		}
-
-		v1Metadata := imageapi.DockerV1CompatibilityImage{}
-		if err := json.Unmarshal([]byte(manifest.History[0].DockerV1Compatibility), &v1Metadata); err != nil {
-			return err
-		}
-
-		image.DockerImageLayers = make([]imageapiv1.ImageLayer, len(manifest.FSLayers))
-		for i, layer := range manifest.FSLayers {
-			image.DockerImageLayers[i].MediaType = schema1.MediaTypeManifestLayer
-			image.DockerImageLayers[i].Name = layer.DockerBlobSum
-		}
-		if len(manifest.History) == len(image.DockerImageLayers) {
-			// This code does not work for images converted from v2 to v1, since V1Compatibility does not
-			// contain size information in this case.
-			image.DockerImageLayers[0].LayerSize = v1Metadata.Size
-			var size = imageapi.DockerV1CompatibilityImageSize{}
-			for i, obj := range manifest.History[1:] {
-				size.Size = 0
-				if err := json.Unmarshal([]byte(obj.DockerV1Compatibility), &size); err != nil {
-					continue
-				}
-				image.DockerImageLayers[i+1].LayerSize = size.Size
-			}
-		}
-		// reverse order of the layers for v1 (lowest = 0, highest = i)
-		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
-			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
-		}
-
-		dockerImage := &imageapi.DockerImage{}
-
-		dockerImage.ID = v1Metadata.ID
-		dockerImage.Parent = v1Metadata.Parent
-		dockerImage.Comment = v1Metadata.Comment
-		dockerImage.Created = v1Metadata.Created
-		dockerImage.Container = v1Metadata.Container
-		dockerImage.ContainerConfig = v1Metadata.ContainerConfig
-		dockerImage.DockerVersion = v1Metadata.DockerVersion
-		dockerImage.Author = v1Metadata.Author
-		dockerImage.Config = v1Metadata.Config
-		dockerImage.Architecture = v1Metadata.Architecture
-		if len(image.DockerImageLayers) > 0 {
-			size := int64(0)
-			layerSet := sets.NewString()
-			for _, layer := range image.DockerImageLayers {
-				if layerSet.Has(layer.Name) {
-					continue
-				}
-				layerSet.Insert(layer.Name)
-				size += layer.LayerSize
-			}
-			dockerImage.Size = size
-		} else {
-			dockerImage.Size = v1Metadata.Size
-		}
-
-		image.DockerImageMetadata.Object = dockerImage
-	case 2:
-		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
-
-		if len(image.DockerImageConfig) == 0 {
-			return fmt.Errorf("dockerImageConfig must not be empty for manifest schema 2")
-		}
-		config := imageapi.DockerImageConfig{}
-		if err := json.Unmarshal([]byte(image.DockerImageConfig), &config); err != nil {
-			return fmt.Errorf("failed to parse dockerImageConfig: %v", err)
-		}
-
-		image.DockerImageLayers = make([]imageapiv1.ImageLayer, len(manifest.Layers))
-		for i, layer := range manifest.Layers {
-			image.DockerImageLayers[i].Name = layer.Digest
-			image.DockerImageLayers[i].LayerSize = layer.Size
-			image.DockerImageLayers[i].MediaType = layer.MediaType
-		}
-		// reverse order of the layers for v1 (lowest = 0, highest = i)
-		for i, j := 0, len(image.DockerImageLayers)-1; i < j; i, j = i+1, j-1 {
-			image.DockerImageLayers[i], image.DockerImageLayers[j] = image.DockerImageLayers[j], image.DockerImageLayers[i]
-		}
-		dockerImage := &imageapi.DockerImage{}
-
-		dockerImage.ID = manifest.Config.Digest
-		dockerImage.Parent = config.Parent
-		dockerImage.Comment = config.Comment
-		dockerImage.Created = config.Created
-		dockerImage.Container = config.Container
-		dockerImage.ContainerConfig = config.ContainerConfig
-		dockerImage.DockerVersion = config.DockerVersion
-		dockerImage.Author = config.Author
-		dockerImage.Config = config.Config
-		dockerImage.Architecture = config.Architecture
-		dockerImage.Size = int64(len(image.DockerImageConfig))
-
-		layerSet := sets.NewString(dockerImage.ID)
-		if len(image.DockerImageLayers) > 0 {
-			for _, layer := range image.DockerImageLayers {
-				if layerSet.Has(layer.Name) {
-					continue
-				}
-				layerSet.Insert(layer.Name)
-				dockerImage.Size += layer.LayerSize
-			}
-		}
-		image.DockerImageMetadata.Object = dockerImage
-	default:
-		return fmt.Errorf("unrecognized Docker image manifest schema %d for %q (%s)", manifest.SchemaVersion, image.Name, image.DockerImageReference)
-	}
-
-	if image.DockerImageMetadata.Object != nil && len(image.DockerImageMetadata.Raw) == 0 {
-		meta, ok := image.DockerImageMetadata.Object.(*imageapi.DockerImage)
-		if !ok {
-			return fmt.Errorf("docker image metadata object is not docker image")
-		}
-		gvString := image.DockerImageMetadataVersion
-		if len(gvString) == 0 {
-			gvString = "1.0"
-		}
-		if !strings.Contains(gvString, "/") {
-			gvString = "/" + gvString
-		}
-
-		version, err := schema.ParseGroupVersion(gvString)
-		if err != nil {
-			return err
-		}
-		data, err := runtime.Encode(kapi.Codecs.LegacyCodec(version), meta)
-		if err != nil {
-			return err
-		}
-		image.DockerImageMetadata.Raw = data
-		image.DockerImageMetadataVersion = version.Version
-	}
-
-	return nil
 }

--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -51,6 +51,10 @@ const (
 	// downconverted.
 	ImporterPreferOSAnnotation = "importer.image.openshift.io/prefer-os"
 
+	// ImageManifestBlobStoredAnnotation indicates that manifest and config blobs of image are stored in on
+	// storage of integrated Docker registry.
+	ImageManifestBlobStoredAnnotation = "image.openshift.io/manifestBlobStored"
+
 	// DefaultImageTag is used when an image tag is needed and the configuration does not specify a tag to use.
 	DefaultImageTag = "latest"
 

--- a/pkg/image/registry/image/strategy.go
+++ b/pkg/image/registry/image/strategy.go
@@ -43,6 +43,10 @@ func (s imageStrategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Obje
 	if err := util.ImageWithMetadata(newImage); err != nil {
 		utilruntime.HandleError(fmt.Errorf("Unable to update image metadata for %q: %v", newImage.Name, err))
 	}
+	if newImage.Annotations[imageapi.ImageManifestBlobStoredAnnotation] == "true" {
+		newImage.DockerImageManifest = ""
+		newImage.DockerImageConfig = ""
+	}
 }
 
 // Validate validates a new image.
@@ -115,6 +119,11 @@ func (s imageStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime
 
 	if err = util.ImageWithMetadata(newImage); err != nil {
 		utilruntime.HandleError(fmt.Errorf("Unable to update image metadata for %q: %v", newImage.Name, err))
+	}
+
+	if newImage.Annotations[imageapi.ImageManifestBlobStoredAnnotation] == "true" {
+		newImage.DockerImageManifest = ""
+		newImage.DockerImageConfig = ""
 	}
 }
 


### PR DESCRIPTION
Instead of filling metadata in the image object in the registry, send the manifest and config blobs to the master and let it do the job.

Resolves #16306
Resolves: [bz#1491589](https://bugzilla.redhat.com/show_bug.cgi?id=1491589)