### PR TITLE
 filter out 'turn this on' config structs for admission

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/patch.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/patch.go
@@ -1,0 +1,9 @@
+package admission
+
+var (
+	// FactoryFilterFn allows the injection of a global filter on all admission factory function.  This allows
+	// us to inject a filtering function for things like config rewriting just before construction.
+	FactoryFilterFn func(Factory) Factory = func(delegate Factory) Factory {
+		return delegate
+	}
+)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
@@ -98,7 +98,7 @@ func (ps *Plugins) getPlugin(name string, config io.Reader) (Interface, bool, er
 		return nil, true, nil
 	}
 
-	ret, err := f(config2)
+	ret, err := FactoryFilterFn(f)(config2)
 	return ret, true, err
 }
 


### PR DESCRIPTION
Alternative to https://github.com/openshift/origin/pull/16505 to allow our enablement of config.  I think this aligns more closely with a goal of calling the "normal" https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/admission.go#L78 path.

