### PR TITLE
UPSTREAM: 45611: remove use of printf semantics for view-last-applied cmd

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -142,13 +142,13 @@ func (o *ViewLastAppliedOptions) RunApplyViewLastApplied() error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(jsonBuffer.Bytes()))
+			fmt.Fprint(o.Out, string(jsonBuffer.Bytes()))
 		case "yaml":
 			yamlOutput, err := yaml.JSONToYAML([]byte(str))
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(yamlOutput))
+			fmt.Fprint(o.Out, string(yamlOutput))
 		}
 	}
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1503601

Picks changes introduced in upstream PR https://github.com/kubernetes/kubernetes/pull/45611 which removes printf() semantics from the output of `apply view-last-applied`. Using printf() was causing values with `%` to be interpreted as Go format code, which in turn adding unwanted statements such as `(MISSING)!` to the yaml / json output of the command.

cc @openshift/cli-review 