### PR TITLE
UPSTREAM: kubernetes-incubator/cluster-capacity: <drop>: update OWNERS

### DIFF
--- a/cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/OWNERS
+++ b/cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/OWNERS
@@ -1,3 +1,8 @@
-ingvagabund
-aveshagarwal
-hodovska
+reviewers:
+  - ingvagabund
+  - aveshagarwal
+  - hodovska
+approvers:
+  - ingvagabund
+  - aveshagarwal
+  - hodovska


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Same rationale as https://github.com/openshift/origin/pull/15463

Currently breaking our merge queue