### PR TITLE
Fix symbol-link inconsistency under Windows

### DIFF
--- a/cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/vendor/github.com/prometheus/procfs/fixtures/26231/exe
+++ b/cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/vendor/github.com/prometheus/procfs/fixtures/26231/exe
@@ -1,1 +1,0 @@
-/usr/bin/vim

--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/vendor/github.com/prometheus/procfs/fixtures/26231/exe
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/vendor/github.com/prometheus/procfs/fixtures/26231/exe
@@ -1,1 +1,0 @@
-/usr/bin/vim


### PR DESCRIPTION
The two files removed by this PR uses absolute path in its symbol link. When the code is checkout under Windows if git's symlink feature is enabled, the contents of these two files will contain additional drive letters, which make git believe their contents are modified (but actually not). Remove them from repository should be OK as they are only used to test vendor's code.