### PR TITLE
Fix initialization of iptables under networkpolicy plugin

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -164,7 +164,8 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 			srcChain: "FORWARD",
 			srcRule:  []string{"-i", Tun0, "!", "-o", Tun0, "-m", "comment", "--comment", "administrator overrides"},
 			rules:    nil,
-		})
+		},
+	)
 
 	var masqRules [][]string
 	var masq2Rules [][]string
@@ -182,16 +183,6 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 		filterRules = append(filterRules, []string{"-s", cidr, "-m", "comment", "--comment", "forward traffic to SDN", "-j", "ACCEPT"})
 	}
 
-	if !n.masqueradeServices {
-		masq2Rules = append(masq2Rules, []string{"-j", "MASQUERADE"})
-		chainArray = append(chainArray,
-			Chain{
-				table: "nat",
-				name:  "OPENSHIFT-MASQUERADE-2",
-				rules: masq2Rules,
-			})
-	}
-
 	chainArray = append(chainArray,
 		Chain{
 			table:    "nat",
@@ -206,7 +197,18 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 			srcChain: "FORWARD",
 			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
 			rules:    filterRules,
-		})
+		},
+	)
+	if !n.masqueradeServices {
+		masq2Rules = append(masq2Rules, []string{"-j", "MASQUERADE"})
+		chainArray = append(chainArray,
+			Chain{
+				table: "nat",
+				name:  "OPENSHIFT-MASQUERADE-2",
+				rules: masq2Rules,
+			},
+		)
+	}
 	return chainArray
 }
 


### PR DESCRIPTION
#16884 broke the networkpolicy plugin because it now ends up trying to create the OPENSHIFT-MASQUERADE chain before the OPENSHIFT-MASQUERADE-2 chain, when the OPENSHIFT-MASQUERADE chain has rules pointing to the OPENSHIFT-MASQUERADE-2 chain. (I had thought that OPENSHIFT-FIREWALL-FORWARD and OPENSHIFT-ADMIN-OUTPUT-RULES were the only two chains whose ordering mattered, which *used to be* true, but isn't any longer.)

https://bugzilla.redhat.com/show_bug.cgi?id=1501855