### PR TITLE
Remove uses of legacy client

### DIFF
--- a/pkg/build/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission.go
@@ -20,7 +20,6 @@ import (
 	authenticationclient "github.com/openshift/origin/pkg/auth/client"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	jenkinscontroller "github.com/openshift/origin/pkg/build/controller/jenkins"
-	"github.com/openshift/origin/pkg/client"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/config/cmd"
@@ -39,7 +38,6 @@ type jenkinsBootstrapper struct {
 
 	privilegedRESTClientConfig restclient.Config
 	serviceClient              coreclient.ServicesGetter
-	openshiftClient            client.Interface
 	templateClient             templateclient.Interface
 
 	jenkinsConfig configapi.JenkinsPipelineConfig
@@ -47,7 +45,6 @@ type jenkinsBootstrapper struct {
 
 var _ = oadmission.WantsJenkinsPipelineConfig(&jenkinsBootstrapper{})
 var _ = oadmission.WantsRESTClientConfig(&jenkinsBootstrapper{})
-var _ = oadmission.WantsDeprecatedOpenshiftClient(&jenkinsBootstrapper{})
 var _ = oadmission.WantsOpenshiftInternalTemplateClient(&jenkinsBootstrapper{})
 var _ = kadmission.WantsInternalKubeClientSet(&jenkinsBootstrapper{})
 
@@ -153,17 +150,16 @@ func (q *jenkinsBootstrapper) SetInternalKubeClientSet(c kclientset.Interface) {
 	q.serviceClient = c.Core()
 }
 
-func (a *jenkinsBootstrapper) SetDeprecatedOpenshiftClient(oclient client.Interface) {
-	a.openshiftClient = oclient
-}
-
 func (a *jenkinsBootstrapper) SetOpenShiftInternalTemplateClient(c templateclient.Interface) {
 	a.templateClient = c
 }
 
 func (a *jenkinsBootstrapper) Validate() error {
-	if a.openshiftClient == nil {
-		return fmt.Errorf("missing openshiftClient")
+	if a.serviceClient == nil {
+		return fmt.Errorf("missing serviceClient")
+	}
+	if a.templateClient == nil {
+		return fmt.Errorf("missing templateClient")
 	}
 	return nil
 }

--- a/pkg/build/admission/strategyrestrictions/admission_test.go
+++ b/pkg/build/admission/strategyrestrictions/admission_test.go
@@ -11,116 +11,127 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
 	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/pkg/apis/authorization"
+	fakekubeclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	kubeadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
-	"github.com/openshift/origin/pkg/client"
-	"github.com/openshift/origin/pkg/client/testclient"
+	fakebuildclient "github.com/openshift/origin/pkg/build/generated/internalclientset/fake"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 )
 
 func TestBuildAdmission(t *testing.T) {
 	tests := []struct {
-		name             string
-		kind             schema.GroupKind
-		resource         schema.GroupResource
-		subResource      string
-		object           runtime.Object
-		oldObject        runtime.Object
-		responseObject   runtime.Object
-		reviewResponse   *authorizationapi.SubjectAccessReviewResponse
-		expectedResource string
-		expectAccept     bool
-		expectedError    string
+		name                string
+		kind                schema.GroupKind
+		resource            schema.GroupResource
+		subResource         string
+		object              runtime.Object
+		oldObject           runtime.Object
+		responseObject      runtime.Object
+		reviewResponse      *authorization.SubjectAccessReview
+		expectedResource    string
+		expectedSubresource string
+		expectAccept        bool
+		expectedError       string
 	}{
 		{
-			name:             "allowed source build",
-			object:           testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			reviewResponse:   reviewResponse(true, ""),
-			expectedResource: authorizationapi.SourceBuildResource,
-			expectAccept:     true,
+			name:                "allowed source build",
+			object:              testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			reviewResponse:      reviewResponse(true, ""),
+			expectedResource:    "builds",
+			expectedSubresource: "source",
+			expectAccept:        true,
 		},
 		{
-			name:             "allowed source build clone",
-			object:           testBuildRequest("buildname"),
-			responseObject:   testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			subResource:      "clone",
-			reviewResponse:   reviewResponse(true, ""),
-			expectedResource: authorizationapi.SourceBuildResource,
-			expectAccept:     true,
+			name:                "allowed source build clone",
+			object:              testBuildRequest("test-build"),
+			responseObject:      testBuild(buildapi.BuildStrategy{SourceStrategy: &buildapi.SourceBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			subResource:         "clone",
+			reviewResponse:      reviewResponse(true, ""),
+			expectedResource:    "builds",
+			expectedSubresource: "source",
+			expectAccept:        true,
 		},
 		{
-			name:             "denied docker build",
-			object:           testBuild(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			reviewResponse:   reviewResponse(false, "cannot create build of type docker build"),
-			expectAccept:     false,
-			expectedResource: authorizationapi.DockerBuildResource,
+			name:                "denied docker build",
+			object:              testBuild(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			reviewResponse:      reviewResponse(false, "cannot create build of type docker build"),
+			expectAccept:        false,
+			expectedResource:    "builds",
+			expectedSubresource: "docker",
 		},
 		{
-			name:             "denied docker build clone",
-			object:           testBuildRequest("buildname"),
-			responseObject:   testBuild(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			subResource:      "clone",
-			reviewResponse:   reviewResponse(false, "cannot create build of type docker build"),
-			expectAccept:     false,
-			expectedResource: authorizationapi.DockerBuildResource,
+			name:                "denied docker build clone",
+			object:              testBuildRequest("buildname"),
+			responseObject:      testBuild(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			subResource:         "clone",
+			reviewResponse:      reviewResponse(false, "cannot create build of type docker build"),
+			expectAccept:        false,
+			expectedResource:    "builds",
+			expectedSubresource: "docker",
 		},
 		{
-			name:             "allowed custom build",
-			object:           testBuild(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			reviewResponse:   reviewResponse(true, ""),
-			expectedResource: authorizationapi.CustomBuildResource,
-			expectAccept:     true,
+			name:                "allowed custom build",
+			object:              testBuild(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			reviewResponse:      reviewResponse(true, ""),
+			expectedResource:    "builds",
+			expectedSubresource: "custom",
+			expectAccept:        true,
 		},
 		{
-			name:             "allowed build config",
-			object:           testBuildConfig(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
-			kind:             buildapi.Kind("BuildConfig"),
-			resource:         buildapi.Resource("buildconfigs"),
-			reviewResponse:   reviewResponse(true, ""),
-			expectAccept:     true,
-			expectedResource: authorizationapi.DockerBuildResource,
+			name:                "allowed build config",
+			object:              testBuildConfig(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
+			kind:                buildapi.Kind("BuildConfig"),
+			resource:            buildapi.Resource("buildconfigs"),
+			reviewResponse:      reviewResponse(true, ""),
+			expectAccept:        true,
+			expectedResource:    "builds",
+			expectedSubresource: "docker",
 		},
 		{
-			name:             "allowed build config instantiate",
-			responseObject:   testBuildConfig(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
-			object:           testBuildRequest("buildname"),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("buildconfigs"),
-			subResource:      "instantiate",
-			reviewResponse:   reviewResponse(true, ""),
-			expectAccept:     true,
-			expectedResource: authorizationapi.DockerBuildResource,
+			name:                "allowed build config instantiate",
+			responseObject:      testBuildConfig(buildapi.BuildStrategy{DockerStrategy: &buildapi.DockerBuildStrategy{}}),
+			object:              testBuildRequest("test-buildconfig"),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("buildconfigs"),
+			subResource:         "instantiate",
+			reviewResponse:      reviewResponse(true, ""),
+			expectAccept:        true,
+			expectedResource:    "builds",
+			expectedSubresource: "docker",
 		},
 		{
-			name:             "forbidden build config",
-			object:           testBuildConfig(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("buildconfigs"),
-			reviewResponse:   reviewResponse(false, ""),
-			expectAccept:     false,
-			expectedResource: authorizationapi.CustomBuildResource,
+			name:                "forbidden build config",
+			object:              testBuildConfig(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("buildconfigs"),
+			reviewResponse:      reviewResponse(false, ""),
+			expectAccept:        false,
+			expectedResource:    "builds",
+			expectedSubresource: "custom",
 		},
 		{
-			name:             "forbidden build config instantiate",
-			responseObject:   testBuildConfig(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
-			object:           testBuildRequest("buildname"),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("buildconfigs"),
-			subResource:      "instantiate",
-			reviewResponse:   reviewResponse(false, ""),
-			expectAccept:     false,
-			expectedResource: authorizationapi.CustomBuildResource,
+			name:                "forbidden build config instantiate",
+			responseObject:      testBuildConfig(buildapi.BuildStrategy{CustomStrategy: &buildapi.CustomBuildStrategy{}}),
+			object:              testBuildRequest("buildname"),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("buildconfigs"),
+			subResource:         "instantiate",
+			reviewResponse:      reviewResponse(false, ""),
+			expectAccept:        false,
+			expectedResource:    "builds",
+			expectedSubresource: "custom",
 		},
 		{
 			name:           "unrecognized request object",
@@ -141,46 +152,77 @@ func TestBuildAdmission(t *testing.T) {
 			expectAccept:   true,
 		},
 		{
-			name:             "allowed jenkins pipeline build",
-			object:           testBuild(buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			reviewResponse:   reviewResponse(true, ""),
-			expectedResource: authorizationapi.JenkinsPipelineBuildResource,
-			expectAccept:     true,
+			name:                "allowed jenkins pipeline build",
+			object:              testBuild(buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			reviewResponse:      reviewResponse(true, ""),
+			expectedResource:    "builds",
+			expectedSubresource: "jenkinspipeline",
+			expectAccept:        true,
 		},
 		{
-			name:             "allowed jenkins pipeline build clone",
-			object:           testBuildRequest("buildname"),
-			responseObject:   testBuild(buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}),
-			kind:             buildapi.Kind("Build"),
-			resource:         buildapi.Resource("builds"),
-			subResource:      "clone",
-			reviewResponse:   reviewResponse(true, ""),
-			expectedResource: authorizationapi.JenkinsPipelineBuildResource,
-			expectAccept:     true,
+			name:                "allowed jenkins pipeline build clone",
+			object:              testBuildRequest("test-build"),
+			responseObject:      testBuild(buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}),
+			kind:                buildapi.Kind("Build"),
+			resource:            buildapi.Resource("builds"),
+			subResource:         "clone",
+			reviewResponse:      reviewResponse(true, ""),
+			expectedResource:    "builds",
+			expectedSubresource: "jenkinspipeline",
+			expectAccept:        true,
 		},
 	}
 
+	emptyResponse := &authorization.SubjectAccessReview{}
 	ops := []admission.Operation{admission.Create, admission.Update}
 	for _, test := range tests {
-		for _, op := range ops {
-			client := fakeClient(test.expectedResource, test.reviewResponse, test.responseObject)
-			c := NewBuildByStrategy()
-			c.(oadmission.WantsDeprecatedOpenshiftClient).SetDeprecatedOpenshiftClient(client)
-			attrs := admission.NewAttributesRecord(test.object, test.oldObject, test.kind.WithVersion("version"), "default", "name", test.resource.WithVersion("version"), test.subResource, op, fakeUser())
-			err := c.Admit(attrs)
-			if err != nil && test.expectAccept {
-				t.Errorf("%s: unexpected error: %v", test.name, err)
-			}
-
-			if !apierrors.IsForbidden(err) && !test.expectAccept {
-				if (len(test.expectedError) != 0) || (test.expectedError == err.Error()) {
-					continue
+		t.Run(test.name, func(t *testing.T) {
+			for _, op := range ops {
+				fakeBuildClient := fakebuildclient.NewSimpleClientset()
+				if test.responseObject != nil {
+					fakeBuildClient = fakebuildclient.NewSimpleClientset(test.responseObject)
 				}
-				t.Errorf("%s: expecting reject error, got %v", test.name, err)
+
+				fakeKubeClient := fakekubeclient.NewSimpleClientset()
+				fakeKubeClient.PrependReactor("create", "subjectaccessreviews", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+					review, ok := action.(clientgotesting.CreateAction).GetObject().(*authorization.SubjectAccessReview)
+					if !ok {
+						return true, emptyResponse, fmt.Errorf("unexpected object received: %#v", review)
+					}
+					if review.Spec.ResourceAttributes.Group != buildapi.GroupName {
+						return true, emptyResponse, fmt.Errorf("unexpected group received: %s. expected: %s",
+							review.Spec.ResourceAttributes.Group, buildapi.GroupName)
+					}
+					if review.Spec.ResourceAttributes.Resource != test.expectedResource {
+						return true, emptyResponse, fmt.Errorf("unexpected resource received: %s. expected: %s",
+							review.Spec.ResourceAttributes.Resource, test.expectedResource)
+					}
+					if review.Spec.ResourceAttributes.Subresource != test.expectedSubresource {
+						return true, emptyResponse, fmt.Errorf("unexpected subresource received: %s. expected: %s",
+							review.Spec.ResourceAttributes.Subresource, test.expectedSubresource)
+					}
+					return true, test.reviewResponse, nil
+				})
+
+				c := NewBuildByStrategy()
+				c.(kubeadmission.WantsInternalKubeClientSet).SetInternalKubeClientSet(fakeKubeClient)
+				c.(oadmission.WantsOpenshiftInternalBuildClient).SetOpenshiftInternalBuildClient(fakeBuildClient)
+				attrs := admission.NewAttributesRecord(test.object, test.oldObject, test.kind.WithVersion("version"), "foo", "test-build", test.resource.WithVersion("version"), test.subResource, op, fakeUser())
+				err := c.Admit(attrs)
+				if err != nil && test.expectAccept {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				if !apierrors.IsForbidden(err) && !test.expectAccept {
+					if (len(test.expectedError) != 0) || (test.expectedError == err.Error()) {
+						continue
+					}
+					t.Errorf("expecting reject error, got %v", err)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -194,35 +236,11 @@ func fakeUser() user.Info {
 	}
 }
 
-func fakeClient(expectedResource string, reviewResponse *authorizationapi.SubjectAccessReviewResponse, obj runtime.Object) client.Interface {
-	emptyResponse := &authorizationapi.SubjectAccessReviewResponse{}
-
-	fake := &testclient.Fake{}
-	fake.AddReactor("create", "localsubjectaccessreviews", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		review, ok := action.(clientgotesting.CreateAction).GetObject().(*authorizationapi.LocalSubjectAccessReview)
-		if !ok {
-			return true, emptyResponse, fmt.Errorf("unexpected object received: %#v", review)
-		}
-		if review.Action.Resource != expectedResource {
-			return true, emptyResponse, fmt.Errorf("unexpected resource received: %s. expected: %s",
-				review.Action.Resource, expectedResource)
-		}
-		return true, reviewResponse, nil
-	})
-	fake.AddReactor("get", "buildconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, obj, nil
-	})
-	fake.AddReactor("get", "builds", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, obj, nil
-	})
-
-	return fake
-}
-
 func testBuild(strategy buildapi.BuildStrategy) *buildapi.Build {
 	return &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-build",
+			Namespace: "foo",
+			Name:      "test-build",
 		},
 		Spec: buildapi.BuildSpec{
 			CommonSpec: buildapi.CommonSpec{
@@ -235,7 +253,8 @@ func testBuild(strategy buildapi.BuildStrategy) *buildapi.Build {
 func testBuildConfig(strategy buildapi.BuildStrategy) *buildapi.BuildConfig {
 	return &buildapi.BuildConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-buildconfig",
+			Namespace: "foo",
+			Name:      "test-buildconfig",
 		},
 		Spec: buildapi.BuildConfigSpec{
 			CommonSpec: buildapi.CommonSpec{
@@ -245,17 +264,20 @@ func testBuildConfig(strategy buildapi.BuildStrategy) *buildapi.BuildConfig {
 	}
 }
 
-func reviewResponse(allowed bool, msg string) *authorizationapi.SubjectAccessReviewResponse {
-	return &authorizationapi.SubjectAccessReviewResponse{
-		Allowed: allowed,
-		Reason:  msg,
+func reviewResponse(allowed bool, msg string) *authorization.SubjectAccessReview {
+	return &authorization.SubjectAccessReview{
+		Status: authorization.SubjectAccessReviewStatus{
+			Allowed: allowed,
+			Reason:  msg,
+		},
 	}
 }
 
 func testBuildRequest(name string) runtime.Object {
 	return &buildapi.BuildRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Namespace: "foo",
+			Name:      name,
 		},
 	}
 }

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -10,13 +10,13 @@ import (
 
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
-	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
+	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	userinformer "github.com/openshift/origin/pkg/user/generated/informers/internalversion"
@@ -24,10 +24,10 @@ import (
 )
 
 type PluginInitializer struct {
-	OpenshiftClient                      client.Interface
 	OpenshiftInternalAuthorizationClient authorizationclient.Interface
 	OpenshiftInternalBuildClient         buildclient.Interface
 	OpenshiftInternalImageClient         imageclient.Interface
+	OpenshiftInternalQuotaClient         quotaclient.Interface
 	OpenshiftInternalTemplateClient      templateclient.Interface
 	OpenshiftInternalUserClient          userclient.Interface
 	ProjectCache                         *cache.ProjectCache
@@ -46,9 +46,6 @@ type PluginInitializer struct {
 // Initialize will check the initialization interfaces implemented by each plugin
 // and provide the appropriate initialization data
 func (i *PluginInitializer) Initialize(plugin admission.Interface) {
-	if wantsDeprecatedOpenshiftClient, ok := plugin.(WantsDeprecatedOpenshiftClient); ok {
-		wantsDeprecatedOpenshiftClient.SetDeprecatedOpenshiftClient(i.OpenshiftClient)
-	}
 	if wantsOpenshiftAuthorizationClient, ok := plugin.(WantsOpenshiftInternalAuthorizationClient); ok {
 		wantsOpenshiftAuthorizationClient.SetOpenshiftInternalAuthorizationClient(i.OpenshiftInternalAuthorizationClient)
 	}
@@ -57,6 +54,9 @@ func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	}
 	if wantsOpenshiftImageClient, ok := plugin.(WantsOpenshiftInternalImageClient); ok {
 		wantsOpenshiftImageClient.SetOpenshiftInternalImageClient(i.OpenshiftInternalImageClient)
+	}
+	if wantsOpenshiftQuotaClient, ok := plugin.(WantsOpenshiftInternalQuotaClient); ok {
+		wantsOpenshiftQuotaClient.SetOpenshiftInternalQuotaClient(i.OpenshiftInternalQuotaClient)
 	}
 	if WantsOpenshiftInternalTemplateClient, ok := plugin.(WantsOpenshiftInternalTemplateClient); ok {
 		WantsOpenshiftInternalTemplateClient.SetOpenShiftInternalTemplateClient(i.OpenshiftInternalTemplateClient)

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/kubernetes/pkg/quota"
 
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
+	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -25,6 +26,7 @@ import (
 type PluginInitializer struct {
 	OpenshiftClient                      client.Interface
 	OpenshiftInternalAuthorizationClient authorizationclient.Interface
+	OpenshiftInternalBuildClient         buildclient.Interface
 	OpenshiftInternalImageClient         imageclient.Interface
 	OpenshiftInternalTemplateClient      templateclient.Interface
 	OpenshiftInternalUserClient          userclient.Interface
@@ -49,6 +51,9 @@ func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	}
 	if wantsOpenshiftAuthorizationClient, ok := plugin.(WantsOpenshiftInternalAuthorizationClient); ok {
 		wantsOpenshiftAuthorizationClient.SetOpenshiftInternalAuthorizationClient(i.OpenshiftInternalAuthorizationClient)
+	}
+	if wantsOpenshiftBuildClient, ok := plugin.(WantsOpenshiftInternalBuildClient); ok {
+		wantsOpenshiftBuildClient.SetOpenshiftInternalBuildClient(i.OpenshiftInternalBuildClient)
 	}
 	if wantsOpenshiftImageClient, ok := plugin.(WantsOpenshiftInternalImageClient); ok {
 		wantsOpenshiftImageClient.SetOpenshiftInternalImageClient(i.OpenshiftInternalImageClient)

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -8,6 +8,7 @@ import (
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/quota"
 
+	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -18,23 +19,26 @@ import (
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	userinformer "github.com/openshift/origin/pkg/user/generated/informers/internalversion"
+	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
 
 type PluginInitializer struct {
-	OpenshiftClient                 client.Interface
-	OpenshiftInternalImageClient    imageclient.Interface
-	OpenshiftInternalTemplateClient templateclient.Interface
-	ProjectCache                    *cache.ProjectCache
-	OriginQuotaRegistry             quota.Registry
-	Authorizer                      kauthorizer.Authorizer
-	JenkinsPipelineConfig           configapi.JenkinsPipelineConfig
-	RESTClientConfig                restclient.Config
-	Informers                       kinternalinformers.SharedInformerFactory
-	ClusterResourceQuotaInformer    quotainformer.ClusterResourceQuotaInformer
-	ClusterQuotaMapper              clusterquotamapping.ClusterQuotaMapper
-	RegistryHostnameRetriever       imageapi.RegistryHostnameRetriever
-	SecurityInformers               securityinformer.SharedInformerFactory
-	UserInformers                   userinformer.SharedInformerFactory
+	OpenshiftClient                      client.Interface
+	OpenshiftInternalAuthorizationClient authorizationclient.Interface
+	OpenshiftInternalImageClient         imageclient.Interface
+	OpenshiftInternalTemplateClient      templateclient.Interface
+	OpenshiftInternalUserClient          userclient.Interface
+	ProjectCache                         *cache.ProjectCache
+	OriginQuotaRegistry                  quota.Registry
+	Authorizer                           kauthorizer.Authorizer
+	JenkinsPipelineConfig                configapi.JenkinsPipelineConfig
+	RESTClientConfig                     restclient.Config
+	Informers                            kinternalinformers.SharedInformerFactory
+	ClusterResourceQuotaInformer         quotainformer.ClusterResourceQuotaInformer
+	ClusterQuotaMapper                   clusterquotamapping.ClusterQuotaMapper
+	RegistryHostnameRetriever            imageapi.RegistryHostnameRetriever
+	SecurityInformers                    securityinformer.SharedInformerFactory
+	UserInformers                        userinformer.SharedInformerFactory
 }
 
 // Initialize will check the initialization interfaces implemented by each plugin
@@ -43,11 +47,17 @@ func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	if wantsDeprecatedOpenshiftClient, ok := plugin.(WantsDeprecatedOpenshiftClient); ok {
 		wantsDeprecatedOpenshiftClient.SetDeprecatedOpenshiftClient(i.OpenshiftClient)
 	}
+	if wantsOpenshiftAuthorizationClient, ok := plugin.(WantsOpenshiftInternalAuthorizationClient); ok {
+		wantsOpenshiftAuthorizationClient.SetOpenshiftInternalAuthorizationClient(i.OpenshiftInternalAuthorizationClient)
+	}
 	if wantsOpenshiftImageClient, ok := plugin.(WantsOpenshiftInternalImageClient); ok {
 		wantsOpenshiftImageClient.SetOpenshiftInternalImageClient(i.OpenshiftInternalImageClient)
 	}
 	if WantsOpenshiftInternalTemplateClient, ok := plugin.(WantsOpenshiftInternalTemplateClient); ok {
 		WantsOpenshiftInternalTemplateClient.SetOpenShiftInternalTemplateClient(i.OpenshiftInternalTemplateClient)
+	}
+	if WantsOpenshiftInternalUserClient, ok := plugin.(WantsOpenshiftInternalUserClient); ok {
+		WantsOpenshiftInternalUserClient.SetOpenshiftInternalUserClient(i.OpenshiftInternalUserClient)
 	}
 	if wantsProjectCache, ok := plugin.(WantsProjectCache); ok {
 		wantsProjectCache.SetProjectCache(i.ProjectCache)

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -9,24 +9,17 @@ import (
 
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
-	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
+	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	userinformer "github.com/openshift/origin/pkg/user/generated/informers/internalversion"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
-
-// WantDeprecatedOpenshiftClient should be implemented by admission plugins that need
-// an Openshift client
-type WantsDeprecatedOpenshiftClient interface {
-	SetDeprecatedOpenshiftClient(client.Interface)
-	admission.Validator
-}
 
 type WantsOpenshiftInternalAuthorizationClient interface {
 	SetOpenshiftInternalAuthorizationClient(authorizationclient.Interface)
@@ -42,6 +35,11 @@ type WantsOpenshiftInternalBuildClient interface {
 // an Openshift internal image client
 type WantsOpenshiftInternalImageClient interface {
 	SetOpenshiftInternalImageClient(imageclient.Interface)
+	admission.Validator
+}
+
+type WantsOpenshiftInternalQuotaClient interface {
+	SetOpenshiftInternalQuotaClient(quotaclient.Interface)
 	admission.Validator
 }
 

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/kubernetes/pkg/quota"
 
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
+	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
@@ -29,6 +30,11 @@ type WantsDeprecatedOpenshiftClient interface {
 
 type WantsOpenshiftInternalAuthorizationClient interface {
 	SetOpenshiftInternalAuthorizationClient(authorizationclient.Interface)
+	admission.Validator
+}
+
+type WantsOpenshiftInternalBuildClient interface {
+	SetOpenshiftInternalBuildClient(buildclient.Interface)
 	admission.Validator
 }
 

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -7,6 +7,7 @@ import (
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/quota"
 
+	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	"github.com/openshift/origin/pkg/client"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
@@ -16,12 +17,25 @@ import (
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	userinformer "github.com/openshift/origin/pkg/user/generated/informers/internalversion"
+	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
 
 // WantDeprecatedOpenshiftClient should be implemented by admission plugins that need
 // an Openshift client
 type WantsDeprecatedOpenshiftClient interface {
 	SetDeprecatedOpenshiftClient(client.Interface)
+	admission.Validator
+}
+
+type WantsOpenshiftInternalAuthorizationClient interface {
+	SetOpenshiftInternalAuthorizationClient(authorizationclient.Interface)
+	admission.Validator
+}
+
+// WantsOpenshiftInternalImageClient should be implemented by admission plugins that need
+// an Openshift internal image client
+type WantsOpenshiftInternalImageClient interface {
+	SetOpenshiftInternalImageClient(imageclient.Interface)
 	admission.Validator
 }
 
@@ -32,10 +46,8 @@ type WantsOpenshiftInternalTemplateClient interface {
 	admission.Validator
 }
 
-// WantsOpenshiftInternalImageClient should be implemented by admission plugins that need
-// an Openshift internal image client
-type WantsOpenshiftInternalImageClient interface {
-	SetOpenshiftInternalImageClient(imageclient.Interface)
+type WantsOpenshiftInternalUserClient interface {
+	SetOpenshiftInternalUserClient(userclient.Interface)
 	admission.Validator
 }
 

--- a/pkg/cmd/server/origin/controller/quota.go
+++ b/pkg/cmd/server/origin/controller/quota.go
@@ -22,7 +22,6 @@ func RunResourceQuotaManager(ctx ControllerContext) (bool, error) {
 
 	resourceQuotaRegistry := quota.NewOriginQuotaRegistry(
 		ctx.ImageInformers.Image().InternalVersion().ImageStreams(),
-		ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
 	)
 
 	resourceQuotaControllerOptions := &kresourcequota.ResourceQuotaControllerOptions{
@@ -34,7 +33,6 @@ func RunResourceQuotaManager(ctx ControllerContext) (bool, error) {
 		ControllerFactory: quotacontroller.NewAllResourceReplenishmentControllerFactory(
 			ctx.ExternalKubeInformers,
 			ctx.ImageInformers.Image().InternalVersion().ImageStreams(),
-			ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
 		),
 		ReplenishmentResyncPeriod: replenishmentSyncPeriodFunc,
 	}
@@ -53,7 +51,6 @@ func (c *ClusterQuotaReconciliationControllerConfig) RunController(ctx Controlle
 	resourceQuotaRegistry := quota.NewAllResourceQuotaRegistry(
 		ctx.ExternalKubeInformers,
 		ctx.ImageInformers.Image().InternalVersion().ImageStreams(),
-		ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
 		ctx.ClientBuilder.ClientOrDie(saName),
 	)
 	groupKindsToReplenish := quota.AllEvaluatedGroupKinds
@@ -64,14 +61,13 @@ func (c *ClusterQuotaReconciliationControllerConfig) RunController(ctx Controlle
 	options := clusterquotareconciliation.ClusterQuotaReconcilationControllerOptions{
 		ClusterQuotaInformer: ctx.QuotaInformers.Quota().InternalVersion().ClusterResourceQuotas(),
 		ClusterQuotaMapper:   clusterQuotaMappingController.GetClusterQuotaMapper(),
-		ClusterQuotaClient:   ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
+		ClusterQuotaClient:   ctx.ClientBuilder.OpenshiftInternalQuotaClientOrDie(saName).Quota().ClusterResourceQuotas(),
 
 		Registry:     resourceQuotaRegistry,
 		ResyncPeriod: c.DefaultResyncPeriod,
 		ControllerFactory: quotacontroller.NewAllResourceReplenishmentControllerFactory(
 			ctx.ExternalKubeInformers,
 			ctx.ImageInformers.Image().InternalVersion().ImageStreams(),
-			ctx.ClientBuilder.DeprecatedOpenshiftClientOrDie(saName),
 		),
 		ReplenishmentResyncPeriod: controller.StaticResyncPeriodFunc(c.DefaultReplenishmentSyncPeriod),
 		GroupKindsToReplenish:     groupKindsToReplenish,

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -92,6 +92,7 @@ import (
 	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion"
+	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	userinformer "github.com/openshift/origin/pkg/user/generated/informers/internalversion"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
@@ -217,6 +218,10 @@ func BuildMasterConfig(options configapi.MasterConfig, informers InformerAccess)
 	if err != nil {
 		return nil, err
 	}
+	quotaClient, err := quotaclient.NewForConfig(privilegedLoopbackClientConfig)
+	if err != nil {
+		return nil, err
+	}
 	templateClient, err := templateclient.NewForConfig(privilegedLoopbackClientConfig)
 	if err != nil {
 		return nil, err
@@ -248,7 +253,6 @@ func BuildMasterConfig(options configapi.MasterConfig, informers InformerAccess)
 	quotaRegistry := quota.NewAllResourceQuotaRegistryForAdmission(
 		informers.GetExternalKubeInformers(),
 		informers.GetImageInformers().Image().InternalVersion().ImageStreams(),
-		privilegedLoopbackOpenShiftClient,
 		privilegedLoopbackKubeClientsetExternal,
 	)
 
@@ -295,10 +299,10 @@ func BuildMasterConfig(options configapi.MasterConfig, informers InformerAccess)
 		restMapper,
 		quotaRegistry)
 	openshiftPluginInitializer := &oadmission.PluginInitializer{
-		OpenshiftClient:                      privilegedLoopbackOpenShiftClient,
 		OpenshiftInternalAuthorizationClient: authorizationClient,
 		OpenshiftInternalBuildClient:         buildClient,
 		OpenshiftInternalImageClient:         imageClient,
+		OpenshiftInternalQuotaClient:         quotaClient,
 		OpenshiftInternalTemplateClient:      templateClient,
 		OpenshiftInternalUserClient:          userClient,
 		ProjectCache:                         projectCache,

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -70,6 +70,7 @@ import (
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	authorizationinformer "github.com/openshift/origin/pkg/authorization/generated/informers/internalversion"
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
+	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
 	osclient "github.com/openshift/origin/pkg/client"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -208,6 +209,10 @@ func BuildMasterConfig(options configapi.MasterConfig, informers InformerAccess)
 	if err != nil {
 		return nil, err
 	}
+	buildClient, err := buildclient.NewForConfig(privilegedLoopbackClientConfig)
+	if err != nil {
+		return nil, err
+	}
 	imageClient, err := imageclient.NewForConfig(privilegedLoopbackClientConfig)
 	if err != nil {
 		return nil, err
@@ -292,6 +297,7 @@ func BuildMasterConfig(options configapi.MasterConfig, informers InformerAccess)
 	openshiftPluginInitializer := &oadmission.PluginInitializer{
 		OpenshiftClient:                      privilegedLoopbackOpenShiftClient,
 		OpenshiftInternalAuthorizationClient: authorizationClient,
+		OpenshiftInternalBuildClient:         buildClient,
 		OpenshiftInternalImageClient:         imageClient,
 		OpenshiftInternalTemplateClient:      templateClient,
 		OpenshiftInternalUserClient:          userClient,

--- a/pkg/project/admission/requestlimit/admission.go
+++ b/pkg/project/admission/requestlimit/admission.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	kapi "k8s.io/kubernetes/pkg/api"
 
-	"github.com/openshift/origin/pkg/client"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configlatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	requestlimitapi "github.com/openshift/origin/pkg/project/admission/requestlimit/api"
@@ -20,6 +19,8 @@ import (
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
+	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
+	usertypedclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
 )
 
 // allowedTerminatingProjects is the number of projects that are owned by a user, are in terminating state,
@@ -62,14 +63,14 @@ func readConfig(reader io.Reader) (*requestlimitapi.ProjectRequestLimitConfig, e
 
 type projectRequestLimit struct {
 	*admission.Handler
-	client client.Interface
+	client usertypedclient.UsersGetter
 	config *requestlimitapi.ProjectRequestLimitConfig
 	cache  *projectcache.ProjectCache
 }
 
 // ensure that the required Openshift admission interfaces are implemented
 var _ = oadmission.WantsProjectCache(&projectRequestLimit{})
-var _ = oadmission.WantsDeprecatedOpenshiftClient(&projectRequestLimit{})
+var _ = oadmission.WantsOpenshiftInternalUserClient(&projectRequestLimit{})
 
 // Admit ensures that only a configured number of projects can be requested by a particular user.
 func (o *projectRequestLimit) Admit(a admission.Attributes) (err error) {
@@ -166,8 +167,8 @@ func (o *projectRequestLimit) projectCountByRequester(userName string) (int, err
 	return count, nil
 }
 
-func (o *projectRequestLimit) SetDeprecatedOpenshiftClient(client client.Interface) {
-	o.client = client
+func (o *projectRequestLimit) SetOpenshiftInternalUserClient(client userclient.Interface) {
+	o.client = client.User()
 }
 
 func (o *projectRequestLimit) SetProjectCache(cache *projectcache.ProjectCache) {

--- a/pkg/project/admission/requestlimit/admission_test.go
+++ b/pkg/project/admission/requestlimit/admission_test.go
@@ -14,12 +14,12 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	requestlimitapi "github.com/openshift/origin/pkg/project/admission/requestlimit/api"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
+	fakeuserclient "github.com/openshift/origin/pkg/user/generated/internalclientset/fake"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	// install all APIs
@@ -152,8 +152,8 @@ func TestMaxProjectByRequester(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		user := fakeUser("testuser", tc.userLabels)
-		client := testclient.NewSimpleFake(user)
-		reqLimit.(oadmission.WantsDeprecatedOpenshiftClient).SetDeprecatedOpenshiftClient(client)
+		client := fakeuserclient.NewSimpleClientset(user)
+		reqLimit.(oadmission.WantsOpenshiftInternalUserClient).SetOpenshiftInternalUserClient(client)
 
 		maxProjects, hasLimit, err := reqLimit.(*projectRequestLimit).maxProjectsByRequester("testuser")
 		if err != nil {
@@ -266,8 +266,9 @@ func TestAdmit(t *testing.T) {
 			"user3": {5, 3},
 			"user4": {1, 0},
 		})
-		client := &testclient.Fake{}
-		client.AddReactor("get", "users", userFn(map[string]labels.Set{
+
+		client := fakeuserclient.NewSimpleClientset()
+		client.PrependReactor("get", "users", userFn(map[string]labels.Set{
 			"user2": {"bronze": "yes"},
 			"user3": {"platinum": "yes"},
 			"user4": {"unknown": "yes"},
@@ -276,7 +277,7 @@ func TestAdmit(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
-		reqLimit.(oadmission.WantsDeprecatedOpenshiftClient).SetDeprecatedOpenshiftClient(client)
+		reqLimit.(oadmission.WantsOpenshiftInternalUserClient).SetOpenshiftInternalUserClient(client)
 		reqLimit.(oadmission.WantsProjectCache).SetProjectCache(pCache)
 		if err = reqLimit.(admission.Validator).Validate(); err != nil {
 			t.Fatalf("validation error: %v", err)

--- a/pkg/quota/admission/clusterresourcequota/accessor.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor.go
@@ -13,16 +13,16 @@ import (
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 	utilquota "k8s.io/kubernetes/pkg/quota"
 
-	oclient "github.com/openshift/origin/pkg/client"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+	quotatypedclient "github.com/openshift/origin/pkg/quota/generated/internalclientset/typed/quota/internalversion"
 	quotalister "github.com/openshift/origin/pkg/quota/generated/listers/quota/internalversion"
 )
 
 type clusterQuotaAccessor struct {
 	clusterQuotaLister quotalister.ClusterResourceQuotaLister
 	namespaceLister    kcorelisters.NamespaceLister
-	clusterQuotaClient oclient.ClusterResourceQuotasInterface
+	clusterQuotaClient quotatypedclient.ClusterResourceQuotasGetter
 
 	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper
 
@@ -36,7 +36,7 @@ type clusterQuotaAccessor struct {
 func newQuotaAccessor(
 	clusterQuotaLister quotalister.ClusterResourceQuotaLister,
 	namespaceLister kcorelisters.NamespaceLister,
-	clusterQuotaClient oclient.ClusterResourceQuotasInterface,
+	clusterQuotaClient quotatypedclient.ClusterResourceQuotasGetter,
 	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper,
 ) *clusterQuotaAccessor {
 	updatedCache, err := lru.New(100)

--- a/pkg/quota/admission/clusterresourcequota/accessor_test.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor_test.go
@@ -15,10 +15,10 @@ import (
 	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 	quotaapiv1 "github.com/openshift/origin/pkg/quota/apis/quota/v1"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+	fakequotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset/fake"
 	quotalister "github.com/openshift/origin/pkg/quota/generated/listers/quota/internalversion"
 )
 
@@ -105,9 +105,9 @@ func TestUpdateQuota(t *testing.T) {
 		}
 		quotaLister := quotalister.NewClusterResourceQuotaLister(quotaIndexer)
 
-		client := testclient.NewSimpleFake(objs...)
+		client := fakequotaclient.NewSimpleClientset(objs...)
 
-		accessor := newQuotaAccessor(quotaLister, nil, client, nil)
+		accessor := newQuotaAccessor(quotaLister, nil, client.Quota(), nil)
 
 		actualErr := accessor.UpdateQuotaStatus(tc.quotaToUpdate)
 		switch {
@@ -296,9 +296,9 @@ func TestGetQuota(t *testing.T) {
 		}
 		namespaceLister := kcorelisters.NewNamespaceLister(namespaceIndexer)
 
-		client := testclient.NewSimpleFake()
+		client := fakequotaclient.NewSimpleClientset()
 
-		accessor := newQuotaAccessor(quotaLister, namespaceLister, client, tc.mapperFunc())
+		accessor := newQuotaAccessor(quotaLister, namespaceLister, client.Quota(), tc.mapperFunc())
 
 		actualQuotas, actualErr := accessor.GetQuotas(tc.requestedNamespace)
 		switch {

--- a/pkg/quota/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/admission/clusterresourcequota/admission.go
@@ -16,10 +16,11 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
 	resourcequotaapi "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota"
 
-	oclient "github.com/openshift/origin/pkg/client"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
+	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
+	quotatypedclient "github.com/openshift/origin/pkg/quota/generated/internalclientset/typed/quota/internalversion"
 	quotalister "github.com/openshift/origin/pkg/quota/generated/listers/quota/internalversion"
 )
 
@@ -39,7 +40,7 @@ type clusterQuotaAdmission struct {
 	namespaceLister    kcorelisters.NamespaceLister
 	clusterQuotaSynced func() bool
 	namespaceSynced    func() bool
-	clusterQuotaClient oclient.ClusterResourceQuotasInterface
+	clusterQuotaClient quotatypedclient.ClusterResourceQuotasGetter
 	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper
 
 	lockFactory LockFactory
@@ -52,7 +53,7 @@ type clusterQuotaAdmission struct {
 }
 
 var _ oadmission.WantsInternalKubernetesInformers = &clusterQuotaAdmission{}
-var _ oadmission.WantsDeprecatedOpenshiftClient = &clusterQuotaAdmission{}
+var _ oadmission.WantsOpenshiftInternalQuotaClient = &clusterQuotaAdmission{}
 var _ oadmission.WantsClusterQuota = &clusterQuotaAdmission{}
 
 const (
@@ -132,8 +133,8 @@ func (q *clusterQuotaAdmission) SetInternalKubernetesInformers(informers kintern
 	q.namespaceSynced = informers.Core().InternalVersion().Namespaces().Informer().HasSynced
 }
 
-func (q *clusterQuotaAdmission) SetDeprecatedOpenshiftClient(client oclient.Interface) {
-	q.clusterQuotaClient = client
+func (q *clusterQuotaAdmission) SetOpenshiftInternalQuotaClient(client quotaclient.Interface) {
+	q.clusterQuotaClient = client.Quota()
 }
 
 func (q *clusterQuotaAdmission) SetClusterQuota(clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper, informers quotainformer.ClusterResourceQuotaInformer) {

--- a/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller.go
+++ b/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller.go
@@ -21,17 +21,17 @@ import (
 	"k8s.io/kubernetes/pkg/controller/resourcequota"
 	utilquota "k8s.io/kubernetes/pkg/quota"
 
-	"github.com/openshift/origin/pkg/client"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
+	quotatypedclient "github.com/openshift/origin/pkg/quota/generated/internalclientset/typed/quota/internalversion"
 	quotalister "github.com/openshift/origin/pkg/quota/generated/listers/quota/internalversion"
 )
 
 type ClusterQuotaReconcilationControllerOptions struct {
 	ClusterQuotaInformer quotainformer.ClusterResourceQuotaInformer
 	ClusterQuotaMapper   clusterquotamapping.ClusterQuotaMapper
-	ClusterQuotaClient   client.ClusterResourceQuotasInterface
+	ClusterQuotaClient   quotatypedclient.ClusterResourceQuotaInterface
 
 	// Knows how to calculate usage
 	Registry utilquota.Registry
@@ -50,7 +50,7 @@ type ClusterQuotaReconcilationController struct {
 	clusterQuotaLister quotalister.ClusterResourceQuotaLister
 	clusterQuotaSynced func() bool
 	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper
-	clusterQuotaClient client.ClusterResourceQuotasInterface
+	clusterQuotaClient quotatypedclient.ClusterResourceQuotaInterface
 
 	resyncPeriod time.Duration
 
@@ -316,7 +316,7 @@ func (c *ClusterQuotaReconcilationController) syncQuotaForNamespaces(originalQuo
 		return kutilerrors.NewAggregate(reconcilationErrors), retryItems
 	}
 
-	if _, err := c.clusterQuotaClient.ClusterResourceQuotas().UpdateStatus(quota); err != nil {
+	if _, err := c.clusterQuotaClient.UpdateStatus(quota); err != nil {
 		return kutilerrors.NewAggregate(append(reconcilationErrors, err)), workItems
 	}
 

--- a/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller_test.go
+++ b/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller_test.go
@@ -15,10 +15,10 @@ import (
 	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	utilquota "k8s.io/kubernetes/pkg/quota"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 	quotaapiv1 "github.com/openshift/origin/pkg/quota/apis/quota/v1"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
+	fakequotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset/fake"
 )
 
 func defaultQuota() *quotaapi.ClusterResourceQuota {
@@ -224,13 +224,13 @@ func TestSyncFunc(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		client := testclient.NewSimpleFake(tc.startingQuota())
+		client := fakequotaclient.NewSimpleClientset(tc.startingQuota())
 
 		quotaUsageCalculationFunc = tc.calculationFunc
 		// we only need these fields to test the sync func
 		controller := ClusterQuotaReconcilationController{
 			clusterQuotaMapper: tc.mapperFunc(),
-			clusterQuotaClient: client,
+			clusterQuotaClient: client.Quota().ClusterResourceQuotas(),
 		}
 
 		actualErr, actualRetries := controller.syncQuotaForNamespaces(tc.startingQuota(), tc.workItems)

--- a/pkg/quota/controller/replenishment_controller.go
+++ b/pkg/quota/controller/replenishment_controller.go
@@ -8,7 +8,6 @@ import (
 	kexternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
 	kresourcequota "k8s.io/kubernetes/pkg/controller/resourcequota"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageinternalversion "github.com/openshift/origin/pkg/image/generated/informers/internalversion/image/internalversion"
 )
@@ -54,7 +53,7 @@ func ImageStreamReplenishmentUpdateFunc(options *kresourcequota.ReplenishmentCon
 }
 
 // NewAllResourceReplenishmentControllerFactory returns a ReplenishmentControllerFactory  that knows how to replenish all known resources
-func NewAllResourceReplenishmentControllerFactory(informerFactory kexternalinformers.SharedInformerFactory, imageStreamInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface) kresourcequota.ReplenishmentControllerFactory {
+func NewAllResourceReplenishmentControllerFactory(informerFactory kexternalinformers.SharedInformerFactory, imageStreamInformer imageinternalversion.ImageStreamInformer) kresourcequota.ReplenishmentControllerFactory {
 	return kresourcequota.UnionReplenishmentControllerFactory{
 		kresourcequota.NewReplenishmentControllerFactory(informerFactory),
 		NewReplenishmentControllerFactory(imageStreamInformer),

--- a/pkg/quota/image/imagestreamtag_evaluator.go
+++ b/pkg/quota/image/imagestreamtag_evaluator.go
@@ -13,7 +13,6 @@ import (
 	kquota "k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/quota/generic"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageinternalversion "github.com/openshift/origin/pkg/image/generated/listers/image/internalversion"
 )
@@ -23,16 +22,14 @@ var imageStreamTagResources = []kapi.ResourceName{
 }
 
 type imageStreamTagEvaluator struct {
-	store         imageinternalversion.ImageStreamLister
-	istNamespacer osclient.ImageStreamTagsNamespacer
+	store imageinternalversion.ImageStreamLister
 }
 
 // NewImageStreamTagEvaluator computes resource usage of ImageStreamsTags. Its sole purpose is to handle
 // UPDATE admission operations on imageStreamTags resource.
-func NewImageStreamTagEvaluator(store imageinternalversion.ImageStreamLister, istNamespacer osclient.ImageStreamTagsNamespacer) kquota.Evaluator {
+func NewImageStreamTagEvaluator(store imageinternalversion.ImageStreamLister) kquota.Evaluator {
 	return &imageStreamTagEvaluator{
-		store:         store,
-		istNamespacer: istNamespacer,
+		store: store,
 	}
 }
 

--- a/pkg/quota/image/imagestreamtag_evaluator_test.go
+++ b/pkg/quota/image/imagestreamtag_evaluator_test.go
@@ -7,7 +7,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kquota "k8s.io/kubernetes/pkg/quota"
 
-	"github.com/openshift/origin/pkg/client/testclient"
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageinformer "github.com/openshift/origin/pkg/image/generated/informers/internalversion"
@@ -200,14 +199,12 @@ func TestImageStreamTagEvaluatorUsage(t *testing.T) {
 			expectedISCount: 1,
 		},
 	} {
-		fakeClient := &testclient.Fake{}
-		fakeClient.AddReactor("get", "imagestreams", imagetest.GetFakeImageStreamGetHandler(t, tc.iss...))
 		imageInformers := imageinformer.NewSharedInformerFactory(imageinternal.NewSimpleClientset(), 0)
 		isInformer := imageInformers.Image().InternalVersion().ImageStreams()
 		for _, is := range tc.iss {
 			isInformer.Informer().GetIndexer().Add(&is)
 		}
-		evaluator := NewImageStreamTagEvaluator(isInformer.Lister(), fakeClient)
+		evaluator := NewImageStreamTagEvaluator(isInformer.Lister())
 
 		usage, err := evaluator.Usage(&tc.ist)
 		if err != nil {

--- a/pkg/quota/image/registry.go
+++ b/pkg/quota/image/registry.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/quota/generic"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageinternalversion "github.com/openshift/origin/pkg/image/generated/informers/internalversion/image/internalversion"
 )
@@ -15,9 +14,9 @@ import (
 // NewImageQuotaRegistry returns a registry for quota evaluation of OpenShift resources related to images in
 // internal registry. It evaluates only image streams and related virtual resources that can cause a creation
 // of new image stream objects.
-func NewImageQuotaRegistry(isInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface) quota.Registry {
+func NewImageQuotaRegistry(isInformer imageinternalversion.ImageStreamInformer) quota.Registry {
 	imageStream := NewImageStreamEvaluator(isInformer.Lister())
-	imageStreamTag := NewImageStreamTagEvaluator(isInformer.Lister(), osClient)
+	imageStreamTag := NewImageStreamTagEvaluator(isInformer.Lister())
 	imageStreamImport := NewImageStreamImportEvaluator(isInformer.Lister())
 	return &generic.GenericRegistry{
 		InternalEvaluators: map[schema.GroupKind]quota.Evaluator{
@@ -33,9 +32,9 @@ func NewImageQuotaRegistry(isInformer imageinternalversion.ImageStreamInformer, 
 // of new image stream objects.
 // This is different that is used for reconciliation because admission has to check all forms of a resource (legacy and groupified), but
 // reconciliation only has to check one.
-func NewImageQuotaRegistryForAdmission(isInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface) quota.Registry {
+func NewImageQuotaRegistryForAdmission(isInformer imageinternalversion.ImageStreamInformer) quota.Registry {
 	imageStream := NewImageStreamEvaluator(isInformer.Lister())
-	imageStreamTag := NewImageStreamTagEvaluator(isInformer.Lister(), osClient)
+	imageStreamTag := NewImageStreamTagEvaluator(isInformer.Lister())
 	imageStreamImport := NewImageStreamImportEvaluator(isInformer.Lister())
 	return &generic.GenericRegistry{
 		// TODO remove the LegacyKind entries below when the legacy api group is no longer supported

--- a/pkg/quota/registry.go
+++ b/pkg/quota/registry.go
@@ -8,7 +8,6 @@ import (
 	kquota "k8s.io/kubernetes/pkg/quota"
 	"k8s.io/kubernetes/pkg/quota/install"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageinternalversion "github.com/openshift/origin/pkg/image/generated/informers/internalversion/image/internalversion"
 	"github.com/openshift/origin/pkg/quota/image"
@@ -16,28 +15,28 @@ import (
 
 // NewOriginQuotaRegistry returns a registry object that knows how to evaluate quota usage of OpenShift
 // resources.
-func NewOriginQuotaRegistry(isInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface) kquota.Registry {
-	return image.NewImageQuotaRegistry(isInformer, osClient)
+func NewOriginQuotaRegistry(isInformer imageinternalversion.ImageStreamInformer) kquota.Registry {
+	return image.NewImageQuotaRegistry(isInformer)
 }
 
 // NewAllResourceQuotaRegistry returns a registry object that knows how to evaluate all resources
-func NewAllResourceQuotaRegistry(informerFactory kexternalinformers.SharedInformerFactory, isInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface, kubeClientSet clientset.Interface) kquota.Registry {
-	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet, informerFactory), NewOriginQuotaRegistry(isInformer, osClient)}
+func NewAllResourceQuotaRegistry(informerFactory kexternalinformers.SharedInformerFactory, isInformer imageinternalversion.ImageStreamInformer, kubeClientSet clientset.Interface) kquota.Registry {
+	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet, informerFactory), NewOriginQuotaRegistry(isInformer)}
 }
 
 // NewOriginQuotaRegistryForAdmission returns a registry object that knows how to evaluate quota usage of OpenShift
 // resources.
 // This is different that is used for reconciliation because admission has to check all forms of a resource (legacy and groupified), but
 // reconciliation only has to check one.
-func NewOriginQuotaRegistryForAdmission(isInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface) kquota.Registry {
-	return image.NewImageQuotaRegistryForAdmission(isInformer, osClient)
+func NewOriginQuotaRegistryForAdmission(isInformer imageinternalversion.ImageStreamInformer) kquota.Registry {
+	return image.NewImageQuotaRegistryForAdmission(isInformer)
 }
 
 // NewAllResourceQuotaRegistryForAdmission returns a registry object that knows how to evaluate all resources for *admission*.
 // This is different that is used for reconciliation because admission has to check all forms of a resource (legacy and groupified), but
 // reconciliation only has to check one.
-func NewAllResourceQuotaRegistryForAdmission(informerFactory kexternalinformers.SharedInformerFactory, isInformer imageinternalversion.ImageStreamInformer, osClient osclient.Interface, kubeClientSet clientset.Interface) kquota.Registry {
-	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet, informerFactory), NewOriginQuotaRegistryForAdmission(isInformer, osClient)}
+func NewAllResourceQuotaRegistryForAdmission(informerFactory kexternalinformers.SharedInformerFactory, isInformer imageinternalversion.ImageStreamInformer, kubeClientSet clientset.Interface) kquota.Registry {
+	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet, informerFactory), NewOriginQuotaRegistryForAdmission(isInformer)}
 }
 
 // AllEvaluatedGroupKinds is the list of all group kinds that we evaluate for quotas in openshift and kube


### PR DESCRIPTION
@mfojtik I put the easy ones in a single commit. The harder ones I put in separate commits

This clears the admission ones from your list.