### PR TITLE
Router support for Strict-Transport-Security (hsts)

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -9,23 +9,28 @@
 {{- $router_ip_v4_v6_mode := env "ROUTER_IP_V4_V6_MODE" "v4" }}
 
 
-{{/* A bunch of regular expressions.  Each should be wrapped in (?:) so that it is safe to include bare */}}
-{{/* quadPattern: Match a quad in an IP address; e.g. 123 */}}
+{{- /* A bunch of regular expressions.  Each should be wrapped in (?:) so that it is safe to include bare */}}
+{{- /* quadPattern: Match a quad in an IP address; e.g. 123 */}}
 {{- $quadPattern := `(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])` -}}
 
-{{/* ipPattern: Match an IPv4 address; e.g. 192.168.21.23 */}}
+{{- /* ipPattern: Match an IPv4 address; e.g. 192.168.21.23 */}}
 {{- $ipPattern := printf `(?:%s\.%s\.%s\.%s)` $quadPattern $quadPattern $quadPattern $quadPattern -}}
 
-{{/* cidrPattern: Match an IP and network size in CIDR form; e.g. 192.168.21.23/24 */}}
+{{- /* cidrPattern: Match an IP and network size in CIDR form; e.g. 192.168.21.23/24 */}}
 {{- $cidrPattern := printf `(?:%s(?:/(?:[0-9]|[1-2][0-9]|3[0-2]))?)` $ipPattern -}}
 
-{{/* cidrListPattern: Match a space separated list of CIDRs; e.g. 192.168.21.23/24 192.10.2.12 */}}
+{{- /* cidrListPattern: Match a space separated list of CIDRs; e.g. 192.168.21.23/24 192.10.2.12 */}}
 {{- $cidrListPattern := printf `(?:%s(?: +%s)*)` $cidrPattern $cidrPattern -}}
 
-{{/* cookie name pattern: */}}
+{{- /* cookie name pattern: */}}
 {{- $cookieNamePattern := `[a-zA-Z0-9_-]+` -}}
 
 {{- $timeSpecPattern := `[1-9][0-9]*(us|ms|s|m|h|d)?` }}
+
+{{- /* hsts header in response: */}}
+{{- $hstsOptionalTokenPattern := `(?:includeSubDomains|preload)` }}
+{{- $hstsPattern := printf `(?:%[1]s[;])*max-age=(?:\d+|"\d+")(?:[;]%[1]s)*`  $hstsOptionalTokenPattern -}}
+
 global
   maxconn {{env "ROUTER_MAX_CONNECTIONS" "20000"}}
 
@@ -385,6 +390,9 @@ backend be_secure:{{$cfgIdx}}
     {{- end }}
   {{- end }}{{/* end disable cookies check */}}
 
+  {{- with $hsts := firstMatch $hstsPattern (index $cfg.Annotations "haproxy.router.openshift.io/hsts_header") }}
+  http-response set-header Strict-Transport-Security {{$hsts}}
+  {{- end }}{{/* hsts header */}}
 
   {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
     {{- if ne $weight 0 }}


### PR DESCRIPTION
Strict-Transport-Security (hsts) support (RFC 6797) is a way that the
host can tell clients to always use https requests to the host. It is
controlled by adding the haproxy.router.openshift.io/hsts_header annotation
to the route. When the Strict-Transport-Security response is received
by a client, it respects the request until:
1) It is updated by the response from the host to another request.
2) the max-age decrements to 0

The max-age is only updated when the client receives a response
that contains the Strict-Transport-Security header. Other than
that the client just decrements max-age to 0.  When hsts is no longer
desired for a host set max-age=0 in the annotation rather than
deleting the annotation.  There is no telling when a client will 
make a request to the host.

In the route add the annotation:
metadata:
  annotations:
    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains

Where max-age=<seconds> is required and
includeSubDomains and
preload
are optional.

When the annotation is present for a route https responses will
include the Strict-Transport-Security header with the annotation's
value. The annotation value must contain max-age=<seconds> and it
may contain either or both of: includeSubDomains and preload.

max-age sets the length of time the client should force requests
to the host to be https.  max-age=31536000 is one year.

includeSubDomains requests all subdomains of the host should
observe the max-age of the host.

preload tells the client to include this host in its host preload list.

Bug: 1430035
https://bugzilla.redhat.com/show_bug.cgi?id=1430035

Trello:
https://trello.com/c/H1FhCI1I/452-3-sccfsi-support-hsts-policy