### PR TITLE
Use config map for election with start controllers

### DIFF
--- a/pkg/cmd/server/start/start_controllers.go
+++ b/pkg/cmd/server/start/start_controllers.go
@@ -88,7 +88,7 @@ func NewCommandStartMasterControllers(name, basename string, out, errout io.Writ
 				LockName:      lockServiceName,
 				LockNamespace: "kube-system",
 				LockResource: configapi.GroupResource{
-					Resource: "endpoints",
+					Resource: "configmaps",
 				},
 			}
 		}


### PR DESCRIPTION
This change makes an invocation of

```
openshift start master controllers \
    --config=master-config.yaml \
    --lock-service-name=openshift-controllers
```

use a config map based lock.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @smarterclayton

/kind bug

cc @sdodson @jupierce