### PR TITLE
Fix image layers order

### DIFF
--- a/pkg/image/apis/image/helper_test.go
+++ b/pkg/image/apis/image/helper_test.go
@@ -596,6 +596,9 @@ func TestImageWithMetadata(t *testing.T) {
 			expectedImage: Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "id",
+					Annotations: map[string]string{
+						DockerImageLayersOrderAnnotation: DockerImageLayersOrderAscending,
+					},
 				},
 				DockerImageManifest: validImageWithManifestData().DockerImageManifest,
 				DockerImageLayers: []ImageLayer{
@@ -675,15 +678,18 @@ func TestImageWithMetadata(t *testing.T) {
 			expectedImage: Image{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "id",
+					Annotations: map[string]string{
+						DockerImageLayersOrderAnnotation: DockerImageLayersOrderAscending,
+					},
 				},
 				DockerImageConfig:            validImageWithManifestV2Data().DockerImageConfig,
 				DockerImageManifest:          validImageWithManifestV2Data().DockerImageManifest,
 				DockerImageManifestMediaType: "application/vnd.docker.distribution.manifest.v2+json",
 				DockerImageLayers: []ImageLayer{
-					{Name: "sha256:b4ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 639152},
-					{Name: "sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 235231},
-					{Name: "sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 235231},
 					{Name: "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 5312},
+					{Name: "sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 235231},
+					{Name: "sha256:86e0e091d0da6bde2456dbb48306f3956bbeb2eae1b5b9a43045843f69fe4aaa", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 235231},
+					{Name: "sha256:b4ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4", MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip", LayerSize: 639152},
 				},
 				DockerImageMetadata: DockerImage{
 					ID:            "sha256:815d06b56f4138afacd0009b8e3799fcdce79f0507bf8d0588e219b93ab6fd4d",

--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -28,6 +28,17 @@ const (
 	// ExcludeImageSecretAnnotation indicates that a secret should not be returned by imagestream/secrets.
 	ExcludeImageSecretAnnotation = "openshift.io/image.excludeSecret"
 
+	// DockerImageLayersOrderAnnotation describes layers order in the docker image.
+	DockerImageLayersOrderAnnotation = "openshift.io/image.dockerLayersOrder"
+
+	// DockerImageLayersOrderAscending indicates that image layers are sorted in
+	// the order of their addition (from oldest to latest)
+	DockerImageLayersOrderAscending = "ascending"
+
+	// DockerImageLayersOrderDescending indicates that layers are sorted in
+	// reversed order of their addition (from newest to oldest).
+	DockerImageLayersOrderDescending = "descending"
+
 	// DefaultImageTag is used when an image tag is needed and the configuration does not specify a tag to use.
 	DefaultImageTag = "latest"
 


### PR DESCRIPTION
Until now, the order of the layers was not so important to us. With the advent of tasks, where order matters, we need to have an annotation that describes the order of the layers.
