### PR TITLE
Add PKCE support to oc

### DIFF
--- a/pkg/auth/server/tokenrequest/endpoints.go
+++ b/pkg/auth/server/tokenrequest/endpoints.go
@@ -94,7 +94,7 @@ func (endpoints *endpointDetails) safeInitOsinOAuthClientOnce() error {
 // requestToken works for getting a token in your browser and seeing what your token is
 func (endpoints *endpointDetails) requestToken(w http.ResponseWriter, req *http.Request) {
 	authReq := endpoints.osinOAuthClient.NewAuthorizeRequest(osincli.CODE)
-	oauthURL := authReq.GetAuthorizeUrlWithParams("")
+	oauthURL := authReq.GetAuthorizeUrl()
 
 	http.Redirect(w, req, oauthURL.String(), http.StatusFound)
 }

--- a/pkg/oauth/apiserver/auth.go
+++ b/pkg/oauth/apiserver/auth.go
@@ -152,7 +152,7 @@ func (c *OAuthServerConfig) getOsinOAuthClient() (*osincli.Client, error) {
 	}
 
 	osOAuthClientConfig := newOpenShiftOAuthClientConfig(browserClient.Name, browserClient.Secret, c.Options.MasterPublicURL, c.Options.MasterURL)
-	osOAuthClientConfig.RedirectUrl = c.Options.MasterPublicURL + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, tokenrequest.DisplayTokenEndpoint)
+	osOAuthClientConfig.RedirectUrl = oauthutil.OpenShiftOAuthTokenDisplayURL(c.Options.MasterPublicURL)
 
 	osOAuthClient, err := osincli.NewClient(osOAuthClientConfig)
 	if err != nil {
@@ -425,7 +425,7 @@ func (c *OAuthServerConfig) getAuthenticationHandler(mux cmdutil.Mux, errorHandl
 			}
 		} else if requestHeaderProvider, isRequestHeader := identityProvider.Provider.(*configapi.RequestHeaderIdentityProvider); isRequestHeader {
 			// We might be redirecting to an external site, we need to fully resolve the request URL to the public master
-			baseRequestURL, err := url.Parse(c.Options.MasterPublicURL + oauthutil.OpenShiftOAuthAPIPrefix + osinserver.AuthorizePath)
+			baseRequestURL, err := url.Parse(oauthutil.OpenShiftOAuthAuthorizeURL(c.Options.MasterPublicURL))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/oauth/apiserver/oauth_apiserver.go
+++ b/pkg/oauth/apiserver/oauth_apiserver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 
 	"github.com/pborman/uuid"
 
@@ -20,7 +19,6 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	"github.com/openshift/origin/pkg/auth/server/session"
-	"github.com/openshift/origin/pkg/auth/server/tokenrequest"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/api/latest"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
@@ -223,7 +221,7 @@ func (c *OAuthServerConfig) EnsureBootstrapOAuthClients(context genericapiserver
 		ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftBrowserClientID},
 		Secret:                uuid.New(),
 		RespondWithChallenges: false,
-		RedirectURIs:          []string{c.Options.MasterPublicURL + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, tokenrequest.DisplayTokenEndpoint)},
+		RedirectURIs:          []string{oauthutil.OpenShiftOAuthTokenDisplayURL(c.Options.MasterPublicURL)},
 		GrantMethod:           oauthapi.GrantHandlerAuto,
 	}
 	if err := ensureOAuthClient(browserClient, c.OAuthClientClient, true, true); err != nil {
@@ -234,7 +232,7 @@ func (c *OAuthServerConfig) EnsureBootstrapOAuthClients(context genericapiserver
 		ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftCLIClientID},
 		Secret:                "",
 		RespondWithChallenges: true,
-		RedirectURIs:          []string{c.Options.MasterPublicURL + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, tokenrequest.ImplicitTokenEndpoint)},
+		RedirectURIs:          []string{oauthutil.OpenShiftOAuthTokenImplicitURL(c.Options.MasterPublicURL)},
 		GrantMethod:           oauthapi.GrantHandlerAuto,
 	}
 	if err := ensureOAuthClient(cliClient, c.OAuthClientClient, false, false); err != nil {

--- a/pkg/oauth/util/url.go
+++ b/pkg/oauth/util/url.go
@@ -2,21 +2,29 @@ package util
 
 import (
 	"path"
+	"strings"
 
 	"github.com/openshift/origin/pkg/auth/server/tokenrequest"
 	"github.com/openshift/origin/pkg/oauth/server/osinserver"
 )
 
-const (
-	OpenShiftOAuthAPIPrefix = "/oauth"
-)
+const OpenShiftOAuthAPIPrefix = "/oauth"
 
 func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
-	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, osinserver.AuthorizePath)
+	return openShiftOAuthURL(masterAddr, osinserver.AuthorizePath)
 }
 func OpenShiftOAuthTokenURL(masterAddr string) string {
-	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, osinserver.TokenPath)
+	return openShiftOAuthURL(masterAddr, osinserver.TokenPath)
 }
 func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
-	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, tokenrequest.RequestTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, tokenrequest.RequestTokenEndpoint)
+}
+func OpenShiftOAuthTokenDisplayURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, tokenrequest.DisplayTokenEndpoint)
+}
+func OpenShiftOAuthTokenImplicitURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, tokenrequest.ImplicitTokenEndpoint)
+}
+func openShiftOAuthURL(masterAddr, oauthEndpoint string) string {
+	return strings.TrimRight(masterAddr, "/") + path.Join(OpenShiftOAuthAPIPrefix, oauthEndpoint)
 }


### PR DESCRIPTION
This change updates RequestToken to support an OAuth code flow along with the existing token flow.  The code flow is set as the default.  RequestToken also performs a check against the server's OAuth metadata endpoint.  If the server supports PKCE with S256 (which all recent versions of OpenShift do), than RequestToken includes PKCE data to strengthen the code flow since we must use a public OAuth client with oc.  Care was taken to preserve the existing behavior of following redirects that are part of the challenge flow (an authenticating proxy for example) while acting on redirects that are instead part of the OAuth flow (exchanging the code for an access token).  The use of all OAuth URL constants was consolidated into a single location to guarantee they are used correctly.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Followups: #16579