### PR TITLE
Change image for complete-dc-hooks.yaml to centos7 which will be already pre-pulled

### DIFF
--- a/test/testdata/complete-dc-hooks.yaml
+++ b/test/testdata/complete-dc-hooks.yaml
@@ -34,7 +34,8 @@ spec:
         name: complete-dc-hooks
     spec:
       containers:
-      - image: "docker.io/busybox"
+      - image: "docker.io/centos:centos7"
+        imagePullPolicy: IfNotPresent
         name: myapp
         command:
         - "/bin/sleep"


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/14367