### PR TITLE
Refine prometheus auth metrics

### DIFF
--- a/pkg/auth/prometheus/metrics.go
+++ b/pkg/auth/prometheus/metrics.go
@@ -8,29 +8,66 @@ const (
 	authSubsystem = "openshift_auth"
 )
 
+const (
+	SuccessResult = "success"
+	FailResult    = "failure"
+	ErrorResult   = "error"
+)
+
 var (
-	authCounterTotal = prometheus.NewCounterVec(
+	authPasswordTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: authSubsystem,
-			Name:      "auth_count_total",
-			Help:      "Counts total authentication attempts",
+			Name:      "password_total",
+			Help:      "Counts total password authentication attempts",
 		}, []string{},
 	)
-	authCounterResult = prometheus.NewCounterVec(
+	authFormCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: authSubsystem,
-			Name:      "auth_count_result",
-			Help:      "Counts authentication attempts by result",
+			Name:      "form_password_count",
+			Help:      "Counts form password authentication attempts",
+		}, []string{},
+	)
+	authFormCounterResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: authSubsystem,
+			Name:      "form_password_count_result",
+			Help:      "Counts form password authentication attempts by result",
+		}, []string{"result"},
+	)
+	authBasicCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: authSubsystem,
+			Name:      "basic_password_count",
+			Help:      "Counts basic password authentication attempts",
+		}, []string{},
+	)
+	authBasicCounterResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: authSubsystem,
+			Name:      "basic_password_count_result",
+			Help:      "Counts basic password authentication attempts by result",
 		}, []string{"result"},
 	)
 )
 
 func init() {
-	prometheus.MustRegister(authCounterTotal)
-	prometheus.MustRegister(authCounterResult)
+	prometheus.MustRegister(authPasswordTotal)
+	prometheus.MustRegister(authFormCounter)
+	prometheus.MustRegister(authFormCounterResult)
+	prometheus.MustRegister(authBasicCounter)
+	prometheus.MustRegister(authBasicCounterResult)
 }
 
-func Record(result string) {
-	authCounterTotal.WithLabelValues().Inc()
-	authCounterResult.WithLabelValues(result).Inc()
+func RecordBasicPasswordAuth(result string) {
+	authPasswordTotal.WithLabelValues().Inc()
+	authBasicCounter.WithLabelValues().Inc()
+	authBasicCounterResult.WithLabelValues(result).Inc()
+}
+
+func RecordFormPasswordAuth(result string) {
+	authPasswordTotal.WithLabelValues().Inc()
+	authFormCounter.WithLabelValues().Inc()
+	authFormCounterResult.WithLabelValues(result).Inc()
 }

--- a/pkg/auth/server/login/login.go
+++ b/pkg/auth/server/login/login.go
@@ -165,26 +165,25 @@ func (l *Login) handleLogin(w http.ResponseWriter, req *http.Request) {
 		failed(errorCodeUserRequired, w, req)
 		return
 	}
-	var result string
+	var result string = metrics.SuccessResult
 	defer func() {
-		metrics.Record(result)
+		metrics.RecordFormPasswordAuth(result)
 	}()
 	user, ok, err := l.auth.AuthenticatePassword(username, password)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf(`Error authenticating %q with provider %q: %v`, username, l.provider, err))
 		failed(errorpage.AuthenticationErrorCode(err), w, req)
-		result = "error"
+		result = metrics.ErrorResult
 		return
 	}
 	if !ok {
 		glog.V(4).Infof(`Login with provider %q failed for %q`, l.provider, username)
 		failed(errorCodeAccessDenied, w, req)
-		result = "failure"
+		result = metrics.FailResult
 		return
 	}
 	glog.V(4).Infof(`Login with provider %q succeeded for %q: %#v`, l.provider, username, user)
 	l.auth.AuthenticationSucceeded(user, then, w, req)
-	result = "success"
 }
 
 // NewLoginFormRenderer creates a login form renderer that takes in an optional custom template to


### PR DESCRIPTION
Previously we only captured web console logins, so this adds a count for basic logins through oc.
It also corrects the redundant "auth" in the counter names.

An example query after doing 4 separate console logins and 3 separate `oc login -u dev -p foo` invocations:
```
{__name__=~"openshift_auth.*"}

openshift_auth_basic_password_count{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",instance="localhost",job="kubernetes-nodes",kubernetes_io_hostname="localhost"} | 3
-- | --
openshift_auth_basic_password_count{instance="192.168.1.101:8443",job="kubernetes-apiservers"} | 3
openshift_auth_basic_password_count_result{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",instance="localhost",job="kubernetes-nodes",kubernetes_io_hostname="localhost",result="success"} | 3
openshift_auth_basic_password_count_result{instance="192.168.1.101:8443",job="kubernetes-apiservers",result="success"} | 3
openshift_auth_form_password_count{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",instance="localhost",job="kubernetes-nodes",kubernetes_io_hostname="localhost"} | 4
openshift_auth_form_password_count{instance="192.168.1.101:8443",job="kubernetes-apiservers"} | 4
openshift_auth_form_password_count_result{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",instance="localhost",job="kubernetes-nodes",kubernetes_io_hostname="localhost",result="success"} | 4
openshift_auth_form_password_count_result{instance="192.168.1.101:8443",job="kubernetes-apiservers",result="success"} | 4
openshift_auth_password_total{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",instance="localhost",job="kubernetes-nodes",kubernetes_io_hostname="localhost"} | 7
openshift_auth_password_total{instance="192.168.1.101:8443",job="kubernetes-apiservers"}
```
@openshift/sig-security 