### PR TITLE
Use glog local name instead of log

### DIFF
--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/golang/glog"
+	"github.com/golang/glog"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,7 +44,7 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 		return nil
 	}
 
-	log.Infof("Initializing SDN master of type %q", networkConfig.NetworkPluginName)
+	glog.Infof("Initializing SDN master of type %q", networkConfig.NetworkPluginName)
 
 	master := &OsdnMaster{
 		kClient:           kClient,
@@ -92,10 +92,10 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 			if _, err = master.networkClient.Network().ClusterNetworks().Create(configCN); err != nil {
 				return false, err
 			}
-			log.Infof("Created ClusterNetwork %s", common.ClusterNetworkToString(configCN))
+			glog.Infof("Created ClusterNetwork %s", common.ClusterNetworkToString(configCN))
 
 			if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
-				log.Errorf("Cluster contains objects incompatible with new ClusterNetwork: %v", err)
+				glog.Errorf("Cluster contains objects incompatible with new ClusterNetwork: %v", err)
 			}
 		} else {
 			configChanged, err := clusterNetworkChanged(configCN, existingCN)
@@ -106,15 +106,15 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 				configCN.TypeMeta = existingCN.TypeMeta
 				configCN.ObjectMeta = existingCN.ObjectMeta
 				if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
-					log.Errorf("Attempting to modify cluster to exclude existing objects: %v", err)
+					glog.Errorf("Attempting to modify cluster to exclude existing objects: %v", err)
 					return false, err
 				}
 				if _, err = master.networkClient.Network().ClusterNetworks().Update(configCN); err != nil {
 					return false, err
 				}
-				log.Infof("Updated ClusterNetwork %s", common.ClusterNetworkToString(configCN))
+				glog.Infof("Updated ClusterNetwork %s", common.ClusterNetworkToString(configCN))
 			} else {
-				log.V(5).Infof("No change to ClusterNetwork %s", common.ClusterNetworkToString(configCN))
+				glog.V(5).Infof("No change to ClusterNetwork %s", common.ClusterNetworkToString(configCN))
 			}
 		}
 

--- a/pkg/network/master/vnids.go
+++ b/pkg/network/master/vnids.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/golang/glog"
+	"github.com/golang/glog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -121,7 +121,7 @@ func (vmap *masterVNIDMap) allocateNetID(nsName string) (uint32, bool, error) {
 	}
 
 	vmap.setVNID(nsName, netid)
-	log.Infof("Allocated netid %d for namespace %q", netid, nsName)
+	glog.Infof("Allocated netid %d for namespace %q", netid, nsName)
 	return netid, exists, nil
 }
 
@@ -143,9 +143,9 @@ func (vmap *masterVNIDMap) releaseNetID(nsName string) error {
 		if err := vmap.netIDManager.Release(netid); err != nil {
 			return fmt.Errorf("Error while releasing netid %d for namespace %q, %v", netid, nsName, err)
 		}
-		log.Infof("Released netid %d for namespace %q", netid, nsName)
+		glog.Infof("Released netid %d for namespace %q", netid, nsName)
 	} else {
-		log.V(5).Infof("netid %d for namespace %q is still in use", netid, nsName)
+		glog.V(5).Infof("netid %d for namespace %q is still in use", netid, nsName)
 	}
 	return nil
 }
@@ -196,7 +196,7 @@ func (vmap *masterVNIDMap) updateNetID(nsName string, action network.PodNetworkA
 
 	// Set new network ID
 	vmap.setVNID(nsName, netid)
-	log.Infof("Updated netid %d for namespace %q", netid, nsName)
+	glog.Infof("Updated netid %d for namespace %q", netid, nsName)
 	return netid, nil
 }
 
@@ -289,17 +289,17 @@ func (master *OsdnMaster) watchNamespaces() {
 
 func (master *OsdnMaster) handleAddOrUpdateNamespace(obj, _ interface{}, eventType watch.EventType) {
 	ns := obj.(*kapi.Namespace)
-	log.V(5).Infof("Watch %s event for Namespace %q", eventType, ns.Name)
+	glog.V(5).Infof("Watch %s event for Namespace %q", eventType, ns.Name)
 	if err := master.vnids.assignVNID(master.networkClient, ns.Name); err != nil {
-		log.Errorf("Error assigning netid: %v", err)
+		glog.Errorf("Error assigning netid: %v", err)
 	}
 }
 
 func (master *OsdnMaster) handleDeleteNamespace(obj interface{}) {
 	ns := obj.(*kapi.Namespace)
-	log.V(5).Infof("Watch %s event for Namespace %q", watch.Deleted, ns.Name)
+	glog.V(5).Infof("Watch %s event for Namespace %q", watch.Deleted, ns.Name)
 	if err := master.vnids.revokeVNID(master.networkClient, ns.Name); err != nil {
-		log.Errorf("Error revoking netid: %v", err)
+		glog.Errorf("Error revoking netid: %v", err)
 	}
 }
 
@@ -308,7 +308,7 @@ func (master *OsdnMaster) watchNetNamespaces() {
 		netns := delta.Object.(*networkapi.NetNamespace)
 		name := netns.ObjectMeta.Name
 
-		log.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, name)
+		glog.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, name)
 		switch delta.Type {
 		case cache.Sync, cache.Added, cache.Updated:
 			err := master.vnids.updateVNID(master.networkClient, netns)

--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -3,7 +3,7 @@
 package node
 
 import (
-	log "github.com/golang/glog"
+	"github.com/golang/glog"
 
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -27,7 +27,7 @@ func (plugin *OsdnNode) updateVXLANMulticastRules(subnets hostSubnetMap) {
 		}
 	}
 	if err := plugin.oc.UpdateVXLANMulticastFlows(remoteIPs); err != nil {
-		log.Errorf("Error updating OVS VXLAN multicast flows: %v", err)
+		glog.Errorf("Error updating OVS VXLAN multicast flows: %v", err)
 	}
 }
 
@@ -39,7 +39,7 @@ func (node *OsdnNode) watchSubnets() {
 			return nil
 		}
 
-		log.V(5).Infof("Watch %s event for HostSubnet %q", delta.Type, hs.ObjectMeta.Name)
+		glog.V(5).Infof("Watch %s event for HostSubnet %q", delta.Type, hs.ObjectMeta.Name)
 		switch delta.Type {
 		case cache.Sync, cache.Added, cache.Updated:
 			oldSubnet, exists := subnets[string(hs.UID)]
@@ -52,7 +52,7 @@ func (node *OsdnNode) watchSubnets() {
 				}
 			}
 			if err := node.networkInfo.ValidateNodeIP(hs.HostIP); err != nil {
-				log.Warningf("Ignoring invalid subnet for node %s: %v", hs.HostIP, err)
+				glog.Warningf("Ignoring invalid subnet for node %s: %v", hs.HostIP, err)
 				break
 			}
 

--- a/pkg/network/node/vnids.go
+++ b/pkg/network/node/vnids.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/golang/glog"
+	"github.com/golang/glog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -131,7 +131,7 @@ func (vmap *nodeVNIDMap) setVNID(name string, id uint32, mcEnabled bool) {
 	vmap.mcEnabled[name] = mcEnabled
 	vmap.addNamespaceToSet(name, id)
 
-	log.Infof("Associate netid %d to namespace %q with mcEnabled %v", id, name, mcEnabled)
+	glog.Infof("Associate netid %d to namespace %q with mcEnabled %v", id, name, mcEnabled)
 }
 
 func (vmap *nodeVNIDMap) unsetVNID(name string) (id uint32, err error) {
@@ -145,7 +145,7 @@ func (vmap *nodeVNIDMap) unsetVNID(name string) (id uint32, err error) {
 	vmap.removeNamespaceFromSet(name, id)
 	delete(vmap.ids, name)
 	delete(vmap.mcEnabled, name)
-	log.Infof("Dissociate netid %d from namespace %q", id, name)
+	glog.Infof("Dissociate netid %d from namespace %q", id, name)
 	return id, nil
 }
 
@@ -181,7 +181,7 @@ func (vmap *nodeVNIDMap) watchNetNamespaces() {
 	common.RunEventQueue(vmap.networkClient.Network().RESTClient(), common.NetNamespaces, func(delta cache.Delta) error {
 		netns := delta.Object.(*networkapi.NetNamespace)
 
-		log.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, netns.ObjectMeta.Name)
+		glog.V(5).Infof("Watch %s event for NetNamespace %q", delta.Type, netns.ObjectMeta.Name)
 		switch delta.Type {
 		case cache.Sync, cache.Added, cache.Updated:
 			// Skip this event if nothing has changed


### PR DESCRIPTION
Clayton did a drive-by fix of this in node.go recently. Let's fix it everywhere else too.
(I guess for some reason the old openshift-sdn code all imported the module as `log`, but nothing else in origin does that, so it's inconsistent and makes it annoying when moving things between files.)
