### PR TITLE
Changed the "no password" test to expect an HTTP 401 status

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -95,7 +95,7 @@ var _ = g.Describe("[Conformance][networking][router] openshift router metrics",
 			defer func() { oc.AdminKubeClient().Core().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
 			g.By("preventing access without a username and password")
-			err = expectURLStatusCodeExec(ns, execPodName, fmt.Sprintf("http://%s:%d/metrics", host, statsPort), 403)
+			err = expectURLStatusCodeExec(ns, execPodName, fmt.Sprintf("http://%s:%d/metrics", host, statsPort), 401)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("checking for the expected metrics")


### PR DESCRIPTION
Before the test would expect an HTTP 403 status code when no password
was sent.  But we changed the code to send a 401 when the password is
not provided so that browsers will prompt the user for a password.

This changes the test to match the expected behavior.