### PR TITLE
don't run serial tests any more when FOCUS is specified

### DIFF
--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -11,17 +11,10 @@ function os::test::extended::focus () {
 	if [[ -n "${FOCUS:-}" ]]; then
 		exitstatus=0
 
-		# first run anything that isn't explicitly declared [Serial], and matches the $FOCUS, in a parallel mode.
+		# run anything that isn't explicitly declared [Serial], and matches the $FOCUS, in a parallel mode.
+		# FOCUS cannot now be used for [Serial] tests; it is intended that these will be split out anyway.
 		os::log::info "Running parallel tests N=${PARALLEL_NODES:-<default>} with focus ${FOCUS}"
 		TEST_REPORT_FILE_NAME=focus_parallel TEST_PARALLEL="${PARALLEL_NODES:-5}" os::test::extended::run -- -ginkgo.skip "\[Serial\]" -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
-
-		# Then run everything that requires serial and matches the $FOCUS, serially.
-		# there is bit of overlap here because not all serial tests declare [Serial], so they might have run in the
-		# parallel section above.  Hopefully your focus was precise enough to exclude them, and we should be adding
-		# the [Serial] tag to them as needed.
-		os::log::info ""
-		os::log::info "Running serial tests with focus ${FOCUS}"
-		TEST_REPORT_FILE_NAME=focus_serial os::test::extended::run -- -suite "serial.conformance.openshift.io" -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 		os::test::extended::merge_junit
 


### PR DESCRIPTION
follow up from #16842, may also solve the same issue as #16806