### PR TITLE
use the upstream namespaced roles

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/all.go
+++ b/pkg/cmd/server/bootstrappolicy/all.go
@@ -1,7 +1,6 @@
 package bootstrappolicy
 
 import (
-	"k8s.io/kubernetes/pkg/apis/rbac"
 	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
 )
 
@@ -9,11 +8,7 @@ func Policy() *rbacrest.PolicyData {
 	return &rbacrest.PolicyData{
 		ClusterRoles:        GetBootstrapClusterRoles(),
 		ClusterRoleBindings: GetBootstrapClusterRoleBindings(),
-		Roles: map[string][]rbac.Role{
-			DefaultOpenShiftSharedResourcesNamespace: GetBootstrapOpenshiftRoles(DefaultOpenShiftSharedResourcesNamespace),
-		},
-		RoleBindings: map[string][]rbac.RoleBinding{
-			DefaultOpenShiftSharedResourcesNamespace: GetBootstrapOpenshiftRoleBindings(DefaultOpenShiftSharedResourcesNamespace),
-		},
+		Roles:               NamespaceRoles(),
+		RoleBindings:        NamespaceRoleBindings(),
 	}
 }

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -32,8 +32,6 @@ const (
 
 // groups
 const (
-	UnauthenticatedUsername = "system:anonymous"
-
 	AuthenticatedGroup      = "system:authenticated"
 	AuthenticatedOAuthGroup = "system:authenticated:oauth"
 	UnauthenticatedGroup    = "system:unauthenticated"
@@ -42,7 +40,6 @@ const (
 	MastersGroup            = "system:masters"
 	NodesGroup              = "system:nodes"
 	NodeAdminsGroup         = "system:node-admins"
-	NodeReadersGroup        = "system:node-readers"
 )
 
 // Roles
@@ -113,23 +110,14 @@ const (
 	StatusCheckerRoleBindingName      = StatusCheckerRoleName + "-binding"
 	ImagePullerRoleBindingName        = ImagePullerRoleName + "s"
 	ImageBuilderRoleBindingName       = ImageBuilderRoleName + "s"
-	RouterRoleBindingName             = RouterRoleName + "s"
-	RegistryRoleBindingName           = RegistryRoleName + "s"
 	MasterRoleBindingName             = MasterRoleName + "s"
-	NodeRoleBindingName               = NodeRoleName + "s"
 	NodeProxierRoleBindingName        = NodeProxierRoleName + "s"
 	NodeAdminRoleBindingName          = NodeAdminRoleName + "s"
-	NodeReaderRoleBindingName         = NodeReaderRoleName + "s"
 	SDNReaderRoleBindingName          = SDNReaderRoleName + "s"
-	SDNManagerRoleBindingName         = SDNManagerRoleName + "s"
 	WebHooksRoleBindingName           = WebHooksRoleName + "s"
 	DiscoveryRoleBindingName          = DiscoveryRoleName + "-binding"
-	RegistryAdminRoleBindingName      = RegistryAdminRoleName + "s"
-	RegistryViewerRoleBindingName     = RegistryViewerRoleName + "s"
-	RegistryEditorRoleBindingName     = RegistryEditorRoleName + "s"
 
 	BuildStrategyDockerRoleBindingName          = BuildStrategyDockerRoleName + "-binding"
-	BuildStrategyCustomRoleBindingName          = BuildStrategyCustomRoleName + "-binding"
 	BuildStrategySourceRoleBindingName          = BuildStrategySourceRoleName + "-binding"
 	BuildStrategyJenkinsPipelineRoleBindingName = BuildStrategyJenkinsPipelineRoleName + "-binding"
 

--- a/pkg/cmd/server/bootstrappolicy/namespace_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/namespace_policy.go
@@ -1,0 +1,70 @@
+package bootstrappolicy
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
+)
+
+var (
+	// namespaceRoles is a map of namespace to slice of roles to create
+	namespaceRoles = map[string][]rbac.Role{}
+
+	// namespaceRoleBindings is a map of namespace to slice of roleBindings to create
+	namespaceRoleBindings = map[string][]rbac.RoleBinding{}
+)
+
+func init() {
+	namespaceRoles[DefaultOpenShiftSharedResourcesNamespace] = GetBootstrapOpenshiftRoles(DefaultOpenShiftSharedResourcesNamespace)
+	namespaceRoleBindings[DefaultOpenShiftSharedResourcesNamespace] = GetBootstrapOpenshiftRoleBindings(DefaultOpenShiftSharedResourcesNamespace)
+}
+
+func GetBootstrapOpenshiftRoles(openshiftNamespace string) []rbac.Role {
+	return []rbac.Role{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      OpenshiftSharedResourceViewRoleName,
+				Namespace: openshiftNamespace,
+			},
+			Rules: []rbac.PolicyRule{
+				rbac.NewRule(read...).
+					Groups(templateGroup, legacyTemplateGroup).
+					Resources("templates").
+					RuleOrDie(),
+				rbac.NewRule(read...).
+					Groups(imageGroup, legacyImageGroup).
+					Resources("imagestreams", "imagestreamtags", "imagestreamimages").
+					RuleOrDie(),
+				// so anyone can pull from openshift/* image streams
+				rbac.NewRule("get").
+					Groups(imageGroup, legacyImageGroup).
+					Resources("imagestreams/layers").
+					RuleOrDie(),
+			},
+		},
+	}
+}
+
+// NamespaceRoles returns a map of namespace to slice of roles to create
+func NamespaceRoles() map[string][]rbac.Role {
+	ret := map[string][]rbac.Role{}
+	for k, v := range namespaceRoles {
+		ret[k] = v
+	}
+	for k, v := range bootstrappolicy.NamespaceRoles() {
+		ret[k] = v
+	}
+	return ret
+}
+
+// NamespaceRoleBindings returns a map of namespace to slice of roles to create
+func NamespaceRoleBindings() map[string][]rbac.RoleBinding {
+	ret := map[string][]rbac.RoleBinding{}
+	for k, v := range namespaceRoleBindings {
+		ret[k] = v
+	}
+	for k, v := range bootstrappolicy.NamespaceRoleBindings() {
+		ret[k] = v
+	}
+	return ret
+}

--- a/pkg/cmd/server/bootstrappolicy/namespace_policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/namespace_policy_test.go
@@ -1,0 +1,46 @@
+package bootstrappolicy
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
+)
+
+func TestOpenshiftNamespacePolicyNamespaces(t *testing.T) {
+	for ns := range namespaceRoles {
+		if ns == DefaultOpenShiftSharedResourcesNamespace {
+			continue
+		}
+		if strings.HasPrefix(ns, "openshift-") {
+			continue
+		}
+		t.Errorf("bootstrap role in %q,but must be under %q", ns, "openshift-")
+	}
+
+	for ns := range namespaceRoleBindings {
+		if ns == DefaultOpenShiftSharedResourcesNamespace {
+			continue
+		}
+		if strings.HasPrefix(ns, "openshift-") {
+			continue
+		}
+		t.Errorf("bootstrap rolebinding in %q,but must be under %q", ns, "openshift-")
+	}
+}
+
+func TestKubeNamespacePolicyNamespaces(t *testing.T) {
+	for ns := range bootstrappolicy.NamespaceRoles() {
+		if strings.HasPrefix(ns, "kube-") {
+			continue
+		}
+		t.Errorf("bootstrap role in %q,but must be under %q", ns, "kube-")
+	}
+
+	for ns := range bootstrappolicy.NamespaceRoles() {
+		if strings.HasPrefix(ns, "kube-") {
+			continue
+		}
+		t.Errorf("bootstrap rolebinding in %q,but must be under %q", ns, "kube-")
+	}
+}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -87,32 +87,6 @@ var (
 	legacyNetworkGroup  = networkapi.LegacyGroupName
 )
 
-func GetBootstrapOpenshiftRoles(openshiftNamespace string) []rbac.Role {
-	return []rbac.Role{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      OpenshiftSharedResourceViewRoleName,
-				Namespace: openshiftNamespace,
-			},
-			Rules: []rbac.PolicyRule{
-				rbac.NewRule(read...).
-					Groups(templateGroup, legacyTemplateGroup).
-					Resources("templates").
-					RuleOrDie(),
-				rbac.NewRule(read...).
-					Groups(imageGroup, legacyImageGroup).
-					Resources("imagestreams", "imagestreamtags", "imagestreamimages").
-					RuleOrDie(),
-				// so anyone can pull from openshift/* image streams
-				rbac.NewRule("get").
-					Groups(imageGroup, legacyImageGroup).
-					Resources("imagestreams/layers").
-					RuleOrDie(),
-			},
-		},
-	}
-}
-
 func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 	// four resource can be a single line
 	// up to ten-ish resources per line otherwise


### PR DESCRIPTION
Adds reconcilation for namespaced roles which includes the upstream namespaced roles that back controllers.  Added unit tests to keep the roles in reserved namespaces.

@openshift/sig-security 
@jim-minter creates `kube-system   extension-apiserver-authentication-reader`