### PR TITLE
Added an OWNERS file with networking team members for the router

### DIFF
--- a/pkg/cmd/infra/router/OWNERS
+++ b/pkg/cmd/infra/router/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - knobunc
+  - rchopra
+  - pravisankar
+  - pecameron
+  - jtanenbaum
+approvers:
+  - knobunc
+  - rchopra
+


### PR DESCRIPTION
The networking team owns the router, I added an OWNERS file and added
some members from the team to it so that we can maintain the code.