### PR TITLE
Pass STATS_PASSWORD and STATS_USERNAME in a secret

### DIFF
--- a/pkg/generate/app/env.go
+++ b/pkg/generate/app/env.go
@@ -104,6 +104,46 @@ func (e Environment) List() []kapi.EnvVar {
 	return env
 }
 
+type EnvVars map[string]kapi.EnvVar
+
+// Add - adds an environment variable to the current environment
+// name - is the environment variable name.
+// value - is the value (string) assigned to the environment variable.
+func (e EnvVars) Add(name, value string) {
+	e[name] = kapi.EnvVar{Name: name, Value: value}
+}
+
+// AddSecret - adds an environment variable that references a secret
+// to the current environment.
+// The secret is created elsewhere. This just sets up the environment
+// variable to reference a specified key in the named secret.
+// name - is the environment variable name.
+// secret - is the name of the previously created secret.
+// key - is the key within the secret.
+func (e EnvVars) AddSecret(name, secret, key string) {
+	e[name] = kapi.EnvVar{Name: name,
+		ValueFrom: &kapi.EnvVarSource{
+			SecretKeyRef: &kapi.SecretKeySelector{
+				LocalObjectReference: kapi.LocalObjectReference{
+					Name: secret,
+				},
+				Key: key,
+			},
+		},
+	}
+}
+
+// Create a sorted list of all environment variables
+func (e EnvVars) List() []kapi.EnvVar {
+	env := []kapi.EnvVar{}
+	for _, v := range e {
+		env = append(env, v)
+	}
+	sort.Sort(sortedEnvVar(env))
+
+	return env
+}
+
 type sortedEnvVar []kapi.EnvVar
 
 func (m sortedEnvVar) Len() int           { return len(m) }

--- a/pkg/generate/app/env_test.go
+++ b/pkg/generate/app/env_test.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestNewEnvironment(t *testing.T) {
+	envs := Environment{
+		"AA": "AAd",
+		"BB": "BBd",
+	}
+	env := NewEnvironment(envs)
+	if len(env) != 2 {
+		t.Errorf("expected two items, got %d  %v", len(env), env)
+	}
+}
+
+func TestAdd(t *testing.T) {
+	envs := Environment{}
+	env := NewEnvironment(envs)
+	if len(env) != 0 {
+		t.Errorf("expected two items, got %d  %v", len(env), env)
+	}
+	envs1 := Environment{
+		"CC": "CCd",
+	}
+	env.Add(envs1)
+	if len(env) != 1 {
+		t.Errorf("expected 1 items, got %d  %v", len(env), env)
+	}
+}
+
+func TestAddEnvVars(t *testing.T) {
+	env := EnvVars{}
+	env.Add("CC", "CCd")
+	if len(env) != 1 {
+		t.Errorf("expected 1 items, got %d  %v", len(env), env)
+	}
+}
+
+func TestAddSecret(t *testing.T) {
+	env := EnvVars{}
+	env.AddSecret("CC", "CCd", "CCs")
+	if len(env) != 1 {
+		t.Errorf("expected 1 items, got %d %v", len(env), env)
+	}
+}
+
+func TestListEnvars(t *testing.T) {
+	env := EnvVars{}
+	env.AddSecret("CC", "CCd", "CCs")
+	env.Add("DD", "DDd")
+	if len(env) != 2 {
+		t.Errorf("expected 2 items, got %d %v", len(env), env)
+	}
+	envvars := env.List()
+	if len(envvars) != 2 {
+		t.Errorf("expected 2 items, got %d  %v", len(envvars), envvars)
+	}
+
+}

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -42,10 +42,13 @@ os::cmd::expect_failure_and_text 'oc adm router --dry-run --host-network=false -
 os::cmd::expect_failure_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --router-canonical-hostname=1.2.3.4 -o yaml' 'error: canonical hostname must not be an IP address'
 # max_conn
 os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --max-connections=14583 -o yaml' '14583'
-# ciphers 
+# ciphers
 os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --ciphers=modern -o yaml' 'modern'
 # strict-sni
 os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --strict-sni -o yaml' 'ROUTER_STRICT_SNI'
+
+# stats username and password
+os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --stats-password="xxx" --stats-user="statman" -o yaml' 'name: router-stats'
 
 # mount tls crt as secret
 os::cmd::expect_success_and_not_text 'oc adm router --dry-run --host-network=false --host-ports=false -o yaml' 'value: /etc/pki/tls/private/tls.crt'
@@ -69,6 +72,7 @@ os::cmd::expect_success_and_text 'oc get dc/router -o yaml' 'readinessProbe'
 # delete the router and deployment config, leaving the clusterrolebinding and service account
 os::cmd::expect_success_and_text "oc delete svc/router" 'service "router" deleted'
 os::cmd::expect_success_and_text "oc delete dc/router" 'deploymentconfig "router" deleted'
+os::cmd::expect_success_and_text "oc delete secret/router-stats" 'secret "router-stats" deleted'
 # create a router and check for success with a warning about the existing clusterrolebinding
 os::cmd::expect_success_and_text "oc adm router" 'warning: clusterrolebindings "router-router-role" already exists'
 


### PR DESCRIPTION
The router statistics page is protected by a username/password
login. The username and password are passed in the clear in environment
variables that are displayed in the clear in the dc and pod.

This change places the username and password into a secret and mentions
the secret in the environment variables in the dc and pod. The
information is in the clear in the running router pod (oc rsh <router> env)

https://trello.com/c/oMw9La1n/502-3-sccfsi-haproxy-statistics-page-password-is-stored-in-cleartext-routersecurity