### PR TITLE
Fix crash on last node when deleting second-to-last node

### DIFF
--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -20,7 +20,7 @@ func (node *OsdnNode) SubnetStartNode() error {
 type hostSubnetMap map[string]*networkapi.HostSubnet
 
 func (plugin *OsdnNode) updateVXLANMulticastRules(subnets hostSubnetMap) {
-	remoteIPs := make([]string, 0, len(subnets)-1)
+	remoteIPs := make([]string, 0, len(subnets))
 	for _, subnet := range subnets {
 		if subnet.HostIP != plugin.localIP {
 			remoteIPs = append(remoteIPs, subnet.HostIP)


### PR DESCRIPTION
`subnets` doesn't contain the current node, so when that's the last node left this would end up trying to allocate an array with -1 elements. (Yes this means the `subnet.HostIP != plugin.localIP` check there is unnecessary, but it's still correct.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1501319