### PR TITLE
add `oc adm version` command

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -5737,6 +5737,49 @@ _oc_adm_verify-image-signature()
     noun_aliases=()
 }
 
+_oc_adm_version()
+{
+    last_command="oc_adm_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_adm()
 {
     last_command="oc_adm"
@@ -5773,6 +5816,7 @@ _oc_adm()
     commands+=("top")
     commands+=("uncordon")
     commands+=("verify-image-signature")
+    commands+=("version")
 
     flags=()
     two_word_flags=()

--- a/contrib/completions/bash/openshift
+++ b/contrib/completions/bash/openshift
@@ -5572,6 +5572,49 @@ _openshift_admin_verify-image-signature()
     noun_aliases=()
 }
 
+_openshift_admin_version()
+{
+    last_command="openshift_admin_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _openshift_admin()
 {
     last_command="openshift_admin"
@@ -5608,6 +5651,7 @@ _openshift_admin()
     commands+=("top")
     commands+=("uncordon")
     commands+=("verify-image-signature")
+    commands+=("version")
 
     flags=()
     two_word_flags=()
@@ -10995,6 +11039,49 @@ _openshift_cli_adm_verify-image-signature()
     noun_aliases=()
 }
 
+_openshift_cli_adm_version()
+{
+    last_command="openshift_cli_adm_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _openshift_cli_adm()
 {
     last_command="openshift_cli_adm"
@@ -11031,6 +11118,7 @@ _openshift_cli_adm()
     commands+=("top")
     commands+=("uncordon")
     commands+=("verify-image-signature")
+    commands+=("version")
 
     flags=()
     two_word_flags=()

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -5886,6 +5886,49 @@ _oc_adm_verify-image-signature()
     noun_aliases=()
 }
 
+_oc_adm_version()
+{
+    last_command="oc_adm_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_adm()
 {
     last_command="oc_adm"
@@ -5922,6 +5965,7 @@ _oc_adm()
     commands+=("top")
     commands+=("uncordon")
     commands+=("verify-image-signature")
+    commands+=("version")
 
     flags=()
     two_word_flags=()

--- a/contrib/completions/zsh/openshift
+++ b/contrib/completions/zsh/openshift
@@ -5721,6 +5721,49 @@ _openshift_admin_verify-image-signature()
     noun_aliases=()
 }
 
+_openshift_admin_version()
+{
+    last_command="openshift_admin_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _openshift_admin()
 {
     last_command="openshift_admin"
@@ -5757,6 +5800,7 @@ _openshift_admin()
     commands+=("top")
     commands+=("uncordon")
     commands+=("verify-image-signature")
+    commands+=("version")
 
     flags=()
     two_word_flags=()
@@ -11144,6 +11188,49 @@ _openshift_cli_adm_verify-image-signature()
     noun_aliases=()
 }
 
+_openshift_cli_adm_version()
+{
+    last_command="openshift_cli_adm_version"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--certificate-authority=")
+    flags_with_completion+=("--certificate-authority")
+    flags_completion+=("_filedir")
+    flags+=("--client-certificate=")
+    flags_with_completion+=("--client-certificate")
+    flags_completion+=("_filedir")
+    flags+=("--client-key=")
+    flags_with_completion+=("--client-key")
+    flags_completion+=("_filedir")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags_with_completion+=("--config")
+    flags_completion+=("_filedir")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _openshift_cli_adm()
 {
     last_command="openshift_cli_adm"
@@ -11180,6 +11267,7 @@ _openshift_cli_adm()
     commands+=("top")
     commands+=("uncordon")
     commands+=("verify-image-signature")
+    commands+=("version")
 
     flags=()
     two_word_flags=()

--- a/docs/man/man1/.files_generated_oc
+++ b/docs/man/man1/.files_generated_oc
@@ -95,6 +95,7 @@ oc-adm-top-pod.1
 oc-adm-top.1
 oc-adm-uncordon.1
 oc-adm-verify-image-signature.1
+oc-adm-version.1
 oc-adm.1
 oc-annotate.1
 oc-apply-edit-last-applied.1

--- a/docs/man/man1/.files_generated_openshift
+++ b/docs/man/man1/.files_generated_openshift
@@ -95,6 +95,7 @@ openshift-admin-top-pod.1
 openshift-admin-top.1
 openshift-admin-uncordon.1
 openshift-admin-verify-image-signature.1
+openshift-admin-version.1
 openshift-admin.1
 openshift-cli-adm-build-chain.1
 openshift-cli-adm-ca-create-key-pair.1
@@ -193,6 +194,7 @@ openshift-cli-adm-top-pod.1
 openshift-cli-adm-top.1
 openshift-cli-adm-uncordon.1
 openshift-cli-adm-verify-image-signature.1
+openshift-cli-adm-version.1
 openshift-cli-adm.1
 openshift-cli-annotate.1
 openshift-cli-apply-edit-last-applied.1

--- a/pkg/oc/admin/admin.go
+++ b/pkg/oc/admin/admin.go
@@ -145,9 +145,6 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 		cmd.NewCmdOptions(out),
 	)
 
-	if name == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, out, cmd.VersionOptions{}))
-	}
-
+	cmds.AddCommand(cmd.NewCmdVersion(fullName, f, out, cmd.VersionOptions{}))
 	return cmds
 }


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1498356

Adds version cmd to `oc adm`

**Example**
```
$ oc adm version
oc adm v3.7.0-alpha.1+afd90cd-822-dirty
kubernetes v1.7.0+80709908fd

...
```

cc @openshift/cli-review 