### PR TITLE
cluster up registry route exposure

### DIFF
--- a/pkg/oc/bootstrap/docker/status.go
+++ b/pkg/oc/bootstrap/docker/status.go
@@ -207,7 +207,10 @@ func status(container *types.ContainerJSON, config *api.MasterConfig) string {
 		status += fmt.Sprintf("The OpenShift cluster was started %s ago\n\n", duration)
 	}
 
-	status = status + fmt.Sprintf("Web console URL: %s\n", config.AssetConfig.MasterPublicURL)
+	status = status + fmt.Sprintf("Web console URL:    %s\n", config.AssetConfig.MasterPublicURL)
+	status = status + fmt.Sprintf("Image Registry URL: %[1]s\n"+
+		"    To login using docker:\n"+
+		"    docker login %[1]s -u developer -p $(oc whoami -t)\n", config.ImagePolicyConfig.ExternalRegistryHostname)
 	if config.AssetConfig.MetricsPublicURL != "" {
 		status = status + fmt.Sprintf("Metrics URL:     %s\n", config.AssetConfig.MetricsPublicURL)
 	}

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -1156,7 +1156,6 @@ func (c *ClientStartConfig) ServerInfo(out io.Writer) error {
 		msg += "To login as administrator:\n" +
 			"    oc login -u system:admin\n\n"
 	}
-
 	msg += c.checkProxySettings()
 
 	fmt.Fprintf(out, msg)


### PR DESCRIPTION
PR exposes `oc cluster up` registry using default `routingSuffix` 
It configured docker daemon to trust self-signed certificates, used by image registry.
Updated master-config.yaml file for internal and external registry configuration/hostnames
Externalise nip.io to constants
Externalise RoutingConfigSubdomain to external function for reuse.
Tests added for this.


https://trello.com/c/8DR2emei/1140-2-expose-the-openshift-registry-through-a-route-when-started-with-cluster-up-registry 
