### PR TITLE
Router stats-port=0 error

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -247,7 +247,7 @@ func (o *TemplateRouterOptions) Run() error {
 
 	statsPort := o.StatsPort
 	switch {
-	case o.MetricsType == "haproxy":
+	case o.MetricsType == "haproxy" && statsPort != 0:
 		if len(o.StatsUsername) == 0 || len(o.StatsPassword) == 0 {
 			glog.Warningf("Metrics were requested but no username or password has been provided - the metrics endpoint will not be accessible to prevent accidental security breaches")
 		}

--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -682,7 +682,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 		env["ROUTER_CANONICAL_HOSTNAME"] = cfg.RouterCanonicalHostname
 	}
 	// automatically start the internal metrics agent if we are handling a known type
-	if cfg.Type == "haproxy-router" {
+	if cfg.Type == "haproxy-router" && cfg.StatsPort != 0 {
 		env["ROUTER_LISTEN_ADDR"] = fmt.Sprintf("0.0.0.0:%d", cfg.StatsPort)
 		env["ROUTER_METRICS_TYPE"] = "haproxy"
 	}


### PR DESCRIPTION
When type=haproxy-router, stats-port must not be 0.

Fixes bug: 1466133
https://bugzilla.redhat.com/show_bug.cgi?id=1466133