### PR TITLE
Update console OPENSHIFT_CONSTANTS flags for cluster up

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -850,12 +850,7 @@ func (h *Helper) updateConfig(configDir string, opt *StartOptions) error {
 		}
 		cfg.AssetConfig.ExtensionScripts = append(cfg.AssetConfig.ExtensionScripts, serviceCatalogExtensionPath)
 
-		extension := `
-window.OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE = {
-  service_catalog_landing_page: true,
-  template_service_broker: true
-};
-`
+		extension := "window.OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED = true;\n"
 		extensionPath := filepath.Join(configDir, "master", "servicecatalog-extension.js")
 		err = ioutil.WriteFile(extensionPath, []byte(extension), 0644)
 		if err != nil {


### PR DESCRIPTION
The following flag has been removed:

  OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.service_catalog_landing_page

The following flag has been renamed:

  OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE.template_service_broker

The new name is

  OPENSHIFT_CONSTANTS.TEMPLATE_SERVICE_BROKER_ENABLED

as the broker is no longer tech preview.

See https://github.com/openshift/origin-web-console/pull/2387

/assign @bparees 
cc @jwforres 