### PR TITLE
ensure node exists if --node-name given

### DIFF
--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -272,6 +272,21 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 		}
 	}
 
+	// if a nodeName was specified, ensure node exists
+	if len(o.NodeName) > 0 {
+		r := f.NewBuilder(true).
+			NamespaceParam(cmdNamespace).
+			SingleResourceType().
+			ResourceTypeOrNameArgs(true, []string{"nodes", o.NodeName}...).
+			Flatten().
+			Do()
+
+		_, err := r.Infos()
+		if err != nil {
+			return err
+		}
+	}
+
 	config, err := f.ClientConfig()
 	if err != nil {
 		return err

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -24,7 +24,7 @@ os::cmd::expect_success_and_text "oc debug -t dc/test-deployment-config -o yaml"
 os::cmd::expect_success_and_not_text "oc debug --tty=false dc/test-deployment-config -o yaml" 'tty'
 os::cmd::expect_success_and_not_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" 'stdin'
 os::cmd::expect_success_and_not_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" 'tty'
-os::cmd::expect_failure_and_text "oc debug dc/test-deployment-config --node-name=invalid -- /bin/env" 'on node "invalid"'
+os::cmd::expect_failure_and_text "oc debug dc/test-deployment-config --node-name=invalid -- /bin/env" 'nodes "invalid" not found'
 # Does not require a real resource on the server
 os::cmd::expect_success_and_not_text "oc debug -T -f examples/hello-openshift/hello-pod.json -o yaml" 'tty'
 os::cmd::expect_success_and_text "oc debug -f examples/hello-openshift/hello-pod.json --keep-liveness --keep-readiness -o yaml" ''


### PR DESCRIPTION
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1474262

Ensures a node exists before creating a debug pod (if a nodeName is specified using `--node-name`).
If a nodeName is not specified, current behavior is unchanged.

**Before**
```
$ oc debug dc/mydc --node-name="nonexistent"
Debugging with pod/<pod>, original command: container-entrypoint /usr/libexec/s2i/run
Waiting for pod to start ...

Removing debug pod ...
error: unable to create the debug pod "mydc" on node "nonexistent"
```

**After**
```
$ oc debug dc/mydc --node-name="nonexistent"
Error from server (NotFound): nodes "nonexistent" not found
```

cc @openshift/cli-review 