### PR TITLE
Router: Do not include accept-proxy in port list when using proxy protocol and syn eater

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -85,7 +85,7 @@ if [ -n "$old_pids" ]; then
   if $(set | grep DROP_SYN_DURING_RESTART= > /dev/null) && [[ "$DROP_SYN_DURING_RESTART" == 'true' || "$DROP_SYN_DURING_RESTART" == '1' ]]; then
     # We install the syn eater so that connections that come in during the restart don't
     # go onto the wrong socket, which is then closed.
-    ports=$(grep -E '^\s*bind\s+:[[:digit:]]+\w' "$config_file" | cut -f2 -d: | paste -d, -s)
+    ports=$(grep -E -o '^\s*bind\s+:[[:digit:]]+\w' "$config_file" | cut -f2 -d: | paste -d, -s)
     if [ -n "$ports" ]; then
       # If this doesn't insert, we don't care, we still want to reload
       /usr/sbin/iptables -I INPUT -p tcp -m multiport --dports $ports --syn -j DROP \


### PR DESCRIPTION
When enabling both proxy protocol (ROUTER_USE_PROXY_PROTOCOL) and DROP_SYN_DURING_RESTART, the ports variable in reload-haproxy is set to: 
```
80 accept-proxy,443 accept-proxy
``` 

This makes the reload script fail with:

```
Bad argument `accept-proxy,445'
Try `iptables -h' or 'iptables --help' for more information.
``` 

This PR fixes that by adding `-o` to grep, which makes grep only return the match from the reqex

