### PR TITLE
Fix multi attach log spam

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -101,6 +101,10 @@ type DesiredStateOfWorld interface {
 	// GetKeepTerminatedPodVolumesForNode determines if node wants volumes to be
 	// mounted and attached for terminated pods
 	GetKeepTerminatedPodVolumesForNode(k8stypes.NodeName) bool
+
+	// Mark multiattach error as reported to prevent spamming multiple
+	// events for same error
+	SetMultiAttachError(v1.UniqueVolumeName, k8stypes.NodeName)
 }
 
 // VolumeToAttach represents a volume that should be attached to a node.
@@ -327,6 +331,21 @@ func (dsw *desiredStateOfWorld) VolumeExists(
 	}
 
 	return false
+}
+
+func (dsw *desiredStateOfWorld) SetMultiAttachError(
+	volumeName v1.UniqueVolumeName,
+	nodeName k8stypes.NodeName) {
+	dsw.RLock()
+	defer dsw.RUnlock()
+
+	nodeObj, nodeExists := dsw.nodesManaged[nodeName]
+	if nodeExists {
+		if volumeObj, volumeExists := nodeObj.volumesToAttach[volumeName]; volumeExists {
+			volumeObj.multiAttachErrorReported = true
+			dsw.nodesManaged[nodeName].volumesToAttach[volumeName] = volumeObj
+		}
+	}
 }
 
 // GetKeepTerminatedPodVolumesForNode determines if node wants volumes to be

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -336,8 +336,8 @@ func (dsw *desiredStateOfWorld) VolumeExists(
 func (dsw *desiredStateOfWorld) SetMultiAttachError(
 	volumeName v1.UniqueVolumeName,
 	nodeName k8stypes.NodeName) {
-	dsw.RLock()
-	defer dsw.RUnlock()
+	dsw.Lock()
+	defer dsw.Unlock()
 
 	nodeObj, nodeExists := dsw.nodesManaged[nodeName]
 	if nodeExists {

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -236,52 +236,56 @@ func (rc *reconciler) reconcile() {
 		}
 	}
 
-	// Ensure volumes that should be attached are attached.
-	for _, volumeToAttach := range rc.desiredStateOfWorld.GetVolumesToAttach() {
-		if rc.actualStateOfWorld.VolumeNodeExists(
-			volumeToAttach.VolumeName, volumeToAttach.NodeName) {
-			// Volume/Node exists, touch it to reset detachRequestedTime
-			glog.V(5).Infof(volumeToAttach.GenerateMsgDetailed("Volume attached--touching", ""))
-			rc.actualStateOfWorld.ResetDetachRequestTime(volumeToAttach.VolumeName, volumeToAttach.NodeName)
-		} else {
-			// Don't even try to start an operation if there is already one running
-			if rc.attacherDetacher.IsOperationPending(volumeToAttach.VolumeName, "") {
-				glog.V(10).Infof("Operation for volume %q is already running. Can't start attach for %q", volumeToAttach.VolumeName, volumeToAttach.NodeName)
-				continue
-			}
-
-			if rc.isMultiAttachForbidden(volumeToAttach.VolumeSpec) {
-				nodes := rc.actualStateOfWorld.GetNodesForVolume(volumeToAttach.VolumeName)
-				if len(nodes) > 0 {
-					if !volumeToAttach.MultiAttachErrorReported {
-						simpleMsg, detailedMsg := volumeToAttach.GenerateMsg("Multi-Attach error", "Volume is already exclusively attached to one node and can't be attached to another")
-						for _, pod := range volumeToAttach.ScheduledPods {
-							rc.recorder.Eventf(pod, v1.EventTypeWarning, kevents.FailedAttachVolume, simpleMsg)
-						}
-						volumeToAttach.MultiAttachErrorReported = true
-						glog.Warningf(detailedMsg)
-					}
-					continue
-				}
-			}
-
-			// Volume/Node doesn't exist, spawn a goroutine to attach it
-			glog.V(5).Infof(volumeToAttach.GenerateMsgDetailed("Starting attacherDetacher.AttachVolume", ""))
-			err := rc.attacherDetacher.AttachVolume(volumeToAttach.VolumeToAttach, rc.actualStateOfWorld)
-			if err == nil {
-				glog.Infof(volumeToAttach.GenerateMsgDetailed("attacherDetacher.AttachVolume started", ""))
-			}
-			if err != nil && !exponentialbackoff.IsExponentialBackoff(err) {
-				// Ignore exponentialbackoff.IsExponentialBackoff errors, they are expected.
-				// Log all other errors.
-				glog.Errorf(volumeToAttach.GenerateErrorDetailed("attacherDetacher.AttachVolume failed to start", err).Error())
-			}
-		}
-	}
+	rc.attachDesiredVolumes()
 
 	// Update Node Status
 	err := rc.nodeStatusUpdater.UpdateNodeStatuses()
 	if err != nil {
 		glog.Warningf("UpdateNodeStatuses failed with: %v", err)
 	}
+}
+
+func (rc *reconciler) attachDesiredVolumes() {
+	// Ensure volumes that should be attached are attached.
+	for _, volumeToAttach := range rc.desiredStateOfWorld.GetVolumesToAttach() {
+		if rc.actualStateOfWorld.VolumeNodeExists(volumeToAttach.VolumeName, volumeToAttach.NodeName) {
+			// Volume/Node exists, touch it to reset detachRequestedTime
+			glog.V(5).Infof(volumeToAttach.GenerateMsgDetailed("Volume attached--touching", ""))
+			rc.actualStateOfWorld.ResetDetachRequestTime(volumeToAttach.VolumeName, volumeToAttach.NodeName)
+			continue
+		}
+		// Don't even try to start an operation if there is already one running
+		if rc.attacherDetacher.IsOperationPending(volumeToAttach.VolumeName, "") {
+			glog.V(10).Infof("Operation for volume %q is already running. Can't start attach for %q", volumeToAttach.VolumeName, volumeToAttach.NodeName)
+			continue
+		}
+
+		if rc.isMultiAttachForbidden(volumeToAttach.VolumeSpec) {
+			nodes := rc.actualStateOfWorld.GetNodesForVolume(volumeToAttach.VolumeName)
+			if len(nodes) > 0 {
+				if !volumeToAttach.MultiAttachErrorReported {
+					simpleMsg, detailedMsg := volumeToAttach.GenerateMsg("Multi-Attach error", "Volume is already exclusively attached to one node and can't be attached to another")
+					for _, pod := range volumeToAttach.ScheduledPods {
+						rc.recorder.Eventf(pod, v1.EventTypeWarning, kevents.FailedAttachVolume, simpleMsg)
+					}
+					rc.desiredStateOfWorld.SetMultiAttachError(volumeToAttach.VolumeName, volumeToAttach.NodeName)
+					glog.Warningf(detailedMsg)
+				}
+				continue
+			}
+		}
+
+		// Volume/Node doesn't exist, spawn a goroutine to attach it
+		glog.V(5).Infof(volumeToAttach.GenerateMsgDetailed("Starting attacherDetacher.AttachVolume", ""))
+		err := rc.attacherDetacher.AttachVolume(volumeToAttach.VolumeToAttach, rc.actualStateOfWorld)
+		if err == nil {
+			glog.Infof(volumeToAttach.GenerateMsgDetailed("attacherDetacher.AttachVolume started", ""))
+		}
+		if err != nil && !exponentialbackoff.IsExponentialBackoff(err) {
+			// Ignore exponentialbackoff.IsExponentialBackoff errors, they are expected.
+			// Log all other errors.
+			glog.Errorf(volumeToAttach.GenerateErrorDetailed("attacherDetacher.AttachVolume failed to start", err).Error())
+		}
+	}
+
 }

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -364,11 +364,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteMany(t *testing.
 	waitForTotalAttachCallCount(t, 2 /* expectedAttachCallCount */, fakePlugin)
 	verifyNewDetacherCallCount(t, true /* expectZeroNewDetacherCallCount */, fakePlugin)
 	waitForDetachCallCount(t, 0 /* expectedDetachCallCount */, fakePlugin)
-
-	nodesForVolume := asw.GetNodesForVolume(generatedVolumeName)
-	if len(nodesForVolume) != 2 {
-		t.Fatal("Volume was not attached to both nodes")
-	}
+	waitForAttachedToNodesCount(t, 2 /* expectedNodeCount */, generatedVolumeName, asw)
 
 	// Act
 	dsw.DeletePod(types.UniquePodName(podName1), generatedVolumeName, nodeName1)
@@ -455,13 +451,9 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 	waitForTotalAttachCallCount(t, 1 /* expectedAttachCallCount */, fakePlugin)
 	verifyNewDetacherCallCount(t, true /* expectZeroNewDetacherCallCount */, fakePlugin)
 	waitForDetachCallCount(t, 0 /* expectedDetachCallCount */, fakePlugin)
+	waitForAttachedToNodesCount(t, 1 /* expectedNodeCount */, generatedVolumeName, asw)
 
 	nodesForVolume := asw.GetNodesForVolume(generatedVolumeName)
-	if len(nodesForVolume) == 0 {
-		t.Fatal("Volume was not attached to any node")
-	} else if len(nodesForVolume) != 1 {
-		t.Fatal("Volume was attached to multiple nodes")
-	}
 
 	// check if multiattach is marked
 	// at least one volume should be marked with multiattach error
@@ -696,6 +688,39 @@ func waitForTotalDetachCallCount(
 		t.Fatalf(
 			"Total DetachCallCount does not match expected value. Expected: <%v>",
 			expectedDetachCallCount)
+	}
+}
+
+func waitForAttachedToNodesCount(
+	t *testing.T,
+	expectedNodeCount int,
+	volumeName v1.UniqueVolumeName,
+	asw cache.ActualStateOfWorld) {
+
+	err := retryWithExponentialBackOff(
+		time.Duration(5*time.Millisecond),
+		func() (bool, error) {
+			count := len(asw.GetNodesForVolume(volumeName))
+			if count == expectedNodeCount {
+				return true, nil
+			}
+			t.Logf(
+				"Warning: Wrong number of nodes having <%v> attached. Expected: <%v> Actual: <%v>. Will retry.",
+				volumeName,
+				expectedNodeCount,
+				count)
+
+			return false, nil
+		},
+	)
+
+	if err != nil {
+		count := len(asw.GetNodesForVolume(volumeName))
+		t.Fatalf(
+			"Wrong number of nodes having <%v> attached. Expected: <%v> Actual: <%v>",
+			volumeName,
+			expectedNodeCount,
+			count)
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -463,6 +463,17 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 		t.Fatal("Volume was attached to multiple nodes")
 	}
 
+	// check if multiattach is marked
+	// at least one volume should be marked with multiattach error
+	nodeAttachedTo := nodesForVolume[0]
+	for _, volumeToAttach := range dsw.GetVolumesToAttach() {
+		if volumeToAttach.NodeName != nodeAttachedTo {
+			if !volumeToAttach.MultiAttachErrorReported {
+				t.Fatalf("Expected volume %q on node %q to have multiattach error", volumeToAttach.VolumeName, volumeToAttach.NodeName)
+			}
+		}
+	}
+
 	// Act
 	podToDelete := ""
 	if nodesForVolume[0] == nodeName1 {


### PR DESCRIPTION
This PR fixes multiattach log spam. 

Subsequent PRs are for fixing test flakes and a lock error. All these PRs have already been merged into master.

