### PR TITLE
contain annotations to the appropriate group

### DIFF
--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -29,7 +29,7 @@ const (
 	ExcludeImageSecretAnnotation = "openshift.io/image.excludeSecret"
 
 	// DockerImageLayersOrderAnnotation describes layers order in the docker image.
-	DockerImageLayersOrderAnnotation = "openshift.io/image.dockerLayersOrder"
+	DockerImageLayersOrderAnnotation = "image.openshift.io/dockerLayersOrder"
 
 	// DockerImageLayersOrderAscending indicates that image layers are sorted in
 	// the order of their addition (from oldest to latest)


### PR DESCRIPTION
https://github.com/openshift/origin/pull/16430 created a new annotation, but it is logically contained to the image api group.  Rather than take up space in the global annotation namespace, we should be containing these to the group involved.

Once we reach a critical mass, it will make sense to write bilingual code for a upgrade+N and plan an `oadm migrate`.  We may even be able to get clever in strategies since we have old and new to know which annotation was twiddled.