### PR TITLE
Allow enabling admission plugins (with configurations) via DefaultAdmissionConfig  and stop passing DefaultAdmissionConfig to admission plugins.

### DIFF
--- a/pkg/cmd/server/origin/admission/chain_builder.go
+++ b/pkg/cmd/server/origin/admission/chain_builder.go
@@ -296,11 +296,17 @@ func newAdmissionChain(pluginNames []string, admissionConfigFilename string, plu
 				return nil, err
 			}
 
-			plugin, err = OriginAdmissionPlugins.InitPlugin(pluginName, pluginConfigReader, admissionInitializer)
+			enabled, pluginConfigReaderCopy := IsAdmissionPluginActivated(pluginName, pluginConfigReader)
+			if !enabled {
+				continue
+			}
+
+			plugin, err = OriginAdmissionPlugins.InitPlugin(pluginName, pluginConfigReaderCopy, admissionInitializer)
 			if err != nil {
 				// should have been caught with validation
 				return nil, err
 			}
+
 			if plugin == nil {
 				continue
 			}


### PR DESCRIPTION
In OpenShift, admission plugins can be enabled and disabled by using DefaultAdmissionConfig.
However enabling of admission plugins with configurations (like ResourceQuota, PodTolerationRestriction etc) via DefaultAdmissionConfig as follows:

```
admissionConfig:
  pluginConfig:
    PodTolerationRestriction: 
      configuration:
        kind: DefaultAdmissionConfig
        apiVersion: v1
        disable: false
```
fails with following error: 
`F0922 09:36:24.937280    5768 start_master.go:115] Couldn't init admission plugin "PodTolerationRestriction": no kind "DefaultAdmissionConfig" is registered for version "v1"`

The reason for this error  is that DefaultAdmissionConfig is being passed to admission plugins which dont understand it,  and so the error. This error does not happen with admission plugins that do not accept any configurations.

Though admission plugins with configurations can also be enabled by passing their own configurations, it might be confusing for users why some plugins can be enabled by DefaultAdmissionConfig and some not. 

This PR addresses the above issue.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1492999

@sjenning @deads2k 
