### PR TITLE
Require network API objects to have IPv4 addresses

### DIFF
--- a/pkg/network/apis/network/validation/validation.go
+++ b/pkg/network/apis/network/validation/validation.go
@@ -16,6 +16,28 @@ import (
 	"github.com/openshift/origin/pkg/util/netutils"
 )
 
+func validateCIDRv4(cidr string) (*net.IPNet, error) {
+	ipnet, err := netutils.ParseCIDRMask(cidr)
+	if err != nil {
+		return nil, err
+	}
+	if ipnet.IP.To4() == nil {
+		return nil, fmt.Errorf("must be an IPv4 network")
+	}
+	return ipnet, nil
+}
+
+func validateIPv4(ip string) (net.IP, error) {
+	bytes := net.ParseIP(ip)
+	if bytes == nil {
+		return nil, fmt.Errorf("invalid IP address")
+	}
+	if bytes.To4() == nil {
+		return nil, fmt.Errorf("must be an IPv4 address")
+	}
+	return bytes, nil
+}
+
 var defaultClusterNetwork *networkapi.ClusterNetwork
 
 // SetDefaultClusterNetwork sets the expected value of the default ClusterNetwork record
@@ -30,7 +52,7 @@ func ValidateClusterNetwork(clusterNet *networkapi.ClusterNetwork) field.ErrorLi
 
 	if len(clusterNet.Network) != 0 || clusterNet.HostSubnetLength != 0 {
 		//In the case that a user manually makes a clusterNetwork object with clusterNet.Network and clusterNet.HostubnetLength at least make sure they are valid values
-		clusterIPNet, err := netutils.ParseCIDRMask(clusterNet.Network)
+		clusterIPNet, err := validateCIDRv4(clusterNet.Network)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("network"), clusterNet.Network, err.Error()))
 		} else {
@@ -46,12 +68,12 @@ func ValidateClusterNetwork(clusterNet *networkapi.ClusterNetwork) field.ErrorLi
 	if len(clusterNet.ClusterNetworks) == 0 && len(clusterNet.Network) == 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("clusterNetworks"), clusterNet.ClusterNetworks, "must have at least one cluster network CIDR"))
 	}
-	serviceIPNet, err := netutils.ParseCIDRMask(clusterNet.ServiceNetwork)
+	serviceIPNet, err := validateCIDRv4(clusterNet.ServiceNetwork)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("serviceNetwork"), clusterNet.ServiceNetwork, err.Error()))
 	}
 	for i, cn := range clusterNet.ClusterNetworks {
-		clusterIPNet, err := netutils.ParseCIDRMask(cn.CIDR)
+		clusterIPNet, err := validateCIDRv4(cn.CIDR)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("clusterNetworks").Index(i).Child("cidr"), cn.CIDR, err.Error()))
 			continue
@@ -115,18 +137,19 @@ func ValidateHostSubnet(hs *networkapi.HostSubnet) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("subnet"), hs.Subnet, "field cannot be empty"))
 		}
 	} else {
-		_, err := netutils.ParseCIDRMask(hs.Subnet)
+		_, err := validateCIDRv4(hs.Subnet)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("subnet"), hs.Subnet, err.Error()))
 		}
 	}
+	// In theory this has to be IPv4, but it's possible some clusters might be limping along with IPv6 values?
 	if net.ParseIP(hs.HostIP) == nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("hostIP"), hs.HostIP, "invalid IP address"))
 	}
 
 	for i, egressIP := range hs.EgressIPs {
-		if net.ParseIP(egressIP) == nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("egressIPs").Index(i), egressIP, "invalid IP address"))
+		if _, err := validateIPv4(egressIP); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("egressIPs").Index(i), egressIP, err.Error()))
 		}
 	}
 
@@ -157,8 +180,8 @@ func ValidateNetNamespace(netnamespace *networkapi.NetNamespace) field.ErrorList
 	}
 
 	for i, ip := range netnamespace.EgressIPs {
-		if net.ParseIP(ip) == nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("egressIPs").Index(i), ip, "invalid IP address"))
+		if _, err := validateIPv4(ip); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("egressIPs").Index(i), ip, err.Error()))
 		}
 	}
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1500664 points out problems that occur if you specify an IPv6 EgressIP. In fact, we shouldn't be allowing IPv6 addresses for any network API objects:

- `ClusterNetwork.Network` / `ClusterNetwork.ClusterNetworks[].CIDR` must be IPv4 because we only support an IPv4 SDN right now, for multiple reasons throughout kube and the SDN code. (Among other things, the HostSubnet allocator implicitly assumes IPv4, so while it's currently possible to start up a master with an IPv6 `clusterNetworkCIDR` value, it won't ever succeed in allocating any HostSubnets, so no nodes will ever successfully start up.)
- `ClusterNetwork.ServiceNetwork` must be IPv4 because kube-proxy only supports all-IPv4 or all-IPv6, and service rules must be able to refer to pod IPs, and since those are IPv4, then service IPs must be IPv4 too.
- `HostSubnet.HostIP` must be IPv4 because the node's IP address is used in kube-proxy rules, which per the above must be IPv4 only
- `HostSubnet.Subnet` must be IPv4 because it's a subset of the cluster network, which is IPv4
- `HostSubnet.EgressIPs` must be IPv4 because they are used for NATting in iptables rules.
- `NetNamespace.EgressIPs` must be IPv4 because they have to match some hostsubnet's `EgressIPs`.
- `EgressNetworkPolicyPeer.CIDRSelector` ... well, ... actually I guess these don't *need* to be IPv4; it's pointless to specify an IPv6 value here since pods don't have IPv6 connectivity, but nothing will break if you do.

So this PR requires all of the above except `EgressNetworkPolicyPeer.CIDRSelector` to be IPv4.
