### PR TITLE
build-go.sh: Fix unbound variable STARTTIME

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -28,7 +28,7 @@ if [[ -z "$@" ]]; then
 
     os::build::make_openshift_binary_symlinks
 
-    ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"
+    exit
   fi
 
   build_targets=("${OS_CROSS_COMPILE_TARGETS[@]}")


### PR DESCRIPTION
Delete stale code that was causing `make` and `hack/build-go.sh` to fail with the following error:

    hack/build-go.sh: line 31: STARTTIME: unbound variable

The code in question is superseded by the `cleanup` hook added in commit cd94e23d7506777a81607af88c6dbd909587c0bc, which also deleted the initialization of `STARTTIME`.