### PR TITLE
Update/fix HPA controller policy

### DIFF
--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -964,7 +964,22 @@ items:
   subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler
-    namespace: kube-system
+    namespace: openshift-infra
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:controller:horizontal-pod-autoscaler
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:controller:horizontal-pod-autoscaler
+  subjects:
+  - kind: ServiceAccount
+    name: horizontal-pod-autoscaler
+    namespace: openshift-infra
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -6687,9 +6687,25 @@ items:
   subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler
-    namespace: kube-system
+    namespace: openshift-infra
   userNames:
-  - system:serviceaccount:kube-system:horizontal-pod-autoscaler
+  - system:serviceaccount:openshift-infra:horizontal-pod-autoscaler
+- apiVersion: v1
+  groupNames: null
+  kind: ClusterRoleBinding
+  metadata:
+    annotations:
+      openshift.io/reconcile-protect: "false"
+    creationTimestamp: null
+    name: system:controller:horizontal-pod-autoscaler
+  roleRef:
+    name: system:controller:horizontal-pod-autoscaler
+  subjects:
+  - kind: ServiceAccount
+    name: horizontal-pod-autoscaler
+    namespace: openshift-infra
+  userNames:
+  - system:serviceaccount:openshift-infra:horizontal-pod-autoscaler
 - apiVersion: v1
   groupNames: null
   kind: ClusterRoleBinding


### PR DESCRIPTION
A recent commit changed the name of the service account that the HPA
controller was running under.  Whereas before it ran as
`kube-system:horizontal-pod-autoscaler`, it now runs as
`openshift-infra:horizontal-pod-autoscaler`.  This updates the policy to
add permissions for OpenShift resources to the OpenShift SA name, and
binds the Kube cluster role to the OpenShift SA name.

Note that when the polymorphic scale client eventually lands, and we
drop our custom HPA setup, we'll probably have to change the policy
back again.