### PR TITLE
Added networking team members to the relevant oc adm commands

### DIFF
--- a/pkg/oc/admin/diagnostics/OWNERS
+++ b/pkg/oc/admin/diagnostics/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - fabianofranz
+  - juanvallejo
+  - knobunc
+  - pravisankar
+  - rajatchopra
+approvers:
+  - fabianofranz
+  - knobunc
+  - pravisankar

--- a/pkg/oc/admin/router/OWNERS
+++ b/pkg/oc/admin/router/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - fabianofranz
+  - juanvallejo
+  - knobunc
+  - pecameron
+  - pravisankar
+  - rajatchopra
+approvers:
+  - fabianofranz
+  - knobunc
+  - rajatchopra


### PR DESCRIPTION
The networking team owns 'oc adm router' and parts of 'oc adm
diagnostics' so I've added relevant team members to the owners files.