### PR TITLE
resolve image secrets in the buildcontroller

### DIFF
--- a/pkg/api/meta/builds.go
+++ b/pkg/api/meta/builds.go
@@ -24,8 +24,8 @@ func NewBuildMutator(build *buildapi.Build) ImageReferenceMutator {
 
 func (m *buildSpecMutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	var errs field.ErrorList
-	for i, image := range m.spec.Source.Images {
-		if err := fn(&image.From); err != nil {
+	for i := range m.spec.Source.Images {
+		if err := fn(&m.spec.Source.Images[i].From); err != nil {
 			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("source", "images").Index(i).Child("from", "name")))
 			continue
 		}
@@ -46,6 +46,12 @@ func (m *buildSpecMutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 		if err := fn(&s.From); err != nil {
 			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "sourceStrategy", "from", "name")))
 		}
+		if s.RuntimeImage != nil {
+			if err := fn(s.RuntimeImage); err != nil {
+				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "sourceStrategy", "runtimeImage", "from", "name")))
+			}
+		}
+
 	}
 	if m.output {
 		if s := m.spec.Output.To; s != nil {

--- a/pkg/build/generator/generator_test.go
+++ b/pkg/build/generator/generator_test.go
@@ -1391,7 +1391,7 @@ func TestSubstituteImageCustomAllMatch(t *testing.T) {
 	build.Spec.Strategy.CustomStrategy.Env = make([]kapi.EnvVar, 2)
 	build.Spec.Strategy.CustomStrategy.Env[0] = kapi.EnvVar{Name: "someImage", Value: originalImage}
 	build.Spec.Strategy.CustomStrategy.Env[1] = kapi.EnvVar{Name: buildapi.CustomBuildStrategyBaseImageKey, Value: originalImage}
-	updateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
+	UpdateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
 	if build.Spec.Strategy.CustomStrategy.Env[0].Value != originalImage {
 		t.Errorf("Random env variable %s was improperly substituted in custom strategy", build.Spec.Strategy.CustomStrategy.Env[0].Name)
 	}
@@ -1422,7 +1422,7 @@ func TestSubstituteImageCustomAllMismatch(t *testing.T) {
 
 	// Full custom build with base image that is not matched
 	// Base image name should be unchanged
-	updateCustomImageEnv(build.Spec.Strategy.CustomStrategy, "dummy")
+	UpdateCustomImageEnv(build.Spec.Strategy.CustomStrategy, "dummy")
 	if build.Spec.Strategy.CustomStrategy.From.Name != originalImage {
 		t.Errorf("Base image name was improperly substituted in custom strategy %s %s", build.Spec.Strategy.CustomStrategy.From.Name, originalImage)
 	}
@@ -1444,7 +1444,7 @@ func TestSubstituteImageCustomBaseMatchEnvMismatch(t *testing.T) {
 	build.Spec.Strategy.CustomStrategy.Env = make([]kapi.EnvVar, 2)
 	build.Spec.Strategy.CustomStrategy.Env[0] = kapi.EnvVar{Name: "someEnvVar", Value: originalImage}
 	build.Spec.Strategy.CustomStrategy.Env[1] = kapi.EnvVar{Name: buildapi.CustomBuildStrategyBaseImageKey, Value: "dummy"}
-	updateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
+	UpdateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
 	if build.Spec.Strategy.CustomStrategy.Env[0].Value != originalImage {
 		t.Errorf("Random env variable %s was improperly substituted in custom strategy", build.Spec.Strategy.CustomStrategy.Env[0].Name)
 	}
@@ -1472,7 +1472,7 @@ func TestSubstituteImageCustomBaseMatchEnvMissing(t *testing.T) {
 	// existing environment variable should be untouched
 	build.Spec.Strategy.CustomStrategy.Env = make([]kapi.EnvVar, 1)
 	build.Spec.Strategy.CustomStrategy.Env[0] = kapi.EnvVar{Name: "someImage", Value: originalImage}
-	updateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
+	UpdateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
 	if build.Spec.Strategy.CustomStrategy.Env[0].Value != originalImage {
 		t.Errorf("Random env variable was improperly substituted in custom strategy")
 	}
@@ -1497,7 +1497,7 @@ func TestSubstituteImageCustomBaseMatchEnvNil(t *testing.T) {
 
 	// Custom build with a base Image but no environment variables
 	// base image should be replaced, new image environment variable should be added
-	updateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
+	UpdateCustomImageEnv(build.Spec.Strategy.CustomStrategy, newImage)
 	if build.Spec.Strategy.CustomStrategy.Env[0].Name != buildapi.CustomBuildStrategyBaseImageKey || build.Spec.Strategy.CustomStrategy.Env[0].Value != newImage {
 		t.Errorf("New image name variable was not added to environment list in custom strategy")
 	}

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -7,21 +7,29 @@ import (
 	o "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture     = exutil.FixturePath("testdata", "test-imagesource-build.yaml")
-		oc               = exutil.NewCLI("build-image-source", exutil.KubeConfigPath())
-		imageSourceLabel = exutil.ParseLabelsOrDie("app=imagesourceapp")
-		imageDockerLabel = exutil.ParseLabelsOrDie("app=imagedockerapp")
+		buildConfigFixture = exutil.FixturePath("testdata", "test-imagesource-buildconfig.yaml")
+		s2iBuildFixture    = exutil.FixturePath("testdata", "test-imageresolution-s2i-build.yaml")
+		dockerBuildFixture = exutil.FixturePath("testdata", "test-imageresolution-docker-build.yaml")
+		customBuildFixture = exutil.FixturePath("testdata", "test-imageresolution-custom-build.yaml")
+		oc                 = exutil.NewCLI("build-image-source", exutil.KubeConfigPath())
+		imageSourceLabel   = exutil.ParseLabelsOrDie("app=imagesourceapp")
+		imageDockerLabel   = exutil.ParseLabelsOrDie("app=imagedockerapp")
+		sourceBuildLabel   = exutil.ParseLabelsOrDie("openshift.io/build.name=imagesourcebuild")
+		dockerBuildLabel   = exutil.ParseLabelsOrDie("openshift.io/build.name=imagedockerbuild")
+		customBuildLabel   = exutil.ParseLabelsOrDie("openshift.io/build.name=imagecustombuild")
 	)
 
 	g.Context("", func() {
-
 		g.JustBeforeEach(func() {
 			g.By("waiting for builder service account")
 			err := exutil.WaitForBuilderAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()))
@@ -39,10 +47,10 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 			}
 		})
 
-		g.Describe("build with image source", func() {
+		g.Describe("buildconfig with input source image and s2i strategy", func() {
 			g.It("should complete successfully and contain the expected file", func() {
 				g.By("Creating build configs for source build")
-				err := oc.Run("create").Args("-f", buildFixture).Execute()
+				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("starting building the private input image")
@@ -50,7 +58,7 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 				br.AssertSuccess()
 
 				g.By("starting the source strategy build")
-				br, err = exutil.StartBuildAndWait(oc, "imagesourcebuild")
+				br, err = exutil.StartBuildAndWait(oc, "imagesourcebuildconfig")
 				br.AssertSuccess()
 
 				g.By("expecting the pod to deploy successfully")
@@ -66,10 +74,10 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 				o.Expect(out).To(o.ContainSubstring("ruby"))
 			})
 		})
-		g.Describe("build with image docker", func() {
+		g.Describe("buildconfig with input source image and docker strategy", func() {
 			g.It("should complete successfully and contain the expected file", func() {
 				g.By("Creating build configs for docker build")
-				err := oc.Run("create").Args("-f", buildFixture).Execute()
+				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("starting building the private input image")
@@ -77,7 +85,7 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 				br.AssertSuccess()
 
 				g.By("starting the docker strategy build")
-				br, err = exutil.StartBuildAndWait(oc, "imagedockerbuild")
+				br, err = exutil.StartBuildAndWait(oc, "imagedockerbuildconfig")
 				br.AssertSuccess()
 
 				g.By("expect the pod to deploy successfully")
@@ -92,7 +100,150 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(out).To(o.ContainSubstring("ruby"))
 			})
+		})
+		g.Describe("creating a build with an input source image and s2i strategy", func() {
+			g.It("should resolve the imagestream references and secrets", func() {
+				g.By("Creating build configs for input image")
+				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
 
+				g.By("starting building the private input image")
+				br, err := exutil.StartBuildAndWait(oc, "inputimage")
+				br.AssertSuccess()
+
+				g.By("Creating a build for source build")
+				err = oc.Run("create").Args("-f", s2iBuildFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("expecting the build pod to start running")
+				pods, err := exutil.WaitForPods(oc.KubeClient().Core().Pods(oc.Namespace()), sourceBuildLabel, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(len(pods)).To(o.Equal(1))
+				pod, err := oc.KubeClient().Core().Pods(oc.Namespace()).Get(pods[0], metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				foundEnv := false
+				for _, env := range pod.Spec.Containers[0].Env {
+					if env.Name == "BUILD" {
+						foundEnv = true
+
+						obj, _, err := kapi.Codecs.UniversalDecoder().Decode([]byte(env.Value), nil, nil)
+						o.Expect(err).NotTo(o.HaveOccurred())
+						ok := false
+						build, ok := obj.(*buildapi.Build)
+						o.Expect(ok).To(o.BeTrue(), "could not convert build env\n %s\n to a build object", env.Value)
+						o.Expect(build.Spec.Strategy.SourceStrategy.From.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Strategy.SourceStrategy.From.Name).To(o.ContainSubstring("@sha256:"))
+						o.Expect(build.Spec.Strategy.SourceStrategy.PullSecret).NotTo(o.BeNil())
+
+						o.Expect(build.Spec.Source.Images[0].From.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Source.Images[0].From.Name).To(o.ContainSubstring("@sha256:"))
+						o.Expect(build.Spec.Source.Images[0].PullSecret).NotTo(o.BeNil())
+
+						o.Expect(build.Spec.Output.To.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Output.PushSecret).NotTo(o.BeNil())
+					}
+				}
+				o.Expect(foundEnv).To(o.BeTrue(), "did not find BUILD env in build pod %#v", pod)
+			})
+		})
+		g.Describe("creating a build with an input source image and docker strategy", func() {
+			g.It("should resolve the imagestream references and secrets", func() {
+				g.By("Creating build configs for input image")
+				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("starting building the private input image")
+				br, err := exutil.StartBuildAndWait(oc, "inputimage")
+				br.AssertSuccess()
+
+				g.By("Creating a build for docker build")
+				err = oc.Run("create").Args("-f", dockerBuildFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("expecting the build pod to start running")
+				pods, err := exutil.WaitForPods(oc.KubeClient().Core().Pods(oc.Namespace()), dockerBuildLabel, exutil.CheckPodIsRunningFn, 1, 2*time.Minute)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(len(pods)).To(o.Equal(1))
+				pod, err := oc.KubeClient().Core().Pods(oc.Namespace()).Get(pods[0], metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				foundEnv := false
+				for _, env := range pod.Spec.Containers[0].Env {
+					if env.Name == "BUILD" {
+						foundEnv = true
+
+						obj, _, err := kapi.Codecs.UniversalDecoder().Decode([]byte(env.Value), nil, nil)
+						o.Expect(err).NotTo(o.HaveOccurred())
+						ok := false
+						build, ok := obj.(*buildapi.Build)
+						o.Expect(ok).To(o.BeTrue(), "could not convert build env\n %s\n to a build object", env.Value)
+						o.Expect(build.Spec.Strategy.DockerStrategy.From.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Strategy.DockerStrategy.From.Name).To(o.ContainSubstring("@sha256:"))
+						o.Expect(build.Spec.Strategy.DockerStrategy.PullSecret).NotTo(o.BeNil())
+
+						o.Expect(build.Spec.Source.Images[0].From.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Source.Images[0].From.Name).To(o.ContainSubstring("@sha256:"))
+						o.Expect(build.Spec.Source.Images[0].PullSecret).NotTo(o.BeNil())
+
+						o.Expect(build.Spec.Output.To.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Output.PushSecret).NotTo(o.BeNil())
+					}
+				}
+				o.Expect(foundEnv).To(o.BeTrue(), "did not find BUILD env in build pod %#v", pod)
+			})
+		})
+		g.Describe("creating a build with an input source image and custom strategy", func() {
+			g.It("should resolve the imagestream references and secrets", func() {
+				g.By("Creating build configs for input image")
+				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("starting building the private input image")
+				br, err := exutil.StartBuildAndWait(oc, "inputimage")
+				br.AssertSuccess()
+
+				g.By("Creating a build for custom build")
+				err = oc.AsAdmin().Run("create").Args("-f", customBuildFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("expecting the build pod to exist")
+				pods, err := exutil.WaitForPods(oc.KubeClient().Core().Pods(oc.Namespace()), customBuildLabel, func(kapiv1.Pod) bool { return true }, 1, 2*time.Minute)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(len(pods)).To(o.Equal(1))
+				pod, err := oc.KubeClient().Core().Pods(oc.Namespace()).Get(pods[0], metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				foundBuildEnv := false
+				foundCustomEnv := false
+				for _, env := range pod.Spec.Containers[0].Env {
+					if env.Name == "BUILD" {
+						foundBuildEnv = true
+
+						obj, _, err := kapi.Codecs.UniversalDecoder().Decode([]byte(env.Value), nil, nil)
+						o.Expect(err).NotTo(o.HaveOccurred())
+						ok := false
+						build, ok := obj.(*buildapi.Build)
+						o.Expect(ok).To(o.BeTrue(), "could not convert build env\n %s\n to a build object", env.Value)
+						o.Expect(build.Spec.Strategy.CustomStrategy.From.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Strategy.CustomStrategy.From.Name).To(o.ContainSubstring("@sha256:"))
+						o.Expect(build.Spec.Strategy.CustomStrategy.PullSecret).NotTo(o.BeNil())
+
+						o.Expect(build.Spec.Source.Images[0].From.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Source.Images[0].From.Name).To(o.ContainSubstring("@sha256:"))
+						o.Expect(build.Spec.Source.Images[0].PullSecret).NotTo(o.BeNil())
+
+						o.Expect(build.Spec.Output.To.Kind).To(o.Equal("DockerImage"))
+						o.Expect(build.Spec.Output.PushSecret).NotTo(o.BeNil())
+					}
+					if env.Name == buildapi.CustomBuildStrategyBaseImageKey {
+						foundCustomEnv = true
+						o.Expect(env.Value).To(o.ContainSubstring("@sha256:"))
+					}
+				}
+				o.Expect(foundBuildEnv).To(o.BeTrue(), "did not find BUILD env in build pod %#v", pod)
+				o.Expect(foundCustomEnv).To(o.BeTrue(), "did not find Custom base image env in build pod %#v", pod)
+			})
 		})
 	})
 })

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -174,7 +174,10 @@
 // test/extended/testdata/test-env-pod.json
 // test/extended/testdata/test-gitserver-tokenauth.yaml
 // test/extended/testdata/test-gitserver.yaml
-// test/extended/testdata/test-imagesource-build.yaml
+// test/extended/testdata/test-imageresolution-custom-build.yaml
+// test/extended/testdata/test-imageresolution-docker-build.yaml
+// test/extended/testdata/test-imageresolution-s2i-build.yaml
+// test/extended/testdata/test-imagesource-buildconfig.yaml
 // test/extended/testdata/test-nosrc-build.json
 // test/extended/testdata/test-s2i-build-quota.json
 // test/extended/testdata/test-s2i-build.json
@@ -9917,7 +9920,148 @@ func testExtendedTestdataTestGitserverYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataTestImagesourceBuildYaml = []byte(`apiVersion: v1
+var _testExtendedTestdataTestImageresolutionCustomBuildYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: v1
+  kind: Build
+  metadata:
+    labels:
+      build: imagecustombuild
+    name: imagecustombuild
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: imagesourceapp:latest
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+        paths:
+        - destinationDir: injected/dir
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+    strategy:
+      customStrategy:
+        from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+`)
+
+func testExtendedTestdataTestImageresolutionCustomBuildYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataTestImageresolutionCustomBuildYaml, nil
+}
+
+func testExtendedTestdataTestImageresolutionCustomBuildYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataTestImageresolutionCustomBuildYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/test-imageresolution-custom-build.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataTestImageresolutionDockerBuildYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: v1
+  kind: Build
+  metadata:
+    labels:
+      build: imagedockerbuild
+    name: imagedockerbuild
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: imagedockerapp:latest
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+        paths:
+        - destinationDir: injected/dir
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+`)
+
+func testExtendedTestdataTestImageresolutionDockerBuildYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataTestImageresolutionDockerBuildYaml, nil
+}
+
+func testExtendedTestdataTestImageresolutionDockerBuildYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataTestImageresolutionDockerBuildYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/test-imageresolution-docker-build.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataTestImageresolutionS2iBuildYaml = []byte(`apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: v1
+  kind: Build
+  metadata:
+    labels:
+      build: imagesourcebuild
+    name: imagesourcebuild
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: imagesourceapp:latest
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+        paths:
+        - destinationDir: injected/dir
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+`)
+
+func testExtendedTestdataTestImageresolutionS2iBuildYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataTestImageresolutionS2iBuildYaml, nil
+}
+
+func testExtendedTestdataTestImageresolutionS2iBuildYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataTestImageresolutionS2iBuildYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/test-imageresolution-s2i-build.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataTestImagesourceBuildconfigYaml = []byte(`apiVersion: v1
 kind: List
 metadata: {}
 items:
@@ -9945,7 +10089,7 @@ items:
   metadata:
     labels:
       build: imagesourcebuild
-    name: imagesourcebuild
+    name: imagesourcebuildconfig
   spec:
     output:
       to:
@@ -9973,7 +10117,7 @@ items:
   metadata:
     labels:
       build: imagedockerbuild
-    name: imagedockerbuild
+    name: imagedockerbuildconfig
   spec:
     output:
       to:
@@ -10098,17 +10242,17 @@ items:
     - type: ConfigChange
 `)
 
-func testExtendedTestdataTestImagesourceBuildYamlBytes() ([]byte, error) {
-	return _testExtendedTestdataTestImagesourceBuildYaml, nil
+func testExtendedTestdataTestImagesourceBuildconfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataTestImagesourceBuildconfigYaml, nil
 }
 
-func testExtendedTestdataTestImagesourceBuildYaml() (*asset, error) {
-	bytes, err := testExtendedTestdataTestImagesourceBuildYamlBytes()
+func testExtendedTestdataTestImagesourceBuildconfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataTestImagesourceBuildconfigYamlBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "test/extended/testdata/test-imagesource-build.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "test/extended/testdata/test-imagesource-buildconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -28477,7 +28621,10 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/test-env-pod.json": testExtendedTestdataTestEnvPodJson,
 	"test/extended/testdata/test-gitserver-tokenauth.yaml": testExtendedTestdataTestGitserverTokenauthYaml,
 	"test/extended/testdata/test-gitserver.yaml": testExtendedTestdataTestGitserverYaml,
-	"test/extended/testdata/test-imagesource-build.yaml": testExtendedTestdataTestImagesourceBuildYaml,
+	"test/extended/testdata/test-imageresolution-custom-build.yaml": testExtendedTestdataTestImageresolutionCustomBuildYaml,
+	"test/extended/testdata/test-imageresolution-docker-build.yaml": testExtendedTestdataTestImageresolutionDockerBuildYaml,
+	"test/extended/testdata/test-imageresolution-s2i-build.yaml": testExtendedTestdataTestImageresolutionS2iBuildYaml,
+	"test/extended/testdata/test-imagesource-buildconfig.yaml": testExtendedTestdataTestImagesourceBuildconfigYaml,
 	"test/extended/testdata/test-nosrc-build.json": testExtendedTestdataTestNosrcBuildJson,
 	"test/extended/testdata/test-s2i-build-quota.json": testExtendedTestdataTestS2iBuildQuotaJson,
 	"test/extended/testdata/test-s2i-build.json": testExtendedTestdataTestS2iBuildJson,
@@ -28939,7 +29086,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"test-env-pod.json": &bintree{testExtendedTestdataTestEnvPodJson, map[string]*bintree{}},
 				"test-gitserver-tokenauth.yaml": &bintree{testExtendedTestdataTestGitserverTokenauthYaml, map[string]*bintree{}},
 				"test-gitserver.yaml": &bintree{testExtendedTestdataTestGitserverYaml, map[string]*bintree{}},
-				"test-imagesource-build.yaml": &bintree{testExtendedTestdataTestImagesourceBuildYaml, map[string]*bintree{}},
+				"test-imageresolution-custom-build.yaml": &bintree{testExtendedTestdataTestImageresolutionCustomBuildYaml, map[string]*bintree{}},
+				"test-imageresolution-docker-build.yaml": &bintree{testExtendedTestdataTestImageresolutionDockerBuildYaml, map[string]*bintree{}},
+				"test-imageresolution-s2i-build.yaml": &bintree{testExtendedTestdataTestImageresolutionS2iBuildYaml, map[string]*bintree{}},
+				"test-imagesource-buildconfig.yaml": &bintree{testExtendedTestdataTestImagesourceBuildconfigYaml, map[string]*bintree{}},
 				"test-nosrc-build.json": &bintree{testExtendedTestdataTestNosrcBuildJson, map[string]*bintree{}},
 				"test-s2i-build-quota.json": &bintree{testExtendedTestdataTestS2iBuildQuotaJson, map[string]*bintree{}},
 				"test-s2i-build.json": &bintree{testExtendedTestdataTestS2iBuildJson, map[string]*bintree{}},

--- a/test/extended/testdata/test-imageresolution-custom-build.yaml
+++ b/test/extended/testdata/test-imageresolution-custom-build.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: v1
+  kind: Build
+  metadata:
+    labels:
+      build: imagecustombuild
+    name: imagecustombuild
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: imagesourceapp:latest
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+        paths:
+        - destinationDir: injected/dir
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+    strategy:
+      customStrategy:
+        from:
+          kind: ImageStreamTag
+          name: inputimage:latest

--- a/test/extended/testdata/test-imageresolution-docker-build.yaml
+++ b/test/extended/testdata/test-imageresolution-docker-build.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: v1
+  kind: Build
+  metadata:
+    labels:
+      build: imagedockerbuild
+    name: imagedockerbuild
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: imagedockerapp:latest
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+        paths:
+        - destinationDir: injected/dir
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: inputimage:latest

--- a/test/extended/testdata/test-imageresolution-s2i-build.yaml
+++ b/test/extended/testdata/test-imageresolution-s2i-build.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: v1
+  kind: Build
+  metadata:
+    labels:
+      build: imagesourcebuild
+    name: imagesourcebuild
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: imagesourceapp:latest
+    source:
+      git:
+        uri: https://github.com/openshift/ruby-hello-world.git
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: inputimage:latest
+        paths:
+        - destinationDir: injected/dir
+          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: inputimage:latest

--- a/test/extended/testdata/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/test-imagesource-buildconfig.yaml
@@ -26,7 +26,7 @@ items:
   metadata:
     labels:
       build: imagesourcebuild
-    name: imagesourcebuild
+    name: imagesourcebuildconfig
   spec:
     output:
       to:
@@ -54,7 +54,7 @@ items:
   metadata:
     labels:
       build: imagedockerbuild
-    name: imagedockerbuild
+    name: imagedockerbuildconfig
   spec:
     output:
       to:


### PR DESCRIPTION
fixes #16609

things that need new tests:

- [x] image source imagestreams being resolved when specified in a build object (they weren't before)
- [x] all push/pull secrets being resolved when you create a build directly (regardless of whether you create w/ imagestreams or dockerimage refs
- [x] resolution for custom strategy builds