### PR TITLE
Record events on openshift-sdn startup and pod restart

### DIFF
--- a/pkg/cmd/server/kubernetes/network/network_config.go
+++ b/pkg/cmd/server/kubernetes/network/network_config.go
@@ -67,7 +67,7 @@ func New(options configapi.NodeConfig, clusterDomain string, proxyConfig *compon
 	var sdnNode network.NodeInterface
 	var sdnProxy network.ProxyInterface
 	if network.IsOpenShiftNetworkPlugin(options.NetworkConfig.NetworkPluginName) {
-		sdnNode, sdnProxy, err = NewSDNInterfaces(options, networkClient, internalKubeClient, internalKubeInformers, proxyConfig)
+		sdnNode, sdnProxy, err = NewSDNInterfaces(options, networkClient, kubeClient, internalKubeClient, internalKubeInformers, proxyConfig)
 		if err != nil {
 			return nil, fmt.Errorf("SDN initialization failed: %v", err)
 		}

--- a/pkg/cmd/server/kubernetes/network/sdn_linux.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_linux.go
@@ -3,8 +3,13 @@ package network
 import (
 	"strings"
 
+	kclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	kv1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	kclientv1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	kinternalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -14,7 +19,7 @@ import (
 	sdnproxy "github.com/openshift/origin/pkg/network/proxy"
 )
 
-func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.Interface, kubeClient kclientset.Interface, internalKubeInformers kinternalinformers.SharedInformerFactory, proxyconfig *componentconfig.KubeProxyConfiguration) (network.NodeInterface, network.ProxyInterface, error) {
+func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.Interface, kubeClientset kclientset.Interface, kubeClient kinternalclientset.Interface, internalKubeInformers kinternalinformers.SharedInformerFactory, proxyconfig *componentconfig.KubeProxyConfiguration) (network.NodeInterface, network.ProxyInterface, error) {
 	runtimeEndpoint := options.DockerConfig.DockerShimSocket
 	runtime, ok := options.KubeletArguments["container-runtime"]
 	if ok && len(runtime) == 1 && runtime[0] == "remote" {
@@ -29,6 +34,10 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 	// SDN's hostport handling when run under CRI-O.
 	enableHostports := !strings.Contains(runtimeEndpoint, "crio")
 
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(&kv1core.EventSinkImpl{Interface: kubeClientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, kclientv1.EventSource{Component: "openshift-sdn", Host: options.NodeName})
+
 	node, err := sdnnode.New(&sdnnode.OsdnNodeConfig{
 		PluginName:         options.NetworkConfig.NetworkPluginName,
 		Hostname:           options.NodeName,
@@ -41,6 +50,7 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 		IPTablesSyncPeriod: proxyconfig.IPTables.SyncPeriod.Duration,
 		ProxyMode:          proxyconfig.Mode,
 		EnableHostports:    enableHostports,
+		Recorder:           recorder,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/cmd/server/kubernetes/network/sdn_unsupported.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_unsupported.go
@@ -5,8 +5,9 @@ package network
 import (
 	"fmt"
 
+	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	kinternalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -14,6 +15,6 @@ import (
 	networkclient "github.com/openshift/origin/pkg/network/generated/internalclientset"
 )
 
-func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.Interface, kubeClient kclientset.Interface, internalKubeInformers kinternalinformers.SharedInformerFactory, proxyconfig *componentconfig.KubeProxyConfiguration) (network.NodeInterface, network.ProxyInterface, error) {
+func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.Interface, kubeClientset kclientset.Interface, kubeClient kinternalclientset.Interface, internalKubeInformers kinternalinformers.SharedInformerFactory, proxyconfig *componentconfig.KubeProxyConfiguration) (network.NodeInterface, network.ProxyInterface, error) {
 	return nil, nil, fmt.Errorf("SDN not supported on this platform")
 }


### PR DESCRIPTION
openshift-sdn should fire an event similar to the kubelet and kube-proxy
about startup, and when it decides to kill a pod due to openvswitch
restarting should report that via an event.

```
10h        10h         1         localhost.localdomain   Node                                   Normal    Starting                  openshift-sdn, localhost.localdomain   Starting openshift-sdn.
```

When ovs is restarted and the openshift-sdn is restarted

```
10h        10h         1         imagetest               Pod                                    Warning   NetworkFailed             openshift-sdn, localhost.localdomain   The pod's network interface has been lost and the pod will be stopped.
```