### PR TITLE
Print the namespace in the endpoints change log message

### DIFF
--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -143,7 +143,7 @@ func NewTemplatePlugin(cfg TemplatePluginConfig, lookupSvc ServiceLookup) (*Temp
 func (p *TemplatePlugin) HandleEndpoints(eventType watch.EventType, endpoints *kapi.Endpoints) error {
 	key := endpointsKey(endpoints)
 
-	glog.V(4).Infof("Processing %d Endpoints for Name: %v (%v)", len(endpoints.Subsets), endpoints.Name, eventType)
+	glog.V(4).Infof("Processing %d Endpoints for %s/%s (%v)", len(endpoints.Subsets), endpoints.Namespace, endpoints.Name, eventType)
 
 	for i, s := range endpoints.Subsets {
 		glog.V(4).Infof("  Subset %d : %#v", i, s)


### PR DESCRIPTION
Before we were logging the name of the endpoints, but not the
namespace, making it hard to grep for the endpoint in the logs if
there were multiple services with the same name in different
namespaces.

This makes the message consistent with the other log messages.