### PR TITLE
Fix defaulting of legacy ClusterNetwork fields

### DIFF
--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -59,7 +59,7 @@ func ParseNetworkInfo(clusterNetwork []networkapi.ClusterNetworkEntry, serviceNe
 		if err != nil {
 			_, cidr, err := net.ParseCIDR(entry.CIDR)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse ClusterNetwork CIDR %s: %v", cidr, err)
+				return nil, fmt.Errorf("failed to parse ClusterNetwork CIDR %s: %v", entry.CIDR, err)
 			}
 			glog.Errorf("Configured clusterNetworks value %q is invalid; treating it as %q", entry.CIDR, cidr.String())
 		}


### PR DESCRIPTION
3.6 nodes can't currently start up against a 3.7 master (eg, during upgrade) because the old ClusterNetwork fields aren't set. (Some absent-minded reviewer had even noticed that this was broken and then not fixed yet (https://github.com/openshift/origin/pull/14558#discussion_r140820817) and then approved the PR anyway.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1502866

cc @eparis 