### PR TITLE
 use the upstream admission plugin construction for most plugins

### DIFF
--- a/pkg/assets/apiserver/asset_apiserver.go
+++ b/pkg/assets/apiserver/asset_apiserver.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	oauthutil "github.com/openshift/origin/pkg/oauth/util"
-	clusterresourceoverrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 	"github.com/openshift/origin/pkg/util/httprequest"
 	oversion "github.com/openshift/origin/pkg/version"
 )
@@ -44,8 +43,7 @@ const (
 type AssetServerConfig struct {
 	GenericConfig *genericapiserver.Config
 
-	Options               oapi.AssetConfig
-	LimitRequestOverrides *clusterresourceoverrideapi.ClusterResourceOverrideConfig
+	Options oapi.AssetConfig
 
 	PublicURL url.URL
 }
@@ -218,20 +216,19 @@ func (c *completedAssetServerConfig) addWebConsoleConfig(serverMux *genericmux.P
 
 	// Generated web console config and server version
 	config := assets.WebConsoleConfig{
-		APIGroupAddr:          masterURL.Host,
-		APIGroupPrefix:        server.APIGroupPrefix,
-		MasterAddr:            masterURL.Host,
-		MasterPrefix:          api.Prefix,
-		KubernetesAddr:        masterURL.Host,
-		KubernetesPrefix:      server.DefaultLegacyAPIPrefix,
-		OAuthAuthorizeURI:     oauthutil.OpenShiftOAuthAuthorizeURL(masterURL.String()),
-		OAuthTokenURI:         oauthutil.OpenShiftOAuthTokenURL(masterURL.String()),
-		OAuthRedirectBase:     c.Options.PublicURL,
-		OAuthClientID:         OpenShiftWebConsoleClientID,
-		LogoutURI:             c.Options.LogoutURL,
-		LoggingURL:            c.Options.LoggingPublicURL,
-		MetricsURL:            c.Options.MetricsPublicURL,
-		LimitRequestOverrides: c.LimitRequestOverrides,
+		APIGroupAddr:      masterURL.Host,
+		APIGroupPrefix:    server.APIGroupPrefix,
+		MasterAddr:        masterURL.Host,
+		MasterPrefix:      api.Prefix,
+		KubernetesAddr:    masterURL.Host,
+		KubernetesPrefix:  server.DefaultLegacyAPIPrefix,
+		OAuthAuthorizeURI: oauthutil.OpenShiftOAuthAuthorizeURL(masterURL.String()),
+		OAuthTokenURI:     oauthutil.OpenShiftOAuthTokenURL(masterURL.String()),
+		OAuthRedirectBase: c.Options.PublicURL,
+		OAuthClientID:     OpenShiftWebConsoleClientID,
+		LogoutURI:         c.Options.LogoutURL,
+		LoggingURL:        c.Options.LoggingPublicURL,
+		MetricsURL:        c.Options.MetricsPublicURL,
 	}
 	kVersionInfo := kversion.Get()
 	oVersionInfo := oversion.Get()

--- a/pkg/cmd/server/api/install/install.go
+++ b/pkg/cmd/server/api/install/install.go
@@ -5,6 +5,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/apis/apiserver"
+	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	"k8s.io/apiserver/pkg/apis/audit"
 	auditv1alpha1 "k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 
@@ -33,6 +35,8 @@ func init() {
 	// policy file inside master-config.yaml
 	audit.AddToScheme(configapi.Scheme)
 	auditv1alpha1.AddToScheme(configapi.Scheme)
+	apiserver.AddToScheme(configapi.Scheme)
+	apiserverv1alpha1.AddToScheme(configapi.Scheme)
 }
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {

--- a/pkg/cmd/server/api/latest/latest.go
+++ b/pkg/cmd/server/api/latest/latest.go
@@ -22,4 +22,8 @@ var OldestVersion = schema.GroupVersion{Group: "", Version: "v1"}
 // with a set of versions to choose.
 var Versions = []schema.GroupVersion{{Group: "", Version: "v1"}}
 
-var Codec = serializer.NewCodecFactory(configapi.Scheme).LegacyCodec(schema.GroupVersion{Group: "", Version: "v1"})
+var Codec = serializer.NewCodecFactory(configapi.Scheme).LegacyCodec(
+	schema.GroupVersion{Group: "", Version: "v1"},
+	schema.GroupVersion{Group: "apiserver.k8s.io", Version: "v1alpha1"},
+	schema.GroupVersion{Group: "audit.k8s.io", Version: "v1alpha1"},
+)

--- a/pkg/cmd/server/api/validation/master_test.go
+++ b/pkg/cmd/server/api/validation/master_test.go
@@ -274,6 +274,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 		options configapi.MasterConfig
 
 		warningFields []string
+		errorFields   []string
 	}{
 		{
 			name: "stock everything",
@@ -287,7 +288,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 					},
 				},
 			},
-			warningFields: []string{"kubernetesMasterConfig.admissionConfig.pluginOrderOverride"},
+			errorFields: []string{"kubernetesMasterConfig.admissionConfig.pluginOrderOverride"},
 		},
 		{
 			name: "specified kube admission order 02",
@@ -393,7 +394,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 					},
 				},
 			},
-			warningFields: []string{"kubernetesMasterConfig.admissionConfig.pluginConfig[foo]"},
+			errorFields: []string{"kubernetesMasterConfig.admissionConfig.pluginConfig"},
 		},
 	}
 
@@ -436,6 +437,21 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 				t.Errorf("%s: didn't find %q", tc.name, expectedField)
 			}
 		}
+
+		for _, expectedField := range tc.errorFields {
+			found := false
+			for _, result := range results.Errors {
+				if result.Field == expectedField {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("%s: didn't find %q", tc.name, expectedField)
+			}
+		}
+
 	}
 }
 

--- a/pkg/cmd/server/origin/admission/config_test.go
+++ b/pkg/cmd/server/origin/admission/config_test.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	overrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
@@ -107,14 +106,14 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		options               configapi.MasterConfig
-		admissionChainBuilder func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet kclientset.Interface, pluginInitializer admission.PluginInitializer) (admission.Interface, error)
+		admissionChainBuilder func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error)
 	}{
 		{
 			name: "stock everything",
 			options: configapi.MasterConfig{
 				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet kclientset.Interface, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
 				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
 					t.Errorf("%s: expected %v, got %v", "stock everything", combinedAdmissionControlPlugins, pluginNames)
 				}
@@ -129,7 +128,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 					PluginOrderOverride: []string{"foo"},
 				},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet kclientset.Interface, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
 				isKube := reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins)
 
 				expectedOrigin := []string{"foo"}
@@ -151,7 +150,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 					},
 				},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet kclientset.Interface, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
 				isKube := reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins)
 				isOrigin := reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins)
 				if !isKube && !isOrigin {
@@ -172,7 +171,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 					},
 				},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginConfig map[string]configapi.AdmissionPluginConfig, options configapi.MasterConfig, kubeClientSet kclientset.Interface, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
 				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
 					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 01", combinedAdmissionControlPlugins, pluginNames)
 				}
@@ -183,7 +182,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 
 	for _, tc := range testCases {
 		newAdmissionChainFunc = tc.admissionChainBuilder
-		_, _ = NewAdmissionChains(tc.options, nil, nil)
+		_, _ = NewAdmissionChains(tc.options, nil)
 	}
 }
 

--- a/pkg/cmd/server/origin/admission/sync_test.go
+++ b/pkg/cmd/server/origin/admission/sync_test.go
@@ -38,11 +38,10 @@ var admissionPluginsNotUsedByKube = sets.NewString(
 )
 
 func TestKubeAdmissionControllerUsage(t *testing.T) {
-	kubeAdmissionPlugins := &admission.Plugins{}
-	kubeapiserver.RegisterAllAdmissionPlugins(kubeAdmissionPlugins)
+	kubeapiserver.RegisterAllAdmissionPlugins(&admission.Plugins{})
 	registeredKubePlugins := sets.NewString(OriginAdmissionPlugins.Registered()...)
 
-	usedAdmissionPlugins := sets.NewString(KubeAdmissionPlugins...)
+	usedAdmissionPlugins := sets.NewString(kubeAdmissionPlugins...)
 
 	if missingPlugins := usedAdmissionPlugins.Difference(registeredKubePlugins); len(missingPlugins) != 0 {
 		t.Errorf("%v not found", missingPlugins.List())
@@ -58,7 +57,7 @@ func TestKubeAdmissionControllerUsage(t *testing.T) {
 }
 
 func TestAdmissionOnOffCoverage(t *testing.T) {
-	configuredAdmissionPlugins := sets.NewString(CombinedAdmissionControlPlugins...)
+	configuredAdmissionPlugins := sets.NewString(combinedAdmissionControlPlugins...)
 	allCoveredAdmissionPlugins := sets.String{}
 	allCoveredAdmissionPlugins.Insert(DefaultOnPlugins.List()...)
 	allCoveredAdmissionPlugins.Insert(DefaultOffPlugins.List()...)

--- a/pkg/cmd/server/origin/asset_apiserver_adapter.go
+++ b/pkg/cmd/server/origin/asset_apiserver_adapter.go
@@ -1,13 +1,8 @@
 package origin
 
 import (
-	"os"
-
 	assetapiserver "github.com/openshift/origin/pkg/assets/apiserver"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	"github.com/openshift/origin/pkg/cmd/util/pluginconfig"
-	"github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride"
-	clusterresourceoverrideapi "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride/api"
 )
 
 // TODO this is taking a very large config for a small piece of it.  The information must be broken up at some point so that
@@ -20,42 +15,9 @@ func NewAssetServerConfigFromMasterConfig(masterConfigOptions configapi.MasterCo
 
 	// this fix up indicates that our assetConfig lacks sufficient information
 	ret.GenericConfig.CorsAllowedOriginList = masterConfigOptions.CORSAllowedOrigins
-	ret.LimitRequestOverrides, err = getResourceOverrideConfig(masterConfigOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	return ret, nil
-}
-
-// getResourceOverrideConfig looks in two potential places where ClusterResourceOverrideConfig can be specified
-func getResourceOverrideConfig(masterConfigOptions configapi.MasterConfig) (*clusterresourceoverrideapi.ClusterResourceOverrideConfig, error) {
-	overrideConfig, err := checkForOverrideConfig(masterConfigOptions.AdmissionConfig)
-	if err != nil {
-		return nil, err
-	}
-	if overrideConfig != nil {
-		return overrideConfig, nil
-	}
-	return nil, nil
-}
-
-// checkForOverrideConfig looks for ClusterResourceOverrideConfig plugin cfg in the admission PluginConfig
-func checkForOverrideConfig(ac configapi.AdmissionConfig) (*clusterresourceoverrideapi.ClusterResourceOverrideConfig, error) {
-	overridePluginConfigFile, err := pluginconfig.GetPluginConfigFile(ac.PluginConfig, clusterresourceoverrideapi.PluginName, "")
-	if err != nil {
-		return nil, err
-	}
-	if overridePluginConfigFile == "" {
-		return nil, nil
-	}
-	configFile, err := os.Open(overridePluginConfigFile)
-	if err != nil {
-		return nil, err
-	}
-	overrideConfig, err := clusterresourceoverride.ReadConfig(configFile)
-	if err != nil {
-		return nil, err
-	}
-	return overrideConfig, nil
 }

--- a/pkg/cmd/server/origin/asset_apiserver_adapter.go
+++ b/pkg/cmd/server/origin/asset_apiserver_adapter.go
@@ -37,14 +37,7 @@ func getResourceOverrideConfig(masterConfigOptions configapi.MasterConfig) (*clu
 	if overrideConfig != nil {
 		return overrideConfig, nil
 	}
-	if masterConfigOptions.KubernetesMasterConfig == nil { // external kube gets you a nil pointer here
-		return nil, nil
-	}
-	overrideConfig, err = checkForOverrideConfig(masterConfigOptions.KubernetesMasterConfig.AdmissionConfig)
-	if err != nil {
-		return nil, err
-	}
-	return overrideConfig, nil
+	return nil, nil
 }
 
 // checkForOverrideConfig looks for ClusterResourceOverrideConfig plugin cfg in the admission PluginConfig

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -44,7 +44,6 @@ func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Confi
 	// most of the config actually remains the same.  We only need to mess with a couple items
 	genericConfig := kubeAPIServerConfig
 	// TODO try to stop special casing these.  We should all agree on them.
-	genericConfig.AdmissionControl = c.AdmissionControl
 	genericConfig.RESTOptionsGetter = c.RESTOptionsGetter
 
 	ret := &OpenshiftAPIConfig{

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -149,7 +149,7 @@ func BuildMasterConfig(
 	if err != nil {
 		return nil, err
 	}
-	admission, err := originadmission.NewAdmissionChains(options, kubeInternalClient, admissionInitializer)
+	admission, err := originadmission.NewAdmissionChains(options, admissionInitializer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/util/pluginconfig/config.go
+++ b/pkg/cmd/util/pluginconfig/config.go
@@ -2,15 +2,11 @@ package pluginconfig
 
 import (
 	"io/ioutil"
-	"os"
 
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	kapiserverinstall "k8s.io/apiserver/pkg/apis/apiserver/install"
-	kapiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/api/latest"
@@ -20,7 +16,6 @@ var (
 	groupFactoryRegistry = make(announced.APIGroupFactoryRegistry)
 	registry             = registered.NewOrDie("")
 	scheme               = runtime.NewScheme()
-	codecs               = serializer.NewCodecFactory(scheme)
 )
 
 func init() {
@@ -57,77 +52,6 @@ func GetPluginConfigFile(pluginConfig map[string]configapi.AdmissionPluginConfig
 	// global plugin config file (if any).
 	if cfg, hasConfig := pluginConfig[pluginName]; hasConfig {
 		configFilePath, err := GetPluginConfig(cfg)
-		if err != nil {
-			return "", err
-		}
-		return configFilePath, nil
-	}
-	return defaultConfigFilePath, nil
-}
-
-func GetAdmissionConfigurationConfig(pluginName string, cfg configapi.AdmissionPluginConfig) (string, error) {
-	if cfg.Configuration == nil && cfg.Location == "" {
-		return "", nil
-	}
-
-	var cfgJSON []byte
-	if cfg.Configuration == nil {
-		f, err := os.Open(cfg.Location)
-		if err != nil {
-			return "", err
-		}
-		data, err := ioutil.ReadAll(f)
-		if err != nil {
-			return "", err
-		}
-		cfgJSON, err = kyaml.ToJSON(data)
-		if err != nil {
-			return "", err
-		}
-	} else {
-		var err error
-		cfgJSON, err = runtime.Encode(latest.Codec, cfg.Configuration)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// convert into versioned admission plugin configuration
-	obj := kapiserverv1alpha1.AdmissionConfiguration{
-		Plugins: []kapiserverv1alpha1.AdmissionPluginConfiguration{
-			{
-				Name:          pluginName,
-				Configuration: runtime.RawExtension{Raw: cfgJSON},
-			},
-		},
-	}
-
-	configFile, err := ioutil.TempFile("", "admission-plugin-config")
-	if err != nil {
-		return "", err
-	}
-	if err = configFile.Close(); err != nil {
-		return "", err
-	}
-	codec := codecs.LegacyCodec(kapiserverv1alpha1.SchemeGroupVersion)
-	data, err := runtime.Encode(codec, &obj)
-	if err != nil {
-		return "", err
-	}
-	if err = ioutil.WriteFile(configFile.Name(), data, 0644); err != nil {
-		return "", err
-	}
-	return configFile.Name(), nil
-}
-
-// GetAdmissionConfigurationFile translates from the master plugin config to a file name containing
-// a particular plugin's config (the file may be a temp file if config is embedded), embedded in
-// k8s.io/apiserver/pkg/apis/apiserver.AdmissionConfiguration.
-func GetAdmissionConfigurationFile(pluginConfig map[string]configapi.AdmissionPluginConfig, pluginName string, defaultConfigFilePath string) (string, error) {
-	// Check whether a config is specified for this plugin. If not, default to the
-	// global plugin config file (if any).
-	if cfg, hasConfig := pluginConfig[pluginName]; hasConfig {
-		configFilePath, err := GetAdmissionConfigurationConfig(pluginName, cfg)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cmd/util/pluginconfig/config_test.go
+++ b/pkg/cmd/util/pluginconfig/config_test.go
@@ -1,15 +1,8 @@
 package pluginconfig
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	kapiserverinternal "k8s.io/apiserver/pkg/apis/apiserver"
-	kapiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -43,108 +36,5 @@ func TestGetPluginConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(testConfig, resultConfig) {
 		t.Errorf("Unexpected config. Expected: %#v. Got: %#v", testConfig, resultConfig)
-	}
-}
-
-func readAdmissionConfigurationFile(t *testing.T, fileName string, into runtime.Object) *kapiserverinternal.AdmissionConfiguration {
-	data, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	codec := configapi.Codecs.UniversalDecoder()
-	obj, err := runtime.Decode(codec, data)
-	if err != nil {
-		t.Fatalf("unexpected conversion error: %v", err)
-	}
-	admissionConfig, ok := obj.(*kapiserverinternal.AdmissionConfiguration)
-	if !ok {
-		t.Fatalf("expected kapiserverinternal.AdmissionConfiguration, got: %#v", obj)
-	}
-
-	if len(admissionConfig.Plugins) != 1 {
-		t.Fatalf("expected exactly one plugin config, got: %#v", admissionConfig.Plugins)
-	}
-
-	embeddedUnknown, ok := admissionConfig.Plugins[0].Configuration.(*runtime.Unknown)
-	if !ok {
-		t.Fatalf("expected embedded Unknown, got: %#v", admissionConfig.Plugins[0].Configuration)
-	}
-
-	err = runtime.DecodeInto(codec, embeddedUnknown.Raw, into)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return admissionConfig
-}
-
-func TestGetAdmissionConfigurationConfigWithConfiguration(t *testing.T) {
-	configapi.Scheme.AddKnownTypes(oapi.SchemeGroupVersion, &testtypes.TestConfig{})
-	configapi.Scheme.AddKnownTypeWithName(latest.Version.WithKind("TestConfig"), &testtypes.TestConfigV1{})
-	kapiserverv1alpha1.AddToScheme(configapi.Scheme)
-	kapiserverinternal.AddToScheme(configapi.Scheme)
-
-	testConfig := &testtypes.TestConfig{
-		Item1: "item1value",
-		Item2: []string{"element1", "element2"},
-	}
-
-	cfg := configapi.AdmissionPluginConfig{
-		Configuration: testConfig,
-	}
-	fileName, err := GetAdmissionConfigurationConfig("test", cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	resultConfig := &testtypes.TestConfig{}
-	admissionConfig := readAdmissionConfigurationFile(t, fileName, resultConfig)
-
-	if !reflect.DeepEqual(testConfig, resultConfig) {
-		t.Errorf("Unexpected config. Expected: %#v. Got: %#v", testConfig, admissionConfig.Plugins[0].Configuration)
-	}
-}
-
-func TestGetAdmissionConfigurationConfigWithLocation(t *testing.T) {
-	configapi.Scheme.AddKnownTypes(oapi.SchemeGroupVersion, &testtypes.TestConfig{})
-	configapi.Scheme.AddKnownTypeWithName(latest.Version.WithKind("TestConfig"), &testtypes.TestConfigV1{})
-	kapiserverv1alpha1.AddToScheme(configapi.Scheme)
-	kapiserverinternal.AddToScheme(configapi.Scheme)
-
-	f, err := ioutil.TempFile("", "plugin-config.yaml")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err = f.Close(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer os.Remove(f.Name())
-
-	testConfig := &testtypes.TestConfig{
-		Item1: "item1value",
-		Item2: []string{"element1", "element2"},
-	}
-
-	testJSON, err := json.Marshal(testConfig)
-	if err != nil {
-		t.Fatalf("unexpected conversion error: %v", err)
-	}
-	if err := ioutil.WriteFile(f.Name(), testJSON, 0644); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	cfg := configapi.AdmissionPluginConfig{
-		Location: f.Name(),
-	}
-	fileName, err := GetAdmissionConfigurationConfig("test", cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	resultConfig := &testtypes.TestConfig{}
-	admissionConfig := readAdmissionConfigurationFile(t, fileName, resultConfig)
-
-	if !reflect.DeepEqual(testConfig, resultConfig) {
-		t.Errorf("Unexpected config. Expected: %#v. Got: %#v", testConfig, admissionConfig.Plugins[0].Configuration)
 	}
 }

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -188,7 +188,7 @@ func setupAdmissionPluginTestConfig(t *testing.T, value string) string {
 func TestKubernetesAdmissionPluginOrderOverride(t *testing.T) {
 	registerAdmissionPlugins(t, "plugin1", "plugin2", "plugin3")
 	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
-		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
+		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
 	})
 	defer fn()
 
@@ -206,8 +206,8 @@ func TestKubernetesAdmissionPluginConfigFile(t *testing.T) {
 	configFile := setupAdmissionPluginTestConfig(t, "plugin1configvalue")
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
-		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
-		config.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
+		config.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin1": {
 				Location: configFile,
 			},
@@ -224,8 +224,8 @@ func TestKubernetesAdmissionPluginEmbeddedConfig(t *testing.T) {
 	registerAdmissionPluginTestConfigType()
 	registerAdmissionPlugins(t, "plugin1", "plugin2")
 	kubeClient, _, fn := setupAdmissionTest(t, func(config *configapi.MasterConfig) {
-		config.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
-		config.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+		config.AdmissionConfig.PluginOrderOverride = []string{"plugin1", "plugin2"}
+		config.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 			"plugin1": {
 				Configuration: &testtypes.TestPluginConfig{
 					Data: "embeddedvalue1",
@@ -301,7 +301,7 @@ func TestAlwaysPullImagesOn(t *testing.T) {
 		t.Fatalf("error creating config: %v", err)
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"AlwaysPullImages": {
 			Configuration: &configapi.DefaultAdmissionConfig{},
 		},

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -114,12 +114,11 @@ func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.Cl
 	if masterConfig.KubernetesMasterConfig == nil {
 		masterConfig.KubernetesMasterConfig = &api.KubernetesMasterConfig{}
 	}
-	kubeMaster := masterConfig.KubernetesMasterConfig
-	if kubeMaster.AdmissionConfig.PluginConfig == nil {
-		kubeMaster.AdmissionConfig.PluginConfig = map[string]api.AdmissionPluginConfig{}
+	if masterConfig.AdmissionConfig.PluginConfig == nil {
+		masterConfig.AdmissionConfig.PluginConfig = map[string]api.AdmissionPluginConfig{}
 	}
 	// set our config as desired
-	kubeMaster.AdmissionConfig.PluginConfig[overrideapi.PluginName] =
+	masterConfig.AdmissionConfig.PluginConfig[overrideapi.PluginName] =
 		api.AdmissionPluginConfig{Configuration: pluginConfig}
 
 	// start up a server and return useful clients to that server

--- a/test/integration/endpoint_admission_test.go
+++ b/test/integration/endpoint_admission_test.go
@@ -57,7 +57,7 @@ func TestEndpointAdmission(t *testing.T) {
 		t.Fatalf("error creating config: %v", err)
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		serviceadmit.RestrictedEndpointsPluginName: {
 			Configuration: &configapi.DefaultAdmissionConfig{},
 		},

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -886,8 +886,7 @@ func testEtcdStoragePath(t *testing.T, etcdServer *etcdtest.EtcdTestServer, gett
 	if err != nil {
 		t.Fatalf("error getting master config: %#v", err)
 	}
-	masterConfig.AdmissionConfig.PluginOrderOverride = []string{"PodNodeSelector"}                        // remove most admission checks to make testing easier
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginOrderOverride = []string{"PodNodeSelector"} // remove most admission checks to make testing easier
+	masterConfig.AdmissionConfig.PluginOrderOverride = []string{"PodNodeSelector"} // remove most admission checks to make testing easier
 	// enable APIs that are off by default
 	masterConfig.KubernetesMasterConfig.APIServerArguments = map[string][]string{
 		"runtime-config": {

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -63,7 +63,6 @@ func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *plugina
 		},
 	}
 	masterConfig.AdmissionConfig.PluginConfig = cfg
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = cfg
 
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
@@ -102,7 +101,6 @@ func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNo
 		},
 	}
 	masterConfig.AdmissionConfig.PluginConfig = cfg
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = cfg
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
 		t.Fatalf("error starting server: %v", err)

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -76,7 +76,7 @@ func setupRunOnceDurationTest(t *testing.T, pluginConfig *pluginapi.RunOnceDurat
 	if err != nil {
 		t.Fatalf("error creating config: %v", err)
 	}
-	masterConfig.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig = map[string]configapi.AdmissionPluginConfig{
 		"RunOnceDuration": {
 			Configuration: pluginConfig,
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/conversion.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/conversion.go
@@ -1,0 +1,70 @@
+package v1alpha1
+
+import (
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ runtime.NestedObjectDecoder = &AdmissionConfiguration{}
+
+// DecodeNestedObjects handles encoding RawExtensions on the AdmissionConfiguration, ensuring the
+// objects are decoded with the provided decoder.
+func (c *AdmissionConfiguration) DecodeNestedObjects(d runtime.Decoder) error {
+	// decoding failures result in a runtime.Unknown object being created in Object and passed
+	// to conversion
+	for k, v := range c.Plugins {
+		decodeNestedRawExtensionOrUnknown(d, &v.Configuration)
+		c.Plugins[k] = v
+	}
+	return nil
+}
+
+var _ runtime.NestedObjectEncoder = &AdmissionConfiguration{}
+
+// EncodeNestedObjects handles encoding RawExtensions on the AdmissionConfiguration, ensuring the
+// objects are encoded with the provided encoder.
+func (c *AdmissionConfiguration) EncodeNestedObjects(e runtime.Encoder) error {
+	for k, v := range c.Plugins {
+		if err := encodeNestedRawExtension(e, &v.Configuration); err != nil {
+			return err
+		}
+		c.Plugins[k] = v
+	}
+	return nil
+}
+
+func decodeNestedRawExtensionOrUnknown(d runtime.Decoder, ext *runtime.RawExtension) {
+	if ext.Raw == nil || ext.Object != nil {
+		return
+	}
+	obj, gvk, err := d.Decode(ext.Raw, nil, nil)
+	if err != nil {
+		unk := &runtime.Unknown{Raw: ext.Raw}
+		if runtime.IsNotRegisteredError(err) {
+			if _, gvk, err := d.Decode(ext.Raw, nil, unk); err == nil {
+				unk.APIVersion = gvk.GroupVersion().String()
+				unk.Kind = gvk.Kind
+				ext.Object = unk
+				return
+			}
+		}
+		// TODO: record mime-type with the object
+		if gvk != nil {
+			unk.APIVersion = gvk.GroupVersion().String()
+			unk.Kind = gvk.Kind
+		}
+		obj = unk
+	}
+	ext.Object = obj
+}
+
+func encodeNestedRawExtension(e runtime.Encoder, ext *runtime.RawExtension) error {
+	if ext.Raw != nil || ext.Object == nil {
+		return nil
+	}
+	data, err := runtime.Encode(e, ext.Object)
+	if err != nil {
+		return err
+	}
+	ext.Raw = data
+	return nil
+}


### PR DESCRIPTION
We still have four special ones that really need to take config.  That may or may not happen in 3.7

@aveshagarwal you can start to see the pay-off here.  This has exposed some debt-y config problems where the controller configuration was being built from the admission config.

/assign soltysh
/assign mfojtik

@mfojtik This collapses our admission path and eliminates drift for 3.7.  We probably need to fix the build controller config problem (spoke with @bparees already) for 3.7.