### PR TITLE
format error returned from failed templateinstance less unpleasantly

### DIFF
--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -158,7 +158,7 @@ func (c *TemplateInstanceController) sync(key string) error {
 				Type:    templateapi.TemplateInstanceInstantiateFailure,
 				Status:  kapi.ConditionTrue,
 				Reason:  "Failed",
-				Message: err.Error(),
+				Message: formatError(err),
 			})
 		}
 	}
@@ -174,7 +174,7 @@ func (c *TemplateInstanceController) sync(key string) error {
 				Type:    templateapi.TemplateInstanceInstantiateFailure,
 				Status:  kapi.ConditionTrue,
 				Reason:  "Failed",
-				Message: err.Error(),
+				Message: formatError(err),
 			})
 			templateInstance.SetCondition(templateapi.TemplateInstanceCondition{
 				Type:    templateapi.TemplateInstanceReady,
@@ -546,4 +546,18 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 	}
 
 	return nil
+}
+
+// formatError returns err.Error(), unless err is an Aggregate, in which case it
+// "\n"-separates the contained errors.
+func formatError(err error) string {
+	if err, ok := err.(kerrs.Aggregate); ok {
+		var errorStrings []string
+		for _, err := range err.Errors() {
+			errorStrings = append(errorStrings, err.Error())
+		}
+		return strings.Join(errorStrings, "\n")
+	}
+
+	return err.Error()
 }


### PR DESCRIPTION
```
# oc get templateinstances a71f7ab8-e448-4826-8f05-32a185222dd8 -o yaml
...
status:
  conditions:
  - lastTransitionTime: 2017-10-03T18:11:30Z
    message: |-
      secrets "cakephp-mysql-example" already exists
      services "cakephp-mysql-example" already exists
      routes "cakephp-mysql-example" already exists
      imagestreams "cakephp-mysql-example" already exists
      buildconfigs "cakephp-mysql-example" already exists
      deploymentconfigs "cakephp-mysql-example" already exists
      services "mysql" already exists
      deploymentconfigs "mysql" already exists
    reason: Failed
    status: "True"
    type: InstantiateFailure
```

@spadgett @rhamilto