### PR TITLE
more build metric massage; add unit test; adjust integration test

### DIFF
--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -119,26 +119,26 @@ Returns PLEG (pod lifecycle event generator) latency metrics.  This represents t
 
 ### OpenShift build related queries
 
-> count(openshift_build_running_phase_start_time_seconds{} < time() - 600)
+> count(openshift_build_active_time_seconds{phase="running"} < time() - 600)
 
 Returns the number of builds that have been running for more than 10 minutes (600 seconds).
 
-> count(openshift_build_new_pending_phase_creation_time_seconds{} < time() - 600)
+> count(openshift_build_active_time_seconds{phase="pending"} < time() - 600)
 
 Returns the number of build that have been waiting at least 10 minutes (600 seconds) to start.
 
-> sum(openshift_build_failed_phase_total{})
+> sum(openshift_build_total{phase="failed"})
 
 Returns the number of failed builds, regardless of the failure reason.
 
-> sum(openshift_build_terminal_phase_total{phase="complete"})
+> openshift_build_total{phase="failed",reason="fetchsourcefailed"}
+
+Returns the number of failed builds because of problems retrieving source from the associated Git repository.
+
+> sum(openshift_build_total{phase="complete"})
 
 Returns the number of successfully completed builds.
 
-> openshift_build_failed_phase_total{}
-
-Returns the latest totals, per failure reason, for any failed builds.
-
-> openshift_build_failed_phase_total{} offset 5m
+> openshift_build_total{phase="failed"} offset 5m
 
 Returns the failed builds totals, per failure reason, from 5 minutes ago.

--- a/pkg/build/metrics/prometheus/metrics_test.go
+++ b/pkg/build/metrics/prometheus/metrics_test.go
@@ -1,0 +1,138 @@
+package prometheus
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	internalversion "github.com/openshift/origin/pkg/build/generated/listers/build/internalversion"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type fakeLister []*buildapi.Build
+
+func (f fakeLister) List(labels.Selector) ([]*buildapi.Build, error) {
+	return f, nil
+}
+func (fakeLister) Builds(string) internalversion.BuildNamespaceLister {
+	return nil
+}
+
+type fakeResponseWriter struct {
+	bytes.Buffer
+	statusCode int
+	header     http.Header
+}
+
+func (f *fakeResponseWriter) Header() http.Header {
+	return f.header
+}
+
+func (f *fakeResponseWriter) WriteHeader(statusCode int) {
+	f.statusCode = statusCode
+}
+
+func TestMetrics(t *testing.T) {
+	// went per line vs. a block of expected test in case assumptions on ordering are subverted, as well as defer on
+	// getting newlines right
+	expectedResponse := []string{
+		"# HELP openshift_build_total Counts builds by phase and reason",
+		"# TYPE openshift_build_total gauge",
+		"openshift_build_total{phase=\"cancelled\",reason=\"\"} 1",
+		"openshift_build_total{phase=\"complete\",reason=\"\"} 1",
+		"openshift_build_total{phase=\"error\",reason=\"\"} 1",
+		"openshift_build_total{phase=\"failed\",reason=\"exceededretrytimeout\"} 1",
+		"# HELP openshift_build_active_time_seconds Shows the last transition time in unix epoch for running builds by namespace, name, and phase",
+		"# TYPE openshift_build_active_time_seconds gauge",
+		"openshift_build_active_time_seconds{name=\"testname1\",namespace=\"testnamespace\",phase=\"new\"} 123",
+		"openshift_build_active_time_seconds{name=\"testname2\",namespace=\"testnamespace\",phase=\"pending\"} 123",
+		"openshift_build_active_time_seconds{name=\"testname3\",namespace=\"testnamespace\",phase=\"running\"} 123",
+	}
+	registry := prometheus.NewRegistry()
+
+	buildLister := &fakeLister{
+		{
+			Status: buildapi.BuildStatus{
+				Phase: buildapi.BuildPhaseComplete,
+			},
+		},
+		{
+			Status: buildapi.BuildStatus{
+				Phase: buildapi.BuildPhaseCancelled,
+			},
+		},
+		{
+			Status: buildapi.BuildStatus{
+				Phase: buildapi.BuildPhaseError,
+			},
+		},
+		{
+			Status: buildapi.BuildStatus{
+				Phase:  buildapi.BuildPhaseFailed,
+				Reason: buildapi.StatusReasonExceededRetryTimeout,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testnamespace",
+				Name:      "testname1",
+				CreationTimestamp: metav1.Time{
+					Time: time.Unix(123, 0),
+				},
+			},
+			Status: buildapi.BuildStatus{
+				Phase: buildapi.BuildPhaseNew,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testnamespace",
+				Name:      "testname2",
+				CreationTimestamp: metav1.Time{
+					Time: time.Unix(123, 0),
+				},
+			},
+			Status: buildapi.BuildStatus{
+				Phase: buildapi.BuildPhasePending,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testnamespace",
+				Name:      "testname3",
+			},
+			Status: buildapi.BuildStatus{
+				Phase: buildapi.BuildPhaseRunning,
+				StartTimestamp: &metav1.Time{
+					Time: time.Unix(123, 0),
+				},
+			},
+		},
+	}
+
+	bc := buildCollector{
+		lister: buildLister,
+	}
+
+	registry.MustRegister(&bc)
+
+	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.PanicOnError})
+	rw := &fakeResponseWriter{header: http.Header{}}
+	h.ServeHTTP(rw, &http.Request{})
+
+	respStr := rw.String()
+
+	for _, s := range expectedResponse {
+		if !strings.Contains(respStr, s) {
+			t.Errorf("expected string %s did not appear in %s", s, respStr)
+		}
+	}
+}

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -15,7 +15,7 @@ var metricsRegexp = regexp.MustCompile("(?m)^# HELP ([^ ]*)")
 
 func TestMetrics(t *testing.T) {
 	expectedMetrics := []string{
-		"openshift_build_terminal_phase_total",
+		"openshift_build_total",
 		"openshift_template_instance_total",
 	}
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/16613
- another rev or metric tweaks
  a) include reason in count/gauge
  b) include active phases in count/gauge
  c) merge successful and failed builds (no longer worry if reason empty string)
  d) converge new/pending/running in one constant time metric
- mimic @jim-minter 's approach for metric unit test 
- adjust integration and extended tests for metric changes

@openshift/devex ptal