### PR TITLE
incorporate failed container reason in failed build pod messages

### DIFF
--- a/pkg/build/apis/build/types.go
+++ b/pkg/build/apis/build/types.go
@@ -538,6 +538,7 @@ const (
 	StatusMessageBuildPodExists                  = "The pod for this build already exists and is older than the build."
 	StatusMessageNoBuildContainerStatus          = "The pod for this build has no container statuses indicating success or failure."
 	StatusMessageFailedContainer                 = "The pod for this build has at least one container with a non-zero exit status."
+	StatusMessageFailedContainerWithReason = "The pod for this build has at least one container with a non-zero exit status and the following reported reason: "
 	StatusMessageGenericBuildFailed              = "Generic Build failure - check logs for details."
 	StatusMessageUnresolvableEnvironmentVariable = "Unable to resolve build environment variable reference."
 	StatusMessageCannotRetrieveServiceAccount    = "Unable to look up the service account associated with this build."


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/15032

@openshift/devex 

@bparees - if you are good with the general approach, I'll move past this prototype phase add testing, etc.

it took over half a dozen `guru` searches, but I was able to connect the dots between the kubelet's polling of container status for the pod and the Reason field of the terminated state; hence, I believe situations like the OOMKilled in the issue should be propagated