### PR TITLE
warn on missing service cert signer in oadm diagnostics

### DIFF
--- a/pkg/cmd/server/api/validation/master.go
+++ b/pkg/cmd/server/api/validation/master.go
@@ -336,7 +336,9 @@ func ValidateControllerConfig(config api.ControllerConfig, fldPath *field.Path) 
 			validationResults.AddErrors(field.Invalid(fldPath.Child("election", "lockResource", "resource"), election.LockResource.Resource, "may not be empty"))
 		}
 	}
-	if config.ServiceServingCert.Signer != nil {
+	if config.ServiceServingCert.Signer == nil {
+		validationResults.AddWarnings(field.Required(fldPath.Child("serviceServingCert", "signer"), "required for the service serving cert signer; automatic serving certificate signing will fail"))
+	} else {
 		validationResults.AddErrors(ValidateCertInfo(*config.ServiceServingCert.Signer, true, fldPath.Child("serviceServingCert.signer"))...)
 	}
 

--- a/pkg/cmd/server/api/validation/master_test.go
+++ b/pkg/cmd/server/api/validation/master_test.go
@@ -401,7 +401,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 	// these fields have warnings in the empty case
 	defaultWarningFields := sets.NewString(
 		"serviceAccountConfig.managedNames", "serviceAccountConfig.publicKeyFiles", "serviceAccountConfig.privateKeyFile", "serviceAccountConfig.masterCA",
-		"projectConfig.securityAllocator", "kubernetesMasterConfig.proxyClientInfo", "auditConfig.auditFilePath", "aggregatorConfig.proxyClientInfo")
+		"projectConfig.securityAllocator", "kubernetesMasterConfig.proxyClientInfo", "auditConfig.auditFilePath", "aggregatorConfig.proxyClientInfo", "controllerConfig.serviceServingCert.signer")
 
 	for _, tc := range testCases {
 		results := ValidateMasterConfig(&tc.options, nil)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1501952

Updates master-config.yaml validation to warn on missing service serving signer cert configuration.

@mrobson 

```
[deads@deads-02 origin]$ oc adm diagnostics --master-config=openshift.local.config/master/master-config.yaml MasterConfigCheck
[Note] Determining if client configuration exists for client/cluster diagnostics
Info:  Successfully read a client config file at '/home/deads/.kube/config'
[Note] Performing systemd discovery

[Note] Running diagnostic: MasterConfigCheck
       Description: Check the master config file
       
WARN:  [DH0005 from diagnostic MasterConfigCheck@openshift/origin/pkg/diagnostics/host/check_master_config.go:52]
       Validation of master config file 'openshift.local.config/master/master-config.yaml' warned:
       assetConfig.loggingPublicURL: Invalid value: "": required to view aggregated container logs in the console
       assetConfig.metricsPublicURL: Invalid value: "": required to view cluster metrics in the console
       controllerConfig.serviceServingCert.signer: Required value: required for the service serving cert signer; automatic serving certificate signing will fail
       
[Note] Summary of diagnostics execution (version v3.7.0-alpha.1+05f812f-1107-dirty):
[Note] Warnings seen: 1
```