### PR TITLE
UPSTREAM: 52168: Fix incorrect status msg in podautoscaler

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/podautoscaler/horizontal.go
@@ -452,7 +452,14 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 			desiredReplicas = scaleUpLimit
 		case hpa.Spec.MinReplicas != nil && desiredReplicas < *hpa.Spec.MinReplicas:
 			// make sure we aren't below our minimum
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was less than the minimum replica count")
+			var statusMsg string
+			if desiredReplicas == 0 {
+				statusMsg = "the desired replica count was zero"
+			} else {
+				statusMsg = "the desired replica count was less than the minimum replica count"
+			}
+
+			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", statusMsg)
 			desiredReplicas = *hpa.Spec.MinReplicas
 		case desiredReplicas == 0:
 			//  never scale down to 0, reserved for disabling autoscaling


### PR DESCRIPTION
This cherry-picks kubernetes/kubernetes#52168. It is mainly a cosmetic issue, as the fix changes the HPA status conditions to convey better information, but the initial information was not technically incorrect.

Fixes bug 1493347
https://bugzilla.redhat.com/show_bug.cgi?id=1493347