### PR TITLE
hack/build-images.sh: fix image build order

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -51,8 +51,6 @@ for i in `jobs -p`; do wait $i; done
 
 # images that depend on "${tag_prefix}-base"
 ( os::build::image "${tag_prefix}"                       images/origin ) &
-( os::build::image "${tag_prefix}-haproxy-router"        images/router/haproxy ) &
-( os::build::image "${tag_prefix}-keepalived-ipfailover" images/ipfailover/keepalived ) &
 ( os::build::image "${tag_prefix}-docker-registry"       images/dockerregistry ) &
 ( os::build::image "${tag_prefix}-egress-router"         images/egress/router ) &
 ( os::build::image "${tag_prefix}-egress-http-proxy"     images/egress/http-proxy ) &
@@ -61,6 +59,8 @@ for i in `jobs -p`; do wait $i; done
 for i in `jobs -p`; do wait $i; done
 
 # images that depend on "${tag_prefix}
+( os::build::image "${tag_prefix}-haproxy-router"        images/router/haproxy ) &
+( os::build::image "${tag_prefix}-keepalived-ipfailover" images/ipfailover/keepalived ) &
 ( os::build::image "${tag_prefix}-gitserver"             examples/gitserver ) &
 ( os::build::image "${tag_prefix}-deployer"              images/deployer ) &
 ( os::build::image "${tag_prefix}-recycler"              images/recycler ) &


### PR DESCRIPTION
- haproxy-router and keepalived-ipfailover depend on openshift/origin not openshift/origin-base