### PR TITLE
Switch from defaulting to converting clusterNetworkCIDR

### DIFF
--- a/pkg/cmd/server/api/serialization_test.go
+++ b/pkg/cmd/server/api/serialization_test.go
@@ -112,14 +112,22 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 					obj.NetworkConfig.ServiceNetworkCIDR = "10.0.0.0/24"
 				}
 			}
-			if len(obj.NetworkConfig.ClusterNetworks) == 0 {
-				clusterNetwork := []configapi.ClusterNetworkEntry{
-					{
-						CIDR:             "10.128.0.0/14",
-						HostSubnetLength: 9,
-					},
+			if c.RandBool() {
+				if len(obj.NetworkConfig.ClusterNetworks) == 0 {
+					clusterNetwork := []configapi.ClusterNetworkEntry{
+						{
+							CIDR:             "10.128.0.0/14",
+							HostSubnetLength: 9,
+						},
+					}
+					obj.NetworkConfig.ClusterNetworks = clusterNetwork
 				}
-				obj.NetworkConfig.ClusterNetworks = clusterNetwork
+				obj.NetworkConfig.DeprecatedClusterNetworkCIDR = obj.NetworkConfig.ClusterNetworks[0].CIDR
+				obj.NetworkConfig.DeprecatedHostSubnetLength = obj.NetworkConfig.ClusterNetworks[0].HostSubnetLength
+			} else {
+				obj.NetworkConfig.ClusterNetworks = nil
+				obj.NetworkConfig.DeprecatedClusterNetworkCIDR = ""
+				obj.NetworkConfig.DeprecatedHostSubnetLength = 0
 			}
 
 			// TODO stop duplicating the conversion in the test.

--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -849,10 +849,10 @@ func ValidateIngressIPNetworkCIDR(config *api.MasterConfig, fldPath *field.Path)
 func ValidateDeprecatedClusterNetworkConfig(config *api.MasterConfig, fldPath *field.Path) ValidationResults {
 	validationResults := ValidationResults{}
 
-	if len(config.NetworkConfig.ClusterNetworks) > 0 && config.NetworkConfig.DeprecatedHostSubnetLength != 0 {
+	if len(config.NetworkConfig.ClusterNetworks) > 0 && config.NetworkConfig.DeprecatedHostSubnetLength != config.NetworkConfig.ClusterNetworks[0].HostSubnetLength {
 		validationResults.AddErrors(field.Invalid(fldPath.Child("hostSubnetLength"), config.NetworkConfig.DeprecatedHostSubnetLength, "cannot set hostSubnetLength and clusterNetworks, please use clusterNetworks"))
 	}
-	if len(config.NetworkConfig.ClusterNetworks) > 0 && config.NetworkConfig.DeprecatedClusterNetworkCIDR != "" {
+	if len(config.NetworkConfig.ClusterNetworks) > 0 && config.NetworkConfig.DeprecatedClusterNetworkCIDR != config.NetworkConfig.ClusterNetworks[0].CIDR {
 		validationResults.AddErrors(field.Invalid(fldPath.Child("clusterNetworkCIDR"), config.NetworkConfig.DeprecatedClusterNetworkCIDR, "cannot set clusterNetworkCIDR and clusterNetworks, please use clusterNetworks"))
 	}
 	return validationResults


### PR DESCRIPTION
Fixes break. On disk, deprecated fields override the first value in
the clusterNetworks array if specified. When writing out, the deprecated
fields are set to the first value of the network CIDR.

Fixes #16627

This fixes oc cluster up. @csrwng @JacobTanenbaum 