### PR TITLE
UPSTREAM: 53916: update .dockercfg content to config.json

### DIFF
--- a/pkg/oc/cli/secrets/dockercfg.go
+++ b/pkg/oc/cli/secrets/dockercfg.go
@@ -125,7 +125,9 @@ func (o CreateDockerConfigOptions) NewDockerSecret() (*api.Secret, error) {
 		Email:    o.EmailAddress,
 	}
 
-	dockerCfg := map[string]credentialprovider.DockerConfigEntry{o.RegistryLocation: dockercfgAuth}
+	dockerCfg := credentialprovider.DockerConfigJson{
+		Auths: map[string]credentialprovider.DockerConfigEntry{o.RegistryLocation: dockercfgAuth},
+	}
 
 	dockercfgContent, err := json.Marshal(dockerCfg)
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry.go
@@ -122,7 +122,9 @@ func handleDockercfgContent(username, password, email, server string) ([]byte, e
 		Email:    email,
 	}
 
-	dockerCfg := map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth}
+	dockerCfg := credentialprovider.DockerConfigJson{
+		Auths: map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth},
+	}
 
 	return json.Marshal(dockerCfg)
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry_test.go
@@ -59,6 +59,26 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		"test-valid-use-append-hash": {
+			params: map[string]interface{}{
+				"name":            "foo-94759gc65b",
+				"docker-server":   server,
+				"docker-username": username,
+				"docker-password": password,
+				"docker-email":    email,
+				"append-hash":     "true",
+			},
+			expected: &api.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo-94759gc65b",
+				},
+				Data: map[string][]byte{
+					api.DockerConfigKey: secretData,
+				},
+				Type: api.SecretTypeDockercfg,
+			},
+			expectErr: false,
+		},
 		"test-valid-use-no-email": {
 			params: map[string]interface{}{
 				"name":            "foo",


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1476330

update the data format of .dockercfg to match the new docker config.json
format, which encapsulates all registry auth objects in an overall
"auths" object when an option `--config-format` is specified with the value
`--config-format=config.json`:

```json
{
    "auths": {
        "reg.url": {
            "auth": "...=="
        }
    }
}
```

cc @openshift/cli-review @bparees @mfojtik 