### PR TITLE
cli: prefer public docker image repository

### DIFF
--- a/pkg/oc/cli/describe/describer.go
+++ b/pkg/oc/cli/describe/describer.go
@@ -760,7 +760,11 @@ func (d *ImageStreamDescriber) Describe(namespace, name string, settings kprinte
 func DescribeImageStream(imageStream *imageapi.ImageStream) (string, error) {
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageStream.ObjectMeta)
-		formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
+		if len(imageStream.Status.PublicDockerImageRepository) > 0 {
+			formatString(out, "Docker Pull Spec", imageStream.Status.PublicDockerImageRepository)
+		} else {
+			formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
+		}
 		formatString(out, "Image Lookup", fmt.Sprintf("local=%t", imageStream.Spec.LookupPolicy.Local))
 		formatImageStreamTags(out, imageStream)
 		return nil

--- a/pkg/oc/cli/describe/printer.go
+++ b/pkg/oc/cli/describe/printer.go
@@ -501,6 +501,9 @@ func printImageStream(stream *imageapi.ImageStream, w io.Writer, opts kprinters.
 	if len(repo) == 0 {
 		repo = stream.Status.DockerImageRepository
 	}
+	if len(stream.Status.PublicDockerImageRepository) > 0 {
+		repo = stream.Status.PublicDockerImageRepository
+	}
 	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s", name, repo, tags, latestTime); err != nil {
 		return err
 	}


### PR DESCRIPTION
@smarterclayton @fabianofranz since we added the publicDockerImageRepository, we should present it to users. I would guess that if that is configured for the master, I want my users see the public pull specs in oc get and oc describe over in-cluster IP's. Agree?