### PR TITLE
apps: make rollout latest work for any annotation triggered types

### DIFF
--- a/pkg/image/trigger/resolve/resolve.go
+++ b/pkg/image/trigger/resolve/resolve.go
@@ -1,0 +1,31 @@
+package resolve
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	triggerapi "github.com/openshift/origin/pkg/image/apis/image/v1/trigger"
+	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
+)
+
+// LatestTriggerImagePullSpec resolves the latest image pull spec for given
+// object reference and returns the docker image reference.
+func LatestTriggerImagePullSpec(c imageclient.ImageStreamTagsGetter, namespace string, ref triggerapi.ObjectReference) (*imageapi.DockerImageReference, error) {
+	if len(ref.Namespace) > 0 {
+		namespace = ref.Namespace
+	}
+	tag, err := c.ImageStreamTags(namespace).Get(ref.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to get latest pull spec for %s/%s: %v", namespace, ref.Name, err)
+	}
+	if len(tag.Image.DockerImageReference) == 0 {
+		return nil, fmt.Errorf("image pull spec for %s/%s is empty", namespace, ref.Name)
+	}
+	dockerImageReference, err := imageapi.ParseDockerImageReference(tag.Image.DockerImageReference)
+	if err != nil {
+		return nil, err
+	}
+	return &dockerImageReference, nil
+}


### PR DESCRIPTION
This will make it possible to manually trigger upstream deployments with annotation trigger set by using `rollout latest`. The annotation trigger has to be "paused" to make this work.
The use case for this is to have control over what is being deployed, similar to OpenShift "automatic: false".

Example flow:
```
→ oc tag --source docker centos:7 centos:latest
Tag centos:latest set to centos:7.
→ oc set image-lookup centos
imagestream "centos" updated
→ oc run test --image=centos:latest --generator=deployment/apps.v1beta1 --command -- /bin/sleep infinity
→ oc set triggers deploy/test --from-image=centos:latest -c test --manual
deployment "test" updated
// Simulate image change
→ oc tag --source docker centos:6 centos:latest
Tag centos:latest set to centos:6.
→ oc rollout latest deployment/test
deployment "test" rolled out
// Running this again results in error (this is different from dc rollout latest, but it does not make sense to run rollout with the same outcome...)
→ oc rollout latest deployment/test
error: deployment "test" already runs the latest images
```

Also extended to StatefulSets, CronJobs, DaemonSets