### PR TITLE
Router metrics should be protected by delegated auth

### DIFF
--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -1,47 +1,156 @@
 package metrics
 
 import (
+	"crypto/tls"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
+	"strings"
+
+	"github.com/cockroachdb/cmux"
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"k8s.io/apiserver/pkg/server/healthz"
 
-	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
+
+type Listener struct {
+	Addr string
+
+	TLSConfig *tls.Config
+
+	Username string
+	Password string
+
+	Authenticator authenticator.Request
+	Authorizer    authorizer.Authorizer
+	Record        authorizer.AttributesRecord
+
+	Checks []healthz.HealthzChecker
+}
+
+func (l Listener) handler() http.Handler {
+	mux := http.NewServeMux()
+	healthz.InstallHandler(mux, l.Checks...)
+
+	if l.Authenticator != nil {
+		protected := http.NewServeMux()
+		protected.HandleFunc("/debug/pprof/", pprof.Index)
+		protected.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		protected.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		protected.Handle("/metrics", prometheus.Handler())
+		mux.Handle("/", l.authorizeHandler(protected))
+	}
+	return mux
+}
+
+func (l Listener) authorizeHandler(protected http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if len(l.Username) > 0 || len(l.Password) > 0 {
+			if u, p, ok := req.BasicAuth(); ok {
+				if u == l.Username && p == l.Password {
+					protected.ServeHTTP(w, req)
+				} else {
+					http.Error(w, fmt.Sprintf("Unauthorized"), http.StatusUnauthorized)
+				}
+				return
+			}
+		}
+
+		user, ok, err := l.Authenticator.AuthenticateRequest(req)
+		if err != nil {
+			glog.V(3).Infof("Unable to authenticate: %v", err)
+			http.Error(w, "Unable to authenticate due to an error", http.StatusInternalServerError)
+			return
+		}
+		scopedRecord := l.Record
+		switch req.Method {
+		case "POST":
+			scopedRecord.Verb = "create"
+		case "GET", "HEAD":
+			scopedRecord.Verb = "get"
+		case "PUT":
+			scopedRecord.Verb = "update"
+		case "PATCH":
+			scopedRecord.Verb = "patch"
+		case "DELETE":
+			scopedRecord.Verb = "delete"
+		default:
+			scopedRecord.Verb = ""
+		}
+		switch {
+		case req.URL.Path == "/metrics":
+			scopedRecord.Subresource = "metrics"
+		case strings.HasPrefix(req.URL.Path, "/debug/"):
+			scopedRecord.Subresource = "debug"
+		}
+		scopedRecord.User = user
+		ok, reason, err := l.Authorizer.Authorize(scopedRecord)
+		if err != nil {
+			glog.V(3).Infof("Unable to authenticate: %v", err)
+			http.Error(w, "Unable to authenticate due to an error", http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			http.Error(w, fmt.Sprintf("Unauthorized %s", reason), http.StatusUnauthorized)
+			return
+		}
+		protected.ServeHTTP(w, req)
+	})
+}
 
 // Listen starts a server for health, metrics, and profiling on the provided listen port.
 // It will terminate the process if the server fails. Metrics and profiling are only exposed
 // if username and password are provided and the user's input matches.
-func Listen(listenAddr string, username, password string, checks ...healthz.HealthzChecker) {
+func (l Listener) Listen() {
+	handler := l.handler()
+
+	tcpl, err := net.Listen("tcp", l.Addr)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// if a TLS connection was requested, set up a connection mux that will send TLS requests to
+	// the TLS server but send HTTP requests to the HTTP server. Preserves the ability for HTTP
+	// health checks to call HTTP on the router while still allowing TLS certs and end to end
+	// metrics protection.
+	m := cmux.New(tcpl)
+
+	// match HTTP first
+	httpl := m.Match(cmux.HTTP1Fast())
 	go func() {
-		mux := http.NewServeMux()
-		healthz.InstallHandler(mux, checks...)
-
-		// TODO: exclude etcd and other unused metrics
-
-		// never enable profiling or metrics without protection
-		if len(username) > 0 && len(password) > 0 {
-			protected := http.NewServeMux()
-			protected.HandleFunc("/debug/pprof/", pprof.Index)
-			protected.HandleFunc("/debug/pprof/profile", pprof.Profile)
-			protected.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-			protected.Handle("/metrics", prometheus.Handler())
-			mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-				if u, p, ok := req.BasicAuth(); !ok || u != username || p != password {
-					http.Error(w, "Unauthorized", http.StatusUnauthorized)
-					return
-				}
-				protected.ServeHTTP(w, req)
-			})
+		s := &http.Server{
+			Handler: handler,
 		}
-
-		server := &http.Server{
-			Addr:    listenAddr,
-			Handler: mux,
+		if err := s.Serve(httpl); err != cmux.ErrListenerClosed {
+			glog.Fatal(err)
 		}
-		glog.Infof("Router health and metrics port listening at %s", listenAddr)
-		glog.Fatal(server.ListenAndServe())
 	}()
 
+	// match TLS if configured
+	if l.TLSConfig != nil {
+		glog.Infof("Router health and metrics port listening at %s on HTTP and HTTPS", l.Addr)
+		tlsl := m.Match(cmux.Any())
+		tlsl = tls.NewListener(tlsl, l.TLSConfig)
+		go func() {
+			s := &http.Server{
+				Handler: handler,
+			}
+			if err := s.Serve(tlsl); err != cmux.ErrListenerClosed {
+				glog.Fatal(err)
+			}
+		}()
+	} else {
+		glog.Infof("Router health and metrics port listening at %s", l.Addr)
+	}
+
+	go func() {
+		if err := m.Serve(); !strings.Contains(err.Error(), "use of closed network connection") {
+			glog.Fatal(err)
+		}
+	}()
 }


### PR DESCRIPTION
Allow additional authorization checking from the master by performing
delegating auth when the router metrics endpoint is accessed. Use the
cmux library to put HTTP and HTTPS on the same port so that we can avoid
complex setup requirements for routers which must be HTTP available for
healthchecks, but should be HTTPS protected for accepting client
authentication.

Uses the delegating authorizer to protect the endpoint with the SAR for

    group: route.openshift.io
    resource: routers
    name: <router-name>
    subresource: metrics for /metrics and debug for /debug

@deads2k this is a compromise between three factors:

1. we can't change the stats port easily (exposing another port makes me die a bit)
2. we have to remain backwards compatible with existing deployments
3. we would prefer to use delegated auth for metrics over the other options (username/pass)

Opinions?