### PR TITLE
Router: Changed default resource resync interval from 10mins to 30mins

### DIFF
--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -59,7 +59,7 @@ type RouterSelection struct {
 
 // Bind sets the appropriate labels
 func (o *RouterSelection) Bind(flag *pflag.FlagSet) {
-	flag.DurationVar(&o.ResyncInterval, "resync-interval", 10*time.Minute, "The interval at which the route list should be fully refreshed")
+	flag.DurationVar(&o.ResyncInterval, "resync-interval", controllerfactory.DefaultResyncInterval, "The interval at which the route list should be fully refreshed")
 	flag.StringVar(&o.HostnameTemplate, "hostname-template", cmdutil.Env("ROUTER_SUBDOMAIN", ""), "If specified, a template that should be used to generate the hostname for a route without spec.host (e.g. '${name}-${namespace}.myapps.mycompany.com')")
 	flag.BoolVar(&o.OverrideHostname, "override-hostname", cmdutil.Env("ROUTER_OVERRIDE_HOSTNAME", "") == "true", "Override the spec.host value for a route with --hostname-template")
 	flag.StringVar(&o.LabelSelector, "labels", cmdutil.Env("ROUTE_LABELS", ""), "A label selector to apply to the routes to watch")

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -28,6 +28,10 @@ import (
 	informerfactory "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 )
 
+const (
+	DefaultResyncInterval = 30 * time.Minute
+)
+
 // RouterControllerFactory initializes and manages the watches that drive a router
 // controller. It supports optional scoping on Namespace, Labels, and Fields of routes.
 // If Namespace is empty, it means "all namespaces".
@@ -52,7 +56,7 @@ func NewDefaultRouterControllerFactory(rc routeclientset.Interface, pc projectcl
 		KClient:        kc,
 		RClient:        rc,
 		ProjectClient:  pc,
-		ResyncInterval: 10 * time.Minute,
+		ResyncInterval: DefaultResyncInterval,
 
 		Namespace: v1.NamespaceAll,
 		informers: map[reflect.Type]kcache.SharedIndexInformer{},

--- a/pkg/router/controller/factory/factory.go
+++ b/pkg/router/controller/factory/factory.go
@@ -77,13 +77,18 @@ func (f *RouterControllerFactory) Create(plugin router.Plugin, watchNodes, enabl
 		NamespaceRoutes:        make(map[string]map[string]*routeapi.Route),
 		NamespaceEndpoints:     make(map[string]map[string]*kapi.Endpoints),
 
-		ProjectClient: f.ProjectClient,
-		ProjectLabels: f.ProjectLabels,
-		// Check projects a bit more often than we resync events, so that we aren't always waiting
-		// the maximum interval for new items to come into the list
-		ProjectSyncInterval: f.ResyncInterval - 10*time.Second,
+		ProjectClient:       f.ProjectClient,
+		ProjectLabels:       f.ProjectLabels,
 		ProjectWaitInterval: 10 * time.Second,
 		ProjectRetries:      5,
+	}
+
+	// Check projects a bit more often than we resync events, so that we aren't always waiting
+	// the maximum interval for new items to come into the list
+	if f.ResyncInterval > 10*time.Second {
+		rc.ProjectSyncInterval = f.ResyncInterval - 10*time.Second
+	} else {
+		rc.ProjectSyncInterval = f.ResyncInterval
 	}
 
 	f.initInformers(rc)


### PR DESCRIPTION
- Resyncs are mainly intended for robustness. Mainly to handle the case
where the resource handler failed to process the item and we hope this
will be fixed if we process the item again after sometime(resync interval).
Yes, this may fix some transient errors but if we resync frequently then
there could be big penalities.

- Currently router watches these resources: routes, endpoints, nodes,
namespaces, ingresses and secrets. When we have many routes
(like several thousand in online case), processing these items takes
long time, router reload itself takes few seconds (not milliseconds).
Due to short resync interval there will be constant churn of reprocessing
of all the items for all these resources.

- Earlier we needed shorter resync interval because sharded router was depending
on this interval but with #16039 that limitation is removed.

10 mins seems aggressive for some rare transient errors, changed defaults
to 30 mins. Admin can edit router deployment config if they need custom resync interval.

Fixed project sync interval in router