### PR TITLE
clusterup add .skip_pv marker

### DIFF
--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -222,6 +222,7 @@ type CommonStartConfig struct {
 	HTTPSProxy               string
 	NoProxy                  []string
 	CACert                   string
+	PVCount                  int
 
 	dockerClient    dockerhelper.Interface
 	dockerHelper    *dockerhelper.Helper
@@ -910,7 +911,7 @@ func (c *ClientStartConfig) StartOpenShift(out io.Writer) error {
 		return err
 	}
 
-	err = c.OpenShiftHelper().SetupPersistentStorage(authorizationClient.Authorization(), kClient, securityClient, c.HostPersistentVolumesDir)
+	err = c.OpenShiftHelper().SetupPersistentStorage(authorizationClient.Authorization(), kClient, securityClient, c.HostPersistentVolumesDir, c.HostPersistentVolumesDir)
 	if err != nil {
 		return err
 	}

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -53,6 +53,14 @@ function os::test::extended::clusterup::verify_persistent_volumes () {
     os::cmd::expect_success "oc login -u developer"
 }
 
+function os::test::extended::clusterup::skip_persistent_volumes () {
+    mkdir -p /tmp/pv
+    touch /tmp/pv/.skip_pv
+    os::cmd::expect_success_and_text "oc cluster up --host-pv-dir=/tmp/pv/" "Skip persistent volume creation"
+    os::cmd::expect_success "oc login -u system:admin"
+    os::cmd::expect_success_and_text "oc get pv | wc -l" "0"
+}
+
 function os::test::extended::clusterup::verify_metrics () {
     os::cmd::expect_success "oc login -u system:admin"
     os::cmd::expect_success_and_text "oc get pods -n openshift-infra" "metrics-deployer"
@@ -269,6 +277,12 @@ function os::test::extended::clusterup::portinuse_cleanup () {
 }
 
 
+# Verifies that clusterup handle different scenarios with persistent volumes setup
+function os::test::extended::clusterup::persistentvolumes () {
+    os::test::extended::clusterup::skip_persistent_volumes
+    rm -rf /tmp/pv
+}
+
 readonly default_tests=(
     "service_catalog"
     "noargs"
@@ -277,6 +291,7 @@ readonly default_tests=(
     "numerichostname"
     "portinuse"
     "svcaccess"
+    "persistentvolumes"
 
 # enable once https://github.com/openshift/origin/issues/16995 is fixed
 #    "default"


### PR DESCRIPTION
Added .skip_pv marker for oc cluster up command. 
When the marker is detected in the PV folder - no PV's will be created leaving this configuration for the user.

as per https://trello.com/c/HbpYqEkm/1250-1-cluster-up-option-to-set-number-of-pvs-to-create-clusterup added pv count. 

@csrwng @jim-minter 