### PR TITLE
use reconcilation to ensure rbac resources

### DIFF
--- a/pkg/cmd/server/origin/ensure.go
+++ b/pkg/cmd/server/origin/ensure.go
@@ -1,24 +1,11 @@
 package origin
 
 import (
-	"github.com/golang/glog"
-
-	kapierror "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	kapi "k8s.io/kubernetes/pkg/api"
 )
 
 // ensureOpenShiftSharedResourcesNamespace is called as part of global policy initialization to ensure shared namespace exists
 func (c *MasterConfig) ensureOpenShiftSharedResourcesNamespace(context genericapiserver.PostStartHookContext) error {
-	if _, err := c.PrivilegedLoopbackKubernetesClientsetInternal.Core().Namespaces().Get(c.Options.PolicyConfig.OpenShiftSharedResourcesNamespace, metav1.GetOptions{}); kapierror.IsNotFound(err) {
-		namespace, createErr := c.PrivilegedLoopbackKubernetesClientsetInternal.Core().Namespaces().Create(&kapi.Namespace{ObjectMeta: metav1.ObjectMeta{Name: c.Options.PolicyConfig.OpenShiftSharedResourcesNamespace}})
-		if createErr != nil {
-			glog.Errorf("Error creating namespace: %v due to %v\n", c.Options.PolicyConfig.OpenShiftSharedResourcesNamespace, createErr)
-			return nil
-		}
-
-		EnsureNamespaceServiceAccountRoleBindings(c.PrivilegedLoopbackKubernetesClientsetInternal, c.PrivilegedLoopbackOpenShiftClient, namespace)
-	}
+	ensureNamespaceServiceAccountRoleBindings(context, c.Options.PolicyConfig.OpenShiftSharedResourcesNamespace)
 	return nil
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -59,7 +59,6 @@ func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Confi
 		KubeInternalInformers:              c.InternalKubeInformers,
 		QuotaInformers:                     c.QuotaInformers,
 		SecurityInformers:                  c.SecurityInformers,
-		DeprecatedOpenshiftClient:          c.PrivilegedLoopbackOpenShiftClient,
 		RuleResolver:                       c.RuleResolver,
 		SubjectLocator:                     c.SubjectLocator,
 		LimitVerifier:                      c.LimitVerifier,


### PR DESCRIPTION
Use reconciliation to ensure namespaced roles exist for SAs in auto-created namespaces.

@openshift/sig-security 
@mfojtik also eliminates deprecated client usage.