### PR TITLE
ensure knownObjects is not nil

### DIFF
--- a/pkg/oc/cli/cmd/observe/observe.go
+++ b/pkg/oc/cli/cmd/observe/observe.go
@@ -345,8 +345,7 @@ func (o *ObserveOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args
 	}
 
 	o.argumentStore = &objectArgumentsStore{}
-	switch {
-	case len(o.nameSyncCommand) > 0:
+	if len(o.nameSyncCommand) > 0 {
 		o.argumentStore.keyFn = func() ([]string, error) {
 			var out []byte
 			err := retryCommandError(o.retryExitStatus, o.retryCount, func() error {
@@ -377,10 +376,8 @@ func (o *ObserveOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args
 			glog.V(4).Infof("Found existing keys: %v", outputNames)
 			return outputNames, nil
 		}
-		o.knownObjects = o.argumentStore
-	case len(o.deleteCommand) > 0:
-		o.knownObjects = o.argumentStore
 	}
+	o.knownObjects = o.argumentStore
 
 	return nil
 }


### PR DESCRIPTION
Related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1377940

`knownObjects` was being left `nil` if none of the switch cases were hit.
This, in turn, caused a nil pointer dereference [here](https://github.com/kubernetes/client-go/blob/master/tools/cache/delta_fifo.go#L542)

cc @openshift/cli-review @smarterclayton 