### PR TITLE
simplify controller start

### DIFF
--- a/pkg/cmd/server/origin/controller/quota.go
+++ b/pkg/cmd/server/origin/controller/quota.go
@@ -15,9 +15,9 @@ import (
 )
 
 func RunResourceQuotaManager(ctx ControllerContext) (bool, error) {
-	concurrentResourceQuotaSyncs := int(ctx.KubeControllerContext.Options.ConcurrentResourceQuotaSyncs)
-	resourceQuotaSyncPeriod := ctx.KubeControllerContext.Options.ResourceQuotaSyncPeriod.Duration
-	replenishmentSyncPeriodFunc := calculateResyncPeriod(ctx.KubeControllerContext.Options.MinResyncPeriod.Duration)
+	concurrentResourceQuotaSyncs := int(ctx.OpenshiftControllerOptions.ResourceQuotaOptions.ConcurrentSyncs)
+	resourceQuotaSyncPeriod := ctx.OpenshiftControllerOptions.ResourceQuotaOptions.SyncPeriod.Duration
+	replenishmentSyncPeriodFunc := calculateResyncPeriod(ctx.OpenshiftControllerOptions.ResourceQuotaOptions.MinResyncPeriod.Duration)
 	saName := "resourcequota-controller"
 
 	resourceQuotaRegistry := quota.NewOriginQuotaRegistry(

--- a/pkg/cmd/server/origin/controller/serviceaccount.go
+++ b/pkg/cmd/server/origin/controller/serviceaccount.go
@@ -68,7 +68,7 @@ func (c *ServiceAccountTokenControllerOptions) RunController(ctx ControllerConte
 			RootCA:           c.RootCA,
 			ServiceServingCA: c.ServiceServingCA,
 		},
-	).Run(int(ctx.KubeControllerContext.Options.ConcurrentSATokenSyncs), ctx.Stop)
+	).Run(int(ctx.OpenshiftControllerOptions.ServiceAccountTokenOptions.ConcurrentSyncs), ctx.Stop)
 	return true, nil
 }
 

--- a/pkg/cmd/server/start/controllers.go
+++ b/pkg/cmd/server/start/controllers.go
@@ -1,57 +1,50 @@
 package start
 
 import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
-	cmapp "k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	cmappoptions "k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
-	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	kclientsetexternal "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/pkg/controller"
 
-	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/cmd/server/cm"
 	origincontrollers "github.com/openshift/origin/pkg/cmd/server/origin/controller"
+	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 )
 
-func getControllerContext(options configapi.MasterConfig, controllerManagerOptions *cmappoptions.CMServer, cloudProvider cloudprovider.Interface, informers *informers, stopCh <-chan struct{}) (origincontrollers.ControllerContext, error) {
-	loopbackConfig, _, kubeExternal, _, err := getAllClients(options)
-	if err != nil {
-		return origincontrollers.ControllerContext{}, err
-	}
+func newControllerContext(
+	openshiftControllerOptions origincontrollers.OpenshiftControllerOptions,
+	privilegedLoopbackConfig *rest.Config,
+	kubeExternal kclientsetexternal.Interface,
+	informers *informers,
+	stopCh <-chan struct{},
+) origincontrollers.ControllerContext {
+
 	// divide up the QPS since it re-used separately for every client
 	// TODO, eventually make this configurable individually in some way.
-	if loopbackConfig.QPS > 0 {
-		loopbackConfig.QPS = loopbackConfig.QPS/10 + 1
+	if privilegedLoopbackConfig.QPS > 0 {
+		privilegedLoopbackConfig.QPS = privilegedLoopbackConfig.QPS/10 + 1
 	}
-	if loopbackConfig.Burst > 0 {
-		loopbackConfig.Burst = loopbackConfig.Burst/10 + 1
-	}
-
-	rootClientBuilder := controller.SimpleControllerClientBuilder{
-		ClientConfig: loopbackConfig,
-	}
-
-	availableResources, err := cmapp.GetAvailableResources(rootClientBuilder)
-	if err != nil {
-		return origincontrollers.ControllerContext{}, err
+	if privilegedLoopbackConfig.Burst > 0 {
+		privilegedLoopbackConfig.Burst = privilegedLoopbackConfig.Burst/10 + 1
 	}
 
 	openshiftControllerContext := origincontrollers.ControllerContext{
-		KubeControllerContext: cmapp.ControllerContext{
-			ClientBuilder: controller.SAControllerClientBuilder{
-				ClientConfig:         rest.AnonymousClientConfig(loopbackConfig),
-				CoreClient:           kubeExternal.Core(),
-				AuthenticationClient: kubeExternal.Authentication(),
-				Namespace:            "kube-system",
-			},
-			InformerFactory:    newGenericInformers(informers),
-			Options:            *controllerManagerOptions,
-			AvailableResources: availableResources,
-			Cloud:              cloudProvider,
-			Stop:               stopCh,
-		},
+		OpenshiftControllerOptions: openshiftControllerOptions,
+
 		ClientBuilder: origincontrollers.OpenshiftControllerClientBuilder{
 			ControllerClientBuilder: controller.SAControllerClientBuilder{
-				ClientConfig:         rest.AnonymousClientConfig(loopbackConfig),
+				ClientConfig:         rest.AnonymousClientConfig(privilegedLoopbackConfig),
 				CoreClient:           kubeExternal.Core(),
 				AuthenticationClient: kubeExternal.Authentication(),
 				Namespace:            bootstrappolicy.DefaultOpenShiftInfraNamespace,
@@ -69,5 +62,68 @@ func getControllerContext(options configapi.MasterConfig, controllerManagerOptio
 		Stop:                   stopCh,
 	}
 
-	return openshiftControllerContext, nil
+	return openshiftControllerContext
+}
+
+// getOpenshiftControllerOptions parses the CLI args used by the kube-controllers (which control these options today), so that
+// we can defer making the controller options structs until we have a better idea what they should look like.
+// This does mean we pull in an upstream command that hopefully won't change much.
+func getOpenshiftControllerOptions(args map[string][]string) (origincontrollers.OpenshiftControllerOptions, error) {
+	cmserver := cmappoptions.NewCMServer()
+	if err := cmdflags.Resolve(args, cm.OriginControllerManagerAddFlags(cmserver)); len(err) > 0 {
+		return origincontrollers.OpenshiftControllerOptions{}, kutilerrors.NewAggregate(err)
+	}
+
+	return origincontrollers.OpenshiftControllerOptions{
+		HPAControllerOptions: origincontrollers.HPAControllerOptions{
+			SyncPeriod:               cmserver.KubeControllerManagerConfiguration.HorizontalPodAutoscalerSyncPeriod,
+			UpscaleForbiddenWindow:   cmserver.KubeControllerManagerConfiguration.HorizontalPodAutoscalerUpscaleForbiddenWindow,
+			DownscaleForbiddenWindow: cmserver.KubeControllerManagerConfiguration.HorizontalPodAutoscalerDownscaleForbiddenWindow,
+		},
+		ResourceQuotaOptions: origincontrollers.ResourceQuotaOptions{
+			ConcurrentSyncs: cmserver.KubeControllerManagerConfiguration.ConcurrentResourceQuotaSyncs,
+			SyncPeriod:      cmserver.KubeControllerManagerConfiguration.ResourceQuotaSyncPeriod,
+			MinResyncPeriod: cmserver.KubeControllerManagerConfiguration.MinResyncPeriod,
+		},
+		ServiceAccountTokenOptions: origincontrollers.ServiceAccountTokenOptions{
+			ConcurrentSyncs: cmserver.KubeControllerManagerConfiguration.ConcurrentSATokenSyncs,
+		},
+	}, nil
+}
+
+// getLeaderElectionOptions parses the CLI args used by the openshift controller leader election (which control these options today), so that
+// we can defer making the options structs until we have a better idea what they should look like.
+// This does mean we pull in an upstream command that hopefully won't change much.
+func getLeaderElectionOptions(args map[string][]string) (componentconfig.LeaderElectionConfiguration, error) {
+	cmserver := cmappoptions.NewCMServer()
+	cmserver.LeaderElection.RetryPeriod = metav1.Duration{Duration: 3 * time.Second}
+
+	if err := cmdflags.Resolve(args, cm.OriginControllerManagerAddFlags(cmserver)); len(err) > 0 {
+		return componentconfig.LeaderElectionConfiguration{}, kutilerrors.NewAggregate(err)
+	}
+
+	return cmserver.KubeControllerManagerConfiguration.LeaderElection, nil
+}
+
+func waitForHealthyAPIServer(client rest.Interface) error {
+	var healthzContent string
+	// If apiserver is not running we should wait for some time and fail only then. This is particularly
+	// important when we start apiserver and controller manager at the same time.
+	err := wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
+		healthStatus := 0
+		resp := client.Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		if healthStatus != http.StatusOK {
+			glog.Errorf("Server isn't healthy yet. Waiting a little while.")
+			return false, nil
+		}
+		content, _ := resp.Raw()
+		healthzContent = string(content)
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("server unhealthy: %v: %v", healthzContent, err)
+	}
+
+	return nil
 }

--- a/pkg/cmd/server/start/start_kube_controller_manager.go
+++ b/pkg/cmd/server/start/start_kube_controller_manager.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 )
 
-// newControllerContext provides a function which overrides the default and plugs a different set of informers in
-func newControllerContext(informers *informers) func(s *controlleroptions.CMServer, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (controllerapp.ControllerContext, error) {
+// newKubeControllerContext provides a function which overrides the default and plugs a different set of informers in
+func newKubeControllerContext(informers *informers) func(s *controlleroptions.CMServer, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (controllerapp.ControllerContext, error) {
 	oldContextFunc := controllerapp.CreateControllerContext
 	return func(s *controlleroptions.CMServer, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (controllerapp.ControllerContext, error) {
 		ret, err := oldContextFunc(s, rootClientBuilder, clientBuilder, stop)
@@ -218,7 +218,7 @@ func createRecylerTemplate(recyclerImage string) (string, error) {
 
 func runEmbeddedKubeControllerManager(kubeconfigFile, saPrivateKeyFile, saRootCAFile, podEvictionTimeout string, dynamicProvisioningEnabled bool, cmdLineArgs map[string][]string,
 	recyclerImage string, informers *informers) {
-	controllerapp.CreateControllerContext = newControllerContext(informers)
+	controllerapp.CreateControllerContext = newKubeControllerContext(informers)
 	controllerapp.StartInformers = func(stop <-chan struct{}) {
 		informers.Start(stop)
 	}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -164,7 +164,6 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (*client.Cli
 		Stop:               wait.NeverStop,
 	}
 	openshiftControllerContext := origincontrollers.ControllerContext{
-		KubeControllerContext: controllerContext,
 		ClientBuilder: origincontrollers.OpenshiftControllerClientBuilder{
 			ControllerClientBuilder: controller.SAControllerClientBuilder{
 				ClientConfig:         restclient.AnonymousClientConfig(&openshiftConfig.PrivilegedLoopbackClientConfig),


### PR DESCRIPTION
Last commit is unique.  This removes the direct usage of the controller manager options struct for unrelated controller initialization. We still use it for parsing (I didn't want to get stuck writing new config.  This isn't net new usage.  I just made the links obvious).

