### PR TITLE
ClusterRoleLister: Use GetByKey()

### DIFF
--- a/pkg/authorization/generated/listers/authorization/internalversion/clusterpolicy.go
+++ b/pkg/authorization/generated/listers/authorization/internalversion/clusterpolicy.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	authorization "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterPolicyLister) List(selector labels.Selector) (ret []*authorizati
 
 // Get retrieves the ClusterPolicy from the index for a given name.
 func (s *clusterPolicyLister) Get(name string) (*authorization.ClusterPolicy, error) {
-	key := &authorization.ClusterPolicy{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/internalversion/clusterpolicybinding.go
+++ b/pkg/authorization/generated/listers/authorization/internalversion/clusterpolicybinding.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	authorization "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterPolicyBindingLister) List(selector labels.Selector) (ret []*auth
 
 // Get retrieves the ClusterPolicyBinding from the index for a given name.
 func (s *clusterPolicyBindingLister) Get(name string) (*authorization.ClusterPolicyBinding, error) {
-	key := &authorization.ClusterPolicyBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/internalversion/clusterrole.go
+++ b/pkg/authorization/generated/listers/authorization/internalversion/clusterrole.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	authorization "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*authorization
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*authorization.ClusterRole, error) {
-	key := &authorization.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/internalversion/clusterrolebinding.go
+++ b/pkg/authorization/generated/listers/authorization/internalversion/clusterrolebinding.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	authorization "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*author
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*authorization.ClusterRoleBinding, error) {
-	key := &authorization.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/v1/clusterpolicy.go
+++ b/pkg/authorization/generated/listers/authorization/v1/clusterpolicy.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterPolicyLister) List(selector labels.Selector) (ret []*v1.ClusterP
 
 // Get retrieves the ClusterPolicy from the index for a given name.
 func (s *clusterPolicyLister) Get(name string) (*v1.ClusterPolicy, error) {
-	key := &v1.ClusterPolicy{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/v1/clusterpolicybinding.go
+++ b/pkg/authorization/generated/listers/authorization/v1/clusterpolicybinding.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterPolicyBindingLister) List(selector labels.Selector) (ret []*v1.C
 
 // Get retrieves the ClusterPolicyBinding from the index for a given name.
 func (s *clusterPolicyBindingLister) Get(name string) (*v1.ClusterPolicyBinding, error) {
-	key := &v1.ClusterPolicyBinding{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/v1/clusterrole.go
+++ b/pkg/authorization/generated/listers/authorization/v1/clusterrole.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1.ClusterRol
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1.ClusterRole, error) {
-	key := &v1.ClusterRole{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/generated/listers/authorization/v1/clusterrolebinding.go
+++ b/pkg/authorization/generated/listers/authorization/v1/clusterrolebinding.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1.Clu
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1.ClusterRoleBinding, error) {
-	key := &v1.ClusterRoleBinding{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/generated/listers/image/internalversion/image.go
+++ b/pkg/image/generated/listers/image/internalversion/image.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	image "github.com/openshift/origin/pkg/image/apis/image"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *imageLister) List(selector labels.Selector) (ret []*image.Image, err er
 
 // Get retrieves the Image from the index for a given name.
 func (s *imageLister) Get(name string) (*image.Image, error) {
-	key := &image.Image{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/generated/listers/image/v1/image.go
+++ b/pkg/image/generated/listers/image/v1/image.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/image/apis/image/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *imageLister) List(selector labels.Selector) (ret []*v1.Image, err error
 
 // Get retrieves the Image from the index for a given name.
 func (s *imageLister) Get(name string) (*v1.Image, error) {
-	key := &v1.Image{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/generated/listers/network/internalversion/clusternetwork.go
+++ b/pkg/network/generated/listers/network/internalversion/clusternetwork.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	network "github.com/openshift/origin/pkg/network/apis/network"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterNetworkLister) List(selector labels.Selector) (ret []*network.Cl
 
 // Get retrieves the ClusterNetwork from the index for a given name.
 func (s *clusterNetworkLister) Get(name string) (*network.ClusterNetwork, error) {
-	key := &network.ClusterNetwork{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/generated/listers/network/internalversion/hostsubnet.go
+++ b/pkg/network/generated/listers/network/internalversion/hostsubnet.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	network "github.com/openshift/origin/pkg/network/apis/network"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *hostSubnetLister) List(selector labels.Selector) (ret []*network.HostSu
 
 // Get retrieves the HostSubnet from the index for a given name.
 func (s *hostSubnetLister) Get(name string) (*network.HostSubnet, error) {
-	key := &network.HostSubnet{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/generated/listers/network/internalversion/netnamespace.go
+++ b/pkg/network/generated/listers/network/internalversion/netnamespace.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	network "github.com/openshift/origin/pkg/network/apis/network"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *netNamespaceLister) List(selector labels.Selector) (ret []*network.NetN
 
 // Get retrieves the NetNamespace from the index for a given name.
 func (s *netNamespaceLister) Get(name string) (*network.NetNamespace, error) {
-	key := &network.NetNamespace{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/generated/listers/network/v1/clusternetwork.go
+++ b/pkg/network/generated/listers/network/v1/clusternetwork.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/network/apis/network/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterNetworkLister) List(selector labels.Selector) (ret []*v1.Cluster
 
 // Get retrieves the ClusterNetwork from the index for a given name.
 func (s *clusterNetworkLister) Get(name string) (*v1.ClusterNetwork, error) {
-	key := &v1.ClusterNetwork{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/generated/listers/network/v1/hostsubnet.go
+++ b/pkg/network/generated/listers/network/v1/hostsubnet.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/network/apis/network/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *hostSubnetLister) List(selector labels.Selector) (ret []*v1.HostSubnet,
 
 // Get retrieves the HostSubnet from the index for a given name.
 func (s *hostSubnetLister) Get(name string) (*v1.HostSubnet, error) {
-	key := &v1.HostSubnet{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/generated/listers/network/v1/netnamespace.go
+++ b/pkg/network/generated/listers/network/v1/netnamespace.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/network/apis/network/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *netNamespaceLister) List(selector labels.Selector) (ret []*v1.NetNamesp
 
 // Get retrieves the NetNamespace from the index for a given name.
 func (s *netNamespaceLister) Get(name string) (*v1.NetNamespace, error) {
-	key := &v1.NetNamespace{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/internalversion/oauthaccesstoken.go
+++ b/pkg/oauth/generated/listers/oauth/internalversion/oauthaccesstoken.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	oauth "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthAccessTokenLister) List(selector labels.Selector) (ret []*oauth.OA
 
 // Get retrieves the OAuthAccessToken from the index for a given name.
 func (s *oAuthAccessTokenLister) Get(name string) (*oauth.OAuthAccessToken, error) {
-	key := &oauth.OAuthAccessToken{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/internalversion/oauthauthorizetoken.go
+++ b/pkg/oauth/generated/listers/oauth/internalversion/oauthauthorizetoken.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	oauth "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthAuthorizeTokenLister) List(selector labels.Selector) (ret []*oauth
 
 // Get retrieves the OAuthAuthorizeToken from the index for a given name.
 func (s *oAuthAuthorizeTokenLister) Get(name string) (*oauth.OAuthAuthorizeToken, error) {
-	key := &oauth.OAuthAuthorizeToken{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/internalversion/oauthclient.go
+++ b/pkg/oauth/generated/listers/oauth/internalversion/oauthclient.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	oauth "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthClientLister) List(selector labels.Selector) (ret []*oauth.OAuthCl
 
 // Get retrieves the OAuthClient from the index for a given name.
 func (s *oAuthClientLister) Get(name string) (*oauth.OAuthClient, error) {
-	key := &oauth.OAuthClient{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/internalversion/oauthclientauthorization.go
+++ b/pkg/oauth/generated/listers/oauth/internalversion/oauthclientauthorization.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	oauth "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthClientAuthorizationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the OAuthClientAuthorization from the index for a given name.
 func (s *oAuthClientAuthorizationLister) Get(name string) (*oauth.OAuthClientAuthorization, error) {
-	key := &oauth.OAuthClientAuthorization{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/v1/oauthaccesstoken.go
+++ b/pkg/oauth/generated/listers/oauth/v1/oauthaccesstoken.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/oauth/apis/oauth/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthAccessTokenLister) List(selector labels.Selector) (ret []*v1.OAuth
 
 // Get retrieves the OAuthAccessToken from the index for a given name.
 func (s *oAuthAccessTokenLister) Get(name string) (*v1.OAuthAccessToken, error) {
-	key := &v1.OAuthAccessToken{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/v1/oauthauthorizetoken.go
+++ b/pkg/oauth/generated/listers/oauth/v1/oauthauthorizetoken.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/oauth/apis/oauth/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthAuthorizeTokenLister) List(selector labels.Selector) (ret []*v1.OA
 
 // Get retrieves the OAuthAuthorizeToken from the index for a given name.
 func (s *oAuthAuthorizeTokenLister) Get(name string) (*v1.OAuthAuthorizeToken, error) {
-	key := &v1.OAuthAuthorizeToken{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/v1/oauthclient.go
+++ b/pkg/oauth/generated/listers/oauth/v1/oauthclient.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/oauth/apis/oauth/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthClientLister) List(selector labels.Selector) (ret []*v1.OAuthClien
 
 // Get retrieves the OAuthClient from the index for a given name.
 func (s *oAuthClientLister) Get(name string) (*v1.OAuthClient, error) {
-	key := &v1.OAuthClient{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/generated/listers/oauth/v1/oauthclientauthorization.go
+++ b/pkg/oauth/generated/listers/oauth/v1/oauthclientauthorization.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/oauth/apis/oauth/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *oAuthClientAuthorizationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the OAuthClientAuthorization from the index for a given name.
 func (s *oAuthClientAuthorizationLister) Get(name string) (*v1.OAuthClientAuthorization, error) {
-	key := &v1.OAuthClientAuthorization{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/generated/listers/project/internalversion/project.go
+++ b/pkg/project/generated/listers/project/internalversion/project.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	project "github.com/openshift/origin/pkg/project/apis/project"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *projectLister) List(selector labels.Selector) (ret []*project.Project, 
 
 // Get retrieves the Project from the index for a given name.
 func (s *projectLister) Get(name string) (*project.Project, error) {
-	key := &project.Project{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/generated/listers/project/v1/project.go
+++ b/pkg/project/generated/listers/project/v1/project.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/project/apis/project/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *projectLister) List(selector labels.Selector) (ret []*v1.Project, err e
 
 // Get retrieves the Project from the index for a given name.
 func (s *projectLister) Get(name string) (*v1.Project, error) {
-	key := &v1.Project{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/quota/generated/listers/quota/internalversion/clusterresourcequota.go
+++ b/pkg/quota/generated/listers/quota/internalversion/clusterresourcequota.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	quota "github.com/openshift/origin/pkg/quota/apis/quota"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterResourceQuotaLister) List(selector labels.Selector) (ret []*quot
 
 // Get retrieves the ClusterResourceQuota from the index for a given name.
 func (s *clusterResourceQuotaLister) Get(name string) (*quota.ClusterResourceQuota, error) {
-	key := &quota.ClusterResourceQuota{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/quota/generated/listers/quota/v1/clusterresourcequota.go
+++ b/pkg/quota/generated/listers/quota/v1/clusterresourcequota.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/quota/apis/quota/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *clusterResourceQuotaLister) List(selector labels.Selector) (ret []*v1.C
 
 // Get retrieves the ClusterResourceQuota from the index for a given name.
 func (s *clusterResourceQuotaLister) Get(name string) (*v1.ClusterResourceQuota, error) {
-	key := &v1.ClusterResourceQuota{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/generated/listers/security/internalversion/securitycontextconstraints.go
+++ b/pkg/security/generated/listers/security/internalversion/securitycontextconstraints.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	security "github.com/openshift/origin/pkg/security/apis/security"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *securityContextConstraintsLister) List(selector labels.Selector) (ret [
 
 // Get retrieves the SecurityContextConstraints from the index for a given name.
 func (s *securityContextConstraintsLister) Get(name string) (*security.SecurityContextConstraints, error) {
-	key := &security.SecurityContextConstraints{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/generated/listers/security/v1/securitycontextconstraints.go
+++ b/pkg/security/generated/listers/security/v1/securitycontextconstraints.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/security/apis/security/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *securityContextConstraintsLister) List(selector labels.Selector) (ret [
 
 // Get retrieves the SecurityContextConstraints from the index for a given name.
 func (s *securityContextConstraintsLister) Get(name string) (*v1.SecurityContextConstraints, error) {
-	key := &v1.SecurityContextConstraints{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/template/generated/listers/template/internalversion/brokertemplateinstance.go
+++ b/pkg/template/generated/listers/template/internalversion/brokertemplateinstance.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	template "github.com/openshift/origin/pkg/template/apis/template"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *brokerTemplateInstanceLister) List(selector labels.Selector) (ret []*te
 
 // Get retrieves the BrokerTemplateInstance from the index for a given name.
 func (s *brokerTemplateInstanceLister) Get(name string) (*template.BrokerTemplateInstance, error) {
-	key := &template.BrokerTemplateInstance{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/template/generated/listers/template/v1/brokertemplateinstance.go
+++ b/pkg/template/generated/listers/template/v1/brokertemplateinstance.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/template/apis/template/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *brokerTemplateInstanceLister) List(selector labels.Selector) (ret []*v1
 
 // Get retrieves the BrokerTemplateInstance from the index for a given name.
 func (s *brokerTemplateInstanceLister) Get(name string) (*v1.BrokerTemplateInstance, error) {
-	key := &v1.BrokerTemplateInstance{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/generated/listers/user/internalversion/group.go
+++ b/pkg/user/generated/listers/user/internalversion/group.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	user "github.com/openshift/origin/pkg/user/apis/user"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *groupLister) List(selector labels.Selector) (ret []*user.Group, err err
 
 // Get retrieves the Group from the index for a given name.
 func (s *groupLister) Get(name string) (*user.Group, error) {
-	key := &user.Group{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/generated/listers/user/internalversion/identity.go
+++ b/pkg/user/generated/listers/user/internalversion/identity.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	user "github.com/openshift/origin/pkg/user/apis/user"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *identityLister) List(selector labels.Selector) (ret []*user.Identity, e
 
 // Get retrieves the Identity from the index for a given name.
 func (s *identityLister) Get(name string) (*user.Identity, error) {
-	key := &user.Identity{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/generated/listers/user/internalversion/user.go
+++ b/pkg/user/generated/listers/user/internalversion/user.go
@@ -5,7 +5,6 @@ package internalversion
 import (
 	user "github.com/openshift/origin/pkg/user/apis/user"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *userLister) List(selector labels.Selector) (ret []*user.User, err error
 
 // Get retrieves the User from the index for a given name.
 func (s *userLister) Get(name string) (*user.User, error) {
-	key := &user.User{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/generated/listers/user/v1/group.go
+++ b/pkg/user/generated/listers/user/v1/group.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/user/apis/user/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *groupLister) List(selector labels.Selector) (ret []*v1.Group, err error
 
 // Get retrieves the Group from the index for a given name.
 func (s *groupLister) Get(name string) (*v1.Group, error) {
-	key := &v1.Group{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/generated/listers/user/v1/identity.go
+++ b/pkg/user/generated/listers/user/v1/identity.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/user/apis/user/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *identityLister) List(selector labels.Selector) (ret []*v1.Identity, err
 
 // Get retrieves the Identity from the index for a given name.
 func (s *identityLister) Get(name string) (*v1.Identity, error) {
-	key := &v1.Identity{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/generated/listers/user/v1/user.go
+++ b/pkg/user/generated/listers/user/v1/user.go
@@ -5,7 +5,6 @@ package v1
 import (
 	v1 "github.com/openshift/origin/pkg/user/apis/user/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -39,8 +38,7 @@ func (s *userLister) List(selector labels.Selector) (ret []*v1.User, err error) 
 
 // Get retrieves the User from the index for a given name.
 func (s *userLister) Get(name string) (*v1.User, error) {
-	key := &v1.User{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -323,8 +323,7 @@ func (s *$.type|private$Lister) $.type|publicPlural$(namespace string) $.type|pu
 var typeLister_NonNamespacedGet = `
 // Get retrieves the $.type|public$ from the index for a given name.
 func (s *$.type|private$Lister) Get(name string) (*$.type|raw$, error) {
-  key := &$.type|raw${ObjectMeta: $.objectMeta|raw${Name: name}}
-  obj, exists, err := s.indexer.Get(key)
+  obj, exists, err := s.indexer.GetByKey(name)
   if err != nil {
     return nil, err
   }


### PR DESCRIPTION
**DO NOT MERGE** Experimental patch, see #16954

Avoid allocation of temporary rbac.ClusterRole.

Signed-off-by: Christian Heimes <cheimes@redhat.com>

CC @openshift/sig-security 