### PR TITLE
UPSTREAM: <carry>: increase timeout in TestCancelAndReadd even more

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/node/timed_workers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/node/timed_workers_test.go
@@ -61,7 +61,7 @@ func TestExecuteDelayed(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(3 * time.Second)
+	then := now.Add(10 * time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)
@@ -89,7 +89,7 @@ func TestCancel(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(3 * time.Second)
+	then := now.Add(10 * time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)
@@ -119,7 +119,7 @@ func TestCancelAndReadd(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(3 * time.Second)
+	then := now.Add(10 * time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/16404.

Apparently https://github.com/openshift/origin/pull/16077 didn't fix the problem. https://github.com/openshift/origin/issues/16404 is showing that we're hitting this more and more.

@mfojtik @kargakis @enj ptal

