### PR TITLE
oc cluster up: fix "No log available from 'origin' container"

### DIFF
--- a/pkg/oc/bootstrap/docker/dockerhelper/helper.go
+++ b/pkg/oc/bootstrap/docker/dockerhelper/helper.go
@@ -202,7 +202,7 @@ func (h *Helper) HostIP() string {
 
 func (h *Helper) ContainerLog(container string, numLines int) string {
 	outBuf := &bytes.Buffer{}
-	if err := h.client.ContainerLogs(container, types.ContainerLogsOptions{Tail: strconv.Itoa(numLines)}, outBuf, outBuf); err != nil {
+	if err := h.client.ContainerLogs(container, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true, Tail: strconv.Itoa(numLines)}, outBuf, outBuf); err != nil {
 		glog.V(2).Infof("Error getting container %q log: %v", container, err)
 	}
 	return outBuf.String()


### PR DESCRIPTION
`oc cluster up` fails on my machine and doesn't show the logs:
```
   Error: cannot add privileged SCC to pvinstaller service account
   Details:
     No log available from "origin" container
```
I see the following error, when I'm running it with `--loglevel=8`:
```
I1023 18:54:53.723538   13327 helper.go:206] Error getting container "origin" log: Error response from daemon: {"message":"Bad parameters: you must choose at least one stream"}
```
This PR fixes `Bad parameters: you must choose at least one stream` error by requesting stdout and stderr streams from Docker API.

PTAL @csrwng 
CC @simo5 