### PR TITLE
image-pruning: dereference ImageStreamTags

### DIFF
--- a/pkg/apps/graph/nodes/nodes.go
+++ b/pkg/apps/graph/nodes/nodes.go
@@ -3,13 +3,42 @@ package nodes
 import (
 	"github.com/gonum/graph"
 
+	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
+
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
-	depoyapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
 )
 
+// EnsureDaemonSetNode adds the provided daemon set to the graph if it does not exist
+func EnsureDaemonSetNode(g osgraph.MutableUniqueGraph, ds *kapisext.DaemonSet) *DaemonSetNode {
+	dsName := DaemonSetNodeName(ds)
+	dsNode := osgraph.EnsureUnique(
+		g,
+		dsName,
+		func(node osgraph.Node) graph.Node {
+			return &DaemonSetNode{Node: node, DaemonSet: ds, IsFound: true}
+		},
+	).(*DaemonSetNode)
+
+	podTemplateSpecNode := kubegraph.EnsurePodTemplateSpecNode(g, &ds.Spec.Template, ds.Namespace, dsName)
+	g.AddEdge(dsNode, podTemplateSpecNode, osgraph.ContainsEdgeKind)
+
+	return dsNode
+}
+
+func FindOrCreateSyntheticDaemonSetNode(g osgraph.MutableUniqueGraph, ds *kapisext.DaemonSet) *DaemonSetNode {
+	return osgraph.EnsureUnique(
+		g,
+		DaemonSetNodeName(ds),
+		func(node osgraph.Node) graph.Node {
+			return &DaemonSetNode{Node: node, DaemonSet: ds, IsFound: false}
+		},
+	).(*DaemonSetNode)
+}
+
 // EnsureDeploymentConfigNode adds the provided deployment config to the graph if it does not exist
-func EnsureDeploymentConfigNode(g osgraph.MutableUniqueGraph, dc *depoyapi.DeploymentConfig) *DeploymentConfigNode {
+func EnsureDeploymentConfigNode(g osgraph.MutableUniqueGraph, dc *deployapi.DeploymentConfig) *DeploymentConfigNode {
 	dcName := DeploymentConfigNodeName(dc)
 	dcNode := osgraph.EnsureUnique(
 		g,
@@ -27,7 +56,7 @@ func EnsureDeploymentConfigNode(g osgraph.MutableUniqueGraph, dc *depoyapi.Deplo
 	return dcNode
 }
 
-func FindOrCreateSyntheticDeploymentConfigNode(g osgraph.MutableUniqueGraph, dc *depoyapi.DeploymentConfig) *DeploymentConfigNode {
+func FindOrCreateSyntheticDeploymentConfigNode(g osgraph.MutableUniqueGraph, dc *deployapi.DeploymentConfig) *DeploymentConfigNode {
 	return osgraph.EnsureUnique(
 		g,
 		DeploymentConfigNodeName(dc),

--- a/pkg/apps/graph/nodes/types.go
+++ b/pkg/apps/graph/nodes/types.go
@@ -3,13 +3,43 @@ package nodes
 import (
 	"reflect"
 
+	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
+
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
 )
 
 var (
+	DaemonSetNodeKind        = reflect.TypeOf(kapisext.DaemonSet{}).Name()
 	DeploymentConfigNodeKind = reflect.TypeOf(deployapi.DeploymentConfig{}).Name()
 )
+
+func DaemonSetNodeName(o *kapisext.DaemonSet) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(DaemonSetNodeKind, o)
+}
+
+type DaemonSetNode struct {
+	osgraph.Node
+	DaemonSet *kapisext.DaemonSet
+
+	IsFound bool
+}
+
+func (n DaemonSetNode) Found() bool {
+	return n.IsFound
+}
+
+func (n DaemonSetNode) Object() interface{} {
+	return n.DaemonSet
+}
+
+func (n DaemonSetNode) String() string {
+	return string(DaemonSetNodeName(n.DaemonSet))
+}
+
+func (*DaemonSetNode) Kind() string {
+	return DaemonSetNodeKind
+}
 
 func DeploymentConfigNodeName(o *deployapi.DeploymentConfig) osgraph.UniqueName {
 	return osgraph.GetUniqueRuntimeObjectNodeName(DeploymentConfigNodeKind, o)

--- a/pkg/apps/graph/nodes/types.go
+++ b/pkg/apps/graph/nodes/types.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	DaemonSetNodeKind        = reflect.TypeOf(kapisext.DaemonSet{}).Name()
+	DeploymentNodeKind       = reflect.TypeOf(kapisext.Deployment{}).Name()
 	DeploymentConfigNodeKind = reflect.TypeOf(deployapi.DeploymentConfig{}).Name()
 )
 
@@ -39,6 +40,33 @@ func (n DaemonSetNode) String() string {
 
 func (*DaemonSetNode) Kind() string {
 	return DaemonSetNodeKind
+}
+
+func DeploymentNodeName(o *kapisext.Deployment) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(DeploymentNodeKind, o)
+}
+
+type DeploymentNode struct {
+	osgraph.Node
+	Deployment *kapisext.Deployment
+
+	IsFound bool
+}
+
+func (n DeploymentNode) Found() bool {
+	return n.IsFound
+}
+
+func (n DeploymentNode) Object() interface{} {
+	return n.Deployment
+}
+
+func (n DeploymentNode) String() string {
+	return string(DeploymentNodeName(n.Deployment))
+}
+
+func (*DeploymentNode) Kind() string {
+	return DeploymentNodeKind
 }
 
 func DeploymentConfigNodeName(o *deployapi.DeploymentConfig) osgraph.UniqueName {

--- a/pkg/apps/graph/nodes/types.go
+++ b/pkg/apps/graph/nodes/types.go
@@ -13,6 +13,7 @@ var (
 	DaemonSetNodeKind        = reflect.TypeOf(kapisext.DaemonSet{}).Name()
 	DeploymentNodeKind       = reflect.TypeOf(kapisext.Deployment{}).Name()
 	DeploymentConfigNodeKind = reflect.TypeOf(deployapi.DeploymentConfig{}).Name()
+	ReplicaSetNodeKind       = reflect.TypeOf(kapisext.ReplicaSet{}).Name()
 )
 
 func DaemonSetNodeName(o *kapisext.DaemonSet) osgraph.UniqueName {
@@ -94,4 +95,31 @@ func (n DeploymentConfigNode) String() string {
 
 func (*DeploymentConfigNode) Kind() string {
 	return DeploymentConfigNodeKind
+}
+
+func ReplicaSetNodeName(o *kapisext.ReplicaSet) osgraph.UniqueName {
+	return osgraph.GetUniqueRuntimeObjectNodeName(ReplicaSetNodeKind, o)
+}
+
+type ReplicaSetNode struct {
+	osgraph.Node
+	ReplicaSet *kapisext.ReplicaSet
+
+	IsFound bool
+}
+
+func (n ReplicaSetNode) Found() bool {
+	return n.IsFound
+}
+
+func (n ReplicaSetNode) Object() interface{} {
+	return n.ReplicaSet
+}
+
+func (n ReplicaSetNode) String() string {
+	return string(ReplicaSetNodeName(n.ReplicaSet))
+}
+
+func (*ReplicaSetNode) Kind() string {
+	return ReplicaSetNodeKind
 }

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -552,6 +552,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("get", "list").Groups(buildGroup, legacyBuildGroup).Resources("buildconfigs", "builds").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
+				rbac.NewRule("get", "list").Groups(extensionsGroup).Resources("deployments").RuleOrDie(),
 
 				rbac.NewRule("delete").Groups(imageGroup, legacyImageGroup).Resources("images").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreams").RuleOrDie(),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -553,6 +553,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("get", "list").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(extensionsGroup).Resources("deployments").RuleOrDie(),
+				rbac.NewRule("get", "list").Groups(extensionsGroup).Resources("replicasets").RuleOrDie(),
 
 				rbac.NewRule("delete").Groups(imageGroup, legacyImageGroup).Resources("images").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreams").RuleOrDie(),

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -551,6 +551,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("list").Groups(kapiGroup).Resources("limitranges").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(buildGroup, legacyBuildGroup).Resources("buildconfigs", "builds").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
+				rbac.NewRule("get", "list").Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule("delete").Groups(imageGroup, legacyImageGroup).Resources("images").RuleOrDie(),
 				rbac.NewRule("get", "list").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreams").RuleOrDie(),

--- a/pkg/image/graph/nodes/nodes.go
+++ b/pkg/image/graph/nodes/nodes.go
@@ -36,8 +36,12 @@ func EnsureAllImageStreamTagNodes(g osgraph.MutableUniqueGraph, is *imageapi.Ima
 	return ret
 }
 
-func FindImage(g osgraph.MutableUniqueGraph, imageName string) graph.Node {
-	return g.Find(ImageNodeName(&imageapi.Image{ObjectMeta: metav1.ObjectMeta{Name: imageName}}))
+func FindImage(g osgraph.MutableUniqueGraph, imageName string) *ImageNode {
+	n := g.Find(ImageNodeName(&imageapi.Image{ObjectMeta: metav1.ObjectMeta{Name: imageName}}))
+	if imageNode, ok := n.(*ImageNode); ok {
+		return imageNode
+	}
+	return nil
 }
 
 // EnsureDockerRepositoryNode adds the named Docker repository tag reference to the graph if it does

--- a/pkg/image/prune/testutil/util.go
+++ b/pkg/image/prune/testutil/util.go
@@ -1,0 +1,444 @@
+package testutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
+
+	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+)
+
+const (
+	Layer1 = "tarsum.dev+sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	Layer2 = "tarsum.dev+sha256:b194de3772ebbcdc8f244f663669799ac1cb141834b7cb8b69100285d357a2b0"
+	Layer3 = "tarsum.dev+sha256:c937c4bb1c1a21cc6d94340812262c6472092028972ae69b551b1a70d4276171"
+	Layer4 = "tarsum.dev+sha256:2aaacc362ac6be2b9e9ae8c6029f6f616bb50aec63746521858e47841b90fabd"
+	Layer5 = "tarsum.dev+sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+var (
+	Config1 = "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749"
+	Config2 = "sha256:8ddc19f16526912237dd8af81971d5e4dd0587907234be2b83e249518d5b673f"
+)
+
+// ImageList turns the given images into ImageList.
+func ImageList(images ...imageapi.Image) imageapi.ImageList {
+	return imageapi.ImageList{
+		Items: images,
+	}
+}
+
+// AgedImage creates a test image with specified age.
+func AgedImage(id, ref string, ageInMinutes int64) imageapi.Image {
+	return CreatedImage(id, ref, time.Now().Add(time.Duration(ageInMinutes)*time.Minute*-1))
+}
+
+// CreatedImage creates a test image with the CreationTime set to the given timestamp.
+func CreatedImage(id, ref string, created time.Time) imageapi.Image {
+	image := ImageWithLayers(id, ref, nil, Layer1, Layer2, Layer3, Layer4, Layer5)
+	image.CreationTimestamp = metav1.NewTime(created)
+	return image
+}
+
+// SizedImage returns a test image of given size.
+func SizedImage(id, ref string, size int64, configName *string) imageapi.Image {
+	image := ImageWithLayers(id, ref, configName, Layer1, Layer2, Layer3, Layer4, Layer5)
+	image.CreationTimestamp = metav1.NewTime(metav1.Now().Add(time.Duration(-1) * time.Minute))
+	image.DockerImageMetadata.Size = size
+
+	return image
+}
+
+// Image returns a default test image object 120 minutes old.
+func Image(id, ref string) imageapi.Image {
+	return AgedImage(id, ref, 120)
+}
+
+// Image returns a default test image referencing the given layers.
+func ImageWithLayers(id, ref string, configName *string, layers ...string) imageapi.Image {
+	image := imageapi.Image{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: id,
+			Annotations: map[string]string{
+				imageapi.ManagedByOpenShiftAnnotation: "true",
+			},
+		},
+		DockerImageReference:         ref,
+		DockerImageManifestMediaType: schema1.MediaTypeManifest,
+	}
+
+	if configName != nil {
+		image.DockerImageMetadata = imageapi.DockerImage{
+			ID: *configName,
+		}
+		image.DockerImageConfig = fmt.Sprintf("{Digest: %s}", *configName)
+		image.DockerImageManifestMediaType = schema2.MediaTypeManifest
+	}
+
+	image.DockerImageLayers = []imageapi.ImageLayer{}
+	for _, layer := range layers {
+		image.DockerImageLayers = append(image.DockerImageLayers, imageapi.ImageLayer{Name: layer})
+	}
+
+	return image
+}
+
+// UnmanagedImage creates a test image object lacking managed by OpenShift annotation.
+func UnmanagedImage(id, ref string, hasAnnotations bool, annotation, value string) imageapi.Image {
+	image := ImageWithLayers(id, ref, nil)
+	if !hasAnnotations {
+		image.Annotations = nil
+	} else {
+		delete(image.Annotations, imageapi.ManagedByOpenShiftAnnotation)
+		image.Annotations[annotation] = value
+	}
+	return image
+}
+
+// PodList turns the given pods into PodList.
+func PodList(pods ...kapi.Pod) kapi.PodList {
+	return kapi.PodList{
+		Items: pods,
+	}
+}
+
+// Pod creates and returns a pod having the given docker image references.
+func Pod(namespace, name string, phase kapi.PodPhase, containerImages ...string) kapi.Pod {
+	return AgedPod(namespace, name, phase, -1, containerImages...)
+}
+
+// AgedPod creates and returns a pod of particular age.
+func AgedPod(namespace, name string, phase kapi.PodPhase, ageInMinutes int64, containerImages ...string) kapi.Pod {
+	pod := kapi.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/pod/" + name,
+		},
+		Spec: PodSpec(containerImages...),
+		Status: kapi.PodStatus{
+			Phase: phase,
+		},
+	}
+
+	if ageInMinutes >= 0 {
+		pod.CreationTimestamp = metav1.NewTime(metav1.Now().Add(time.Duration(-1*ageInMinutes) * time.Minute))
+	}
+
+	return pod
+}
+
+// PodSpec creates a pod specification having the given docker image references.
+func PodSpec(containerImages ...string) kapi.PodSpec {
+	spec := kapi.PodSpec{
+		Containers: []kapi.Container{},
+	}
+	for _, image := range containerImages {
+		container := kapi.Container{
+			Image: image,
+		}
+		spec.Containers = append(spec.Containers, container)
+	}
+	return spec
+}
+
+// StreamList turns the given streams into StreamList.
+func StreamList(streams ...imageapi.ImageStream) imageapi.ImageStreamList {
+	return imageapi.ImageStreamList{
+		Items: streams,
+	}
+}
+
+// Stream creates and returns a test ImageStream object 1 minute old
+func Stream(registry, namespace, name string, tags map[string]imageapi.TagEventList) imageapi.ImageStream {
+	return AgedStream(registry, namespace, name, -1, tags)
+}
+
+// Stream creates and returns a test ImageStream object of given age.
+func AgedStream(registry, namespace, name string, ageInMinutes int64, tags map[string]imageapi.TagEventList) imageapi.ImageStream {
+	stream := imageapi.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: imageapi.ImageStreamStatus{
+			DockerImageRepository: fmt.Sprintf("%s/%s/%s", registry, namespace, name),
+			Tags: tags,
+		},
+	}
+
+	if ageInMinutes >= 0 {
+		stream.CreationTimestamp = metav1.NewTime(metav1.Now().Add(time.Duration(-1*ageInMinutes) * time.Minute))
+	}
+
+	return stream
+}
+
+// Stream creates an ImageStream object and returns a pointer to it.
+func StreamPtr(registry, namespace, name string, tags map[string]imageapi.TagEventList) *imageapi.ImageStream {
+	s := Stream(registry, namespace, name, tags)
+	return &s
+}
+
+// Tags creates a map of tags for image stream status.
+func Tags(list ...namedTagEventList) map[string]imageapi.TagEventList {
+	m := make(map[string]imageapi.TagEventList, len(list))
+	for _, tag := range list {
+		m[tag.name] = tag.events
+	}
+	return m
+}
+
+type namedTagEventList struct {
+	name   string
+	events imageapi.TagEventList
+}
+
+// Tag creates tag entries for Tags function.
+func Tag(name string, events ...imageapi.TagEvent) namedTagEventList {
+	return namedTagEventList{
+		name: name,
+		events: imageapi.TagEventList{
+			Items: events,
+		},
+	}
+}
+
+// TagEvent creates a TagEvent object.
+func TagEvent(id, ref string) imageapi.TagEvent {
+	return imageapi.TagEvent{
+		Image:                id,
+		DockerImageReference: ref,
+	}
+}
+
+// YoungTagEvent creates a TagEvent with the given created timestamp.
+func YoungTagEvent(id, ref string, created metav1.Time) imageapi.TagEvent {
+	return imageapi.TagEvent{
+		Image:                id,
+		Created:              created,
+		DockerImageReference: ref,
+	}
+}
+
+// RCList turns the given replication controllers into RCList.
+func RCList(rcs ...kapi.ReplicationController) kapi.ReplicationControllerList {
+	return kapi.ReplicationControllerList{
+		Items: rcs,
+	}
+}
+
+// RC creates and returns a ReplicationController.
+func RC(namespace, name string, containerImages ...string) kapi.ReplicationController {
+	return kapi.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/rc/" + name,
+		},
+		Spec: kapi.ReplicationControllerSpec{
+			Template: &kapi.PodTemplateSpec{
+				Spec: PodSpec(containerImages...),
+			},
+		},
+	}
+}
+
+// DSList turns the given daemon sets into DaemonSetList.
+func DSList(dss ...kapisext.DaemonSet) kapisext.DaemonSetList {
+	return kapisext.DaemonSetList{
+		Items: dss,
+	}
+}
+
+// DS creates and returns a DaemonSet object.
+func DS(namespace, name string, containerImages ...string) kapisext.DaemonSet {
+	return kapisext.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/ds/" + name,
+		},
+		Spec: kapisext.DaemonSetSpec{
+			Template: kapi.PodTemplateSpec{
+				Spec: PodSpec(containerImages...),
+			},
+		},
+	}
+}
+
+// DeploymentList turns the given deployments into DeploymentList.
+func DeploymentList(deployments ...kapisext.Deployment) kapisext.DeploymentList {
+	return kapisext.DeploymentList{
+		Items: deployments,
+	}
+}
+
+// Deployment creates and returns aDeployment object.
+func Deployment(namespace, name string, containerImages ...string) kapisext.Deployment {
+	return kapisext.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/deployment/" + name,
+		},
+		Spec: kapisext.DeploymentSpec{
+			Template: kapi.PodTemplateSpec{
+				Spec: PodSpec(containerImages...),
+			},
+		},
+	}
+}
+
+// DCList turns the given deployment configs into DeploymentConfigList.
+func DCList(dcs ...deployapi.DeploymentConfig) deployapi.DeploymentConfigList {
+	return deployapi.DeploymentConfigList{
+		Items: dcs,
+	}
+}
+
+// DC creates and returns a DeploymentConfig object.
+func DC(namespace, name string, containerImages ...string) deployapi.DeploymentConfig {
+	return deployapi.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/dc/" + name,
+		},
+		Spec: deployapi.DeploymentConfigSpec{
+			Template: &kapi.PodTemplateSpec{
+				Spec: PodSpec(containerImages...),
+			},
+		},
+	}
+}
+
+// RSList turns the given replica set into ReplicaSetList.
+func RSList(rss ...kapisext.ReplicaSet) kapisext.ReplicaSetList {
+	return kapisext.ReplicaSetList{
+		Items: rss,
+	}
+}
+
+// RS creates and returns a ReplicaSet object.
+func RS(namespace, name string, containerImages ...string) kapisext.ReplicaSet {
+	return kapisext.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/rs/" + name,
+		},
+		Spec: kapisext.ReplicaSetSpec{
+			Template: kapi.PodTemplateSpec{
+				Spec: PodSpec(containerImages...),
+			},
+		},
+	}
+}
+
+// BCList turns the given build configs into BuildConfigList.
+func BCList(bcs ...buildapi.BuildConfig) buildapi.BuildConfigList {
+	return buildapi.BuildConfigList{
+		Items: bcs,
+	}
+}
+
+// BC creates and returns a BuildConfig object.
+func BC(namespace, name, strategyType, fromKind, fromNamespace, fromName string) buildapi.BuildConfig {
+	return buildapi.BuildConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/bc/" + name,
+		},
+		Spec: buildapi.BuildConfigSpec{
+			CommonSpec: CommonSpec(strategyType, fromKind, fromNamespace, fromName),
+		},
+	}
+}
+
+// BuildList turns the given builds into BuildList.
+func BuildList(builds ...buildapi.Build) buildapi.BuildList {
+	return buildapi.BuildList{
+		Items: builds,
+	}
+}
+
+// Build creates and returns a Build object.
+func Build(namespace, name, strategyType, fromKind, fromNamespace, fromName string) buildapi.Build {
+	return buildapi.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			SelfLink:  "/build/" + name,
+		},
+		Spec: buildapi.BuildSpec{
+			CommonSpec: CommonSpec(strategyType, fromKind, fromNamespace, fromName),
+		},
+	}
+}
+
+// LimitList turns the given limits into LimitRanges.
+func LimitList(limits ...int64) []*kapi.LimitRange {
+	list := make([]*kapi.LimitRange, len(limits))
+	for _, limit := range limits {
+		quantity := resource.NewQuantity(limit, resource.BinarySI)
+		list = append(list, &kapi.LimitRange{
+			Spec: kapi.LimitRangeSpec{
+				Limits: []kapi.LimitRangeItem{
+					{
+						Type: imageapi.LimitTypeImage,
+						Max: kapi.ResourceList{
+							kapi.ResourceStorage: *quantity,
+						},
+					},
+				},
+			},
+		})
+	}
+	return list
+}
+
+// CommonSpec creates and returns CommonSpec object.
+func CommonSpec(strategyType, fromKind, fromNamespace, fromName string) buildapi.CommonSpec {
+	spec := buildapi.CommonSpec{
+		Strategy: buildapi.BuildStrategy{},
+	}
+	switch strategyType {
+	case "source":
+		spec.Strategy.SourceStrategy = &buildapi.SourceBuildStrategy{
+			From: kapi.ObjectReference{
+				Kind:      fromKind,
+				Namespace: fromNamespace,
+				Name:      fromName,
+			},
+		}
+	case "docker":
+		spec.Strategy.DockerStrategy = &buildapi.DockerBuildStrategy{
+			From: &kapi.ObjectReference{
+				Kind:      fromKind,
+				Namespace: fromNamespace,
+				Name:      fromName,
+			},
+		}
+	case "custom":
+		spec.Strategy.CustomStrategy = &buildapi.CustomBuildStrategy{
+			From: kapi.ObjectReference{
+				Kind:      fromKind,
+				Namespace: fromNamespace,
+				Name:      fromName,
+			},
+		}
+	}
+
+	return spec
+}

--- a/pkg/oc/admin/prune/images.go
+++ b/pkg/oc/admin/prune/images.go
@@ -72,8 +72,8 @@ var (
 			--insecure-skip-tls-verify or allowed for insecure connection)`)
 
 	imagesExample = templates.Examples(`
-	  # See, what the prune command would delete if only images more than an hour old and obsoleted
-	  # by 3 newer revisions under the same tag were considered.
+	  # See, what the prune command would delete if only images and their referrers were more than an hour old
+	  # and obsoleted by 3 newer revisions under the same tag were considered.
 	  %[1]s %[2]s --keep-tag-revisions=3 --keep-younger-than=60m
 
 	  # To actually perform the prune operation, the confirm flag must be appended
@@ -146,7 +146,7 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 
 	cmd.Flags().BoolVar(&opts.Confirm, "confirm", opts.Confirm, "If true, specify that image pruning should proceed. Defaults to false, displaying what would be deleted but not actually deleting anything. Requires a valid route to the integrated Docker registry (see --registry-url).")
 	cmd.Flags().BoolVar(opts.AllImages, "all", *opts.AllImages, "Include images that were imported from external registries as candidates for pruning.  If pruned, all the mirrored objects associated with them will also be removed from the integrated registry.")
-	cmd.Flags().DurationVar(opts.KeepYoungerThan, "keep-younger-than", *opts.KeepYoungerThan, "Specify the minimum age of an image for it to be considered a candidate for pruning.")
+	cmd.Flags().DurationVar(opts.KeepYoungerThan, "keep-younger-than", *opts.KeepYoungerThan, "Specify the minimum age of an image and its referrers for it to be considered a candidate for pruning.")
 	cmd.Flags().IntVar(opts.KeepTagRevisions, "keep-tag-revisions", *opts.KeepTagRevisions, "Specify the number of image revisions for a tag in an image stream that will be preserved.")
 	cmd.Flags().BoolVar(opts.PruneOverSizeLimit, "prune-over-size-limit", *opts.PruneOverSizeLimit, "Specify if images which are exceeding LimitRanges (see 'openshift.io/Image'), specified in the same namespace, should be considered for pruning. This flag cannot be combined with --keep-younger-than nor --keep-tag-revisions.")
 	cmd.Flags().StringVar(&opts.CABundle, "certificate-authority", opts.CABundle, "The path to a certificate authority bundle to use when communicating with the managed Docker registries. Defaults to the certificate authority data from the current user's config file. It cannot be used together with --force-insecure.")

--- a/pkg/oc/admin/prune/images.go
+++ b/pkg/oc/admin/prune/images.go
@@ -270,6 +270,14 @@ func (o PruneImagesOptions) Run() error {
 		fmt.Fprintf(os.Stderr, "Failed to list daemonsets: %v\n - * Make sure to update clusterRoleBindings.\n", err)
 	}
 
+	allDeployments, err := o.KubeClient.Extensions().Deployments(o.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		if !kerrors.IsForbidden(err) {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "Failed to list deployments: %v\n - * Make sure to update clusterRoleBindings.\n", err)
+	}
+
 	allDCs, err := o.AppsClient.DeploymentConfigs(o.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -342,6 +350,7 @@ func (o PruneImagesOptions) Run() error {
 		BCs:                allBCs,
 		Builds:             allBuilds,
 		DSs:                allDSs,
+		Deployments:        allDeployments,
 		DCs:                allDCs,
 		LimitRanges:        limitRangesMap,
 		DryRun:             o.Confirm == false,

--- a/pkg/oc/admin/prune/images.go
+++ b/pkg/oc/admin/prune/images.go
@@ -264,6 +264,7 @@ func (o PruneImagesOptions) Run() error {
 
 	allDSs, err := o.KubeClient.Extensions().DaemonSets(o.Namespace).List(metav1.ListOptions{})
 	if err != nil {
+		// TODO: remove in future (3.9) release
 		if !kerrors.IsForbidden(err) {
 			return err
 		}
@@ -272,6 +273,7 @@ func (o PruneImagesOptions) Run() error {
 
 	allDeployments, err := o.KubeClient.Extensions().Deployments(o.Namespace).List(metav1.ListOptions{})
 	if err != nil {
+		// TODO: remove in future (3.9) release
 		if !kerrors.IsForbidden(err) {
 			return err
 		}
@@ -281,6 +283,15 @@ func (o PruneImagesOptions) Run() error {
 	allDCs, err := o.AppsClient.DeploymentConfigs(o.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
+	}
+
+	allRSs, err := o.KubeClient.Extensions().ReplicaSets(o.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		// TODO: remove in future (3.9) release
+		if !kerrors.IsForbidden(err) {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "Failed to list replicasets: %v\n - * Make sure to update clusterRoleBindings.\n", err)
 	}
 
 	limitRangesList, err := o.KubeClient.Core().LimitRanges(o.Namespace).List(metav1.ListOptions{})
@@ -352,6 +363,7 @@ func (o PruneImagesOptions) Run() error {
 		DSs:                allDSs,
 		Deployments:        allDeployments,
 		DCs:                allDCs,
+		RSs:                allRSs,
 		LimitRanges:        limitRangesMap,
 		DryRun:             o.Confirm == false,
 		RegistryClient:     registryClient,

--- a/pkg/oc/admin/prune/images_test.go
+++ b/pkg/oc/admin/prune/images_test.go
@@ -1,17 +1,39 @@
 package prune
 
 import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff"
+
+	restfake "k8s.io/client-go/rest/fake"
 
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset/fake"
 	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset/fake"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/fake"
+	"github.com/openshift/origin/pkg/image/prune/testutil"
+	"github.com/openshift/origin/pkg/version"
 )
 
+var logLevel = flag.Int("loglevel", 0, "")
+
 func TestImagePruneNamespaced(t *testing.T) {
+	flag.Lookup("v").Value.Set(fmt.Sprint(*logLevel))
 	kFake := fake.NewSimpleClientset()
 	imageFake := imageclient.NewSimpleClientset()
 	opts := &PruneImagesOptions{
@@ -22,6 +44,7 @@ func TestImagePruneNamespaced(t *testing.T) {
 		ImageClient: imageFake.Image(),
 		KubeClient:  kFake,
 		Out:         ioutil.Discard,
+		ErrOut:      os.Stderr,
 	}
 
 	if err := opts.Run(); err != nil {
@@ -45,4 +68,120 @@ func TestImagePruneNamespaced(t *testing.T) {
 			t.Errorf("Unexpected namespace while pruning %s: %s", a.GetResource(), a.GetNamespace())
 		}
 	}
+}
+
+func TestImagePruneErrOnBadReference(t *testing.T) {
+	flag.Lookup("v").Value.Set(fmt.Sprint(*logLevel))
+	podBad := testutil.Pod("foo", "pod1", kapi.PodRunning, "invalid image reference")
+	podGood := testutil.Pod("foo", "pod2", kapi.PodRunning, "example.com/foo/bar@sha256:0000000000000000000000000000000000000000000000000000000000000000")
+	dep := testutil.Deployment("foo", "dep1", "do not blame me")
+	bcBad := testutil.BC("foo", "bc1", "source", "ImageStreamImage", "foo", "bar:invalid-digest")
+
+	kFake := fake.NewSimpleClientset(&podBad, &podGood, &dep)
+	imageFake := imageclient.NewSimpleClientset()
+	fakeDiscovery := &fakeVersionDiscovery{
+		masterVersion: version.Get(),
+	}
+
+	switch d := kFake.Discovery().(type) {
+	case *fakediscovery.FakeDiscovery:
+		fakeDiscovery.FakeDiscovery = d
+	default:
+		t.Fatalf("unexpected discovery type: %T != %T", d, &fakediscovery.FakeDiscovery{})
+	}
+
+	errBuf := bytes.NewBuffer(make([]byte, 0, 4096))
+	opts := &PruneImagesOptions{
+		AppsClient:      appsclient.NewSimpleClientset().Apps(),
+		BuildClient:     buildclient.NewSimpleClientset(&bcBad).Build(),
+		ImageClient:     imageFake.Image(),
+		KubeClient:      kFake,
+		DiscoveryClient: fakeDiscovery,
+		Out:             ioutil.Discard,
+		ErrOut:          errBuf,
+	}
+
+	verifyOutput := func(out string, expectClientVersionMismatch bool) {
+		t.Logf("pruner error output: %s\n", out)
+
+		badRefErrors := sets.NewString()
+		for _, l := range strings.Split(out, "\n") {
+			if strings.HasPrefix(l, "  ") {
+				badRefErrors.Insert(l[2:])
+			}
+		}
+		expBadRefErrors := sets.NewString(
+			`Pod[foo/pod1]: invalid docker image reference "invalid image reference": invalid reference format`,
+			`BuildConfig[foo/bc1]: invalid ImageStreamImage reference "bar:invalid-digest": expected exactly one @ in the isimage name "bar:invalid-digest"`,
+			`Deployment[foo/dep1]: invalid docker image reference "do not blame me": invalid reference format`)
+
+		if a, e := badRefErrors, expBadRefErrors; !a.Equal(e) {
+			t.Fatalf("got unexpected invalid reference errors: %s", diff.ObjectDiff(a, e))
+		}
+
+		if expectClientVersionMismatch {
+			if msg := "client version"; !strings.Contains(strings.ToLower(out), msg) {
+				t.Errorf("expected message %q is not contained in the output", msg)
+			}
+		} else {
+			for _, msg := range []string{"failed to get master api version", "client version"} {
+				if strings.Contains(strings.ToLower(out), msg) {
+					t.Errorf("got unexpected message %q in the output", msg)
+				}
+			}
+		}
+	}
+
+	err := opts.Run()
+	if err == nil {
+		t.Fatal("Unexpected non-error")
+	}
+
+	t.Logf("pruner error: %s\n", err)
+	verifyOutput(errBuf.String(), false)
+
+	t.Logf("bump master version and try again")
+	fakeDiscovery.masterVersion.Minor += "1"
+	errBuf.Reset()
+	err = opts.Run()
+	if err == nil {
+		t.Fatal("Unexpected non-error")
+	}
+
+	t.Logf("pruner error: %s\n", err)
+	verifyOutput(errBuf.String(), true)
+}
+
+type fakeVersionDiscovery struct {
+	*fakediscovery.FakeDiscovery
+	masterVersion version.Info
+}
+
+func (f *fakeVersionDiscovery) RESTClient() restclient.Interface {
+	return &restfake.RESTClient{
+		APIRegistry:          kapi.Registry,
+		NegotiatedSerializer: scheme.Codecs,
+		Client: restfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path != "/version/openshift" {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+				}, nil
+			}
+			header := http.Header{}
+			header.Set("Content-Type", runtime.ContentTypeJSON)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header,
+				Body:       objBody(&f.masterVersion),
+			}, nil
+		}),
+	}
+}
+
+func objBody(object interface{}) io.ReadCloser {
+	output, err := json.MarshalIndent(object, "", "")
+	if err != nil {
+		panic(err)
+	}
+	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
 }

--- a/pkg/oc/admin/top/graph.go
+++ b/pkg/oc/admin/top/graph.go
@@ -74,13 +74,12 @@ func addImageStreamsToGraph(g graph.Graph, streams *imageapi.ImageStreamList) {
 		for tag, history := range stream.Status.Tags {
 			for i := range history.Items {
 				image := history.Items[i]
-				n := imagegraph.FindImage(g, image.Image)
-				if n == nil {
+				imageNode := imagegraph.FindImage(g, image.Image)
+				if imageNode == nil {
 					glog.V(2).Infof("Unable to find image %q in graph (from tag=%q, dockerImageReference=%s)",
 						history.Items[i].Image, tag, image.DockerImageReference)
 					continue
 				}
-				imageNode := n.(*imagegraph.ImageNode)
 				glog.V(4).Infof("Adding edge from %q to %q", imageStreamNode.UniqueName(), imageNode.UniqueName())
 				edgeKind := ImageStreamImageEdgeKind
 				if i > 1 {

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1872,6 +1872,27 @@ items:
     - get
     - list
   - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - extensions
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - extensions
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+  - apiGroups:
     - ""
     - image.openshift.io
     resources:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -2042,6 +2042,30 @@ items:
     - get
     - list
   - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+  - apiGroups:
     - ""
     - image.openshift.io
     attributeRestrictions: null


### PR DESCRIPTION
Create strong references to images for each pod/bc/dc/etc that uses `<host>/<repo>:tag` reference.

Resolves [bz#1498604](https://bugzilla.redhat.com/show_bug.cgi?id=1498604) and https://bugzilla.redhat.com/show_bug.cgi?id=1386917



Images can manually removed using `oc delete`. Image stream tags having references to these images become obsolete - we may delete them.

To be sure that we don't remove reference to image that has just been created (and we don't know about it), make sure to honor `--keep-younger-than`.