### PR TITLE
Mute a warning in NetworkPolicy handling

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -448,7 +448,7 @@ func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, _ interface{}, eventTyp
 		return
 	}
 	if pod.Status.PodIP == "" {
-		glog.Warningf("PodIP is not set for pod %q", getPodFullName(pod))
+		glog.V(5).Infof("PodIP is not set for pod %q; ignoring", getPodFullName(pod))
 		return
 	}
 


### PR DESCRIPTION
When a Pod is first added, it won't have an IP address yet; we'll get an update event once it does.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1501850
