### PR TITLE
registry: Calculate schema 1 layer sizes in the registry

### DIFF
--- a/pkg/dockerregistry/server/manifestschema2handler.go
+++ b/pkg/dockerregistry/server/manifestschema2handler.go
@@ -10,6 +10,9 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
+
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	imageapiv1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 )
 
 var (
@@ -61,8 +64,16 @@ func (h *manifestSchema2Handler) Digest() (digest.Digest, error) {
 	return digest.FromBytes(p), nil
 }
 
+func (h *manifestSchema2Handler) Layers(ctx context.Context) ([]imageapiv1.ImageLayer, error) {
+	return nil, ErrNotImplemented
+}
+
 func (h *manifestSchema2Handler) Manifest() distribution.Manifest {
 	return h.manifest
+}
+
+func (h *manifestSchema2Handler) Metadata(ctx context.Context) (*imageapi.DockerImage, error) {
+	return nil, ErrNotImplemented
 }
 
 func (h *manifestSchema2Handler) Payload() (mediaType string, payload []byte, canonical []byte, err error) {

--- a/pkg/dockerregistry/server/pullthroughblobstore_test.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore_test.go
@@ -751,17 +751,17 @@ func (t *testBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribut
 
 func (t *testBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
 	t.calls["Put"]++
-	return distribution.Descriptor{}, fmt.Errorf("method not implemented")
+	return distribution.Descriptor{}, ErrNotImplemented
 }
 
 func (t *testBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
 	t.calls["Create"]++
-	return nil, fmt.Errorf("method not implemented")
+	return nil, ErrNotImplemented
 }
 
 func (t *testBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
 	t.calls["Resume"]++
-	return nil, fmt.Errorf("method not implemented")
+	return nil, ErrNotImplemented
 }
 
 func (t *testBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
@@ -783,7 +783,7 @@ func (t *testBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, re
 
 func (t *testBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	t.calls["Delete"]++
-	return fmt.Errorf("method not implemented")
+	return ErrNotImplemented
 }
 
 type testBlobFileReader struct {

--- a/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice_test.go
@@ -571,7 +571,7 @@ func (t *testManifestService) Put(ctx context.Context, manifest distribution.Man
 
 func (t *testManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
 	t.calls["Delete"]++
-	return fmt.Errorf("method not implemented")
+	return ErrNotImplemented
 }
 
 const etcdDigest = "sha256:958608f8ecc1dc62c93b6c610f3a834dae4220c9642e6e8b4e0f2b3ad7cbd238"

--- a/pkg/image/util/helpers.go
+++ b/pkg/image/util/helpers.go
@@ -167,7 +167,7 @@ func ReorderImageLayers(image *imageapi.Image) {
 	layersOrder, ok := image.Annotations[imageapi.DockerImageLayersOrderAnnotation]
 	if !ok {
 		switch image.DockerImageManifestMediaType {
-		case schema1.MediaTypeManifest:
+		case schema1.MediaTypeManifest, schema1.MediaTypeSignedManifest:
 			layersOrder = imageapi.DockerImageLayersOrderAscending
 		case schema2.MediaTypeManifest:
 			layersOrder = imageapi.DockerImageLayersOrderDescending
@@ -212,7 +212,7 @@ func ManifestMatchesImage(image *imageapi.Image, newManifest []byte) (bool, erro
 		if err != nil {
 			return false, err
 		}
-	case schema1.MediaTypeManifest, "":
+	case schema1.MediaTypeManifest, schema1.MediaTypeSignedManifest, "":
 		var m schema1.SignedManifest
 		if err := json.Unmarshal(newManifest, &m); err != nil {
 			return false, err


### PR DESCRIPTION
Manifest V2 schema 1 lacks blob sizes in most cases. The registry is the only component that can fix the missing sizes. In case of schema 1, the registry must fill the image metadata and send it to the master API.

Resolves [bz#1491589](https://bugzilla.redhat.com/show_bug.cgi?id=1491589)