### PR TITLE
Cleanup: Multiple cluster network CIDR validation

### DIFF
--- a/pkg/network/apis/network/validation/validation.go
+++ b/pkg/network/apis/network/validation/validation.go
@@ -28,22 +28,7 @@ func ValidateClusterNetwork(clusterNet *networkapi.ClusterNetwork) field.ErrorLi
 	allErrs := validation.ValidateObjectMeta(&clusterNet.ObjectMeta, false, path.ValidatePathSegmentName, field.NewPath("metadata"))
 	var testedCIDRS []*net.IPNet
 
-	if len(clusterNet.Network) != 0 || clusterNet.HostSubnetLength != 0 {
-		//In the case that a user manually makes a clusterNetwork object with clusterNet.Network and clusterNet.HostubnetLength at least make sure they are valid values
-		clusterIPNet, err := netutils.ParseCIDRMask(clusterNet.Network)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("network"), clusterNet.Network, err.Error()))
-		} else {
-			maskLen, addrLen := clusterIPNet.Mask.Size()
-			if clusterNet.HostSubnetLength > uint32(addrLen-maskLen) {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), clusterNet.HostSubnetLength, "subnet length is too large for clusterNetwork"))
-			} else if clusterNet.HostSubnetLength < 2 {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("hostSubnetLength"), clusterNet.HostSubnetLength, "subnet length must be at least 2"))
-			}
-		}
-	}
-
-	if len(clusterNet.ClusterNetworks) == 0 && len(clusterNet.Network) == 0 {
+	if len(clusterNet.ClusterNetworks) == 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("clusterNetworks"), clusterNet.ClusterNetworks, "must have at least one cluster network CIDR"))
 	}
 	serviceIPNet, err := netutils.ParseCIDRMask(clusterNet.ServiceNetwork)


### PR DESCRIPTION
Removed old network and hostsubnetlength validations.
Rationale:
  - Conversions are already applied before we do validations,
    so these old values doesn't matter and all of our code only
    operates on new clusterNetworks object.
  - Even if network/hostsubnetlength fields are manually set
    through create/update REST api, we will catch that error
    as 'cannot change the default ClusterNetwork record via API'.