### PR TITLE
extended: annotated registry tests

### DIFF
--- a/test/extended/imageapis/limitrange_admission.go
+++ b/test/extended/imageapis/limitrange_admission.go
@@ -21,7 +21,7 @@ import (
 
 const limitRangeName = "limits"
 
-var _ = g.Describe("[Feature:ImageQuota][Serial] Image limit range", func() {
+var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image limit range", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("limitrange-admission", exutil.KubeConfigPath())
 

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -26,7 +26,7 @@ const (
 	waitTimeout = time.Second * 30
 )
 
-var _ = g.Describe("[Feature:ImageQuota][Serial] Image resource quota", func() {
+var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image resource quota", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("resourcequota-admission", exutil.KubeConfigPath())
 

--- a/test/extended/images/hardprune.go
+++ b/test/extended/images/hardprune.go
@@ -17,7 +17,7 @@ import (
 	testutil "github.com/openshift/origin/test/util"
 )
 
-var _ = g.Describe("[Feature:ImagePrune][Serial] Image hard prune", func() {
+var _ = g.Describe("[Feature:ImagePrune][registry][Serial] Image hard prune", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("prune-images", exutil.KubeConfigPath())
 	var originalAcceptSchema2 *bool

--- a/test/extended/images/prune.go
+++ b/test/extended/images/prune.go
@@ -28,7 +28,7 @@ const (
 	externalImageReference = "docker.io/openshift/origin-release:golang-1.4"
 )
 
-var _ = g.Describe("[Feature:ImagePrune][Serial] Image prune", func() {
+var _ = g.Describe("[Feature:ImagePrune][registry][Serial] Image prune", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("prune-images", exutil.KubeConfigPath())
 

--- a/test/extended/registry/signature.go
+++ b/test/extended/registry/signature.go
@@ -12,7 +12,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[imageapis][registry][Skipped] image signature workflow", func() {
+var _ = g.Describe("[imageapis][registry][Skipped][Serial] image signature workflow", func() {
 
 	defer g.GinkgoRecover()
 


### PR DESCRIPTION
To make them easily focus-able in CI.

Obsoletes openshift/aos-cd-jobs#729