### PR TITLE
UPSTREAM: opencontainers/runc: 1344: fix cpu.cfs_quota_us changed when systemd daemon-reload using systemd

### DIFF
--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
@@ -269,6 +269,13 @@ func (m *Manager) Apply(pid int) error {
 			newProp("CPUShares", uint64(c.Resources.CpuShares)))
 	}
 
+	// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
+	if c.Resources.CpuQuota != 0 && c.Resources.CpuPeriod != 0 {
+		cpuQuotaPerSecUSec := c.Resources.CpuQuota * 1000000 / c.Resources.CpuPeriod
+		properties = append(properties,
+			newProp("CPUQuotaPerSecUSec", uint64(cpuQuotaPerSecUSec)))
+	}
+
 	if c.Resources.BlkioWeight != 0 {
 		properties = append(properties,
 			newProp("BlockIOWeight", uint64(c.Resources.BlkioWeight)))


### PR DESCRIPTION
https://github.com/opencontainers/runc/pull/1344

master PR:
https://github.com/openshift/origin/pull/16480

also see https://bugzilla.redhat.com/show_bug.cgi?id=1455071

@derekwaynecarr @runcom 