### PR TITLE
catalog: RBAC - added missing get for service-catalog-controller

### DIFF
--- a/examples/service-catalog/service-catalog.yaml
+++ b/examples/service-catalog/service-catalog.yaml
@@ -130,6 +130,7 @@ objects:
     - serviceinstancecredentials
     verbs:
     - list
+    - get
     - watch
   - apiGroups:
     - ""

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13737,6 +13737,7 @@ objects:
     - serviceinstancecredentials
     verbs:
     - list
+    - get
     - watch
   - apiGroups:
     - ""


### PR DESCRIPTION
service-catalog-controller role  was missing the get operation for ServiceBrokers, ServiceInstances and ServiceInstanceCredentials