### PR TITLE
syscontainers: cgroup devices cleanup

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -497,12 +497,7 @@
 	"resources": {
 	    "devices": [
 		{
-		    "allow": false,
-		    "access": "rwm"
-		},
-		{
 		    "allow": true,
-		    "type": "b",
 		    "access": "rwm"
 		}
 	    ]

--- a/images/openvswitch/system-container/config.json.template
+++ b/images/openvswitch/system-container/config.json.template
@@ -231,17 +231,6 @@
             "source": "proc"
         },
         {
-            "destination": "/dev",
-            "type": "tmpfs",
-            "source": "tmpfs",
-            "options": [
-                "nosuid",
-                "strictatime",
-                "mode=755",
-                "size=65536k"
-            ]
-        },
-        {
 	    "type": "bind",
 	    "source": "/run",
 	    "destination": "/run",
@@ -305,7 +294,7 @@
 	"resources": {
 	    "devices": [
 		{
-		    "allow": false,
+		    "allow": true,
 		    "access": "rwm"
 		}
 	    ]

--- a/images/origin/system-container/config.json.template
+++ b/images/origin/system-container/config.json.template
@@ -210,14 +210,63 @@
     ],
     "hooks": {},
     "linux": {
-	"resources": {
-	    "devices": [
-		{
-		    "allow": false,
-		    "access": "rwm"
-		}
-	    ]
-	},
+        "resources": {
+            "devices": [
+                {
+                    "allow": false,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 1,
+                    "minor": 5,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 1,
+                    "minor": 3,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 1,
+                    "minor": 9,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 1,
+                    "minor": 8,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 5,
+                    "minor": 0,
+                    "access": "rwm"
+                },
+                {
+                    "allow": true,
+                    "type": "c",
+                    "major": 5,
+                    "minor": 1,
+                    "access": "rwm"
+                },
+                {
+                    "allow": false,
+                    "type": "c",
+                    "major": 10,
+                    "minor": 229,
+                    "access": "rwm"
+                }
+            ]
+        },
 	"namespaces": [
 	    {
 		"type": "mount"


### PR DESCRIPTION
fix the OCI spec file for the devices cgroup:

- Both Openvswitch and Node system containers have access to the host devices.

- Master has only access to standard devices.
