### PR TITLE
Make govet check glog.Info/Warning calls

### DIFF
--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -30,7 +30,7 @@ function govet_blacklist_contains() {
 }
 
 for test_dir in $(os::util::list_go_src_dirs); do
-	if ! result="$(go tool vet -shadow=false "${test_dir}" 2>&1)"; then
+	if ! result="$(go tool vet -shadow=false -printfuncs=Info,Infof,Warning,Warningf "${test_dir}" 2>&1)"; then
 		while read -r line; do
 			if ! govet_blacklist_contains "${line}"; then
 				echo "${line}"

--- a/pkg/apps/prune/prune.go
+++ b/pkg/apps/prune/prune.go
@@ -116,11 +116,11 @@ func (p *deploymentDeleter) DeleteDeployment(deployment *kapi.ReplicationControl
 		dpSelector := deployutil.DeployerPodSelector(deployment.Name)
 		deployers, err := p.pods.Pods(deployment.Namespace).List(metav1.ListOptions{LabelSelector: dpSelector.String()})
 		if err != nil {
-			glog.Warning("Cannot list deployer pods for %q: %v\n", deployment.Name, err)
+			glog.Warningf("Cannot list deployer pods for %q: %v\n", deployment.Name, err)
 		} else {
 			for _, pod := range deployers.Items {
 				if err := p.pods.Pods(pod.Namespace).Delete(pod.Name, nil); err != nil {
-					glog.Warning("Cannot remove deployer pod %q: %v\n", pod.Name, err)
+					glog.Warningf("Cannot remove deployer pod %q: %v\n", pod.Name, err)
 				}
 			}
 		}

--- a/pkg/assets/apiserver/asset_apiserver.go
+++ b/pkg/assets/apiserver/asset_apiserver.go
@@ -302,7 +302,7 @@ func RunAssetServer(assetServer *AssetServer, stopCh <-chan struct{}) error {
 	go assetServer.GenericAPIServer.PrepareRun().Run(stopCh)
 
 	glog.Infof("Web console listening at https://%s", assetServer.GenericAPIServer.SecureServingInfo.BindAddress)
-	glog.Infof("Web console available at %s", assetServer.PublicURL)
+	glog.Infof("Web console available at %s", assetServer.PublicURL.String())
 
 	// Attempt to verify the server came up for 20 seconds (100 tries * 100ms, 100ms timeout per try)
 	return cmdutil.WaitForSuccessfulDial(true, assetServer.GenericAPIServer.SecureServingInfo.BindNetwork, assetServer.GenericAPIServer.SecureServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)

--- a/pkg/image/importer/client.go
+++ b/pkg/image/importer/client.go
@@ -171,7 +171,7 @@ func (r *repositoryRetriever) ping(registry url.URL, insecure bool, transport ht
 	resp, err := pingClient.Do(req)
 	if err != nil {
 		if insecure && registry.Scheme == "https" {
-			glog.V(5).Infof("Falling back to an HTTP check for an insecure registry %s: %v", registry, err)
+			glog.V(5).Infof("Falling back to an HTTP check for an insecure registry %s: %v", registry.String(), err)
 			registry.Scheme = "http"
 			_, nErr := r.ping(registry, true, transport)
 			if nErr != nil {

--- a/pkg/image/importer/dockerv1client/client.go
+++ b/pkg/image/importer/dockerv1client/client.go
@@ -488,7 +488,7 @@ func (c *connection) authenticateV2(header string) (string, error) {
 // the appropriate endpoint token. It will try HTTP if HTTPS fails and insecure connections
 // are allowed.
 func (c *connection) getRepositoryV1(name string) (repository, error) {
-	glog.V(4).Infof("Getting repository %s from %s", name, c.url)
+	glog.V(4).Infof("Getting repository %s from %s", name, c.url.String())
 
 	base := c.url
 	base.Path = path.Join(base.Path, fmt.Sprintf("/v1/repositories/%s/images", name))

--- a/pkg/image/registry/imagestreamimport/rest.go
+++ b/pkg/image/registry/imagestreamimport/rest.go
@@ -485,7 +485,7 @@ func (r *REST) importSuccessful(
 	switch {
 	case kapierrors.IsAlreadyExists(err):
 		if err := util.ImageWithMetadata(image); err != nil {
-			glog.V(4).Infof("Unable to update image metadata during image import when image already exists %q: err", image.Name, err)
+			glog.V(4).Infof("Unable to update image metadata during image import when image already exists %q: %v", image.Name, err)
 		}
 		updated = image
 		fallthrough

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -148,7 +148,7 @@ func (np *networkPolicyPlugin) AddNetNamespace(netns *networkapi.NetNamespace) {
 	defer np.lock.Unlock()
 
 	if _, exists := np.namespaces[netns.NetID]; exists {
-		glog.Warning("Got AddNetNamespace for already-existing namespace %s (%d)", netns.NetName, netns.NetID)
+		glog.Warningf("Got AddNetNamespace for already-existing namespace %s (%d)", netns.NetName, netns.NetID)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (np *networkPolicyPlugin) AddNetNamespace(netns *networkapi.NetNamespace) {
 
 func (np *networkPolicyPlugin) UpdateNetNamespace(netns *networkapi.NetNamespace, oldNetID uint32) {
 	if netns.NetID != oldNetID {
-		glog.Warning("Got VNID change for namespace %s while using %s plugin", netns.NetName, network.NetworkPolicyPluginName)
+		glog.Warningf("Got VNID change for namespace %s while using %s plugin", netns.NetName, network.NetworkPolicyPluginName)
 	}
 
 	np.node.podManager.UpdateLocalMulticastRules(netns.NetID)


### PR DESCRIPTION
The default set of names covered by govet's checking of Printf-like functions includes Log, Error, and Fatal, but not Info or Warning. (Noticed in #16793.)