### PR TITLE
Require cluster id for AWS

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -384,6 +384,13 @@ func BuildControllerManagerServer(masterConfig configapi.MasterConfig) (*cmapp.C
 		return nil, nil, err
 	}
 	if cloud != nil {
+		if cloud.HasClusterID() == false {
+			if cmserver.AllowUntaggedCloud == true {
+				glog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")
+			} else {
+				return nil, nil, fmt.Errorf("no ClusterID Found.  A ClusterID is required for the cloud provider to function properly.  This check can be bypassed by setting the allow-untagged-cloud option")
+			}
+		}
 		glog.V(2).Infof("Successfully initialized cloud provider: %q from the config file: %q\n", cmserver.CloudProvider, cmserver.CloudConfigFile)
 	}
 

--- a/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/options/options.go
@@ -71,6 +71,8 @@ func (s *CloudControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(componentconfig.IPVar{Val: &s.Address}, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider, "The provider of cloud services. Cannot be empty.")
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
+	fs.BoolVar(&s.AllowUntaggedCloud, "allow-untagged-cloud", false, "Allow the cluster to run without the cluster-id on cloud instances.  This is a legacy mode of operation and a cluster-id will be required in the future.")
+	fs.MarkDeprecated("allow-untagged-cloud", "This flag is deprecated and will be removed in a future release.  A cluster-id will be required on cloud instances")
 	fs.DurationVar(&s.MinResyncPeriod.Duration, "min-resync-period", s.MinResyncPeriod.Duration, "The resync period in reflectors will be random between MinResyncPeriod and 2*MinResyncPeriod")
 	fs.DurationVar(&s.NodeMonitorPeriod.Duration, "node-monitor-period", s.NodeMonitorPeriod.Duration,
 		"The period for syncing NodeStatus in NodeController.")

--- a/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/controller-manager.go
+++ b/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/controller-manager.go
@@ -61,6 +61,14 @@ func main() {
 		glog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}
 
+	if cloud.HasClusterID() == false {
+		if s.AllowUntaggedCloud == true {
+			glog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")
+		} else {
+			glog.Fatalf("no ClusterID Found.  A ClusterID is required for the cloud provider to function properly.  This check can be bypassed by setting the allow-untagged-cloud option")
+		}
+	}
+
 	if err := app.Run(s, cloud); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -405,6 +405,14 @@ func CreateControllerContext(s *options.CMServer, rootClientBuilder, clientBuild
 	if cloud != nil {
 		// Initialize the cloud provider with a reference to the clientBuilder
 		cloud.Initialize(rootClientBuilder)
+
+		if cloud.HasClusterID() == false {
+			if s.AllowUntaggedCloud == true {
+				glog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")
+			} else {
+				return ControllerContext{}, fmt.Errorf("no ClusterID Found.  A ClusterID is required for the cloud provider to function properly.  This check can be bypassed by setting the allow-untagged-cloud option")
+			}
+		}
 	}
 
 	ctx := ControllerContext{

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
@@ -134,6 +134,8 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.BoolVar(&s.UseServiceAccountCredentials, "use-service-account-credentials", s.UseServiceAccountCredentials, "If true, use individual service account credentials for each controller.")
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider, "The provider for cloud services.  Empty string for no provider.")
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
+	fs.BoolVar(&s.AllowUntaggedCloud, "allow-untagged-cloud", false, "Allow the cluster to run without the cluster-id on cloud instances.  This is a legacy mode of operation and a cluster-id will be required in the future.")
+	fs.MarkDeprecated("allow-untagged-cloud", "This flag is deprecated and will be removed in a future release.  A cluster-id will be required on cloud instances")
 	fs.Int32Var(&s.ConcurrentEndpointSyncs, "concurrent-endpoint-syncs", s.ConcurrentEndpointSyncs, "The number of endpoint syncing operations that will be done concurrently. Larger number = faster endpoint updating, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentRCSyncs, "concurrent_rc_syncs", s.ConcurrentRCSyncs, "The number of replication controllers that are allowed to sync concurrently. Larger number = more responsive replica management, but more CPU (and network) load")

--- a/vendor/k8s.io/kubernetes/pkg/apis/componentconfig/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/componentconfig/types.go
@@ -671,6 +671,8 @@ type KubeControllerManagerConfiguration struct {
 	CloudProvider string
 	// cloudConfigFile is the path to the cloud provider configuration file.
 	CloudConfigFile string
+	// run with untagged cloud instances
+	AllowUntaggedCloud bool
 	// concurrentEndpointSyncs is the number of endpoint syncing operations
 	// that will be done concurrently. Larger number = faster endpoint updating,
 	// but more CPU (and network) load.

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/cloud.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/cloud.go
@@ -45,6 +45,8 @@ type Interface interface {
 	ProviderName() string
 	// ScrubDNS provides an opportunity for cloud-provider-specific code to process DNS settings for pods.
 	ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string)
+	// HasClusterID returns true if a ClusterID is required and set
+	HasClusterID() bool
 }
 
 // Clusters is an abstract, pluggable interface for clusters of containers.

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
@@ -947,6 +947,11 @@ func (c *Cloud) Routes() (cloudprovider.Routes, bool) {
 	return c, true
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (c *Cloud) HasClusterID() bool {
+	return len(c.tagging.clusterID()) > 0
+}
+
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/tags.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/tags.go
@@ -276,3 +276,7 @@ func (t *awsTagging) buildTags(lifecycle ResourceLifecycle, additionalTags map[s
 
 	return tags
 }
+
+func (t *awsTagging) clusterID() string {
+	return t.ClusterID
+}

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/tags.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/tags.go
@@ -75,7 +75,7 @@ func (t *awsTagging) init(legacyClusterID string, clusterID string) error {
 	if clusterID != "" {
 		glog.Infof("AWS cloud filtering on ClusterID: %v", clusterID)
 	} else {
-		glog.Infof("AWS cloud - no clusterID filtering")
+		glog.Warning("AWS cloud - no clusterID filtering applied for shared resources; do not run multiple clusters in this AZ.")
 	}
 
 	return nil

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure.go
@@ -290,6 +290,11 @@ func (az *Cloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []stri
 	return nameservers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (az *Cloud) HasClusterID() bool {
+	return true
+}
+
 // ProviderName returns the cloud provider ID.
 func (az *Cloud) ProviderName() string {
 	return CloudProviderName

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -120,6 +120,11 @@ func (cs *CSCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 	return nameservers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (cs *CSCloud) HasClusterID() bool {
+	return true
+}
+
 // GetZone returns the Zone containing the region that the program is running in.
 func (cs *CSCloud) GetZone() (cloudprovider.Zone, error) {
 	glog.V(2).Infof("Current zone is %v", cs.zone)

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/fake/fake.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/fake/fake.go
@@ -111,6 +111,11 @@ func (f *FakeCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []s
 	return nameservers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (f *FakeCloud) HasClusterID() bool {
+	return true
+}
+
 // LoadBalancer returns a fake implementation of LoadBalancer.
 // Actually it just returns f itself.
 func (f *FakeCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce.go
@@ -362,6 +362,11 @@ func (gce *GCECloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []
 	return nameservers, srchOut
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (gce *GCECloud) HasClusterID() bool {
+	return true
+}
+
 // GCECloud implements cloudprovider.Interface.
 var _ cloudprovider.Interface = (*GCECloud)(nil)
 

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/mesos/mesos.go
@@ -313,3 +313,8 @@ func (c *MesosCloud) NodeAddresses(nodeName types.NodeName) ([]v1.NodeAddress, e
 func (c *MesosCloud) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress, error) {
 	return []v1.NodeAddress{}, errors.New("unimplemented")
 }
+
+// HasClusterID returns true if the cluster has a clusterID
+func (c *MesosCloud) HasClusterID() bool {
+	return true
+}

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
@@ -424,6 +424,11 @@ func (os *OpenStack) ScrubDNS(nameServers, searches []string) ([]string, []strin
 	return nameServers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (os *OpenStack) HasClusterID() bool {
+	return true
+}
+
 func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	glog.V(4).Info("openstack.LoadBalancer() called")
 

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -134,6 +134,11 @@ func (v *OVirtCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []
 	return nameservers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (v *OVirtCloud) HasClusterID() bool {
+	return true
+}
+
 // LoadBalancer returns an implementation of LoadBalancer for oVirt cloud
 func (v *OVirtCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return nil, false

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/photon/photon.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/photon/photon.go
@@ -539,6 +539,11 @@ func (pc *PCCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 	return nameservers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (pc *PCCloud) HasClusterID() bool {
+	return true
+}
+
 // Attaches given virtual disk volume to the compute running kubelet.
 func (pc *PCCloud) AttachDisk(pdID string, nodeName k8stypes.NodeName) error {
 	photonClient, err := getPhotonClient(pc)

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -466,6 +466,11 @@ func (os *Rackspace) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []
 	return nameservers, searches
 }
 
+// HasClusterID returns true if the cluster has a clusterID
+func (os *Rackspace) HasClusterID() bool {
+	return true
+}
+
 func (os *Rackspace) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	return nil, false
 }

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -1930,3 +1930,8 @@ func removeClusterFromVDiskPath(vDiskPath string) string {
 	}
 	return vDiskPath
 }
+
+// HasClusterID returns true if the cluster has a clusterID
+func (vs *VSphere) HasClusterID() bool {
+	return true
+}


### PR DESCRIPTION
Backporting of:

https://github.com/kubernetes/kubernetes/pull/48612
https://github.com/kubernetes/kubernetes/pull/49215

Plus changes in master-controller startup to look for the flag to allow untagged clouds or exit.