### PR TITLE
Fix the "supress health checks when only one backing service" logic

### DIFF
--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -267,7 +267,7 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 
 	out := make([]Endpoint, 0, len(endpoints.Subsets)*4)
 
-	// TODO: review me for sanity
+	// Now build the actual endpoints we pass to the template
 	for _, s := range subsets {
 		for _, p := range s.Ports {
 			if excludeUDP && p.Protocol == kapi.ProtocolUDP {

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -265,10 +265,9 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 		wasIdled = true
 	}
 
-	// Take a reasonable guess at the number of endpoints to avoid reallocating the out array when we append
 	out := make([]Endpoint, 0, len(endpoints.Subsets)*4)
 
-	// Now build the actual endpoints we pass to the template
+	// TODO: review me for sanity
 	for _, s := range subsets {
 		for _, p := range s.Ports {
 			if excludeUDP && p.Protocol == kapi.ProtocolUDP {
@@ -305,12 +304,6 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 				out = append(out, ep)
 			}
 		}
-	}
-
-	// We want to disable endpoint checks if there is only one endpoint
-	// We skip the case where it is idled, since we set NoHealthCheck above
-	if wasIdled == false && len(out) == 1 {
-		out[0].NoHealthCheck = true
 	}
 
 	return out

--- a/pkg/router/template/plugin_test.go
+++ b/pkg/router/template/plugin_test.go
@@ -275,16 +275,15 @@ func TestHandleEndpoints(t *testing.T) {
 				Name: "foo/test", //service name from kapi.endpoints object
 				EndpointTable: []Endpoint{
 					{
-						ID:            "ept:test:1.1.1.1:345",
-						IP:            "1.1.1.1",
-						Port:          "345",
-						NoHealthCheck: true,
+						ID:   "ept:test:1.1.1.1:345",
+						IP:   "1.1.1.1",
+						Port: "345",
 					},
 				},
 			},
 		},
 		{
-			name:      "Endpoint mod (one ep, one address)",
+			name:      "Endpoint mod",
 			eventType: watch.Modified,
 			endpoints: &kapi.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
@@ -300,143 +299,9 @@ func TestHandleEndpoints(t *testing.T) {
 				Name: "foo/test",
 				EndpointTable: []Endpoint{
 					{
-						ID:            "pod:pod-1:test:2.2.2.2:8080",
-						IP:            "2.2.2.2",
-						Port:          "8080",
-						NoHealthCheck: true,
-					},
-				},
-			},
-		},
-		{
-			name:      "Endpoint mod (second ep, one address each)",
-			eventType: watch.Modified,
-			endpoints: &kapi.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "test",
-				},
-				Subsets: []kapi.EndpointSubset{
-					{
-						Addresses: []kapi.EndpointAddress{{IP: "2.2.2.2", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-1"}}},
-						Ports:     []kapi.EndpointPort{{Port: 8080}},
-					},
-					{
-						Addresses: []kapi.EndpointAddress{{IP: "3.3.3.3", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-2"}}},
-						Ports:     []kapi.EndpointPort{{Port: 8081}},
-					},
-				},
-			},
-			expectedServiceUnit: &ServiceUnit{
-				Name: "foo/test",
-				EndpointTable: []Endpoint{
-					{
-						ID:            "pod:pod-1:test:2.2.2.2:8080",
-						IP:            "2.2.2.2",
-						Port:          "8080",
-						NoHealthCheck: false,
-					},
-					{
-						ID:            "pod:pod-2:test:3.3.3.3:8081",
-						IP:            "3.3.3.3",
-						Port:          "8081",
-						NoHealthCheck: false,
-					},
-				},
-			},
-		},
-		{
-			name:      "Endpoint mod (one ep, two addresses)",
-			eventType: watch.Modified,
-			endpoints: &kapi.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "test",
-				},
-				Subsets: []kapi.EndpointSubset{
-					{
-						Addresses: []kapi.EndpointAddress{
-							{IP: "3.3.3.3", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-2"}},
-							{IP: "4.4.4.4", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-3"}},
-						},
-						Ports: []kapi.EndpointPort{{Port: 8080}},
-					},
-				},
-			},
-			expectedServiceUnit: &ServiceUnit{
-				Name: "foo/test",
-				EndpointTable: []Endpoint{
-					{
-						ID:            "pod:pod-2:test:3.3.3.3:8080",
-						IP:            "3.3.3.3",
-						Port:          "8080",
-						NoHealthCheck: false,
-					},
-					{
-						ID:            "pod:pod-3:test:4.4.4.4:8080",
-						IP:            "4.4.4.4",
-						Port:          "8080",
-						NoHealthCheck: false,
-					},
-				},
-			},
-		},
-		{
-			name:      "Endpoint mod (one ep, two ports)",
-			eventType: watch.Modified,
-			endpoints: &kapi.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "test",
-				},
-				Subsets: []kapi.EndpointSubset{
-					{
-						Addresses: []kapi.EndpointAddress{
-							{IP: "3.3.3.3", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-2"}},
-						},
-						Ports: []kapi.EndpointPort{{Port: 8080}, {Port: 8081}},
-					},
-				},
-			},
-			expectedServiceUnit: &ServiceUnit{
-				Name: "foo/test",
-				EndpointTable: []Endpoint{
-					{
-						ID:            "pod:pod-2:test:3.3.3.3:8080",
-						IP:            "3.3.3.3",
-						Port:          "8080",
-						NoHealthCheck: false,
-					},
-					{
-						ID:            "pod:pod-2:test:3.3.3.3:8081",
-						IP:            "3.3.3.3",
-						Port:          "8081",
-						NoHealthCheck: false,
-					},
-				},
-			},
-		},
-		{
-			name:      "Endpoint mod (back to one ep)",
-			eventType: watch.Modified,
-			endpoints: &kapi.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "test",
-				},
-				Subsets: []kapi.EndpointSubset{{
-					Addresses: []kapi.EndpointAddress{{IP: "3.3.3.3", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-1"}}},
-					Ports:     []kapi.EndpointPort{{Port: 8080}},
-				}},
-			},
-			expectedServiceUnit: &ServiceUnit{
-				Name: "foo/test",
-				EndpointTable: []Endpoint{
-					{
-						ID:            "pod:pod-1:test:3.3.3.3:8080",
-						IP:            "3.3.3.3",
-						Port:          "8080",
-						NoHealthCheck: true,
+						ID:   "pod:pod-1:test:2.2.2.2:8080",
+						IP:   "2.2.2.2",
+						Port: "8080",
 					},
 				},
 			},
@@ -450,8 +315,8 @@ func TestHandleEndpoints(t *testing.T) {
 					Name:      "test",
 				},
 				Subsets: []kapi.EndpointSubset{{
-					Addresses: []kapi.EndpointAddress{{IP: "3.3.3.3", TargetRef: &kapi.ObjectReference{Kind: "Pod", Name: "pod-1"}}},
-					Ports:     []kapi.EndpointPort{{Port: 8080}},
+					Addresses: []kapi.EndpointAddress{{IP: "3.3.3.3"}},
+					Ports:     []kapi.EndpointPort{{Port: 0}},
 				}},
 			},
 			expectedServiceUnit: &ServiceUnit{

--- a/pkg/router/template/template_helper_test.go
+++ b/pkg/router/template/template_helper_test.go
@@ -1,6 +1,7 @@
 package templaterouter
 
 import (
+	"reflect"
 	"regexp"
 	"testing"
 )
@@ -294,6 +295,171 @@ func TestMatchPattern(t *testing.T) {
 		match := matchPattern(tt.pattern, tt.input)
 		if match {
 			t.Errorf("%s: expected %s not to match %s, but did", tt.name, tt.input, tt.pattern)
+		}
+	}
+}
+
+func TestEndpointsForAlias(t *testing.T) {
+	testEndpoints := []struct {
+		name       string
+		preferPort string
+		eps        []Endpoint
+		expected   []Endpoint
+	}{
+		{
+			name:       "Test no preference with a single endpoint",
+			preferPort: "",
+			eps: []Endpoint{
+				{
+					ID:       "ep1",
+					Port:     "80",
+					PortName: "http",
+				},
+			},
+			expected: []Endpoint{
+				{
+					ID:            "ep1",
+					Port:          "80",
+					PortName:      "http",
+					NoHealthCheck: true,
+				},
+			},
+		},
+		{
+			name:       "Test no preference with multiple",
+			preferPort: "",
+			eps: []Endpoint{
+				{
+					ID:       "ep1",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep1",
+					Port:     "443",
+					PortName: "https",
+				},
+				{
+					ID:       "ep2",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep3",
+					Port:     "80",
+					PortName: "http",
+				},
+			},
+			expected: []Endpoint{
+				{
+					ID:       "ep1",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep1",
+					Port:     "443",
+					PortName: "https",
+				},
+				{
+					ID:       "ep2",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep3",
+					Port:     "80",
+					PortName: "http",
+				},
+			},
+		},
+		{
+			name:       "Test a preference resulting in multiple",
+			preferPort: "http",
+			eps: []Endpoint{
+				{
+					ID:       "ep1",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep1",
+					Port:     "443",
+					PortName: "https",
+				},
+				{
+					ID:       "ep2",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep3",
+					Port:     "80",
+					PortName: "http",
+				},
+			},
+			expected: []Endpoint{
+				{
+					ID:       "ep1",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep2",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep3",
+					Port:     "80",
+					PortName: "http",
+				},
+			},
+		},
+		{
+			name:       "Test a preference resulting in one",
+			preferPort: "https",
+			eps: []Endpoint{
+				{
+					ID:       "ep1",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep1",
+					Port:     "443",
+					PortName: "https",
+				},
+				{
+					ID:       "ep2",
+					Port:     "80",
+					PortName: "http",
+				},
+				{
+					ID:       "ep3",
+					Port:     "80",
+					PortName: "http",
+				},
+			},
+			expected: []Endpoint{
+				{
+					ID:            "ep1",
+					Port:          "443",
+					PortName:      "https",
+					NoHealthCheck: true,
+				},
+			},
+		},
+	}
+
+	for _, te := range testEndpoints {
+		eps := endpointsForAlias(
+			ServiceAliasConfig{PreferPort: te.preferPort},
+			ServiceUnit{EndpointTable: te.eps},
+		)
+
+		if !reflect.DeepEqual(te.expected, eps) {
+			t.Errorf("%s: expected result: %#v, got: %#v", te.name, te.expected, eps)
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 4833eb5d9f770fe8ab2b991f1c4d114cd09bf99c and then fixes the implementation.

Previously we had attempted to suppress the health checks, but it was looking at the endpoints of the service, not the servers that back the route.  The problem is that if we just look at endpoints, then if a route has two backing services, each with one endpoint, we would incorrectly suppress the health checks.

Fixes bug 1507664 (https://bugzilla.redhat.com/show_bug.cgi?id=1507664)