### PR TITLE
Image policy should ignore unchanged images on update

### DIFF
--- a/pkg/api/meta/builds.go
+++ b/pkg/api/meta/builds.go
@@ -3,14 +3,16 @@ package meta
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	kapi "k8s.io/kubernetes/pkg/api"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 )
 
 type buildSpecMutator struct {
-	spec   *buildapi.CommonSpec
-	path   *field.Path
-	output bool
+	spec    *buildapi.CommonSpec
+	oldSpec *buildapi.CommonSpec
+	path    *field.Path
+	output  bool
 }
 
 // NewBuildMutator returns an ImageReferenceMutator that includes the output field.
@@ -22,41 +24,90 @@ func NewBuildMutator(build *buildapi.Build) ImageReferenceMutator {
 	}
 }
 
+func hasIdenticalImageSourceObjectReference(spec *buildapi.CommonSpec, ref kapi.ObjectReference) bool {
+	if spec == nil {
+		return false
+	}
+	for i := range spec.Source.Images {
+		if spec.Source.Images[i].From == ref {
+			return true
+		}
+	}
+	return false
+}
+
+func hasIdenticalStrategyFrom(spec, oldSpec *buildapi.CommonSpec) bool {
+	if oldSpec == nil {
+		return false
+	}
+	switch {
+	case spec.Strategy.CustomStrategy != nil:
+		if oldSpec.Strategy.CustomStrategy != nil {
+			return spec.Strategy.CustomStrategy.From == oldSpec.Strategy.CustomStrategy.From
+		}
+	case spec.Strategy.DockerStrategy != nil:
+		if oldSpec.Strategy.DockerStrategy != nil {
+			return hasIdenticalObjectReference(spec.Strategy.DockerStrategy.From, oldSpec.Strategy.DockerStrategy.From)
+		}
+	case spec.Strategy.SourceStrategy != nil:
+		if oldSpec.Strategy.SourceStrategy != nil {
+			return spec.Strategy.SourceStrategy.From == oldSpec.Strategy.SourceStrategy.From
+		}
+	}
+	return false
+}
+
+func hasIdenticalObjectReference(ref, oldRef *kapi.ObjectReference) bool {
+	if ref == nil || oldRef == nil {
+		return false
+	}
+	return *ref == *oldRef
+}
+
 func (m *buildSpecMutator) Mutate(fn ImageReferenceMutateFunc) field.ErrorList {
 	var errs field.ErrorList
 	for i := range m.spec.Source.Images {
+		if hasIdenticalImageSourceObjectReference(m.oldSpec, m.spec.Source.Images[i].From) {
+			continue
+		}
 		if err := fn(&m.spec.Source.Images[i].From); err != nil {
 			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("source", "images").Index(i).Child("from", "name")))
 			continue
 		}
 	}
-	if s := m.spec.Strategy.CustomStrategy; s != nil {
-		if err := fn(&s.From); err != nil {
-			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "customStrategy", "from", "name")))
+	if !hasIdenticalStrategyFrom(m.spec, m.oldSpec) {
+		if s := m.spec.Strategy.CustomStrategy; s != nil {
+			if err := fn(&s.From); err != nil {
+				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "customStrategy", "from", "name")))
+			}
 		}
-	}
-	if s := m.spec.Strategy.DockerStrategy; s != nil {
-		if s.From != nil {
-			if err := fn(s.From); err != nil {
-				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "dockerStrategy", "from", "name")))
+		if s := m.spec.Strategy.DockerStrategy; s != nil {
+			if s.From != nil {
+				if err := fn(s.From); err != nil {
+					errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "dockerStrategy", "from", "name")))
+				}
+			}
+		}
+		if s := m.spec.Strategy.SourceStrategy; s != nil {
+			if err := fn(&s.From); err != nil {
+				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "sourceStrategy", "from", "name")))
 			}
 		}
 	}
-	if s := m.spec.Strategy.SourceStrategy; s != nil {
-		if err := fn(&s.From); err != nil {
-			errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "sourceStrategy", "from", "name")))
-		}
-		if s.RuntimeImage != nil {
+	if s := m.spec.Strategy.SourceStrategy; s != nil && s.RuntimeImage != nil {
+		if m.oldSpec == nil || m.oldSpec.Strategy.SourceStrategy == nil || !hasIdenticalObjectReference(s.RuntimeImage, m.oldSpec.Strategy.SourceStrategy.RuntimeImage) {
 			if err := fn(s.RuntimeImage); err != nil {
 				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("strategy", "sourceStrategy", "runtimeImage", "from", "name")))
 			}
 		}
-
 	}
+
 	if m.output {
 		if s := m.spec.Output.To; s != nil {
-			if err := fn(s); err != nil {
-				errs = append(errs, fieldErrorOrInternal(err, m.path.Child("output", "to")))
+			if m.oldSpec == nil || m.oldSpec.Output.To == nil || !hasIdenticalObjectReference(s, m.oldSpec.Output.To) {
+				if err := fn(s); err != nil {
+					errs = append(errs, fieldErrorOrInternal(err, m.path.Child("output", "to")))
+				}
 			}
 		}
 	}

--- a/pkg/api/meta/builds_test.go
+++ b/pkg/api/meta/builds_test.go
@@ -1,0 +1,315 @@
+package meta
+
+import (
+	"reflect"
+	"testing"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func imageRef(name string) *kapi.ObjectReference {
+	ref := imageRefValue(name)
+	return &ref
+}
+func imageRefValue(name string) kapi.ObjectReference {
+	return kapi.ObjectReference{Kind: "DockerImage", Name: name}
+}
+
+func Test_buildSpecMutator_Mutate(t *testing.T) {
+	type fields struct {
+		spec    *buildapi.CommonSpec
+		oldSpec *buildapi.CommonSpec
+		path    *field.Path
+		output  bool
+	}
+	type args struct {
+		fn ImageReferenceMutateFunc
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     field.ErrorList
+		wantSpec *buildapi.CommonSpec
+	}{
+		{
+			name:   "no-op",
+			fields: fields{spec: &buildapi.CommonSpec{}},
+		},
+		{
+			name: "passes reference",
+			fields: fields{spec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test")},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if !reflect.DeepEqual(ref, imageRef("test")) {
+					t.Errorf("unexpected ref: %#v", ref)
+				}
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test")},
+				},
+			},
+		},
+		{
+			name: "mutates docker reference",
+			fields: fields{spec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test")},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				ref.Name = "test-2"
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test-2")},
+				},
+			},
+		},
+		{
+			name: "mutates source reference",
+			fields: fields{spec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{From: imageRefValue("test")},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				ref.Name = "test-2"
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{From: imageRefValue("test-2")},
+				},
+			},
+		},
+		{
+			name: "mutates source runtimeImage reference",
+			fields: fields{spec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{
+						RuntimeImage: imageRef("test"),
+					},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name == "test" {
+					ref.Name = "test-2"
+				}
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{
+						RuntimeImage: imageRef("test-2"),
+					},
+				},
+			},
+		},
+		{
+			name: "mutates custom reference",
+			fields: fields{spec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					CustomStrategy: &buildapi.CustomBuildStrategy{From: imageRefValue("test")},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				ref.Name = "test-2"
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					CustomStrategy: &buildapi.CustomBuildStrategy{From: imageRefValue("test-2")},
+				},
+			},
+		},
+		{
+			name: "mutates image source references",
+			fields: fields{spec: &buildapi.CommonSpec{
+				Source: buildapi.BuildSource{Images: []buildapi.ImageSource{
+					{From: imageRefValue("test-1")},
+					{From: imageRefValue("test-2")},
+					{From: imageRefValue("test-3")},
+				}},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name == "test-2" {
+					ref.Name = "test-4"
+				}
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Source: buildapi.BuildSource{Images: []buildapi.ImageSource{
+					{From: imageRefValue("test-1")},
+					{From: imageRefValue("test-4")},
+					{From: imageRefValue("test-3")},
+				}},
+			},
+		},
+		{
+			name: "mutates only changed references",
+			fields: fields{
+				spec: &buildapi.CommonSpec{
+					Source: buildapi.BuildSource{Images: []buildapi.ImageSource{
+						{From: imageRefValue("test-1")},
+						{From: imageRefValue("test-2")},
+						{From: imageRefValue("test-3")},
+					}},
+				},
+				oldSpec: &buildapi.CommonSpec{
+					Source: buildapi.BuildSource{Images: []buildapi.ImageSource{
+						{From: imageRefValue("test-1")},
+						{From: imageRefValue("test-3")},
+					}},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name != "test-2" {
+					t.Errorf("did not expect to be called for existing reference")
+				}
+				ref.Name = "test-4"
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Source: buildapi.BuildSource{Images: []buildapi.ImageSource{
+					{From: imageRefValue("test-1")},
+					{From: imageRefValue("test-4")},
+					{From: imageRefValue("test-3")},
+				}},
+			},
+		},
+		{
+			name: "skips when docker reference unchanged",
+			fields: fields{
+				spec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test")},
+					},
+				},
+				oldSpec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test")},
+					},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				t.Errorf("should not have called mutator")
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{From: imageRef("test")},
+				},
+			},
+		},
+		{
+			name: "skips when custom reference unchanged",
+			fields: fields{
+				spec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						CustomStrategy: &buildapi.CustomBuildStrategy{From: imageRefValue("test")},
+					},
+				},
+				oldSpec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						CustomStrategy: &buildapi.CustomBuildStrategy{From: imageRefValue("test")},
+					},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				t.Errorf("should not have called mutator")
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					CustomStrategy: &buildapi.CustomBuildStrategy{From: imageRefValue("test")},
+				},
+			},
+		},
+		{
+			name: "skips when source reference unchanged",
+			fields: fields{
+				spec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						SourceStrategy: &buildapi.SourceBuildStrategy{From: imageRefValue("test")},
+					},
+				},
+				oldSpec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						SourceStrategy: &buildapi.SourceBuildStrategy{From: imageRefValue("test")},
+					},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				t.Errorf("should not have called mutator")
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{From: imageRefValue("test")},
+				},
+			},
+		},
+		{
+			name: "skips when source reference unchanged",
+			fields: fields{
+				spec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						SourceStrategy: &buildapi.SourceBuildStrategy{
+							From:         imageRefValue("test"),
+							RuntimeImage: imageRef("test-2"),
+						},
+					},
+				},
+				oldSpec: &buildapi.CommonSpec{
+					Strategy: buildapi.BuildStrategy{
+						SourceStrategy: &buildapi.SourceBuildStrategy{
+							From:         imageRefValue("test"),
+							RuntimeImage: imageRef("test-2"),
+						},
+					},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				t.Errorf("should not have called mutator")
+				return nil
+			}},
+			wantSpec: &buildapi.CommonSpec{
+				Strategy: buildapi.BuildStrategy{
+					SourceStrategy: &buildapi.SourceBuildStrategy{
+						From:         imageRefValue("test"),
+						RuntimeImage: imageRef("test-2"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &buildSpecMutator{
+				spec:    tt.fields.spec,
+				oldSpec: tt.fields.oldSpec,
+				path:    tt.fields.path,
+				output:  tt.fields.output,
+			}
+			if tt.wantSpec == nil {
+				tt.wantSpec = &buildapi.CommonSpec{}
+			}
+			if got := m.Mutate(tt.args.fn); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSpecMutator.Mutate() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.wantSpec, tt.fields.spec) {
+				t.Errorf("buildSpecMutator.Mutate() spec = %#v, want %#v", tt.fields.spec, tt.wantSpec)
+			}
+		})
+	}
+}

--- a/pkg/api/meta/pods_test.go
+++ b/pkg/api/meta/pods_test.go
@@ -6,7 +6,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapiv1 "k8s.io/kubernetes/pkg/api/v1"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 )
@@ -92,4 +94,291 @@ func knownResourceKinds() map[schema.GroupKind]struct{} {
 		result[ka] = struct{}{}
 	}
 	return result
+}
+
+func Test_podSpecMutator_Mutate(t *testing.T) {
+	imageRef := func(name string) *kapi.ObjectReference {
+		ref := imageRefValue(name)
+		return &ref
+	}
+
+	type fields struct {
+		spec    *kapi.PodSpec
+		oldSpec *kapi.PodSpec
+		path    *field.Path
+	}
+	type args struct {
+		fn ImageReferenceMutateFunc
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     field.ErrorList
+		wantSpec *kapi.PodSpec
+	}{
+		{
+			name:   "no-op",
+			fields: fields{spec: &kapi.PodSpec{}},
+		},
+		{
+			name: "passes init container reference",
+			fields: fields{spec: &kapi.PodSpec{
+				InitContainers: []kapi.Container{
+					{Name: "1", Image: "test"},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if !reflect.DeepEqual(ref, imageRef("test")) {
+					t.Errorf("unexpected ref: %#v", ref)
+				}
+				return nil
+			}},
+			wantSpec: &kapi.PodSpec{
+				InitContainers: []kapi.Container{
+					{Name: "1", Image: "test"},
+				},
+			},
+		},
+		{
+			name: "passes container reference",
+			fields: fields{spec: &kapi.PodSpec{
+				Containers: []kapi.Container{
+					{Name: "1", Image: "test"},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if !reflect.DeepEqual(ref, imageRef("test")) {
+					t.Errorf("unexpected ref: %#v", ref)
+				}
+				return nil
+			}},
+			wantSpec: &kapi.PodSpec{
+				Containers: []kapi.Container{
+					{Name: "1", Image: "test"},
+				},
+			},
+		},
+
+		{
+			name: "mutates reference",
+			fields: fields{spec: &kapi.PodSpec{
+				InitContainers: []kapi.Container{
+					{Name: "1", Image: "test"},
+				},
+				Containers: []kapi.Container{
+					{Name: "2", Image: "test-2"},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name == "test-2" {
+					ref.Name = "test-3"
+				}
+				return nil
+			}},
+			wantSpec: &kapi.PodSpec{
+				InitContainers: []kapi.Container{
+					{Name: "1", Image: "test"},
+				},
+				Containers: []kapi.Container{
+					{Name: "2", Image: "test-3"},
+				},
+			},
+		},
+		{
+			name: "mutates only changed references",
+			fields: fields{
+				spec: &kapi.PodSpec{
+					InitContainers: []kapi.Container{
+						{Name: "1", Image: "test"},
+					},
+					Containers: []kapi.Container{
+						{Name: "2", Image: "test-2"},
+					},
+				},
+				oldSpec: &kapi.PodSpec{
+					InitContainers: []kapi.Container{
+						{Name: "1", Image: "test-1"},
+					},
+					Containers: []kapi.Container{
+						{Name: "2", Image: "test-2"},
+					},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name != "test" {
+					t.Errorf("did not expect to be called for existing reference")
+				}
+				ref.Name = "test-3"
+				return nil
+			}},
+			wantSpec: &kapi.PodSpec{
+				InitContainers: []kapi.Container{
+					{Name: "1", Image: "test-3"},
+				},
+				Containers: []kapi.Container{
+					{Name: "2", Image: "test-2"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &podSpecMutator{
+				spec:    tt.fields.spec,
+				oldSpec: tt.fields.oldSpec,
+				path:    tt.fields.path,
+			}
+			if tt.wantSpec == nil {
+				tt.wantSpec = &kapi.PodSpec{}
+			}
+			if got := m.Mutate(tt.args.fn); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSpecMutator.Mutate() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.wantSpec, tt.fields.spec) {
+				t.Errorf("buildSpecMutator.Mutate() spec = %v, want %v", tt.fields.spec, tt.wantSpec)
+			}
+		})
+	}
+}
+
+func Test_podSpecV1Mutator_Mutate(t *testing.T) {
+	type fields struct {
+		spec    *kapiv1.PodSpec
+		oldSpec *kapiv1.PodSpec
+		path    *field.Path
+	}
+	type args struct {
+		fn ImageReferenceMutateFunc
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     field.ErrorList
+		wantSpec *kapiv1.PodSpec
+	}{
+		{
+			name:   "no-op",
+			fields: fields{spec: &kapiv1.PodSpec{}},
+		},
+		{
+			name: "passes init container reference",
+			fields: fields{spec: &kapiv1.PodSpec{
+				InitContainers: []kapiv1.Container{
+					{Name: "1", Image: "test"},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if !reflect.DeepEqual(ref, imageRef("test")) {
+					t.Errorf("unexpected ref: %#v", ref)
+				}
+				return nil
+			}},
+			wantSpec: &kapiv1.PodSpec{
+				InitContainers: []kapiv1.Container{
+					{Name: "1", Image: "test"},
+				},
+			},
+		},
+		{
+			name: "passes container reference",
+			fields: fields{spec: &kapiv1.PodSpec{
+				Containers: []kapiv1.Container{
+					{Name: "1", Image: "test"},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if !reflect.DeepEqual(ref, imageRef("test")) {
+					t.Errorf("unexpected ref: %#v", ref)
+				}
+				return nil
+			}},
+			wantSpec: &kapiv1.PodSpec{
+				Containers: []kapiv1.Container{
+					{Name: "1", Image: "test"},
+				},
+			},
+		},
+
+		{
+			name: "mutates reference",
+			fields: fields{spec: &kapiv1.PodSpec{
+				InitContainers: []kapiv1.Container{
+					{Name: "1", Image: "test"},
+				},
+				Containers: []kapiv1.Container{
+					{Name: "2", Image: "test-2"},
+				},
+			}},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name == "test-2" {
+					ref.Name = "test-3"
+				}
+				return nil
+			}},
+			wantSpec: &kapiv1.PodSpec{
+				InitContainers: []kapiv1.Container{
+					{Name: "1", Image: "test"},
+				},
+				Containers: []kapiv1.Container{
+					{Name: "2", Image: "test-3"},
+				},
+			},
+		},
+		{
+			name: "mutates only changed references",
+			fields: fields{
+				spec: &kapiv1.PodSpec{
+					InitContainers: []kapiv1.Container{
+						{Name: "1", Image: "test"},
+					},
+					Containers: []kapiv1.Container{
+						{Name: "2", Image: "test-2"},
+					},
+				},
+				oldSpec: &kapiv1.PodSpec{
+					InitContainers: []kapiv1.Container{
+						{Name: "1", Image: "test-1"},
+					},
+					Containers: []kapiv1.Container{
+						{Name: "2", Image: "test-2"},
+					},
+				},
+			},
+			args: args{fn: func(ref *kapi.ObjectReference) error {
+				if ref.Name != "test" {
+					t.Errorf("did not expect to be called for existing reference")
+				}
+				ref.Name = "test-3"
+				return nil
+			}},
+			wantSpec: &kapiv1.PodSpec{
+				InitContainers: []kapiv1.Container{
+					{Name: "1", Image: "test-3"},
+				},
+				Containers: []kapiv1.Container{
+					{Name: "2", Image: "test-2"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &podSpecV1Mutator{
+				spec:    tt.fields.spec,
+				oldSpec: tt.fields.oldSpec,
+				path:    tt.fields.path,
+			}
+			if tt.wantSpec == nil {
+				tt.wantSpec = &kapiv1.PodSpec{}
+			}
+			if got := m.Mutate(tt.args.fn); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSpecMutator.Mutate() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.wantSpec, tt.fields.spec) {
+				t.Errorf("buildSpecMutator.Mutate() spec = %v, want %v", tt.fields.spec, tt.wantSpec)
+			}
+		})
+	}
 }

--- a/pkg/image/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/admission/imagepolicy/imagepolicy.go
@@ -189,7 +189,7 @@ func (a *imagePolicyPlugin) Admit(attr admission.Attributes) error {
 		return nil
 	}
 
-	m, err := meta.GetImageReferenceMutator(attr.GetObject())
+	m, err := meta.GetImageReferenceMutator(attr.GetObject(), attr.GetOldObject())
 	if err != nil {
 		return apierrs.NewForbidden(gr, attr.GetName(), fmt.Errorf("unable to apply image policy against objects of type %T: %v", attr.GetObject(), err))
 	}


### PR DESCRIPTION
If an UPDATE policy decision is made, references that are unchanged
should not be reprocessed. This ensures that storage migration can
continue working even if a restrictive image policy is in place.

@bparees @enj