### PR TITLE
Add debug to build authentication

### DIFF
--- a/pkg/build/builder/cmd/scmauth/cacert.go
+++ b/pkg/build/builder/cmd/scmauth/cacert.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/golang/glog"
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
 )
 
@@ -31,7 +32,10 @@ func (s CACert) Setup(baseDir string, context SCMAuthContext) error {
 		return err
 	}
 	defer gitconfig.Close()
-	gitconfig.WriteString(fmt.Sprintf(CACertConfig, filepath.Join(baseDir, CACertName)))
+	content := fmt.Sprintf(CACertConfig, filepath.Join(baseDir, CACertName))
+	glog.V(5).Infof("Adding CACert Auth to %s:\n%s\n", gitconfig.Name(), content)
+	gitconfig.WriteString(content)
+
 	return ensureGitConfigIncludes(gitconfig.Name(), context)
 }
 

--- a/pkg/build/builder/cmd/scmauth/gitconfig.go
+++ b/pkg/build/builder/cmd/scmauth/gitconfig.go
@@ -2,6 +2,8 @@ package scmauth
 
 import (
 	"path/filepath"
+
+	"github.com/golang/glog"
 )
 
 const GitConfigName = ".gitconfig"
@@ -11,6 +13,7 @@ type GitConfig struct{}
 
 // Setup adds the secret .gitconfig as an include to the .gitconfig file to be used in the build
 func (_ GitConfig) Setup(baseDir string, context SCMAuthContext) error {
+	glog.V(4).Infof("Adding user-provided gitconfig %s to build gitconfig", filepath.Join(baseDir, GitConfigName))
 	return ensureGitConfigIncludes(filepath.Join(baseDir, GitConfigName), context)
 }
 

--- a/pkg/build/builder/cmd/scmauth/password.go
+++ b/pkg/build/builder/cmd/scmauth/password.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/golang/glog"
+
 	"github.com/openshift/origin/pkg/util/file"
 
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
@@ -77,7 +79,11 @@ func (u UsernamePassword) Setup(baseDir string, context SCMAuthContext) error {
 		}
 		defer gitconfig.Close()
 
-		fmt.Fprintf(gitconfig, UserPassGitConfig, gitcredentials.Name())
+		configContent := fmt.Sprintf(UserPassGitConfig, gitcredentials.Name())
+
+		glog.V(5).Infof("Adding username/password credentials to git config:\n%s\n", configContent)
+
+		fmt.Fprintf(gitconfig, "%s", configContent)
 		fmt.Fprintf(gitcredentials, "%s", gitconfigURL.String())
 
 		return ensureGitConfigIncludes(gitconfig.Name(), context)

--- a/pkg/build/builder/cmd/scmauth/sshkey.go
+++ b/pkg/build/builder/cmd/scmauth/sshkey.go
@@ -3,6 +3,8 @@ package scmauth
 import (
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/golang/glog"
 )
 
 const SSHPrivateKeyMethodName = "ssh-privatekey"
@@ -21,9 +23,13 @@ func (_ SSHPrivateKey) Setup(baseDir string, context SCMAuthContext) error {
 	if err := script.Chmod(0711); err != nil {
 		return err
 	}
-	if _, err := script.WriteString("#!/bin/sh\nssh -i " +
+	content := "#!/bin/sh\nssh -i " +
 		filepath.Join(baseDir, SSHPrivateKeyMethodName) +
-		" -o StrictHostKeyChecking=false \"$@\"\n"); err != nil {
+		" -o StrictHostKeyChecking=false \"$@\"\n"
+
+	glog.V(5).Infof("Adding Private SSH Auth:\n%s\n", content)
+
+	if _, err := script.WriteString(content); err != nil {
 		return err
 	}
 	// set environment variable to tell git to use the SSH wrapper

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -1849,6 +1849,9 @@ objects:
         name: ${SOURCE_SECRET}
     strategy:
       sourceStrategy:
+        env:
+        - name: BUILD_LOGLEVEL
+          value: "5"
         from:
           kind: ImageStreamTag
           name: ruby:latest

--- a/test/extended/testdata/builds/test-auth-build.yaml
+++ b/test/extended/testdata/builds/test-auth-build.yaml
@@ -27,6 +27,9 @@ objects:
         name: ${SOURCE_SECRET}
     strategy:
       sourceStrategy:
+        env:
+        - name: BUILD_LOGLEVEL
+          value: "5"
         from:
           kind: ImageStreamTag
           name: ruby:latest


### PR DESCRIPTION
Adds debugging to build authentication code to diagnose extended test failures

fixes https://github.com/openshift/origin/issues/16481

No actual secret data is written to the log, just contents of the gitconfig that reference the secrets