### PR TITLE
UPSTREAM: 53464: use unstructured builder - oc export

### DIFF
--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -141,12 +141,44 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		newInfos := []*resource.Info{}
 		errs := []error{}
 		for _, info := range infos {
+			converted := false
+
+			// convert unstructured object to runtime.Object
+			data, err := runtime.Encode(kapi.Codecs.LegacyCodec(), info.Object)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			decoded, err := runtime.Decode(f.Decoder(true), data)
+			if err == nil {
+				// ignore error, if any, in order to allow resources
+				// not known by the client to still be exported
+				info.Object = decoded
+				converted = true
+			}
+
 			if err := exporter.Export(info.Object, exact); err != nil {
 				if err == ErrExportOmit {
 					continue
 				}
 				errs = append(errs, err)
 			}
+
+			// if an unstructured resource was successfully converted by the universal decoder,
+			// re-convert that object once again into its external version.
+			// If object cannot be converted to an external version, ignore error and proceed with
+			// internal version.
+			if converted {
+				if data, err = runtime.Encode(kapi.Codecs.LegacyCodec(outputVersion), info.Object); err == nil {
+					external, err := runtime.Decode(f.Decoder(false), data)
+					if err != nil {
+						errs = append(errs, fmt.Errorf("error: failed to convert resource to external version: %v", err))
+						continue
+					}
+					info.Object = external
+				}
+			}
+
 			newInfos = append(newInfos, info)
 		}
 		if len(errs) > 0 {

--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -110,8 +110,17 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		return err
 	}
 
-	mapper, typer := f.Object()
-	b := f.NewBuilder(true).
+	builder, err := f.NewUnstructuredBuilder(true)
+	if err != nil {
+		return err
+	}
+
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
+	b := builder.
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: filenames}).
 		SelectorParam(selector).

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -392,6 +392,10 @@ func (u *Unstructured) GetCreationTimestamp() metav1.Time {
 
 func (u *Unstructured) SetCreationTimestamp(timestamp metav1.Time) {
 	ts, _ := timestamp.MarshalQueryParameter()
+	if len(ts) == 0 {
+		u.setNestedField(nil, "metadata", "creationTimestamp")
+		return
+	}
 	u.setNestedField(ts, "metadata", "creationTimestamp")
 }
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1496755

Use unstructured builder to obtain resources before exporting.
This allows us to support service-catalog resources.

**Before**
```
$ oc export serviceinstance/my-service-instance
the provided version "servicecatalog.k8s.io/v1alpha1" has no relevant versions: group servicecatalog.k8s.io has not been registered
no matches for servicecatalog.k8s.io/, Kind=ServiceInstance
```

**After**
```
$ oc export serviceinstance/my-service-instance
apiVersion: servicecatalog.k8s.io/v1alpha1
kind: ServiceInstance
metadata:
  creationTimestamp: ""
  deletionTimestamp: null
  finalizers:
  - kubernetes-incubator/service-catalog
  generation: 1
  name: my-service-instance
  namespace: ""
...
```

cc @openshift/cli-review 