### PR TITLE
apps: tweak some deployment extended test for speed

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -470,15 +470,15 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			g.By("verifying that status.replicas is set")
 			replicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.replicas}\"").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(replicas).To(o.ContainSubstring("2"))
+			o.Expect(replicas).To(o.ContainSubstring("1"))
 			g.By("verifying that status.updatedReplicas is set")
 			updatedReplicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.updatedReplicas}\"").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(updatedReplicas).To(o.ContainSubstring("2"))
+			o.Expect(updatedReplicas).To(o.ContainSubstring("1"))
 			g.By("verifying that status.availableReplicas is set")
 			availableReplicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.availableReplicas}\"").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(availableReplicas).To(o.ContainSubstring("2"))
+			o.Expect(availableReplicas).To(o.ContainSubstring("1"))
 			g.By("verifying that status.unavailableReplicas is set")
 			unavailableReplicas, err := oc.Run("get").Args(resource, "--output=jsonpath=\"{.status.unavailableReplicas}\"").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -778,7 +778,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 		})
 	})
 
-	g.Describe("reaper [Conformance]", func() {
+	g.Describe("reaper [Conformance][Slow]", func() {
 		g.AfterEach(func() {
 			failureTrap(oc, "brokendeployment", g.CurrentGinkgoTestDescription().Failed)
 		})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -1922,7 +1922,7 @@ spec:
         name: history-limit
     spec:
       containers:
-      - image: "docker.io/alpine:3.6"
+      - image: "docker.io/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:
@@ -2114,7 +2114,7 @@ kind: DeploymentConfig
 metadata:
   name: deployment-simple
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     name: deployment-simple
   strategy:

--- a/test/extended/testdata/deployments/deployment-history-limit.yaml
+++ b/test/extended/testdata/deployments/deployment-history-limit.yaml
@@ -12,7 +12,7 @@ spec:
         name: history-limit
     spec:
       containers:
-      - image: "docker.io/alpine:3.6"
+      - image: "docker.io/centos:centos7"
         imagePullPolicy: IfNotPresent
         name: myapp
         command:

--- a/test/extended/testdata/deployments/deployment-simple.yaml
+++ b/test/extended/testdata/deployments/deployment-simple.yaml
@@ -3,7 +3,7 @@ kind: DeploymentConfig
 metadata:
   name: deployment-simple
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     name: deployment-simple
   strategy:


### PR DESCRIPTION
This optimize some deployment tests by using the common image for testing (not alpine..). 
Also marks the reaper test as slow, because for some reason it is slow.
And changing the simple deployment fixture to be 1 replica instead of 2 (we don't test the replica counts anywhere anyway).