### PR TITLE
UPSTREAM: 53069: Align imagefs eviction defaults with image gc defaults

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config_test.go
+++ b/pkg/cmd/server/kubernetes/node/node_config_test.go
@@ -72,7 +72,7 @@ func TestKubeletDefaults(t *testing.T) {
 			EnableCustomMetrics:            false,
 			EnableDebuggingHandlers:        true,
 			EnableServer:                   true,
-			EvictionHard:                   "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%",
+			EvictionHard:                   "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%",
 			FileCheckFrequency:             metav1.Duration{Duration: 20 * time.Second}, // overridden
 			HealthzBindAddress:             "127.0.0.1",                                 // disabled
 			HealthzPort:                    10248,                                       // disabled

--- a/vendor/k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/vendor/k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -370,7 +370,7 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 		obj.HairpinMode = PromiscuousBridge
 	}
 	if obj.EvictionHard == nil {
-		temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"
+		temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%"
 		obj.EvictionHard = &temp
 	}
 	if obj.EvictionPressureTransitionPeriod == zeroDuration {


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/53069

https://trello.com/c/dTvvtua7

@derekwaynecarr 