### PR TITLE
Use `os::cmd` in verification scripts

### DIFF
--- a/hack/verify-cli-conventions.sh
+++ b/hack/verify-cli-conventions.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying CLI Conventions ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
 # ensure we have the latest compiled binaries
 os::util::ensure::built_binary_exists 'clicheck'
 
-if ! output=$(clicheck 2>&1)
-then
-	echo "FAILURE: CLI is not following one or more required conventions:"
-	echo "$output"
-	exit 1
-else
-  echo "SUCCESS: CLI is following all tested conventions."
-fi
+os::test::junit::declare_suite_start "verify/cli-conventions"
+os::cmd::expect_success "clicheck"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-bindata.sh
+++ b/hack/verify-generated-bindata.sh
@@ -1,41 +1,19 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Bindata ====="
+function cleanup() {
+    return_code=$?
+    rm -rf "${TMP_GENERATED_BOOTSTRAP_DIR}"
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
 TMP_GENERATED_BOOTSTRAP_DIR="_output/verify-bindata"
 
-echo "Generating bindata..."
-if ! output=`OUTPUT_ROOT=${TMP_GENERATED_BOOTSTRAP_DIR} ${OS_ROOT}/hack/update-generated-bindata.sh 2>&1`
-then
-	echo "FAILURE: Generation of fresh bindata failed:"
-	echo "$output"
-  exit 1
-fi
-
-echo "Diffing current bootstrap bindata against freshly generated bindata"
-ret=0
-diff -Naup "${OS_ROOT}/pkg/oc/bootstrap/bindata.go" "${TMP_GENERATED_BOOTSTRAP_DIR}/pkg/oc/bootstrap/bindata.go" || ret=$?
-if [[ $ret -eq 0 ]]
-then
-  echo "SUCCESS: Generated bootstrap bindata up to date."
-else
-  rm -rf "${TMP_GENERATED_BOOTSTRAP_DIR}"
-  echo "FAILURE: Generated bootstrap bindata out of date. Please run hack/update-generated-bindata.sh"
-  exit 1
-fi
-
-echo "Diffing current test/extended bindata against freshly generated bindata"
-ret=0
-diff -Naup "${OS_ROOT}/test/extended/testdata/bindata.go" "${TMP_GENERATED_BOOTSTRAP_DIR}/test/extended/testdata/bindata.go" || ret=$?
-rm -rf "${TMP_GENERATED_BOOTSTRAP_DIR}"
-if [[ $ret -eq 0 ]]
-then
-  echo "SUCCESS: Generated test/extended bindata up to date."
-else
-  rm -rf "${TMP_GENERATED_BOOTSTRAP_DIR}"
-  echo "FAILURE: Generated test/extended bindata out of date. Please run hack/update-generated-bindata.sh"
-  exit 1
-fi
-
-rm -rf "${TMP_GENERATED_BOOTSTRAP_DIR}"
+os::test::junit::declare_suite_start "verify/bindata"
+os::cmd::expect_success "OUTPUT_ROOT=${TMP_GENERATED_BOOTSTRAP_DIR} ${OS_ROOT}/hack/update-generated-bindata.sh"
+os::cmd::expect_success "diff -Naup ${OS_ROOT}/pkg/oc/bootstrap/bindata.go ${TMP_GENERATED_BOOTSTRAP_DIR}/pkg/oc/bootstrap/bindata.go"
+os::cmd::expect_success "diff -Naup ${OS_ROOT}/test/extended/testdata/bindata.go ${TMP_GENERATED_BOOTSTRAP_DIR}/test/extended/testdata/bindata.go"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-clientsets.sh
+++ b/hack/verify-generated-clientsets.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Client sets ====="
-if output=$(VERIFY=--verify-only ${OS_ROOT}/hack/update-generated-clientsets.sh 2>&1)
-then
-  echo "SUCCESS: Generated client sets up to date."
-else
-  echo "FAILURE: Generated client sets out of date. Please run hack/update-generated-clientsets.sh"
-  echo "${output}"
-  exit 1
-fi
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
+
+os::test::junit::declare_suite_start "verify/clientsets"
+os::cmd::expect_success "VERIFY=--verify-only ${OS_ROOT}/hack/update-generated-clientsets.sh"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-conversions.sh
+++ b/hack/verify-generated-conversions.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Conversions ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-if ! output=`${OS_ROOT}/hack/update-generated-conversions.sh --verify-only 2>&1`
-then
-  echo "FAILURE: Verification of conversions failed:"
-  echo "$output"
-  exit 1
-fi
-
-# ex: ts=2 sw=2 et filetype=sh
+os::test::junit::declare_suite_start "verify/conversions"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-conversions.sh --verify-only"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-deep-copies.sh
+++ b/hack/verify-generated-deep-copies.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Deep Copies ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-if ! output=`${OS_ROOT}/hack/update-generated-deep-copies.sh --verify-only 2>&1`
-then
-  echo "FAILURE: Verifying deep copies failed:"
-  echo "$output"
-  exit 1
-fi
-
-# ex: ts=2 sw=2 et filetype=sh
+os::test::junit::declare_suite_start "verify/deep-copies"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-deep-copies.sh --verify-only"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-defaulters.sh
+++ b/hack/verify-generated-defaulters.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Defaulters ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-if ! output=`${OS_ROOT}/hack/update-generated-defaulters.sh --verify-only 2>&1`
-then
-  echo "FAILURE: Verification of defaulters failed:"
-  echo "$output"
-  exit 1
-fi
-
-# ex: ts=2 sw=2 et filetype=sh
+os::test::junit::declare_suite_start "verify/defaulters"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-defaulters.sh --verify-only"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-docs.sh
+++ b/hack/verify-generated-docs.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Docs ====="
+function cleanup() {
+    return_code=$?
+    rm -rf "${TMP_GENERATED_DOCS_ROOT}"
+    rm -rf "${TMP_GENERATED_DOCS_MAN_ROOT}"
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
 GENERATED_DOCS_ROOT_REL="docs/generated"
 GENERATED_DOCS_ROOT="${OS_ROOT}/${GENERATED_DOCS_ROOT_REL}"
@@ -12,36 +20,8 @@ GENERATED_DOCS_MAN_ROOT_REL="docs/man/man1"
 GENERATED_DOCS_MAN_ROOT="${OS_ROOT}/${GENERATED_DOCS_MAN_ROOT_REL}"
 TMP_GENERATED_DOCS_MAN_ROOT="${OS_ROOT}/${TMP_GENERATED_DOCS_ROOT_REL}/${GENERATED_DOCS_MAN_ROOT_REL}"
 
-echo "Generating fresh docs..."
-if ! output=`${OS_ROOT}/hack/update-generated-docs.sh ${TMP_GENERATED_DOCS_ROOT_REL} 2>&1`
-then
-	echo "FAILURE: Generation of fresh docs failed:"
-	echo "$output"
-  exit 1
-fi
-
-echo "Diffing current docs against freshly generated docs"
-ret=0
-diff -Naupr "${GENERATED_DOCS_ROOT}" "${TMP_GENERATED_DOCS_ROOT}" || ret=$?
-rm -rf "${TMP_GENERATED_DOCS_ROOT}"
-
-echo "Diffing current man pages against freshly generated man pages"
-retman=0
-diff -Naupr "${GENERATED_DOCS_MAN_ROOT}" "${TMP_GENERATED_DOCS_MAN_ROOT}" || retman=$?
-rm -rf "${TMP_GENERATED_DOCS_MAN_ROOT}"
-
-if [[ $ret -eq 0 ]] && [[ $retman -eq 0 ]]
-then
-  echo "SUCCESS: Generated docs and man pages up to date."
-elif [[ $ret -eq 0 ]] && [[ $retman -ne 0 ]]
-then
-  echo "FAILURE: Generated docs up to date, but generated man pages out of date. Please run hack/update-generated-docs.sh"
-  exit 1
-elif [[ $ret -ne 0 ]] && [[ $retman -eq 0 ]]
-then
-  echo "FAILURE: Generated man pages up to date, but generated docs out of date. Please run hack/update-generated-docs.sh"
-  exit 1
-else
-  echo "FAILURE: Generated docs and man pages out of date. Please run hack/update-generated-docs.sh"
-  exit 1
-fi
+os::test::junit::declare_suite_start "verify/docs"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-docs.sh ${TMP_GENERATED_DOCS_ROOT_REL}"
+os::cmd::expect_success "diff -Naupr ${GENERATED_DOCS_ROOT} ${TMP_GENERATED_DOCS_ROOT}"
+os::cmd::expect_success "diff -Naupr ${GENERATED_DOCS_MAN_ROOT} ${TMP_GENERATED_DOCS_MAN_ROOT}"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-informers.sh
+++ b/hack/verify-generated-informers.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Informers ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-if ! output=`${OS_ROOT}/hack/update-generated-informers.sh --verify-only 2>&1`
-then
-  echo "FAILURE: Verification of informers failed:"
-  echo "$output"
-  exit 1
-fi
-
-# ex: ts=2 sw=2 et filetype=sh
+os::test::junit::declare_suite_start "verify/informers"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-informers.sh --verify-only"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-json-codecs.sh
+++ b/hack/verify-generated-json-codecs.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Ugorji JSON Codecs ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-output=$(find ${OS_ROOT}/vendor/k8s.io/kubernetes -name "types.generated.go")
-if [[ -n "${output}" ]]; then
-  os::log::fatal "FAILURE: Verification of existing ugorji JSON codecs failed. These should NOT exist:\n${output}"
-fi
+os::test::junit::declare_suite_start "verify/codecs"
+# no ugorji codecs should be checked in
+os::cmd::expect_success_and_not_text "find ${OS_ROOT}/vendor/k8s.io/kubernetes -name 'types.generated.go'" "."
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-listers.sh
+++ b/hack/verify-generated-listers.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Listers ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-if ! output=`${OS_ROOT}/hack/update-generated-listers.sh --verify-only 2>&1`
-then
-  echo "FAILURE: Verification of listers failed:"
-  echo "$output"
-  exit 1
-fi
-
-# ex: ts=2 sw=2 et filetype=sh
+os::test::junit::declare_suite_start "verify/listers"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-listers.sh --verify-only"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-openapi.sh
+++ b/hack/verify-generated-openapi.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated OpenAPI ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-if ! output=`${OS_ROOT}/hack/update-generated-openapi.sh --verify-only 2>&1`
-then
-  echo "FAILURE: Verification of openapi failed:"
-  echo "$output"
-  exit 1
-fi
-
-# ex: ts=2 sw=2 et filetype=sh
+os::test::junit::declare_suite_start "verify/openapi"
+os::cmd::expect_success "${OS_ROOT}/hack/update-generated-openapi.sh --verify-only"
+os::test::junit::declare_suite_end

--- a/hack/verify-generated-swagger-descriptions.sh
+++ b/hack/verify-generated-swagger-descriptions.sh
@@ -3,6 +3,14 @@
 # This script verifies that generated Swagger self-describing documentation is up to date.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-echo "===== Verifying Generated Swagger Descriptions ====="
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
 
-VERIFY=true "${OS_ROOT}/hack/update-generated-swagger-descriptions.sh"
+os::test::junit::declare_suite_start "verify/swagger-descriptions"
+os::cmd::expect_success "VERIFY=true ${OS_ROOT}/hack/update-generated-swagger-descriptions.sh"
+os::test::junit::declare_suite_end

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+function cleanup() {
+    return_code=$?
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
+
 os::golang::verify_go_version
 
 bad_files=$(os::util::list_go_src_files | xargs gofmt -s -l)

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+function cleanup() {
+    return_code=$?
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
+
 os::golang::verify_go_version
 
 govet_blacklist=(
@@ -36,9 +43,5 @@ done
 # We don't want to exit on the first failure of go vet, so just keep track of
 # whether a failure occurred or not.
 if [[ -n "${FAILURE:-}" ]]; then
-	echo "FAILURE: go vet failed!"
-	exit 1
-else
-	echo "SUCCESS: go vet succeeded!"
-	exit 0
+	os::log::fatal "FAILURE: go vet failed!"
 fi

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -4,6 +4,16 @@
 # conform to our import restrictions
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
+
 os::util::ensure::built_binary_exists 'import-verifier'
 
-import-verifier "${OS_ROOT}/hack/import-restrictions.json"
+os::test::junit::declare_suite_start "verify/imports"
+os::cmd::expect_success "import-verifier ${OS_ROOT}/hack/import-restrictions.json"
+os::test::junit::declare_suite_end

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
+
 if ! git status &> /dev/null; then
-  echo "FAILURE: Not a Git repository"
-  exit 1
+  os::log::fatal "Not a Git repository"
 fi
 
 os::util::ensure::built_binary_exists 'commitchecker'
 
-echo "===== Verifying UPSTREAM Commits ====="
-commitchecker
-echo "SUCCESS: All commits are valid."
+os::test::junit::declare_suite_start "verify/upstream-commits"
+os::cmd::expect_success "commitchecker"
+os::test::junit::declare_suite_end


### PR DESCRIPTION
Our verification scripts are mostly using very old mechanisms for
running commands and asserting specific things about them. We can use
the `os::cmd` framework to make these scripts more uniform, robust and
user-friendly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @deads2k @smarterclayton 
/assign @deads2k 