### PR TITLE
Introduce custom Grafana for openshift prometheus.

### DIFF
--- a/examples/grafana/README.md
+++ b/examples/grafana/README.md
@@ -1,0 +1,27 @@
+# grafana-ocp
+
+This template creates a custom Grafana instance preconfigured to gather Prometheus openshift metrics.
+It is uses OAuth token to login openshift Prometheus.
+
+
+## To deploy grafana
+Note: make sure to have openshift prometheus deployed.
+(https://github.com/openshift/origin/tree/master/examples/prometheus)
+
+1. ```oc create namespace grafana```
+2. ```oc new-app -f grafana-ocp.yaml```
+3. grab the grafana url ``` oc get route |awk 'NR==2 {print $2}' ```
+4. grab the ocp token, from openshift master run: ```oc sa get-token prometheus -n kube-system```
+5. browse to grafana datasource's and add new prometheus datasource. 
+6. grab the prometheus url via ```oc get route -n kube-system prometheus |awk 'NR==2 {print $2}'``` and paste the prometheus url e.g https://prometheus-kube-system.apps.example.com
+7. paste the token string at the token field.
+8. checkout the TLS checkbox.
+9. save & test and make sure all green.
+
+### Pull standalone docker grafana instance
+to build standalone docker instance see
+https://github.com/mrsiano/grafana-ocp
+
+#### Resources 
+- example video https://youtu.be/srCApR_J3Os
+- deploy openshift prometheus https://github.com/openshift/origin/tree/master/examples/prometheus 

--- a/examples/grafana/grafana-ocp.yaml
+++ b/examples/grafana/grafana-ocp.yaml
@@ -1,0 +1,76 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: grafana-ocp
+  annotations:
+    "openshift.io/display-name": Grafana ocp
+    description: |
+      Grafana server with patched Prometheus datasource.
+    iconClass: icon-cogs
+    tags: "metrics,monitoring,grafana,prometheus"
+parameters:
+- description: External URL for the grafana route
+  name: ROUTE_URL
+  value: ""
+- description: The namespace to instantiate heapster under. Defaults to 'grafana'.
+  name: NAMESPACE
+  value: grafana
+objects:
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: grafana-ocp
+    namespace: "${NAMESPACE}"
+  spec:
+    host: "${ROUTE_URL}"
+    to:
+      name: grafana-ocp
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: grafana-ocp
+    namespace: "${NAMESPACE}"
+    labels:
+      metrics-infra: grafana-ocp
+      name: grafana-ocp
+  spec:
+    selector:
+      name: grafana-ocp
+    ports:
+    - port: 8082
+      protocol: TCP
+      targetPort: grafana-http
+- apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    name: grafana-ocp
+    namespace: "${NAMESPACE}"
+    labels:
+      metrics-infra: grafana-ocp
+      name: grafana-ocp
+  spec:
+    selector:
+      name: grafana-ocp
+    replicas: 1
+    template:
+      version: v1
+      metadata:
+        labels:
+          metrics-infra: grafana-ocp
+          name: grafana-ocp
+      spec:
+        volumes:
+        - name: data
+          emptyDir: {}
+        containers:
+        - image: "mrsiano/grafana-ocp:latest"
+          name: grafana-ocp
+          ports:
+          - name: grafana-http
+            containerPort: 3000
+          volumeMounts:
+          - name: data
+            mountPath: "/root/go/src/github.com/grafana/grafana/data"
+          command:
+          - "./bin/grafana-server"


### PR DESCRIPTION
A template creates a custom Grafana instance preconfigured to gather Prometheus openshift metrics.
It uses OAuth token to login openshift Prometheus.