### PR TITLE
Move api installation import before importing actual api to prevent races during kind registration

### DIFF
--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -16,6 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/api"
 
+	// install API explicitly before origin api to prevent races during kind registration
+	_ "github.com/openshift/origin/pkg/api/install"
+
 	oapi "github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"


### PR DESCRIPTION
@deads2k @enj I was hitting this error when running integration. I might be not the only one hitting it. 
```
error in registering resource: buildconfigs, /, Kind=BuildConfig matches multiple kinds [/v1, Kind=BuildConfig /v1, Kind=BuildConfig], 
error in registering resource: buildconfigs/instantiate, /, Kind=BuildConfig matches multiple kinds [/v1, Kind=BuildConfig /v1, Kind=BuildConfig], 
error in registering resource: buildconfigs/instantiatebinary, /, Kind=BuildConfig matches multiple kinds [/v1, Kind=BuildConfig /v1, Kind=BuildConfig], 
error in registering resource: buildconfigs/webhooks, /, Kind=BuildConfig matches multiple kinds [/v1, Kind=BuildConfig /v1, Kind=BuildConfig], 
error in registering resource: builds, /, Kind=Build matches multiple kinds [/v1, Kind=Build /v1, Kind=Build], 
error in registering resource: builds/clone, /, Kind=Build matches multiple kinds [/v1, Kind=Build /v1, Kind=Build], 
error in registering resource: builds/details, /, Kind=Build matches multiple kinds [/v1, Kind=Build /v1, Kind=Build], 
error in registering resource: builds/log, /, Kind=Build matches multiple kinds [/v1, Kind=Build /v1, Kind=Build], 
error in registering resource: clusterrolebindings, /, Kind=ClusterRoleBinding matches multiple kinds [/v1, Kind=ClusterRoleBinding /v1, Kind=ClusterRoleBinding], 
error in registering resource: clusterroles, /, Kind=ClusterRole matches multiple kinds [/v1, Kind=ClusterRole /v1, Kind=ClusterRole], 
error in registering resource: localresourceaccessreviews, /, Kind=LocalResourceAccessReview matches multiple kinds [/v1, Kind=LocalResourceAccessReview /v1, Kind=LocalResourceAccessReview], 
error in registering resource: localsubjectaccessreviews, /, Kind=LocalSubjectAccessReview matches multiple kinds [/v1, Kind=LocalSubjectAccessReview /v1, Kind=LocalSubjectAccessReview], 
error in registering resource: resourceaccessreviews, /, Kind=ResourceAccessReview matches multiple kinds [/v1, Kind=ResourceAccessReview /v1, Kind=ResourceAccessReview], 
error in registering resource: rolebindingrestrictions, /, Kind=RoleBindingRestriction matches multiple kinds [/v1, Kind=RoleBindingRestriction /v1, Kind=RoleBindingRestriction], 
error in registering resource: rolebindings, /, Kind=RoleBinding matches multiple kinds [/v1, Kind=RoleBinding /v1, Kind=RoleBinding], 
error in registering resource: roles, /, Kind=Role matches multiple kinds [/v1, Kind=Role /v1, Kind=Role], 
error in registering resource: selfsubjectrulesreviews, /, Kind=SelfSubjectRulesReview matches multiple kinds [/v1, Kind=SelfSubjectRulesReview /v1, Kind=SelfSubjectRulesReview], 
error in registering resource: subjectaccessreviews, /, Kind=SubjectAccessReview matches multiple kinds [/v1, Kind=SubjectAccessReview /v1, Kind=SubjectAccessReview], 
error in registering resource: subjectrulesreviews, /, Kind=SubjectRulesReview matches multiple kinds [/v1, Kind=SubjectRulesReview /v1, Kind=SubjectRulesReview]
```