### PR TITLE
preserve imagestream "imported-from" annotation value

### DIFF
--- a/pkg/generate/app/imageref.go
+++ b/pkg/generate/app/imageref.go
@@ -313,8 +313,7 @@ func (r *ImageRef) ImageStream() (*imageapi.ImageStream, error) {
 		stream.Spec.Tags = make(map[string]imageapi.TagReference)
 	}
 	stream.Spec.Tags[r.InternalTag()] = imageapi.TagReference{
-		// Make this a constant
-		Annotations: map[string]string{"openshift.io/imported-from": r.Reference.Exact()},
+		Annotations: map[string]string{imageapi.ImportedFromAnnotation: r.Reference.Exact()},
 		From: &kapi.ObjectReference{
 			Kind: "DockerImage",
 			Name: r.PullSpec(),

--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -19,6 +19,9 @@ const (
 	// ManagedByOpenShiftAnnotation indicates that an image is managed by OpenShift's registry.
 	ManagedByOpenShiftAnnotation = "openshift.io/image.managed"
 
+	// ImportedFromAnnotation indicates the original source repository of an imagestream.
+	ImportedFromAnnotation = "openshift.io/imported-from"
+
 	// DockerImageRepositoryCheckAnnotation indicates that OpenShift has
 	// attempted to import tag and image information from an external Docker
 	// image repository.

--- a/pkg/oc/cli/cmd/exporter.go
+++ b/pkg/oc/cli/cmd/exporter.go
@@ -208,6 +208,17 @@ func (e *DefaultExporter) Export(obj runtime.Object, exact bool) error {
 			}
 			for name, ref := range t.Spec.Tags {
 				if _, ok := t.Status.Tags[name]; ok {
+					// if the original spec tag contained an ImportedFromAnnotation,
+					// replace the status tag with it
+					if origSrc, ok := ref.Annotations[imageapi.ImportedFromAnnotation]; ok {
+						newTag, exists := newSpec.Tags[name]
+						if !exists {
+							continue
+						}
+						newTag.From.Name = origSrc
+						newSpec.Tags[name] = newTag
+					}
+
 					continue
 				}
 				// TODO: potentially trim some of these


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1497623

Prevent the value of an imagestream Spec tag from being replaced with
refs from its Status tag if the Spec tag contains an `imported-from` annotation.
This prevents errors resolving the image repository when the imagestream
resource is re-created from the exported object.

cc @openshift/cli-review 