### PR TITLE
remove dependency on kube api helpers from api types

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -67,7 +67,6 @@
       "vendor/k8s.io/kubernetes/pkg/api",
       "vendor/k8s.io/kubernetes/pkg/api/v1",
       "vendor/k8s.io/kubernetes/pkg/apis/rbac",
-      "vendor/k8s.io/kubernetes/pkg/api/helper",
       "vendor/k8s.io/apiserver/pkg/authentication/serviceaccount",
       "vendor/k8s.io/apiserver/pkg/authentication/user"
     ]
@@ -105,7 +104,6 @@
       "vendor/k8s.io/kubernetes/pkg/api/v1",
       "vendor/k8s.io/kubernetes/pkg/apis/extensions",
       "vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1",
-      "vendor/k8s.io/kubernetes/pkg/api/helper",
       "github.com/openshift/origin/pkg/image/apis/image"
     ]
   },
@@ -172,8 +170,7 @@
     ],
     "allowedImportPackages": [
       "vendor/k8s.io/kubernetes/pkg/api",
-      "vendor/k8s.io/kubernetes/pkg/api/v1",
-      "vendor/k8s.io/kubernetes/pkg/api/helper"
+      "vendor/k8s.io/kubernetes/pkg/api/v1"
     ]
   },
 

--- a/pkg/apps/apis/apps/v1/defaults_test.go
+++ b/pkg/apps/apis/apps/v1/defaults_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
@@ -550,7 +550,7 @@ func TestDefaults(t *testing.T) {
 			t.FailNow()
 		}
 		// TODO(rebase): check that there are no fields which have different semantics for nil and []
-		if !kapihelper.Semantic.DeepEqual(got.Spec, expected.Spec) {
+		if !equality.Semantic.DeepEqual(got.Spec, expected.Spec) {
 			t.Errorf("got different than expected:\nA:\t%#v\nB:\t%#v\n\nDiff:\n%s\n\n%s", got, expected, diff.ObjectDiff(expected, got), diff.ObjectGoPrintSideBySide(expected, got))
 		}
 	}

--- a/pkg/authorization/apis/authorization/v1/defaults.go
+++ b/pkg/authorization/apis/authorization/v1/defaults.go
@@ -1,9 +1,8 @@
 package v1
 
 import (
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
-
 	internal "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 var oldAllowAllPolicyRule = PolicyRule{APIGroups: nil, Verbs: []string{internal.VerbAll}, Resources: []string{internal.ResourceAll}}
@@ -22,7 +21,7 @@ func SetDefaults_PolicyRule(obj *PolicyRule) {
 		len(obj.NonResourceURLsSlice) == 0 &&
 		// semantic equalities will ignore nil vs empty for other fields as a safety
 		// DO NOT REMOVE THIS CHECK unless you replace it with full equality comparisons
-		kapihelper.Semantic.Equalities.DeepEqual(oldAllowAllPolicyRule, *obj)
+		equality.Semantic.DeepEqual(oldAllowAllPolicyRule, *obj)
 
 	if oldAllowAllRule {
 		obj.APIGroups = []string{internal.APIGroupAll}

--- a/pkg/authorization/apis/authorization/validation/validation.go
+++ b/pkg/authorization/apis/authorization/validation/validation.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/validation/path"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	"k8s.io/kubernetes/pkg/api/validation"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
@@ -305,7 +305,7 @@ func validateRoleUpdate(role *authorizationapi.Role, oldRole *authorizationapi.R
 
 func isNewRule(rule authorizationapi.PolicyRule, oldRole *authorizationapi.Role) bool {
 	for _, r := range oldRole.Rules {
-		if r.AttributeRestrictions != nil && kapihelper.Semantic.DeepEqual(rule, r) { // only do expensive comparision against rules that have attribute restrictions
+		if r.AttributeRestrictions != nil && equality.Semantic.DeepEqual(rule, r) { // only do expensive comparision against rules that have attribute restrictions
 			return false
 		}
 	}

--- a/pkg/quota/admission/clusterresourcequota/accessor.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor.go
@@ -5,11 +5,11 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	etcd "k8s.io/apiserver/pkg/storage/etcd"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 	utilquota "k8s.io/kubernetes/pkg/quota"
 
@@ -158,7 +158,7 @@ func (e *clusterQuotaAccessor) waitForReadyClusterQuotaNames(namespaceName strin
 		if err != nil {
 			return false, err
 		}
-		if kapihelper.Semantic.DeepEqual(namespaceSelectionFields, clusterquotamapping.GetSelectionFields(namespace)) {
+		if equality.Semantic.DeepEqual(namespaceSelectionFields, clusterquotamapping.GetSelectionFields(namespace)) {
 			return true, nil
 		}
 		return false, nil

--- a/pkg/quota/admission/clusterresourcequota/accessor_test.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,7 +13,6 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 
 	"github.com/openshift/origin/pkg/client/testclient"
@@ -145,7 +145,7 @@ func TestUpdateQuota(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			continue
 		}
-		if !kapihelper.Semantic.DeepEqual(expectedV1, actualV1) {
+		if !equality.Semantic.DeepEqual(expectedV1, actualV1) {
 			t.Errorf("%s: %v", tc.name, utildiff.ObjectDiff(expectedV1, actualV1))
 			continue
 		}
@@ -324,7 +324,7 @@ func TestGetQuota(t *testing.T) {
 		}
 
 		expectedQuotas := tc.expectedQuotas()
-		if !kapihelper.Semantic.DeepEqual(expectedQuotas, actualQuotaPointers) {
+		if !equality.Semantic.DeepEqual(expectedQuotas, actualQuotaPointers) {
 			t.Errorf("%s: expectedLen: %v actualLen: %v", tc.name, len(expectedQuotas), len(actualQuotas))
 			for i := range expectedQuotas {
 				expectedV1, err := kapi.Scheme.ConvertToVersion(expectedQuotas[i], quotaapiv1.SchemeGroupVersion)
@@ -337,7 +337,7 @@ func TestGetQuota(t *testing.T) {
 					t.Errorf("%s: unexpected error: %v", tc.name, err)
 					continue
 				}
-				t.Errorf("%s: %v equal? %v", tc.name, utildiff.ObjectDiff(expectedV1, actualV1), kapihelper.Semantic.DeepEqual(expectedV1, actualV1))
+				t.Errorf("%s: %v equal? %v", tc.name, utildiff.ObjectDiff(expectedV1, actualV1), equality.Semantic.DeepEqual(expectedV1, actualV1))
 			}
 			continue
 		}

--- a/pkg/quota/apis/quota/deep_copy_test.go
+++ b/pkg/quota/apis/quota/deep_copy_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/conversion"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 )
@@ -28,7 +28,7 @@ func TestDeepCopy(t *testing.T) {
 	if !reflect.DeepEqual(check, original) {
 		t.Error("before mutation of copy, check and original should be identical but are not, likely failure in deepequal")
 	}
-	if !kapihelper.Semantic.DeepEqual(check, original) {
+	if !equality.Semantic.DeepEqual(check, original) {
 		t.Error("before mutation of copy, check and original should be identical but are not, likely failure in deepequal")
 	}
 
@@ -40,7 +40,7 @@ func TestDeepCopy(t *testing.T) {
 	if !reflect.DeepEqual(copied, original) {
 		t.Error("before mutation of copy, copied and original should be identical but are not, likely failure in deepequal")
 	}
-	if !kapihelper.Semantic.DeepEqual(copied, original) {
+	if !equality.Semantic.DeepEqual(copied, original) {
 		t.Error("before mutation of copy, copied and original should be identical but are not, likely failure in deepequal")
 	}
 
@@ -62,14 +62,14 @@ func TestDeepCopy(t *testing.T) {
 	if !reflect.DeepEqual(check, original) {
 		t.Error("after mutation of copy, check and original should be identical but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
 	}
-	if !kapihelper.Semantic.DeepEqual(check, original) {
+	if !equality.Semantic.DeepEqual(check, original) {
 		t.Error("after mutation of copy, check and original should be identical but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
 	}
 
 	if reflect.DeepEqual(original, copied) {
 		t.Error("after mutation of copy, original and copied should be different but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
 	}
-	if kapihelper.Semantic.DeepEqual(original, copied) {
+	if equality.Semantic.DeepEqual(original, copied) {
 		t.Error("after mutation of copy, original and copied should be different but are not, likely failure in deep copy (ensure custom DeepCopy is being used)")
 	}
 }

--- a/pkg/quota/apis/quota/types.go
+++ b/pkg/quota/apis/quota/types.go
@@ -4,9 +4,9 @@ import (
 	"container/list"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 )
 
 // +genclient
@@ -141,7 +141,7 @@ func (o ResourceQuotasStatusByNamespace) DeepCopy() ResourceQuotasStatusByNamesp
 
 func init() {
 	// Tell the reflection package how to compare our unexported type
-	if err := kapihelper.Semantic.AddFuncs(
+	if err := equality.Semantic.AddFuncs(
 		func(o1, o2 ResourceQuotasStatusByNamespace) bool {
 			return reflect.DeepEqual(o1.orderedMap, o2.orderedMap)
 		},

--- a/pkg/quota/controller/clusterquotamapping/mapper.go
+++ b/pkg/quota/controller/clusterquotamapping/mapper.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 )
@@ -193,7 +193,7 @@ func (m *clusterQuotaMapper) removeNamespace(namespaceName string) {
 }
 
 func selectorMatches(selector quotaapi.ClusterResourceQuotaSelector, exists bool, quota *quotaapi.ClusterResourceQuota) bool {
-	return exists && kapihelper.Semantic.DeepEqual(selector, quota.Spec.Selector)
+	return exists && equality.Semantic.DeepEqual(selector, quota.Spec.Selector)
 }
 func selectionFieldsMatch(selectionFields SelectionFields, exists bool, namespace metav1.Object) bool {
 	return exists && reflect.DeepEqual(selectionFields, GetSelectionFields(namespace))

--- a/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller.go
+++ b/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/resourcequota"
 	utilquota "k8s.io/kubernetes/pkg/quota"
@@ -256,7 +256,7 @@ func (c *ClusterQuotaReconcilationController) syncQuotaForNamespaces(originalQuo
 
 	// get the list of namespaces that match this cluster quota
 	matchingNamespaceNamesList, quotaSelector := c.clusterQuotaMapper.GetNamespacesFor(quota.Name)
-	if !kapihelper.Semantic.DeepEqual(quotaSelector, quota.Spec.Selector) {
+	if !equality.Semantic.DeepEqual(quotaSelector, quota.Spec.Selector) {
 		return fmt.Errorf("mapping not up to date, have=%v need=%v", quotaSelector, quota.Spec.Selector), workItems
 	}
 	matchingNamespaceNames := sets.NewString(matchingNamespaceNamesList...)
@@ -276,7 +276,7 @@ func (c *ClusterQuotaReconcilationController) syncQuotaForNamespaces(originalQuo
 		}
 
 		// if there's no work for us to do, do nothing
-		if !item.forceRecalculation && namespaceLoaded && kapihelper.Semantic.DeepEqual(namespaceTotals.Hard, quota.Spec.Quota.Hard) {
+		if !item.forceRecalculation && namespaceLoaded && equality.Semantic.DeepEqual(namespaceTotals.Hard, quota.Spec.Quota.Hard) {
 			continue
 		}
 
@@ -312,7 +312,7 @@ func (c *ClusterQuotaReconcilationController) syncQuotaForNamespaces(originalQuo
 	quota.Status.Total.Hard = quota.Spec.Quota.Hard
 
 	// if there's no change, no update, return early.  NewAggregate returns nil on empty input
-	if kapihelper.Semantic.DeepEqual(quota, originalQuota) {
+	if equality.Semantic.DeepEqual(quota, originalQuota) {
 		return kutilerrors.NewAggregate(reconcilationErrors), retryItems
 	}
 

--- a/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller_test.go
+++ b/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utildiff "k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgotesting "k8s.io/client-go/testing"
 	kapi "k8s.io/kubernetes/pkg/api"
-	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	utilquota "k8s.io/kubernetes/pkg/quota"
 
 	"github.com/openshift/origin/pkg/client/testclient"
@@ -284,7 +284,7 @@ func TestSyncFunc(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 			continue
 		}
-		if !kapihelper.Semantic.DeepEqual(expectedV1, actualV1) {
+		if !equality.Semantic.DeepEqual(expectedV1, actualV1) {
 			t.Errorf("%s: %v", tc.name, utildiff.ObjectDiff(expectedV1, actualV1))
 			continue
 		}


### PR DESCRIPTION
Turn the ratchet!  We're getting really close.  This eliminates the kubernetes helper dep by using the apimachinery semantic equalities.