### PR TITLE
Decrement retries count during migration

### DIFF
--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -385,7 +385,6 @@ type migrateTracker struct {
 	dryRun    bool
 
 	found, ignored, unchanged, errors int
-	retries                           int
 
 	resourcesWithErrors sets.String
 }
@@ -408,8 +407,7 @@ func (t *migrateTracker) report(prefix string, info *resource.Info, err error) {
 // to retries times.
 func (t *migrateTracker) attempt(info *resource.Info, retries int) {
 	t.found++
-	t.retries = retries
-	result, err := t.try(info)
+	result, err := t.try(info, retries)
 	switch {
 	case err != nil:
 		t.resourcesWithErrors.Insert(info.Mapping.Resource)
@@ -438,7 +436,7 @@ func (t *migrateTracker) attempt(info *resource.Info, retries int) {
 
 // try will mutate the info and attempt to save, recalculating if there are any retries left.
 // The result of the attempt or an error will be returned.
-func (t *migrateTracker) try(info *resource.Info) (attemptResult, error) {
+func (t *migrateTracker) try(info *resource.Info, retries int) (attemptResult, error) {
 	reporter, err := t.migrateFn(info)
 	if err != nil {
 		return attemptResultError, err
@@ -455,11 +453,11 @@ func (t *migrateTracker) try(info *resource.Info) (attemptResult, error) {
 				return attemptResultUnchanged, nil
 			}
 			if canRetry(err) {
-				if t.retries > 0 {
+				if retries > 0 {
 					if bool(glog.V(1)) && err != ErrRecalculate {
 						t.report("retry:", info, err)
 					}
-					result, err := t.try(info)
+					result, err := t.try(info, retries-1)
 					switch result {
 					case attemptResultUnchanged, attemptResultIgnore:
 						result = attemptResultSuccess


### PR DESCRIPTION
This change fixes a bug in the migration command that could lead to it being permanently stuck in a retry loop.  This would only happen if some other entity continuously changed a resource that was in the process of being migrated.  The command would then attempt to retry due to the conflict error.  Since the retry count was never decremented, the migration would essentially be stuck in an infinite loop.  To avoid having to mutate global state, `retries` was removed as a field of `migrateTracker`.  It is instead directly passed to the `try` function and thus is reset on every invocation of `result.Visit`.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @smarterclayton

@sdodson @jupierce you saw this during an upgrade: https://bugzilla.redhat.com/show_bug.cgi?id=1489168