### PR TITLE
Fix old replicas count in scaled RC event message

### DIFF
--- a/pkg/apps/controller/deploymentconfig/deploymentconfig_controller.go
+++ b/pkg/apps/controller/deploymentconfig/deploymentconfig_controller.go
@@ -286,11 +286,11 @@ func (c *DeploymentConfigController) reconcileDeployments(existingDeployments []
 				return err
 			}); err != nil {
 				c.recorder.Eventf(config, v1.EventTypeWarning, "ReplicationControllerScaleFailed",
-					"Failed to scale replication controler %q from %d to %d: %v", deployment.Name, oldReplicaCount, newReplicaCount, err)
+					"Failed to scale replication controler %q from %d to %d: %v", deployment.Name, *oldReplicaCount, newReplicaCount, err)
 				return err
 			}
 
-			c.recorder.Eventf(config, v1.EventTypeNormal, "ReplicationControllerScaled", "Scaled replication controller %q from %d to %d", copied.Name, oldReplicaCount, newReplicaCount)
+			c.recorder.Eventf(config, v1.EventTypeNormal, "ReplicationControllerScaled", "Scaled replication controller %q from %d to %d", copied.Name, *oldReplicaCount, newReplicaCount)
 			toAppend = copied
 		}
 


### PR DESCRIPTION
Dereference `oldReplicaCount` when formatting the "Failed to scale" or "Scaled replication controller foo from x to y" event message in the deployment config controller.

Commit 7d2ac22d1a56398a0f17e9dbeaf54d5767a7f613 changed `oldReplicaCount` from an integer to an integer pointer but did not update these formats to dereference it, which caused the controller to record events with bogus numbers, as in the following example:

    Scaled replication controller "router-1" from 842424714384 to 0