### PR TITLE
Handle Egress IP already being present when trying to add it

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -297,7 +297,11 @@ func (eip *egressIPWatcher) claimEgressIP(egressIP, egressHex string) error {
 	}
 	err = netlink.AddrAdd(eip.localEgressLink, addr)
 	if err != nil {
-		return fmt.Errorf("could not add egress IP %q to %s: %v", egressIPNet, eip.localEgressLink.Attrs().Name, err)
+		if err == syscall.EEXIST {
+			glog.V(2).Infof("Egress IP %q already exists on %s", egressIPNet, eip.localEgressLink.Attrs().Name)
+		} else {
+			return fmt.Errorf("could not add egress IP %q to %s: %v", egressIPNet, eip.localEgressLink.Attrs().Name, err)
+		}
 	}
 
 	if err := eip.iptables.AddEgressIPRules(egressIP, egressHex); err != nil {


### PR DESCRIPTION
When restarting openshift-node, an egress IP might already be present on the interface. We need to not consider that an error (so that iptables rules and OVS flows will still also get added, if necessary).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1506149
