### PR TITLE
handle build describer edge-case

### DIFF
--- a/pkg/oc/cli/describe/describer.go
+++ b/pkg/oc/cli/describe/describer.go
@@ -226,7 +226,12 @@ func describeBuildDuration(build *buildapi.Build) string {
 		// time a still running build has been running in a pod
 		duration := metav1.Now().Rfc3339Copy().Time.Sub(build.Status.StartTimestamp.Rfc3339Copy().Time)
 		return fmt.Sprintf("running for %v", duration)
+	} else if build.Status.CompletionTimestamp == nil &&
+		build.Status.StartTimestamp == nil &&
+		build.Status.Phase == buildapi.BuildPhaseCancelled {
+		return "<none>"
 	}
+
 	duration := build.Status.CompletionTimestamp.Rfc3339Copy().Time.Sub(build.Status.StartTimestamp.Rfc3339Copy().Time)
 	return fmt.Sprintf("%v", duration)
 }


### PR DESCRIPTION
Potentially addresses the panic seen in: 
https://bugzilla.redhat.com/show_bug.cgi?id=1482045

Fix potential cause for panic in build-duration describer.
Whenever a build's status contained a nil StartTimestamp &
a nil CompletionStamp & the build.Status.Phase == "Cancelled",
the default attempt at obtaining a duration value would try to
access an `Rfc3339Copy().Time` value from the nil
build.Status.CompletionTimeStamp.

cc @openshift/cli-review 