### PR TITLE
prometheus alerts for openshift build subsystem

### DIFF
--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -116,3 +116,29 @@ Returns a running count (not a rate) of docker operations that have failed since
 > kubelet_pleg_relist_latency_microseconds
 
 Returns PLEG (pod lifecycle event generator) latency metrics.  This represents the latency experienced by calls from the kubelet to the container runtime (i.e. docker or CRI-O).  High PLEG latency is often related to disk I/O performance on the docker storage partition.
+
+### OpenShift build related queries
+
+> count(openshift_build_running_phase_start_time_seconds{} < time() - 600)
+
+Returns the number of builds that have been running for more than 10 minutes (600 seconds).
+
+> count(openshift_build_new_pending_phase_creation_time_seconds{} < time() - 600)
+
+Returns the number of build that have been waiting at least 10 minutes (600 seconds) to start.
+
+> sum(openshift_build_failed_phase_total{})
+
+Returns the number of failed builds, regardless of the failure reason.
+
+> sum(openshift_build_terminal_phase_total{phase="complete"})
+
+Returns the number of successfully completed builds.
+
+> openshift_build_failed_phase_total{}
+
+Returns the latest totals, per failure reason, for any failed builds.
+
+> openshift_build_failed_phase_total{} offset 5m
+
+Returns the failed builds totals, per failure reason, from 5 minutes ago.

--- a/pkg/build/metrics/prometheus/metrics.go
+++ b/pkg/build/metrics/prometheus/metrics.go
@@ -1,43 +1,59 @@
 package prometheus
 
 import (
-	kselector "k8s.io/apimachinery/pkg/labels"
 	"strings"
 
 	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kselector "k8s.io/apimachinery/pkg/labels"
+
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	internalversion "github.com/openshift/origin/pkg/build/generated/listers/build/internalversion"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
-	separator               = "_"
-	buildSubsystem          = "openshift_build"
-	terminalBuildCount      = "terminal_phase_total"
-	terminalBuildCountQuery = buildSubsystem + separator + terminalBuildCount
-	activeBuildCount        = "running_phase_start_time_seconds"
-	activeBuildCountQuery   = buildSubsystem + separator + activeBuildCount
+	separator                 = "_"
+	buildSubsystem            = "openshift_build"
+	terminalBuildCount        = "terminal_phase_total"
+	terminalBuildCountQuery   = buildSubsystem + separator + terminalBuildCount
+	failedBuildCount          = "failed_phase_total"
+	failedBuildCountQuery     = buildSubsystem + separator + failedBuildCount
+	activeBuildCount          = "running_phase_start_time_seconds"
+	activeBuildCountQuery     = buildSubsystem + separator + activeBuildCount
+	newPendingBuildCount      = "new_pending_phase_creation_time_seconds"
+	newPendingBuildCountQuery = buildSubsystem + separator + newPendingBuildCount
+	errorBuildReason          = "BuildPodError"
 )
 
 var (
-	// decided not to have a separate counter for failed builds, which have reasons,
-	// vs. the other "finished" builds phases, where the reason is not set
 	terminalBuildCountDesc = prometheus.NewDesc(
-		buildSubsystem+separator+terminalBuildCount,
-		"Counts total terminal builds by phase",
+		terminalBuildCountQuery,
+		"Counts total successful/aborted builds by phase",
 		[]string{"phase"},
 		nil,
 	)
+	failedBuildCountDesc = prometheus.NewDesc(
+		failedBuildCountQuery,
+		"Counts total failed builds by reason",
+		[]string{"reason"},
+		nil,
+	)
 	activeBuildCountDesc = prometheus.NewDesc(
-		buildSubsystem+separator+activeBuildCount,
-		"Show the start time in unix epoch form of running builds by namespace, name, and phase",
+		activeBuildCountQuery,
+		"Show the start time in unix epoch form of running builds by namespace and name",
+		[]string{"namespace", "name"},
+		nil,
+	)
+	newPendingBuildCountDesc = prometheus.NewDesc(
+		newPendingBuildCountQuery,
+		"Show the creation time in unix epoch form of new or pending builds by namespace, name, and phase",
 		[]string{"namespace", "name", "phase"},
 		nil,
 	)
 	bc             = buildCollector{}
 	registered     = false
-	failedPhase    = strings.ToLower(string(buildapi.BuildPhaseFailed))
-	errorPhase     = strings.ToLower(string(buildapi.BuildPhaseError))
 	cancelledPhase = strings.ToLower(string(buildapi.BuildPhaseCancelled))
 	completePhase  = strings.ToLower(string(buildapi.BuildPhaseComplete))
 )
@@ -77,46 +93,62 @@ func (bc *buildCollector) Collect(ch chan<- prometheus.Metric) {
 
 	// since we do not collect terminal build metrics on a per build basis, collectBuild will return counts
 	// to be added to the total amount posted to prometheus
-	var failed, error, cancelled, complete int
+	var cancelledCount, completeCount int
+	reasons := map[string]int{}
 	for _, b := range result {
-		f, e, cc, cp := bc.collectBuild(ch, b)
-		failed = failed + f
-		error = error + e
-		cancelled = cancelled + cc
-		complete = complete + cp
+		cc, cp, r := bc.collectBuild(ch, b)
+		for key, value := range r {
+			reasons[key] = reasons[key] + value
+		}
+		cancelledCount = cancelledCount + cc
+		completeCount = completeCount + cp
 	}
-	addCountGauge(ch, terminalBuildCountDesc, failedPhase, float64(failed))
-	addCountGauge(ch, terminalBuildCountDesc, errorPhase, float64(error))
-	addCountGauge(ch, terminalBuildCountDesc, cancelledPhase, float64(cancelled))
-	addCountGauge(ch, terminalBuildCountDesc, completePhase, float64(complete))
+	// explicitly note there are no failed builds
+	if len(reasons) == 0 {
+		addCountGauge(ch, failedBuildCountDesc, "", float64(0))
+	}
+	for reason, count := range reasons {
+		addCountGauge(ch, failedBuildCountDesc, reason, float64(count))
+	}
+	addCountGauge(ch, terminalBuildCountDesc, cancelledPhase, float64(cancelledCount))
+	addCountGauge(ch, terminalBuildCountDesc, completePhase, float64(completeCount))
 }
 
-func addCountGauge(ch chan<- prometheus.Metric, desc *prometheus.Desc, phase string, v float64) {
-	lv := []string{phase}
+func addCountGauge(ch chan<- prometheus.Metric, desc *prometheus.Desc, label string, v float64) {
+	lv := []string{label}
 	ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
 }
 
-func addTimeGauge(ch chan<- prometheus.Metric, b *buildapi.Build, desc *prometheus.Desc) {
-	if b.Status.StartTimestamp != nil {
-		lv := []string{b.ObjectMeta.Namespace, b.ObjectMeta.Name, strings.ToLower(string(b.Status.Phase))}
-		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(b.Status.StartTimestamp.Unix()), lv...)
+func addTimeGauge(ch chan<- prometheus.Metric, b *buildapi.Build, time *metav1.Time, desc *prometheus.Desc, phase string) {
+	if time != nil {
+		lv := []string{b.ObjectMeta.Namespace, b.ObjectMeta.Name}
+		if len(phase) > 0 {
+			lv = append(lv, strings.ToLower(phase))
+		}
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(time.Unix()), lv...)
 	}
 }
 
-func (bc *buildCollector) collectBuild(ch chan<- prometheus.Metric, b *buildapi.Build) (failed, error, cancelled, complete int) {
+func (bc *buildCollector) collectBuild(ch chan<- prometheus.Metric, b *buildapi.Build) (cancelledCount, completeCount int, reasonsCount map[string]int) {
 
+	reasonsCount = map[string]int{}
 	switch b.Status.Phase {
 	// remember, new and pending builds don't have a start time
+	case buildapi.BuildPhaseNew:
+	case buildapi.BuildPhasePending:
+		addTimeGauge(ch, b, &b.CreationTimestamp, newPendingBuildCountDesc, string(b.Status.Phase))
 	case buildapi.BuildPhaseRunning:
-		addTimeGauge(ch, b, activeBuildCountDesc)
+		addTimeGauge(ch, b, b.Status.StartTimestamp, activeBuildCountDesc, "")
 	case buildapi.BuildPhaseFailed:
-		failed++
+		// currently only failed builds have reasons
+		reasonsCount[string(b.Status.Reason)] = 1
 	case buildapi.BuildPhaseError:
-		error++
+		// it was decided to couple this one under failed, using the custom 'BuildPodError'
+		reasonsCount[errorBuildReason] = 1
 	case buildapi.BuildPhaseCancelled:
-		cancelled++
+		cancelledCount++
 	case buildapi.BuildPhaseComplete:
-		complete++
+		completeCount++
 	}
 	return
 }

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -3,7 +3,6 @@ package prometheus
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	g "github.com/onsi/ginkgo"
@@ -17,13 +16,15 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
+var (
+	execPodName, ns, host, bearerToken string
+	statsPort                          int
+)
+
 var _ = g.Describe("[Feature:Prometheus][Feature:Builds] Prometheus", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLI("prometheus", exutil.KubeConfigPath())
-
-		execPodName, ns, host, bearerToken string
-		statsPort                          int
 	)
 
 	g.BeforeEach(func() {
@@ -31,10 +32,11 @@ var _ = g.Describe("[Feature:Prometheus][Feature:Builds] Prometheus", func() {
 	})
 
 	g.Describe("when installed to the cluster", func() {
-		g.It("should start and expose a secured proxy and verify build metrics after a completed build", func() {
+		g.It("should start and expose a secured proxy and verify build metrics", func() {
 			const (
 				terminalBuildCountQuery = "openshift_build_terminal_phase_total"
 				activeBuildCountQuery   = "openshift_build_running_phase_start_time_seconds"
+				failedBuildCountQuery   = "openshift_build_failed_phase_total"
 			)
 
 			appTemplate := exutil.FixturePath("..", "..", "examples", "jenkins", "application-template.json")
@@ -52,104 +54,55 @@ var _ = g.Describe("[Feature:Prometheus][Feature:Builds] Prometheus", func() {
 			err = expectBearerTokenURLStatusCodeExec(ns, execPodName, fmt.Sprintf("https://%s:%d/graph", host, statsPort), bearerToken, 200)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			executeOpenShiftBuild(oc, appTemplate)
+			br := startOpenShiftBuild(oc, appTemplate)
 
-			g.By("verifying a service account token is able to query build metrics from the Prometheus API")
-			metricTests := map[string][]metricTest{
-				// NOTE - activeBuildCountQuery is dependent on prometheus querying while the build is running;
-				// so far the prometheus query interval and the length of the frontend build have
-				// been sufficient for reliable success here, but bear in mind the timing windows
-				// if this particular metricTest starts flaking
+			g.By("verifying a service account token is able to query active build metrics from the Prometheus API")
+			// NOTE - activeBuildCountQuery is dependent on prometheus querying while the build is running;
+			// timing has been a bit tricky when attempting to query after the build is complete based on the
+			// default prometheus scrapping window, so we do the active query while the build is running
+			activeTests := map[string][]metricTest{
 				activeBuildCountQuery: {
 					metricTest{
-						labels:      map[string]string{"phase": "running"},
-						greaterThan: "0",
+						labels:      map[string]string{"name": "frontend-1"},
+						greaterThan: true,
 					},
 				},
+			}
+			runQueries(activeTests)
+
+			g.By("verifying build completed successfully")
+			err = exutil.WaitForBuildResult(oc.BuildClient().Build().Builds(oc.Namespace()), br)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			br.AssertSuccess()
+
+			g.By("verifying a service account token is able to query terminal build metrics from the Prometheus API")
+			terminalTests := map[string][]metricTest{
 				terminalBuildCountQuery: {
 					metricTest{
 						labels:      map[string]string{"phase": "complete"},
-						greaterThan: "0",
-					},
-					metricTest{
-						labels: map[string]string{"phase": "error"},
-						equals: "0",
-					},
-					metricTest{
-						labels: map[string]string{"phase": "failed"},
-						equals: "0",
+						greaterThan: true,
 					},
 					metricTest{
 						labels: map[string]string{"phase": "cancelled"},
-						equals: "0",
 					},
 				},
 			}
-			// expect all correct metrics within 60 seconds
-			lastErrsMap := map[string]error{}
-			for i := 0; i < 60; i++ {
-				for query, tcs := range metricTests {
-					g.By("perform prometheus metric query " + query)
-					contents, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("https://%s:%d/api/v1/query?query=%s", host, statsPort, query), bearerToken)
-					o.Expect(err).NotTo(o.HaveOccurred())
+			runQueries(terminalTests)
 
-					correctMetrics := map[int]bool{}
-					for i, tc := range tcs {
-						result := prometheusResponse{}
-						json.Unmarshal([]byte(contents), &result)
-						metrics := result.Data.Result
-
-						for _, sample := range metrics {
-							// first see if a metric has all the label names and label values we are looking for
-							foundCorrectLabels := true
-							for labelName, labelValue := range tc.labels {
-								if v, ok := sample.Metric[model.LabelName(labelName)]; ok {
-									if string(v) != labelValue {
-										foundCorrectLabels = false
-										break
-									}
-								} else {
-									foundCorrectLabels = false
-									break
-								}
-							}
-
-							// if found metric with correct set of labels, now see if the metric value is what we are expecting
-							if foundCorrectLabels {
-								switch {
-								case len(tc.equals) > 0:
-									if x, err := strconv.ParseFloat(tc.equals, 64); err == nil && float64(sample.Value) == x {
-										correctMetrics[i] = true
-										break
-									}
-								case len(tc.greaterThan) > 0:
-									if x, err := strconv.ParseFloat(tc.greaterThan, 64); err == nil && float64(sample.Value) > x {
-										correctMetrics[i] = true
-										break
-									}
-								}
-							}
-
-						}
-					}
-
-					if len(correctMetrics) == len(tcs) {
-						delete(metricTests, query) // delete in case there are retries on remaining tests
-						delete(lastErrsMap, query)
-					} else {
-						// maintain separate map of errors for diagnostics
-						lastErrsMap[query] = fmt.Errorf("query %s with results %s only had correct metrics %v", query, contents, correctMetrics)
-					}
-				}
-
-				if len(metricTests) == 0 {
-					break
-				}
-
-				time.Sleep(time.Second)
+			g.By("verifying a service account token is able to query failed build metrics from the Prometheus API")
+			failedTests := map[string][]metricTest{
+				failedBuildCountQuery: {
+					metricTest{
+						labels: map[string]string{"reason": ""},
+					},
+				},
 			}
+			runQueries(failedTests)
 
-			o.Expect(lastErrsMap).To(o.BeEmpty())
+			// NOTE:  in manual testing on a laptop, starting several serial builds in succession was sufficient for catching
+			// at least a few builds in new/pending state with the default prometheus query interval;  but that has not
+			// proven to be the case with automated testing;
+			// so for now, we have no tests with openshift_build_new_pending_phase_creation_time_seconds
 		})
 	})
 })
@@ -166,11 +119,57 @@ type prometheusResponseData struct {
 
 type metricTest struct {
 	labels      map[string]string
-	equals      string
-	greaterThan string
+	greaterThan bool
+	value       float64
+	success     bool
 }
 
-func executeOpenShiftBuild(oc *exutil.CLI, appTemplate string) {
+func runQueries(metricTests map[string][]metricTest) {
+	// expect all correct metrics within 60 seconds
+	errsMap := map[string]error{}
+	for i := 0; i < 60; i++ {
+		for query, tcs := range metricTests {
+			//TODO when the http/query apis discussed at https://github.com/prometheus/client_golang#client-for-the-prometheus-http-api
+			// and introduced at https://github.com/prometheus/client_golang/blob/master/api/prometheus/v1/api.go are vendored into
+			// openshift/origin, look to replace this homegrown http request / query param with that API
+			g.By("perform prometheus metric query " + query)
+			contents, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("https://%s:%d/api/v1/query?query=%s", host, statsPort, query), bearerToken)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			result := prometheusResponse{}
+			json.Unmarshal([]byte(contents), &result)
+			metrics := result.Data.Result
+
+			// for each test case, register that one of the returned metrics has the desired labels and value
+			for j, tc := range tcs {
+				for _, sample := range metrics {
+					if labelsWeWant(sample, tc.labels) && valueWeWant(sample, tc) {
+						tcs[j].success = true
+						break
+					}
+				}
+			}
+
+			// now check the results, see if any bad
+			delete(errsMap, query) // clear out any prior faliures
+			for _, tc := range tcs {
+				if !tc.success {
+					errsMap[query] = fmt.Errorf("query %s for tests %#v had results %s", query, tcs, contents)
+					break
+				}
+			}
+		}
+
+		if len(errsMap) == 0 {
+			break
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	o.Expect(errsMap).To(o.BeEmpty())
+}
+
+func startOpenShiftBuild(oc *exutil.CLI, appTemplate string) *exutil.BuildResult {
 	g.By("waiting for builder service account")
 	err := exutil.WaitForBuilderAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()))
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -185,8 +184,33 @@ func executeOpenShiftBuild(oc *exutil.CLI, appTemplate string) {
 	err = oc.AsAdmin().Run("tag").Args("openshift/nodejs:latest", oc.Namespace()+"/nodejs-010-centos7:latest").Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	g.By("start build, wait for completion")
-	br, err := exutil.StartBuildAndWait(oc, "frontend")
+	g.By("start build")
+	br, err := exutil.StartBuildResult(oc, "frontend")
 	o.Expect(err).NotTo(o.HaveOccurred())
-	br.AssertSuccess()
+	return br
+}
+
+func labelsWeWant(sample *model.Sample, labels map[string]string) bool {
+	//NOTE - prometheus LabelSet.Equals is of little use to us, since the "instance" label
+	// is specific to the host things are running on, so we can't craft an accurate Metric
+	// to compare against
+	for labelName, labelValue := range labels {
+		if v, ok := sample.Metric[model.LabelName(labelName)]; ok {
+			if string(v) != labelValue {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func valueWeWant(sample *model.Sample, tc metricTest) bool {
+	//NOTE - we could use SampleValue has an Equals func, but since SampleValue has no GreaterThan,
+	// we have to go down the float64 compare anyway
+	if tc.greaterThan {
+		return float64(sample.Value) > tc.value
+	}
+	return float64(sample.Value) == tc.value
 }


### PR DESCRIPTION
https://trello.com/c/RskNHpfh/1334-5-prometheus-alerts-for-build-metrics

A WIP initial pass at alerts for the openshift build subsystem

@openshift/devex @smarterclayton @zgalor @moolitayer @mfojtik ptal, defer if bandwidth dictates, and/or pull in others as you each deem fit

Disclaimers:
1) I'm still debating the pros/cons of these alerts with https://docs.google.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/edit#heading=h.2efurbugauf in mind

2) still debating the template parameters / defaults for the various thresholds ... I still have a to-do to revisit with ops contacts potential default values based on their existing zabbix monitoring

3) still debating the severity as well

4) based on the activity in https://github.com/openshift/origin/pull/16026 I did not include the `miqTarget` annotation

I also removed the space in the existing alert name based on how I interpreted various naming conventions.

And other than the query on the alerts URI, the extended test changes stemmed from flakiness experienced during testing that was unrelated to the addition of the alerts.

thanks