### PR TITLE
Fix UDP service blackhole problem when number of endpoints changes from 0 to non-0

### DIFF
--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -21,6 +21,7 @@ RUN dnf -y update && dnf -y install\
  bridge-utils\
  ethtool\
  iptables-services\
+ conntrack-tools\
  openvswitch\
  python-netaddr\
  python2-pyroute2\

--- a/origin.spec
+++ b/origin.spec
@@ -121,6 +121,7 @@ Requires:       socat
 Requires:       nfs-utils
 Requires:       ethtool
 Requires:       device-mapper-persistent-data >= 0.6.2
+Requires:       conntrack-tools
 Requires(post):   systemd
 Requires(preun):  systemd
 Requires(postun): systemd


### PR DESCRIPTION
When a UDP service goes from 0 endpoints to 1, we need to run "conntrack -D ..." in case there are cached conntrack entries from pods hitting the "-j REJECT" iptables rule that gets installed for services with no endpoints.

Additionally, we need to make sure that OpenShift nodes have conntrack-tools installed so that they can actually run /sbin/conntrack in this and other cases. (There are additional bugs open about fixing the official images.)

Upstream: https://github.com/kubernetes/kubernetes/pull/48524
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1487438