### PR TITLE
Set access token expiration correctly for code and implicit flows

### DIFF
--- a/pkg/auth/oauth/handlers/authenticator.go
+++ b/pkg/auth/oauth/handlers/authenticator.go
@@ -46,9 +46,12 @@ func (h *AuthorizeAuthenticator) HandleAuthorize(ar *osin.AuthorizeRequest, resp
 	ar.UserData = info
 	ar.Authorized = true
 
-	if e, ok := ar.Client.(TokenMaxAgeSeconds); ok {
-		if maxAge := e.GetTokenMaxAgeSeconds(); maxAge != nil {
-			ar.Expiration = *maxAge
+	// If requesting a token directly, optionally override the expiration
+	if ar.Type == osin.TOKEN {
+		if e, ok := ar.Client.(TokenMaxAgeSeconds); ok {
+			if maxAge := e.GetTokenMaxAgeSeconds(); maxAge != nil {
+				ar.Expiration = *maxAge
+			}
 		}
 	}
 
@@ -101,7 +104,14 @@ func (h *AccessAuthenticator) HandleAccess(ar *osin.AccessRequest, w http.Respon
 		if info != nil {
 			ar.AccessData.UserData = info
 		}
+
+		if e, ok := ar.Client.(TokenMaxAgeSeconds); ok {
+			if maxAge := e.GetTokenMaxAgeSeconds(); maxAge != nil {
+				ar.Expiration = *maxAge
+			}
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/client/oauthauthorizetoken.go
+++ b/pkg/client/oauthauthorizetoken.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
+
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 )
 
@@ -10,6 +13,7 @@ type OAuthAuthorizeTokensInterface interface {
 
 type OAuthAuthorizeTokenInterface interface {
 	Create(token *oauthapi.OAuthAuthorizeToken) (*oauthapi.OAuthAuthorizeToken, error)
+	Get(name string, options metav1.GetOptions) (*oauthapi.OAuthAuthorizeToken, error)
 	Delete(name string) error
 }
 
@@ -31,5 +35,11 @@ func (c *oauthAuthorizeTokenInterface) Delete(name string) (err error) {
 func (c *oauthAuthorizeTokenInterface) Create(token *oauthapi.OAuthAuthorizeToken) (result *oauthapi.OAuthAuthorizeToken, err error) {
 	result = &oauthapi.OAuthAuthorizeToken{}
 	err = c.r.Post().Resource("oauthauthorizetokens").Body(token).Do().Into(result)
+	return
+}
+
+func (c *oauthAuthorizeTokenInterface) Get(name string, options metav1.GetOptions) (result *oauthapi.OAuthAuthorizeToken, err error) {
+	result = &oauthapi.OAuthAuthorizeToken{}
+	err = c.r.Get().Resource("oauthauthorizetokens").Name(name).VersionedParams(&options, kapi.ParameterCodec).Do().Into(result)
 	return
 }

--- a/pkg/client/testclient/fake_oauthauthorizetoken.go
+++ b/pkg/client/testclient/fake_oauthauthorizetoken.go
@@ -1,6 +1,7 @@
 package testclient
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgotesting "k8s.io/client-go/testing"
 
@@ -20,6 +21,15 @@ func (c *FakeOAuthAuthorizeTokens) Delete(name string) error {
 
 func (c *FakeOAuthAuthorizeTokens) Create(inObj *oauthapi.OAuthAuthorizeToken) (*oauthapi.OAuthAuthorizeToken, error) {
 	obj, err := c.Fake.Invokes(clientgotesting.NewRootCreateAction(oAuthAuthorizeTokensResource, inObj), inObj)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*oauthapi.OAuthAuthorizeToken), err
+}
+
+func (c *FakeOAuthAuthorizeTokens) Get(name string, options metav1.GetOptions) (*oauthapi.OAuthAuthorizeToken, error) {
+	obj, err := c.Fake.Invokes(clientgotesting.NewRootGetAction(oAuthAuthorizeTokensResource, name), &oauthapi.OAuthAuthorizeToken{})
 	if obj == nil {
 		return nil, err
 	}


### PR DESCRIPTION
The expiration was only being set during the authorization request, which meant it was only set for implicit flow access tokens, and was incorrectly set on authorization tokens.

Fixed up and added tests for both flows

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1493903