### PR TITLE
prevent client from looking up specific node in `oc debug`

### DIFF
--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -275,21 +275,6 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 		}
 	}
 
-	// if a nodeName was specified, ensure node exists
-	if len(o.NodeName) > 0 {
-		r := f.NewBuilder(true).
-			NamespaceParam(cmdNamespace).
-			SingleResourceType().
-			ResourceTypeOrNameArgs(true, []string{"nodes", o.NodeName}...).
-			Flatten().
-			Do()
-
-		_, err := r.Infos()
-		if err != nil {
-			return err
-		}
-	}
-
 	config, err := f.ClientConfig()
 	if err != nil {
 		return err

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -24,7 +24,7 @@ os::cmd::expect_success_and_text "oc debug -t dc/test-deployment-config -o yaml"
 os::cmd::expect_success_and_not_text "oc debug --tty=false dc/test-deployment-config -o yaml" 'tty'
 os::cmd::expect_success_and_not_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" 'stdin'
 os::cmd::expect_success_and_not_text "oc debug dc/test-deployment-config -o yaml -- /bin/env" 'tty'
-os::cmd::expect_failure_and_text "oc debug dc/test-deployment-config --node-name=invalid -- /bin/env" 'nodes "invalid" not found'
+os::cmd::expect_failure_and_text "oc debug dc/test-deployment-config --node-name=invalid -- /bin/env" 'on node "invalid"'
 # Does not require a real resource on the server
 os::cmd::expect_success_and_not_text "oc debug -T -f examples/hello-openshift/hello-pod.json -o yaml" 'tty'
 os::cmd::expect_success_and_text "oc debug -f examples/hello-openshift/hello-pod.json --keep-liveness --keep-readiness -o yaml" ''


### PR DESCRIPTION
Reverts https://github.com/openshift/origin/pull/16387
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1505698

PR #16387 prevented a debug pod from being created at all, if a
specified node-name pointed to a node that did not exist.

Although the patch aimed to make "debug" command failures more
immediate, a client should not attempt to retrieve a specific node in
the "debug" command, as there is no guarantee that the user has access
to retrieve node information. While this means that the "debug" command

cc @openshift/cli-review @smarterclayton 