### PR TITLE
Fix route checking in alreadySetUp

### DIFF
--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -89,9 +89,9 @@ func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR string, clusterNetwo
 	if err != nil {
 		return false
 	}
-	for _, route := range routes {
+	for _, clusterCIDR := range clusterNetworkCIDR {
 		found = false
-		for _, clusterCIDR := range clusterNetworkCIDR {
+		for _, route := range routes {
 			if route.Dst != nil && route.Dst.String() == clusterCIDR {
 				found = true
 				break


### PR DESCRIPTION
We want to check that each cluster network has a corresponding route, not that each route has a corresponding cluster network.

Fixes #16630 
