### PR TITLE
UPSTREAM: 53606: use deployment pod template if 0 replicas

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -29,10 +29,8 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
-	deployutil "github.com/openshift/origin/pkg/apps/util"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/cmd/util"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
 // New creates a default Factory for commands that should share identical server
@@ -145,87 +143,6 @@ func (f *Factory) ExtractFileContents(obj runtime.Object) (map[string][]byte, bo
 		return out, true, nil
 	default:
 		return nil, false, nil
-	}
-}
-
-// ApproximatePodTemplateForObject returns a pod template object for the provided source.
-// It may return both an error and a object. It attempt to return the best possible template
-// available at the current time.
-func (f *Factory) ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error) {
-	switch t := object.(type) {
-	case *imageapi.ImageStreamTag:
-		// create a minimal pod spec that uses the image referenced by the istag without any introspection
-		// it possible that we could someday do a better job introspecting it
-		return &api.PodTemplateSpec{
-			Spec: api.PodSpec{
-				RestartPolicy: api.RestartPolicyNever,
-				Containers: []api.Container{
-					{Name: "container-00", Image: t.Image.DockerImageReference},
-				},
-			},
-		}, nil
-	case *imageapi.ImageStreamImage:
-		// create a minimal pod spec that uses the image referenced by the istag without any introspection
-		// it possible that we could someday do a better job introspecting it
-		return &api.PodTemplateSpec{
-			Spec: api.PodSpec{
-				RestartPolicy: api.RestartPolicyNever,
-				Containers: []api.Container{
-					{Name: "container-00", Image: t.Image.DockerImageReference},
-				},
-			},
-		}, nil
-	case *deployapi.DeploymentConfig:
-		fallback := t.Spec.Template
-
-		kc, err := f.ClientSet()
-		if err != nil {
-			return fallback, err
-		}
-
-		latestDeploymentName := deployutil.LatestDeploymentNameForConfig(t)
-		deployment, err := kc.Core().ReplicationControllers(t.Namespace).Get(latestDeploymentName, metav1.GetOptions{})
-		if err != nil {
-			return fallback, err
-		}
-
-		fallback = deployment.Spec.Template
-
-		pods, err := kc.Core().Pods(deployment.Namespace).List(metav1.ListOptions{LabelSelector: labels.SelectorFromSet(deployment.Spec.Selector).String()})
-		if err != nil {
-			return fallback, err
-		}
-
-		for i := range pods.Items {
-			pod := &pods.Items[i]
-			if fallback == nil || pod.CreationTimestamp.Before(fallback.CreationTimestamp) {
-				fallback = &api.PodTemplateSpec{
-					ObjectMeta: pod.ObjectMeta,
-					Spec:       pod.Spec,
-				}
-			}
-		}
-		return fallback, nil
-
-	default:
-		pod, err := f.AttachablePodForObject(object, 1*time.Minute)
-		if pod != nil {
-			return &api.PodTemplateSpec{
-				ObjectMeta: pod.ObjectMeta,
-				Spec:       pod.Spec,
-			}, err
-		}
-		switch t := object.(type) {
-		case *api.ReplicationController:
-			return t.Spec.Template, err
-		case *extensions.ReplicaSet:
-			return &t.Spec.Template, err
-		case *extensions.DaemonSet:
-			return &t.Spec.Template, err
-		case *batch.Job:
-			return &t.Spec.Template, err
-		}
-		return nil, err
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/testing/fake.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/testing/fake.go
@@ -437,6 +437,10 @@ func (f *FakeFactory) AttachablePodForObject(ob runtime.Object, timeout time.Dur
 	return nil, nil
 }
 
+func (f *FakeFactory) ApproximatePodTemplateForObject(obj runtime.Object) (*api.PodTemplateSpec, error) {
+	return f.ApproximatePodTemplateForObject(obj)
+}
+
 func (f *FakeFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
 	return false, nil
 }
@@ -677,6 +681,10 @@ func (f *fakeAPIFactory) AttachablePodForObject(object runtime.Object, timeout t
 		}
 		return nil, fmt.Errorf("cannot attach to %v: not implemented", gvks[0])
 	}
+}
+
+func (f *fakeAPIFactory) ApproximatePodTemplateForObject(obj runtime.Object) (*api.PodTemplateSpec, error) {
+	return f.Factory.ApproximatePodTemplateForObject(obj)
 }
 
 func (f *fakeAPIFactory) Validator(validate bool, cacheDir string) (validation.Schema, error) {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -218,6 +218,11 @@ type ObjectMappingFactory interface {
 	// AttachablePodForObject returns the pod to which to attach given an object.
 	AttachablePodForObject(object runtime.Object, timeout time.Duration) (*api.Pod, error)
 
+	// ApproximatePodTemplateForObject returns a pod template object for the provided source.
+	// It may return both an error and a object. It attempt to return the best possible template
+	// available at the current time.
+	ApproximatePodTemplateForObject(runtime.Object) (*api.PodTemplateSpec, error)
+
 	// Returns a schema that can validate objects stored on disk.
 	Validator(validate bool, cacheDir string) (validation.Schema, error)
 	// SwaggerSchema returns the schema declaration for the provided group version kind.

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -347,6 +348,28 @@ func (f *ring1Factory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusVi
 		return nil, err
 	}
 	return kubectl.StatusViewerFor(mapping.GroupVersionKind.GroupKind(), clientset)
+}
+
+func (f *ring1Factory) ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error) {
+	switch t := object.(type) {
+	case *api.Pod:
+		return &api.PodTemplateSpec{
+			ObjectMeta: t.ObjectMeta,
+			Spec:       t.Spec,
+		}, nil
+	case *api.ReplicationController:
+		return t.Spec.Template, nil
+	case *extensions.ReplicaSet:
+		return &t.Spec.Template, nil
+	case *extensions.DaemonSet:
+		return &t.Spec.Template, nil
+	case *extensions.Deployment:
+		return &t.Spec.Template, nil
+	case *batch.Job:
+		return &t.Spec.Template, nil
+	}
+
+	return nil, fmt.Errorf("unable to extract pod template from type %v", reflect.TypeOf(object))
 }
 
 func (f *ring1Factory) AttachablePodForObject(object runtime.Object, timeout time.Duration) (*api.Pod, error) {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/14286
Fixes https://github.com/openshift/origin/issues/14915

Prevent `oc debug` from hanging indefinitely when dealing
with a deployment that has been scaled down to 0.

cc @openshift/cli-review @smarterclayton 