### PR TITLE
add template-service-broker command

### DIFF
--- a/cmd/template-service-broker/tsb.go
+++ b/cmd/template-service-broker/tsb.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/util/logs"
+
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+	tsbcmd "github.com/openshift/origin/pkg/templateservicebroker/cmd/server"
+)
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	cmd := tsbcmd.NewCommandStartTemplateServiceBrokerServer(os.Stdout, os.Stderr, wait.NeverStop)
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	if err := cmd.Execute(); err != nil {
+		glog.Fatal(err)
+	}
+}

--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -39,6 +39,7 @@ readonly OS_CROSS_COMPILE_TARGETS=(
   cmd/openshift
   cmd/oc
   cmd/kubefed
+  cmd/template-service-broker
 )
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")
 


### PR DESCRIPTION
Adds a TSB binary to use instead of the openshift/origin command.  This is needed for eventual repo separation.

@bparees @jim-minter @sdodson @gabemontero 
@smarterclayton new top level binary for a logically discrete component.