### PR TITLE
image: fix signature import from secure registries

### DIFF
--- a/pkg/image/controller/signature/container_image_downloader.go
+++ b/pkg/image/controller/signature/container_image_downloader.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/containers/image/docker"
+	"github.com/golang/glog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -32,7 +33,11 @@ func (s *containerImageSignatureDownloader) DownloadImageSignatures(image *image
 	}
 	source, err := reference.NewImageSource(nil, nil)
 	if err != nil {
-		return nil, err
+		// In case we fail to talk to registry to get the image metadata (private
+		// registry, internal registry, etc...), do not fail with error to avoid
+		// spamming logs.
+		glog.V(4).Infof("Failed to get %q: %v", image.DockerImageReference, err)
+		return []imageapi.ImageSignature{}, nil
 	}
 	defer source.Close()
 


### PR DESCRIPTION
@miminar || @dmage || @legionus do you guys have secure registry running? I'm trying to verify if this fixes this problem: https://gist.github.com/zhouying7780/bfc1d61e68cdaf821b9538a9e6cca501

Note that we don't have to be super-secure here because the signature importer does not care if the registry is secure or not, just need for the ping to pass... 