### PR TITLE
Make admin project creation wait for SAR

### DIFF
--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -47,10 +47,12 @@ func TestLogin(t *testing.T) {
 	if loginOptions.Username != username {
 		t.Fatalf("Unexpected user after authentication: %#v", loginOptions)
 	}
+	authorizationInterface := authorizationclient.NewForConfigOrDie(clusterAdminClientConfig).Authorization()
 
 	newProjectOptions := &newproject.NewProjectOptions{
 		ProjectClient:     projectclient.NewForConfigOrDie(clusterAdminClientConfig).Project(),
-		RoleBindingClient: authorizationclient.NewForConfigOrDie(clusterAdminClientConfig),
+		RoleBindingClient: authorizationInterface,
+		SARClient:         authorizationInterface.SubjectAccessReviews(),
 		ProjectName:       project,
 		AdminRole:         bootstrappolicy.AdminRoleName,
 		AdminUser:         username,

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -617,10 +617,12 @@ func CreateNewProject(clientConfig *restclient.Config, projectName, adminUser st
 	if err != nil {
 		return nil, nil, err
 	}
+	authorizationInterface := authorizationClient.Authorization()
 
 	newProjectOptions := &newproject.NewProjectOptions{
 		ProjectClient:     projectClient,
-		RoleBindingClient: authorizationClient.Authorization(),
+		RoleBindingClient: authorizationInterface,
+		SARClient:         authorizationInterface.SubjectAccessReviews(),
 		ProjectName:       projectName,
 		AdminRole:         bootstrappolicy.AdminRoleName,
 		AdminUser:         adminUser,


### PR DESCRIPTION
This change adds a SAR check to direct project creation to ensure that the designated user can get the project which was created for them.  It also updates the project integration tests to be more tolerant of the project ACL being out of date.  This race condition became more apparent as we moved to the generated clients since those clients were smaller and had their own rate limiters (instead of a one big client that could do everything and shared the same rate limiter).  Since the new clients would perform actions at a faster pace, the race against the project ACL would occur more frequently.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Fixes #16716

/kind bug

/assign @smarterclayton @simo5 @deads2k