### PR TITLE
remove most legacy client usage from diagnostics

### DIFF
--- a/pkg/diagnostics/cluster/node_definitions.go
+++ b/pkg/diagnostics/cluster/node_definitions.go
@@ -9,10 +9,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/authorization"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/diagnostics/log"
 	"github.com/openshift/origin/pkg/diagnostics/types"
 )
@@ -49,7 +48,6 @@ other options for 'oc adm manage-node').
 // NodeDefinitions is a Diagnostic for analyzing the nodes in a cluster.
 type NodeDefinitions struct {
 	KubeClient kclientset.Interface
-	OsClient   *osclient.Client
 }
 
 const NodeDefinitionsName = "NodeDefinitions"
@@ -63,10 +61,10 @@ func (d *NodeDefinitions) Description() string {
 }
 
 func (d *NodeDefinitions) CanRun() (bool, error) {
-	if d.KubeClient == nil || d.OsClient == nil {
-		return false, errors.New("must have kube and os client")
+	if d.KubeClient == nil {
+		return false, errors.New("must have kube  client")
 	}
-	can, err := userCan(d.OsClient, authorizationapi.Action{
+	can, err := userCan(d.KubeClient.Authorization(), &authorization.ResourceAttributes{
 		Verb:     "list",
 		Group:    kapi.GroupName,
 		Resource: "nodes",

--- a/pkg/diagnostics/cluster/rolebindings.go
+++ b/pkg/diagnostics/cluster/rolebindings.go
@@ -6,6 +6,8 @@ import (
 
 	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/authorization"
+	authorizationtypedclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
@@ -17,7 +19,7 @@ import (
 // ClusterRoleBindings is a Diagnostic to check that the default cluster role bindings match expectations
 type ClusterRoleBindings struct {
 	ClusterRoleBindingsClient osclient.ClusterRoleBindingsInterface
-	SARClient                 osclient.SubjectAccessReviews
+	SARClient                 authorizationtypedclient.SelfSubjectAccessReviewsGetter
 }
 
 const (
@@ -40,7 +42,7 @@ func (d *ClusterRoleBindings) CanRun() (bool, error) {
 		return false, fmt.Errorf("must have client.SubjectAccessReviews")
 	}
 
-	return userCan(d.SARClient, authorizationapi.Action{
+	return userCan(d.SARClient, &authorization.ResourceAttributes{
 		Verb:     "list",
 		Group:    authorizationapi.GroupName,
 		Resource: "clusterrolebindings",

--- a/pkg/diagnostics/cluster/roles.go
+++ b/pkg/diagnostics/cluster/roles.go
@@ -6,6 +6,8 @@ import (
 
 	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/authorization"
+	authorizationtypedclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
@@ -18,7 +20,7 @@ import (
 // ClusterRoles is a Diagnostic to check that the default cluster roles match expectations
 type ClusterRoles struct {
 	ClusterRolesClient osclient.ClusterRolesInterface
-	SARClient          osclient.SubjectAccessReviews
+	SARClient          authorizationtypedclient.SelfSubjectAccessReviewsGetter
 }
 
 const (
@@ -68,7 +70,7 @@ func (d *ClusterRoles) CanRun() (bool, error) {
 		return false, fmt.Errorf("must have client.SubjectAccessReviews")
 	}
 
-	return userCan(d.SARClient, authorizationapi.Action{
+	return userCan(d.SARClient, &authorization.ResourceAttributes{
 		Verb:     "list",
 		Group:    authorizationapi.GroupName,
 		Resource: "clusterroles",

--- a/pkg/diagnostics/cluster/util.go
+++ b/pkg/diagnostics/cluster/util.go
@@ -1,17 +1,21 @@
 package cluster
 
 import (
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	osclient "github.com/openshift/origin/pkg/client"
+	"k8s.io/kubernetes/pkg/apis/authorization"
+	authorizationtypedclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 )
 
-func userCan(sarClient osclient.SubjectAccessReviews, action authorizationapi.Action) (bool, error) {
-	resp, err := sarClient.SubjectAccessReviews().Create(&authorizationapi.SubjectAccessReview{Action: action})
+func userCan(sarClient authorizationtypedclient.SelfSubjectAccessReviewsGetter, action *authorization.ResourceAttributes) (bool, error) {
+	resp, err := sarClient.SelfSubjectAccessReviews().Create(&authorization.SelfSubjectAccessReview{
+		Spec: authorization.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: action,
+		},
+	})
 	if err != nil {
 		return false, err
 	}
 
-	if resp.Allowed {
+	if resp.Status.Allowed {
 		return true, nil
 	}
 

--- a/pkg/diagnostics/network/setup.go
+++ b/pkg/diagnostics/network/setup.go
@@ -238,7 +238,7 @@ func (d *NetworkDiagnostic) makeNamespaceGlobal(nsName string) error {
 	var netns *networkapi.NetNamespace
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		var err error
-		netns, err = d.OSClient.NetNamespaces().Get(nsName, metav1.GetOptions{})
+		netns, err = d.NetNamespacesClient.NetNamespaces().Get(nsName, metav1.GetOptions{})
 		if kerrs.IsNotFound(err) {
 			// NetNamespace not created yet
 			return false, nil
@@ -253,12 +253,12 @@ func (d *NetworkDiagnostic) makeNamespaceGlobal(nsName string) error {
 
 	network.SetChangePodNetworkAnnotation(netns, network.GlobalPodNetwork, "")
 
-	if _, err = d.OSClient.NetNamespaces().Update(netns); err != nil {
+	if _, err = d.NetNamespacesClient.NetNamespaces().Update(netns); err != nil {
 		return err
 	}
 
 	return wait.ExponentialBackoff(backoff, func() (bool, error) {
-		updatedNetNs, err := d.OSClient.NetNamespaces().Get(netns.NetName, metav1.GetOptions{})
+		updatedNetNs, err := d.NetNamespacesClient.NetNamespaces().Get(netns.NetName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/diagnostics/networkpod/pod.go
+++ b/pkg/diagnostics/networkpod/pod.go
@@ -11,10 +11,10 @@ import (
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/diagnostics/networkpod/util"
 	"github.com/openshift/origin/pkg/diagnostics/types"
 	"github.com/openshift/origin/pkg/network"
+	networktypedclient "github.com/openshift/origin/pkg/network/generated/internalclientset/typed/network/internalversion"
 )
 
 const (
@@ -23,8 +23,9 @@ const (
 
 // CheckPodNetwork is a Diagnostic to check communication between pods in the cluster.
 type CheckPodNetwork struct {
-	KubeClient kclientset.Interface
-	OSClient   *osclient.Client
+	KubeClient           kclientset.Interface
+	NetNamespacesClient  networktypedclient.NetNamespacesGetter
+	ClusterNetworkClient networktypedclient.ClusterNetworksGetter
 
 	vnidMap map[string]uint32
 	res     types.DiagnosticResult
@@ -44,7 +45,7 @@ func (d CheckPodNetwork) Description() string {
 func (d CheckPodNetwork) CanRun() (bool, error) {
 	if d.KubeClient == nil {
 		return false, errors.New("must have kube client")
-	} else if d.OSClient == nil {
+	} else if d.NetNamespacesClient == nil || d.ClusterNetworkClient == nil {
 		return false, errors.New("must have openshift client")
 	}
 	return true, nil
@@ -54,7 +55,7 @@ func (d CheckPodNetwork) CanRun() (bool, error) {
 func (d CheckPodNetwork) Check() types.DiagnosticResult {
 	d.res = types.NewDiagnosticResult(CheckPodNetworkName)
 
-	pluginName, ok, err := util.GetOpenShiftNetworkPlugin(d.OSClient)
+	pluginName, ok, err := util.GetOpenShiftNetworkPlugin(d.ClusterNetworkClient)
 	if err != nil {
 		d.res.Error("DPodNet1001", err, fmt.Sprintf("Checking network plugin failed. Error: %s", err))
 		return d.res
@@ -71,7 +72,7 @@ func (d CheckPodNetwork) Check() types.DiagnosticResult {
 	}
 
 	if network.IsOpenShiftMultitenantNetworkPlugin(pluginName) {
-		netnsList, err := d.OSClient.NetNamespaces().List(metav1.ListOptions{})
+		netnsList, err := d.NetNamespacesClient.NetNamespaces().List(metav1.ListOptions{})
 		if err != nil {
 			d.res.Error("DPodNet1004", err, fmt.Sprintf("Getting all network namespaces failed. Error: %s", err))
 			return d.res

--- a/pkg/diagnostics/networkpod/util/util.go
+++ b/pkg/diagnostics/networkpod/util/util.go
@@ -11,11 +11,11 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 
-	osclient "github.com/openshift/origin/pkg/client"
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/network"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
+	networktypedclient "github.com/openshift/origin/pkg/network/generated/internalclientset/typed/network/internalversion"
 	"github.com/openshift/origin/pkg/util/netutils"
 )
 
@@ -48,8 +48,8 @@ func GetNetworkDiagDefaultTestPodImage() string {
 	return imageTemplate.ExpandOrDie("deployer")
 }
 
-func GetOpenShiftNetworkPlugin(osClient *osclient.Client) (string, bool, error) {
-	cn, err := osClient.ClusterNetwork().Get(networkapi.ClusterNetworkDefault, metav1.GetOptions{})
+func GetOpenShiftNetworkPlugin(clusterNetworkClient networktypedclient.ClusterNetworksGetter) (string, bool, error) {
+	cn, err := clusterNetworkClient.ClusterNetworks().Get(networkapi.ClusterNetworkDefault, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return "", false, nil


### PR DESCRIPTION
Removes almost all usage `pkg/client` in diagnostics.  A couple spots are left because they rely on `oadm` command which still use the old clients.  I'll attack them next.

