### PR TITLE
hack in field selectors for 3.6

### DIFF
--- a/pkg/authorization/apis/authorization/v1/conversion.go
+++ b/pkg/authorization/apis/authorization/v1/conversion.go
@@ -399,8 +399,18 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "ClusterPolicy",
+		oapi.GetFieldLabelConversionFunc(newer.ClusterPolicyToSelectableFields(&newer.ClusterPolicy{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "ClusterPolicyBinding",
+		oapi.GetFieldLabelConversionFunc(newer.ClusterPolicyBindingToSelectableFields(&newer.ClusterPolicyBinding{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "ClusterPolicyBinding",
 		oapi.GetFieldLabelConversionFunc(newer.ClusterPolicyBindingToSelectableFields(&newer.ClusterPolicyBinding{}), nil),
 	); err != nil {
 		return err
@@ -411,8 +421,18 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Policy",
+		oapi.GetFieldLabelConversionFunc(newer.PolicyToSelectableFields(&newer.Policy{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "PolicyBinding",
+		oapi.GetFieldLabelConversionFunc(newer.PolicyBindingToSelectableFields(&newer.PolicyBinding{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "PolicyBinding",
 		oapi.GetFieldLabelConversionFunc(newer.PolicyBindingToSelectableFields(&newer.PolicyBinding{}), nil),
 	); err != nil {
 		return err
@@ -423,8 +443,18 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Role",
+		oapi.GetFieldLabelConversionFunc(newer.RoleToSelectableFields(&newer.Role{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "RoleBinding",
+		oapi.GetFieldLabelConversionFunc(newer.RoleBindingToSelectableFields(&newer.RoleBinding{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "RoleBinding",
 		oapi.GetFieldLabelConversionFunc(newer.RoleBindingToSelectableFields(&newer.RoleBinding{}), nil),
 	); err != nil {
 		return err

--- a/pkg/build/apis/build/v1/conversion.go
+++ b/pkg/build/apis/build/v1/conversion.go
@@ -179,9 +179,19 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Build",
+		oapi.GetFieldLabelConversionFunc(newer.BuildToSelectableFields(&newer.Build{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "BuildConfig",
 		oapi.GetFieldLabelConversionFunc(newer.BuildConfigToSelectableFields(&newer.BuildConfig{}), map[string]string{"name": "metadata.name"}),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "BuildConfig",
+		oapi.GetFieldLabelConversionFunc(newer.BuildConfigToSelectableFields(&newer.BuildConfig{}), nil),
 	); err != nil {
 		return err
 	}

--- a/pkg/deploy/apis/apps/v1/conversion.go
+++ b/pkg/deploy/apis/apps/v1/conversion.go
@@ -130,5 +130,10 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "DeploymentConfig",
+		oapi.GetFieldLabelConversionFunc(newer.DeploymentConfigToSelectableFields(&newer.DeploymentConfig{}), nil),
+	); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/image/apis/image/v1/conversion.go
+++ b/pkg/image/apis/image/v1/conversion.go
@@ -283,9 +283,19 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Image",
+		oapi.GetFieldLabelConversionFunc(newer.ImageToSelectableFields(&newer.Image{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "ImageStream",
 		oapi.GetFieldLabelConversionFunc(newer.ImageStreamToSelectableFields(&newer.ImageStream{}), map[string]string{"name": "metadata.name"}),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "ImageStream",
+		oapi.GetFieldLabelConversionFunc(newer.ImageStreamToSelectableFields(&newer.ImageStream{}), nil),
 	); err != nil {
 		return err
 	}

--- a/pkg/oauth/apis/oauth/v1/conversion.go
+++ b/pkg/oauth/apis/oauth/v1/conversion.go
@@ -13,8 +13,18 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "OAuthAccessToken",
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthAccessTokenToSelectableFields(&oauthapi.OAuthAccessToken{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "OAuthAuthorizeToken",
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthAuthorizeTokenToSelectableFields(&oauthapi.OAuthAuthorizeToken{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "OAuthAuthorizeToken",
 		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthAuthorizeTokenToSelectableFields(&oauthapi.OAuthAuthorizeToken{}), nil),
 	); err != nil {
 		return err
@@ -25,8 +35,18 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "OAuthClient",
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthClientToSelectableFields(&oauthapi.OAuthClient{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "OAuthClientAuthorization",
+		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthClientAuthorizationToSelectableFields(&oauthapi.OAuthClientAuthorization{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "OAuthClientAuthorization",
 		oapi.GetFieldLabelConversionFunc(oauthapi.OAuthClientAuthorizationToSelectableFields(&oauthapi.OAuthClientAuthorization{}), nil),
 	); err != nil {
 		return err

--- a/pkg/project/apis/project/v1/conversion.go
+++ b/pkg/project/apis/project/v1/conversion.go
@@ -9,7 +9,12 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
-	return scheme.AddFieldLabelConversionFunc("v1", "Project",
+	if err := scheme.AddFieldLabelConversionFunc("v1", "Project",
+		oapi.GetFieldLabelConversionFunc(namespace.NamespaceToSelectableFields(&kapi.Namespace{}), nil),
+	); err != nil {
+		return err
+	}
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Project",
 		oapi.GetFieldLabelConversionFunc(namespace.NamespaceToSelectableFields(&kapi.Namespace{}), nil),
 	)
 }

--- a/pkg/route/apis/route/v1/conversion.go
+++ b/pkg/route/apis/route/v1/conversion.go
@@ -8,7 +8,12 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
-	return scheme.AddFieldLabelConversionFunc("v1", "Route",
+	if err := scheme.AddFieldLabelConversionFunc("v1", "Route",
+		oapi.GetFieldLabelConversionFunc(routeapi.RouteToSelectableFields(&routeapi.Route{}), nil),
+	); err != nil {
+		return err
+	}
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Route",
 		oapi.GetFieldLabelConversionFunc(routeapi.RouteToSelectableFields(&routeapi.Route{}), nil),
 	)
 }

--- a/pkg/template/apis/template/v1/conversion.go
+++ b/pkg/template/apis/template/v1/conversion.go
@@ -15,14 +15,29 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Template",
+		oapi.GetFieldLabelConversionFunc(templateapi.TemplateToSelectableFields(&templateapi.Template{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "TemplateInstance",
 		oapi.GetFieldLabelConversionFunc(templateapi.TemplateInstanceToSelectableFields(&templateapi.TemplateInstance{}), nil),
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "TemplateInstance",
+		oapi.GetFieldLabelConversionFunc(templateapi.TemplateInstanceToSelectableFields(&templateapi.TemplateInstance{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "BrokerTemplateInstance",
+		oapi.GetFieldLabelConversionFunc(templateapi.BrokerTemplateInstanceToSelectableFields(&templateapi.BrokerTemplateInstance{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "BrokerTemplateInstance",
 		oapi.GetFieldLabelConversionFunc(templateapi.BrokerTemplateInstanceToSelectableFields(&templateapi.BrokerTemplateInstance{}), nil),
 	); err != nil {
 		return err

--- a/pkg/user/apis/user/v1/conversion.go
+++ b/pkg/user/apis/user/v1/conversion.go
@@ -13,14 +13,29 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Group",
+		oapi.GetFieldLabelConversionFunc(userapi.GroupToSelectableFields(&userapi.Group{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "Identity",
 		oapi.GetFieldLabelConversionFunc(userapi.IdentityToSelectableFields(&userapi.Identity{}), nil),
 	); err != nil {
 		return err
 	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "Identity",
+		oapi.GetFieldLabelConversionFunc(userapi.IdentityToSelectableFields(&userapi.Identity{}), nil),
+	); err != nil {
+		return err
+	}
 
 	if err := scheme.AddFieldLabelConversionFunc("v1", "User",
+		oapi.GetFieldLabelConversionFunc(userapi.UserToSelectableFields(&userapi.User{}), nil),
+	); err != nil {
+		return err
+	}
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.String(), "User",
 		oapi.GetFieldLabelConversionFunc(userapi.UserToSelectableFields(&userapi.User{}), nil),
 	); err != nil {
 		return err

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -308,14 +308,14 @@ var _ = g.Describe("[builds][Slow] starting a build using CLI", func() {
 			g.By("verifying the build output contains the changes.")
 			o.Expect(buildLog).To(o.ContainSubstring("bar"))
 		})
-		g.It("Should fail on non-existent build-arg", func() {
+		g.It("Should complete with a warning on non-existent build-arg", func() {
 			g.By("starting the build with --build-arg flag")
 			br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=bar=foo")
-			br.AssertFailure()
+			br.AssertSuccess()
 			buildLog, err := br.Logs()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			g.By("verifying the build failed due to Docker.")
-			o.Expect(buildLog).To(o.ContainSubstring("One or more build-args [bar] were not consumed, failing build"))
+			g.By("verifying the build completed with a warning.")
+			o.Expect(buildLog).To(o.ContainSubstring("One or more build-args [bar] were not consumed"))
 		})
 	})
 


### PR DESCRIPTION
This doesn't make any of the structural fixes to make field selectors more consistent and reliable across APIs, but it should enable compatible field selection in the 3.6 groupified APIs.

@bparees @gabemontero per request