### PR TITLE
Bug - propagate docker build image failure

### DIFF
--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -128,7 +128,7 @@ function os::build::image::internal::docker() {
 	local options=()
 
 	if ! docker build ${OS_BUILD_IMAGE_ARGS:-} -t "${tag}" "${directory}"; then
-		return "$?"
+		return 1
 	fi
 
 	if [[ -n "${extra_tag}" ]]; then


### PR DESCRIPTION
The '!' is a reserved word and if it precedes a pipeline, it reverses the exit status of the pipeline. In this case, 'return "$?"' was always 0.

It was decided that the actual exit code of docker build is not important and returning 1 to indicate an error should suffice.

https://linux.die.net/man/1/bash - section about pipelines
http://tldp.org/LDP/abs/html/exit-status.html#EXITSTATUSREF