### PR TITLE
DeploymentConfig replicas should be optional, other fields too

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_apps_apis_apps_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_apps_apis_apps_v1.proto
@@ -130,6 +130,7 @@ message DeploymentConfigRollbackSpec {
 // DeploymentConfigSpec represents the desired state of the deployment.
 message DeploymentConfigSpec {
   // Strategy describes how a deployment is executed.
+  // +optional
   optional DeploymentStrategy strategy = 1;
 
   // MinReadySeconds is the minimum number of seconds for which a newly created pod should
@@ -140,9 +141,11 @@ message DeploymentConfigSpec {
   // Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
   // are defined, a new deployment can only occur as a result of an explicit client update to the
   // DeploymentConfig with a new LatestVersion. If null, defaults to having a config change trigger.
+  // +optional
   optional DeploymentTriggerPolicies triggers = 2;
 
   // Replicas is the number of desired replicas.
+  // +optional
   optional int32 replicas = 3;
 
   // RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
@@ -153,6 +156,7 @@ message DeploymentConfigSpec {
   // Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
   // deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
   // or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+  // +optional
   optional bool test = 5;
 
   // Paused indicates that the deployment config is paused resulting in no new deployments on template

--- a/api/protobuf-spec/github_com_openshift_origin_pkg_image_apis_image_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_image_apis_image_v1.proto
@@ -461,6 +461,7 @@ message TagReference {
   optional string name = 1;
 
   // Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.
+  // +optional
   map<string, string> annotations = 2;
 
   // Optional; if specified, a reference to another image that this tag should point to. Valid values
@@ -478,6 +479,7 @@ message TagReference {
   // to import the newest remote tag. To trigger a new import, clients may set this value to zero which
   // will reset the generation to the latest stream generation. Legacy clients will send this value as
   // nil which will be merged with the current tag generation.
+  // +optional
   optional int64 generation = 5;
 
   // ImportPolicy is information that controls how images may be imported by the server.

--- a/api/swagger-spec/oapi-v1.json
+++ b/api/swagger-spec/oapi-v1.json
@@ -23170,8 +23170,7 @@
     "id": "v1.DeploymentConfig",
     "description": "Deployment Configs define the template for a pod and manages deploying new images or configuration changes. A single deployment configuration is usually analogous to a single micro-service. Can support many different deployment patterns, including full restart, customizable rolling updates, and  fully custom behaviors, as well as pre- and post- deployment hooks. Each individual deployment is represented as a replication controller.\n\nA deployment is \"triggered\" when its configuration is changed or a tag in an Image Stream is changed. Triggers can be disabled to allow manual control over a deployment. The \"strategy\" determines how the deployment is carried out and may be changed at any time. The `latestVersion` field is updated when a new deployment is triggered by any means.",
     "required": [
-     "spec",
-     "status"
+     "spec"
     ],
     "properties": {
      "kind": {

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -87032,8 +87032,7 @@
    "com.github.openshift.origin.pkg.apps.apis.apps.v1.DeploymentConfig": {
     "description": "Deployment Configs define the template for a pod and manages deploying new images or configuration changes. A single deployment configuration is usually analogous to a single micro-service. Can support many different deployment patterns, including full restart, customizable rolling updates, and  fully custom behaviors, as well as pre- and post- deployment hooks. Each individual deployment is represented as a replication controller.\n\nA deployment is \"triggered\" when its configuration is changed or a tag in an Image Stream is changed. Triggers can be disabled to allow manual control over a deployment. The \"strategy\" determines how the deployment is carried out and may be changed at any time. The `latestVersion` field is updated when a new deployment is triggered by any means.",
     "required": [
-     "spec",
-     "status"
+     "spec"
     ],
     "properties": {
      "apiVersion": {
@@ -87192,12 +87191,6 @@
    },
    "com.github.openshift.origin.pkg.apps.apis.apps.v1.DeploymentConfigSpec": {
     "description": "DeploymentConfigSpec represents the desired state of the deployment.",
-    "required": [
-     "strategy",
-     "triggers",
-     "replicas",
-     "test"
-    ],
     "properties": {
      "minReadySeconds": {
       "description": "MinReadySeconds is the minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -90677,9 +90670,7 @@
    "com.github.openshift.origin.pkg.image.apis.image.v1.TagReference": {
     "description": "TagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.",
     "required": [
-     "name",
-     "annotations",
-     "generation"
+     "name"
     ],
     "properties": {
      "annotations": {

--- a/pkg/apps/apis/apps/v1/defaults_test.go
+++ b/pkg/apps/apis/apps/v1/defaults_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -540,19 +541,20 @@ func TestDefaults(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Logf("test %d", i)
-		original := test.original
-		expected := test.expected
-		obj2 := roundTrip(t, runtime.Object(original))
-		got, ok := obj2.(*DeploymentConfig)
-		if !ok {
-			t.Errorf("unexpected object: %v", got)
-			t.FailNow()
-		}
-		// TODO(rebase): check that there are no fields which have different semantics for nil and []
-		if !equality.Semantic.DeepEqual(got.Spec, expected.Spec) {
-			t.Errorf("got different than expected:\nA:\t%#v\nB:\t%#v\n\nDiff:\n%s\n\n%s", got, expected, diff.ObjectDiff(expected, got), diff.ObjectGoPrintSideBySide(expected, got))
-		}
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Logf("test %d", i)
+			original := test.original
+			expected := test.expected
+			obj2 := roundTrip(t, runtime.Object(original))
+			got, ok := obj2.(*DeploymentConfig)
+			if !ok {
+				t.Fatalf("unexpected object: %v", got)
+			}
+			// TODO(rebase): check that there are no fields which have different semantics for nil and []
+			if !equality.Semantic.DeepEqual(got.Spec, expected.Spec) {
+				t.Errorf("got different than expected:\nA:\t%#v\nB:\t%#v\n\nDiff:\n%s\n\n%s", got, expected, diff.ObjectDiff(expected, got), diff.ObjectGoPrintSideBySide(expected, got))
+			}
+		})
 	}
 }
 

--- a/pkg/apps/apis/apps/v1/generated.proto
+++ b/pkg/apps/apis/apps/v1/generated.proto
@@ -130,6 +130,7 @@ message DeploymentConfigRollbackSpec {
 // DeploymentConfigSpec represents the desired state of the deployment.
 message DeploymentConfigSpec {
   // Strategy describes how a deployment is executed.
+  // +optional
   optional DeploymentStrategy strategy = 1;
 
   // MinReadySeconds is the minimum number of seconds for which a newly created pod should
@@ -140,9 +141,11 @@ message DeploymentConfigSpec {
   // Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
   // are defined, a new deployment can only occur as a result of an explicit client update to the
   // DeploymentConfig with a new LatestVersion. If null, defaults to having a config change trigger.
+  // +optional
   optional DeploymentTriggerPolicies triggers = 2;
 
   // Replicas is the number of desired replicas.
+  // +optional
   optional int32 replicas = 3;
 
   // RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
@@ -153,6 +156,7 @@ message DeploymentConfigSpec {
   // Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
   // deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
   // or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+  // +optional
   optional bool test = 5;
 
   // Paused indicates that the deployment config is paused resulting in no new deployments on template

--- a/pkg/apps/apis/apps/v1/types.go
+++ b/pkg/apps/apis/apps/v1/types.go
@@ -33,12 +33,13 @@ type DeploymentConfig struct {
 	Spec DeploymentConfigSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// Status represents the current deployment state.
-	Status DeploymentConfigStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+	Status DeploymentConfigStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // DeploymentConfigSpec represents the desired state of the deployment.
 type DeploymentConfigSpec struct {
 	// Strategy describes how a deployment is executed.
+	// +optional
 	Strategy DeploymentStrategy `json:"strategy" protobuf:"bytes,1,opt,name=strategy"`
 
 	// MinReadySeconds is the minimum number of seconds for which a newly created pod should
@@ -49,9 +50,11 @@ type DeploymentConfigSpec struct {
 	// Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers
 	// are defined, a new deployment can only occur as a result of an explicit client update to the
 	// DeploymentConfig with a new LatestVersion. If null, defaults to having a config change trigger.
+	// +optional
 	Triggers DeploymentTriggerPolicies `json:"triggers" protobuf:"bytes,2,rep,name=triggers"`
 
 	// Replicas is the number of desired replicas.
+	// +optional
 	Replicas int32 `json:"replicas" protobuf:"varint,3,opt,name=replicas"`
 
 	// RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks.
@@ -62,6 +65,7 @@ type DeploymentConfigSpec struct {
 	// Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the
 	// deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding
 	// or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.
+	// +optional
 	Test bool `json:"test" protobuf:"varint,5,opt,name=test"`
 
 	// Paused indicates that the deployment config is paused resulting in no new deployments on template

--- a/pkg/image/apis/image/v1/generated.proto
+++ b/pkg/image/apis/image/v1/generated.proto
@@ -461,6 +461,7 @@ message TagReference {
   optional string name = 1;
 
   // Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.
+  // +optional
   map<string, string> annotations = 2;
 
   // Optional; if specified, a reference to another image that this tag should point to. Valid values
@@ -478,6 +479,7 @@ message TagReference {
   // to import the newest remote tag. To trigger a new import, clients may set this value to zero which
   // will reset the generation to the latest stream generation. Legacy clients will send this value as
   // nil which will be merged with the current tag generation.
+  // +optional
   optional int64 generation = 5;
 
   // ImportPolicy is information that controls how images may be imported by the server.

--- a/pkg/image/apis/image/v1/types.go
+++ b/pkg/image/apis/image/v1/types.go
@@ -203,6 +203,7 @@ type TagReference struct {
 	// Name of the tag
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.
+	// +optional
 	Annotations map[string]string `json:"annotations" protobuf:"bytes,2,rep,name=annotations"`
 	// Optional; if specified, a reference to another image that this tag should point to. Valid values
 	// are ImageStreamTag, ImageStreamImage, and DockerImage.
@@ -217,6 +218,7 @@ type TagReference struct {
 	// to import the newest remote tag. To trigger a new import, clients may set this value to zero which
 	// will reset the generation to the latest stream generation. Legacy clients will send this value as
 	// nil which will be merged with the current tag generation.
+	// +optional
 	Generation *int64 `json:"generation" protobuf:"varint,5,opt,name=generation"`
 	// ImportPolicy is information that controls how images may be imported by the server.
 	ImportPolicy TagImportPolicy `json:"importPolicy,omitempty" protobuf:"bytes,6,opt,name=importPolicy"`

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -192,7 +192,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"spec", "status"},
+					Required: []string{"spec"},
 				},
 			},
 			Dependencies: []string{
@@ -429,7 +429,6 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"strategy", "triggers", "replicas", "test"},
 				},
 			},
 			Dependencies: []string{
@@ -6741,7 +6740,7 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 					},
-					Required: []string{"name", "annotations", "generation"},
+					Required: []string{"name"},
 				},
 			},
 			Dependencies: []string{


### PR DESCRIPTION
Make a set of fields truly optional in openapi, and also make replicas a
pointer so we can default it.

Found this when I tried to use --validate - these were a bunch of obvious things.