### PR TITLE
Print the entirety of Go test stderr in warning

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -191,8 +191,8 @@ if [[ -n "${junit_report}" ]]; then
     set -o pipefail
 
     if [[ -s "${test_error_file}" ]]; then
-        os::log::warning "\`go test\` had the following output to stderr:"
-        cat "${test_error_file}"
+        os::log::warning "\`go test\` had the following output to stderr:
+$( cat "${test_error_file}") "
     fi
 
     if grep -q 'WARNING: DATA RACE' "${test_output_file}"; then


### PR DESCRIPTION
Tooling picks up lines prefixed with `[WARNING]` so we should print the
entirety of what `go test` outputs to stderr in a warning block for
easier developer viewing of logs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @deads2k