### PR TITLE
snip bad authorization api dependencies

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -64,16 +64,13 @@
       "github.com/openshift/origin/pkg/api/apihelpers"
     ],
     "allowedImportPackages": [
-      "vendor/github.com/google/gofuzz",
       "vendor/k8s.io/kubernetes/pkg/api",
       "vendor/k8s.io/kubernetes/pkg/api/v1",
-      "vendor/k8s.io/kubernetes/pkg/api/validation",
       "vendor/k8s.io/kubernetes/pkg/apis/rbac",
       "vendor/k8s.io/kubernetes/pkg/api/helper",
       "github.com/openshift/origin/pkg/user/apis/user/validation",
       "vendor/k8s.io/apiserver/pkg/authentication/serviceaccount",
-      "vendor/k8s.io/apiserver/pkg/authentication/user",
-      "github.com/openshift/origin/pkg/authorization/rulevalidation"
+      "vendor/k8s.io/apiserver/pkg/authentication/user"
     ]
   },
 

--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -68,7 +68,6 @@
       "vendor/k8s.io/kubernetes/pkg/api/v1",
       "vendor/k8s.io/kubernetes/pkg/apis/rbac",
       "vendor/k8s.io/kubernetes/pkg/api/helper",
-      "github.com/openshift/origin/pkg/user/apis/user/validation",
       "vendor/k8s.io/apiserver/pkg/authentication/serviceaccount",
       "vendor/k8s.io/apiserver/pkg/authentication/user"
     ]

--- a/pkg/authorization/apis/authorization/install/install.go
+++ b/pkg/authorization/apis/authorization/install/install.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/origin/pkg/api/legacy"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 )
 
@@ -26,7 +27,7 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  authorizationapi.GroupName,
 			VersionPreferenceOrder:     []string{authorizationapiv1.SchemeGroupVersion.Version},
-			AddInternalObjectsToScheme: authorizationapi.AddToScheme,
+			AddInternalObjectsToScheme: internalObjectsToScheme,
 			RootScopedKinds:            sets.NewString("ClusterRole", "ClusterRoleBinding", "ClusterPolicy", "ClusterPolicyBinding", "SubjectAccessReview", "ResourceAccessReview"),
 		},
 		announced.VersionToSchemeFunc{
@@ -35,4 +36,11 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
+}
+
+func internalObjectsToScheme(scheme *runtime.Scheme) error {
+	if err := authorizationapi.AddToScheme(scheme); err != nil {
+		return err
+	}
+	return rbacconversion.AddToScheme(scheme)
 }

--- a/pkg/authorization/apis/authorization/rbacconversion/conversion_test.go
+++ b/pkg/authorization/apis/authorization/rbacconversion/conversion_test.go
@@ -1,4 +1,4 @@
-package authorization_test // prevent import cycle between authorizationapi and rulevalidation
+package rbacconversion
 
 import (
 	"fmt"
@@ -28,10 +28,10 @@ func TestOriginClusterRoleFidelity(t *testing.T) {
 		ocr2 := &authorizationapi.ClusterRole{}
 		rcr := &rbac.ClusterRole{}
 		fuzzer.Fuzz(ocr)
-		if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
+		if err := Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr2, nil); err != nil {
+		if err := Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(ocr, ocr2) {
@@ -46,10 +46,10 @@ func TestOriginRoleFidelity(t *testing.T) {
 		or2 := &authorizationapi.Role{}
 		rr := &rbac.Role{}
 		fuzzer.Fuzz(or)
-		if err := authorizationapi.Convert_authorization_Role_To_rbac_Role(or, rr, nil); err != nil {
+		if err := Convert_authorization_Role_To_rbac_Role(or, rr, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_rbac_Role_To_authorization_Role(rr, or2, nil); err != nil {
+		if err := Convert_rbac_Role_To_authorization_Role(rr, or2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(or, or2) {
@@ -64,10 +64,10 @@ func TestOriginClusterRoleBindingFidelity(t *testing.T) {
 		ocrb2 := &authorizationapi.ClusterRoleBinding{}
 		rcrb := &rbac.ClusterRoleBinding{}
 		fuzzer.Fuzz(ocrb)
-		if err := authorizationapi.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(ocrb, rcrb, nil); err != nil {
+		if err := Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(ocrb, rcrb, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(rcrb, ocrb2, nil); err != nil {
+		if err := Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(rcrb, ocrb2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(ocrb, ocrb2) {
@@ -82,10 +82,10 @@ func TestOriginRoleBindingFidelity(t *testing.T) {
 		orb2 := &authorizationapi.RoleBinding{}
 		rrb := &rbac.RoleBinding{}
 		fuzzer.Fuzz(orb)
-		if err := authorizationapi.Convert_authorization_RoleBinding_To_rbac_RoleBinding(orb, rrb, nil); err != nil {
+		if err := Convert_authorization_RoleBinding_To_rbac_RoleBinding(orb, rrb, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_rbac_RoleBinding_To_authorization_RoleBinding(rrb, orb2, nil); err != nil {
+		if err := Convert_rbac_RoleBinding_To_authorization_RoleBinding(rrb, orb2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(orb, orb2) {
@@ -100,10 +100,10 @@ func TestRBACClusterRoleFidelity(t *testing.T) {
 		rcr2 := &rbac.ClusterRole{}
 		ocr := &authorizationapi.ClusterRole{}
 		fuzzer.Fuzz(rcr)
-		if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr, nil); err != nil {
+		if err := Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr2, nil); err != nil {
+		if err := Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(rcr, rcr2) {
@@ -118,10 +118,10 @@ func TestRBACRoleFidelity(t *testing.T) {
 		rr2 := &rbac.Role{}
 		or := &authorizationapi.Role{}
 		fuzzer.Fuzz(rr)
-		if err := authorizationapi.Convert_rbac_Role_To_authorization_Role(rr, or, nil); err != nil {
+		if err := Convert_rbac_Role_To_authorization_Role(rr, or, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_authorization_Role_To_rbac_Role(or, rr2, nil); err != nil {
+		if err := Convert_authorization_Role_To_rbac_Role(or, rr2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(rr, rr2) {
@@ -136,10 +136,10 @@ func TestRBACClusterRoleBindingFidelity(t *testing.T) {
 		rcrb2 := &rbac.ClusterRoleBinding{}
 		ocrb := &authorizationapi.ClusterRoleBinding{}
 		fuzzer.Fuzz(rcrb)
-		if err := authorizationapi.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(rcrb, ocrb, nil); err != nil {
+		if err := Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(rcrb, ocrb, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(ocrb, rcrb2, nil); err != nil {
+		if err := Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(ocrb, rcrb2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(rcrb, rcrb2) {
@@ -154,10 +154,10 @@ func TestRBACRoleBindingFidelity(t *testing.T) {
 		rrb2 := &rbac.RoleBinding{}
 		orb := &authorizationapi.RoleBinding{}
 		fuzzer.Fuzz(rrb)
-		if err := authorizationapi.Convert_rbac_RoleBinding_To_authorization_RoleBinding(rrb, orb, nil); err != nil {
+		if err := Convert_rbac_RoleBinding_To_authorization_RoleBinding(rrb, orb, nil); err != nil {
 			t.Fatal(err)
 		}
-		if err := authorizationapi.Convert_authorization_RoleBinding_To_rbac_RoleBinding(orb, rrb2, nil); err != nil {
+		if err := Convert_authorization_RoleBinding_To_rbac_RoleBinding(orb, rrb2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(rrb, rrb2) {
@@ -176,7 +176,7 @@ func TestConversionErrors(t *testing.T) {
 			name:     "invalid origin role ref",
 			expected: `invalid origin role binding rolebindingname: attempts to reference role in namespace "ns1" instead of current namespace "ns0"`,
 			f: func() error {
-				return authorizationapi.Convert_authorization_RoleBinding_To_rbac_RoleBinding(&authorizationapi.RoleBinding{
+				return Convert_authorization_RoleBinding_To_rbac_RoleBinding(&authorizationapi.RoleBinding{
 					ObjectMeta: metav1.ObjectMeta{Name: "rolebindingname", Namespace: "ns0"},
 					RoleRef:    api.ObjectReference{Namespace: "ns1"},
 				}, &rbac.RoleBinding{}, nil)
@@ -186,7 +186,7 @@ func TestConversionErrors(t *testing.T) {
 			name:     "invalid origin subject kind",
 			expected: `invalid kind for origin subject: "fancyuser"`,
 			f: func() error {
-				return authorizationapi.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(&authorizationapi.ClusterRoleBinding{
+				return Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(&authorizationapi.ClusterRoleBinding{
 					Subjects: []api.ObjectReference{
 						{Kind: "fancyuser"},
 					},
@@ -197,7 +197,7 @@ func TestConversionErrors(t *testing.T) {
 			name:     "invalid origin rol ref namespace",
 			expected: `invalid origin cluster role binding clusterrolebindingname: attempts to reference role in namespace "fancyns" instead of cluster scope`,
 			f: func() error {
-				return authorizationapi.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(&authorizationapi.ClusterRoleBinding{
+				return Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(&authorizationapi.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{Name: "clusterrolebindingname"},
 					RoleRef: api.ObjectReference{
 						Namespace: "fancyns",
@@ -209,7 +209,7 @@ func TestConversionErrors(t *testing.T) {
 			name:     "invalid RBAC subject kind",
 			expected: `invalid kind for rbac subject: "evenfancieruser"`,
 			f: func() error {
-				return authorizationapi.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(&rbac.ClusterRoleBinding{
+				return Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(&rbac.ClusterRoleBinding{
 					Subjects: []rbac.Subject{
 						{Kind: "evenfancieruser"},
 					},
@@ -220,7 +220,7 @@ func TestConversionErrors(t *testing.T) {
 			name:     "invalid RBAC rol ref kind",
 			expected: `invalid kind "anewfancykind" for rbac role ref "fancyrolref"`,
 			f: func() error {
-				return authorizationapi.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(&rbac.ClusterRoleBinding{
+				return Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(&rbac.ClusterRoleBinding{
 					RoleRef: rbac.RoleRef{
 						Name: "fancyrolref",
 						Kind: "anewfancykind",
@@ -247,10 +247,10 @@ func TestAttributeRestrictionsRuleLoss(t *testing.T) {
 	}
 	ocr2 := &authorizationapi.ClusterRole{}
 	rcr := &rbac.ClusterRole{}
-	if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
+	if err := Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr2, nil); err != nil {
+	if err := Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr2, nil); err != nil {
 		t.Fatal(err)
 	}
 	if covered, uncoveredRules := rulevalidation.Covers(ocr.Rules, ocr2.Rules); !covered {
@@ -276,10 +276,10 @@ func TestResourceAndNonResourceRuleSplit(t *testing.T) {
 	}
 	ocr2 := &authorizationapi.ClusterRole{}
 	rcr := &rbac.ClusterRole{}
-	if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
+	if err := Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, rcr, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr2, nil); err != nil {
+	if err := Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, ocr2, nil); err != nil {
 		t.Fatal(err)
 	}
 	// We need to break down the input rules so Covers does not get confused by ResourceNames
@@ -303,7 +303,7 @@ func TestAnnotationsConversion(t *testing.T) {
 		ocr.Annotations = map[string]string{"openshift.io/reconcile-protect": boolval}
 		ocr2 := &authorizationapi.ClusterRole{}
 		crcr := &rbac.ClusterRole{}
-		if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, crcr, nil); err != nil {
+		if err := Convert_authorization_ClusterRole_To_rbac_ClusterRole(ocr, crcr, nil); err != nil {
 			t.Fatal(err)
 		}
 		value, ok := crcr.Annotations[rbac.AutoUpdateAnnotationKey]
@@ -314,7 +314,7 @@ func TestAnnotationsConversion(t *testing.T) {
 		} else {
 			t.Fatal(fmt.Errorf("Missing converted Annotation"))
 		}
-		if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(crcr, ocr2, nil); err != nil {
+		if err := Convert_rbac_ClusterRole_To_authorization_ClusterRole(crcr, ocr2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(ocr, ocr2) {
@@ -327,7 +327,7 @@ func TestAnnotationsConversion(t *testing.T) {
 		rcr.Annotations = map[string]string{rbac.AutoUpdateAnnotationKey: boolval}
 		rcr2 := &rbac.ClusterRole{}
 		cocr := &authorizationapi.ClusterRole{}
-		if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, cocr, nil); err != nil {
+		if err := Convert_rbac_ClusterRole_To_authorization_ClusterRole(rcr, cocr, nil); err != nil {
 			t.Fatal(err)
 		}
 		value, ok = cocr.Annotations["openshift.io/reconcile-protect"]
@@ -338,7 +338,7 @@ func TestAnnotationsConversion(t *testing.T) {
 		} else {
 			t.Fatal(fmt.Errorf("Missing converted Annotation"))
 		}
-		if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(cocr, rcr2, nil); err != nil {
+		if err := Convert_authorization_ClusterRole_To_rbac_ClusterRole(cocr, rcr2, nil); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(rcr, rcr2) {
@@ -511,13 +511,4 @@ func sortAndDeduplicateRBACRulesFields(in []rbac.PolicyRule) {
 		rule.ResourceNames = sets.NewString(rule.ResourceNames...).List()
 		rule.NonResourceURLs = sets.NewString(rule.NonResourceURLs...).List()
 	}
-}
-
-// copied from authorizationapi since it is a private helper and we need to test in a different package to prevent an import cycle
-func getRBACRoleRefKind(namespace string) string {
-	kind := "ClusterRole"
-	if len(namespace) != 0 {
-		kind = "Role"
-	}
-	return kind
 }

--- a/pkg/authorization/apis/authorization/register.go
+++ b/pkg/authorization/apis/authorization/register.go
@@ -17,7 +17,7 @@ var (
 	LegacySchemeBuilder    = runtime.NewSchemeBuilder(addLegacyKnownTypes)
 	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
 
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addConversionFuncs)
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 

--- a/pkg/authorization/apis/authorization/v1/conversion.go
+++ b/pkg/authorization/apis/authorization/v1/conversion.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/openshift/origin/pkg/api/apihelpers"
 	newer "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
 func Convert_v1_SubjectAccessReview_To_authorization_SubjectAccessReview(in *SubjectAccessReview, out *newer.SubjectAccessReview, s conversion.Scope) error {
@@ -152,7 +151,7 @@ func Convert_v1_RoleBinding_To_authorization_RoleBinding(in *RoleBinding, out *n
 		return nil
 	}
 
-	out.Subjects = newer.BuildSubjects(in.UserNames, in.GroupNames, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	out.Subjects = newer.BuildSubjects(in.UserNames, in.GroupNames)
 
 	return nil
 }
@@ -198,7 +197,7 @@ func Convert_v1_ClusterRoleBinding_To_authorization_ClusterRoleBinding(in *Clust
 		return nil
 	}
 
-	out.Subjects = newer.BuildSubjects(in.UserNames, in.GroupNames, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	out.Subjects = newer.BuildSubjects(in.UserNames, in.GroupNames)
 
 	return nil
 }

--- a/pkg/authorization/registry/selfsubjectrulesreview/storage.go
+++ b/pkg/authorization/registry/selfsubjectrulesreview/storage.go
@@ -14,6 +14,7 @@ import (
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectrulesreview"
 )
@@ -68,7 +69,7 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ bool) (runti
 
 	ret := &authorizationapi.SelfSubjectRulesReview{
 		Status: authorizationapi.SubjectRulesReviewStatus{
-			Rules: authorizationapi.Convert_rbac_PolicyRules_To_authorization_PolicyRules(rules), //TODO can we fix this ?
+			Rules: rbacconversion.Convert_rbac_PolicyRules_To_authorization_PolicyRules(rules), //TODO can we fix this ?
 		},
 	}
 

--- a/pkg/authorization/registry/subjectrulesreview/storage.go
+++ b/pkg/authorization/registry/subjectrulesreview/storage.go
@@ -15,6 +15,7 @@ import (
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 )
 
@@ -57,7 +58,7 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ bool) (runti
 
 	ret := &authorizationapi.SubjectRulesReview{
 		Status: authorizationapi.SubjectRulesReviewStatus{
-			Rules: authorizationapi.Convert_rbac_PolicyRules_To_authorization_PolicyRules(rules), //TODO can we fix this ?
+			Rules: rbacconversion.Convert_rbac_PolicyRules_To_authorization_PolicyRules(rules), //TODO can we fix this ?
 		},
 	}
 

--- a/pkg/authorization/registry/util/convert.go
+++ b/pkg/authorization/registry/util/convert.go
@@ -5,13 +5,14 @@ import (
 	"k8s.io/kubernetes/pkg/apis/rbac"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 )
 
 // ClusterRoleToRBAC turns an OpenShift ClusterRole into a Kubernetes RBAC
 // ClusterRole, the returned object is safe to mutate
 func ClusterRoleToRBAC(obj *authorizationapi.ClusterRole) (*rbac.ClusterRole, error) {
 	convertedObj := &rbac.ClusterRole{}
-	if err := authorizationapi.Convert_authorization_ClusterRole_To_rbac_ClusterRole(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_authorization_ClusterRole_To_rbac_ClusterRole(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -27,7 +28,7 @@ func ClusterRoleToRBAC(obj *authorizationapi.ClusterRole) (*rbac.ClusterRole, er
 // RBAC ClusterRoleBinding, the returned object is safe to mutate
 func ClusterRoleBindingToRBAC(obj *authorizationapi.ClusterRoleBinding) (*rbac.ClusterRoleBinding, error) {
 	convertedObj := &rbac.ClusterRoleBinding{}
-	if err := authorizationapi.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -43,7 +44,7 @@ func ClusterRoleBindingToRBAC(obj *authorizationapi.ClusterRoleBinding) (*rbac.C
 // the returned object is safe to mutate
 func RoleToRBAC(obj *authorizationapi.Role) (*rbac.Role, error) {
 	convertedObj := &rbac.Role{}
-	if err := authorizationapi.Convert_authorization_Role_To_rbac_Role(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_authorization_Role_To_rbac_Role(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -59,7 +60,7 @@ func RoleToRBAC(obj *authorizationapi.Role) (*rbac.Role, error) {
 // Rolebinding, the returned object is safe to mutate
 func RoleBindingToRBAC(obj *authorizationapi.RoleBinding) (*rbac.RoleBinding, error) {
 	convertedObj := &rbac.RoleBinding{}
-	if err := authorizationapi.Convert_authorization_RoleBinding_To_rbac_RoleBinding(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_authorization_RoleBinding_To_rbac_RoleBinding(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -75,7 +76,7 @@ func RoleBindingToRBAC(obj *authorizationapi.RoleBinding) (*rbac.RoleBinding, er
 // ClusterRole, the returned object is safe to mutate
 func ClusterRoleFromRBAC(obj *rbac.ClusterRole) (*authorizationapi.ClusterRole, error) {
 	convertedObj := &authorizationapi.ClusterRole{}
-	if err := authorizationapi.Convert_rbac_ClusterRole_To_authorization_ClusterRole(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_rbac_ClusterRole_To_authorization_ClusterRole(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -91,7 +92,7 @@ func ClusterRoleFromRBAC(obj *rbac.ClusterRole) (*authorizationapi.ClusterRole, 
 // an Openshift ClusterRoleBinding, the returned object is safe to mutate
 func ClusterRoleBindingFromRBAC(obj *rbac.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error) {
 	convertedObj := &authorizationapi.ClusterRoleBinding{}
-	if err := authorizationapi.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -107,7 +108,7 @@ func ClusterRoleBindingFromRBAC(obj *rbac.ClusterRoleBinding) (*authorizationapi
 // the returned object is safe to mutate
 func RoleFromRBAC(obj *rbac.Role) (*authorizationapi.Role, error) {
 	convertedObj := &authorizationapi.Role{}
-	if err := authorizationapi.Convert_rbac_Role_To_authorization_Role(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_rbac_Role_To_authorization_Role(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.
@@ -123,7 +124,7 @@ func RoleFromRBAC(obj *rbac.Role) (*authorizationapi.Role, error) {
 // Rolebinding, the returned object is safe to mutate
 func RoleBindingFromRBAC(obj *rbac.RoleBinding) (*authorizationapi.RoleBinding, error) {
 	convertedObj := &authorizationapi.RoleBinding{}
-	if err := authorizationapi.Convert_rbac_RoleBinding_To_authorization_RoleBinding(obj, convertedObj, nil); err != nil {
+	if err := rbacconversion.Convert_rbac_RoleBinding_To_authorization_RoleBinding(obj, convertedObj, nil); err != nil {
 		return nil, err
 	}
 	// do a deep copy here since conversion does not guarantee a new object.

--- a/pkg/oc/admin/policy/modify_roles.go
+++ b/pkg/oc/admin/policy/modify_roles.go
@@ -14,7 +14,6 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
 const (
@@ -402,7 +401,7 @@ func (o *RoleModificationOptions) AddRole() error {
 	roleBinding.RoleRef.Namespace = o.RoleNamespace
 	roleBinding.RoleRef.Name = o.RoleName
 
-	newSubjects := authorizationapi.BuildSubjects(o.Users, o.Groups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	newSubjects := authorizationapi.BuildSubjects(o.Users, o.Groups)
 	newSubjects = append(newSubjects, o.Subjects...)
 
 subjectCheck:
@@ -443,7 +442,7 @@ func (o *RoleModificationOptions) RemoveRole() error {
 		return fmt.Errorf("unable to locate RoleBinding for %v/%v", o.RoleNamespace, o.RoleName)
 	}
 
-	subjectsToRemove := authorizationapi.BuildSubjects(o.Users, o.Groups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	subjectsToRemove := authorizationapi.BuildSubjects(o.Users, o.Groups)
 	subjectsToRemove = append(subjectsToRemove, o.Subjects...)
 
 	for _, roleBinding := range roleBindings {

--- a/pkg/oc/admin/policy/modify_scc.go
+++ b/pkg/oc/admin/policy/modify_scc.go
@@ -15,7 +15,6 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/security/legacyclient"
-	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
 const (
@@ -139,7 +138,7 @@ func (o *SCCModificationOptions) CompleteUsers(f *clientcmd.Factory, args []stri
 	}
 
 	o.SCCName = args[0]
-	o.Subjects = authorizationapi.BuildSubjects(args[1:], []string{}, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	o.Subjects = authorizationapi.BuildSubjects(args[1:], []string{})
 
 	if (len(o.Subjects) == 0) && (len(saNames) == 0) {
 		return errors.New("you must specify at least one user or service account")
@@ -169,7 +168,7 @@ func (o *SCCModificationOptions) CompleteGroups(f *clientcmd.Factory, args []str
 	}
 
 	o.SCCName = args[0]
-	o.Subjects = authorizationapi.BuildSubjects([]string{}, args[1:], uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	o.Subjects = authorizationapi.BuildSubjects([]string{}, args[1:])
 
 	_, kc, err := f.Clients()
 	if err != nil {

--- a/pkg/oc/admin/policy/reconcile_clusterrolebindings.go
+++ b/pkg/oc/admin/policy/reconcile_clusterrolebindings.go
@@ -22,8 +22,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-
-	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
 // ReconcileClusterRoleBindingsRecommendedName is the recommended command name
@@ -125,7 +123,7 @@ func (o *ReconcileClusterRoleBindingsOptions) Complete(cmd *cobra.Command, f *cl
 
 	o.Output = kcmdutil.GetFlagString(cmd, "output")
 
-	o.ExcludeSubjects = authorizationapi.BuildSubjects(excludeUsers, excludeGroups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	o.ExcludeSubjects = authorizationapi.BuildSubjects(excludeUsers, excludeGroups)
 
 	mapper, _ := f.Object()
 	for _, resourceString := range args {

--- a/pkg/oc/admin/policy/remove_from_project.go
+++ b/pkg/oc/admin/policy/remove_from_project.go
@@ -15,7 +15,6 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
 
 const (
@@ -108,7 +107,7 @@ func (o *RemoveFromProjectOptions) Run() error {
 	sasRemoved := sets.String{}
 	othersRemoved := sets.String{}
 
-	subjectsToRemove := authorizationapi.BuildSubjects(o.Users, o.Groups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	subjectsToRemove := authorizationapi.BuildSubjects(o.Users, o.Groups)
 
 	for _, currBinding := range roleBindings.Items {
 		originalSubjects := make([]kapi.ObjectReference, len(currBinding.Subjects))

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -13,7 +13,6 @@ import (
 	groupscmd "github.com/openshift/origin/pkg/oc/admin/groups"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
-	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -89,7 +88,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 	roleBinding := &authorizationapi.RoleBinding{}
 	roleBinding.Name = "admins"
 	roleBinding.RoleRef.Name = "admin"
-	roleBinding.Subjects = authorizationapi.BuildSubjects([]string{}, valerieGroups, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	roleBinding.Subjects = authorizationapi.BuildSubjects([]string{}, valerieGroups)
 	_, err = clusterAdminClient.RoleBindings("empty").Create(roleBinding)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -150,7 +149,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 	roleBinding := &authorizationapi.RoleBinding{}
 	roleBinding.Name = "admins"
 	roleBinding.RoleRef.Name = "admin"
-	roleBinding.Subjects = authorizationapi.BuildSubjects([]string{}, []string{theGroup.Name}, uservalidation.ValidateUserName, uservalidation.ValidateGroupName)
+	roleBinding.Subjects = authorizationapi.BuildSubjects([]string{}, []string{theGroup.Name})
 	_, err = clusterAdminClient.RoleBindings("empty").Create(roleBinding)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/rbac"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -141,7 +142,7 @@ func TestRestrictUsers(t *testing.T) {
 	// Creating a RBAC rolebinding when the subject is not already bound
 	// should also fail.
 	rbacRolebindingBob := &rbac.RoleBinding{}
-	if err := authorizationapi.Convert_authorization_RoleBinding_To_rbac_RoleBinding(rolebindingBob, rbacRolebindingBob, nil); err != nil {
+	if err := rbacconversion.Convert_authorization_RoleBinding_To_rbac_RoleBinding(rolebindingBob, rbacRolebindingBob, nil); err != nil {
 		t.Fatalf("failed to convert RoleBinding: %v", err)
 	}
 	if _, err := clusterAdminKubeClient.Rbac().RoleBindings("namespace").Create(rbacRolebindingBob); !kapierrors.IsForbidden(err) {


### PR DESCRIPTION
Dependencies outside of apimachinery and the upstream api objects need to be removed.  This removes several from authorization.openshift.io.

@openshift/sig-security fyi
@mfojtik 