### PR TITLE
Create template-service-broker subpackage and image

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -46,6 +46,8 @@ tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
 ( os::build::image "${tag_prefix}-pod"                   images/pod ) &
 ( os::build::image "${tag_prefix}-cluster-capacity"      images/cluster-capacity ) &
 ( os::build::image "${tag_prefix}-service-catalog"       images/service-catalog ) &
+( os::build::image "${tag_prefix}-template-service-broker"  images/template-service-broker ) &
+
 
 for i in `jobs -p`; do wait $i; done
 

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -51,6 +51,7 @@ images=(
   openshift/origin-gitserver
   openshift/origin-cluster-capacity
   openshift/origin-service-catalog
+  openshift/origin-template-service-broker
   openshift/hello-openshift
   openshift/openvswitch
   openshift/node

--- a/images/template-service-broker/.cccp.yml
+++ b/images/template-service-broker/.cccp.yml
@@ -1,0 +1,1 @@
+job-id: origin-template-service-broker

--- a/images/template-service-broker/Dockerfile
+++ b/images/template-service-broker/Dockerfile
@@ -1,0 +1,8 @@
+FROM openshift/origin-source
+
+RUN INSTALL_PKGS="origin-template-service-broker" && \
+    yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
+    rpm -V ${INSTALL_PKGS} && \
+    yum clean all
+
+CMD [ "/usr/bin/template-service-broker" ]

--- a/images/template-service-broker/OWNERS
+++ b/images/template-service-broker/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - jminter
+  - deads
+approvers:
+  - jminter

--- a/origin.spec
+++ b/origin.spec
@@ -194,6 +194,11 @@ Summary:        %{product_name} Service Catalog
 %description service-catalog
 %{summary}
 
+%package template-service-broker
+Summary: Template Service Broker
+%description template-service-broker
+%{summary}
+
 %package cluster-capacity
 Summary:        %{product_name} Cluster Capacity Analysis Tool
 
@@ -264,7 +269,7 @@ PLATFORM="$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 install -d %{buildroot}%{_bindir}
 
 # Install linux components
-for bin in oc openshift dockerregistry kubefed
+for bin in oc openshift dockerregistry kubefed template-service-broker
 do
   echo "+++ INSTALLING ${bin}"
   install -p -m 755 _output/local/bin/${PLATFORM}/${bin} %{buildroot}%{_bindir}/${bin}
@@ -616,6 +621,9 @@ fi
 %files cluster-capacity
 %{_bindir}/hypercc
 %{_bindir}/cluster-capacity
+
+%files template-service-broker
+%{_bindir}/template-service-broker
 
 
 %pretrans docker-excluder


### PR DESCRIPTION
My intent is to create the image in this PR too but I'm having trouble getting origin built at all right now.

```
++ Building go targets for linux/amd64: images/pod cmd/dockerregistry cmd/gitserver vendor/k8s.io/kubernetes/cmd/hyperkube pkg/network/sdn-cni-plugin vendor/github.com/containernetworking/cni/plugins/ipam/host-local vendor/github.com/containernetworking/cni/plugins/main/loopback examples/hello-openshift
can't load package: package github.com/openshift/origin/pkg/network/sdn-cni-plugin: cannot find package "github.com/openshift/origin/pkg/network/sdn-cni-plugin" in any of:
        /usr/lib/golang/src/github.com/openshift/origin/pkg/network/sdn-cni-plugin (from $GOROOT)
        /home/rdu/sdodson/go/src/github.com/openshift/origin/pkg/network/sdn-cni-plugin (from $GOPATH)
[ERROR] PID 7568: hack/lib/build/binaries.sh:228: `GOOS=${platform%/*} GOARCH=${platform##*/} go install -pkgdir "${OS_OUTPUT_PKGDIR}/${platform}" -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_envvar:-}" -ldflags="${local_ldflags}" "${goflags[@]:+${goflags[@]}}" "${nonstatics[@]}"` exited with status 1.
[INFO]          Stack Trace: 
[INFO]            1: hack/lib/build/binaries.sh:228: `GOOS=${platform%/*} GOARCH=${platform##*/} go install -pkgdir "${OS_OUTPUT_PKGDIR}/${platform}" -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_envvar:-}" -ldflags="${local_ldflags}" "${goflags[@]:+${goflags[@]}}" "${nonstatics[@]}"`
[INFO]            2: hack/lib/build/binaries.sh:158: os::build::internal::build_binaries
[INFO]            3: hack/lib/build/binaries.sh:141: os::build::build_binaries
[INFO]            4: hack/build-cross.sh:75: os::build::build_static_binaries
[INFO]   Exiting with code 1.
[ERROR] PID 7462: hack/lib/build/binaries.sh:152: `local -a binaries=("$@")` exited with status 1.
[INFO]          Stack Trace: 
[INFO]            1: hack/lib/build/binaries.sh:152: `local -a binaries=("$@")`
[INFO]            2: hack/lib/build/binaries.sh:141: os::build::build_binaries
[INFO]            3: hack/build-cross.sh:75: os::build::build_static_binaries
[INFO]   Exiting with code 1.
error: Bad exit status from /var/tmp/rpm-tmp.uQabdB (%build)
```