### PR TITLE
Convert a ton of test packages to generated clients

### DIFF
--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -95,7 +95,7 @@ type ImageStreamInterface interface {
 var _ ImageStreamMappingInterface = imageclientv1.ImageStreamMappingInterface(nil)
 
 type ImageStreamMappingInterface interface {
-	Create(mapping *imageapiv1.ImageStreamMapping) (*imageapiv1.ImageStreamMapping, error)
+	Create(mapping *imageapiv1.ImageStreamMapping) (*metav1.Status, error)
 }
 
 var _ ImageStreamTagInterface = imageclientv1.ImageStreamTagInterface(nil)

--- a/pkg/dockerregistry/testutil/fakeopenshift.go
+++ b/pkg/dockerregistry/testutil/fakeopenshift.go
@@ -379,11 +379,11 @@ func (fos *FakeOpenShift) imageStreamMappingsHandler(action clientgotesting.Acti
 		func() (bool, runtime.Object, error) {
 			switch action := action.(type) {
 			case clientgotesting.CreateActionImpl:
-				ism, err := fos.CreateImageStreamMapping(
+				_, err := fos.CreateImageStreamMapping(
 					action.GetNamespace(),
 					action.Object.(*imageapiv1.ImageStreamMapping),
 				)
-				return true, ism, err
+				return true, &metav1.Status{}, err
 			}
 			return fos.todo(action)
 		},

--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -387,7 +387,8 @@ type TagEventCondition struct {
 }
 
 // +genclient
-// +genclient:onlyVerbs=create
+// +genclient:skipVerbs=get,list,create,update,patch,delete,deleteCollection,watch
+// +genclient:method=Create,verb=create,result=k8s.io/apimachinery/pkg/apis/meta/v1.Status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageStreamMapping represents a mapping from a single tag to a Docker image as

--- a/pkg/image/apis/image/v1/types.go
+++ b/pkg/image/apis/image/v1/types.go
@@ -322,7 +322,8 @@ type TagEventCondition struct {
 }
 
 // +genclient
-// +genclient:onlyVerbs=create
+// +genclient:skipVerbs=get,list,create,update,patch,delete,deleteCollection,watch
+// +genclient:method=Create,verb=create,result=k8s.io/apimachinery/pkg/apis/meta/v1.Status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageStreamMapping represents a mapping from a single tag to a Docker image as

--- a/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreammapping.go
+++ b/pkg/image/generated/clientset/typed/image/v1/fake/fake_imagestreammapping.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	testing "k8s.io/client-go/testing"
 )
@@ -16,13 +17,13 @@ var imagestreammappingsResource = schema.GroupVersionResource{Group: "image.open
 
 var imagestreammappingsKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "v1", Kind: "ImageStreamMapping"}
 
-// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
-func (c *FakeImageStreamMappings) Create(imageStreamMapping *v1.ImageStreamMapping) (result *v1.ImageStreamMapping, err error) {
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the status, and an error, if there is any.
+func (c *FakeImageStreamMappings) Create(imageStreamMapping *v1.ImageStreamMapping) (result *meta_v1.Status, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(imagestreammappingsResource, c.ns, imageStreamMapping), &v1.ImageStreamMapping{})
+		Invokes(testing.NewCreateAction(imagestreammappingsResource, c.ns, imageStreamMapping), &meta_v1.Status{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ImageStreamMapping), err
+	return obj.(*meta_v1.Status), err
 }

--- a/pkg/image/generated/clientset/typed/image/v1/imagestreammapping.go
+++ b/pkg/image/generated/clientset/typed/image/v1/imagestreammapping.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -13,7 +14,8 @@ type ImageStreamMappingsGetter interface {
 
 // ImageStreamMappingInterface has methods to work with ImageStreamMapping resources.
 type ImageStreamMappingInterface interface {
-	Create(*v1.ImageStreamMapping) (*v1.ImageStreamMapping, error)
+	Create(*v1.ImageStreamMapping) (*meta_v1.Status, error)
+
 	ImageStreamMappingExpansion
 }
 
@@ -31,9 +33,9 @@ func newImageStreamMappings(c *ImageV1Client, namespace string) *imageStreamMapp
 	}
 }
 
-// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
-func (c *imageStreamMappings) Create(imageStreamMapping *v1.ImageStreamMapping) (result *v1.ImageStreamMapping, err error) {
-	result = &v1.ImageStreamMapping{}
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the status, and an error, if there is any.
+func (c *imageStreamMappings) Create(imageStreamMapping *v1.ImageStreamMapping) (result *meta_v1.Status, err error) {
+	result = &meta_v1.Status{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("imagestreammappings").

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreammapping.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/fake/fake_imagestreammapping.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	image "github.com/openshift/origin/pkg/image/apis/image"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	testing "k8s.io/client-go/testing"
 )
@@ -16,13 +17,13 @@ var imagestreammappingsResource = schema.GroupVersionResource{Group: "image.open
 
 var imagestreammappingsKind = schema.GroupVersionKind{Group: "image.openshift.io", Version: "", Kind: "ImageStreamMapping"}
 
-// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
-func (c *FakeImageStreamMappings) Create(imageStreamMapping *image.ImageStreamMapping) (result *image.ImageStreamMapping, err error) {
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the status, and an error, if there is any.
+func (c *FakeImageStreamMappings) Create(imageStreamMapping *image.ImageStreamMapping) (result *v1.Status, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(imagestreammappingsResource, c.ns, imageStreamMapping), &image.ImageStreamMapping{})
+		Invokes(testing.NewCreateAction(imagestreammappingsResource, c.ns, imageStreamMapping), &v1.Status{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*image.ImageStreamMapping), err
+	return obj.(*v1.Status), err
 }

--- a/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreammapping.go
+++ b/pkg/image/generated/internalclientset/typed/image/internalversion/imagestreammapping.go
@@ -2,6 +2,7 @@ package internalversion
 
 import (
 	image "github.com/openshift/origin/pkg/image/apis/image"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rest "k8s.io/client-go/rest"
 )
 
@@ -13,7 +14,8 @@ type ImageStreamMappingsGetter interface {
 
 // ImageStreamMappingInterface has methods to work with ImageStreamMapping resources.
 type ImageStreamMappingInterface interface {
-	Create(*image.ImageStreamMapping) (*image.ImageStreamMapping, error)
+	Create(*image.ImageStreamMapping) (*v1.Status, error)
+
 	ImageStreamMappingExpansion
 }
 
@@ -31,9 +33,9 @@ func newImageStreamMappings(c *ImageClient, namespace string) *imageStreamMappin
 	}
 }
 
-// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the imageStreamMapping, and an error, if there is any.
-func (c *imageStreamMappings) Create(imageStreamMapping *image.ImageStreamMapping) (result *image.ImageStreamMapping, err error) {
-	result = &image.ImageStreamMapping{}
+// Create takes the representation of a imageStreamMapping and creates it.  Returns the server's representation of the status, and an error, if there is any.
+func (c *imageStreamMappings) Create(imageStreamMapping *image.ImageStreamMapping) (result *v1.Status, err error) {
+	result = &v1.Status{}
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("imagestreammappings").

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			br.AssertSuccess()
 		}
 
-		buildConfig, err := oc.Client().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
+		buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(g.GinkgoWriter, "%v", err)
 		}
@@ -68,7 +68,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 
 		g.By("waiting up to one minute for pruning to complete")
 		err = wait.PollImmediate(pollingInterval, timeout, func() (bool, error) {
-			builds, err = oc.Client().Builds(oc.Namespace()).List(metav1.ListOptions{})
+			builds, err = oc.BuildClient().Build().Builds(oc.Namespace()).List(metav1.ListOptions{})
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "%v", err)
 				return false, err
@@ -104,7 +104,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			br.AssertFailure()
 		}
 
-		buildConfig, err := oc.Client().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
+		buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(g.GinkgoWriter, "%v", err)
 		}
@@ -113,7 +113,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 
 		g.By("waiting up to one minute for pruning to complete")
 		err = wait.PollImmediate(pollingInterval, timeout, func() (bool, error) {
-			builds, err = oc.Client().Builds(oc.Namespace()).List(metav1.ListOptions{})
+			builds, err = oc.BuildClient().Build().Builds(oc.Namespace()).List(metav1.ListOptions{})
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "%v", err)
 				return false, err
@@ -149,7 +149,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			err = oc.Run("cancel-build").Args(fmt.Sprintf("myphp-%d", i)).Execute()
 		}
 
-		buildConfig, err := oc.Client().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
+		buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(g.GinkgoWriter, "%v", err)
 		}
@@ -158,7 +158,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 
 		g.By("waiting up to one minute for pruning to complete")
 		err = wait.PollImmediate(pollingInterval, timeout, func() (bool, error) {
-			builds, err = oc.Client().Builds(oc.Namespace()).List(metav1.ListOptions{})
+			builds, err = oc.BuildClient().Build().Builds(oc.Namespace()).List(metav1.ListOptions{})
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "%v", err)
 				return false, err
@@ -194,7 +194,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			br.AssertFailure()
 		}
 
-		buildConfig, err := oc.Client().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
+		buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(g.GinkgoWriter, "%v", err)
 		}
@@ -203,7 +203,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 
 		g.By("waiting up to one minute for pruning to complete")
 		err = wait.PollImmediate(pollingInterval, timeout, func() (bool, error) {
-			builds, err = oc.Client().Builds(oc.Namespace()).List(metav1.ListOptions{})
+			builds, err = oc.BuildClient().Build().Builds(oc.Namespace()).List(metav1.ListOptions{})
 			if err != nil {
 				fmt.Fprintf(g.GinkgoWriter, "%v", err)
 				return false, err
@@ -233,7 +233,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 		err := oc.Run("create").Args("-f", groupBuildConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		buildConfig, err := oc.Client().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
+		buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(g.GinkgoWriter, "%v", err)
 		}
@@ -249,7 +249,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 		err := oc.Run("create").Args("-f", legacyBuildConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		buildConfig, err := oc.Client().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
+		buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(g.GinkgoWriter, "%v", err)
 		}

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for build to finish")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), s2iBuildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), s2iBuildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn, nil)
 			if err != nil {
 				exutil.DumpBuildLogs("s2icontext", oc)
 			}
@@ -51,7 +51,7 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
 			g.By("waiting for a deployment")
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")
@@ -98,7 +98,7 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 
 			// build will fail if we don't use the right context dir because there won't be a dockerfile present.
 			g.By("waiting for build to finish")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), dockerBuildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), dockerBuildName, exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn, nil)
 			if err != nil {
 				exutil.DumpBuildLogs("dockercontext", oc)
 			}

--- a/test/extended/builds/controller_compat.go
+++ b/test/extended/builds/controller_compat.go
@@ -21,32 +21,32 @@ var _ = g.Describe("[bldcompat][Slow][Compatibility] build controller", func() {
 
 	g.Describe("RunBuildControllerTest", func() {
 		g.It("should succeed", func() {
-			build.RunBuildControllerTest(g.GinkgoT(), oc.AdminClient(), oc.InternalAdminKubeClient())
+			build.RunBuildControllerTest(g.GinkgoT(), oc.BuildClient().Build(), oc.InternalAdminKubeClient())
 		})
 	})
 	g.Describe("RunBuildControllerPodSyncTest", func() {
 		g.It("should succeed", func() {
-			build.RunBuildControllerPodSyncTest(g.GinkgoT(), oc.AdminClient(), oc.InternalAdminKubeClient())
+			build.RunBuildControllerPodSyncTest(g.GinkgoT(), oc.BuildClient().Build(), oc.InternalAdminKubeClient())
 		})
 	})
 	g.Describe("RunImageChangeTriggerTest [SkipPrevControllers]", func() {
 		g.It("should succeed", func() {
-			build.RunImageChangeTriggerTest(g.GinkgoT(), oc.AdminClient())
+			build.RunImageChangeTriggerTest(g.GinkgoT(), oc.AdminBuildClient().Build(), oc.AdminImageClient().Image())
 		})
 	})
 	g.Describe("RunBuildDeleteTest", func() {
 		g.It("should succeed", func() {
-			build.RunBuildDeleteTest(g.GinkgoT(), oc.AdminClient(), oc.InternalAdminKubeClient())
+			build.RunBuildDeleteTest(g.GinkgoT(), oc.AdminBuildClient().Build(), oc.InternalAdminKubeClient())
 		})
 	})
 	g.Describe("RunBuildRunningPodDeleteTest", func() {
 		g.It("should succeed", func() {
-			build.RunBuildRunningPodDeleteTest(g.GinkgoT(), oc.AdminClient(), oc.InternalAdminKubeClient())
+			build.RunBuildRunningPodDeleteTest(g.GinkgoT(), oc.AdminBuildClient().Build(), oc.InternalAdminKubeClient())
 		})
 	})
 	g.Describe("RunBuildConfigChangeControllerTest", func() {
 		g.It("should succeed", func() {
-			build.RunBuildConfigChangeControllerTest(g.GinkgoT(), oc.AdminClient(), oc.InternalAdminKubeClient())
+			build.RunBuildConfigChangeControllerTest(g.GinkgoT(), oc.AdminBuildClient().Build())
 		})
 	})
 })

--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -7,6 +7,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = g.Describe("[Feature:Builds][Slow] completed builds should have digest of the image in their status", func() {
@@ -62,7 +63,7 @@ func testBuildDigest(oc *exutil.CLI, buildFixture string, buildLogLevel uint) {
 		g.By("checking that the image digest has been saved to the build status")
 		o.Expect(br.Build.Status.Output.To).NotTo(o.BeNil())
 
-		ist, err := oc.Client().ImageStreamTags(oc.Namespace()).Get("test", "latest")
+		ist, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("test:latest", v1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(br.Build.Status.Output.To.ImageDigest).To(o.Equal(ist.Image.Name))
 	})

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -41,14 +41,14 @@ USER 1001
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting a test build")
-			bc, err := oc.Client().BuildConfigs(oc.Namespace()).Get("busybox", metav1.GetOptions{})
+			bc, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("busybox", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(bc.Spec.Source.Git).To(o.BeNil())
 			o.Expect(*bc.Spec.Source.Dockerfile).To(o.Equal(testDockerfile))
 
 			buildName := "busybox-1"
 			g.By("expecting the Dockerfile build is in Complete phase")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), buildName, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), buildName, nil, nil, nil)
 			//debug for failures
 			if err != nil {
 				exutil.DumpBuildLogs("busybox", oc)
@@ -56,7 +56,7 @@ USER 1001
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("getting the build Docker image reference from ImageStream")
-			image, err := oc.Client().ImageStreamTags(oc.Namespace()).Get("busybox", "custom")
+			image, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("busybox:custom", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
 		})
@@ -67,7 +67,7 @@ USER 1001
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting a test build")
-			bc, err := oc.Client().BuildConfigs(oc.Namespace()).Get("centos", metav1.GetOptions{})
+			bc, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("centos", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(bc.Spec.Source.Git).To(o.BeNil())
 			o.Expect(*bc.Spec.Source.Dockerfile).To(o.Equal(testDockerfile2))
@@ -76,7 +76,7 @@ USER 1001
 
 			buildName := "centos-1"
 			g.By("expecting the Dockerfile build is in Complete phase")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), buildName, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), buildName, nil, nil, nil)
 			//debug for failures
 			if err != nil {
 				exutil.DumpBuildLogs("centos", oc)
@@ -84,12 +84,12 @@ USER 1001
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("getting the built Docker image reference from ImageStream")
-			image, err := oc.Client().ImageStreamTags(oc.Namespace()).Get("centos", "latest")
+			image, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("centos:latest", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
 
 			g.By("checking for the imported tag")
-			_, err = oc.Client().ImageStreamTags(oc.Namespace()).Get("centos", "7")
+			_, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("centos:7", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
@@ -99,13 +99,13 @@ USER 1001
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting a test build")
-			bc, err := oc.Client().BuildConfigs(oc.Namespace()).Get("scratch", metav1.GetOptions{})
+			bc, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("scratch", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(*bc.Spec.Source.Dockerfile).To(o.Equal(testDockerfile3))
 
 			buildName := "scratch-1"
 			g.By("expecting the Dockerfile build is in Complete phase")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), buildName, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), buildName, nil, nil, nil)
 			//debug for failures
 			if err != nil {
 				exutil.DumpBuildLogs("scratch", oc)

--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonPostCommitHookFailed))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessagePostCommitHookFailed))
@@ -65,7 +65,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			// is set if one is going to be set.
 			err = wait.Poll(time.Second, 30*time.Second, func() (bool, error) {
 				// note this is the same build variable used in the test scope
-				build, err = oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+				build, err = oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 				if err != nil {
 					return true, err
 				}
@@ -89,7 +89,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonFetchSourceFailed))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessageFetchSourceFailed))
@@ -108,7 +108,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonFetchSourceFailed))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessageFetchSourceFailed))
@@ -127,7 +127,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonInvalidContextDirectory))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessageInvalidContextDirectory))
@@ -146,7 +146,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonPullBuilderImageFailed))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessagePullBuilderImageFailed))
@@ -165,7 +165,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonPushImageToRegistryFailed))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessagePushImageToRegistryFailed))
@@ -184,7 +184,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(reasonAssembleFailed))
 			o.Expect(build.Status.Message).To(o.Equal(messageAssembleFailed))
@@ -203,7 +203,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(reasonFetchRuntimeArtifacts))
 			o.Expect(build.Status.Message).To(o.Equal(messageFetchRuntimeArtifacts))
@@ -222,7 +222,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 			br.AssertFailure()
 			br.DumpLogs()
 
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Reason).To(o.Equal(buildapi.StatusReasonGenericBuildFailed))
 			o.Expect(build.Status.Message).To(o.Equal(buildapi.StatusMessageGenericBuildFailed))

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -74,7 +74,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use private repositories as build
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("expecting the deployment of the gitserver to be in the Complete phase")
-		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), gitServerDeploymentConfigName, 1, oc)
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), gitServerDeploymentConfigName, 1, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		sourceSecretName := secretFunc()

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for imagestreams to be imported")
-		err = exutil.WaitForAnImageStream(oc.AdminClient().ImageStreams("openshift"), "ruby", exutil.CheckImageStreamLatestTagPopulatedFn, exutil.CheckImageStreamTagNotFoundFn)
+		err = exutil.WaitForAnImageStream(oc.AdminImageClient().Image().ImageStreams("openshift"), "ruby", exutil.CheckImageStreamLatestTagPopulatedFn, exutil.CheckImageStreamTagNotFoundFn)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -42,10 +42,10 @@ var _ = g.Describe("[Feature:Builds][Slow] result image should have proper label
 			br.AssertSuccess()
 
 			g.By("getting the Docker image reference from ImageStream")
-			imageRef, err := exutil.GetDockerImageReference(oc.Client().ImageStreams(oc.Namespace()), "test", "latest")
+			imageRef, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			imageLabels, err := eximages.GetImageLabels(oc.Client().ImageStreamImages(oc.Namespace()), "test", imageRef)
+			imageLabels, err := eximages.GetImageLabels(oc.ImageClient().Image().ImageStreamImages(oc.Namespace()), "test", imageRef)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("inspecting the new image for proper Docker labels")
@@ -71,10 +71,10 @@ var _ = g.Describe("[Feature:Builds][Slow] result image should have proper label
 			br.AssertSuccess()
 
 			g.By("getting the Docker image reference from ImageStream")
-			imageRef, err := exutil.GetDockerImageReference(oc.Client().ImageStreams(oc.Namespace()), "test", "latest")
+			imageRef, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			imageLabels, err := eximages.GetImageLabels(oc.Client().ImageStreamImages(oc.Namespace()), "test", imageRef)
+			imageLabels, err := eximages.GetImageLabels(oc.ImageClient().Image().ImageStreamImages(oc.Namespace()), "test", imageRef)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("inspecting the new image for proper Docker labels")

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -42,14 +42,14 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for the build to complete")
-		err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), a58+"-1", nil, nil, nil)
+		err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), a58+"-1", nil, nil, nil)
 		if err != nil {
 			exutil.DumpBuildLogs(a58, oc)
 		}
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for the deployment to complete")
-		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), a58, 1, oc)
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), a58, 1, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[Feature:Builds] build with empty source", func() {
 			br.AssertSuccess()
 
 			g.By(fmt.Sprintf("verifying the status of %q", br.BuildPath))
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Spec.Source.Dockerfile).To(o.BeNil())
 			o.Expect(build.Spec.Source.Git).To(o.BeNil())

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -35,7 +35,7 @@ USER 1001
 
 	g.It("should succeed [Conformance]", func() {
 		g.By("creating a build directly")
-		build, err := oc.AdminClient().Builds(oc.Namespace()).Create(&buildapi.Build{
+		build, err := oc.AdminBuildClient().Build().Builds(oc.Namespace()).Create(&buildapi.Build{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "optimized",
 			},
@@ -55,7 +55,7 @@ USER 1001
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(build.Spec.Strategy.DockerStrategy.ImageOptimizationPolicy).ToNot(o.BeNil())
 		result := exutil.NewBuildResult(oc, build)
-		err = exutil.WaitForBuildResult(oc.AdminClient().Builds(oc.Namespace()), result)
+		err = exutil.WaitForBuildResult(oc.AdminBuildClient().Build().Builds(oc.Namespace()), result)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(result.BuildSuccess).To(o.BeTrue(), "Build did not succeed: %v", result)
 

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -109,7 +109,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for jenkins deployment")
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), "jenkins", 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "jenkins", 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			j = jenkins.NewRef(oc)
@@ -470,7 +470,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 					g.By("Waiting for the build uri")
 					var jenkinsBuildURI string
 					for {
-						build, err := oc.Client().Builds(oc.Namespace()).Get(br.BuildName, metav1.GetOptions{})
+						build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.BuildName, metav1.GetOptions{})
 						if err != nil {
 							errs <- fmt.Errorf("error getting build: %s", err)
 							return
@@ -520,7 +520,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 					defer g.GinkgoRecover()
 
 					for {
-						build, err := oc.Client().Builds(oc.Namespace()).Get(br.BuildName, metav1.GetOptions{})
+						build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.BuildName, metav1.GetOptions{})
 						switch {
 						case err != nil:
 							errs <- fmt.Errorf("error getting build: %s", err)

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[Feature:Builds] build have source revision metadata", func(
 			br.AssertSuccess()
 
 			g.By(fmt.Sprintf("verifying the status of %q", br.BuildPath))
-			build, err := oc.Client().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Spec.Revision).NotTo(o.BeNil())
 			o.Expect(build.Spec.Revision.Git).NotTo(o.BeNil())

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[Feature:Builds][Slow][Serial] using build configuration run
 			)
 			bcName := "sample-parallel-build"
 
-			buildWatch, err := oc.Client().Builds(oc.Namespace()).Watch(metav1.ListOptions{
+			buildWatch, err := oc.BuildClient().Build().Builds(oc.Namespace()).Watch(metav1.ListOptions{
 				LabelSelector: buildutil.BuildConfigSelector(bcName).String(),
 			})
 			defer buildWatch.Stop()
@@ -127,7 +127,7 @@ var _ = g.Describe("[Feature:Builds][Slow][Serial] using build configuration run
 				startedBuilds = append(startedBuilds, strings.TrimSpace(strings.Split(stdout, "/")[1]))
 			}
 
-			buildWatch, err := oc.Client().Builds(oc.Namespace()).Watch(metav1.ListOptions{
+			buildWatch, err := oc.BuildClient().Build().Builds(oc.Namespace()).Watch(metav1.ListOptions{
 				LabelSelector: buildutil.BuildConfigSelector(bcName).String(),
 			})
 			defer buildWatch.Stop()
@@ -192,7 +192,7 @@ var _ = g.Describe("[Feature:Builds][Slow][Serial] using build configuration run
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 
-			buildWatch, err := oc.Client().Builds(oc.Namespace()).Watch(metav1.ListOptions{
+			buildWatch, err := oc.BuildClient().Build().Builds(oc.Namespace()).Watch(metav1.ListOptions{
 				LabelSelector: buildutil.BuildConfigSelector(bcName).String(),
 			})
 			defer buildWatch.Stop()
@@ -235,7 +235,7 @@ var _ = g.Describe("[Feature:Builds][Slow][Serial] using build configuration run
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 
-			buildWatch, err := oc.Client().Builds(oc.Namespace()).Watch(metav1.ListOptions{
+			buildWatch, err := oc.BuildClient().Build().Builds(oc.Namespace()).Watch(metav1.ListOptions{
 				LabelSelector: buildutil.BuildConfigSelector(bcName).String(),
 			})
 			defer buildWatch.Stop()
@@ -308,7 +308,7 @@ var _ = g.Describe("[Feature:Builds][Slow][Serial] using build configuration run
 
 			bcName := "sample-serial-latest-only-build"
 			buildVerified := map[string]bool{}
-			buildWatch, err := oc.Client().Builds(oc.Namespace()).Watch(metav1.ListOptions{
+			buildWatch, err := oc.BuildClient().Build().Builds(oc.Namespace()).Watch(metav1.ListOptions{
 				LabelSelector: buildutil.BuildConfigSelector(bcName).String(),
 			})
 			defer buildWatch.Stop()

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Feature:Builds][Slow] s2i build with environment file in so
 			br.AssertSuccess()
 
 			g.By("getting the Docker image reference from ImageStream")
-			imageName, err := exutil.GetDockerImageReference(oc.Client().ImageStreams(oc.Namespace()), "test", "latest")
+			imageName, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("instantiating a pod and service with the new image")

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[Feature:Builds][Slow] incremental s2i build", func() {
 			br2.AssertSuccess()
 
 			g.By("getting the Docker image reference from ImageStream")
-			imageName, err := exutil.GetDockerImageReference(oc.Client().ImageStreams(oc.Namespace()), "internal-image", "latest")
+			imageName, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "internal-image", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("instantiating a pod and service with the new image")

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 			br.AssertSuccess()
 
 			g.By("getting the image name")
-			image, err := exutil.GetDockerImageReference(oc.Client().ImageStreams(oc.Namespace()), "test", "latest")
+			image, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying the build secrets were available during build and not present in the output image")
@@ -83,7 +83,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 			br.AssertSuccess()
 
 			g.By("getting the image name")
-			image, err := exutil.GetDockerImageReference(oc.Client().ImageStreams(oc.Namespace()), "test", "latest")
+			image, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying the secrets are present in container output")

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -240,7 +240,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 				build = b
 				return exutil.CheckBuildCancelledFn(b)
 			}
-			err := exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), "sample-build-binary-invalidnodeselector-1", nil, nil, cancelFn)
+			err := exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), "sample-build-binary-invalidnodeselector-1", nil, nil, cancelFn)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build.Status.Phase).To(o.Equal(buildapi.BuildPhaseCancelled))
 			exutil.CheckForBuildEvent(oc.KubeClient().Core(), build, buildapi.BuildCancelledEventReason, buildapi.BuildCancelledEventMessage)
@@ -275,7 +275,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 			})
 
 			o.Expect(buildName).ToNot(o.BeEmpty())
-			build, err := oc.Client().Builds(oc.Namespace()).Get(buildName, metav1.GetOptions{})
+			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Get(buildName, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(build).NotTo(o.BeNil(), "build object should exist")
 
@@ -327,7 +327,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the build to complete")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), "ruby-hello-world-1", nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), "ruby-hello-world-1", nil, nil, nil)
 			if err != nil {
 				exutil.DumpBuildLogs("ruby-hello-world", oc)
 			}

--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -99,7 +99,7 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 						allArgs = append(allArgs, params...)
 					}
 
-					config, err := oc.AdminClient().Templates(nsName).Create(templateObj)
+					config, err := oc.AdminTemplateClient().Template().Templates(nsName).Create(templateObj)
 					e2e.Logf("Template %v created, config: %+v", templateObj.Name, config)
 
 					err = oc.SetNamespace(nsName).Run("new-app").Args(allArgs...).Execute()
@@ -129,14 +129,14 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 
 		// Wait for builds and deployments to complete
 		for _, ns := range namespaces {
-			buildList, err := oc.Client().Builds(ns).List(metav1.ListOptions{})
+			buildList, err := oc.BuildClient().Build().Builds(ns).List(metav1.ListOptions{})
 			if err != nil {
 				e2e.Logf("Error listing builds: %v", err)
 			}
 			if len(buildList.Items) > 0 {
 				buildName := buildList.Items[0].Name
 				e2e.Logf("Waiting for build: %q", buildName)
-				err = exutil.WaitForABuild(oc.Client().Builds(ns), buildName, nil, nil, nil)
+				err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(ns), buildName, nil, nil, nil)
 				if err != nil {
 					exutil.DumpBuildLogs(buildName, oc)
 				}
@@ -146,7 +146,7 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 				// deploymentName is buildName without the -1 suffix
 				deploymentName := buildName[:len(buildName)-2]
 				e2e.Logf("Waiting for deployment: %q", deploymentName)
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), ns, deploymentName, 1, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), ns, deploymentName, 1, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				e2e.Logf("Deployment %q completed", deploymentName)
 			}

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -213,13 +213,13 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			name := "deployment-image-resolution"
 			o.Expect(waitForLatestCondition(oc, name, deploymentRunTimeout, deploymentImageTriggersResolved(2))).NotTo(o.HaveOccurred())
 
-			is, err := oc.Client().ImageStreams(oc.Namespace()).Get(name, metav1.GetOptions{})
+			is, err := oc.ImageClient().Image().ImageStreams(oc.Namespace()).Get(name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty())
 			o.Expect(is.Status.Tags["direct"].Items).NotTo(o.BeEmpty())
 			o.Expect(is.Status.Tags["pullthrough"].Items).NotTo(o.BeEmpty())
 
-			dc, err := oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+			dc, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Spec.Triggers).To(o.HaveLen(3))
 
@@ -277,7 +277,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			})
 
 			g.By("verifying the scale is updated on the deployment config")
-			config, err := oc.Client().DeploymentConfigs(oc.Namespace()).Get("deployment-test", metav1.GetOptions{})
+			config, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get("deployment-test", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(config.Spec.Replicas).Should(o.BeEquivalentTo(1))
 			o.Expect(config.Spec.Test).Should(o.BeTrue())
@@ -331,11 +331,11 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			expectLatestVersion := func(version int) {
-				dc, err := oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+				dc, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				latestVersion := dc.Status.LatestVersion
 				err = wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-					dc, err = oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+					dc, err = oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
 					latestVersion = dc.Status.LatestVersion
 					return latestVersion == int64(version), nil
@@ -388,7 +388,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			g.By("verifying the post deployment action happened: tag is set")
 			var istag *imageapi.ImageStreamTag
 			pollErr := wait.PollImmediate(100*time.Millisecond, 1*time.Minute, func() (bool, error) {
-				istag, err = oc.Client().ImageStreamTags(oc.Namespace()).Get("sample-stream", "deployed")
+				istag, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("sample-stream:deployed", metav1.GetOptions{})
 				if kerrors.IsNotFound(err) {
 					return false, nil
 				}
@@ -528,7 +528,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			g.By("waiting for the first rollout to complete")
 			o.Expect(waitForLatestCondition(oc, name, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 
-			dc, err := oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+			dc, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("updating the deployment config in order to trigger a new rollout")
@@ -540,7 +540,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			// Wait for latestVersion=2 to be surfaced in the API
 			latestVersion := dc.Status.LatestVersion
 			err = wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-				dc, err = oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+				dc, err = oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}
@@ -908,7 +908,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			dc.Spec.Triggers = append(dc.Spec.Triggers, deployapi.DeploymentTriggerPolicy{Type: deployapi.DeploymentTriggerOnConfigChange})
 			// This is the last place we can safely say that the time was taken before replicas became ready
 			startTime := time.Now()
-			dc, err = oc.Client().DeploymentConfigs(namespace).Create(dc)
+			dc, err = oc.AppsClient().Apps().DeploymentConfigs(namespace).Create(dc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("verifying the deployment is created")
@@ -1030,7 +1030,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			g.By("should create ControllerRef in RCs it creates", func() {
 				dc, err = readDCFixture(simpleDeploymentFixture)
 				o.Expect(err).NotTo(o.HaveOccurred())
-				dc, err = oc.Client().DeploymentConfigs(namespace).Create(dc)
+				dc, err = oc.AppsClient().Apps().DeploymentConfigs(namespace).Create(dc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentRunning)
@@ -1046,7 +1046,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("releasing RCs that no longer match its selector", func() {
-				dc, err = oc.Client().DeploymentConfigs(namespace).Get(dcName, metav1.GetOptions{})
+				dc, err = oc.AppsClient().Apps().DeploymentConfigs(namespace).Get(dcName, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				patch := []byte(fmt.Sprintf(`{"metadata": {"labels":{"openshift.io/deployment-config.name": "%s-detached"}}}`, dcName))
@@ -1089,7 +1089,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			})
 
 			g.By("deleting owned RCs when deleted", func() {
-				err = oc.Clientset().AppsV1().DeploymentConfigs(namespace).Delete(dcName, &metav1.DeleteOptions{})
+				err = oc.AppsClient().Apps().DeploymentConfigs(namespace).Delete(dcName, &metav1.DeleteOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = wait.PollImmediate(200*time.Millisecond, 5*time.Minute, func() (bool, error) {

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -532,7 +532,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("updating the deployment config in order to trigger a new rollout")
-			_, err = updateConfigWithRetries(oc.Client(), oc.Namespace(), name, func(update *deployapi.DeploymentConfig) {
+			_, err = updateConfigWithRetries(oc.AppsClient().Apps(), oc.Namespace(), name, func(update *deployapi.DeploymentConfig) {
 				one := int64(1)
 				update.Spec.Template.Spec.TerminationGracePeriodSeconds = &one
 			})
@@ -703,7 +703,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 				o.Expect(fmt.Errorf("expected no deployment, found %#v", rcs[0])).NotTo(o.HaveOccurred())
 			}
 
-			_, err = updateConfigWithRetries(oc.Client(), oc.Namespace(), name, func(dc *deployapi.DeploymentConfig) {
+			_, err = updateConfigWithRetries(oc.AppsClient().Apps(), oc.Namespace(), name, func(dc *deployapi.DeploymentConfig) {
 				// TODO: oc rollout pause should patch instead of making a full update
 				dc.Spec.Paused = false
 			})

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -23,8 +23,8 @@ import (
 
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	deployapiv1 "github.com/openshift/origin/pkg/apps/apis/apps/v1"
+	appstypedclientset "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
 	deployutil "github.com/openshift/origin/pkg/apps/util"
-	"github.com/openshift/origin/pkg/client"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -33,7 +33,7 @@ import (
 type updateConfigFunc func(d *deployapi.DeploymentConfig)
 
 // updateConfigWithRetries will try to update a deployment config and ignore any update conflicts.
-func updateConfigWithRetries(dn client.DeploymentConfigsNamespacer, namespace, name string, applyUpdate updateConfigFunc) (*deployapi.DeploymentConfig, error) {
+func updateConfigWithRetries(dn appstypedclientset.DeploymentConfigsGetter, namespace, name string, applyUpdate updateConfigFunc) (*deployapi.DeploymentConfig, error) {
 	var config *deployapi.DeploymentConfig
 	resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var err error

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -310,7 +310,7 @@ func deploymentImageTriggersResolved(expectTriggers int) func(dc *deployapi.Depl
 }
 
 func deploymentInfo(oc *exutil.CLI, name string) (*deployapi.DeploymentConfig, []*kapiv1.ReplicationController, []kapiv1.Pod, error) {
-	dc, err := oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+	dc, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -363,7 +363,7 @@ func waitForSyncedConfig(oc *exutil.CLI, name string, timeout time.Duration) err
 	}
 	generation := dc.Generation
 	return wait.PollImmediate(200*time.Millisecond, timeout, func() (bool, error) {
-		config, err := oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+		config, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -447,7 +447,7 @@ func waitForRCModification(oc *exutil.CLI, namespace string, name string, timeou
 }
 
 func waitForDCModification(oc *exutil.CLI, namespace string, name string, timeout time.Duration, resourceVersion string, condition func(rc *deployapi.DeploymentConfig) (bool, error)) (*deployapi.DeploymentConfig, error) {
-	watcher, err := oc.Client().DeploymentConfigs(namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: name, ResourceVersion: resourceVersion}))
+	watcher, err := oc.AppsClient().Apps().DeploymentConfigs(namespace).Watch(metav1.SingleObject(metav1.ObjectMeta{Name: name, ResourceVersion: resourceVersion}))
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func createDeploymentConfig(oc *exutil.CLI, fixture string) (*deployapi.Deployme
 	var pollErr error
 	var dc *deployapi.DeploymentConfig
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		dc, err = oc.Client().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+		dc, err = oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 		if err != nil {
 			pollErr = err
 			return false, nil

--- a/test/extended/image_ecosystem/jenkins_plugin.go
+++ b/test/extended/image_ecosystem/jenkins_plugin.go
@@ -517,7 +517,7 @@ var _ = g.Describe("[image_ecosystem][jenkins][Slow] openshift pipeline plugin",
 			o.Expect(err).NotTo(o.HaveOccurred())
 			_, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("multitag:prod3", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
-			_, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("multitagprod4", metav1.GetOptions{})
+			_, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("multitag:prod4", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// N to 1 mapping

--- a/test/extended/image_ecosystem/mariadb_ephemeral.go
+++ b/test/extended/image_ecosystem/mariadb_ephemeral.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[image_ecosystem][mariadb][Slow] openshift mariadb image", f
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), "mariadb", 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "mariadb", 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("expecting the mariadb service get endpoints")

--- a/test/extended/image_ecosystem/mongodb_ephemeral.go
+++ b/test/extended/image_ecosystem/mongodb_ephemeral.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[image_ecosystem][mongodb] openshift mongodb image", func() 
 			o.Expect(oc.Run("new-app").Args("-f", templatePath).Execute()).Should(o.Succeed())
 
 			g.By("waiting for the deployment to complete")
-			err := exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), "mongodb", 1, oc)
+			err := exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "mongodb", 1, oc)
 			o.Expect(err).ShouldNot(o.HaveOccurred())
 
 			g.By("expecting the mongodb pod is running")

--- a/test/extended/image_ecosystem/mysql_ephemeral.go
+++ b/test/extended/image_ecosystem/mysql_ephemeral.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[image_ecosystem][mysql][Slow] openshift mysql image", func(
 
 			// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 			// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), "mysql", 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "mysql", 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("expecting the mysql service get endpoints")

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -89,7 +89,7 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 		_, err := exutil.SetupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace(), "1Gi", 2)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = testutil.WaitForPolicyUpdate(oc.Client(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
+		err = testutil.WaitForPolicyUpdate(oc.InternalKubeClient().Authorization(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		exutil.CheckOpenShiftNamespaceImageStreams(oc)

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -102,7 +102,7 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
 		g.By("waiting for the deployment to complete")
-		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), helperName, 1, oc)
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), helperName, 1, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for an endpoint")

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -73,7 +73,7 @@ func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string) func() {
 		_, err := exutil.SetupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace(), "512Mi", 1)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = testutil.WaitForPolicyUpdate(oc.Client(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
+		err = testutil.WaitForPolicyUpdate(oc.InternalKubeClient().Authorization(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		exutil.CheckOpenShiftNamespaceImageStreams(oc)

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -85,7 +85,7 @@ func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string) func() {
 
 		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), postgreSQLHelperName, 1, oc)
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), postgreSQLHelperName, 1, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = e2e.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), postgreSQLHelperName)

--- a/test/extended/image_ecosystem/s2i_perl.go
+++ b/test/extended/image_ecosystem/s2i_perl.go
@@ -39,13 +39,13 @@ var _ = g.Describe("[image_ecosystem][perl][Slow] hot deploy for openshift perl 
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for build to finish")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), rcNameOne, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), rcNameOne, nil, nil, nil)
 			if err != nil {
 				exutil.DumpBuildLogs(dcName, oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")
@@ -79,7 +79,7 @@ var _ = g.Describe("[image_ecosystem][perl][Slow] hot deploy for openshift perl 
 			g.By("turning on hot-deploy")
 			err = oc.Run("env").Args("dc", dcName, "PERL_APACHE2_RELOAD=true").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 2, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 2, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for a new endpoint")

--- a/test/extended/image_ecosystem/s2i_php.go
+++ b/test/extended/image_ecosystem/s2i_php.go
@@ -33,13 +33,13 @@ var _ = g.Describe("[image_ecosystem][php][Slow] hot deploy for openshift php im
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for build to finish")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), dcName, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), dcName, nil, nil, nil)
 			if err != nil {
 				exutil.DumpBuildLogs("cakephp-mysql-example", oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), "cakephp-mysql-example", 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "cakephp-mysql-example", 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")

--- a/test/extended/image_ecosystem/s2i_python.go
+++ b/test/extended/image_ecosystem/s2i_python.go
@@ -40,13 +40,13 @@ var _ = g.Describe("[image_ecosystem][python][Slow] hot deploy for openshift pyt
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for build to finish")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), rcNameOne, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), rcNameOne, nil, nil, nil)
 			if err != nil {
 				exutil.DumpBuildLogs(dcName, oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")
@@ -83,7 +83,7 @@ var _ = g.Describe("[image_ecosystem][python][Slow] hot deploy for openshift pyt
 			g.By("turning on hot-deploy")
 			err = oc.Run("env").Args("dc", dcName, "APP_CONFIG=conf/reload.py").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 2, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 2, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for a new endpoint")

--- a/test/extended/image_ecosystem/s2i_ruby.go
+++ b/test/extended/image_ecosystem/s2i_ruby.go
@@ -38,13 +38,13 @@ var _ = g.Describe("[image_ecosystem][ruby][Slow] hot deploy for openshift ruby 
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for build to finish")
-			err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), rcNameOne, nil, nil, nil)
+			err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), rcNameOne, nil, nil, nil)
 			if err != nil {
 				exutil.DumpBuildLogs(dcName, oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 1, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for endpoint")
@@ -79,7 +79,7 @@ var _ = g.Describe("[image_ecosystem][ruby][Slow] hot deploy for openshift ruby 
 			g.By("turning on hot-deploy")
 			err = oc.Run("env").Args("dc", dcName, "RAILS_ENV=development").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), dcName, 2, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 2, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for a new endpoint")

--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -55,19 +55,19 @@ func NewSampleRepoTest(c SampleRepoConfig) func() {
 				buildName := c.buildConfigName + "-1"
 
 				g.By("expecting the build is in the Complete phase")
-				err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), buildName, nil, nil, nil)
+				err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), buildName, nil, nil, nil)
 				if err != nil {
 					exutil.DumpBuildLogs(c.buildConfigName, oc)
 				}
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("expecting the app deployment to be complete")
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), c.deploymentConfigName, 1, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), c.deploymentConfigName, 1, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				if len(c.dbDeploymentConfigName) > 0 {
 					g.By("expecting the db deployment to be complete")
-					err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.Client(), oc.Namespace(), c.dbDeploymentConfigName, 1, oc)
+					err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), c.dbDeploymentConfigName, 1, oc)
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					g.By("expecting the db service is available")

--- a/test/extended/imageapis/limitrange_admission.go
+++ b/test/extended/imageapis/limitrange_admission.go
@@ -114,7 +114,7 @@ var _ = g.Describe("[Feature:ImageQuota] Image limit range", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(`removing tag "second" from "another" image stream`)
-		err = oc.Client().ImageStreamTags(oc.Namespace()).Delete("another", "second")
+		err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Delete("another:second", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("trying to push image below limits %v", limits))
@@ -149,7 +149,7 @@ var _ = g.Describe("[Feature:ImageQuota] Image limit range", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("trying to tag a docker image exceeding limit %v", limit))
-		is, err := oc.Client().ImageStreams(oc.Namespace()).Get("stream", metav1.GetOptions{})
+		is, err := oc.ImageClient().Image().ImageStreams(oc.Namespace()).Get("stream", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		is.Spec.Tags["foo"] = imageapi.TagReference{
 			Name: "foo",
@@ -161,12 +161,12 @@ var _ = g.Describe("[Feature:ImageQuota] Image limit range", func() {
 				Insecure: true,
 			},
 		}
-		_, err = oc.Client().ImageStreams(oc.Namespace()).Update(is)
+		_, err = oc.ImageClient().Image().ImageStreams(oc.Namespace()).Update(is)
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(quotautil.IsErrorQuotaExceeded(err)).Should(o.Equal(true))
 
 		g.By("re-tagging the image under different tag")
-		is, err = oc.Client().ImageStreams(oc.Namespace()).Get("stream", metav1.GetOptions{})
+		is, err = oc.ImageClient().Image().ImageStreams(oc.Namespace()).Get("stream", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		is.Spec.Tags["duplicate"] = imageapi.TagReference{
 			Name: "duplicate",
@@ -178,7 +178,7 @@ var _ = g.Describe("[Feature:ImageQuota] Image limit range", func() {
 				Insecure: true,
 			},
 		}
-		_, err = oc.Client().ImageStreams(oc.Namespace()).Update(is)
+		_, err = oc.ImageClient().Image().ImageStreams(oc.Namespace()).Update(is)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
@@ -243,7 +243,7 @@ func buildAndPushTestImagesTo(oc *exutil.CLI, isName string, tagPrefix string, n
 		if err != nil {
 			return nil, err
 		}
-		ist, err := oc.Client().ImageStreamTags(oc.Namespace()).Get(isName, tag)
+		ist, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get(isName+":"+tag, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -97,7 +97,7 @@ var _ = g.Describe("[Feature:ImageQuota] Image resource quota", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("deleting first image stream")
-		err = oc.Client().ImageStreams(oc.Namespace()).Delete("first")
+		err = oc.ImageClient().Image().ImageStreams(oc.Namespace()).Delete("first", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		used, err = exutil.WaitForResourceQuotaSync(
 			oc.InternalKubeClient().Core().ResourceQuotas(oc.Namespace()),
@@ -220,14 +220,14 @@ func deleteTestImagesAndStreams(oc *exutil.CLI) {
 		oc.Namespace(),
 	} {
 		g.By(fmt.Sprintf("Deleting images and image streams in project %q", projectName))
-		iss, err := oc.AdminClient().ImageStreams(projectName).List(metav1.ListOptions{})
+		iss, err := oc.AdminImageClient().Image().ImageStreams(projectName).List(metav1.ListOptions{})
 		if err != nil {
 			continue
 		}
 		for _, is := range iss.Items {
 			for _, history := range is.Status.Tags {
 				for i := range history.Items {
-					oc.AdminClient().Images().Delete(history.Items[i].Image)
+					oc.AdminImageClient().Image().Images().Delete(history.Items[i].Image, nil)
 				}
 			}
 			for _, tagRef := range is.Spec.Tags {
@@ -237,7 +237,7 @@ func deleteTestImagesAndStreams(oc *exutil.CLI) {
 					if err != nil {
 						continue
 					}
-					oc.AdminClient().Images().Delete(id)
+					oc.AdminImageClient().Image().Images().Delete(id, nil)
 				}
 			}
 		}
@@ -245,7 +245,7 @@ func deleteTestImagesAndStreams(oc *exutil.CLI) {
 		// let the extended framework take care of the current namespace
 		if projectName != oc.Namespace() {
 			g.By(fmt.Sprintf("Deleting project %q", projectName))
-			oc.AdminClient().Projects().Delete(projectName)
+			oc.AdminProjectClient().Project().Projects().Delete(projectName, nil)
 		}
 	}
 }

--- a/test/extended/images/hardprune.go
+++ b/test/extended/images/hardprune.go
@@ -130,7 +130,7 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 
 		imgs := map[string]*imageapi.Image{}
 		for _, imgName := range []string{baseImg1, baseImg2, baseImg3, baseImg4, childImg1, childImg2, childImg3} {
-			img, err := oc.AsAdmin().Client().Images().Get(imgName, metav1.GetOptions{})
+			img, err := oc.AsAdmin().ImageClient().Image().Images().Get(imgName, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			imgs[imgName] = img
 			o.Expect(img.DockerImageManifestMediaType).To(o.Equal(schema2.MediaTypeManifest))
@@ -158,7 +158,7 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 		 *  childImg3 | baseImg3 | 7 8 9  | c
 		 */
 
-		err = oc.AsAdmin().Client().ImageStreamTags(oc.Namespace()).Delete("a", "latest")
+		err = oc.AsAdmin().ImageClient().Image().ImageStreamTags(oc.Namespace()).Delete("a:latest", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		deleted, err = RunHardPrune(oc, dryRun)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -175,11 +175,11 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 		err = AssertDeletedStorageFiles(deleted, expectedDeletions)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = oc.AsAdmin().Client().Images().Delete(childImg1)
+		err = oc.AsAdmin().ImageClient().Image().Images().Delete(childImg1, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// The repository a-tagged will not be removed even though it has no tags anymore.
 		// For the repository to be removed, the image stream itself needs to be deleted.
-		err = oc.AsAdmin().Client().ImageStreamTags(oc.Namespace()).Delete("a-tagged", "latest")
+		err = oc.AsAdmin().ImageClient().Image().ImageStreamTags(oc.Namespace()).Delete("a-tagged:latest", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		deleted, err = RunHardPrune(oc, dryRun)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -202,7 +202,7 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 		err = AssertDeletedStorageFiles(deleted, expectedDeletions)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = oc.AsAdmin().Client().Images().Delete(baseImg1)
+		err = oc.AsAdmin().ImageClient().Image().Images().Delete(baseImg1, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		deleted, err = RunHardPrune(oc, dryRun)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -219,7 +219,7 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 		err = AssertDeletedStorageFiles(deleted, expectedDeletions)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = oc.AsAdmin().Client().Images().Delete(childImg2)
+		err = oc.AsAdmin().ImageClient().Image().Images().Delete(childImg2, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		deleted, err = RunHardPrune(oc, dryRun)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -243,10 +243,10 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// untag both baseImg2 and childImg2
-		err = oc.AsAdmin().Client().ImageStreams(oc.Namespace()).Delete("b")
+		err = oc.AsAdmin().ImageClient().Image().ImageStreams(oc.Namespace()).Delete("b", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		delete(expectedDeletions.ManifestLinks, oc.Namespace()+"/b")
-		err = oc.AsAdmin().Client().Images().Delete(baseImg2)
+		err = oc.AsAdmin().ImageClient().Image().Images().Delete(baseImg2, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		deleted, err = RunHardPrune(oc, dryRun)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -300,7 +300,7 @@ var _ = g.Describe("[Feature:ImagePrune] Image hard prune", func() {
 		err = AssertDeletedStorageFiles(deleted, expectedDeletions)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = oc.AsAdmin().Client().Images().Delete(childImg3)
+		err = oc.AsAdmin().ImageClient().Image().Images().Delete(childImg3, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		deleted, err = RunHardPrune(oc, dryRun)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/helper.go
+++ b/test/extended/images/helper.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/client/retry"
 
-	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imagetypedclientset "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	registryutil "github.com/openshift/origin/test/extended/registry/util"
 	exutil "github.com/openshift/origin/test/extended/util"
 	testutil "github.com/openshift/origin/test/util"
@@ -140,9 +140,9 @@ var (
 
 // GetImageLabels retrieves Docker labels from image from image repository name and
 // image reference
-func GetImageLabels(c client.ImageStreamImageInterface, imageRepoName, imageRef string) (map[string]string, error) {
+func GetImageLabels(c imagetypedclientset.ImageStreamImageInterface, imageRepoName, imageRef string) (map[string]string, error) {
 	_, imageID, err := imageapi.ParseImageStreamImageName(imageRef)
-	image, err := c.Get(imageRepoName, imageID)
+	image, err := c.Get(imageapi.JoinImageStreamImage(imageRepoName, imageID), metav1.GetOptions{})
 
 	if err != nil {
 		return map[string]string{}, err

--- a/test/extended/images/prune.go
+++ b/test/extended/images/prune.go
@@ -164,10 +164,10 @@ func testPruneImages(oc *exutil.CLI, schemaVersion int) {
 	o.Expect(pruneSize < keepSize).To(o.BeTrue())
 
 	g.By(fmt.Sprintf("ensure uploaded image is of schema %d", schemaVersion))
-	imgPrune, err := oc.AsAdmin().Client().Images().Get(imgPruneName, metav1.GetOptions{})
+	imgPrune, err := oc.AsAdmin().ImageClient().Image().Images().Get(imgPruneName, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(imgPrune.DockerImageManifestMediaType).To(o.Equal(mediaType))
-	imgKeep, err := oc.AsAdmin().Client().Images().Get(imgKeepName, metav1.GetOptions{})
+	imgKeep, err := oc.AsAdmin().ImageClient().Image().Images().Get(imgKeepName, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(imgKeep.DockerImageManifestMediaType).To(o.Equal(mediaType))
 
@@ -260,7 +260,7 @@ func testPruneAllImages(oc *exutil.CLI, setAllImagesToFalse bool, schemaVersion 
 	cleanUp.AddImageStream(isName)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	managedImage, err := oc.AsAdmin().Client().Images().Get(managedImageName, metav1.GetOptions{})
+	managedImage, err := oc.AsAdmin().ImageClient().Image().Images().Get(managedImageName, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	externalImage, blobdgst, err := importImageAndMirrorItsSmallestBlob(oc, externalImageReference, "origin-release:latest")
@@ -353,7 +353,7 @@ func importImageAndMirrorItsSmallestBlob(oc *exutil.CLI, imageReference, destIST
 	if err != nil {
 		return nil, "", err
 	}
-	istag, err := oc.Client().ImageStreamTags(oc.Namespace()).Get(isName, tag)
+	istag, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get(destISTag, metav1.GetOptions{})
 	if err != nil {
 		return nil, "", err
 	}

--- a/test/extended/images/resolve.go
+++ b/test/extended/images/resolve.go
@@ -21,7 +21,7 @@ var _ = g.Describe("[Feature:ImageLookup] Image policy", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("set", "image-lookup").Args("busybox").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		tag, err := oc.Client().ImageStreamTags(oc.Namespace()).Get("busybox", "latest")
+		tag, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("busybox:latest", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(tag.LookupPolicy.Local).To(o.BeTrue())
 
@@ -73,7 +73,7 @@ var _ = g.Describe("[Feature:ImageLookup] Image policy", func() {
 	g.It("should perform lookup when the pod has the resolve-names annotation", func() {
 		err := oc.Run("import-image").Args("busybox:latest", "--confirm").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		tag, err := oc.Client().ImageStreamTags(oc.Namespace()).Get("busybox", "latest")
+		tag, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("busybox:latest", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// pods should auto replace local references

--- a/test/extended/registry/registry.go
+++ b/test/extended/registry/registry.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Conformance][registry][migration] manifest migration from e
 		cleanUp.AddImage(imageDigest, "", "")
 
 		g.By("checking that the image converted...")
-		image, err := oc.AsAdmin().Client().Images().Get(imageDigest, metav1.GetOptions{})
+		image, err := oc.AsAdmin().ImageClient().Image().Images().Get(imageDigest, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(image.DockerImageManifest)).Should(o.Equal(0))
 		imageMetadataNotEmpty(image)
@@ -64,18 +64,18 @@ var _ = g.Describe("[Conformance][registry][migration] manifest migration from e
 		o.Expect(len(manifest)).Should(o.BeNumerically(">", 0))
 
 		g.By("restoring manifest...")
-		image, err = oc.AsAdmin().Client().Images().Get(imageDigest, metav1.GetOptions{})
+		image, err = oc.AsAdmin().ImageClient().Image().Images().Get(imageDigest, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		imageMetadataNotEmpty(image)
 
 		image.DockerImageManifest = string(manifest)
 
-		newImage, err := oc.AsAdmin().Client().Images().Update(image)
+		newImage, err := oc.AsAdmin().ImageClient().Image().Images().Update(image)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		imageMetadataNotEmpty(newImage)
 
 		g.By("checking that the manifest is present in the image...")
-		image, err = oc.AsAdmin().Client().Images().Get(imageDigest, metav1.GetOptions{})
+		image, err = oc.AsAdmin().ImageClient().Image().Images().Get(imageDigest, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(image.DockerImageManifest)).Should(o.BeNumerically(">", 0))
 		o.Expect(image.DockerImageManifest).Should(o.Equal(string(manifest)))
@@ -91,7 +91,7 @@ var _ = g.Describe("[Conformance][registry][migration] manifest migration from e
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("checking that the manifest was removed from the image...")
-		image, err = oc.AsAdmin().Client().Images().Get(imageDigest, metav1.GetOptions{})
+		image, err = oc.AsAdmin().ImageClient().Image().Images().Get(imageDigest, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(len(image.DockerImageManifest)).Should(o.Equal(0))
 		imageMetadataNotEmpty(image)
@@ -127,7 +127,7 @@ func imageMetadataNotEmpty(image *imageapi.Image) {
 
 func waitForImageUpdate(oc *exutil.CLI, image *imageapi.Image) error {
 	return wait.Poll(200*time.Millisecond, 2*time.Minute, func() (bool, error) {
-		newImage, err := oc.AsAdmin().Client().Images().Get(image.Name, metav1.GetOptions{})
+		newImage, err := oc.AsAdmin().ImageClient().Image().Images().Get(image.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/extended/registry/util/util.go
+++ b/test/extended/registry/util/util.go
@@ -137,7 +137,7 @@ func ConfigureRegistry(oc *exutil.CLI, desiredState RegistryConfiguration) error
 		return nil
 	}
 
-	dc, err := oc.Client().DeploymentConfigs(metav1.NamespaceDefault).Get("docker-registry", metav1.GetOptions{})
+	dc, err := oc.AppsClient().Apps().DeploymentConfigs(metav1.NamespaceDefault).Get("docker-registry", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func ConfigureRegistry(oc *exutil.CLI, desiredState RegistryConfiguration) error
 	}
 	return exutil.WaitForDeploymentConfig(
 		oc.AdminKubeClient(),
-		oc.AdminClient(),
+		oc.AdminAppsClient().Apps(),
 		metav1.NamespaceDefault,
 		"docker-registry",
 		waitForVersion,

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] openshift rou
 	)
 
 	g.BeforeEach(func() {
-		dc, err := oc.AdminClient().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
+		dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
 		if kapierrs.IsNotFound(err) {
 			g.Skip("no router installed on the cluster")
 			return

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 			var hostname string
 			err = wait.Poll(time.Second, changeTimeoutSeconds*time.Second, func() (bool, error) {
-				route, err := oc.Client().Routes(ns).Get("serving-cert", metav1.GetOptions{})
+				route, err := oc.RouteClient().Route().Routes(ns).Get("serving-cert", metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -30,7 +30,7 @@ import (
 func createUser(cli *exutil.CLI, name, role string) *userapi.User {
 	name = cli.Namespace() + "-" + name
 
-	user, err := cli.AdminClient().Users().Create(&userapi.User{
+	user, err := cli.AdminUserClient().User().Users().Create(&userapi.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -38,7 +38,7 @@ func createUser(cli *exutil.CLI, name, role string) *userapi.User {
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	if role != "" {
-		_, err = cli.AdminClient().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
+		_, err = cli.AdminAuthorizationClient().Authorization().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-%s-binding", name, role),
 			},
@@ -61,7 +61,7 @@ func createUser(cli *exutil.CLI, name, role string) *userapi.User {
 func createGroup(cli *exutil.CLI, name, role string) *userapi.Group {
 	name = cli.Namespace() + "-" + name
 
-	group, err := cli.AdminClient().Groups().Create(&userapi.Group{
+	group, err := cli.AdminUserClient().User().Groups().Create(&userapi.Group{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -69,7 +69,7 @@ func createGroup(cli *exutil.CLI, name, role string) *userapi.Group {
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	if role != "" {
-		_, err = cli.AdminClient().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
+		_, err = cli.AdminAuthorizationClient().Authorization().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-%s-binding", name, role),
 			},
@@ -90,23 +90,23 @@ func createGroup(cli *exutil.CLI, name, role string) *userapi.Group {
 }
 
 func addUserToGroup(cli *exutil.CLI, username, groupname string) {
-	group, err := cli.AdminClient().Groups().Get(groupname, metav1.GetOptions{})
+	group, err := cli.AdminUserClient().User().Groups().Get(groupname, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	if group != nil {
 		group.Users = append(group.Users, username)
-		_, err = cli.AdminClient().Groups().Update(group)
+		_, err = cli.AdminUserClient().User().Groups().Update(group)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	}
 }
 
 func deleteGroup(cli *exutil.CLI, group *userapi.Group) {
-	err := cli.AdminClient().Groups().Delete(group.Name)
+	err := cli.AdminUserClient().User().Groups().Delete(group.Name, nil)
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
 func deleteUser(cli *exutil.CLI, user *userapi.User) {
-	err := cli.AdminClient().Users().Delete(user.Name)
+	err := cli.AdminUserClient().User().Users().Delete(user.Name, nil)
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -143,7 +143,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 		}
 
 		// additional plumbing to enable impersonateuser to impersonate edituser1
-		role, err := cli.AdminClient().Roles(cli.Namespace()).Create(&authorizationapi.Role{
+		role, err := cli.AdminAuthorizationClient().Authorization().Roles(cli.Namespace()).Create(&authorizationapi.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "impersonater",
 			},
@@ -157,7 +157,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.AdminClient().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
+		_, err = cli.AdminAuthorizationClient().Authorization().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "impersonater-binding",
 			},

--- a/test/extended/templates/templateinstance_objectkinds.go
+++ b/test/extended/templates/templateinstance_objectkinds.go
@@ -55,10 +55,10 @@ var _ = g.Describe("[Conformance][templates] templateinstance object kinds test"
 		_, err = cli.KubeClient().AppsV1beta1().Deployments(cli.Namespace()).Get("deployment", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.Client().Routes(cli.Namespace()).Get("route", metav1.GetOptions{})
+		_, err = cli.RouteClient().Route().Routes(cli.Namespace()).Get("route", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.Client().Routes(cli.Namespace()).Get("newroute", metav1.GetOptions{})
+		_, err = cli.RouteClient().Route().Routes(cli.Namespace()).Get("newroute", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 })

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance readiness test", f
 			return false, err
 		}
 
-		build, err := cli.Client().Builds(cli.Namespace()).Get("cakephp-mysql-example-1", metav1.GetOptions{})
+		build, err := cli.BuildClient().Build().Builds(cli.Namespace()).Get("cakephp-mysql-example-1", metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				err = nil
@@ -48,7 +48,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance readiness test", f
 			return false, err
 		}
 
-		dc, err := cli.Client().DeploymentConfigs(cli.Namespace()).Get("cakephp-mysql-example", metav1.GetOptions{})
+		dc, err := cli.AppsClient().Apps().DeploymentConfigs(cli.Namespace()).Get("cakephp-mysql-example", metav1.GetOptions{})
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				err = nil

--- a/test/extended/templates/templateinstance_security.go
+++ b/test/extended/templates/templateinstance_security.go
@@ -140,7 +140,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 				objects:         []runtime.Object{dummyrolebinding},
 				expectCondition: templateapi.TemplateInstanceInstantiateFailure,
 				checkOK: func(namespace string) bool {
-					_, err := cli.AdminClient().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
+					_, err := cli.AdminAuthorizationClient().Authorization().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
 					return err != nil && kerrors.IsNotFound(err)
 				},
 			},
@@ -151,7 +151,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 				objects:         []runtime.Object{dummyrolebinding},
 				expectCondition: templateapi.TemplateInstanceInstantiateFailure,
 				checkOK: func(namespace string) bool {
-					_, err := cli.AdminClient().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
+					_, err := cli.AdminAuthorizationClient().Authorization().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
 					return err != nil && kerrors.IsNotFound(err)
 				},
 			},
@@ -162,7 +162,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 				objects:         []runtime.Object{dummyrolebinding},
 				expectCondition: templateapi.TemplateInstanceReady,
 				checkOK: func(namespace string) bool {
-					_, err := cli.AdminClient().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
+					_, err := cli.AdminAuthorizationClient().Authorization().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
 					return err == nil
 				},
 			},

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -62,7 +62,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 		o.Expect(errs).To(o.BeEmpty())
 
 		// privatetemplate is an additional template in our namespace
-		privatetemplate, err = cli.Client().Templates(cli.Namespace()).Create(&templateapi.Template{
+		privatetemplate, err = cli.TemplateClient().Template().Templates(cli.Namespace()).Create(&templateapi.Template{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "private",
 			},
@@ -268,7 +268,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		bindroute, err := cli.Client().Routes(cli.Namespace()).Create(&routeapi.Route{
+		bindroute, err := cli.RouteClient().Route().Routes(cli.Namespace()).Create(&routeapi.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "bindroute",
 				Annotations: map[string]string{
@@ -317,7 +317,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 		err = cli.KubeClient().CoreV1().Services(cli.Namespace()).Delete(bindservice.Name, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = cli.Client().Routes(cli.Namespace()).Delete(bindroute.Name)
+		err = cli.RouteClient().Route().Routes(cli.Namespace()).Delete(bindroute.Name, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	}
 

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker security test
 
 		var err error
 
-		template, err = cli.Client().Templates("openshift").Get("cakephp-mysql-example", metav1.GetOptions{})
+		template, err = cli.TemplateClient().Template().Templates("openshift").Get("cakephp-mysql-example", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		clusterrolebinding, err = cli.AdminAuthorizationClient().Authorization().ClusterRoleBindings().Create(&authorizationapi.ClusterRoleBinding{

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker security test
 		template, err = cli.Client().Templates("openshift").Get("cakephp-mysql-example", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		clusterrolebinding, err = cli.AdminClient().ClusterRoleBindings().Create(&authorizationapi.ClusterRoleBinding{
+		clusterrolebinding, err = cli.AdminAuthorizationClient().Authorization().ClusterRoleBindings().Create(&authorizationapi.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cli.Namespace() + "templateservicebroker-client",
 			},
@@ -76,7 +76,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker security test
 		deleteUser(cli, edituser)
 		deleteUser(cli, nopermsuser)
 
-		err := cli.AdminClient().ClusterRoleBindings().Delete(clusterrolebinding.Name)
+		err := cli.AdminAuthorizationClient().Authorization().ClusterRoleBindings().Delete(clusterrolebinding.Name, nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		cli.AdminTemplateClient().Template().BrokerTemplateInstances().Delete(instanceID, nil)

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -25,13 +25,16 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	_ "github.com/openshift/origin/pkg/api/install"
+	appsclientset "github.com/openshift/origin/pkg/apps/generated/internalclientset"
+	authorizationclientset "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	buildclientset "github.com/openshift/origin/pkg/build/generated/internalclientset"
-	"github.com/openshift/origin/pkg/client"
-	oclientset "github.com/openshift/origin/pkg/client/clientset/clientset"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	imageclientset "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	"github.com/openshift/origin/pkg/oc/cli/config"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
+	projectclientset "github.com/openshift/origin/pkg/project/generated/internalclientset"
 	templateclientset "github.com/openshift/origin/pkg/template/generated/internalclientset"
+	userclientset "github.com/openshift/origin/pkg/user/generated/internalclientset"
 	testutil "github.com/openshift/origin/test/util"
 )
 
@@ -183,48 +186,18 @@ func (c *CLI) Verbose() *CLI {
 	return c
 }
 
-// Client provides an OpenShift client for the current user. If the user is not
-// set, then it provides client for the cluster admin user
-func (c *CLI) Client() *client.Client {
+func (c *CLI) AppsClient() appsclientset.Interface {
 	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
-	osClient, err := client.New(clientConfig)
+	client, err := appsclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
 	}
-	return osClient
+	return client
 }
 
-// Clientset provides the new OpenShift clientset for the current user. If the user is not
-// set, then it provides client for the cluster admin user
-func (c *CLI) Clientset() *oclientset.Clientset {
+func (c *CLI) AuthorizationClient() authorizationclientset.Interface {
 	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
-	if err != nil {
-		FatalErr(err)
-	}
-
-	cs, err := oclientset.NewForConfig(clientConfig)
-	if err != nil {
-		FatalErr(err)
-	}
-
-	return cs
-}
-
-// AdminClient provides an OpenShift client for the cluster admin user.
-func (c *CLI) AdminClient() *client.Client {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
-	osClient, err := client.New(clientConfig)
-	if err != nil {
-		FatalErr(err)
-	}
-	return osClient
-}
-
-// Client provides an OpenShift client for the current user. If the user is not
-// set, then it provides client for the cluster admin user
-func (c *CLI) TemplateClient() templateclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
-	client, err := templateclientset.NewForConfig(clientConfig)
+	client, err := authorizationclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
 	}
@@ -240,10 +213,102 @@ func (c *CLI) BuildClient() buildclientset.Interface {
 	return client
 }
 
+func (c *CLI) ImageClient() imageclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	client, err := imageclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) ProjectClient() projectclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	client, err := projectclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+// Client provides an OpenShift client for the current user. If the user is not
+// set, then it provides client for the cluster admin user
+func (c *CLI) TemplateClient() templateclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	client, err := templateclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) UserClient() userclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	client, err := userclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminAppsClient() appsclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := appsclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminAuthorizationClient() authorizationclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := authorizationclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminBuildClient() buildclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := buildclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminImageClient() imageclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := imageclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminProjectClient() projectclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := projectclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
 // AdminClient provides an OpenShift client for the cluster admin user.
 func (c *CLI) AdminTemplateClient() templateclientset.Interface {
 	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
 	client, err := templateclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminUserClient() userclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := userclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
 	}

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/origin/pkg/oc/cli/config"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectclientset "github.com/openshift/origin/pkg/project/generated/internalclientset"
+	routeclientset "github.com/openshift/origin/pkg/route/generated/internalclientset"
 	templateclientset "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	userclientset "github.com/openshift/origin/pkg/user/generated/internalclientset"
 	testutil "github.com/openshift/origin/test/util"
@@ -159,7 +160,7 @@ func (c *CLI) SetupProject(name string, kubeClient kclientset.Interface, _ map[s
 	e2e.Logf("The user is now %q", c.Username())
 
 	e2e.Logf("Creating project %q", c.Namespace())
-	_, err := c.Client().ProjectRequests().Create(&projectapi.ProjectRequest{
+	_, err := c.ProjectClient().Project().ProjectRequests().Create(&projectapi.ProjectRequest{
 		ObjectMeta: metav1.ObjectMeta{Name: c.Namespace()},
 	})
 	if err != nil {
@@ -231,6 +232,15 @@ func (c *CLI) ProjectClient() projectclientset.Interface {
 	return client
 }
 
+func (c *CLI) RouteClient() routeclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	client, err := routeclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
 // Client provides an OpenShift client for the current user. If the user is not
 // set, then it provides client for the cluster admin user
 func (c *CLI) TemplateClient() templateclientset.Interface {
@@ -290,6 +300,15 @@ func (c *CLI) AdminImageClient() imageclientset.Interface {
 func (c *CLI) AdminProjectClient() projectclientset.Interface {
 	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
 	client, err := projectclientset.NewForConfig(clientConfig)
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminRouteClient() routeclientset.Interface {
+	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	client, err := routeclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
 	}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -42,7 +42,6 @@ import (
 	deployutil "github.com/openshift/origin/pkg/apps/util"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildtypedclientset "github.com/openshift/origin/pkg/build/generated/internalclientset/typed/build/internalversion"
-	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagetypeclientset "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	"github.com/openshift/origin/test/extended/testdata"
@@ -599,7 +598,7 @@ func WaitForABuild(c buildtypedclientset.BuildResourceInterface, name string, is
 	}
 	// wait longer for the build to run to completion
 	err = wait.Poll(5*time.Second, 60*time.Minute, func() (bool, error) {
-		list, err := c.List(metav1.ListOptions{FieldSelector: fields.Set{"name": name}.AsSelector().String()})
+		list, err := c.List(metav1.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
 		if err != nil {
 			e2e.Logf("error listing builds: %v", err)
 			return false, err
@@ -669,7 +668,7 @@ func WaitForAnImageStream(client imagetypeclientset.ImageStreamInterface,
 	name string,
 	isOK, isFailed func(*imageapi.ImageStream) bool) error {
 	for {
-		list, err := client.List(metav1.ListOptions{FieldSelector: fields.Set{"name": name}.AsSelector().String()})
+		list, err := client.List(metav1.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
 		if err != nil {
 			return err
 		}
@@ -684,7 +683,7 @@ func WaitForAnImageStream(client imagetypeclientset.ImageStreamInterface,
 		}
 
 		rv := list.ResourceVersion
-		w, err := client.Watch(metav1.ListOptions{FieldSelector: fields.Set{"name": name}.AsSelector().String(), ResourceVersion: rv})
+		w, err := client.Watch(metav1.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(), ResourceVersion: rv})
 		if err != nil {
 			return err
 		}
@@ -996,7 +995,7 @@ func WaitUntilPodIsGone(c kcoreclient.PodInterface, podName string, timeout time
 
 // GetDockerImageReference retrieves the full Docker pull spec from the given ImageStream
 // and tag
-func GetDockerImageReference(c client.ImageStreamInterface, name, tag string) (string, error) {
+func GetDockerImageReference(c imagetypeclientset.ImageStreamInterface, name, tag string) (string, error) {
 	imageStream, err := c.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return "", err

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/authorization"
 	batchv1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	kbatchclient "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/batch/v1"
@@ -37,11 +38,13 @@ import (
 
 	"github.com/openshift/origin/pkg/api/apihelpers"
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	appstypeclientset "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
 	deployutil "github.com/openshift/origin/pkg/apps/util"
-	authapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	buildtypedclientset "github.com/openshift/origin/pkg/build/generated/internalclientset/typed/build/internalversion"
 	"github.com/openshift/origin/pkg/client"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imagetypeclientset "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	"github.com/openshift/origin/test/extended/testdata"
 )
 
@@ -53,7 +56,7 @@ func WaitForOpenShiftNamespaceImageStreams(oc *CLI) error {
 	scan := func() bool {
 		for _, lang := range langs {
 			e2e.Logf("Checking language %v \n", lang)
-			is, err := oc.Client().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
+			is, err := oc.ImageClient().Image().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
 			if err != nil {
 				e2e.Logf("ImageStream Error: %#v \n", err)
 				return false
@@ -94,7 +97,7 @@ func CheckOpenShiftNamespaceImageStreams(oc *CLI) {
 	missing := false
 	langs := []string{"ruby", "nodejs", "perl", "php", "python", "wildfly", "mysql", "postgresql", "mongodb", "jenkins"}
 	for _, lang := range langs {
-		_, err := oc.Client().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
+		_, err := oc.ImageClient().Image().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
 		if err != nil {
 			missing = true
 			break
@@ -419,7 +422,7 @@ func (t *BuildResult) dumpRegistryLogs() {
 	if t.Build != nil && !t.Build.CreationTimestamp.IsZero() {
 		buildStarted = &t.Build.CreationTimestamp.Time
 	} else {
-		proj, err := oc.Client().Projects().Get(oc.Namespace(), metav1.GetOptions{})
+		proj, err := oc.ProjectClient().Project().Projects().Get(oc.Namespace(), metav1.GetOptions{})
 		if err != nil {
 			e2e.Logf("Failed to get project %s: %v\n", oc.Namespace(), err)
 		} else {
@@ -533,11 +536,11 @@ func StartBuildAndWait(oc *CLI, args ...string) (result *BuildResult, err error)
 	if err != nil {
 		return result, err
 	}
-	return result, WaitForBuildResult(oc.Client().Builds(oc.Namespace()), result)
+	return result, WaitForBuildResult(oc.BuildClient().Build().Builds(oc.Namespace()), result)
 }
 
 // WaitForBuildResult updates result wit the state of the build
-func WaitForBuildResult(c client.BuildInterface, result *BuildResult) error {
+func WaitForBuildResult(c buildtypedclientset.BuildResourceInterface, result *BuildResult) error {
 	e2e.Logf("Waiting for %s to complete\n", result.BuildName)
 	err := WaitForABuild(c, result.BuildName,
 		func(b *buildapi.Build) bool {
@@ -570,7 +573,7 @@ func WaitForBuildResult(c client.BuildInterface, result *BuildResult) error {
 }
 
 // WaitForABuild waits for a Build object to match either isOK or isFailed conditions.
-func WaitForABuild(c client.BuildInterface, name string, isOK, isFailed, isCanceled func(*buildapi.Build) bool) error {
+func WaitForABuild(c buildtypedclientset.BuildResourceInterface, name string, isOK, isFailed, isCanceled func(*buildapi.Build) bool) error {
 	if isOK == nil {
 		isOK = CheckBuildSuccessFn
 	}
@@ -662,7 +665,7 @@ func WaitForBuilderAccount(c kcoreclient.ServiceAccountInterface) error {
 }
 
 // WaitForAnImageStream waits for an ImageStream to fulfill the isOK function
-func WaitForAnImageStream(client client.ImageStreamInterface,
+func WaitForAnImageStream(client imagetypeclientset.ImageStreamInterface,
 	name string,
 	isOK, isFailed func(*imageapi.ImageStream) bool) error {
 	for {
@@ -720,7 +723,7 @@ func TimedWaitForAnImageStreamTag(oc *CLI, namespace, name, tag string, waitTime
 	c := make(chan error)
 	go func() {
 		err := WaitForAnImageStream(
-			oc.Client().ImageStreams(namespace),
+			oc.ImageClient().Image().ImageStreams(namespace),
 			name,
 			func(is *imageapi.ImageStream) bool {
 				if history, exists := is.Status.Tags[tag]; !exists || len(history.Items) == 0 {
@@ -756,13 +759,13 @@ var CheckImageStreamTagNotFoundFn = func(i *imageapi.ImageStream) bool {
 
 // WaitForDeploymentConfig waits for a DeploymentConfig to complete transition
 // to a given version and report minimum availability.
-func WaitForDeploymentConfig(kc kclientset.Interface, oc client.Interface, namespace, name string, version int64, cli *CLI) error {
+func WaitForDeploymentConfig(kc kclientset.Interface, dcClient appstypeclientset.DeploymentConfigsGetter, namespace, name string, version int64, cli *CLI) error {
 	e2e.Logf("waiting for deploymentconfig %s/%s to be available with version %d\n", namespace, name, version)
 	var dc *deployapi.DeploymentConfig
 
 	start := time.Now()
 	err := wait.Poll(time.Second, 15*time.Minute, func() (done bool, err error) {
-		dc, err = oc.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+		dc, err = dcClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -1349,17 +1352,19 @@ func (r *podExecutor) Exec(script string) (string, error) {
 // WaitForUserBeAuthorized waits a minute until the cluster bootstrap roles are available
 // and the provided user is authorized to perform the action on the resource.
 func WaitForUserBeAuthorized(oc *CLI, user, verb, resource string) error {
-	sar := authapi.SubjectAccessReview{
-		User: user,
-		Action: authapi.Action{
-			Namespace: oc.Namespace(),
-			Verb:      verb,
-			Resource:  resource,
+	sar := &authorization.SubjectAccessReview{
+		Spec: authorization.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorization.ResourceAttributes{
+				Namespace: oc.Namespace(),
+				Verb:      verb,
+				Resource:  resource,
+			},
+			User: user,
 		},
 	}
 	return wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		resp, err := oc.AdminClient().SubjectAccessReviews().Create(&sar)
-		if err == nil && resp != nil && resp.Allowed {
+		resp, err := oc.InternalAdminKubeClient().Authorization().SubjectAccessReviews().Create(sar)
+		if err == nil && resp != nil && resp.Status.Allowed {
 			return true, nil
 		}
 		return false, err

--- a/test/extended/util/jenkins/ref.go
+++ b/test/extended/util/jenkins/ref.go
@@ -372,7 +372,7 @@ func SetupSnapshotImage(envVarName, localImageName, snapshotImageStream string, 
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for build to finish")
-		err = exutil.WaitForABuild(oc.Client().Builds(oc.Namespace()), snapshotImageStream+"-1", exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn, exutil.CheckBuildCancelledFn)
+		err = exutil.WaitForABuild(oc.BuildClient().Build().Builds(oc.Namespace()), snapshotImageStream+"-1", exutil.CheckBuildSuccessFn, exutil.CheckBuildFailedFn, exutil.CheckBuildCancelledFn)
 		if err != nil {
 			exutil.DumpBuildLogs(snapshotImageStream, oc)
 		}
@@ -424,7 +424,7 @@ func ProcessLogURLAnnotations(oc *exutil.CLI, t *exutil.BuildResult) (*url.URL, 
 func DumpLogs(oc *exutil.CLI, t *exutil.BuildResult) (string, error) {
 	var err error
 	if t.Build == nil {
-		t.Build, err = oc.Client().Builds(oc.Namespace()).Get(t.BuildName, metav1.GetOptions{})
+		t.Build, err = oc.BuildClient().Build().Builds(oc.Namespace()).Get(t.BuildName, metav1.GetOptions{})
 		if err != nil {
 			return "", fmt.Errorf("cannot retrieve build %s: %v", t.BuildName, err)
 		}

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -212,12 +212,12 @@ func TestAuthorizationRestrictedAccessForProjectAdmins(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	markClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
+	_, markClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -509,12 +509,12 @@ func TestAuthorizationResourceAccessReview(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	markClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
+	_, markClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -853,7 +853,7 @@ func TestAuthorizationSubjectAccessReviewAPIGroup(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
+	_, _, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -995,7 +995,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1005,7 +1005,7 @@ func TestAuthorizationSubjectAccessReview(t *testing.T) {
 	}
 	haroldSARGetter := haroldKubeClient.Authorization()
 
-	markClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
+	_, markClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "mallet-project", "mark")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1430,7 +1430,7 @@ func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1495,7 +1495,7 @@ func TestOldLocalSubjectAccessReviewEndpoint(t *testing.T) {
 		otherNamespace := "chisel-project"
 		// we need a real project for this to make it past admission.
 		// TODO, this is an information leaking problem.  This admission plugin leaks knowledge of which projects exist via SARs
-		if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, otherNamespace, "charlie"); err != nil {
+		if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, otherNamespace, "charlie"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -1557,7 +1557,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "hammer-project", "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -58,10 +58,10 @@ func TestClusterQuota(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "first", "harold"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "first", "harold"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "second", "harold"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "second", "harold"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -140,7 +140,7 @@ func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.Cl
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), "peon")
+	_, _, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), "peon")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -31,7 +31,7 @@ func TestDeployScale(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "my-test-user")
+	_, _, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "my-test-user")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -37,7 +37,7 @@ func TestTriggers_manual(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "my-test-user")
+	_, _, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "my-test-user")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestTriggers_imageChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting cluster admin client config: %v", err)
 	}
-	openshiftProjectAdminClient, err := testserver.CreateNewProject(openshiftClusterAdminClient, *openshiftClusterAdminClientConfig, testutil.Namespace(), "bob")
+	_, openshiftProjectAdminClient, err := testserver.CreateNewProject(openshiftClusterAdminClient, *openshiftClusterAdminClientConfig, testutil.Namespace(), "bob")
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestTriggers_imageChange_nonAutomatic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting cluster admin client config: %v", err)
 	}
-	oc, err := testserver.CreateNewProject(openshiftClusterAdminClient, *openshiftClusterAdminClientConfig, testutil.Namespace(), "bob")
+	_, oc, err := testserver.CreateNewProject(openshiftClusterAdminClient, *openshiftClusterAdminClientConfig, testutil.Namespace(), "bob")
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestTriggers_MultipleICTs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting cluster admin client config: %v", err)
 	}
-	openshiftProjectAdminClient, err := testserver.CreateNewProject(openshiftClusterAdminClient, *openshiftClusterAdminClientConfig, testutil.Namespace(), "bob")
+	_, openshiftProjectAdminClient, err := testserver.CreateNewProject(openshiftClusterAdminClient, *openshiftClusterAdminClientConfig, testutil.Namespace(), "bob")
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}
@@ -565,7 +565,7 @@ func TestTriggers_configChange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "my-test-user")
+	_, _, err = testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, namespace, "my-test-user")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/dockerregistry_pullthrough_test.go
+++ b/test/integration/dockerregistry_pullthrough_test.go
@@ -144,7 +144,7 @@ func TestPullThroughInsecure(t *testing.T) {
 		t.Fatalf("error getting cluster admin client config: %v", err)
 	}
 	user := "admin"
-	adminClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), user)
+	_, adminClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), user)
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -97,7 +97,7 @@ func TestEndpointAdmission(t *testing.T) {
 	testOne(t, serviceAccountClient, "default", "external", true)
 
 	// Project admin
-	_, err = testserver.CreateNewProject(clusterAdminOSClient, *clientConfig, "myproject", "myadmin")
+	_, _, err = testserver.CreateNewProject(clusterAdminOSClient, *clientConfig, "myproject", "myadmin")
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}

--- a/test/integration/extensions_api_deletion_test.go
+++ b/test/integration/extensions_api_deletion_test.go
@@ -41,14 +41,14 @@ func TestExtensionsAPIDeletion(t *testing.T) {
 	}
 
 	// create the containing project
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
 		t.Fatalf("unexpected error creating the project: %v", err)
 	}
-	projectAdminClient, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	_, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
 	if err != nil {
 		t.Fatalf("unexpected error getting project admin client: %v", err)
 	}
-	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
+	if err := testutil.WaitForPolicyUpdate(projectAdminKubeClient.Authorization(), projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
 		t.Fatalf("unexpected error waiting for policy update: %v", err)
 	}
 

--- a/test/integration/extensions_api_disabled_test.go
+++ b/test/integration/extensions_api_disabled_test.go
@@ -46,14 +46,14 @@ func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
 	}
 
 	// create the containing project
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
 		t.Fatalf("unexpected error creating the project: %v", err)
 	}
-	projectAdminClient, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	_, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
 	if err != nil {
 		t.Fatalf("unexpected error getting project admin client: %v", err)
 	}
-	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
+	if err := testutil.WaitForPolicyUpdate(projectAdminKubeClient.Authorization(), projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
 		t.Fatalf("unexpected error waiting for policy update: %v", err)
 	}
 
@@ -83,14 +83,14 @@ func TestExtensionsAPIDisabledAutoscaleBatchEnabled(t *testing.T) {
 	}
 
 	// recreate the containing project
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projName, "admin"); err != nil {
 		t.Fatalf("unexpected error creating the project: %v", err)
 	}
-	projectAdminClient, projectAdminKubeClient, _, err = testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
+	_, projectAdminKubeClient, _, err = testutil.GetClientForUser(*clusterAdminClientConfig, "admin")
 	if err != nil {
 		t.Fatalf("unexpected error getting project admin client: %v", err)
 	}
-	if err := testutil.WaitForPolicyUpdate(projectAdminClient, projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
+	if err := testutil.WaitForPolicyUpdate(projectAdminKubeClient.Authorization(), projName, "get", expapi.Resource("horizontalpodautoscalers"), true); err != nil {
 		t.Fatalf("unexpected error waiting for policy update: %v", err)
 	}
 

--- a/test/integration/front_proxy_test.go
+++ b/test/integration/front_proxy_test.go
@@ -108,7 +108,7 @@ func TestFrontProxy(t *testing.T) {
 
 	for _, username := range []string{"david", "jordan"} {
 		projectName := username + "-project"
-		if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, username); err != nil {
+		if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, username); err != nil {
 			t.Fatal(err)
 		}
 		waitForAdd(projectName, w, t)

--- a/test/integration/gc_default_test.go
+++ b/test/integration/gc_default_test.go
@@ -41,7 +41,7 @@ func TestGCDefaults(t *testing.T) {
 	}
 
 	ns := "some-ns-old"
-	if _, err := testserver.CreateNewProject(originClient, *clusterAdminConfig, ns, "adminUser"); err != nil {
+	if _, _, err := testserver.CreateNewProject(originClient, *clusterAdminConfig, ns, "adminUser"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -33,7 +33,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	valerieOpenshiftClient, _, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "valerie")
+	valerieOpenshiftClient, valerieKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "valerie")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := testutil.WaitForPolicyUpdate(valerieOpenshiftClient, "empty", "get", kapi.Resource("pods"), true); err != nil {
+	if err := testutil.WaitForPolicyUpdate(valerieKubeClient.Authorization(), "empty", "get", kapi.Resource("pods"), true); err != nil {
 		t.Error(err)
 	}
 
@@ -121,7 +121,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	valerieOpenshiftClient, _, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "valerie")
+	valerieOpenshiftClient, valerieKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "valerie")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestBasicGroupManipulation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := testutil.WaitForPolicyUpdate(valerieOpenshiftClient, "empty", "get", kapi.Resource("pods"), true); err != nil {
+	if err := testutil.WaitForPolicyUpdate(valerieKubeClient.Authorization(), "empty", "get", kapi.Resource("pods"), true); err != nil {
 		t.Error(err)
 	}
 

--- a/test/integration/imagesigning_test.go
+++ b/test/integration/imagesigning_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	"github.com/openshift/origin/pkg/client"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -21,7 +22,7 @@ import (
 const testUserName = "bob"
 
 func TestImageAddSignature(t *testing.T) {
-	adminClient, userClient, image, fn := testSetupImageSignatureTest(t, testUserName)
+	userKubeClient, adminClient, userClient, image, fn := testSetupImageSignatureTest(t, testUserName)
 	defer fn()
 
 	if len(image.Signatures) != 0 {
@@ -48,7 +49,7 @@ func TestImageAddSignature(t *testing.T) {
 		t.Fatalf("expected forbidden error, not: %v", err)
 	}
 
-	makeUserAnImageSigner(adminClient, userClient, testUserName)
+	makeUserAnImageSigner(adminClient, userKubeClient, testUserName)
 
 	// try to create the signature again
 	created, err = userClient.ImageSignatures().Create(&signature)
@@ -97,9 +98,9 @@ func TestImageAddSignature(t *testing.T) {
 }
 
 func TestImageRemoveSignature(t *testing.T) {
-	adminClient, userClient, image, fn := testSetupImageSignatureTest(t, testUserName)
+	userKubeClient, adminClient, userClient, image, fn := testSetupImageSignatureTest(t, testUserName)
 	defer fn()
-	makeUserAnImageSigner(adminClient, userClient, testUserName)
+	makeUserAnImageSigner(adminClient, userKubeClient, testUserName)
 
 	// create some signatures
 	sigData := []struct {
@@ -195,7 +196,7 @@ func TestImageRemoveSignature(t *testing.T) {
 	}
 }
 
-func testSetupImageSignatureTest(t *testing.T, userName string) (adminClient *client.Client, userClient *client.Client, image *imageapi.Image, cleanup func()) {
+func testSetupImageSignatureTest(t *testing.T, userName string) (userKubeClient kclientset.Interface, adminClient *client.Client, userClient *client.Client, image *imageapi.Image, cleanup func()) {
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -224,17 +225,17 @@ func testSetupImageSignatureTest(t *testing.T, userName string) (adminClient *cl
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	userClient, _, _, err = testutil.GetClientForUser(*clusterAdminConfig, userName)
+	userClient, userKubeClient, _, err = testutil.GetClientForUser(*clusterAdminConfig, userName)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	return adminClient, userClient, image, func() {
+	return userKubeClient, adminClient, userClient, image, func() {
 		testserver.CleanupMasterEtcd(t, masterConfig)
 	}
 }
 
-func makeUserAnImageSigner(clusterAdminClient *client.Client, userClient *client.Client, userName string) error {
+func makeUserAnImageSigner(clusterAdminClient *client.Client, userClient kclientset.Interface, userName string) error {
 	// give bob permissions to update image signatures
 	addImageSignerRole := &policy.RoleModificationOptions{
 		RoleNamespace:       "",
@@ -245,7 +246,7 @@ func makeUserAnImageSigner(clusterAdminClient *client.Client, userClient *client
 	if err := addImageSignerRole.AddRole(); err != nil {
 		return err
 	}
-	return testutil.WaitForClusterPolicyUpdate(userClient, "create", kapi.Resource("imagesignatures"), true)
+	return testutil.WaitForClusterPolicyUpdate(userClient.Authorization(), "create", kapi.Resource("imagesignatures"), true)
 }
 
 func compareSignatures(t *testing.T, a, b imageapi.ImageSignature) {

--- a/test/integration/node_auth_test.go
+++ b/test/integration/node_auth_test.go
@@ -68,9 +68,9 @@ func TestNodeAuth(t *testing.T) {
 	badTokenConfig := clientcmd.AnonymousClientConfig(adminConfig)
 	badTokenConfig.BearerToken = "bad-token"
 
-	bobClient, _, bobConfig, err := testutil.GetClientForUser(*adminConfig, "bob")
+	bobClient, bobKubeClient, bobConfig, err := testutil.GetClientForUser(*adminConfig, "bob")
 	_, _, aliceConfig, err := testutil.GetClientForUser(*adminConfig, "alice")
-	sa1Client, _, sa1Config, err := testutil.GetClientForServiceAccount(adminClient, *adminConfig, "default", "sa1")
+	_, sa1KubeClient, sa1Config, err := testutil.GetClientForServiceAccount(adminClient, *adminConfig, "default", "sa1")
 	_, _, sa2Config, err := testutil.GetClientForServiceAccount(adminClient, *adminConfig, "default", "sa2")
 
 	// Grant Bob system:node-reader, which should let them read metrics and stats
@@ -113,10 +113,10 @@ func TestNodeAuth(t *testing.T) {
 	}
 
 	// Wait for policy cache
-	if err := testutil.WaitForClusterPolicyUpdate(bobClient, "get", kapi.Resource("nodes/metrics"), true); err != nil {
+	if err := testutil.WaitForClusterPolicyUpdate(bobKubeClient.Authorization(), "get", kapi.Resource("nodes/metrics"), true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := testutil.WaitForClusterPolicyUpdate(sa1Client, "get", kapi.Resource("nodes/metrics"), true); err != nil {
+	if err := testutil.WaitForClusterPolicyUpdate(sa1KubeClient.Authorization(), "get", kapi.Resource("nodes/metrics"), true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/oauth_serviceaccount_client_test.go
+++ b/test/integration/oauth_serviceaccount_client_test.go
@@ -72,7 +72,7 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 	}
 
 	projectName := "hammer-project"
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := testserver.WaitForServiceAccounts(clusterAdminKubeClientset, projectName, []string{"default"}); err != nil {

--- a/test/integration/ownerrefs_test.go
+++ b/test/integration/ownerrefs_test.go
@@ -42,7 +42,7 @@ func TestOwnerRefRestriction(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := testserver.CreateNewProject(originClient, *clientConfig, "foo", "admin-user"); err != nil {
+	if _, _, err := testserver.CreateNewProject(originClient, *clientConfig, "foo", "admin-user"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	_, creatorClient, _, err := testutil.GetClientForUser(*clientConfig, "creator")
@@ -60,7 +60,7 @@ func TestOwnerRefRestriction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := testutil.WaitForPolicyUpdate(originClient, "foo", "create", kapi.Resource("services"), true); err != nil {
+	if err := testutil.WaitForPolicyUpdate(creatorClient.Authorization(), "foo", "create", kapi.Resource("services"), true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/policy_commands_test.go
+++ b/test/integration/policy_commands_test.go
@@ -32,7 +32,7 @@ func TestPolicyCommands(t *testing.T) {
 
 	const projectName = "hammer-project"
 
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold")
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -235,13 +235,13 @@ func TestProjectWatch(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-01", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-01", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	waitForAdd("ns-01", w, t)
 
 	// TEST FOR ADD/REMOVE ACCESS
-	joeClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-02", "joe")
+	_, joeClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-02", "joe")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestProjectWatch(t *testing.T) {
 	waitForDelete("ns-02", w, t)
 
 	// TEST FOR DELETE PROJECT
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-03", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "ns-03", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	waitForAdd("ns-03", w, t)
@@ -438,14 +438,14 @@ func TestScopedProjectAccess(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "one", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "one", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Logf("test 1")
 	waitForOnlyAdd("one", allWatch, t)
 	waitForOnlyAdd("one", oneTwoWatch, t)
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "two", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "two", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Logf("test 2")
@@ -453,14 +453,14 @@ func TestScopedProjectAccess(t *testing.T) {
 	waitForOnlyAdd("two", oneTwoWatch, t)
 	waitForOnlyAdd("two", twoThreeWatch, t)
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "three", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "three", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Logf("test 3")
 	waitForOnlyAdd("three", allWatch, t)
 	waitForOnlyAdd("three", twoThreeWatch, t)
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "four", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "four", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	waitForOnlyAdd("four", allWatch, t)
@@ -537,10 +537,10 @@ func TestInvalidRoleRefs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "foo", "bob"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "foo", "bob"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "bar", "alice"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "bar", "alice"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -48,7 +48,7 @@ func TestRestrictUsers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "namespace", "carol"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, "namespace", "carol"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/scc_test.go
+++ b/test/integration/scc_test.go
@@ -33,7 +33,7 @@ func TestPodUpdateSCCEnforcement(t *testing.T) {
 
 	projectName := "hammer-project"
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, "harold"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	_, haroldKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "harold")

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -40,7 +40,7 @@ func TestScopedTokens(t *testing.T) {
 
 	projectName := "hammer-project"
 	userName := "harold"
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName)
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestScopedImpersonation(t *testing.T) {
 
 	projectName := "hammer-project"
 	userName := "harold"
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func TestScopeEscalations(t *testing.T) {
 
 	projectName := "hammer-project"
 	userName := "harold"
-	haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName)
+	_, haroldClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, projectName, userName)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/integration/sdn_test.go
+++ b/test/integration/sdn_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func createProject(osClient *osclient.Client, clientConfig *restclient.Config, name string) (*networkapi.NetNamespace, error) {
-	_, err := testserver.CreateNewProject(osClient, *clientConfig, name, name)
+	_, _, err := testserver.CreateNewProject(osClient, *clientConfig, name, name)
 	if err != nil {
 		return nil, fmt.Errorf("error creating project %q: %v", name, err)
 	}

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -342,7 +342,7 @@ func TestDockercfgTokenDeletedController(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "sa1", Namespace: "ns1"},
 	}
 
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, sa.Namespace, "ignored"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, sa.Namespace, "ignored"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/service_serving_cert_signer_test.go
+++ b/test/integration/service_serving_cert_signer_test.go
@@ -35,7 +35,7 @@ func TestServiceServingCertSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminConfig, "service-serving-cert-signer", "deads"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminConfig, "service-serving-cert-signer", "deads"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/integration/storage_versions_test.go
+++ b/test/integration/storage_versions_test.go
@@ -67,7 +67,7 @@ func setupStorageTests(t *testing.T, ns string) (*configapi.MasterConfig, kclien
 	}
 
 	// create the containing project
-	if _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, ns, "admin"); err != nil {
+	if _, _, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, ns, "admin"); err != nil {
 		t.Fatalf("unexpected error creating the project: %v", err)
 	}
 	_, projectAdminKubeClient, _, err := testutil.GetClientForUser(*clusterAdminClientConfig, "admin")

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -7,6 +7,7 @@ import (
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/client"
@@ -251,13 +252,13 @@ func TestUnprivilegedNewProjectDenied(t *testing.T) {
 	}
 
 	valerieClientConfig.BearerToken = accessToken
-	valerieOpenshiftClient, err := client.New(&valerieClientConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	valerieProjectClient := projectclient.NewForConfigOrDie(&valerieClientConfig)
+	valerieKubeClient := kclientset.NewForConfigOrDie(&valerieClientConfig)
 
-	if err := testutil.WaitForClusterPolicyUpdate(valerieOpenshiftClient, "create", projectapi.Resource("projectrequests"), false); err != nil {
+	if err := testutil.WaitForClusterPolicyUpdate(valerieKubeClient.Authorization(), "create", projectapi.Resource("projectrequests"), false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/test/integration/v2_docker_registry_test.go
+++ b/test/integration/v2_docker_registry_test.go
@@ -91,7 +91,7 @@ func TestV2RegistryGetTags(t *testing.T) {
 		t.Fatalf("error getting cluster admin client config: %v", err)
 	}
 	user := "admin"
-	adminClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), user)
+	_, adminClient, err := testserver.CreateNewProject(clusterAdminClient, *clusterAdminClientConfig, testutil.Namespace(), user)
 	if err != nil {
 		t.Fatalf("error creating project: %v", err)
 	}

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -607,7 +607,7 @@ func WaitForServiceAccounts(clientset kclientset.Interface, namespace string, ac
 
 // CreateNewProject creates a new project using the clusterAdminClient, then gets a token for the adminUser and returns
 // back a client for the admin user
-func CreateNewProject(clusterAdminClient *client.Client, clientConfig restclient.Config, projectName, adminUser string) (*client.Client, error) {
+func CreateNewProject(clusterAdminClient *client.Client, clientConfig restclient.Config, projectName, adminUser string) (kclientset.Interface, *client.Client, error) {
 	newProjectOptions := &newproject.NewProjectOptions{
 		Client:      clusterAdminClient,
 		ProjectName: projectName,
@@ -616,9 +616,9 @@ func CreateNewProject(clusterAdminClient *client.Client, clientConfig restclient
 	}
 
 	if err := newProjectOptions.Run(false); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	client, _, _, err := util.GetClientForUser(clientConfig, adminUser)
-	return client, err
+	client, kubeClient, _, err := util.GetClientForUser(clientConfig, adminUser)
+	return kubeClient, client, err
 }


### PR DESCRIPTION
@mfojtik this changes a ton of usages in our tests for generated clients.

This is going to conflict on any changes to extended tests using clients.  Bumping queue priority.