### PR TITLE
Sleep at the end of every `hack/env` invocation for logs

### DIFF
--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -72,6 +72,11 @@ function os::build::environment::create() {
     fi
     if [[ "${cmd[0]}" == "/bin/sh" || "${cmd[0]}" == "/bin/bash" ]]; then
       additional_context+=" -it"
+    else
+      # container exit races with log collection so we
+      # need to sleep at the end but preserve the exit
+      # code of whatever the user asked for us to run
+      cmd=( '/bin/bash' '-c' "${cmd[*]}; return_code=\$?; sleep 1; exit \${return_code}" )
     fi
   fi
 


### PR DESCRIPTION
When a container exits, the Docker daemon is not very faithful in
collecting all of the logs that the contained processes created before
they finished. We need to sleep at the end of every `hack/env` call to
ensure that we have enough time to notice what happened and we do not
lose logs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>