### PR TITLE
make the working directory editable through an env var

### DIFF
--- a/images/router/nginx/Dockerfile
+++ b/images/router/nginx/Dockerfile
@@ -27,5 +27,6 @@ USER 1001
 EXPOSE 80 443
 WORKDIR /var/lib/nginx/conf
 ENV TEMPLATE_FILE=/var/lib/nginx/conf/nginx-config.template \
-    RELOAD_SCRIPT=/var/lib/nginx/reload-nginx
+    RELOAD_SCRIPT=/var/lib/nginx/reload-nginx \
+    WORKING_DIR=/var/lib/nginx/router
 ENTRYPOINT ["/usr/bin/openshift-router"]

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -96,7 +96,7 @@ func reloadInterval() time.Duration {
 func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.StringVar(&o.RouterName, "name", util.Env("ROUTER_SERVICE_NAME", "public"), "The name the router will identify itself with in the route status")
 	flag.StringVar(&o.RouterCanonicalHostname, "router-canonical-hostname", util.Env("ROUTER_CANONICAL_HOSTNAME", ""), "CanonicalHostname is the external host name for the router that can be used as a CNAME for the host requested for this route. This value is optional and may not be set in all cases.")
-	flag.StringVar(&o.WorkingDir, "working-dir", "/var/lib/haproxy/router", "The working directory for the router plugin")
+	flag.StringVar(&o.WorkingDir, "working-dir", util.Env("WORKING_DIR", "/var/lib/haproxy/router"), "The working directory for the router plugin")
 	flag.StringVar(&o.DefaultCertificate, "default-certificate", util.Env("DEFAULT_CERTIFICATE", ""), "The contents of a default certificate to use for routes that don't expose a TLS server cert; in PEM format")
 	flag.StringVar(&o.DefaultCertificatePath, "default-certificate-path", util.Env("DEFAULT_CERTIFICATE_PATH", ""), "A path to default certificate to use for routes that don't expose a TLS server cert; in PEM format")
 	flag.StringVar(&o.DefaultCertificateDir, "default-certificate-dir", util.Env("DEFAULT_CERTIFICATE_DIR", ""), "A path to a directory that contains a file named tls.crt. If tls.crt is not a PEM file which also contains a private key, it is first combined with a file named tls.key in the same directory. The PEM-format contents are then used as the default certificate. Only used if default-certificate and default-certificate-path are not specified.")


### PR DESCRIPTION
Currently, one has to edit the deployment config and pass command line arguments to /usr/bin/openshift-router
This PR fixes that by supplying the working directory as the image has chosen. The default stays the same.