### PR TITLE
fixing/removing "to to" from help texts and comments

### DIFF
--- a/pkg/build/apis/build/types.go
+++ b/pkg/build/apis/build/types.go
@@ -35,7 +35,7 @@ const (
 	// NOTE: The value for this label may not contain the entire Build name because it will be
 	// truncated to maximum label length.
 	BuildLabel = "openshift.io/build.name"
-	// BuildRunPolicyLabel represents the start policy used to to start the build.
+	// BuildRunPolicyLabel represents the start policy used to start the build.
 	BuildRunPolicyLabel = "openshift.io/build.start-policy"
 	// DefaultDockerLabelNamespace is the key of a Build label, whose values are build metadata.
 	DefaultDockerLabelNamespace = "io.openshift."

--- a/pkg/build/vendor/github.com/openshift/imagebuilder/shell_parser.go
+++ b/pkg/build/vendor/github.com/openshift/imagebuilder/shell_parser.go
@@ -243,7 +243,7 @@ func (sw *shellWord) processDollar() (string, error) {
 			}
 
 			// Grab the current value of the variable in question so we
-			// can use to to determine what to do based on the modifier
+			// can use to determine what to do based on the modifier
 			newValue := sw.getEnv(name)
 
 			switch modifier {

--- a/pkg/oc/cli/cmd/newbuild.go
+++ b/pkg/oc/cli/cmd/newbuild.go
@@ -109,9 +109,9 @@ func NewCmdNewBuild(name, baseName string, f *clientcmd.Factory, in io.Reader, o
 	}
 
 	cmd.Flags().StringSliceVar(&config.SourceRepositories, "code", config.SourceRepositories, "Source code in the build configuration.")
-	cmd.Flags().StringSliceVarP(&config.ImageStreams, "image", "", config.ImageStreams, "Name of an image stream to to use as a builder. (deprecated)")
+	cmd.Flags().StringSliceVarP(&config.ImageStreams, "image", "", config.ImageStreams, "Name of an image stream to be used as a builder. (deprecated)")
 	cmd.Flags().MarkDeprecated("image", "use --image-stream instead")
-	cmd.Flags().StringSliceVarP(&config.ImageStreams, "image-stream", "i", config.ImageStreams, "Name of an image stream to to use as a builder.")
+	cmd.Flags().StringSliceVarP(&config.ImageStreams, "image-stream", "i", config.ImageStreams, "Name of an image stream to be used as a builder.")
 	cmd.Flags().StringSliceVar(&config.DockerImages, "docker-image", config.DockerImages, "Name of a Docker image to use as a builder.")
 	cmd.Flags().StringSliceVar(&config.Secrets, "build-secret", config.Secrets, "Secret and destination to use as an input for the build.")
 	cmd.Flags().StringVar(&config.SourceSecret, "source-secret", "", "The name of an existing secret that should be used for cloning a private git repository.")


### PR DESCRIPTION
This is a trivial change. I stumbled upon there 'to to's while using the `oc` command...