### PR TITLE
[3.6] Verify docker access via non grouped resources

### DIFF
--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -493,7 +493,7 @@ func verifyWithSAR(ctx context.Context, resource, namespace, name, verb string, 
 	sar := authorizationapi.LocalSubjectAccessReview{
 		Action: authorizationapi.Action{
 			Verb:         verb,
-			Group:        imageapi.GroupName,
+			Group:        imageapi.LegacyGroupName,
 			Resource:     resource,
 			ResourceName: name,
 		},
@@ -528,7 +528,7 @@ func verifyPruneAccess(ctx context.Context, client client.SubjectAccessReviews) 
 	sar := authorizationapi.SubjectAccessReview{
 		Action: authorizationapi.Action{
 			Verb:     "delete",
-			Group:    imageapi.GroupName,
+			Group:    imageapi.LegacyGroupName,
 			Resource: "images",
 		},
 	}


### PR DESCRIPTION
In the transition between 3.5 and 3.6, we should target the non grouped resources when performing SARs to confirm image access via docker.  This is because a 3.5 master will only allow a SAR against the non grouped resources.  Once a 3.5 master has been updated to 3.6, it will still only allow a SAR against the non grouped resources.  After cluster role reconciliation is complete and the policy cache is up to date, then the upgraded masters will honor SARs against the group resources.  Waiting for this to occur is not a viable solution since it breaks cluster functionality during a high availability upgrade.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1493213
Fixes #16380

/assign @simo5 @tiran @legionus @mfojtik

@openshift/sig-security 