### PR TITLE
Fix some diagnostic error handling (NetworkCheck and DiagnosticPod)

### DIFF
--- a/pkg/diagnostics/network/run_pod.go
+++ b/pkg/diagnostics/network/run_pod.go
@@ -85,7 +85,7 @@ func (d *NetworkDiagnostic) Check() types.DiagnosticResult {
 		return d.res
 	}
 	if !ok {
-		d.res.Warn("DNet2002", nil, "Skipping network diagnostics check. Reason: Not using openshift network plugin.")
+		d.res.Info("DNet2002", "Skipping network diagnostics check. Reason: Not using openshift network plugin.")
 		return d.res
 	}
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/16847

A keyboard interrupt on the NetworkCheck diagnostic will actually abort it (giving it a chance to clean up) and proceed to the next diagnostic.

The same is done for DiagnosticPod (which previously did not catch the signal and cleanup at all).