### PR TITLE
hack/verify-generated-completions.sh: Do not trap exit on unsupported platforms

### DIFF
--- a/hack/verify-generated-completions.sh
+++ b/hack/verify-generated-completions.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+platform="$(os::build::host_platform)"
+if [[ "${platform}" != "linux/amd64" ]]; then
+  os::log::warning "Completions cannot be verified on non-Linux systems (${platform})"
+  exit 0
+fi
+
 function cleanup() {
     return_code=$?
     rm -rf "${TMP_COMPLETION_ROOT}"
@@ -9,12 +15,6 @@ function cleanup() {
     exit "${return_code}"
 }
 trap "cleanup" EXIT
-
-platform="$(os::build::host_platform)"
-if [[ "${platform}" != "linux/amd64" ]]; then
-  os::log::warning "Completions cannot be verified on non-Linux systems (${platform})"
-  exit 0
-fi
 
 COMPLETION_ROOT_REL="contrib/completions"
 COMPLETION_ROOT="${OS_ROOT}/${COMPLETION_ROOT_REL}"


### PR DESCRIPTION
If hack/verify-generated-completions.sh is run on a non-linux/amd64 target, it will error out when running cleanup. This PR moves the trap after the platform check to prevent this.

/assign @stevekuznetsov 
/area multi-arch tests
/kind bug