### PR TITLE
Remove "template.openshift.io/template-instance" label

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -253,16 +253,16 @@
       "vendor/k8s.io/client-go",
       "vendor/github.com/spf13/cobra",
       "vendor/golang.org",
+      "github.com/openshift/origin/pkg/config/cmd",
       "github.com/openshift/origin/pkg/template/generated",
       "github.com/openshift/origin/pkg/template/servicebroker",
-      "github.com/openshift/origin/pkg/route/generated"
+      "github.com/openshift/origin/pkg/util/rest"
     ],
     "allowedImportPackages": [
       "vendor/github.com/golang/glog",
       "vendor/k8s.io/kubernetes/pkg/api",
       "vendor/k8s.io/kubernetes/pkg/api/install",
       "vendor/k8s.io/kubernetes/pkg/apis/authorization",
-      "vendor/k8s.io/kubernetes/pkg/client/clientset_generated/clientset",
       "vendor/k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
       "vendor/github.com/emicklei/go-restful",
       "vendor/github.com/lestrrat/go-jsschema",

--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -337,9 +337,10 @@ func init() {
 			rbac.NewRule("get", "create", "update", "delete").Groups(templateGroup).Resources("brokertemplateinstances").RuleOrDie(),
 			rbac.NewRule("get", "create", "delete", "assign").Groups(templateGroup).Resources("templateinstances").RuleOrDie(),
 			rbac.NewRule("get", "list", "watch").Groups(templateGroup).Resources("templates").RuleOrDie(),
-			rbac.NewRule("get", "list", "create", "delete").Groups(kapiGroup).Resources("secrets").RuleOrDie(),
-			rbac.NewRule("list").Groups(kapiGroup).Resources("services", "configmaps").RuleOrDie(),
-			rbac.NewRule("list").Groups(routeGroup).Resources("routes").RuleOrDie(),
+			rbac.NewRule("get", "create", "delete").Groups(kapiGroup).Resources("secrets").RuleOrDie(),
+			rbac.NewRule("get").Groups(kapiGroup).Resources("services", "configmaps").RuleOrDie(),
+			rbac.NewRule("get").Groups(legacyRouteGroup).Resources("routes").RuleOrDie(),
+			rbac.NewRule("get").Groups(routeGroup).Resources("routes").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/pkg/template/apis/template/constants.go
+++ b/pkg/template/apis/template/constants.go
@@ -19,10 +19,6 @@ const (
 	// SupportURLAnnotation is the url where support for a template can be found
 	SupportURLAnnotation = "template.openshift.io/support-url"
 
-	// TemplateInstanceLabel is used to label every object created by the
-	// TemplateInstance API.
-	TemplateInstanceLabel = "template.openshift.io/template-instance"
-
 	// ServiceBrokerRoot is the API root of the template service broker.
 	ServiceBrokerRoot = "/brokers/template.openshift.io"
 

--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -395,13 +395,6 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 		return err
 	}
 
-	// We label all objects we create - this is needed by the template service
-	// broker.
-	if template.ObjectLabels == nil {
-		template.ObjectLabels = make(map[string]string)
-	}
-	template.ObjectLabels[templateapi.TemplateInstanceLabel] = templateInstance.Name
-
 	if secret != nil {
 		for i, param := range template.Parameters {
 			if value, ok := secret.Data[param.Name]; ok {
@@ -436,15 +429,17 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 
 	// We add an OwnerReference to all objects we create - this is also needed
 	// by the template service broker for cleanup.
+	templateInstanceOwnerRef := metav1.OwnerReference{
+		APIVersion: templateapiv1.SchemeGroupVersion.String(),
+		Kind:       "TemplateInstance",
+		Name:       templateInstance.Name,
+		UID:        templateInstance.UID,
+	}
+
 	for _, obj := range template.Objects {
 		meta, _ := meta.Accessor(obj)
 		ref := meta.GetOwnerReferences()
-		ref = append(ref, metav1.OwnerReference{
-			APIVersion: templateapiv1.SchemeGroupVersion.String(),
-			Kind:       "TemplateInstance",
-			Name:       templateInstance.Name,
-			UID:        templateInstance.UID,
-		})
+		ref = append(ref, templateInstanceOwnerRef)
 		meta.SetOwnerReferences(ref)
 	}
 
@@ -505,8 +500,11 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 				return nil, err
 			}
 
-			if meta.GetLabels()[templateapi.TemplateInstanceLabel] == templateInstance.Name {
-				createObj, createErr = obj, nil
+			for _, ownerRef := range meta.GetOwnerReferences() {
+				if ownerRef == templateInstanceOwnerRef {
+					createObj, createErr = obj, nil
+					break
+				}
 			}
 		}
 

--- a/pkg/templateservicebroker/cmd/server/start.go
+++ b/pkg/templateservicebroker/cmd/server/start.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 
 	"github.com/spf13/cobra"
@@ -17,8 +18,6 @@ import (
 	authenticationclient "k8s.io/client-go/kubernetes/typed/authentication/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
-
-	"io/ioutil"
 
 	"github.com/openshift/origin/pkg/template/servicebroker/apis/config"
 	configinstall "github.com/openshift/origin/pkg/template/servicebroker/apis/config/install"

--- a/pkg/templateservicebroker/servicebroker/servicebroker.go
+++ b/pkg/templateservicebroker/servicebroker/servicebroker.go
@@ -1,28 +1,30 @@
 package servicebroker
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	restclient "k8s.io/client-go/rest"
-	kclientsetexternal "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
-	extrouteclientset "github.com/openshift/origin/pkg/route/generated/clientset/typed/route/v1"
 	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion/template/internalversion"
 	templateclientset "github.com/openshift/origin/pkg/template/generated/internalclientset"
 	internalversiontemplate "github.com/openshift/origin/pkg/template/generated/internalclientset/typed/template/internalversion"
 	templatelister "github.com/openshift/origin/pkg/template/generated/listers/template/internalversion"
 	"github.com/openshift/origin/pkg/templateservicebroker/openservicebroker/api"
+	restutil "github.com/openshift/origin/pkg/util/rest"
 )
 
 // Broker represents the template service broker.  It implements
 // openservicebroker/api.Broker.
 type Broker struct {
 	kc                 kclientset.Interface
+	extconfig          *restclient.Config
 	templateclient     internalversiontemplate.TemplateInterface
-	extkc              kclientsetexternal.Interface
-	extrouteclient     extrouteclientset.RouteV1Interface
 	lister             templatelister.TemplateLister
 	hasSynced          func() bool
 	templateNamespaces map[string]struct{}
+	restmapper         meta.RESTMapper
 }
 
 var _ api.Broker = &Broker{}
@@ -37,27 +39,22 @@ func NewBroker(saKubeClientConfig *restclient.Config, informer templateinformer.
 	if err != nil {
 		return nil, err
 	}
-	externalKubeClient, err := kclientsetexternal.NewForConfig(saKubeClientConfig)
-	if err != nil {
-		return nil, err
-	}
-	extrouteclientset, err := extrouteclientset.NewForConfig(saKubeClientConfig)
-	if err != nil {
-		return nil, err
-	}
 	templateClient, err := templateclientset.NewForConfig(saKubeClientConfig)
 	if err != nil {
 		return nil, err
 	}
 
+	configCopy := *saKubeClientConfig
+	configCopy.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: kapi.Codecs}
+
 	b := &Broker{
 		kc:                 internalKubeClient,
-		extkc:              externalKubeClient,
-		extrouteclient:     extrouteclientset,
+		extconfig:          &configCopy,
 		templateclient:     templateClient.Template(),
 		lister:             informer.Lister(),
 		hasSynced:          informer.Informer().HasSynced,
 		templateNamespaces: templateNamespaces,
+		restmapper:         restutil.DefaultMultiRESTMapper(),
 	}
 
 	return b, nil

--- a/test/extended/templates/templateservicebroker_bind.go
+++ b/test/extended/templates/templateservicebroker_bind.go
@@ -1,0 +1,119 @@
+package templates
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/user"
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"github.com/openshift/origin/pkg/templateservicebroker/openservicebroker/api"
+	"github.com/openshift/origin/pkg/templateservicebroker/openservicebroker/client"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Conformance][templates] templateservicebroker bind test", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		tsbOC               = exutil.NewCLI("openshift-template-service-broker", exutil.KubeConfigPath())
+		portForwardCmdClose func() error
+
+		cli                = exutil.NewCLI("templates", exutil.KubeConfigPath())
+		instanceID         = "aadda50d-d92c-402d-bd29-5ed2095aad2c"
+		bindingID          = uuid.NewRandom().String()
+		serviceID          = "d261a5c9-db37-40b5-ac0f-5709e0e3aac4"
+		fixture            = exutil.FixturePath("testdata", "templates", "templateservicebroker_bind.yaml")
+		clusterrolebinding *authorizationapi.ClusterRoleBinding
+		brokercli          client.Client
+		cliUser            user.Info
+	)
+
+	g.BeforeEach(func() {
+		framework.SkipIfProviderIs("gce")
+
+		var err error
+
+		brokercli, portForwardCmdClose = EnsureTSB(tsbOC)
+
+		cliUser = &user.DefaultInfo{Name: cli.Username(), Groups: []string{"system:authenticated"}}
+
+		// enable unauthenticated access to the service broker
+		clusterrolebinding, err = cli.AdminAuthorizationClient().Authorization().ClusterRoleBindings().Create(&authorizationapi.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cli.Namespace() + "templateservicebroker-client",
+			},
+			RoleRef: kapi.ObjectReference{
+				Name: bootstrappolicy.TemplateServiceBrokerClientRoleName,
+			},
+			Subjects: []kapi.ObjectReference{
+				{
+					Kind: authorizationapi.GroupKind,
+					Name: bootstrappolicy.UnauthenticatedGroup,
+				},
+			},
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = cli.AsAdmin().Run("new-app").Args(fixture, "-p", "NAMESPACE="+cli.Namespace()).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// wait for templateinstance controller to do its thing
+		err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
+			templateinstance, err := cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Get(instanceID, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			for _, c := range templateinstance.Status.Conditions {
+				if c.Reason == "Failed" && c.Status == kapi.ConditionTrue {
+					return false, fmt.Errorf("failed condition: %s", c.Message)
+				}
+				if c.Reason == "Created" && c.Status == kapi.ConditionTrue {
+					return true, nil
+				}
+			}
+
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.AfterEach(func() {
+		err := cli.AdminAuthorizationClient().Authorization().ClusterRoleBindings().Delete(clusterrolebinding.Name, nil)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = cli.AdminTemplateClient().Template().BrokerTemplateInstances().Delete(instanceID, &metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = portForwardCmdClose()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should pass bind tests", func() {
+		svc, err := cli.KubeClient().Core().Services(cli.Namespace()).Get("service", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		bind, err := brokercli.Bind(context.Background(), cliUser, instanceID, bindingID, &api.BindRequest{
+			ServiceID: serviceID,
+			PlanID:    uuid.NewRandom().String(),
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(bind.Credentials).To(o.HaveKeyWithValue("configmap-username", "configmap-username"))
+		o.Expect(bind.Credentials).To(o.HaveKeyWithValue("secret-username", "secret-username"))
+		o.Expect(bind.Credentials).To(o.HaveKeyWithValue("secret-password", "c2VjcmV0LXBhc3N3b3Jk"))
+		o.Expect(bind.Credentials).To(o.HaveKeyWithValue("service-uri", "http://"+svc.Spec.ClusterIP+":1234"))
+		o.Expect(bind.Credentials).To(o.HaveKeyWithValue("route-uri", "http://host/path"))
+	})
+})

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -45,6 +46,8 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker security test
 	)
 
 	g.BeforeEach(func() {
+		framework.SkipIfProviderIs("gce")
+
 		err := exutil.WaitForBuilderAccount(cli.KubeClient().Core().ServiceAccounts(cli.Namespace()))
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -150,6 +150,7 @@
 // test/extended/testdata/sti-environment-build-app/Gemfile
 // test/extended/testdata/sti-environment-build-app/config.ru
 // test/extended/testdata/templates/templateinstance_objectkinds.yaml
+// test/extended/testdata/templates/templateservicebroker_bind.yaml
 // test/extended/testdata/test-auth-build.yaml
 // test/extended/testdata/test-bc-with-pr-ref.yaml
 // test/extended/testdata/test-build-app/Dockerfile
@@ -7802,6 +7803,105 @@ func testExtendedTestdataTemplatesTemplateinstance_objectkindsYaml() (*asset, er
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/templates/templateinstance_objectkinds.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataTemplatesTemplateservicebroker_bindYaml = []byte(`apiVersion: v1
+kind: Template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+    namespace: ${NAMESPACE}
+
+- apiVersion: template.openshift.io/v1
+  kind: TemplateInstance
+  metadata:
+    name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+    namespace: ${NAMESPACE}
+  spec:
+    template:
+      apiVersion: v1
+      kind: Template
+      metadata:
+        uid: d261a5c9-db37-40b5-ac0f-5709e0e3aac4
+      objects:
+      - apiVersion: v1
+        data:
+          username: configmap-username
+        kind: ConfigMap
+        metadata:
+          annotations:
+            template.openshift.io/expose-configmap-username: "{.data['username']}"
+          name: configmap
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          annotations:
+            template.openshift.io/base64-expose-secret-password: "{.data['password']}"
+            template.openshift.io/expose-secret-username: "{.data['username']}"
+          name: secret
+        stringData:
+          password: secret-password
+          username: secret-username
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            template.openshift.io/expose-service-uri: http://{.spec.clusterIP}:{.spec.ports[?(.name=="port")].port}
+          name: service
+        spec:
+          ports:
+          - name: port
+            port: 1234
+      - apiVersion: v1
+        kind: Route
+        metadata:
+          annotations:
+            template.openshift.io/expose-route-uri: http://{.spec.host}{.spec.path}
+          name: route
+        spec:
+          host: host
+          path: /path
+          to:
+            kind: Service
+            name: service
+
+- apiVersion: template.openshift.io/v1
+  kind: BrokerTemplateInstance
+  metadata:
+    name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+  spec:
+    templateInstance:
+      apiVersion: template.openshift.io/v1
+      kind: TemplateInstance
+      name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+      namespace: ${NAMESPACE}
+
+    secret:
+      apiVersion: v1
+      kind: Secret
+      name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+      namespace: ${NAMESPACE}
+
+parameters:
+- name: NAMESPACE
+  required: true
+`)
+
+func testExtendedTestdataTemplatesTemplateservicebroker_bindYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataTemplatesTemplateservicebroker_bindYaml, nil
+}
+
+func testExtendedTestdataTemplatesTemplateservicebroker_bindYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataTemplatesTemplateservicebroker_bindYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/templates/templateservicebroker_bind.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -28597,6 +28697,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/sti-environment-build-app/Gemfile": testExtendedTestdataStiEnvironmentBuildAppGemfile,
 	"test/extended/testdata/sti-environment-build-app/config.ru": testExtendedTestdataStiEnvironmentBuildAppConfigRu,
 	"test/extended/testdata/templates/templateinstance_objectkinds.yaml": testExtendedTestdataTemplatesTemplateinstance_objectkindsYaml,
+	"test/extended/testdata/templates/templateservicebroker_bind.yaml": testExtendedTestdataTemplatesTemplateservicebroker_bindYaml,
 	"test/extended/testdata/test-auth-build.yaml": testExtendedTestdataTestAuthBuildYaml,
 	"test/extended/testdata/test-bc-with-pr-ref.yaml": testExtendedTestdataTestBcWithPrRefYaml,
 	"test/extended/testdata/test-build-app/Dockerfile": testExtendedTestdataTestBuildAppDockerfile,
@@ -29059,6 +29160,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 				"templates": &bintree{nil, map[string]*bintree{
 					"templateinstance_objectkinds.yaml": &bintree{testExtendedTestdataTemplatesTemplateinstance_objectkindsYaml, map[string]*bintree{}},
+					"templateservicebroker_bind.yaml": &bintree{testExtendedTestdataTemplatesTemplateservicebroker_bindYaml, map[string]*bintree{}},
 				}},
 				"test-auth-build.yaml": &bintree{testExtendedTestdataTestAuthBuildYaml, map[string]*bintree{}},
 				"test-bc-with-pr-ref.yaml": &bintree{testExtendedTestdataTestBcWithPrRefYaml, map[string]*bintree{}},

--- a/test/extended/testdata/templates/templateservicebroker_bind.yaml
+++ b/test/extended/testdata/templates/templateservicebroker_bind.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+    namespace: ${NAMESPACE}
+
+- apiVersion: template.openshift.io/v1
+  kind: TemplateInstance
+  metadata:
+    name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+    namespace: ${NAMESPACE}
+  spec:
+    template:
+      apiVersion: v1
+      kind: Template
+      metadata:
+        uid: d261a5c9-db37-40b5-ac0f-5709e0e3aac4
+      objects:
+      - apiVersion: v1
+        data:
+          username: configmap-username
+        kind: ConfigMap
+        metadata:
+          annotations:
+            template.openshift.io/expose-configmap-username: "{.data['username']}"
+          name: configmap
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          annotations:
+            template.openshift.io/base64-expose-secret-password: "{.data['password']}"
+            template.openshift.io/expose-secret-username: "{.data['username']}"
+          name: secret
+        stringData:
+          password: secret-password
+          username: secret-username
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          annotations:
+            template.openshift.io/expose-service-uri: http://{.spec.clusterIP}:{.spec.ports[?(.name=="port")].port}
+          name: service
+        spec:
+          ports:
+          - name: port
+            port: 1234
+      - apiVersion: v1
+        kind: Route
+        metadata:
+          annotations:
+            template.openshift.io/expose-route-uri: http://{.spec.host}{.spec.path}
+          name: route
+        spec:
+          host: host
+          path: /path
+          to:
+            kind: Service
+            name: service
+
+- apiVersion: template.openshift.io/v1
+  kind: BrokerTemplateInstance
+  metadata:
+    name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+  spec:
+    templateInstance:
+      apiVersion: template.openshift.io/v1
+      kind: TemplateInstance
+      name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+      namespace: ${NAMESPACE}
+
+    secret:
+      apiVersion: v1
+      kind: Secret
+      name: aadda50d-d92c-402d-bd29-5ed2095aad2c
+      namespace: ${NAMESPACE}
+
+parameters:
+- name: NAMESPACE
+  required: true

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3769,20 +3769,25 @@ items:
     - create
     - delete
     - get
-    - list
   - apiGroups:
     - ""
     resources:
     - configmaps
     - services
     verbs:
-    - list
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - routes
+    verbs:
+    - get
   - apiGroups:
     - route.openshift.io
     resources:
     - routes
     verbs:
-    - list
+    - get
   - apiGroups:
     - ""
     resources:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -4118,7 +4118,6 @@ items:
     - create
     - delete
     - get
-    - list
   - apiGroups:
     - ""
     attributeRestrictions: null
@@ -4126,14 +4125,21 @@ items:
     - configmaps
     - services
     verbs:
-    - list
+    - get
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - routes
+    verbs:
+    - get
   - apiGroups:
     - route.openshift.io
     attributeRestrictions: null
     resources:
     - routes
     verbs:
-    - list
+    - get
   - apiGroups:
     - ""
     attributeRestrictions: null


### PR DESCRIPTION
Background: this label was a stopgap before OwnerReferences and TemplateInstance.Status.Objects existed.  Now that these do, and before the templateinstance API is officially released, I'd like to remove the label.  It is unnecessary, and it is problematic on two fronts: it is effectively trying to be a ObjectReference, but it doesn't record Namespace or UID.  That means that it it is broken in the cases of cross-namespace template instantiations (TemplateInstance in one namespace, instantiated object in another), and rapid creation/deletion of TemplateInstances (recently witnessed in an extended test flake).