### PR TITLE
SCC: recognize that SELinux levels can be logically equivalent

### DIFF
--- a/pkg/security/securitycontextconstraints/selinux/mustrunas.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas.go
@@ -2,11 +2,14 @@ package selinux
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	api "k8s.io/kubernetes/pkg/apis/core"
 
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
+	"github.com/openshift/origin/pkg/security/securitycontextconstraints/util"
 )
 
 type mustRunAs struct {
@@ -40,7 +43,7 @@ func (s *mustRunAs) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, 
 		allErrs = append(allErrs, field.Required(fldPath, ""))
 		return allErrs
 	}
-	if seLinux.Level != s.opts.SELinuxOptions.Level {
+	if !equalLevels(s.opts.SELinuxOptions.Level, seLinux.Level) {
 		detail := fmt.Sprintf("must be %s", s.opts.SELinuxOptions.Level)
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("level"), seLinux.Level, detail))
 	}
@@ -58,4 +61,45 @@ func (s *mustRunAs) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, 
 	}
 
 	return allErrs
+}
+
+// equalLevels compares SELinux levels for equality.
+func equalLevels(expected, actual string) bool {
+	if expected == actual {
+		return true
+	}
+	// "s0:c6,c0" => [ "s0", "c6,c0" ]
+	expectedParts := strings.SplitN(expected, ":", 2)
+	actualParts := strings.SplitN(actual, ":", 2)
+
+	// both SELinux levels must be in a format "sX:cY"
+	if len(expectedParts) != 2 || len(actualParts) != 2 {
+		return false
+	}
+
+	if !equalSensitivity(expectedParts[0], actualParts[0]) {
+		return false
+	}
+
+	if !equalCategories(expectedParts[1], actualParts[1]) {
+		return false
+	}
+
+	return true
+}
+
+// equalSensitivity compares sensitivities of the SELinux levels for equality.
+func equalSensitivity(expected, actual string) bool {
+	return expected == actual
+}
+
+// equalCategories compares categories of the SELinux levels for equality.
+func equalCategories(expected, actual string) bool {
+	expectedCategories := strings.Split(expected, ",")
+	actualCategories := strings.Split(actual, ",")
+
+	sort.Strings(expectedCategories)
+	sort.Strings(actualCategories)
+
+	return util.EqualStringSlices(expectedCategories, actualCategories)
 }

--- a/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
@@ -62,9 +62,15 @@ func TestMustRunAsValidate(t *testing.T) {
 		return &api.SELinuxOptions{
 			User:  "user",
 			Role:  "role",
-			Level: "level",
+			Level: "s0:c0,c6",
 			Type:  "type",
 		}
+	}
+
+	newValidOptsWithLevel := func(level string) *api.SELinuxOptions {
+		opts := newValidOpts()
+		opts.Level = level
+		return opts
 	}
 
 	role := newValidOpts()
@@ -101,6 +107,10 @@ func TestMustRunAsValidate(t *testing.T) {
 		},
 		"valid": {
 			seLinux:     newValidOpts(),
+			expectedMsg: "",
+		},
+		"valid with different order of categories": {
+			seLinux:     newValidOptsWithLevel("s0:c6,c0"),
 			expectedMsg: "",
 		},
 	}

--- a/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
@@ -85,41 +85,49 @@ func TestMustRunAsValidate(t *testing.T) {
 	seType := newValidOpts()
 	seType.Type = "invalid"
 
+	validOpts := newValidOpts()
+
 	tests := map[string]struct {
 		podSeLinux  *api.SELinuxOptions
+		sccSeLinux  *api.SELinuxOptions
 		expectedMsg string
 	}{
 		"invalid role": {
 			podSeLinux:  role,
+			sccSeLinux:  validOpts,
 			expectedMsg: "role: Invalid value",
 		},
 		"invalid user": {
 			podSeLinux:  user,
+			sccSeLinux:  validOpts,
 			expectedMsg: "user: Invalid value",
 		},
 		"invalid level": {
 			podSeLinux:  level,
+			sccSeLinux:  validOpts,
 			expectedMsg: "level: Invalid value",
 		},
 		"invalid type": {
 			podSeLinux:  seType,
+			sccSeLinux:  validOpts,
 			expectedMsg: "type: Invalid value",
 		},
 		"valid": {
-			podSeLinux:  newValidOpts(),
+			podSeLinux:  validOpts,
+			sccSeLinux:  validOpts,
 			expectedMsg: "",
 		},
 		"valid with different order of categories": {
 			podSeLinux:  newValidOptsWithLevel("s0:c6,c0"),
+			sccSeLinux:  validOpts,
 			expectedMsg: "",
 		},
 	}
 
-	opts := &securityapi.SELinuxContextStrategyOptions{
-		SELinuxOptions: newValidOpts(),
-	}
-
 	for name, tc := range tests {
+		opts := &securityapi.SELinuxContextStrategyOptions{
+			SELinuxOptions: tc.sccSeLinux,
+		}
 		mustRunAs, err := NewMustRunAs(opts)
 		if err != nil {
 			t.Errorf("unexpected error initializing NewMustRunAs for testcase %s: %#v", name, err)

--- a/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
@@ -86,31 +86,31 @@ func TestMustRunAsValidate(t *testing.T) {
 	seType.Type = "invalid"
 
 	tests := map[string]struct {
-		seLinux     *api.SELinuxOptions
+		podSeLinux  *api.SELinuxOptions
 		expectedMsg string
 	}{
 		"invalid role": {
-			seLinux:     role,
+			podSeLinux:  role,
 			expectedMsg: "role: Invalid value",
 		},
 		"invalid user": {
-			seLinux:     user,
+			podSeLinux:  user,
 			expectedMsg: "user: Invalid value",
 		},
 		"invalid level": {
-			seLinux:     level,
+			podSeLinux:  level,
 			expectedMsg: "level: Invalid value",
 		},
 		"invalid type": {
-			seLinux:     seType,
+			podSeLinux:  seType,
 			expectedMsg: "type: Invalid value",
 		},
 		"valid": {
-			seLinux:     newValidOpts(),
+			podSeLinux:  newValidOpts(),
 			expectedMsg: "",
 		},
 		"valid with different order of categories": {
-			seLinux:     newValidOptsWithLevel("s0:c6,c0"),
+			podSeLinux:  newValidOptsWithLevel("s0:c6,c0"),
 			expectedMsg: "",
 		},
 	}
@@ -126,7 +126,7 @@ func TestMustRunAsValidate(t *testing.T) {
 			continue
 		}
 
-		errs := mustRunAs.Validate(nil, nil, nil, tc.seLinux)
+		errs := mustRunAs.Validate(nil, nil, nil, tc.podSeLinux)
 		//should've passed but didn't
 		if len(tc.expectedMsg) == 0 && len(errs) > 0 {
 			t.Errorf("%s expected no errors but received %v", name, errs)

--- a/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
@@ -79,9 +79,6 @@ func TestMustRunAsValidate(t *testing.T) {
 	user := newValidOpts()
 	user.User = "invalid"
 
-	level := newValidOpts()
-	level.Level = "invalid"
-
 	seType := newValidOpts()
 	seType.Type = "invalid"
 
@@ -102,15 +99,20 @@ func TestMustRunAsValidate(t *testing.T) {
 			sccSeLinux:  validOpts,
 			expectedMsg: "user: Invalid value",
 		},
-		"invalid level": {
-			podSeLinux:  level,
-			sccSeLinux:  validOpts,
+		"levels are not equal": {
+			podSeLinux:  newValidOptsWithLevel("s0"),
+			sccSeLinux:  newValidOptsWithLevel("s0:c1,c2"),
 			expectedMsg: "level: Invalid value",
 		},
-		"invalid type": {
-			podSeLinux:  seType,
-			sccSeLinux:  validOpts,
-			expectedMsg: "type: Invalid value",
+		"levels differ by sensitivity": {
+			podSeLinux:  newValidOptsWithLevel("s0:c6"),
+			sccSeLinux:  newValidOptsWithLevel("s1:c6"),
+			expectedMsg: "level: Invalid value",
+		},
+		"levels differ by categories": {
+			podSeLinux:  newValidOptsWithLevel("s0:c0,c8"),
+			sccSeLinux:  newValidOptsWithLevel("s0:c1,c7"),
+			expectedMsg: "level: Invalid value",
 		},
 		"valid": {
 			podSeLinux:  validOpts,

--- a/pkg/security/securitycontextconstraints/util/util.go
+++ b/pkg/security/securitycontextconstraints/util/util.go
@@ -141,3 +141,17 @@ func SCCAllowsFSType(scc *securityapi.SecurityContextConstraints, fsType securit
 	}
 	return false
 }
+
+// EqualStringSlices compares string slices for equality. Slices are equal when
+// their sizes and elements on similar positions are equal.
+func EqualStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/security/securitycontextconstraints/util/util_test.go
+++ b/pkg/security/securitycontextconstraints/util/util_test.go
@@ -82,3 +82,38 @@ func TestSCCAllowsVolumeType(t *testing.T) {
 		}
 	}
 }
+
+func TestEqualStringSlices(t *testing.T) {
+	tests := map[string]struct {
+		arg1           []string
+		arg2           []string
+		expectedResult bool
+	}{
+		"nil equals to nil": {
+			arg1:           nil,
+			arg2:           nil,
+			expectedResult: true,
+		},
+		"equal by size": {
+			arg1:           []string{"1", "1"},
+			arg2:           []string{"1", "1"},
+			expectedResult: true,
+		},
+		"not equal by size": {
+			arg1:           []string{"1"},
+			arg2:           []string{"1", "1"},
+			expectedResult: false,
+		},
+		"not equal by elements": {
+			arg1:           []string{"1", "1"},
+			arg2:           []string{"1", "2"},
+			expectedResult: false,
+		},
+	}
+
+	for k, v := range tests {
+		if result := EqualStringSlices(v.arg1, v.arg2); result != v.expectedResult {
+			t.Errorf("%s expected to return %t but got %t", k, v.expectedResult, result)
+		}
+	}
+}


### PR DESCRIPTION
For example: s0:c0,c6 is the same as s0:c6,c0

Fixes #15627 