### PR TITLE
Use writeable HOME directory for builder unit test

### DIFF
--- a/pkg/build/builder/source_test.go
+++ b/pkg/build/builder/source_test.go
@@ -24,7 +24,7 @@ func TestCheckRemoteGit(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer server.Close()
-	gitRepo := git.NewRepositoryWithEnv([]string{"GIT_ASKPASS=true"})
+	gitRepo := git.NewRepositoryWithEnv([]string{"GIT_ASKPASS=true", fmt.Sprintf("HOME=%s", os.TempDir())})
 
 	var err error
 	err = checkRemoteGit(gitRepo, server.URL, 10*time.Second)


### PR DESCRIPTION
Fixes test failure when running as user without HOME directory