### PR TITLE
don't create output imagestrem if already exists with newapp

### DIFF
--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -485,63 +485,145 @@ func TestBuildOutputCycleResilience(t *testing.T) {
 	}
 }
 
-func TestBuildOutputCycleWithFollowingTag(t *testing.T) {
-
-	config := &AppConfig{}
-
-	mockIS := &image.ImageStream{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mockimagestream",
-		},
-		Spec: image.ImageStreamSpec{
-			Tags: make(map[string]image.TagReference),
-		},
-	}
-	mockIS.Spec.Tags["latest"] = image.TagReference{
-		From: &kapi.ObjectReference{
-			Kind: "ImageStreamTag",
-			Name: "10.0",
-		},
-	}
-	mockIS.Spec.Tags["10.0"] = image.TagReference{
-		From: &kapi.ObjectReference{
-			Kind: "DockerImage",
-			Name: "mockimage:latest",
-		},
-	}
+func TestBuildOutputCycleWithCircularTag(t *testing.T) {
 
 	dfn := "mockdockerfilename"
-	followingTagCycleBC := &buildapi.BuildConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "buildCfgWithWeirdOutputObjectRef",
-		},
-		Spec: buildapi.BuildConfigSpec{
-			CommonSpec: buildapi.CommonSpec{
-				Source: buildapi.BuildSource{
-					Dockerfile: &dfn,
+
+	tests := []struct {
+		bc       *buildapi.BuildConfig
+		is       []runtime.Object
+		expected string
+	}{
+		{
+			bc: &buildapi.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "buildCfgWithWeirdOutputObjectRef",
 				},
-				Strategy: buildapi.BuildStrategy{
-					DockerStrategy: &buildapi.DockerBuildStrategy{
-						From: &kapi.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: "mockimagestream:latest",
+				Spec: buildapi.BuildConfigSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Dockerfile: &dfn,
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "ImageStreamTag",
+									Name: "mockimagestream:latest",
+								},
+							},
+						},
+						Output: buildapi.BuildOutput{
+							To: &kapi.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "mockimagestream:10.0",
+							},
 						},
 					},
 				},
-				Output: buildapi.BuildOutput{
-					To: &kapi.ObjectReference{
-						Kind: "ImageStreamTag",
-						Name: "mockimagestream:10.0",
+			},
+			is: []runtime.Object{
+				&image.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mockimagestream",
+					},
+					Spec: image.ImageStreamSpec{
+						Tags: map[string]image.TagReference{
+							"latest": {
+								From: &kapi.ObjectReference{
+									Kind: "ImageStreamTag",
+									Name: "10.0",
+								},
+							},
+							"10.0": {
+								From: &kapi.ObjectReference{
+									Kind: "ImageStreamTag",
+									Name: "latest",
+								},
+							},
+						},
 					},
 				},
 			},
+			expected: "image stream tag reference \"mockimagestream:latest\" is a circular loop of image stream tags",
+		},
+		{
+			bc: &buildapi.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "buildCfgWithWeirdOutputObjectRef",
+				},
+				Spec: buildapi.BuildConfigSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Source: buildapi.BuildSource{
+							Dockerfile: &dfn,
+						},
+						Strategy: buildapi.BuildStrategy{
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								From: &kapi.ObjectReference{
+									Kind: "ImageStreamTag",
+									Name: "mockimagestream:latest",
+								},
+							},
+						},
+						Output: buildapi.BuildOutput{
+							To: &kapi.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "fakeimagestream:latest",
+							},
+						},
+					},
+				},
+			},
+			is: []runtime.Object{
+				&image.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mockimagestream",
+					},
+					Spec: image.ImageStreamSpec{
+						Tags: map[string]image.TagReference{
+							"latest": {
+								From: &kapi.ObjectReference{
+									Kind: "ImageStreamTag",
+									Name: "fakeimagestream:latest",
+								},
+							},
+						},
+					},
+				},
+				&image.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fakeimagestream",
+					},
+					Spec: image.ImageStreamSpec{
+						Tags: map[string]image.TagReference{
+							"latest": {
+								From: &kapi.ObjectReference{
+									Kind: "ImageStreamTag",
+									Name: "mockimagestream:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: "image stream tag reference \"mockimagestream:latest\" is a circular loop of image stream tags",
 		},
 	}
 
-	expected := "output image of \"mockimage:latest\" should be different than input"
-	err := config.checkCircularReferences([]runtime.Object{followingTagCycleBC, mockIS})
-	if err == nil || err.Error() != expected {
-		t.Errorf("Expected error from followRefToDockerImage: got \"%v\" versus expected %q", err, expected)
+	config := &AppConfig{}
+	for _, test := range tests {
+		objs := append(test.is, test.bc)
+		// so we test both with the fake image client seeded with the image streams, i.e. existing image streams
+		// and without, i.e. the generate flow is creating the image streams as well
+		config.ImageClient = imagefakeclient.NewSimpleClientset().Image()
+		err := config.checkCircularReferences(objs)
+		if err == nil || err.Error() != test.expected {
+			t.Errorf("Expected error from followRefToDockerImage: got \"%v\" versus expected %q", err, test.expected)
+		}
+		config.ImageClient = imagefakeclient.NewSimpleClientset(test.is...).Image()
+		err = config.checkCircularReferences(objs)
+		if err == nil || err.Error() != test.expected {
+			t.Errorf("Expected error from followRefToDockerImage: got \"%v\" versus expected %q", err, test.expected)
+		}
 	}
 }
 

--- a/pkg/generate/app/errors.go
+++ b/pkg/generate/app/errors.go
@@ -104,3 +104,13 @@ type CircularOutputReferenceError struct {
 func (e CircularOutputReferenceError) Error() string {
 	return fmt.Sprintf("output image of %q should be different than input", e.Reference)
 }
+
+// CircularReferenceError is the error returned by new-app when either the input
+// or output image stream tags employ circular loops
+type CircularReferenceError struct {
+	Reference string
+}
+
+func (e CircularReferenceError) Error() string {
+	return fmt.Sprintf("image stream tag reference %q is a circular loop of image stream tags", e.Reference)
+}

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -376,8 +376,20 @@ os::cmd::expect_success 'oc delete imagestreamtag ruby:2.3'
 os::cmd::expect_failure_and_text 'oc new-app --image-stream ruby https://github.com/openshift/rails-ex --dry-run' 'error: only a partial match was found for \"ruby\":'
 # when the tag is specified explicitly, the operation is successful
 os::cmd::expect_success 'oc new-app --image-stream ruby:2.4 https://github.com/openshift/rails-ex --dry-run'
-
 os::cmd::expect_success 'oc delete imagestreams --all'
+
+# newapp does not attempt to create an imagestream that already exists for a Docker image
+os::cmd::expect_success_and_text 'oc new-app docker.io/ruby:latest~https://github.com/openshift/ruby-ex.git --name=testapp1 --strategy=docker' 'imagestream "ruby" created'
+os::cmd::expect_success_and_not_text 'oc new-app docker.io/ruby:latest~https://github.com/openshift/ruby-ex.git --name=testapp2 --strategy=docker' '"ruby" already exists'
+os::cmd::expect_success 'oc delete all -l app=testapp2'
+os::cmd::expect_success 'oc delete all -l app=testapp1'
+os::cmd::expect_success 'oc delete all -l app=ruby --ignore-not-found'
+os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
+# newapp does not attempt to create an imagestream that already exists for a Docker image
+os::cmd::expect_success 'oc new-app docker.io/ruby:2.2'
+# the next one technically fails cause the DC is already created, but we should still see the ist created
+os::cmd::expect_failure_and_text 'oc new-app docker.io/ruby:2.4' 'imagestreamtag "ruby:2.4" created'
+os::cmd::expect_success 'oc delete imagestreams --all --ignore-not-found'
 
 # check that we can create from the template without errors
 os::cmd::expect_success_and_text 'oc new-app ruby-helloworld-sample -l app=helloworld' 'service "frontend" created'


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/13169 and https://bugzilla.redhat.com/show_bug.cgi?id=1419801

@openshift/devex ptal

/assign csrwng1 bparees