### PR TITLE
fix a segfault with cidr addresses and correct the creation of cluster network object 

### DIFF
--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -62,8 +62,10 @@ func ParseNetworkInfo(clusterNetwork []networkapi.ClusterNetworkEntry, serviceNe
 				return nil, fmt.Errorf("failed to parse ClusterNetwork CIDR %s: %v", entry.CIDR, err)
 			}
 			glog.Errorf("Configured clusterNetworks value %q is invalid; treating it as %q", entry.CIDR, cidr.String())
+			cns = append(cns, ClusterNetwork{ClusterCIDR: cidr, HostSubnetLength: entry.HostSubnetLength})
+		} else {
+			cns = append(cns, ClusterNetwork{ClusterCIDR: cidr, HostSubnetLength: entry.HostSubnetLength})
 		}
-		cns = append(cns, ClusterNetwork{ClusterCIDR: cidr, HostSubnetLength: entry.HostSubnetLength})
 	}
 
 	sn, err := netutils.ParseCIDRMask(serviceNetwork)

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -66,17 +66,22 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 		panic("No ClusterNetworks set in networkConfig; should have been defaulted in if not configured")
 	}
 
+	var parsedClusterNetworkEntries []networkapi.ClusterNetworkEntry
+	for _, entry := range master.networkInfo.ClusterNetworks {
+		parsedClusterNetworkEntries = append(parsedClusterNetworkEntries, networkapi.ClusterNetworkEntry{CIDR: entry.ClusterCIDR.String(), HostSubnetLength: entry.HostSubnetLength})
+	}
+
 	configCN := &networkapi.ClusterNetwork{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterNetwork"},
 		ObjectMeta: metav1.ObjectMeta{Name: networkapi.ClusterNetworkDefault},
 
-		ClusterNetworks: clusterNetworkEntries,
-		ServiceNetwork:  networkConfig.ServiceNetworkCIDR,
+		ClusterNetworks: parsedClusterNetworkEntries,
+		ServiceNetwork:  master.networkInfo.ServiceNetwork.String(),
 		PluginName:      networkConfig.NetworkPluginName,
 
 		// Need to set these for backward compat
-		Network:          clusterNetworkEntries[0].CIDR,
-		HostSubnetLength: clusterNetworkEntries[0].HostSubnetLength,
+		Network:          parsedClusterNetworkEntries[0].CIDR,
+		HostSubnetLength: parsedClusterNetworkEntries[0].HostSubnetLength,
 	}
 	osapivalidation.SetDefaultClusterNetwork(*configCN)
 


### PR DESCRIPTION
Currently the system segfaults if passed a cidr that is not in canonical form, this was due to scoping issues in ParseNetworkInfo().

Also fix the creation of the clusterNetworkObject to use the converted form of the cidr address when creating the clusterNetwork object to conform to how the system used to function 

@knobunc PTAL

found while working on 
Bug: [1506017](https://bugzilla.redhat.com/show_bug.cgi?id=1506017)