### PR TITLE
Remove unneeded extension-apiserver-authentication-reader from service catalog example template.

### DIFF
--- a/examples/service-catalog/service-catalog.yaml
+++ b/examples/service-catalog/service-catalog.yaml
@@ -203,21 +203,6 @@ objects:
     name: service-catalog-controller
 
 - apiVersion: authorization.openshift.io/v1
-  kind: Role
-  metadata:
-    name: extension-apiserver-authentication-reader
-    namespace: ${KUBE_SYSTEM_NAMESPACE}
-  rules:
-  - apiGroups:
-    - ""
-    resourceNames:
-    - extension-apiserver-authentication
-    resources:
-    - configmaps
-    verbs:
-    - get
-
-- apiVersion: authorization.openshift.io/v1
   kind: RoleBinding
   metadata:
     name: extension-apiserver-authentication-reader-binding

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13826,21 +13826,6 @@ objects:
     name: service-catalog-controller
 
 - apiVersion: authorization.openshift.io/v1
-  kind: Role
-  metadata:
-    name: extension-apiserver-authentication-reader
-    namespace: ${KUBE_SYSTEM_NAMESPACE}
-  rules:
-  - apiGroups:
-    - ""
-    resourceNames:
-    - extension-apiserver-authentication
-    resources:
-    - configmaps
-    verbs:
-    - get
-
-- apiVersion: authorization.openshift.io/v1
   kind: RoleBinding
   metadata:
     name: extension-apiserver-authentication-reader-binding


### PR DESCRIPTION
Upstream role was added in #16517.