### PR TITLE
only allow one admission chain for the apiserver

### DIFF
--- a/pkg/cmd/server/api/validation/master_test.go
+++ b/pkg/cmd/server/api/validation/master_test.go
@@ -274,6 +274,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 		options configapi.MasterConfig
 
 		warningFields []string
+		errorFields   []string
 	}{
 		{
 			name: "stock everything",
@@ -287,7 +288,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 					},
 				},
 			},
-			warningFields: []string{"kubernetesMasterConfig.admissionConfig.pluginOrderOverride"},
+			errorFields: []string{"kubernetesMasterConfig.admissionConfig.pluginOrderOverride"},
 		},
 		{
 			name: "specified kube admission order 02",
@@ -393,7 +394,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 					},
 				},
 			},
-			warningFields: []string{"kubernetesMasterConfig.admissionConfig.pluginConfig[foo]"},
+			errorFields: []string{"kubernetesMasterConfig.admissionConfig.pluginConfig"},
 		},
 	}
 
@@ -436,6 +437,21 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 				t.Errorf("%s: didn't find %q", tc.name, expectedField)
 			}
 		}
+
+		for _, expectedField := range tc.errorFields {
+			found := false
+			for _, result := range results.Errors {
+				if result.Field == expectedField {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("%s: didn't find %q", tc.name, expectedField)
+			}
+		}
+
 	}
 }
 

--- a/pkg/cmd/server/origin/admission/sync_test.go
+++ b/pkg/cmd/server/origin/admission/sync_test.go
@@ -38,11 +38,10 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 )
 
 func TestKubeAdmissionControllerUsage(t *testing.T) {
-	kubeAdmissionPlugins := &admission.Plugins{}
-	kubeapiserver.RegisterAllAdmissionPlugins(kubeAdmissionPlugins)
+	kubeapiserver.RegisterAllAdmissionPlugins(&admission.Plugins{})
 	registeredKubePlugins := sets.NewString(OriginAdmissionPlugins.Registered()...)
 
-	usedAdmissionPlugins := sets.NewString(KubeAdmissionPlugins...)
+	usedAdmissionPlugins := sets.NewString(kubeAdmissionPlugins...)
 
 	if missingPlugins := usedAdmissionPlugins.Difference(registeredKubePlugins); len(missingPlugins) != 0 {
 		t.Errorf("%v not found", missingPlugins.List())
@@ -58,7 +57,7 @@ func TestKubeAdmissionControllerUsage(t *testing.T) {
 }
 
 func TestAdmissionOnOffCoverage(t *testing.T) {
-	configuredAdmissionPlugins := sets.NewString(CombinedAdmissionControlPlugins...)
+	configuredAdmissionPlugins := sets.NewString(combinedAdmissionControlPlugins...)
 	allCoveredAdmissionPlugins := sets.String{}
 	allCoveredAdmissionPlugins.Insert(DefaultOnPlugins.List()...)
 	allCoveredAdmissionPlugins.Insert(DefaultOffPlugins.List()...)

--- a/pkg/cmd/server/origin/asset_apiserver_adapter.go
+++ b/pkg/cmd/server/origin/asset_apiserver_adapter.go
@@ -37,14 +37,7 @@ func getResourceOverrideConfig(masterConfigOptions configapi.MasterConfig) (*clu
 	if overrideConfig != nil {
 		return overrideConfig, nil
 	}
-	if masterConfigOptions.KubernetesMasterConfig == nil { // external kube gets you a nil pointer here
-		return nil, nil
-	}
-	overrideConfig, err = checkForOverrideConfig(masterConfigOptions.KubernetesMasterConfig.AdmissionConfig)
-	if err != nil {
-		return nil, err
-	}
-	return overrideConfig, nil
+	return nil, nil
 }
 
 // checkForOverrideConfig looks for ClusterResourceOverrideConfig plugin cfg in the admission PluginConfig

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -44,7 +44,6 @@ func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Confi
 	// most of the config actually remains the same.  We only need to mess with a couple items
 	genericConfig := kubeAPIServerConfig
 	// TODO try to stop special casing these.  We should all agree on them.
-	genericConfig.AdmissionControl = c.AdmissionControl
 	genericConfig.RESTOptionsGetter = c.RESTOptionsGetter
 
 	ret := &OpenshiftAPIConfig{

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -188,7 +188,7 @@ func setupAdmissionPluginTestConfig(t *testing.T, value string) string {
 func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
 	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
-		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
+		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 	})
 	defer fn()
 
@@ -206,8 +206,8 @@ func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
 	configFile := setupAdmissionPluginTestConfig(t, "plugin1configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
-		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
-		config.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
+		config.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin1": {
 				Location: configFile,
 			},
@@ -224,8 +224,8 @@ func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
-		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
-		config.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
+		config.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin1": {
 				Configuration: &testtypes.TestPluginConfig{
 					Data: "embeddedvalue1",
@@ -301,7 +301,7 @@ func TestAlwaysPullImagesOn(t *testing.T) {
 		t.Fatalf("error creating config: %v", err)
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"AlwaysPullImages": {
 			Configuration: &configapi.DefaultAdmissionConfig{},
 		},

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -114,12 +114,11 @@ func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.Cl
 	if masterConfig.KubernetesMasterConfig == nil {
 		masterConfig.KubernetesMasterConfig = &api.KubernetesMasterConfig{}
 	}
-	kubeMaster := masterConfig.KubernetesMasterConfig
-	if kubeMaster.AdmissionConfig.PluginConfig == nil {
-		kubeMaster.AdmissionConfig.PluginConfig = map[string]api.AdmissionPluginConfig{}
+	if masterConfig.AdmissionConfig.PluginConfig == nil {
+		masterConfig.AdmissionConfig.PluginConfig = map[string]api.AdmissionPluginConfig{}
 	}
 	// set our config as desired
-	kubeMaster.AdmissionConfig.PluginConfig[overrideapi.PluginName] =
+	masterConfig.AdmissionConfig.PluginConfig[overrideapi.PluginName] =
 		api.AdmissionPluginConfig{Configuration: pluginConfig}
 
 	// start up a server and return useful clients to that server

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -57,7 +57,7 @@ func TestEndpointAdmission(t *testing.T) {
 		t.Fatalf("error creating config: %v", err)
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		serviceadmit.RestrictedEndpointsPluginName: {
 			Configuration: &configapi.DefaultAdmissionConfig{},
 		},

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -886,8 +886,7 @@ func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, gett
 	if err != nil {
 		t.Fatalf("error getting master config: %#v", err)
 	}
-	masterConfig.AdmissionConfig.PluginOrderOverride = []string{"PodNodeSelector"}                        // remove most admission checks to make testing easier
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"PodNodeSelector"} // remove most admission checks to make testing easier
+	masterConfig.AdmissionConfig.PluginOrderOverride = []string{"PodNodeSelector"} // remove most admission checks to make testing easier
 	// enable APIs that are off by default
 	masterConfig.KubernetesMasterConfig.APIServerArguments = map[string][]string{
 		"runtime-config": {

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -63,7 +63,6 @@ func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *plugina
 		},
 	}
 	masterConfig.AdmissionConfig.PluginConfig = cfg
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = cfg
 
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
@@ -102,7 +101,6 @@ func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNo
 		},
 	}
 	masterConfig.AdmissionConfig.PluginConfig = cfg
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = cfg
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
 		t.Fatalf("error starting server: %v", err)

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -76,7 +76,7 @@ func setupRunOnceDurationTest(t *testing.T, pluginConfig *pluginapi.RunOnceDurat
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"RunOnceDuration": {
 			Configuration: pluginConfig,
 		},


### PR DESCRIPTION
We've been warning on setting different admission chains for multiple release. This blocks server start on it and removes all the extra code related to multiple chains.

@aveshagarwal you were in the area
@ironcladlou we've talked about this recently
@liggitt we talked about this long ago