### PR TITLE
Bug 1481147 - Fix default pod image for network diagnostics

### DIFF
--- a/pkg/diagnostics/network/objects.go
+++ b/pkg/diagnostics/network/objects.go
@@ -113,15 +113,7 @@ func GetTestPod(testPodImage, testPodProtocol, podName, nodeName string, testPod
 		},
 	}
 
-	var trimmedPodImage string
-	imageTokens := strings.Split(testPodImage, "/")
-	n := len(imageTokens)
-	if n < 2 {
-		trimmedPodImage = testPodImage
-	} else {
-		trimmedPodImage = imageTokens[n-2] + "/" + imageTokens[n-1]
-	}
-	if trimmedPodImage == util.NetworkDiagDefaultTestPodImage {
+	if getTrimmedImage(testPodImage) == getTrimmedImage(util.GetNetworkDiagDefaultTestPodImage()) {
 		pod.Spec.Containers[0].Command = []string{
 			"socat", "-T", "1", "-d",
 			fmt.Sprintf("%s-l:%d,reuseaddr,fork,crlf", testPodProtocol, testPodPort),
@@ -129,6 +121,14 @@ func GetTestPod(testPodImage, testPodProtocol, podName, nodeName string, testPod
 		}
 	}
 	return pod
+}
+
+func getTrimmedImage(image string) string {
+	// Image format could be: [<dns-name>/]openshift/origin-deployer[:<tag>]
+	tokens := strings.Split(image, "/")
+	trimImageWithTag := tokens[len(tokens)-1]
+
+	return strings.Split(trimImageWithTag, ":")[0]
 }
 
 func GetTestService(serviceName, podName, podProtocol, nodeName string, podPort int) *kapi.Service {

--- a/pkg/diagnostics/networkpod/util/util.go
+++ b/pkg/diagnostics/networkpod/util/util.go
@@ -37,10 +37,16 @@ const (
 	NetworkDiagDefaultTestPodPort     = 8080
 )
 
-var (
-	NetworkDiagDefaultPodImage     = variable.DefaultImagePrefix
-	NetworkDiagDefaultTestPodImage = variable.DefaultImagePrefix + "-deployer"
-)
+func GetNetworkDiagDefaultPodImage() string {
+	imageTemplate := variable.NewDefaultImageTemplate()
+	imageTemplate.Format = variable.DefaultImagePrefix + ":${version}"
+	return imageTemplate.ExpandOrDie("")
+}
+
+func GetNetworkDiagDefaultTestPodImage() string {
+	imageTemplate := variable.NewDefaultImageTemplate()
+	return imageTemplate.ExpandOrDie("deployer")
+}
 
 func GetOpenShiftNetworkPlugin(osClient *osclient.Client) (string, bool, error) {
 	cn, err := osClient.ClusterNetwork().Get(networkapi.ClusterNetworkDefault, metav1.GetOptions{})

--- a/pkg/oc/admin/diagnostics/diagnostics.go
+++ b/pkg/oc/admin/diagnostics/diagnostics.go
@@ -151,8 +151,8 @@ func NewCmdDiagnostics(name string, fullName string, out io.Writer) *cobra.Comma
 	cmd.Flags().BoolVar(&o.ImageTemplate.Latest, options.FlagLatestImageName, false, "If true, when expanding the image template, use latest version, not release version")
 	cmd.Flags().BoolVar(&o.PreventModification, options.FlagPreventModificationName, false, "If true, may be set to prevent diagnostics making any changes via the API")
 	cmd.Flags().StringVar(&o.NetworkOptions.LogDir, options.FlagNetworkDiagLogDir, netutil.NetworkDiagDefaultLogDir, "Path to store network diagnostic results in case of errors")
-	cmd.Flags().StringVar(&o.NetworkOptions.PodImage, options.FlagNetworkDiagPodImage, netutil.NetworkDiagDefaultPodImage, "Image to use for network diagnostic pod")
-	cmd.Flags().StringVar(&o.NetworkOptions.TestPodImage, options.FlagNetworkDiagTestPodImage, netutil.NetworkDiagDefaultTestPodImage, "Image to use for network diagnostic test pod")
+	cmd.Flags().StringVar(&o.NetworkOptions.PodImage, options.FlagNetworkDiagPodImage, netutil.GetNetworkDiagDefaultPodImage(), "Image to use for network diagnostic pod")
+	cmd.Flags().StringVar(&o.NetworkOptions.TestPodImage, options.FlagNetworkDiagTestPodImage, netutil.GetNetworkDiagDefaultTestPodImage(), "Image to use for network diagnostic test pod")
 	cmd.Flags().StringVar(&o.NetworkOptions.TestPodProtocol, options.FlagNetworkDiagTestPodProtocol, netutil.NetworkDiagDefaultTestPodProtocol, "Protocol used to connect to network diagnostic test pod")
 	cmd.Flags().IntVar(&o.NetworkOptions.TestPodPort, options.FlagNetworkDiagTestPodPort, netutil.NetworkDiagDefaultTestPodPort, "Serving port on the network diagnostic test pod")
 	flagtypes.GLog(cmd.Flags())
@@ -195,10 +195,10 @@ func (o *DiagnosticsOptions) Complete(args []string) error {
 		o.NetworkOptions.LogDir = logdir
 	}
 	if len(o.NetworkOptions.PodImage) == 0 {
-		o.NetworkOptions.PodImage = netutil.NetworkDiagDefaultPodImage
+		o.NetworkOptions.PodImage = netutil.GetNetworkDiagDefaultPodImage()
 	}
 	if len(o.NetworkOptions.TestPodImage) == 0 {
-		o.NetworkOptions.TestPodImage = netutil.NetworkDiagDefaultTestPodImage
+		o.NetworkOptions.TestPodImage = netutil.GetNetworkDiagDefaultTestPodImage()
 	}
 
 	supportedProtocols := sets.NewString(string(kapi.ProtocolTCP), string(kapi.ProtocolUDP))


### PR DESCRIPTION
- This also ensures network diagnostics pod and test pod images uses
  deployed openshift version/tag (not the latest) so that it doesn't
  need to download another same image with latest tag.

- Print more details when network diagnostics test setup fails.
  Currently when network diags fails, it only informs how many test pods failed but doesn't provide why those pods failed. This change will fetch logs for the pods in case of setup failure.


