### PR TITLE
hack/env: Remove tmp volume

### DIFF
--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -30,7 +30,7 @@ os::build::rpm::get_nvra_vars
 tito tag --use-version="${OS_RPM_VERSION}" \
          --use-release="${OS_RPM_RELEASE}" \
          --no-auto-changelog --offline
-tito_tmp_dir="${BASETMPDIR}/tito"
+tito_tmp_dir="${BASEVARTMPDIR}/tito"
 mkdir -p "${tito_tmp_dir}"
 tito build --offline --srpm --rpmbuild-options="--define 'dist .el7'" --output="${tito_tmp_dir}"
 tito build --output="${tito_tmp_dir}" --rpm --no-cleanup --quiet --offline \

--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -10,6 +10,31 @@ function os::build::environment::create() {
   set -o errexit
   local release_image="${OS_BUILD_ENV_IMAGE}"
   local additional_context="${OS_BUILD_ENV_DOCKER_ARGS:-}"
+  local tmpdir_template="openshift-env-XXXXXXXXXX"
+  if [[ -n "${TMPDIR:-}" ]]; then
+    # If TMPDIR is specified, respect it
+    local container_tmpdir
+    container_tmpdir=$(mktemp -d --tmpdir ${tmpdir_template})
+    additional_context+=" -v ${container_tmpdir}:${container_tmpdir} -e TMPDIR=${container_tmpdir}"
+  else
+    # Bind mount /tmp into the container
+    pushd /tmp > /dev/null
+    local container_tmpname
+    container_tmpname=$(mktemp -d ${tmpdir_template})
+    local host_tmp="${OS_BUILD_ENV_HOST_TMPDIR:-/tmp}/${container_tmpname}"
+    local container_tmp="/tmp/${container_tmpname}"
+    popd > /dev/null
+    additional_context+=" -v ${host_tmp}:/tmp -e OS_BUILD_ENV_HOST_TMPDIR=${host_tmp}"
+
+    # Bind mount /var/tmp into the container
+    pushd /var/tmp > /dev/null
+    local container_var_tmpname
+    container_var_tmpname=$(mktemp -d ${tmpdir_template})
+    local host_var_tmp="${OS_BUILD_ENV_HOST_VAR_TMPDIR:-/var/tmp}/${container_var_tmpname}"
+    local container_tmp="/var/tmp/${container_var_tmpname}"
+    popd > /dev/null
+    additional_context+=" -v ${host_var_tmp}:/var/tmp -e OS_BUILD_ENV_HOST_VAR_TMPDIR=${host_var_tmp}"
+  fi
   if [[ "${OS_BUILD_ENV_USE_DOCKER:-y}" == "y" ]]; then
     additional_context+=" --privileged -v /var/run/docker.sock:/var/run/docker.sock"
 
@@ -29,18 +54,6 @@ function os::build::environment::create() {
         docker volume create --name "${OS_BUILD_ENV_VOLUME}" > /dev/null
       fi
 
-      if [[ -n "${OS_BUILD_ENV_TMP_VOLUME:-}" ]]; then
-        if docker volume inspect "${OS_BUILD_ENV_TMP_VOLUME}" >/dev/null 2>&1; then
-          os::log::debug "Re-using volume ${OS_BUILD_ENV_TMP_VOLUME}"
-        else
-          # if OS_BUILD_ENV_VOLUME is set and no volume already exists, create a docker volume to
-          # store the working output so successive iterations can reuse shared code.
-          os::log::debug "Creating volume ${OS_BUILD_ENV_TMP_VOLUME}"
-          docker volume create --name "${OS_BUILD_ENV_TMP_VOLUME}" >/dev/null
-        fi
-        additional_context+=" -v ${OS_BUILD_ENV_TMP_VOLUME}:/tmp"
-      fi
-
       local workingdir
       workingdir=$( os::build::environment::release::workingdir )
       additional_context+=" -v ${OS_BUILD_ENV_VOLUME}:${workingdir}"
@@ -48,7 +61,7 @@ function os::build::environment::create() {
   fi
 
   if [[ -n "${OS_BUILD_ENV_FROM_ARCHIVE-}" ]]; then
-    additional_context+=" -e OS_VERSION_FILE=/tmp/os-version-defs"
+    additional_context+=" -e OS_VERSION_FILE=${workingdir}/os-version-defs"
   else
     additional_context+=" -e OS_VERSION_FILE="
   fi
@@ -105,21 +118,36 @@ readonly -f os::build::environment::release::workingdir
 function os::build::environment::cleanup() {
   local container=$1
   local volume=$2
-  local tmp_volume=$3
   os::log::debug "Stopping container ${container}"
   docker stop --time=0 "${container}" > /dev/null || true
   if [[ -z "${OS_BUILD_ENV_LEAVE_CONTAINER:-}" ]]; then
+    if [[ -n "${TMPDIR:-}" ]]; then
+      os::log::debug "Inspecting container for the TMPDIR env variable"
+      # get the value of TMPDIR from the container
+      local container_tmpdir=$(docker inspect -f '{{range $index, $value := .Config.Env}}{{if eq (index (split $value "=") 0) "TMPDIR"}}{{index (split $value "=") 1}}{{end}}{{end}}' "${container}")
+      os::log::debug "Removing container tmp directory: ${container_tmpdir}"
+      if ! rm -rf "${container_tmpdir}"; then
+        os::log::warning "Failed to remove tmpdir: ${container_tmpdir}"
+      fi
+    else
+      os::log::debug "Inspecting container for bind mounted temp directories"
+      # get the Source directories for the /tmp and /var/tmp Mounts from the container
+      local container_tmpdirs=($(docker inspect -f '{{range .Mounts }}{{if eq .Destination "/tmp" "/var/tmp"}}{{println .Source}}{{end}}{{end}}' "${container}"))
+      os::log::debug "Removing container tmp directories: ${container_tmpdirs[@]}"
+      for tmpdir in "${container_tmpdirs[@]}"; do
+        for tmpdir_prefix in /tmp /var/tmp; do
+          if [[ "${tmpdir}" == ${tmpdir_prefix}/* ]]; then
+            local tmppath="${tmpdir_prefix}/${tmpdir##*/}"
+            os::log::debug "tmp path size: $(du -hs ${tmppath})"
+            if ! rm -rf "${tmpdir_prefix}/${tmpdir##*/}"; then
+              os::log::warning "Failed to remove tmpdir: ${tmppath}"
+           fi
+         fi
+        done
+      done
+    fi
     os::log::debug "Removing container ${container}"
     docker rm "${container}" > /dev/null
-
-    if [[ -z "${OS_BUILD_ENV_REUSE_TMP_VOLUME:-}" ]]; then
-      os::log::debug "Removing tmp build volume"
-      os::build::environment::remove_volume "${tmp_volume}"
-    fi
-    if [[ -n "${OS_BUILD_ENV_CLEAN_BUILD_VOLUME:-}" ]]; then
-      os::log::debug "Removing build volume"
-      os::build::environment::remove_volume "${volume}"
-    fi
   fi
 }
 readonly -f os::build::environment::cleanup
@@ -185,11 +213,11 @@ function os::build::environment::withsource() {
   if [[ -n "${OS_BUILD_ENV_FROM_ARCHIVE-}" ]]; then
     # Generate version definitions. Tree state is clean because we are pulling from git directly.
     OS_GIT_TREE_STATE=clean os::build::version::get_vars
-    os::build::version::save_vars "/tmp/os-version-defs"
+    os::build::version::save_vars "os-version-defs"
 
     os::log::debug "Generating source code archive"
-    tar -cf - -C /tmp/ os-version-defs | docker cp - "${container}:/tmp"
     git archive --format=tar "${commit}" | docker cp - "${container}:${workingdir}"
+    docker cp os-version-defs "${container}:${workingdir}/"
     os::build::environment::start "${container}"
     return
   fi
@@ -244,17 +272,13 @@ readonly -f os::build::environment::remove_volume
 function os::build::environment::run() {
   local commit="${OS_GIT_COMMIT:-HEAD}"
   local volume
-  local tmp_volume
 
   volume="$( os::build::environment::volume_name "origin-build" "${commit}" "${OS_BUILD_ENV_REUSE_VOLUME:-}" )"
-  tmp_volume="$( os::build::environment::volume_name "origin-build-tmp" "${commit}" "${OS_BUILD_ENV_REUSE_TMP_VOLUME:-}" )"
 
   export OS_BUILD_ENV_VOLUME="${volume}"
-  export OS_BUILD_ENV_TMP_VOLUME="${tmp_volume}"
 
   if [[ -n "${OS_BUILD_ENV_VOLUME_FORCE_NEW:-}" ]]; then
     os::build::environment::remove_volume "${volume}"
-    os::build::environment::remove_volume "${tmp_volume}"
   fi
 
   if [[ -n "${OS_BUILD_ENV_PULL_IMAGE:-}" ]]; then
@@ -264,11 +288,10 @@ function os::build::environment::run() {
 
   os::log::debug "Using commit ${commit}"
   os::log::debug "Using volume ${volume}"
-  os::log::debug "Using tmp volume ${tmp_volume}"
 
   local container
   container="$( os::build::environment::create "$@" )"
-  trap "os::build::environment::cleanup ${container} ${volume} ${tmp_volume}" EXIT
+  trap "os::build::environment::cleanup ${container} ${volume}" EXIT
 
   os::log::debug "Using container ${container}"
 

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -51,6 +51,7 @@ readonly -f os::util::environment::setup_time_vars
 #  - KUBELET_HOST
 #  - KUBELET_PORT
 #  - BASETMPDIR
+#  - BASEVARTMPDIR
 #  - ETCD_PORT
 #  - ETCD_PEER_PORT
 #  - API_BIND_HOST
@@ -64,6 +65,7 @@ readonly -f os::util::environment::setup_time_vars
 # Returns:
 #  - export PATH
 #  - export BASETMPDIR
+#  - export BASEVARTMPDIR
 #  - export LOG_DIR
 #  - export VOLUME_DIR
 #  - export ARTIFACT_DIR
@@ -123,6 +125,7 @@ readonly -f os::util::environment::update_path_var
 #  - 1: the path under the root temporary directory for OpenShift where these subdirectories should be made
 # Returns:
 #  - export BASETMPDIR
+#  - export BASEVARTMPDIR
 #  - export BASEOUTDIR
 #  - export LOG_DIR
 #  - export VOLUME_DIR
@@ -137,6 +140,9 @@ function os::util::environment::setup_tmpdir_vars() {
     VOLUME_DIR="${BASETMPDIR}/volumes"
     export VOLUME_DIR
 
+    BASEVARTMPDIR="${TMPDIR:-/var/tmp}/openshift/${sub_dir}"
+    export BASEVARTMPDIR
+
     BASEOUTDIR="${OS_OUTPUT_SCRIPTPATH}/${sub_dir}"
     export BASEOUTDIR
     LOG_DIR="${LOG_DIR:-${BASEOUTDIR}/logs}"
@@ -146,7 +152,7 @@ function os::util::environment::setup_tmpdir_vars() {
     FAKE_HOME_DIR="${BASEOUTDIR}/openshift.local.home"
     export FAKE_HOME_DIR
 
-    mkdir -p "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${FAKE_HOME_DIR}"
+    mkdir -p "${LOG_DIR}" "${VOLUME_DIR}" "${ARTIFACT_DIR}" "${FAKE_HOME_DIR}" "${BASEVARTMPDIR}"
 
     export OS_TMP_ENV_SET="${sub_dir}"
 }


### PR DESCRIPTION
hack/env: Remove tmp volume
- Use host TMPDIR or pass in /tmp and /var/tmp from host instead of using a volume for /tmp
- Add BASEVARTMPDIR variable and update tito to use it

Resolves: https://github.com/openshift/origin/issues/15573
Removes the use of a volume for /tmp introduced here: https://github.com/openshift/origin/pull/15770
Resolves: https://github.com/openshift/origin/issues/16273