### PR TITLE
UPSTREAM: 51750: output `<none>` for colums not found

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/printers/customcolumn.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/customcolumn.go
@@ -176,7 +176,7 @@ func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error
 	}
 	parsers := make([]*jsonpath.JSONPath, len(s.Columns))
 	for ix := range s.Columns {
-		parsers[ix] = jsonpath.New(fmt.Sprintf("column%d", ix))
+		parsers[ix] = jsonpath.New(fmt.Sprintf("column%d", ix)).AllowMissingKeys(true)
 		if err := parsers[ix].Parse(s.Columns[ix].FieldSpec); err != nil {
 			return err
 		}
@@ -226,10 +226,10 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jso
 		if err != nil {
 			return err
 		}
-		if len(values) == 0 || len(values[0]) == 0 {
-			fmt.Fprintf(out, "<none>\t")
-		}
 		valueStrings := []string{}
+		if len(values) == 0 || len(values[0]) == 0 {
+			valueStrings = append(valueStrings, "<none>")
+		}
 		for arrIx := range values {
 			for valIx := range values[arrIx] {
 				valueStrings = append(valueStrings, fmt.Sprintf("%v", values[arrIx][valIx].Interface()))

--- a/vendor/k8s.io/kubernetes/pkg/printers/customcolumn_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/customcolumn_test.go
@@ -286,6 +286,26 @@ bar
 foo       baz
 `,
 		},
+		{
+			columns: []printers.Column{
+				{
+					Header:    "NAME",
+					FieldSpec: "{.metadata.name}",
+				},
+				{
+					Header:    "API_VERSION",
+					FieldSpec: "{.apiVersion}",
+				},
+				{
+					Header:    "NOT_FOUND",
+					FieldSpec: "{.notFound}",
+				},
+			},
+			obj: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, TypeMeta: metav1.TypeMeta{APIVersion: "baz"}},
+			expectedOutput: `NAME      API_VERSION   NOT_FOUND
+foo       baz           <none>
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1505796

Picks changes introduced in https://github.com/kubernetes/kubernetes/pull/51750
to allow the custom-columns to succeed / print all known column values even when
an object's field does not exist.

**Before**
```
$ oc get dc mydc -o custom-columns=NAME:.metadata.name,UNKNOWN:.metadata.unknown
error: unknown is not found
```

**After**
```
$ oc get dc mydc -o custom-columns=NAME:.metadata.name,UNKNOWN:.metadata.unknown
NAME      UNKNOWN
mydc      <none>
```

cc @openshift/cli-review 