### PR TITLE
Correctly parse nested go tests

### DIFF
--- a/tools/junitreport/pkg/api/test_suite.go
+++ b/tools/junitreport/pkg/api/test_suite.go
@@ -19,12 +19,15 @@ func (t *TestSuite) AddProperty(name, value string) {
 func (t *TestSuite) AddTestCase(testCase *TestCase) {
 	t.NumTests += 1
 
-	if testCase.SkipMessage != nil {
+	switch {
+	case testCase.SkipMessage != nil:
 		t.NumSkipped += 1
-	}
-
-	if testCase.FailureOutput != nil {
+	case testCase.FailureOutput != nil:
 		t.NumFailed += 1
+	default:
+		// we do not preserve output on tests that are not failures or skips
+		testCase.SystemOut = ""
+		testCase.SystemErr = ""
 	}
 
 	t.Duration += testCase.Duration

--- a/tools/junitreport/pkg/parser/gotest/example/example_test.go
+++ b/tools/junitreport/pkg/parser/gotest/example/example_test.go
@@ -1,0 +1,40 @@
+package example
+
+/* Used to generate output for testing
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSubTestWithFailures(t *testing.T) {
+	t.Run("subtest-pass-1", func(t *testing.T) {})
+	t.Run("subtest-pass-2", func(t *testing.T) {})
+	t.Run("subtest-fail-1", func(t *testing.T) { fmt.Printf("text line\n"); t.Logf("log line"); t.Errorf("failed") })
+}
+
+func TestSubTestWithFirstFailures(t *testing.T) {
+	t.Run("subtest-fail-1", func(t *testing.T) { fmt.Printf("text line\n"); t.Logf("log line"); t.Errorf("failed") })
+	t.Run("subtest-pass-1", func(t *testing.T) {})
+	t.Run("subtest-pass-2", func(t *testing.T) {})
+}
+
+func TestSubTestWithSubTestFailures(t *testing.T) {
+	t.Run("subtest-pass-1", func(t *testing.T) {})
+	t.Run("subtest-pass-2", func(t *testing.T) {})
+	t.Run("subtest-fail-1", func(t *testing.T) {
+		fmt.Printf("text line\n")
+		t.Logf("log line before")
+		t.Run("sub-subtest-pass-1", func(t *testing.T) {})
+		t.Run("sub-subtest-pass-2", func(t *testing.T) {})
+		t.Run("sub-subtest-fail-1", func(t *testing.T) { fmt.Printf("text line\n"); t.Logf("log line"); t.Errorf("failed") })
+		t.Logf("log line after")
+	})
+}
+
+func TestSubTestWithMiddleFailures(t *testing.T) {
+	t.Run("subtest-pass-1", func(t *testing.T) {})
+	t.Run("subtest-fail-1", func(t *testing.T) { fmt.Printf("text line\n"); t.Logf("log line"); t.Errorf("failed") })
+	t.Run("subtest-pass-2", func(t *testing.T) {})
+}
+*/

--- a/tools/junitreport/pkg/parser/gotest/parser.go
+++ b/tools/junitreport/pkg/parser/gotest/parser.go
@@ -3,7 +3,6 @@ package gotest
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/openshift/origin/tools/junitreport/pkg/api"
@@ -14,101 +13,258 @@ import (
 // NewParser returns a new parser that's capable of parsing Go unit test output
 func NewParser(builder builder.TestSuitesBuilder, stream bool) parser.TestOutputParser {
 	return &testOutputParser{
-		builder:     builder,
-		testParser:  newTestDataParser(),
-		suiteParser: newTestSuiteDataParser(),
-		stream:      stream,
+		builder: builder,
+		stream:  stream,
 	}
 }
 
 type testOutputParser struct {
-	builder     builder.TestSuitesBuilder
-	testParser  testDataParser
-	suiteParser testSuiteDataParser
-	stream      bool
+	builder builder.TestSuitesBuilder
+	stream  bool
+}
+
+const (
+	stateBegin = iota
+	stateOutput
+	stateResults
+	stateComplete
+)
+
+func log(format string, args ...interface{}) {
+	//fmt.Printf(format, args...)
 }
 
 // Parse parses `go test -v` output into test suites. Test output from `go test -v` is not bookmarked for packages, so
 // the parsing strategy is to advance line-by-line, building up a slice of test cases until a package declaration is found,
 // at which point all tests cases are added to that package and the process can start again.
 func (p *testOutputParser) Parse(input *bufio.Scanner) (*api.TestSuites, error) {
-	currentSuite := &api.TestSuite{}
-	var currentTest *api.TestCase
-	var currentTestResult api.TestResult
-	var currentTestOutput []string
+	suites := &api.TestSuites{}
+
+	var testNameStack []string
+	var tests map[string]*api.TestCase
+	var output map[string][]string
+	var messages map[string][]string
+	var currentSuite *api.TestSuite
+	var state int
+	var count int
+	var orderedTests []string
 
 	for input.Scan() {
 		line := input.Text()
-		isTestOutput := true
+		count++
 
-		if p.testParser.MarksBeginning(line) || p.suiteParser.MarksCompletion(line) {
-			if currentTest != nil {
-				// we can't mark the test as failed or skipped until we have all of the test output, which we don't know
-				// we have until we see the next test or the beginning of suite output, so we add it here
-				output := strings.Join(currentTestOutput, "\n")
-				switch currentTestResult {
-				case api.TestResultSkip:
-					currentTest.MarkSkipped(output)
-				case api.TestResultFail:
-					currentTest.MarkFailed("", output)
-				}
+		log("Line %03d: %d: %s\n", count, state, line)
 
-				currentSuite.AddTestCase(currentTest)
+		switch state {
+
+		case stateBegin:
+			// this is the first state
+			name, ok := ExtractRun(line)
+			if !ok {
+				// A test that defines a test.M handler can write output prior to test execution. We will drop this because
+				// we have no place to put it, although the first test case *could* use it in the future.
+				log("  ignored output outside of suite\n")
+				continue
 			}
-			currentTest = &api.TestCase{}
-			currentTestResult = api.TestResultFail
-			currentTestOutput = []string{}
-		}
-
-		if name, matched := p.testParser.ExtractName(line); matched {
-			currentTest.Name = name
-		}
-
-		if result, matched := p.testParser.ExtractResult(line); matched {
-			currentTestResult = result
-		}
-
-		if duration, matched := p.testParser.ExtractDuration(line); matched {
-			if err := currentTest.SetDuration(duration); err != nil {
-				return nil, err
-			}
-		}
-
-		if properties, matched := p.suiteParser.ExtractProperties(line); matched {
-			for name := range properties {
-				currentSuite.AddProperty(name, properties[name])
-			}
-			isTestOutput = false
-		}
-
-		if name, matched := p.suiteParser.ExtractName(line); matched {
-			currentSuite.Name = name
-			isTestOutput = false
-		}
-
-		if duration, matched := p.suiteParser.ExtractDuration(line); matched {
-			if err := currentSuite.SetDuration(duration); err != nil {
-				return nil, err
-			}
-		}
-
-		if p.suiteParser.MarksCompletion(line) {
-			if p.stream {
-				fmt.Fprintln(os.Stdout, line)
-			}
-
-			p.builder.AddSuite(currentSuite)
+			log("  found run command %s\n", name)
 
 			currentSuite = &api.TestSuite{}
-			currentTest = nil
-			isTestOutput = false
-		}
+			tests = make(map[string]*api.TestCase)
+			output = make(map[string][]string)
+			messages = make(map[string][]string)
 
-		// we want to associate any line not directly related to a test suite with a test case to ensure we capture all output
-		if isTestOutput {
-			currentTestOutput = append(currentTestOutput, line)
+			orderedTests = []string{name}
+			testNameStack = []string{name}
+			tests[testNameStack[0]] = &api.TestCase{
+				Name: name,
+			}
+
+			state = stateOutput
+
+		case stateOutput:
+			// open a new test for gathering output
+			if name, ok := ExtractRun(line); ok {
+				log("  found run command %s\n", name)
+				test, ok := tests[name]
+				if !ok {
+					test = &api.TestCase{
+						Name: name,
+					}
+					tests[name] = test
+				}
+				orderedTests = append(orderedTests, name)
+				testNameStack = []string{name}
+				continue
+			}
+
+			// transition to result mode ONLY if it matches a result at the top level
+			if result, name, depth, duration, ok := ExtractResult(line); ok && tests[name] != nil && depth == 0 {
+				test := tests[name]
+				log("  found result %s %s %s\n", result, name, duration)
+				switch result {
+				case api.TestResultPass:
+				case api.TestResultFail:
+					test.FailureOutput = &api.FailureOutput{}
+				case api.TestResultSkip:
+					test.SkipMessage = &api.SkipMessage{}
+				}
+				if err := test.SetDuration(duration); err != nil {
+					return nil, fmt.Errorf("unexpected duration on line %d: %s", count, duration)
+				}
+				testNameStack = []string{name}
+				state = stateResults
+				continue
+			}
+
+			// in output mode, turn output lines into output on the particular test
+			if _, _, ok := ExtractOutput(line); ok {
+				log("  found output\n")
+				output[testNameStack[0]] = append(output[testNameStack[0]], line)
+				continue
+			}
+			log("  fallthrough\n")
+
+		case stateResults:
+			output, depth, ok := ExtractOutput(line)
+			if !ok {
+				return nil, fmt.Errorf("unexpected output on line %d, can't grab results", count)
+			}
+
+			// we're back to the root, we expect either a new RUN, a test suite end, or this is just an
+			// output line that was chopped up
+			if depth == 0 {
+				if name, ok := ExtractRun(line); ok {
+					log("  found run %s\n", name)
+					// starting a new set of runs
+					orderedTests = append(orderedTests, name)
+					testNameStack = []string{name}
+					tests[testNameStack[0]] = &api.TestCase{
+						Name: name,
+					}
+					state = stateOutput
+					continue
+				}
+				switch {
+				case line == "PASS", line == "FAIL":
+					log("  found end of suite\n")
+					// at the end of the suite
+					state = stateComplete
+				default:
+					// a broken output line that was not indented
+					log("  found message\n")
+					name := testNameStack[len(testNameStack)-1]
+					test := tests[name]
+					switch {
+					case test.FailureOutput != nil, test.SkipMessage != nil:
+						messages[name] = append(messages[name], output)
+					}
+				}
+				continue
+			}
+
+			// if this is a result AND we have already declared this as a test, parse it
+			if result, name, _, duration, ok := ExtractResult(output); ok && tests[name] != nil {
+				log("  found result %s %s (%d)\n", result, name, depth)
+				test := tests[name]
+				switch result {
+				case api.TestResultPass:
+				case api.TestResultFail:
+					test.FailureOutput = &api.FailureOutput{}
+				case api.TestResultSkip:
+					test.SkipMessage = &api.SkipMessage{}
+				}
+				if err := test.SetDuration(duration); err != nil {
+					return nil, fmt.Errorf("unexpected duration on line %d: %s", count, duration)
+				}
+				switch {
+				case depth >= len(testNameStack):
+					// we found a new, more deeply nested test
+					testNameStack = append(testNameStack, name)
+				default:
+					if depth < len(testNameStack)-1 {
+						// the current result is less indented than our current test, so remove the deepest
+						// items from the stack
+						testNameStack = testNameStack[:depth]
+					}
+					testNameStack[len(testNameStack)-1] = name
+				}
+				continue
+			}
+
+			// treat as regular output at the appropriate depth
+			log("  found message line %d %v\n", depth, testNameStack)
+			// BUG: in go test, double nested output is double indented for some reason
+			if depth >= len(testNameStack) {
+				depth = len(testNameStack) - 1
+			}
+			name := testNameStack[depth]
+			log("    name %s\n", name)
+			if test, ok := tests[name]; ok {
+				switch {
+				case test.FailureOutput != nil, test.SkipMessage != nil:
+					messages[name] = append(messages[name], output)
+				}
+			}
+
+		case stateComplete:
+			// suite exit line
+			if name, duration, coverage, ok := ExtractPackage(line); ok {
+				currentSuite.Name = name
+				if props, ok := ExtractProperties(coverage); ok {
+					for k, v := range props {
+						currentSuite.AddProperty(k, v)
+					}
+				}
+				for _, name := range orderedTests {
+					test := tests[name]
+					messageLines := messages[name]
+					var extraOutput []string
+					for i, s := range messageLines {
+						if s == "=== OUTPUT" {
+							log("test %s has OUTPUT section, %d %d\n", name, i, len(messageLines))
+							if i < len(messageLines) {
+								log("  test %s add lines: %d\n", name, len(messageLines[i+1:]))
+								extraOutput = messageLines[i+1:]
+							}
+							messageLines = messageLines[:i]
+							break
+						}
+					}
+
+					switch {
+					case test.FailureOutput != nil:
+						test.FailureOutput.Output = strings.Join(messageLines, "\n")
+
+						lines := append(output[name], extraOutput...)
+						test.SystemOut = strings.Join(lines, "\n")
+
+					case test.SkipMessage != nil:
+						test.SkipMessage.Message = strings.Join(messageLines, "\n")
+
+					default:
+						lines := append(output[name], extraOutput...)
+						test.SystemOut = strings.Join(lines, "\n")
+					}
+
+					currentSuite.AddTestCase(test)
+				}
+				if err := currentSuite.SetDuration(duration); err != nil {
+					return nil, fmt.Errorf("unexpected duration on line %d: %s", count, duration)
+				}
+				suites.Suites = append(suites.Suites, currentSuite)
+
+				state = stateBegin
+				continue
+			}
+
+			// coverage only line
+			if props, ok := ExtractProperties(line); ok {
+				for k, v := range props {
+					currentSuite.AddProperty(k, v)
+				}
+			}
 		}
 	}
 
-	return p.builder.Build(), nil
+	return suites, nil
 }

--- a/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_flat_test.go
@@ -55,12 +55,7 @@ func TestFlatParse(t *testing.T) {
 								Name:     "TestOne",
 								Duration: 0.02,
 								FailureOutput: &api.FailureOutput{
-									Output: `=== RUN TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.`,
+									Output: "file_test.go:11: Error message\nfile_test.go:11: Longer\nerror\nmessage.\n",
 								},
 							},
 							{
@@ -87,9 +82,7 @@ func TestFlatParse(t *testing.T) {
 								Name:     "TestOne",
 								Duration: 0.02,
 								SkipMessage: &api.SkipMessage{
-									Message: `=== RUN TestOne
---- SKIP: TestOne (0.02 seconds)
-	file_test.go:11: Skip message`,
+									Message: "file_test.go:11: Skip message\n",
 								},
 							},
 							{
@@ -154,12 +147,7 @@ func TestFlatParse(t *testing.T) {
 								Name:     "TestOne",
 								Duration: 0.02,
 								FailureOutput: &api.FailureOutput{
-									Output: `=== RUN TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.`,
+									Output: "file_test.go:11: Error message\nfile_test.go:11: Longer\nerror\nmessage.\n",
 								},
 							},
 							{
@@ -253,7 +241,7 @@ func TestFlatParse(t *testing.T) {
 			},
 		},
 		{
-			name:     "nested ",
+			name:     "nested",
 			testFile: "9.txt",
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
@@ -283,22 +271,14 @@ func TestFlatParse(t *testing.T) {
 								Name:     "TestOne",
 								Duration: 0.02,
 								FailureOutput: &api.FailureOutput{
-									Output: `=== RUN   TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.`,
+									Output: "file_test.go:11: Error message\nfile_test.go:11: Longer\nerror\nmessage.\n",
 								},
 							},
 							{
 								Name:     "TestTwo",
 								Duration: 0.03,
 								SkipMessage: &api.SkipMessage{
-									Message: `=== RUN   TestTwo
---- SKIP: TestTwo (0.03 seconds)
-	file_test.go:11: Skip message
-PASS`,
+									Message: "file_test.go:11: Skip message\n",
 								},
 							},
 						},
@@ -376,23 +356,23 @@ PASS`,
 	}
 
 	for _, testCase := range testCases {
-		parser := NewParser(flat.NewTestSuitesBuilder(), false)
+		t.Run(testCase.name, func(t *testing.T) {
+			parser := NewParser(flat.NewTestSuitesBuilder(), false)
 
-		testFile := "./../../../test/gotest/testdata/" + testCase.testFile
+			testFile := "./../../../test/gotest/testdata/" + testCase.testFile
 
-		reader, err := os.Open(testFile)
-		if err != nil {
-			t.Errorf("%s: unexpected error opening file %q: %v", testCase.name, testFile, err)
-			continue
-		}
-		testSuites, err := parser.Parse(bufio.NewScanner(reader))
-		if err != nil {
-			t.Errorf("%s: unexpected error parsing file: %v", testCase.name, err)
-			continue
-		}
+			reader, err := os.Open(testFile)
+			if err != nil {
+				t.Fatalf("unexpected error opening file %q: %v", testFile, err)
+			}
+			testSuites, err := parser.Parse(bufio.NewScanner(reader))
+			if err != nil {
+				t.Fatalf("unexpected error parsing file: %v", err)
+			}
 
-		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
-			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
-		}
+			if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
+				t.Errorf("did not produce the correct test suites from file:\n%#v\n%#v", testCase.expectedSuites, testSuites)
+			}
+		})
 	}
 }

--- a/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/diff"
+
 	"github.com/openshift/origin/tools/junitreport/pkg/api"
 	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
 )
@@ -24,24 +26,17 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 0.16,
-						Children: []*api.TestSuite{
+						TestCases: []*api.TestCase{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 0.16,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
-								},
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
 							},
 						},
 					},
@@ -78,34 +73,21 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:      "package",
+						Name:      "package/name",
 						NumTests:  2,
 						NumFailed: 1,
 						Duration:  0.15,
-						Children: []*api.TestSuite{
+						TestCases: []*api.TestCase{
 							{
-								Name:      "package/name",
-								NumTests:  2,
-								NumFailed: 1,
-								Duration:  0.15,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.02,
-										FailureOutput: &api.FailureOutput{
-											Output: `=== RUN TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.`,
-										},
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.13,
-									},
+								Name:     "TestOne",
+								Duration: 0.02,
+								FailureOutput: &api.FailureOutput{
+									Output: "file_test.go:11: Error message\nfile_test.go:11: Longer\nerror\nmessage.\n",
 								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.13,
 							},
 						},
 					},
@@ -118,31 +100,21 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:       "package",
+						Name:       "package/name",
 						NumTests:   2,
 						NumSkipped: 1,
 						Duration:   0.15,
-						Children: []*api.TestSuite{
+						TestCases: []*api.TestCase{
 							{
-								Name:       "package/name",
-								NumTests:   2,
-								NumSkipped: 1,
-								Duration:   0.15,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.02,
-										SkipMessage: &api.SkipMessage{
-											Message: `=== RUN TestOne
---- SKIP: TestOne (0.02 seconds)
-	file_test.go:11: Skip message`,
-										},
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.13,
-									},
+								Name:     "TestOne",
+								Duration: 0.02,
+								SkipMessage: &api.SkipMessage{
+									Message: "file_test.go:11: Skip message\n",
 								},
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.13,
 							},
 						},
 					},
@@ -155,24 +127,17 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 0.16,
-						Children: []*api.TestSuite{
+						TestCases: []*api.TestCase{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 0.16,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
-								},
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
 							},
 						},
 					},
@@ -185,49 +150,36 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:      "package",
-						NumTests:  4,
-						NumFailed: 1,
-						Duration:  0.31,
-						Children: []*api.TestSuite{
+						Name:     "package/name1",
+						NumTests: 2,
+						Duration: 0.16,
+						TestCases: []*api.TestCase{
 							{
-								Name:     "package/name1",
-								NumTests: 2,
-								Duration: 0.16,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+					{
+						Name:      "package/name2",
+						NumTests:  2,
+						Duration:  0.15,
+						NumFailed: 1,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+								FailureOutput: &api.FailureOutput{
+									Output: "file_test.go:11: Error message\nfile_test.go:11: Longer\nerror\nmessage.\n",
 								},
 							},
 							{
-								Name:      "package/name2",
-								NumTests:  2,
-								Duration:  0.15,
-								NumFailed: 1,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.02,
-										FailureOutput: &api.FailureOutput{
-											Output: `=== RUN TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.`,
-										},
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.13,
-									},
-								},
+								Name:     "TestTwo",
+								Duration: 0.13,
 							},
 						},
 					},
@@ -240,30 +192,23 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 0.16,
-						Children: []*api.TestSuite{
+						Properties: []*api.TestSuiteProperty{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 0.16,
-								Properties: []*api.TestSuiteProperty{
-									{
-										Name:  "coverage.statements.pct",
-										Value: "13.37",
-									},
-								},
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
-								},
+								Name:  "coverage.statements.pct",
+								Value: "13.37",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
 							},
 						},
 					},
@@ -276,30 +221,23 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 0.16,
-						Children: []*api.TestSuite{
+						Properties: []*api.TestSuiteProperty{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 0.16,
-								Properties: []*api.TestSuiteProperty{
-									{
-										Name:  "coverage.statements.pct",
-										Value: "10.0",
-									},
-								},
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
-								},
+								Name:  "coverage.statements.pct",
+								Value: "10.0",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
 							},
 						},
 					},
@@ -312,24 +250,17 @@ func TestNestedParse(t *testing.T) {
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 0.05,
-						Children: []*api.TestSuite{
+						TestCases: []*api.TestCase{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 0.05,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.02,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.03,
-									},
-								},
+								Name:     "TestOne",
+								Duration: 0.02,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.03,
 							},
 						},
 					},
@@ -337,90 +268,62 @@ func TestNestedParse(t *testing.T) {
 			},
 		},
 		{
-			name:     "nested ",
+			name:     "nested",
 			testFile: "9.txt",
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:       "package",
-						NumTests:   6,
+						Name:       "package/name",
+						NumTests:   2,
+						NumFailed:  0,
+						NumSkipped: 0,
+						Duration:   0.05,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.02,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.03,
+							},
+						},
+					},
+					{
+						Name:       "package/name/nested",
+						NumTests:   2,
 						NumFailed:  1,
 						NumSkipped: 1,
-						Duration:   0.4,
-						Children: []*api.TestSuite{
+						Duration:   0.05,
+						TestCases: []*api.TestCase{
 							{
-								Name:       "package/name",
-								NumTests:   4,
-								NumFailed:  1,
-								NumSkipped: 1,
-								Duration:   0.1,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.02,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.03,
-									},
-								},
-								Children: []*api.TestSuite{
-
-									{
-										Name:       "package/name/nested",
-										NumTests:   2,
-										NumFailed:  1,
-										NumSkipped: 1,
-										Duration:   0.05,
-										TestCases: []*api.TestCase{
-											{
-												Name:     "TestOne",
-												Duration: 0.02,
-												FailureOutput: &api.FailureOutput{
-													Output: `=== RUN   TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.`,
-												},
-											},
-											{
-												Name:     "TestTwo",
-												Duration: 0.03,
-												SkipMessage: &api.SkipMessage{
-													Message: `=== RUN   TestTwo
---- SKIP: TestTwo (0.03 seconds)
-	file_test.go:11: Skip message
-PASS`, // we include this line greedily even though it does not belong to the test
-												},
-											},
-										},
-									},
+								Name:     "TestOne",
+								Duration: 0.02,
+								FailureOutput: &api.FailureOutput{
+									Output: "file_test.go:11: Error message\nfile_test.go:11: Longer\nerror\nmessage.\n",
 								},
 							},
 							{
-								Name:     "package/other",
-								NumTests: 2,
-								Duration: 0.3,
-								Children: []*api.TestSuite{
-
-									{
-										Name:     "package/other/nested",
-										NumTests: 2,
-										Duration: 0.3,
-										TestCases: []*api.TestCase{
-											{
-												Name:     "TestOne",
-												Duration: 0.1,
-											},
-											{
-												Name:     "TestTwo",
-												Duration: 0.2,
-											},
-										},
-									},
+								Name:     "TestTwo",
+								Duration: 0.03,
+								SkipMessage: &api.SkipMessage{
+									Message: "file_test.go:11: Skip message\n",
 								},
+							},
+						},
+					},
+					{
+						Name:     "package/other/nested",
+						NumTests: 2,
+						Duration: 0.3,
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.1,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.2,
 							},
 						},
 					},
@@ -433,24 +336,17 @@ PASS`, // we include this line greedily even though it does not belong to the te
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 2.16,
-						Children: []*api.TestSuite{
+						TestCases: []*api.TestCase{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 2.16,
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
-								},
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
 							},
 						},
 					},
@@ -463,31 +359,156 @@ PASS`, // we include this line greedily even though it does not belong to the te
 			expectedSuites: &api.TestSuites{
 				Suites: []*api.TestSuite{
 					{
-						Name:     "package",
+						Name:     "package/name",
 						NumTests: 2,
 						Duration: 0.16,
-						Children: []*api.TestSuite{
+						Properties: []*api.TestSuiteProperty{
 							{
-								Name:     "package/name",
-								NumTests: 2,
-								Duration: 0.16,
-								Properties: []*api.TestSuiteProperty{
-									{
-										Name:  "coverage.statements.pct",
-										Value: "10.0",
-									},
-								},
-								TestCases: []*api.TestCase{
-									{
-										Name:     "TestOne",
-										Duration: 0.06,
-									},
-									{
-										Name:     "TestTwo",
-										Duration: 0.1,
-									},
+								Name:  "coverage.statements.pct",
+								Value: "10.0",
+							},
+						},
+						TestCases: []*api.TestCase{
+							{
+								Name:     "TestOne",
+								Duration: 0.06,
+							},
+							{
+								Name:     "TestTwo",
+								Duration: 0.1,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nested tests with inline output",
+			testFile: "14.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "parser/gotest",
+						NumTests:  4,
+						NumFailed: 2,
+						Duration:  0.019,
+						TestCases: []*api.TestCase{
+							{
+								Name: "TestSubTestWithFailures",
+								FailureOutput: &api.FailureOutput{
+									Output: "",
 								},
 							},
+							{
+								Name: "TestSubTestWithFailures/subtest-pass-1",
+							},
+							{
+								Name: "TestSubTestWithFailures/subtest-pass-2",
+							},
+							{
+								Name:      "TestSubTestWithFailures/subtest-fail-1",
+								SystemOut: "text line\n",
+								FailureOutput: &api.FailureOutput{
+									Output: "data_parser_test.go:14: log line\ndata_parser_test.go:14: failed\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "multi-suite nested output with coverage",
+			testFile: "15.txt",
+			expectedSuites: &api.TestSuites{
+				Suites: []*api.TestSuite{
+					{
+						Name:      "parser/gotest",
+						NumTests:  4,
+						NumFailed: 2,
+						Duration:  0.019,
+						TestCases: []*api.TestCase{
+							{
+								Name: "TestSubTestWithFailures",
+								FailureOutput: &api.FailureOutput{
+									Output: "",
+								},
+							},
+							{
+								Name: "TestSubTestWithFailures/subtest-pass-1",
+							},
+							{
+								Name: "TestSubTestWithFailures/subtest-pass-2",
+							},
+							{
+								Name:      "TestSubTestWithFailures/subtest-fail-1",
+								SystemOut: "text line\n",
+								FailureOutput: &api.FailureOutput{
+									Output: "data_parser_test.go:14: log line\ndata_parser_test.go:14: failed\n",
+								},
+							},
+						},
+					},
+					{
+						Name:       "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example",
+						NumTests:   19,
+						NumFailed:  9,
+						Duration:   0.006,
+						Properties: []*api.TestSuiteProperty{{Name: "coverage.statements.pct", Value: "0.0"}},
+						TestCases: []*api.TestCase{
+							{
+								Name:          "TestSubTestWithFailures",
+								FailureOutput: &api.FailureOutput{},
+							},
+							{Name: "TestSubTestWithFailures/subtest-pass-1"},
+							{Name: "TestSubTestWithFailures/subtest-pass-2"},
+							{
+								Name:      "TestSubTestWithFailures/subtest-fail-1",
+								SystemOut: "text line\n",
+								FailureOutput: &api.FailureOutput{
+									Output: "example_test.go:11: log line\nexample_test.go:11: failed\n",
+								},
+							},
+							{
+								Name:          "TestSubTestWithFirstFailures",
+								FailureOutput: &api.FailureOutput{},
+							},
+							{
+								Name:          "TestSubTestWithFirstFailures/subtest-fail-1",
+								FailureOutput: &api.FailureOutput{Output: "example_test.go:15: log line\nexample_test.go:15: failed\n"},
+								SystemOut:     "text line\n",
+							},
+							{Name: "TestSubTestWithFirstFailures/subtest-pass-1"},
+							{Name: "TestSubTestWithFirstFailures/subtest-pass-2"},
+							{
+								Name:          "TestSubTestWithSubTestFailures",
+								FailureOutput: &api.FailureOutput{},
+							},
+							{Name: "TestSubTestWithSubTestFailures/subtest-pass-1"},
+							{Name: "TestSubTestWithSubTestFailures/subtest-pass-2"},
+							{
+								Name:          "TestSubTestWithSubTestFailures/subtest-fail-1",
+								FailureOutput: &api.FailureOutput{Output: "example_test.go:25: log line before\nexample_test.go:29: log line after\n"},
+								SystemOut:     "text line\n",
+							},
+							{Name: "TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-1"},
+							{Name: "TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-2"},
+							{
+								Name:          "TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-fail-1",
+								FailureOutput: &api.FailureOutput{Output: "example_test.go:28: log line\nexample_test.go:28: failed\n"},
+								SystemOut:     "text line\n",
+							},
+							{
+								Name:          "TestSubTestWithMiddleFailures",
+								FailureOutput: &api.FailureOutput{},
+							},
+							{Name: "TestSubTestWithMiddleFailures/subtest-pass-1"},
+							{
+								Name:          "TestSubTestWithMiddleFailures/subtest-fail-1",
+								FailureOutput: &api.FailureOutput{Output: "example_test.go:35: log line\nexample_test.go:35: failed\n"},
+								SystemOut:     "text line\n",
+							},
+							{Name: "TestSubTestWithMiddleFailures/subtest-pass-2"},
 						},
 					},
 				},
@@ -496,23 +517,23 @@ PASS`, // we include this line greedily even though it does not belong to the te
 	}
 
 	for _, testCase := range testCases {
-		parser := NewParser(nested.NewTestSuitesBuilder(testCase.rootSuiteNames), false)
+		t.Run(testCase.name, func(t *testing.T) {
+			parser := NewParser(nested.NewTestSuitesBuilder(testCase.rootSuiteNames), false)
 
-		testFile := "./../../../test/gotest/testdata/" + testCase.testFile
+			testFile := "./../../../test/gotest/testdata/" + testCase.testFile
 
-		reader, err := os.Open(testFile)
-		if err != nil {
-			t.Errorf("%s: unexpected error opening file %q: %v", testCase.name, testFile, err)
-			continue
-		}
-		testSuites, err := parser.Parse(bufio.NewScanner(reader))
-		if err != nil {
-			t.Errorf("%s: unexpected error parsing file: %v", testCase.name, err)
-			continue
-		}
+			reader, err := os.Open(testFile)
+			if err != nil {
+				t.Fatalf("unexpected error opening file %q: %v", testFile, err)
+			}
+			testSuites, err := parser.Parse(bufio.NewScanner(reader))
+			if err != nil {
+				t.Fatalf("unexpected error parsing file: %v", err)
+			}
 
-		if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
-			t.Errorf("%s: did not produce the correct test suites from file:\n\texpected:\n\t%v,\n\tgot\n\t%v", testCase.name, testCase.expectedSuites, testSuites)
-		}
+			if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
+				t.Errorf("did not produce the correct test suites from file:\n %s", diff.ObjectReflectDiff(testCase.expectedSuites, testSuites))
+			}
+		})
 	}
 }

--- a/tools/junitreport/test/gotest/reports/12_flat.xml
+++ b/tools/junitreport/test/gotest/reports/12_flat.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="2" skipped="1" failures="0" time="0.077">
-		<testcase name="TestAuthorizer" time="0"></testcase>
-		<testcase name="TestPopulationMemoryUsage" time="0">
-			<skipped message="=== RUN   TestPopulationMemoryUsage&#xA;--- SKIP: TestPopulationMemoryUsage (0.00s)&#xA;&#x9;node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.&#xA;PASS"></skipped>
-		</testcase>
-	</testsuite>
+        <testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="13" skipped="1" failures="0" time="0.077">
+                <testcase name="TestAuthorizer" time="0"></testcase>
+                <testcase name="TestAuthorizer/allowed_configmap" time="0"></testcase>
+                <testcase name="TestAuthorizer/allowed_secret_via_pod" time="0"></testcase>
+                <testcase name="TestAuthorizer/allowed_shared_secret_via_pod" time="0"></testcase>
+                <testcase name="TestAuthorizer/allowed_shared_secret_via_pvc" time="0"></testcase>
+                <testcase name="TestAuthorizer/allowed_pvc" time="0"></testcase>
+                <testcase name="TestAuthorizer/allowed_pv" time="0"></testcase>
+                <testcase name="TestAuthorizer/disallowed_configmap" time="0"></testcase>
+                <testcase name="TestAuthorizer/disallowed_secret_via_pod" time="0"></testcase>
+                <testcase name="TestAuthorizer/disallowed_shared_secret_via_pvc" time="0"></testcase>
+                <testcase name="TestAuthorizer/disallowed_pvc" time="0"></testcase>
+                <testcase name="TestAuthorizer/disallowed_pv" time="0"></testcase>
+                <testcase name="TestPopulationMemoryUsage" time="0">
+                        <skipped message="node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles."></skipped>
+                </testcase>
+        </testsuite>
 </testsuites>

--- a/tools/junitreport/test/gotest/reports/13_flat.xml
+++ b/tools/junitreport/test/gotest/reports/13_flat.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="2" skipped="1" failures="1" time="0.078">
+	<testsuite name="k8s.io/kubernetes/plugin/pkg/auth/authorizer/node" tests="13" skipped="2" failures="2" time="0.078">
 		<testcase name="TestAuthorizer" time="0">
-			<failure message="">=== RUN   TestAuthorizer&#xA;=== RUN   TestAuthorizer/allowed_configmap&#xA;=== RUN   TestAuthorizer/allowed_secret_via_pod&#xA;=== RUN   TestAuthorizer/allowed_shared_secret_via_pod&#xA;=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc&#xA;=== RUN   TestAuthorizer/allowed_pvc&#xA;=== RUN   TestAuthorizer/allowed_pv&#xA;=== RUN   TestAuthorizer/disallowed_configmap&#xA;=== RUN   TestAuthorizer/disallowed_secret_via_pod&#xA;=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc&#xA;=== RUN   TestAuthorizer/disallowed_pvc&#xA;=== RUN   TestAuthorizer/disallowed_pv&#xA;--- FAIL: TestAuthorizer (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_configmap (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)&#xA;    --- FAIL: TestAuthorizer/allowed_pvc (0.00s)&#xA;    &#x9;node_authorizer_test.go:125: expected true, got false&#xA;    --- PASS: TestAuthorizer/allowed_pv (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)&#xA;    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)&#xA;    --- SKIP: TestAuthorizer/disallowed_pv (0.00s)&#xA;    &#x9;node_authorizer_test.go:121: disallowed pv</failure>
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestAuthorizer/allowed_configmap" time="0"></testcase>
+		<testcase name="TestAuthorizer/allowed_secret_via_pod" time="0"></testcase>
+		<testcase name="TestAuthorizer/allowed_shared_secret_via_pod" time="0"></testcase>
+		<testcase name="TestAuthorizer/allowed_shared_secret_via_pvc" time="0"></testcase>
+		<testcase name="TestAuthorizer/allowed_pvc" time="0">
+			<failure message="">node_authorizer_test.go:125: expected true, got false</failure>
+		</testcase>
+		<testcase name="TestAuthorizer/allowed_pv" time="0"></testcase>
+		<testcase name="TestAuthorizer/disallowed_configmap" time="0"></testcase>
+		<testcase name="TestAuthorizer/disallowed_secret_via_pod" time="0"></testcase>
+		<testcase name="TestAuthorizer/disallowed_shared_secret_via_pvc" time="0"></testcase>
+		<testcase name="TestAuthorizer/disallowed_pvc" time="0"></testcase>
+		<testcase name="TestAuthorizer/disallowed_pv" time="0">
+			<skipped message="node_authorizer_test.go:121: disallowed pv"></skipped>
 		</testcase>
 		<testcase name="TestPopulationMemoryUsage" time="0">
-			<skipped message="=== RUN   TestPopulationMemoryUsage&#xA;--- SKIP: TestPopulationMemoryUsage (0.00s)&#xA;&#x9;node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.&#xA;FAIL&#xA;exit status 1"></skipped>
+			<skipped message="node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles."></skipped>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/tools/junitreport/test/gotest/reports/14_flat.xml
+++ b/tools/junitreport/test/gotest/reports/14_flat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="parser/gotest" tests="4" skipped="0" failures="2" time="0.019">
+		<testcase name="TestSubTestWithFailures" time="0">
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestSubTestWithFailures/subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithFailures/subtest-pass-2" time="0"></testcase>
+		<testcase name="TestSubTestWithFailures/subtest-fail-1" time="0">
+			<failure message="">data_parser_test.go:14: log line&#xA;data_parser_test.go:14: failed</failure>
+			<system-out>text line</system-out>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/15_flat.xml
+++ b/tools/junitreport/test/gotest/reports/15_flat.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="parser/gotest" tests="4" skipped="0" failures="2" time="0.019">
+		<testcase name="TestSubTestWithFailures" time="0">
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestSubTestWithFailures/subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithFailures/subtest-pass-2" time="0"></testcase>
+		<testcase name="TestSubTestWithFailures/subtest-fail-1" time="0">
+			<failure message="">data_parser_test.go:14: log line&#xA;data_parser_test.go:14: failed</failure>
+			<system-out>text line</system-out>
+		</testcase>
+	</testsuite>
+	<testsuite name="github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example" tests="19" skipped="0" failures="9" time="0.006">
+		<property name="coverage.statements.pct" value="0.0"></property>
+		<testcase name="TestSubTestWithFailures" time="0">
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestSubTestWithFailures/subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithFailures/subtest-pass-2" time="0"></testcase>
+		<testcase name="TestSubTestWithFailures/subtest-fail-1" time="0">
+			<failure message="">example_test.go:11: log line&#xA;example_test.go:11: failed</failure>
+			<system-out>text line</system-out>
+		</testcase>
+		<testcase name="TestSubTestWithFirstFailures" time="0">
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestSubTestWithFirstFailures/subtest-fail-1" time="0">
+			<failure message="">example_test.go:15: log line&#xA;example_test.go:15: failed</failure>
+			<system-out>text line</system-out>
+		</testcase>
+		<testcase name="TestSubTestWithFirstFailures/subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithFirstFailures/subtest-pass-2" time="0"></testcase>
+		<testcase name="TestSubTestWithSubTestFailures" time="0">
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestSubTestWithSubTestFailures/subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithSubTestFailures/subtest-pass-2" time="0"></testcase>
+		<testcase name="TestSubTestWithSubTestFailures/subtest-fail-1" time="0">
+			<failure message="">example_test.go:25: log line before</failure>
+			<system-out>text line</system-out>
+		</testcase>
+		<testcase name="TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-2" time="0"></testcase>
+		<testcase name="TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-fail-1" time="0">
+			<failure message="">example_test.go:28: log line&#xA;example_test.go:28: failed&#xA;example_test.go:29: log line after</failure>
+			<system-out>text line</system-out>
+		</testcase>
+		<testcase name="TestSubTestWithMiddleFailures" time="0">
+			<failure message=""></failure>
+		</testcase>
+		<testcase name="TestSubTestWithMiddleFailures/subtest-pass-1" time="0"></testcase>
+		<testcase name="TestSubTestWithMiddleFailures/subtest-fail-1" time="0">
+			<failure message="">example_test.go:35: log line&#xA;example_test.go:35: failed</failure>
+			<system-out>text line</system-out>
+		</testcase>
+		<testcase name="TestSubTestWithMiddleFailures/subtest-pass-2" time="0"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/16_flat.xml
+++ b/tools/junitreport/test/gotest/reports/16_flat.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="package/1" tests="1" skipped="0" failures="0" time="0.16">
+		<testcase name="TestSubTestWithFailures" time="0"></testcase>
+	</testsuite>
+	<testsuite name="package/2" tests="1" skipped="0" failures="0" time="0.16">
+		<testcase name="TestSubTestWithFailures" time="0"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/17_flat.xml
+++ b/tools/junitreport/test/gotest/reports/17_flat.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite name="github.com/openshift/origin/test/integration/runner" tests="4" skipped="0" failures="1" time="764.718">
+		<testcase name="TestIntegration" time="0.05"></testcase>
+		<testcase name="TestIntegration/TestUserInitialization" time="133.72"></testcase>
+		<testcase name="TestIntegration/TestRegistryClientRegistryNotFound" time="0.55">
+			<failure message="">runner_test.go:175: blah&#xA;</failure>
+			<system-out>&#xA;more</system-out>
+		</testcase>
+		<testcase name="TestIntegration/TestRestrictUsers" time="13.19"></testcase>
+	</testsuite>
+</testsuites>

--- a/tools/junitreport/test/gotest/reports/2_flat.xml
+++ b/tools/junitreport/test/gotest/reports/2_flat.xml
@@ -2,7 +2,7 @@
 <testsuites>
 	<testsuite name="package/name" tests="2" skipped="0" failures="1" time="0.15">
 		<testcase name="TestOne" time="0.02">
-			<failure message="">=== RUN TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+			<failure message="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;error&#xA;message.</failure>
 		</testcase>
 		<testcase name="TestTwo" time="0.13"></testcase>
 	</testsuite>

--- a/tools/junitreport/test/gotest/reports/3_flat.xml
+++ b/tools/junitreport/test/gotest/reports/3_flat.xml
@@ -2,7 +2,7 @@
 <testsuites>
 	<testsuite name="package/name" tests="2" skipped="1" failures="0" time="0.15">
 		<testcase name="TestOne" time="0.02">
-			<skipped message="=== RUN TestOne&#xA;--- SKIP: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Skip message"></skipped>
+			<skipped message="file_test.go:11: Skip message"></skipped>
 		</testcase>
 		<testcase name="TestTwo" time="0.13"></testcase>
 	</testsuite>

--- a/tools/junitreport/test/gotest/reports/5_flat.xml
+++ b/tools/junitreport/test/gotest/reports/5_flat.xml
@@ -6,7 +6,7 @@
 	</testsuite>
 	<testsuite name="package/name2" tests="2" skipped="0" failures="1" time="0.15">
 		<testcase name="TestOne" time="0.02">
-			<failure message="">=== RUN TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+			<failure message="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;error&#xA;message.</failure>
 		</testcase>
 		<testcase name="TestTwo" time="0.13"></testcase>
 	</testsuite>

--- a/tools/junitreport/test/gotest/reports/9_flat.xml
+++ b/tools/junitreport/test/gotest/reports/9_flat.xml
@@ -6,10 +6,10 @@
 	</testsuite>
 	<testsuite name="package/name/nested" tests="2" skipped="1" failures="1" time="0.05">
 		<testcase name="TestOne" time="0.02">
-			<failure message="">=== RUN   TestOne&#xA;--- FAIL: TestOne (0.02 seconds)&#xA;&#x9;file_test.go:11: Error message&#xA;&#x9;file_test.go:11: Longer&#xA;&#x9;&#x9;error&#xA;&#x9;&#x9;message.</failure>
+			<failure message="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;error&#xA;message.</failure>
 		</testcase>
 		<testcase name="TestTwo" time="0.03">
-			<skipped message="=== RUN   TestTwo&#xA;--- SKIP: TestTwo (0.03 seconds)&#xA;&#x9;file_test.go:11: Skip message&#xA;PASS"></skipped>
+			<skipped message="file_test.go:11: Skip message"></skipped>
 		</testcase>
 	</testsuite>
 	<testsuite name="package/other/nested" tests="2" skipped="0" failures="0" time="0.3">

--- a/tools/junitreport/test/gotest/summaries/12_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/12_summary.txt
@@ -1,8 +1,5 @@
-Of 2 tests executed in 0.077s, 1 succeeded, 0 failed, and 1 was skipped.
+Of 13 tests executed in 0.077s, 12 succeeded, 0 failed, and 1 was skipped.
 
 In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestPopulationMemoryUsage" was skipped:
-=== RUN   TestPopulationMemoryUsage
---- SKIP: TestPopulationMemoryUsage (0.00s)
-	node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
-PASS
+node_authorizer_test.go:169: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
 

--- a/tools/junitreport/test/gotest/summaries/13_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/13_summary.txt
@@ -1,37 +1,14 @@
-Of 2 tests executed in 0.078s, 0 succeeded, 1 failed, and 1 was skipped.
+Of 13 tests executed in 0.078s, 9 succeeded, 2 failed, and 2 were skipped.
 
 In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestAuthorizer" failed:
-=== RUN   TestAuthorizer
-=== RUN   TestAuthorizer/allowed_configmap
-=== RUN   TestAuthorizer/allowed_secret_via_pod
-=== RUN   TestAuthorizer/allowed_shared_secret_via_pod
-=== RUN   TestAuthorizer/allowed_shared_secret_via_pvc
-=== RUN   TestAuthorizer/allowed_pvc
-=== RUN   TestAuthorizer/allowed_pv
-=== RUN   TestAuthorizer/disallowed_configmap
-=== RUN   TestAuthorizer/disallowed_secret_via_pod
-=== RUN   TestAuthorizer/disallowed_shared_secret_via_pvc
-=== RUN   TestAuthorizer/disallowed_pvc
-=== RUN   TestAuthorizer/disallowed_pv
---- FAIL: TestAuthorizer (0.00s)
-    --- PASS: TestAuthorizer/allowed_configmap (0.00s)
-    --- PASS: TestAuthorizer/allowed_secret_via_pod (0.00s)
-    --- PASS: TestAuthorizer/allowed_shared_secret_via_pod (0.00s)
-    --- PASS: TestAuthorizer/allowed_shared_secret_via_pvc (0.00s)
-    --- FAIL: TestAuthorizer/allowed_pvc (0.00s)
-    	node_authorizer_test.go:125: expected true, got false
-    --- PASS: TestAuthorizer/allowed_pv (0.00s)
-    --- PASS: TestAuthorizer/disallowed_configmap (0.00s)
-    --- PASS: TestAuthorizer/disallowed_secret_via_pod (0.00s)
-    --- PASS: TestAuthorizer/disallowed_shared_secret_via_pvc (0.00s)
-    --- PASS: TestAuthorizer/disallowed_pvc (0.00s)
-    --- SKIP: TestAuthorizer/disallowed_pv (0.00s)
-    	node_authorizer_test.go:121: disallowed pv
+
+
+In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestAuthorizer/allowed_pvc" failed:
+node_authorizer_test.go:125: expected true, got false
+
+In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestAuthorizer/disallowed_pv" was skipped:
+node_authorizer_test.go:121: disallowed pv
 
 In suite "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node", test case "TestPopulationMemoryUsage" was skipped:
-=== RUN   TestPopulationMemoryUsage
---- SKIP: TestPopulationMemoryUsage (0.00s)
-	node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
-FAIL
-exit status 1
+node_authorizer_test.go:172: Skipping large population test. Run with TEST_POPULATION_MEMORY_USAGE=true to output memory profiles.
 

--- a/tools/junitreport/test/gotest/summaries/14_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/14_summary.txt
@@ -1,0 +1,9 @@
+Of 4 tests executed in 0.019s, 2 succeeded, 2 failed, and 0 were skipped.
+
+In suite "parser/gotest", test case "TestSubTestWithFailures" failed:
+
+
+In suite "parser/gotest", test case "TestSubTestWithFailures/subtest-fail-1" failed:
+data_parser_test.go:14: log line
+data_parser_test.go:14: failed
+

--- a/tools/junitreport/test/gotest/summaries/15_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/15_summary.txt
@@ -1,0 +1,41 @@
+Of 23 tests executed in 0.025s, 12 succeeded, 11 failed, and 0 were skipped.
+
+In suite "parser/gotest", test case "TestSubTestWithFailures" failed:
+
+
+In suite "parser/gotest", test case "TestSubTestWithFailures/subtest-fail-1" failed:
+data_parser_test.go:14: log line
+data_parser_test.go:14: failed
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithFailures" failed:
+
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithFailures/subtest-fail-1" failed:
+example_test.go:11: log line
+example_test.go:11: failed
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithFirstFailures" failed:
+
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithFirstFailures/subtest-fail-1" failed:
+example_test.go:15: log line
+example_test.go:15: failed
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithSubTestFailures" failed:
+
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithSubTestFailures/subtest-fail-1" failed:
+example_test.go:25: log line before
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-fail-1" failed:
+example_test.go:28: log line
+example_test.go:28: failed
+example_test.go:29: log line after
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithMiddleFailures" failed:
+
+
+In suite "github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example", test case "TestSubTestWithMiddleFailures/subtest-fail-1" failed:
+example_test.go:35: log line
+example_test.go:35: failed
+

--- a/tools/junitreport/test/gotest/summaries/16_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/16_summary.txt
@@ -1,0 +1,2 @@
+Of 2 tests executed in 0.320s, 2 succeeded, 0 failed, and 0 were skipped.
+

--- a/tools/junitreport/test/gotest/summaries/17_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/17_summary.txt
@@ -1,0 +1,6 @@
+Of 4 tests executed in 764.718s, 3 succeeded, 1 failed, and 0 were skipped.
+
+In suite "github.com/openshift/origin/test/integration/runner", test case "TestIntegration/TestRegistryClientRegistryNotFound" failed:
+runner_test.go:175: blah
+
+

--- a/tools/junitreport/test/gotest/summaries/2_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/2_summary.txt
@@ -1,10 +1,8 @@
 Of 2 tests executed in 0.150s, 1 succeeded, 1 failed, and 0 were skipped.
 
 In suite "package/name", test case "TestOne" failed:
-=== RUN TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.
+file_test.go:11: Error message
+file_test.go:11: Longer
+error
+message.
 

--- a/tools/junitreport/test/gotest/summaries/3_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/3_summary.txt
@@ -1,7 +1,5 @@
 Of 2 tests executed in 0.150s, 1 succeeded, 0 failed, and 1 was skipped.
 
 In suite "package/name", test case "TestOne" was skipped:
-=== RUN TestOne
---- SKIP: TestOne (0.02 seconds)
-	file_test.go:11: Skip message
+file_test.go:11: Skip message
 

--- a/tools/junitreport/test/gotest/summaries/5_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/5_summary.txt
@@ -1,10 +1,8 @@
 Of 4 tests executed in 0.310s, 3 succeeded, 1 failed, and 0 were skipped.
 
 In suite "package/name2", test case "TestOne" failed:
-=== RUN TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.
+file_test.go:11: Error message
+file_test.go:11: Longer
+error
+message.
 

--- a/tools/junitreport/test/gotest/summaries/9_summary.txt
+++ b/tools/junitreport/test/gotest/summaries/9_summary.txt
@@ -1,16 +1,11 @@
 Of 6 tests executed in 0.400s, 4 succeeded, 1 failed, and 1 was skipped.
 
 In suite "package/name/nested", test case "TestOne" failed:
-=== RUN   TestOne
---- FAIL: TestOne (0.02 seconds)
-	file_test.go:11: Error message
-	file_test.go:11: Longer
-		error
-		message.
+file_test.go:11: Error message
+file_test.go:11: Longer
+error
+message.
 
 In suite "package/name/nested", test case "TestTwo" was skipped:
-=== RUN   TestTwo
---- SKIP: TestTwo (0.03 seconds)
-	file_test.go:11: Skip message
-PASS
+file_test.go:11: Skip message
 

--- a/tools/junitreport/test/gotest/testdata/14.txt
+++ b/tools/junitreport/test/gotest/testdata/14.txt
@@ -1,0 +1,14 @@
+=== RUN   TestSubTestWithFailures
+=== RUN   TestSubTestWithFailures/subtest-pass-1
+=== RUN   TestSubTestWithFailures/subtest-pass-2
+=== RUN   TestSubTestWithFailures/subtest-fail-1
+text line
+--- FAIL: TestSubTestWithFailures (0.00s)
+    --- PASS: TestSubTestWithFailures/subtest-pass-1 (0.00s)
+    --- PASS: TestSubTestWithFailures/subtest-pass-2 (0.00s)
+    --- FAIL: TestSubTestWithFailures/subtest-fail-1 (0.00s)
+        data_parser_test.go:14: log line
+        data_parser_test.go:14: failed
+FAIL
+exit status 1
+FAIL    parser/gotest 0.019s

--- a/tools/junitreport/test/gotest/testdata/15.txt
+++ b/tools/junitreport/test/gotest/testdata/15.txt
@@ -1,0 +1,71 @@
+=== RUN   TestSubTestWithFailures
+=== RUN   TestSubTestWithFailures/subtest-pass-1
+=== RUN   TestSubTestWithFailures/subtest-pass-2
+=== RUN   TestSubTestWithFailures/subtest-fail-1
+text line
+--- FAIL: TestSubTestWithFailures (0.00s)
+    --- PASS: TestSubTestWithFailures/subtest-pass-1 (0.00s)
+    --- PASS: TestSubTestWithFailures/subtest-pass-2 (0.00s)
+    --- FAIL: TestSubTestWithFailures/subtest-fail-1 (0.00s)
+        data_parser_test.go:14: log line
+        data_parser_test.go:14: failed
+FAIL
+exit status 1
+FAIL    parser/gotest 0.019s
+=== RUN   TestSubTestWithFailures
+=== RUN   TestSubTestWithFailures/subtest-pass-1
+=== RUN   TestSubTestWithFailures/subtest-pass-2
+=== RUN   TestSubTestWithFailures/subtest-fail-1
+text line
+--- FAIL: TestSubTestWithFailures (0.00s)
+    --- PASS: TestSubTestWithFailures/subtest-pass-1 (0.00s)
+    --- PASS: TestSubTestWithFailures/subtest-pass-2 (0.00s)
+    --- FAIL: TestSubTestWithFailures/subtest-fail-1 (0.00s)
+        example_test.go:11: log line
+        example_test.go:11: failed
+=== RUN   TestSubTestWithFirstFailures
+=== RUN   TestSubTestWithFirstFailures/subtest-fail-1
+text line
+=== RUN   TestSubTestWithFirstFailures/subtest-pass-1
+=== RUN   TestSubTestWithFirstFailures/subtest-pass-2
+--- FAIL: TestSubTestWithFirstFailures (0.00s)
+    --- FAIL: TestSubTestWithFirstFailures/subtest-fail-1 (0.00s)
+        example_test.go:15: log line
+        example_test.go:15: failed
+    --- PASS: TestSubTestWithFirstFailures/subtest-pass-1 (0.00s)
+    --- PASS: TestSubTestWithFirstFailures/subtest-pass-2 (0.00s)
+=== RUN   TestSubTestWithSubTestFailures
+=== RUN   TestSubTestWithSubTestFailures/subtest-pass-1
+=== RUN   TestSubTestWithSubTestFailures/subtest-pass-2
+=== RUN   TestSubTestWithSubTestFailures/subtest-fail-1
+text line
+=== RUN   TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-1
+=== RUN   TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-2
+=== RUN   TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-fail-1
+text line
+--- FAIL: TestSubTestWithSubTestFailures (0.00s)
+    --- PASS: TestSubTestWithSubTestFailures/subtest-pass-1 (0.00s)
+    --- PASS: TestSubTestWithSubTestFailures/subtest-pass-2 (0.00s)
+    --- FAIL: TestSubTestWithSubTestFailures/subtest-fail-1 (0.00s)
+        example_test.go:25: log line before
+        --- PASS: TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-1 (0.00s)
+        --- PASS: TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-pass-2 (0.00s)
+        --- FAIL: TestSubTestWithSubTestFailures/subtest-fail-1/sub-subtest-fail-1 (0.00s)
+                example_test.go:28: log line
+                example_test.go:28: failed
+        example_test.go:29: log line after
+=== RUN   TestSubTestWithMiddleFailures
+=== RUN   TestSubTestWithMiddleFailures/subtest-pass-1
+=== RUN   TestSubTestWithMiddleFailures/subtest-fail-1
+text line
+=== RUN   TestSubTestWithMiddleFailures/subtest-pass-2
+--- FAIL: TestSubTestWithMiddleFailures (0.00s)
+    --- PASS: TestSubTestWithMiddleFailures/subtest-pass-1 (0.00s)
+    --- FAIL: TestSubTestWithMiddleFailures/subtest-fail-1 (0.00s)
+        example_test.go:35: log line
+        example_test.go:35: failed
+    --- PASS: TestSubTestWithMiddleFailures/subtest-pass-2 (0.00s)
+FAIL
+coverage: 0.0% of statements
+exit status 1
+FAIL    github.com/openshift/origin/tools/junitreport/pkg/parser/gotest/example 0.006s

--- a/tools/junitreport/test/gotest/testdata/16.txt
+++ b/tools/junitreport/test/gotest/testdata/16.txt
@@ -1,0 +1,10 @@
+Output before first suite
+=== RUN   TestSubTestWithFailures
+--- PASS: TestSubTestWithFailures (0.00s)
+PASS
+ok  	package/1 0.160s
+Output before second suite
+=== RUN   TestSubTestWithFailures
+--- PASS: TestSubTestWithFailures (0.00s)
+PASS
+ok  	package/2 0.160s

--- a/tools/junitreport/test/gotest/testdata/17.txt
+++ b/tools/junitreport/test/gotest/testdata/17.txt
@@ -1,0 +1,15 @@
+=== RUN   TestIntegration
+=== RUN   TestIntegration/TestUserInitialization
+=== RUN   TestIntegration/TestRegistryClientRegistryNotFound
+=== RUN   TestIntegration/TestRestrictUsers
+--- PASS: TestIntegration (0.05s)
+    --- PASS: TestIntegration/TestUserInitialization (133.72s)
+    --- FAIL: TestIntegration/TestRegistryClientRegistryNotFound (0.55s)
+    	runner_test.go:175: blah
+    		
+    		=== OUTPUT
+    		
+    		more
+    --- PASS: TestIntegration/TestRestrictUsers (13.19s)
+PASS
+ok  	github.com/openshift/origin/test/integration/runner	764.718s

--- a/tools/junitreport/test/integration.sh
+++ b/tools/junitreport/test/integration.sh
@@ -31,52 +31,14 @@ for suite in test/*/; do
 			exit 1
 		fi
 
-		cat "${test}" | junitreport -type "${suite_name}" -suites nested > "${WORKINGDIR}/${test_name}_nested.xml"
-		if ! diff ${diff_args} "${suite}/reports/${test_name}_nested.xml" "${WORKINGDIR}/${test_name}_nested.xml"; then
-			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed for nested suite builder."
-			exit 1
-		fi
-
 		cat "${WORKINGDIR}/${test_name}_flat.xml" | junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
 		if ! diff ${diff_args} "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
 			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize flat XML."
-		fi
-
-		cat "${WORKINGDIR}/${test_name}_nested.xml" | junitreport summarize > "${WORKINGDIR}/${test_name}_summary.txt"
-		if ! diff ${diff_args} "${suite}/summaries/${test_name}_summary.txt" "${WORKINGDIR}/${test_name}_summary.txt"; then
-			echo "[FAIL] Test '${test_name}' in suite '${suite_name}' failed to summarize nested XML."
 		fi
 	done
 
 	echo "[PASS] Test output type passed: ${suite_name}"
 done
-
-echo "[INFO] Testing restricted roots with nested suites..."
-# test some cases with nested suites and given roots
-cat "test/gotest/testdata/1.txt" | junitreport -type gotest -suites nested -roots package/name > "${TMPDIR}/gotest/1_nested_restricted.xml"
-if ! diff ${diff_args} "test/gotest/reports/1_nested_restricted.xml" "${TMPDIR}/gotest/1_nested_restricted.xml"; then
-	echo "[FAIL] Test '1' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name'."
-	exit 1
-fi
-
-cat "test/oscmd/testdata/1.txt" | junitreport -type oscmd -suites nested -roots package/name > "${TMPDIR}/oscmd/1_nested_restricted.xml"
-if ! diff ${diff_args} "test/oscmd/reports/1_nested_restricted.xml" "${TMPDIR}/oscmd/1_nested_restricted.xml"; then
-	echo "[FAIL] Test '1' in suite 'oscmd' failed for nested suite builder with restricted roots: 'package/name'."
-	exit 1
-fi
-
-cat "test/gotest/testdata/9.txt" | junitreport -type gotest -suites nested -roots package/name,package/other > "${TMPDIR}/gotest/9_nested_restricted.xml"
-if ! diff ${diff_args} "test/gotest/reports/9_nested_restricted.xml" "${TMPDIR}/gotest/9_nested_restricted.xml"; then
-	echo "[FAIL] Test '9' in suite 'gotest' failed for nested suite builder with restricted roots: 'package/name,package/other'."
-	exit 1
-fi
-
-cat "test/oscmd/testdata/4.txt" | junitreport -type oscmd -suites nested -roots package/name,package/other > "${TMPDIR}/oscmd/4_nested_restricted.xml"
-if ! diff ${diff_args} "test/oscmd/reports/4_nested_restricted.xml" "${TMPDIR}/oscmd/4_nested_restricted.xml"; then
-	echo "[FAIL] Test '4' in suite 'oscmd' failed for nested suite builder with restricted roots: 'package/name,package/other'."
-	exit 1
-fi
-echo "[PASS] Suite passed: restricted roots"
 
 echo "[PASS] junitreport testing successful"
 popd > /dev/null


### PR DESCRIPTION
Use a stateful parser approach to process each section of the test
output independently. Correctly handles nested tests and nested output
and puts any stdout/err into the SystemOut field of the generated test
result.

Note: this breaks --suite=nested, but was not able to find any users.

@liggitt @stevekuznetsov tests are updated but want to soak this a bit