### PR TITLE
fixes #16902.  Add etcd section to inventory for 'oc cluster up'

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/ansible.go
+++ b/pkg/oc/bootstrap/docker/openshift/ansible.go
@@ -51,6 +51,9 @@ openshift_metrics_hawkular_hostname={{.HawkularHostName}}
 
 [nodes]
 {{.MasterIP}}
+
+[etcd]
+{{.MasterIP}}
 `
 
 const defaultLoggingInventory = `
@@ -81,6 +84,9 @@ openshift_logging_kibana_hostname={{.KibanaHostName}}
 {{.MasterIP}} ansible_connection=local
 
 [nodes]
+{{.MasterIP}}
+
+[etcd]
 {{.MasterIP}}
 `
 


### PR DESCRIPTION
This PR fixes #16902 by added an etcd section to the generated ansible inventory that is required by openshift-ansible