### PR TITLE
WIP - Delete namespaces asynchronously

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/e2e.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/e2e.go
@@ -263,6 +263,7 @@ func RunCleanupActions() {
 var _ = ginkgo.SynchronizedAfterSuite(func() {
 	// Run on all Ginkgo nodes
 	framework.Logf("Running AfterSuite actions on all node")
+	framework.RunCleanupActions()
 	RunCleanupActions()
 }, func() {
 	// Run only Ginkgo on node 1

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -961,10 +961,11 @@ func CheckTestingNSDeletedExcept(c clientset.Interface, skip string) error {
 
 // deleteNS deletes the provided namespace, waits for it to be completely deleted, and then checks
 // whether there are any pods remaining in a non-terminating state.
-func deleteNS(c clientset.Interface, clientPool dynamic.ClientPool, namespace string, timeout time.Duration) error {
-	startTime := time.Now()
+func deleteNS(c clientset.Interface, clientPool dynamic.ClientPool, namespace string, timeout time.Duration, startTime time.Time) error {
 	if err := c.Core().Namespaces().Delete(namespace, nil); err != nil {
-		return err
+		if !apierrs.IsConflict(err) || !strings.Contains(err.Error(), "ensuring all content is removed") {
+			return err
+		}
 	}
 
 	// wait for namespace to delete or timeout.


### PR DESCRIPTION
Queue namespaces so that new tests can run while deletions are in
progress. Makes single threaded tests run a lot faster.