### PR TITLE
add ownerrefs to SSCS

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -229,7 +229,7 @@ func init() {
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraServiceServingCertServiceAccountName},
 		Rules: []rbac.PolicyRule{
 			rbac.NewRule("list", "watch", "update").Groups(kapiGroup).Resources("services").RuleOrDie(),
-			rbac.NewRule("get", "list", "watch", "create", "update").Groups(kapiGroup).Resources("secrets").RuleOrDie(),
+			rbac.NewRule("get", "list", "watch", "create", "update", "delete").Groups(kapiGroup).Resources("secrets").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/pkg/controller/ownerref.go
+++ b/pkg/controller/ownerref.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapihelper "k8s.io/kubernetes/pkg/api/helper"
+)
+
+// EnsureOwnerRef adds the ownerref if needed. Removes ownerrefs with conflicting UIDs.
+// Returns true if the input is mutated.
+func EnsureOwnerRef(metadata metav1.Object, newOwnerRef metav1.OwnerReference) bool {
+	foundButNotEqual := false
+	for _, existingOwnerRef := range metadata.GetOwnerReferences() {
+		if existingOwnerRef.APIVersion == newOwnerRef.APIVersion &&
+			existingOwnerRef.Kind == newOwnerRef.Kind &&
+			existingOwnerRef.Name == newOwnerRef.Name {
+
+			// if we're completely the same, there's nothing to do
+			if kapihelper.Semantic.DeepEqual(existingOwnerRef, newOwnerRef) {
+				return false
+			}
+
+			foundButNotEqual = true
+			break
+		}
+	}
+
+	// if we weren't found, then we just need to add ourselves
+	if !foundButNotEqual {
+		metadata.SetOwnerReferences(append(metadata.GetOwnerReferences(), newOwnerRef))
+		return true
+	}
+
+	// if we need to remove an existing ownerRef, just do the easy thing and build it back from scratch
+	newOwnerRefs := []metav1.OwnerReference{newOwnerRef}
+	for i := range metadata.GetOwnerReferences() {
+		existingOwnerRef := metadata.GetOwnerReferences()[i]
+		if existingOwnerRef.APIVersion == newOwnerRef.APIVersion &&
+			existingOwnerRef.Kind == newOwnerRef.Kind &&
+			existingOwnerRef.Name == newOwnerRef.Name {
+			continue
+		}
+		newOwnerRefs = append(newOwnerRefs, existingOwnerRef)
+	}
+	metadata.SetOwnerReferences(newOwnerRefs)
+	return true
+}
+
+// HasOwnerRef checks to see if an object has a particular owner.  It is not opinionated about
+// the bool fields
+func HasOwnerRef(metadata metav1.Object, needle metav1.OwnerReference) bool {
+	for _, existingOwnerRef := range metadata.GetOwnerReferences() {
+		if existingOwnerRef.APIVersion == needle.APIVersion &&
+			existingOwnerRef.Kind == needle.Kind &&
+			existingOwnerRef.Name == needle.Name &&
+			existingOwnerRef.UID == needle.UID {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/ownerref_test.go
+++ b/pkg/controller/ownerref_test.go
@@ -1,0 +1,221 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kapihelper "k8s.io/kubernetes/pkg/api/helper"
+)
+
+func TestEnsureOwnerRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            *metav1.ObjectMeta
+		newOwnerRef    metav1.OwnerReference
+		expectedOwners []metav1.OwnerReference
+		expectedReturn bool
+	}{
+		{
+			name: "empty",
+			obj:  &metav1.ObjectMeta{},
+			newOwnerRef: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expectedOwners: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+			},
+			expectedReturn: true,
+		},
+		{
+			name: "add",
+			obj: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+				},
+			},
+			newOwnerRef: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expectedOwners: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+				{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+			},
+			expectedReturn: true,
+		},
+		{
+			name: "skip",
+			obj: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+					{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+				},
+			},
+			newOwnerRef: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expectedOwners: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+				{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+			},
+			expectedReturn: false,
+		},
+		{
+			name: "replace on uid",
+			obj: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+					{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("bad-uid")},
+				},
+			},
+			newOwnerRef: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expectedOwners: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+				{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+			},
+			expectedReturn: true,
+		},
+		{
+			name: "preserve controller",
+			obj: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+					{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+				},
+			},
+			newOwnerRef: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), Controller: boolPtr(true),
+			},
+			expectedOwners: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), Controller: boolPtr(true)},
+				{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+			},
+			expectedReturn: true,
+		},
+		{
+			name: "preserve block",
+			obj: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+					{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid")},
+				},
+			},
+			newOwnerRef: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), BlockOwnerDeletion: boolPtr(false),
+			},
+			expectedOwners: []metav1.OwnerReference{
+				{APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), BlockOwnerDeletion: boolPtr(false)},
+				{APIVersion: "v1", Kind: "Foo", Name: "the-other", UID: types.UID("other-uid")},
+			},
+			expectedReturn: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualReturn := EnsureOwnerRef(tc.obj, tc.newOwnerRef)
+			if tc.expectedReturn != actualReturn {
+				t.Errorf("expected %v, got %v", tc.expectedReturn, actualReturn)
+				return
+			}
+			if !kapihelper.Semantic.DeepEqual(tc.expectedOwners, tc.obj.OwnerReferences) {
+				t.Errorf("expected %v, got %v", tc.expectedOwners, tc.obj.OwnerReferences)
+				return
+			}
+		})
+	}
+}
+
+func boolPtr(in bool) *bool {
+	return &in
+}
+
+func TestHasOwnerRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		haystack *metav1.ObjectMeta
+		needle   metav1.OwnerReference
+		expected bool
+	}{
+		{
+			name:     "empty",
+			haystack: &metav1.ObjectMeta{},
+			needle: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expected: false,
+		},
+		{
+			name: "exact",
+			haystack: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+				}},
+			},
+			needle: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expected: true,
+		},
+		{
+			name: "not uid",
+			haystack: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1", Kind: "Foo", Name: "the-name",
+				}},
+			},
+			needle: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+			},
+			expected: false,
+		},
+		{
+			name: "ignored controller",
+			haystack: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+				}},
+			},
+			needle: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), Controller: boolPtr(true),
+			},
+			expected: true,
+		},
+		{
+			name: "ignored block",
+			haystack: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"),
+				}},
+			},
+			needle: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), BlockOwnerDeletion: boolPtr(false),
+			},
+			expected: true,
+		},
+		{
+			name: "ignored both",
+			haystack: &metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), Controller: boolPtr(false),
+				}},
+			},
+			needle: metav1.OwnerReference{
+				APIVersion: "v1", Kind: "Foo", Name: "the-name", UID: types.UID("uid"), BlockOwnerDeletion: boolPtr(false),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := HasOwnerRef(tc.haystack, tc.needle)
+			if tc.expected != actual {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+				return
+			}
+		})
+	}
+}

--- a/pkg/service/controller/servingcert/secret_creating_controller.go
+++ b/pkg/service/controller/servingcert/secret_creating_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/server/crypto/extensions"
+	ocontroller "github.com/openshift/origin/pkg/controller"
 )
 
 const (
@@ -263,6 +264,7 @@ func (sc *ServiceServingCertController) syncService(key string) error {
 			v1.TLSPrivateKeyKey: keyBytes,
 		},
 	}
+	ocontroller.EnsureOwnerRef(secret, ownerRef(service))
 
 	_, err = sc.secretClient.Secrets(service.Namespace).Create(secret)
 	if err != nil && !kapierrors.IsAlreadyExists(err) {
@@ -344,4 +346,13 @@ func (sc *ServiceServingCertController) requiresCertGeneration(service *v1.Servi
 		return true
 	}
 	return true
+}
+
+func ownerRef(service *v1.Service) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Service",
+		Name:       service.Name,
+		UID:        service.UID,
+	}
 }

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3277,6 +3277,7 @@ items:
     - secrets
     verbs:
     - create
+    - delete
     - get
     - list
     - update


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/16401


Adds ownerrefs to the service serving cert signer on creation and regeneration.