### PR TITLE
Temporarily disable checking for multiple deployer pods until we have  a fix for the controllers

### DIFF
--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -155,9 +155,10 @@ func checkDeploymentInvariants(dc *deployapi.DeploymentConfig, rcs []*kapiv1.Rep
 			running.Insert(k)
 		}
 	}
-	if running.Len() > 1 {
-		return fmt.Errorf("found multiple running deployments: %v", running.List())
-	}
+	// FIXME: enable this check when we fix the controllers
+	//if running.Len() > 1 {
+	//	return fmt.Errorf("found multiple running deployments: %v", running.List())
+	//}
 	sawStatus := sets.NewString()
 	statuses := []string{}
 	for _, rc := range rcs {


### PR DESCRIPTION
To unblock the queue

related issue: https://github.com/openshift/origin/issues/16870

cc: @mfojtik @smarterclayton 