### PR TITLE
Improve the process of pod updates by preferring non-mutating SCCs and reducing pod mutations

### DIFF
--- a/pkg/security/securitycontextconstraints/capabilities/mustrunas.go
+++ b/pkg/security/securitycontextconstraints/capabilities/mustrunas.go
@@ -66,17 +66,10 @@ func (s *defaultCapabilities) Generate(pod *api.Pod, container *api.Container) (
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container) field.ErrorList {
+func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// if the security context isn't set then we haven't generated correctly.  Shouldn't get here
-	// if using the provider correctly
-	if container.SecurityContext == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("securityContext"), container.SecurityContext, "no security context is set"))
-		return allErrs
-	}
-
-	if container.SecurityContext.Capabilities == nil {
+	if capabilities == nil {
 		// if container.SC.Caps is nil then nothing was defaulted by the strat or requested by the pod author
 		// if there are no required caps on the strategy and nothing is requested on the pod
 		// then we can safely return here without further validation.
@@ -86,7 +79,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container) f
 
 		// container has no requested caps but we have required caps.  We should have something in
 		// at least the drops on the container.
-		allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities"), container.SecurityContext.Capabilities,
+		allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities"), capabilities,
 			"required capabilities are not set on the securityContext"))
 		return allErrs
 	}
@@ -101,7 +94,7 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container) f
 	// validate that anything being added is in the default or allowed sets
 	defaultAdd := makeCapSet(s.defaultAddCapabilities)
 
-	for _, cap := range container.SecurityContext.Capabilities.Add {
+	for _, cap := range capabilities.Add {
 		sCap := string(cap)
 		if !defaultAdd.Has(sCap) && !allowedAdd.Has(sCap) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "add"), sCap, "capability may not be added"))
@@ -109,12 +102,12 @@ func (s *defaultCapabilities) Validate(pod *api.Pod, container *api.Container) f
 	}
 
 	// validate that anything that is required to be dropped is in the drop set
-	containerDrops := makeCapSet(container.SecurityContext.Capabilities.Drop)
+	containerDrops := makeCapSet(capabilities.Drop)
 
 	for _, requiredDrop := range s.requiredDropCapabilities {
 		sDrop := string(requiredDrop)
 		if !containerDrops.Has(sDrop) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "drop"), container.SecurityContext.Capabilities.Drop,
+			allErrs = append(allErrs, field.Invalid(field.NewPath("capabilities", "drop"), capabilities.Drop,
 				fmt.Sprintf("%s is required to be dropped but was not found", sDrop)))
 		}
 	}

--- a/pkg/security/securitycontextconstraints/capabilities/mustrunas.go
+++ b/pkg/security/securitycontextconstraints/capabilities/mustrunas.go
@@ -33,13 +33,17 @@ func NewDefaultCapabilities(defaultAddCapabilities, requiredDropCapabilities, al
 // 1.  a capabilities.Add set containing all the required adds (unless the
 // 		container specifically is dropping the cap) and container requested adds
 // 2.  a capabilities.Drop set containing all the required drops and container requested drops
+//
+// Returns the original container capabilities if no changes are required.
 func (s *defaultCapabilities) Generate(pod *api.Pod, container *api.Container) (*api.Capabilities, error) {
 	defaultAdd := makeCapSet(s.defaultAddCapabilities)
 	requiredDrop := makeCapSet(s.requiredDropCapabilities)
 	containerAdd := sets.NewString()
 	containerDrop := sets.NewString()
 
+	var containerCapabilities *api.Capabilities
 	if container.SecurityContext != nil && container.SecurityContext.Capabilities != nil {
+		containerCapabilities = container.SecurityContext.Capabilities
 		containerAdd = makeCapSet(container.SecurityContext.Capabilities.Add)
 		containerDrop = makeCapSet(container.SecurityContext.Capabilities.Drop)
 	}
@@ -47,17 +51,17 @@ func (s *defaultCapabilities) Generate(pod *api.Pod, container *api.Container) (
 	// remove any default adds that the container is specifically dropping
 	defaultAdd = defaultAdd.Difference(containerDrop)
 
-	combinedAdd := defaultAdd.Union(containerAdd).List()
-	combinedDrop := requiredDrop.Union(containerDrop).List()
+	combinedAdd := defaultAdd.Union(containerAdd)
+	combinedDrop := requiredDrop.Union(containerDrop)
 
-	// nothing generated?  return nil
-	if len(combinedAdd) == 0 && len(combinedDrop) == 0 {
-		return nil, nil
+	// no changes? return the original capabilities
+	if (len(combinedAdd) == len(containerAdd)) && (len(combinedDrop) == len(containerDrop)) {
+		return containerCapabilities, nil
 	}
 
 	return &api.Capabilities{
-		Add:  capabilityFromStringSlice(combinedAdd),
-		Drop: capabilityFromStringSlice(combinedDrop),
+		Add:  capabilityFromStringSlice(combinedAdd.List()),
+		Drop: capabilityFromStringSlice(combinedDrop.List()),
 	}, nil
 }
 

--- a/pkg/security/securitycontextconstraints/capabilities/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/capabilities/mustrunas_test.go
@@ -321,18 +321,12 @@ func TestValidateAdds(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		container := &api.Container{
-			SecurityContext: &api.SecurityContext{
-				Capabilities: v.containerCaps,
-			},
-		}
-
 		strategy, err := NewDefaultCapabilities(v.defaultAddCaps, v.requiredDropCaps, v.allowedCaps)
 		if err != nil {
 			t.Errorf("%s failed: %v", k, err)
 			continue
 		}
-		errs := strategy.Validate(nil, container)
+		errs := strategy.Validate(nil, nil, v.containerCaps)
 		if v.shouldPass && len(errs) > 0 {
 			t.Errorf("%s should have passed but had errors %v", k, errs)
 			continue
@@ -384,18 +378,12 @@ func TestValidateDrops(t *testing.T) {
 	}
 
 	for k, v := range tests {
-		container := &api.Container{
-			SecurityContext: &api.SecurityContext{
-				Capabilities: v.containerCaps,
-			},
-		}
-
 		strategy, err := NewDefaultCapabilities(v.defaultAddCaps, v.requiredDropCaps, nil)
 		if err != nil {
 			t.Errorf("%s failed: %v", k, err)
 			continue
 		}
-		errs := strategy.Validate(nil, container)
+		errs := strategy.Validate(nil, nil, v.containerCaps)
 		if v.shouldPass && len(errs) > 0 {
 			t.Errorf("%s should have passed but had errors %v", k, errs)
 			continue

--- a/pkg/security/securitycontextconstraints/capabilities/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/capabilities/mustrunas_test.go
@@ -19,6 +19,10 @@ func TestGenerateAdds(t *testing.T) {
 		"no required, no container requests": {
 			expectedCaps: nil,
 		},
+		"no required, no container requests, non-nil": {
+			containerCaps: &api.Capabilities{},
+			expectedCaps:  &api.Capabilities{},
+		},
 		"required, no container requests": {
 			defaultAddCaps: []api.Capability{"foo"},
 			expectedCaps: &api.Capabilities{
@@ -52,13 +56,22 @@ func TestGenerateAdds(t *testing.T) {
 				Add: []api.Capability{"bar", "foo"},
 			},
 		},
-		"generation dedupes": {
-			defaultAddCaps: []api.Capability{"foo", "foo", "foo", "foo"},
+		"generation does not mutate unnecessarily": {
+			defaultAddCaps: []api.Capability{"foo", "bar"},
 			containerCaps: &api.Capabilities{
-				Add: []api.Capability{"foo", "foo", "foo"},
+				Add: []api.Capability{"foo", "foo", "bar", "baz"},
 			},
 			expectedCaps: &api.Capabilities{
-				Add: []api.Capability{"foo"},
+				Add: []api.Capability{"foo", "foo", "bar", "baz"},
+			},
+		},
+		"generation dedupes": {
+			defaultAddCaps: []api.Capability{"foo", "bar"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo", "baz"},
+			},
+			expectedCaps: &api.Capabilities{
+				Add: []api.Capability{"bar", "baz", "foo"},
 			},
 		},
 		"generation is case sensitive - will not dedupe": {
@@ -109,6 +122,10 @@ func TestGenerateDrops(t *testing.T) {
 		"no required, no container requests": {
 			expectedCaps: nil,
 		},
+		"no required, no container requests, non-nil": {
+			containerCaps: &api.Capabilities{},
+			expectedCaps:  &api.Capabilities{},
+		},
 		"required drops are defaulted": {
 			requiredDropCaps: []api.Capability{"foo"},
 			expectedCaps: &api.Capabilities{
@@ -116,12 +133,21 @@ func TestGenerateDrops(t *testing.T) {
 			},
 		},
 		"required drops are defaulted when making container requests": {
-			requiredDropCaps: []api.Capability{"foo"},
+			requiredDropCaps: []api.Capability{"baz"},
 			containerCaps: &api.Capabilities{
 				Drop: []api.Capability{"foo", "bar"},
 			},
 			expectedCaps: &api.Capabilities{
-				Drop: []api.Capability{"bar", "foo"},
+				Drop: []api.Capability{"bar", "baz", "foo"},
+			},
+		},
+		"required drops do not mutate unnecessarily": {
+			requiredDropCaps: []api.Capability{"baz"},
+			containerCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo", "bar", "baz"},
+			},
+			expectedCaps: &api.Capabilities{
+				Drop: []api.Capability{"foo", "bar", "baz"},
 			},
 		},
 		"can drop a required add": {
@@ -155,12 +181,12 @@ func TestGenerateDrops(t *testing.T) {
 			},
 		},
 		"generation dedupes": {
-			requiredDropCaps: []api.Capability{"bar", "bar", "bar", "bar"},
+			requiredDropCaps: []api.Capability{"baz", "foo"},
 			containerCaps: &api.Capabilities{
-				Drop: []api.Capability{"bar", "bar", "bar"},
+				Drop: []api.Capability{"bar", "foo"},
 			},
 			expectedCaps: &api.Capabilities{
-				Drop: []api.Capability{"bar"},
+				Drop: []api.Capability{"bar", "baz", "foo"},
 			},
 		},
 		"generation is case sensitive - will not dedupe": {

--- a/pkg/security/securitycontextconstraints/capabilities/types.go
+++ b/pkg/security/securitycontextconstraints/capabilities/types.go
@@ -10,5 +10,5 @@ type CapabilitiesSecurityContextConstraintsStrategy interface {
 	// Generate creates the capabilities based on policy rules.
 	Generate(pod *api.Pod, container *api.Container) (*api.Capabilities, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container) field.ErrorList
+	Validate(pod *api.Pod, container *api.Container, capabilities *api.Capabilities) field.ErrorList
 }

--- a/pkg/security/securitycontextconstraints/group/mustrunas.go
+++ b/pkg/security/securitycontextconstraints/group/mustrunas.go
@@ -30,13 +30,13 @@ func NewMustRunAs(ranges []securityapi.IDRange, field string) (GroupSecurityCont
 
 // Generate creates the group based on policy rules.  By default this returns the first group of the
 // first range (min val).
-func (s *mustRunAs) Generate(pod *api.Pod) ([]int64, error) {
+func (s *mustRunAs) Generate(_ *api.Pod) ([]int64, error) {
 	return []int64{s.ranges[0].Min}, nil
 }
 
 // Generate a single value to be applied.  This is used for FSGroup.  This strategy will return
 // the first group of the first range (min val).
-func (s *mustRunAs) GenerateSingle(pod *api.Pod) (*int64, error) {
+func (s *mustRunAs) GenerateSingle(_ *api.Pod) (*int64, error) {
 	single := new(int64)
 	*single = s.ranges[0].Min
 	return single, nil
@@ -45,13 +45,8 @@ func (s *mustRunAs) GenerateSingle(pod *api.Pod) (*int64, error) {
 // Validate ensures that the specified values fall within the range of the strategy.
 // Groups are passed in here to allow this strategy to support multiple group fields (fsgroup and
 // supplemental groups).
-func (s *mustRunAs) Validate(pod *api.Pod, groups []int64) field.ErrorList {
+func (s *mustRunAs) Validate(_ *api.Pod, groups []int64) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	if pod.Spec.SecurityContext == nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("securityContext"), pod.Spec.SecurityContext, "unable to validate nil security context"))
-		return allErrs
-	}
 
 	if len(groups) == 0 && len(s.ranges) > 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath(s.field), groups, "unable to validate empty groups against required ranges"))

--- a/pkg/security/securitycontextconstraints/group/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/group/mustrunas_test.go
@@ -94,14 +94,6 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	validPod := func() *api.Pod {
-		return &api.Pod{
-			Spec: api.PodSpec{
-				SecurityContext: &api.PodSecurityContext{},
-			},
-		}
-	}
-
 	tests := map[string]struct {
 		ranges []securityapi.IDRange
 		pod    *api.Pod
@@ -109,19 +101,16 @@ func TestValidate(t *testing.T) {
 		pass   bool
 	}{
 		"nil security context": {
-			pod: &api.Pod{},
 			ranges: []securityapi.IDRange{
 				{Min: 1, Max: 3},
 			},
 		},
 		"empty groups": {
-			pod: validPod(),
 			ranges: []securityapi.IDRange{
 				{Min: 1, Max: 3},
 			},
 		},
 		"not in range": {
-			pod:    validPod(),
 			groups: []int64{5},
 			ranges: []securityapi.IDRange{
 				{Min: 1, Max: 3},
@@ -129,7 +118,6 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		"in range 1": {
-			pod:    validPod(),
 			groups: []int64{2},
 			ranges: []securityapi.IDRange{
 				{Min: 1, Max: 3},
@@ -137,7 +125,6 @@ func TestValidate(t *testing.T) {
 			pass: true,
 		},
 		"in range boundry min": {
-			pod:    validPod(),
 			groups: []int64{1},
 			ranges: []securityapi.IDRange{
 				{Min: 1, Max: 3},
@@ -145,7 +132,6 @@ func TestValidate(t *testing.T) {
 			pass: true,
 		},
 		"in range boundry max": {
-			pod:    validPod(),
 			groups: []int64{3},
 			ranges: []securityapi.IDRange{
 				{Min: 1, Max: 3},
@@ -153,7 +139,6 @@ func TestValidate(t *testing.T) {
 			pass: true,
 		},
 		"singular range": {
-			pod:    validPod(),
 			groups: []int64{4},
 			ranges: []securityapi.IDRange{
 				{Min: 4, Max: 4},
@@ -167,7 +152,7 @@ func TestValidate(t *testing.T) {
 		if err != nil {
 			t.Errorf("error creating strategy for %s: %v", k, err)
 		}
-		errs := s.Validate(v.pod, v.groups)
+		errs := s.Validate(nil, v.groups)
 		if v.pass && len(errs) > 0 {
 			t.Errorf("unexpected errors for %s: %v", k, errs)
 		}

--- a/pkg/security/securitycontextconstraints/group/runasany.go
+++ b/pkg/security/securitycontextconstraints/group/runasany.go
@@ -17,17 +17,17 @@ func NewRunAsAny() (GroupSecurityContextConstraintsStrategy, error) {
 }
 
 // Generate creates the group based on policy rules.  This strategy returns an empty slice.
-func (s *runAsAny) Generate(pod *api.Pod) ([]int64, error) {
+func (s *runAsAny) Generate(_ *api.Pod) ([]int64, error) {
 	return nil, nil
 }
 
 // Generate a single value to be applied.  This is used for FSGroup.  This strategy returns nil.
-func (s *runAsAny) GenerateSingle(pod *api.Pod) (*int64, error) {
+func (s *runAsAny) GenerateSingle(_ *api.Pod) (*int64, error) {
 	return nil, nil
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *runAsAny) Validate(pod *api.Pod, groups []int64) field.ErrorList {
+func (s *runAsAny) Validate(_ *api.Pod, groups []int64) field.ErrorList {
 	return field.ErrorList{}
 
 }

--- a/pkg/security/securitycontextconstraints/group/runasany.go
+++ b/pkg/security/securitycontextconstraints/group/runasany.go
@@ -18,7 +18,7 @@ func NewRunAsAny() (GroupSecurityContextConstraintsStrategy, error) {
 
 // Generate creates the group based on policy rules.  This strategy returns an empty slice.
 func (s *runAsAny) Generate(pod *api.Pod) ([]int64, error) {
-	return []int64{}, nil
+	return nil, nil
 }
 
 // Generate a single value to be applied.  This is used for FSGroup.  This strategy returns nil.

--- a/pkg/security/securitycontextconstraints/matcher.go
+++ b/pkg/security/securitycontextconstraints/matcher.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	sc "k8s.io/kubernetes/pkg/securitycontext"
 
 	allocator "github.com/openshift/origin/pkg/security"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
@@ -71,8 +70,6 @@ func ConstraintAppliesTo(constraint *securityapi.SecurityContextConstraints, use
 // and validates that the sc falls within the scc constraints.  All containers must validate against
 // the same scc or is not considered valid.
 func AssignSecurityContext(provider SecurityContextConstraintsProvider, pod *kapi.Pod, fldPath *field.Path) field.ErrorList {
-	generatedSCs := make([]*kapi.SecurityContext, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
-
 	errs := field.ErrorList{}
 
 	psc, generatedAnnotations, err := provider.CreatePodSecurityContext(pod)
@@ -80,76 +77,35 @@ func AssignSecurityContext(provider SecurityContextConstraintsProvider, pod *kap
 		errs = append(errs, field.Invalid(fldPath.Child("spec", "securityContext"), pod.Spec.SecurityContext, err.Error()))
 	}
 
-	// save the original PSC and validate the generated PSC.  Leave the generated PSC
-	// set for container generation/validation.  We will reset to original post container
-	// validation.
-	originalPSC := pod.Spec.SecurityContext
-	originalAnnotations := pod.Annotations
-
 	pod.Spec.SecurityContext = psc
 	pod.Annotations = generatedAnnotations
 	errs = append(errs, provider.ValidatePodSecurityContext(pod, fldPath.Child("spec", "securityContext"))...)
 
-	// Note: this is not changing the original container, we will set container SCs later so long
-	// as all containers validated under the same SCC.
-	containerPath := fldPath.Child("spec", "initContainers")
-	for i, containerCopy := range pod.Spec.InitContainers {
-		csc, resolutionErrs := resolveContainerSecurityContext(provider, pod, &containerCopy, containerPath.Index(i))
-		errs = append(errs, resolutionErrs...)
-		if len(resolutionErrs) > 0 {
+	for i := range pod.Spec.InitContainers {
+		sc, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.InitContainers[i])
+		if err != nil {
+			errs = append(errs, field.Invalid(field.NewPath("spec", "initContainers").Index(i).Child("securityContext"), "", err.Error()))
 			continue
 		}
-		generatedSCs[i] = csc
+		pod.Spec.InitContainers[i].SecurityContext = sc
+		errs = append(errs, provider.ValidateContainerSecurityContext(pod, &pod.Spec.InitContainers[i], field.NewPath("spec", "initContainers").Index(i).Child("securityContext"))...)
 	}
 
-	base := len(pod.Spec.InitContainers)
-
-	// Note: this is not changing the original container, we will set container SCs later so long
-	// as all containers validated under the same SCC.
-	containerPath = fldPath.Child("spec", "containers")
-	for i, containerCopy := range pod.Spec.Containers {
-		csc, resolutionErrs := resolveContainerSecurityContext(provider, pod, &containerCopy, containerPath.Index(i))
-		errs = append(errs, resolutionErrs...)
-		if len(resolutionErrs) > 0 {
+	for i := range pod.Spec.Containers {
+		sc, err := provider.CreateContainerSecurityContext(pod, &pod.Spec.Containers[i])
+		if err != nil {
+			errs = append(errs, field.Invalid(field.NewPath("spec", "containers").Index(i).Child("securityContext"), "", err.Error()))
 			continue
 		}
-		generatedSCs[i+base] = csc
+		pod.Spec.Containers[i].SecurityContext = sc
+		errs = append(errs, provider.ValidateContainerSecurityContext(pod, &pod.Spec.Containers[i], field.NewPath("spec", "containers").Index(i).Child("securityContext"))...)
 	}
+
 	if len(errs) > 0 {
-		// ensure psc is not mutated if there are errors
-		pod.Spec.SecurityContext = originalPSC
-		pod.Annotations = originalAnnotations
 		return errs
 	}
 
-	// if we've reached this code then we've generated and validated an SC for every container in the
-	// pod so let's apply what we generated.  Note: the psc is already applied.
-	for i := range pod.Spec.InitContainers {
-		pod.Spec.InitContainers[i].SecurityContext = generatedSCs[i]
-	}
-	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].SecurityContext = generatedSCs[i+base]
-	}
 	return nil
-}
-
-// resolveContainerSecurityContext checks the provided container against the provider, returning any
-// validation errors encountered on the resulting security context, or the security context that was
-// resolved. The SecurityContext field of the container is updated, so ensure that a copy of the original
-// container is passed here if you wish to preserve the original input.
-func resolveContainerSecurityContext(provider SecurityContextConstraintsProvider, pod *kapi.Pod, container *kapi.Container, path *field.Path) (*kapi.SecurityContext, field.ErrorList) {
-	// We will determine the effective security context for the container and validate against that
-	// since that is how the sc provider will eventually apply settings in the runtime.
-	// This results in an SC that is based on the Pod's PSC with the set fields from the container
-	// overriding pod level settings.
-	container.SecurityContext = sc.InternalDetermineEffectiveSecurityContext(pod, container)
-
-	csc, err := provider.CreateContainerSecurityContext(pod, container)
-	if err != nil {
-		return nil, field.ErrorList{field.Invalid(path.Child("securityContext"), "", err.Error())}
-	}
-	container.SecurityContext = csc
-	return csc, provider.ValidateContainerSecurityContext(pod, container, path.Child("securityContext"))
 }
 
 // constraintSupportsGroup checks that group is in constraintGroups.

--- a/pkg/security/securitycontextconstraints/provider.go
+++ b/pkg/security/securitycontextconstraints/provider.go
@@ -203,7 +203,7 @@ func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container 
 	// if we're using the non-root strategy set the marker that this container should not be
 	// run as root which will signal to the kubelet to do a final check either on the runAsUser
 	// or, if runAsUser is not set, the image
-	if s.scc.RunAsUser.Type == securityapi.RunAsUserStrategyMustRunAsNonRoot {
+	if sc.RunAsNonRoot == nil && sc.RunAsUser == nil && s.scc.RunAsUser.Type == securityapi.RunAsUserStrategyMustRunAsNonRoot {
 		nonRoot := true
 		sc.RunAsNonRoot = &nonRoot
 	}

--- a/pkg/security/securitycontextconstraints/provider.go
+++ b/pkg/security/securitycontextconstraints/provider.go
@@ -200,11 +200,6 @@ func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container 
 		sc.SELinuxOptions = seLinux
 	}
 
-	if sc.Privileged == nil {
-		priv := false
-		sc.Privileged = &priv
-	}
-
 	// if we're using the non-root strategy set the marker that this container should not be
 	// run as root which will signal to the kubelet to do a final check either on the runAsUser
 	// or, if runAsUser is not set, the image
@@ -325,7 +320,7 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 	allErrs = append(allErrs, s.seLinuxStrategy.Validate(pod, container)...)
 	allErrs = append(allErrs, s.seccompStrategy.ValidateContainer(pod, container)...)
 
-	if !s.scc.AllowPrivilegedContainer && *sc.Privileged {
+	if !s.scc.AllowPrivilegedContainer && sc.Privileged != nil && *sc.Privileged {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("privileged"), *sc.Privileged, "Privileged containers are not allowed"))
 	}
 

--- a/pkg/security/securitycontextconstraints/provider.go
+++ b/pkg/security/securitycontextconstraints/provider.go
@@ -309,7 +309,7 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 	}
 
 	sc := container.SecurityContext
-	allErrs = append(allErrs, s.runAsUserStrategy.Validate(pod, container)...)
+	allErrs = append(allErrs, s.runAsUserStrategy.Validate(fldPath.Child("securityContext"), pod, container, sc.RunAsNonRoot, sc.RunAsUser)...)
 	allErrs = append(allErrs, s.seLinuxStrategy.Validate(fldPath.Child("seLinuxOptions"), pod, container, sc.SELinuxOptions)...)
 	allErrs = append(allErrs, s.seccompStrategy.ValidateContainer(pod, container)...)
 

--- a/pkg/security/securitycontextconstraints/provider.go
+++ b/pkg/security/securitycontextconstraints/provider.go
@@ -124,7 +124,7 @@ func (s *simpleProvider) CreatePodSecurityContext(pod *api.Pod) (*api.PodSecurit
 		}
 	}
 
-	if len(sc.SupplementalGroups) == 0 {
+	if sc.SupplementalGroups == nil {
 		supGroups, err := s.supplementalGroupStrategy.Generate(pod)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/security/securitycontextconstraints/provider.go
+++ b/pkg/security/securitycontextconstraints/provider.go
@@ -324,7 +324,7 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("privileged"), *sc.Privileged, "Privileged containers are not allowed"))
 	}
 
-	allErrs = append(allErrs, s.capabilitiesStrategy.Validate(pod, container)...)
+	allErrs = append(allErrs, s.capabilitiesStrategy.Validate(pod, container, sc.Capabilities)...)
 
 	if !s.scc.AllowHostNetwork && pod.Spec.SecurityContext.HostNetwork {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostNetwork"), pod.Spec.SecurityContext.HostNetwork, "Host network is not allowed to be used"))

--- a/pkg/security/securitycontextconstraints/provider_test.go
+++ b/pkg/security/securitycontextconstraints/provider_test.go
@@ -416,7 +416,7 @@ func TestValidateContainerSecurityContextFailures(t *testing.T) {
 		"failUserSCC": {
 			pod:           failUserPod,
 			scc:           failUserSCC,
-			expectedError: "does not match required UID",
+			expectedError: "runAsUser: Invalid value",
 		},
 		"failSELinuxSCC": {
 			pod:           failSELinuxPod,

--- a/pkg/security/securitycontextconstraints/provider_test.go
+++ b/pkg/security/securitycontextconstraints/provider_test.go
@@ -285,12 +285,12 @@ func TestValidatePodSecurityContextFailures(t *testing.T) {
 		"failNilSELinux": {
 			pod:           failNilSELinuxPod,
 			scc:           failSELinuxSCC,
-			expectedError: "unable to validate nil seLinuxOptions",
+			expectedError: "seLinuxOptions: Required",
 		},
 		"failInvalidSELinux": {
 			pod:           failInvalidSELinuxPod,
 			scc:           failSELinuxSCC,
-			expectedError: "does not match required level.  Found bar, wanted foo",
+			expectedError: "seLinuxOptions.level: Invalid value",
 		},
 		"failNoSeccomp": {
 			pod:           failNoSeccompAllowed,
@@ -421,7 +421,7 @@ func TestValidateContainerSecurityContextFailures(t *testing.T) {
 		"failSELinuxSCC": {
 			pod:           failSELinuxPod,
 			scc:           failSELinuxSCC,
-			expectedError: "does not match required level",
+			expectedError: "seLinuxOptions.level: Invalid value",
 		},
 		"failPrivSCC": {
 			pod:           failPrivPod,

--- a/pkg/security/securitycontextconstraints/selinux/mustrunas.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas.go
@@ -28,41 +28,33 @@ func NewMustRunAs(options *securityapi.SELinuxContextStrategyOptions) (SELinuxSe
 }
 
 // Generate creates the SELinuxOptions based on constraint rules.
-func (s *mustRunAs) Generate(pod *api.Pod, container *api.Container) (*api.SELinuxOptions, error) {
+func (s *mustRunAs) Generate(_ *api.Pod, _ *api.Container) (*api.SELinuxOptions, error) {
 	return s.opts.SELinuxOptions, nil
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *mustRunAs) Validate(pod *api.Pod, container *api.Container) field.ErrorList {
+func (s *mustRunAs) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, seLinux *api.SELinuxOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if container.SecurityContext == nil {
-		detail := fmt.Sprintf("unable to validate nil security context for %s", container.Name)
-		allErrs = append(allErrs, field.Invalid(field.NewPath("securityContext"), container.SecurityContext, detail))
+	if seLinux == nil {
+		allErrs = append(allErrs, field.Required(fldPath, ""))
 		return allErrs
 	}
-	if container.SecurityContext.SELinuxOptions == nil {
-		detail := fmt.Sprintf("unable to validate nil seLinuxOptions for %s", container.Name)
-		allErrs = append(allErrs, field.Invalid(field.NewPath("seLinuxOptions"), container.SecurityContext.SELinuxOptions, detail))
-		return allErrs
-	}
-	seLinuxOptionsPath := field.NewPath("seLinuxOptions")
-	seLinux := container.SecurityContext.SELinuxOptions
 	if seLinux.Level != s.opts.SELinuxOptions.Level {
-		detail := fmt.Sprintf("seLinuxOptions.level on %s does not match required level.  Found %s, wanted %s", container.Name, seLinux.Level, s.opts.SELinuxOptions.Level)
-		allErrs = append(allErrs, field.Invalid(seLinuxOptionsPath.Child("level"), seLinux.Level, detail))
+		detail := fmt.Sprintf("must be %s", s.opts.SELinuxOptions.Level)
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("level"), seLinux.Level, detail))
 	}
 	if seLinux.Role != s.opts.SELinuxOptions.Role {
-		detail := fmt.Sprintf("seLinuxOptions.role on %s does not match required role.  Found %s, wanted %s", container.Name, seLinux.Role, s.opts.SELinuxOptions.Role)
-		allErrs = append(allErrs, field.Invalid(seLinuxOptionsPath.Child("role"), seLinux.Role, detail))
+		detail := fmt.Sprintf("must be %s", s.opts.SELinuxOptions.Role)
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("role"), seLinux.Role, detail))
 	}
 	if seLinux.Type != s.opts.SELinuxOptions.Type {
-		detail := fmt.Sprintf("seLinuxOptions.type on %s does not match required type.  Found %s, wanted %s", container.Name, seLinux.Type, s.opts.SELinuxOptions.Type)
-		allErrs = append(allErrs, field.Invalid(seLinuxOptionsPath.Child("type"), seLinux.Type, detail))
+		detail := fmt.Sprintf("must be %s", s.opts.SELinuxOptions.Type)
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), seLinux.Type, detail))
 	}
 	if seLinux.User != s.opts.SELinuxOptions.User {
-		detail := fmt.Sprintf("seLinuxOptions.user on %s does not match required user.  Found %s, wanted %s", container.Name, seLinux.User, s.opts.SELinuxOptions.User)
-		allErrs = append(allErrs, field.Invalid(seLinuxOptionsPath.Child("user"), seLinux.User, detail))
+		detail := fmt.Sprintf("must be %s", s.opts.SELinuxOptions.User)
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("user"), seLinux.User, detail))
 	}
 
 	return allErrs

--- a/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/mustrunas_test.go
@@ -85,19 +85,19 @@ func TestMustRunAsValidate(t *testing.T) {
 	}{
 		"invalid role": {
 			seLinux:     role,
-			expectedMsg: "does not match required role",
+			expectedMsg: "role: Invalid value",
 		},
 		"invalid user": {
 			seLinux:     user,
-			expectedMsg: "does not match required user",
+			expectedMsg: "user: Invalid value",
 		},
 		"invalid level": {
 			seLinux:     level,
-			expectedMsg: "does not match required level",
+			expectedMsg: "level: Invalid value",
 		},
 		"invalid type": {
 			seLinux:     seType,
-			expectedMsg: "does not match required type",
+			expectedMsg: "type: Invalid value",
 		},
 		"valid": {
 			seLinux:     newValidOpts(),
@@ -115,13 +115,8 @@ func TestMustRunAsValidate(t *testing.T) {
 			t.Errorf("unexpected error initializing NewMustRunAs for testcase %s: %#v", name, err)
 			continue
 		}
-		container := &api.Container{
-			SecurityContext: &api.SecurityContext{
-				SELinuxOptions: tc.seLinux,
-			},
-		}
 
-		errs := mustRunAs.Validate(nil, container)
+		errs := mustRunAs.Validate(nil, nil, nil, tc.seLinux)
 		//should've passed but didn't
 		if len(tc.expectedMsg) == 0 && len(errs) > 0 {
 			t.Errorf("%s expected no errors but received %v", name, errs)

--- a/pkg/security/securitycontextconstraints/selinux/runasany.go
+++ b/pkg/security/securitycontextconstraints/selinux/runasany.go
@@ -23,6 +23,6 @@ func (s *runAsAny) Generate(pod *api.Pod, container *api.Container) (*api.SELinu
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *runAsAny) Validate(pod *api.Pod, container *api.Container) field.ErrorList {
+func (s *runAsAny) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, options *api.SELinuxOptions) field.ErrorList {
 	return field.ErrorList{}
 }

--- a/pkg/security/securitycontextconstraints/selinux/runasany_test.go
+++ b/pkg/security/securitycontextconstraints/selinux/runasany_test.go
@@ -43,7 +43,7 @@ func TestRunAsAnyValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
-	errs := s.Validate(nil, nil)
+	errs := s.Validate(nil, nil, nil, nil)
 	if len(errs) != 0 {
 		t.Errorf("unexpected errors validating with ")
 	}
@@ -51,7 +51,7 @@ func TestRunAsAnyValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
-	errs = s.Validate(nil, nil)
+	errs = s.Validate(nil, nil, nil, nil)
 	if len(errs) != 0 {
 		t.Errorf("unexpected errors validating %v", errs)
 	}

--- a/pkg/security/securitycontextconstraints/selinux/types.go
+++ b/pkg/security/securitycontextconstraints/selinux/types.go
@@ -10,5 +10,5 @@ type SELinuxSecurityContextConstraintsStrategy interface {
 	// Generate creates the SELinuxOptions based on constraint rules.
 	Generate(pod *api.Pod, container *api.Container) (*api.SELinuxOptions, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container) field.ErrorList
+	Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, options *api.SELinuxOptions) field.ErrorList
 }

--- a/pkg/security/securitycontextconstraints/user/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/user/mustrunas_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	api "k8s.io/kubernetes/pkg/apis/core"
-
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
 

--- a/pkg/security/securitycontextconstraints/user/mustrunas_test.go
+++ b/pkg/security/securitycontextconstraints/user/mustrunas_test.go
@@ -1,6 +1,8 @@
 package user
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -58,19 +60,24 @@ func TestMustRunAsValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewMustRunAs %v", err)
 	}
-	container := &api.Container{
-		SecurityContext: &api.SecurityContext{
-			RunAsUser: &badUID,
-		},
+
+	errs := mustRunAs.Validate(nil, nil, nil, nil, nil)
+	expectedMessage := "runAsUser: Required value"
+	if len(errs) == 0 {
+		t.Errorf("expected errors from nil runAsUser but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
 	}
 
-	errs := mustRunAs.Validate(nil, container)
+	errs = mustRunAs.Validate(nil, nil, nil, nil, &badUID)
+	expectedMessage = fmt.Sprintf("runAsUser: Invalid value: %d: must be: %d", badUID, uid)
 	if len(errs) == 0 {
 		t.Errorf("expected errors from mismatch uid but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
 	}
 
-	container.SecurityContext.RunAsUser = &uid
-	errs = mustRunAs.Validate(nil, container)
+	errs = mustRunAs.Validate(nil, nil, nil, nil, &uid)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors from matching uid but got %v", errs)
 	}

--- a/pkg/security/securitycontextconstraints/user/mustrunasrange.go
+++ b/pkg/security/securitycontextconstraints/user/mustrunasrange.go
@@ -9,12 +9,14 @@ import (
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
 
-// mustRunAs implements the RunAsUserSecurityContextConstraintsStrategy interface
+// mustRunAsRange implements the RunAsUserSecurityContextConstraintsStrategy interface
 type mustRunAsRange struct {
 	opts *securityapi.RunAsUserStrategyOptions
 }
 
-// NewMustRunAs provides a strategy that requires the container to run as a specific UID in a range.
+var _ RunAsUserSecurityContextConstraintsStrategy = &mustRunAsRange{}
+
+// NewMustRunAsRange provides a strategy that requires the container to run as a specific UID in a range.
 func NewMustRunAsRange(options *securityapi.RunAsUserStrategyOptions) (RunAsUserSecurityContextConstraintsStrategy, error) {
 	if options == nil {
 		return nil, fmt.Errorf("MustRunAsRange requires run as user options")
@@ -36,28 +38,18 @@ func (s *mustRunAsRange) Generate(pod *api.Pod, container *api.Container) (*int6
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *mustRunAsRange) Validate(pod *api.Pod, container *api.Container) field.ErrorList {
+func (s *mustRunAsRange) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	securityContextPath := field.NewPath("securityContext")
-	if container.SecurityContext == nil {
-		detail := fmt.Sprintf("unable to validate nil security context for container %s", container.Name)
-		allErrs = append(allErrs, field.Invalid(securityContextPath, container.SecurityContext, detail))
-		return allErrs
-	}
-	if container.SecurityContext.RunAsUser == nil {
-		detail := fmt.Sprintf("unable to validate nil RunAsUser for container %s", container.Name)
-		allErrs = append(allErrs, field.Invalid(securityContextPath.Child("runAsUser"), container.SecurityContext.RunAsUser, detail))
+	if runAsUser == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("runAsUser"), ""))
 		return allErrs
 	}
 
-	if *container.SecurityContext.RunAsUser < *s.opts.UIDRangeMin || *container.SecurityContext.RunAsUser > *s.opts.UIDRangeMax {
-		detail := fmt.Sprintf("UID on container %s does not match required range.  Found %d, required min: %d max: %d",
-			container.Name,
-			*container.SecurityContext.RunAsUser,
-			*s.opts.UIDRangeMin,
-			*s.opts.UIDRangeMax)
-		allErrs = append(allErrs, field.Invalid(securityContextPath.Child("runAsUser"), *container.SecurityContext.RunAsUser, detail))
+	if *runAsUser < *s.opts.UIDRangeMin || *runAsUser > *s.opts.UIDRangeMax {
+		detail := fmt.Sprintf("must be in the ranges: [%v, %v]", *s.opts.UIDRangeMin, *s.opts.UIDRangeMax)
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("runAsUser"), *runAsUser, detail))
+		return allErrs
 	}
 
 	return allErrs

--- a/pkg/security/securitycontextconstraints/user/mustrunasrange_test.go
+++ b/pkg/security/securitycontextconstraints/user/mustrunasrange_test.go
@@ -1,0 +1,102 @@
+package user
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	securityapi "github.com/openshift/origin/pkg/security/apis/security"
+)
+
+func TestMustRunAsRangeOptions(t *testing.T) {
+	var uid int64 = 1
+	tests := map[string]struct {
+		opts *securityapi.RunAsUserStrategyOptions
+		pass bool
+	}{
+		"invalid opts, required min and max": {
+			opts: &securityapi.RunAsUserStrategyOptions{},
+			pass: false,
+		},
+		"invalid opts, required max": {
+			opts: &securityapi.RunAsUserStrategyOptions{UIDRangeMin: &uid},
+			pass: false,
+		},
+		"invalid opts, required min": {
+			opts: &securityapi.RunAsUserStrategyOptions{UIDRangeMax: &uid},
+			pass: false,
+		},
+		"valid opts": {
+			opts: &securityapi.RunAsUserStrategyOptions{UIDRangeMin: &uid, UIDRangeMax: &uid},
+			pass: true,
+		},
+	}
+	for name, tc := range tests {
+		_, err := NewMustRunAsRange(tc.opts)
+		if err != nil && tc.pass {
+			t.Errorf("%s expected to pass but received error %v", name, err)
+		}
+		if err == nil && !tc.pass {
+			t.Errorf("%s expected to fail but did not receive an error", name)
+		}
+	}
+}
+
+func TestMustRunAsRangeGenerate(t *testing.T) {
+	var uidMin int64 = 1
+	var uidMax int64 = 10
+	opts := &securityapi.RunAsUserStrategyOptions{UIDRangeMin: &uidMin, UIDRangeMax: &uidMax}
+	mustRunAsRange, err := NewMustRunAsRange(opts)
+	if err != nil {
+		t.Fatalf("unexpected error initializing NewMustRunAsRange %v", err)
+	}
+	generated, err := mustRunAsRange.Generate(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error generating uid %v", err)
+	}
+	if *generated != uidMin {
+		t.Errorf("generated uid does not equal expected uid")
+	}
+}
+
+func TestMustRunAsRangeValidate(t *testing.T) {
+	var uidMin int64 = 1
+	var uidMax int64 = 10
+	opts := &securityapi.RunAsUserStrategyOptions{UIDRangeMin: &uidMin, UIDRangeMax: &uidMax}
+	mustRunAsRange, err := NewMustRunAsRange(opts)
+	if err != nil {
+		t.Fatalf("unexpected error initializing NewMustRunAsRange %v", err)
+	}
+
+	errs := mustRunAsRange.Validate(nil, nil, nil, nil, nil)
+	expectedMessage := "runAsUser: Required value"
+	if len(errs) == 0 {
+		t.Errorf("expected errors from nil runAsUser but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
+	}
+
+	var lowUid int64 = 0
+	errs = mustRunAsRange.Validate(nil, nil, nil, nil, &lowUid)
+	expectedMessage = fmt.Sprintf("runAsUser: Invalid value: %d: must be in the ranges: [%d, %d]", lowUid, uidMin, uidMax)
+	if len(errs) == 0 {
+		t.Errorf("expected errors from mismatch uid but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
+	}
+
+	var highUid int64 = 11
+	errs = mustRunAsRange.Validate(nil, nil, nil, nil, &highUid)
+	expectedMessage = fmt.Sprintf("runAsUser: Invalid value: %d: must be in the ranges: [%d, %d]", highUid, uidMin, uidMax)
+	if len(errs) == 0 {
+		t.Errorf("expected errors from mismatch uid but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
+	}
+
+	var goodUid int64 = 5
+	errs = mustRunAsRange.Validate(nil, nil, nil, nil, &goodUid)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors from matching uid but got %v", errs)
+	}
+}

--- a/pkg/security/securitycontextconstraints/user/nonroot.go
+++ b/pkg/security/securitycontextconstraints/user/nonroot.go
@@ -1,8 +1,6 @@
 package user
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	api "k8s.io/kubernetes/pkg/apis/core"
 
@@ -27,17 +25,18 @@ func (s *nonRoot) Generate(pod *api.Pod, container *api.Container) (*int64, erro
 // of this will pass if either the UID is not set, assuming that the image will provided the UID
 // or if the UID is set it is not root.  In order to work properly this assumes that the kubelet
 // will populate an
-func (s *nonRoot) Validate(pod *api.Pod, container *api.Container) field.ErrorList {
+func (s *nonRoot) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
 	allErrs := field.ErrorList{}
-	securityContextPath := field.NewPath("securityContext")
-	if container.SecurityContext == nil {
-		detail := fmt.Sprintf("unable to validate nil security context for container %s", container.Name)
-		allErrs = append(allErrs, field.Invalid(securityContextPath, container.SecurityContext, detail))
+	if runAsNonRoot == nil && runAsUser == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("runAsNonRoot"), "must be true"))
 		return allErrs
 	}
-	if container.SecurityContext.RunAsUser != nil && *container.SecurityContext.RunAsUser == 0 {
-		detail := fmt.Sprintf("running with the root UID is forbidden by the security context constraints %s", container.Name)
-		allErrs = append(allErrs, field.Invalid(securityContextPath.Child("runAsUser"), *container.SecurityContext.RunAsUser, detail))
+	if runAsNonRoot != nil && *runAsNonRoot == false {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("runAsNonRoot"), *runAsNonRoot, "must be true"))
+		return allErrs
+	}
+	if runAsUser != nil && *runAsUser == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("runAsUser"), *runAsUser, "running with the root UID is forbidden"))
 		return allErrs
 	}
 	return allErrs

--- a/pkg/security/securitycontextconstraints/user/nonroot_test.go
+++ b/pkg/security/securitycontextconstraints/user/nonroot_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"strings"
 	"testing"
 
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -38,27 +39,41 @@ func TestNonRootValidate(t *testing.T) {
 	var badUID int64 = 0
 	s, err := NewRunAsNonRoot(&securityapi.RunAsUserStrategyOptions{})
 	if err != nil {
-		t.Fatalf("unexpected error initializing NewMustRunAs %v", err)
-	}
-	container := &api.Container{
-		SecurityContext: &api.SecurityContext{
-			RunAsUser: &badUID,
-		},
+		t.Fatalf("unexpected error initializing NewRunAsNonRoot %v", err)
 	}
 
-	errs := s.Validate(nil, container)
+	errs := s.Validate(nil, nil, nil, nil, &badUID)
+	expectedMessage := "runAsUser: Invalid value: 0: running with the root UID is forbidden"
 	if len(errs) == 0 {
 		t.Errorf("expected errors from root uid but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
 	}
 
-	container.SecurityContext.RunAsUser = &uid
-	errs = s.Validate(nil, container)
+	errs = s.Validate(nil, nil, nil, nil, nil)
+	expectedMessage = "runAsNonRoot: Required value: must be true"
+	if len(errs) == 0 {
+		t.Errorf("expected error when neither runAsUser nor runAsNonRoot are specified but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
+	}
+
+	no := false
+	errs = s.Validate(nil, nil, nil, &no, nil)
+	expectedMessage = "runAsNonRoot: Invalid value: false: must be true"
+	if len(errs) == 0 {
+		t.Errorf("expected error when runAsNonRoot is false but got none")
+	} else if !strings.Contains(errs[0].Error(), expectedMessage) {
+		t.Errorf("expected error to contain %q but it did not: %v", expectedMessage, errs)
+	}
+
+	errs = s.Validate(nil, nil, nil, nil, &uid)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors from non-root uid but got %v", errs)
 	}
 
-	container.SecurityContext.RunAsUser = nil
-	errs = s.Validate(nil, container)
+	yes := true
+	errs = s.Validate(nil, nil, nil, &yes, nil)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors from nil uid but got %v", errs)
 	}

--- a/pkg/security/securitycontextconstraints/user/nonroot_test.go
+++ b/pkg/security/securitycontextconstraints/user/nonroot_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	api "k8s.io/kubernetes/pkg/apis/core"
-
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
 

--- a/pkg/security/securitycontextconstraints/user/runasany.go
+++ b/pkg/security/securitycontextconstraints/user/runasany.go
@@ -23,6 +23,6 @@ func (s *runAsAny) Generate(pod *api.Pod, container *api.Container) (*int64, err
 }
 
 // Validate ensures that the specified values fall within the range of the strategy.
-func (s *runAsAny) Validate(pod *api.Pod, container *api.Container) field.ErrorList {
+func (s *runAsAny) Validate(fldPath *field.Path, _ *api.Pod, _ *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList {
 	return field.ErrorList{}
 }

--- a/pkg/security/securitycontextconstraints/user/runasany_test.go
+++ b/pkg/security/securitycontextconstraints/user/runasany_test.go
@@ -36,7 +36,7 @@ func TestRunAsAnyValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewRunAsAny %v", err)
 	}
-	errs := s.Validate(nil, nil)
+	errs := s.Validate(nil, nil, nil, nil, nil)
 	if len(errs) != 0 {
 		t.Errorf("unexpected errors validating with ")
 	}

--- a/pkg/security/securitycontextconstraints/user/types.go
+++ b/pkg/security/securitycontextconstraints/user/types.go
@@ -10,5 +10,5 @@ type RunAsUserSecurityContextConstraintsStrategy interface {
 	// Generate creates the uid based on policy rules.
 	Generate(pod *api.Pod, container *api.Container) (*int64, error)
 	// Validate ensures that the specified values fall within the range of the strategy.
-	Validate(pod *api.Pod, container *api.Container) field.ErrorList
+	Validate(fldPath *field.Path, pod *api.Pod, container *api.Container, runAsNonRoot *bool, runAsUser *int64) field.ErrorList
 }


### PR DESCRIPTION
This is adaptation of https://github.com/kubernetes/kubernetes/pull/52849 to SCC.

Details (mostly copy&pasted from original PR):
- SCCs which allow the pod as-is (no defaulting/mutating) are preferred
- During update operations, when mutations to pod specs are disallowed, only non-mutating SCCs are used to validate the pod
- Removes unnecessary mutation of pods:
  - Determines effective security context for pods using a wrapper containing the pod and container security context, rather than building/setting a combined struct on every admission
  - Does not set `privileged: &false` on security contexts with `privileged: nil`
  - Does not set `runAsNonRoot: &true` on security contexts that already have a non-nil, non-0 runAsUser
  - Does not mutate/normalize container capabilities unless changes are required (missing `defaultAddCapabilities` or `requiredDropCapabilities`)

Fixes #16467