### PR TITLE
Correctly handle NotFound errors during migration

### DIFF
--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -47,6 +48,11 @@ func (r ReporterBool) Changed() bool {
 
 func AlwaysRequiresMigration(_ *resource.Info) (Reporter, error) {
 	return ReporterBool(true), nil
+}
+
+// timeStampNow returns the current time in the same format as glog
+func timeStampNow() string {
+	return time.Now().Format("0102 15:04:05.000000")
 }
 
 // NotChanged is a Reporter returned by operations that are guaranteed to be read-only
@@ -397,9 +403,9 @@ func (t *migrateTracker) report(prefix string, info *resource.Info, err error) {
 		ns = "-n " + ns
 	}
 	if err != nil {
-		fmt.Fprintf(t.out, "%-10s %s %s/%s: %v\n", prefix, ns, info.Mapping.Resource, info.Name, err)
+		fmt.Fprintf(t.out, "E%s %-10s %s %s/%s: %v\n", timeStampNow(), prefix, ns, info.Mapping.Resource, info.Name, err)
 	} else {
-		fmt.Fprintf(t.out, "%-10s %s %s/%s\n", prefix, ns, info.Mapping.Resource, info.Name)
+		fmt.Fprintf(t.out, "I%s %-10s %s %s/%s\n", timeStampNow(), prefix, ns, info.Mapping.Resource, info.Name)
 	}
 }
 

--- a/pkg/oc/admin/migrate/migrator_test.go
+++ b/pkg/oc/admin/migrate/migrator_test.go
@@ -1,0 +1,345 @@
+package migrate
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+func TestIsNotFoundForInfo(t *testing.T) {
+	type args struct {
+		info *resource.Info
+		err  error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil err does not match",
+			args: args{
+				info: nil,
+				err:  nil,
+			},
+			want: false,
+		},
+		{
+			name: "simple not found match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "group1",
+					Resource: "kind1", // this is the kind
+				},
+					"name1",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "simple not found match from generic 404 response",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "group1",
+						Resource: "kind1", // this is the kind
+					},
+					"name1",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "simple not match from generic 400 response",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusBadRequest,
+					"",
+					schema.GroupResource{
+						Group:    "group1",
+						Resource: "kind1", // this is the kind
+					},
+					"name1",
+					"",
+					0,
+					false,
+				),
+			},
+			want: false,
+		},
+		{
+			name: "different status error does not match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewAlreadyExists(schema.GroupResource{
+					Group:    "group1",
+					Resource: "kind1", // this is the kind
+				},
+					"name1",
+				),
+			},
+			want: false,
+		},
+		{
+			name: "non status error does not match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: fmt.Errorf("%v",
+					schema.GroupVersionKind{
+						Group: "group1",
+						Kind:  "kind1",
+					},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "case-insensitive not found match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "GROUPA",
+							Kind:  "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "groupA",
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match from generic 404 response",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "ThisGroup",
+							Kind:  "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "thisgroup",
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match, no group in info",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Kind: "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "groupA",
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match, no group in error",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "GROUPA",
+							Kind:  "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not match due to different groups",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "group2",
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: false,
+		},
+		{
+			name: "case-insensitive not found match from generic 404 response, no group in info",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Kind: "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "thisgroup",
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match from generic 404 response, no group in error",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "ThisGroup",
+							Kind:  "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not match from generic 404 response due to different groups",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "thingA",
+							Kind:  "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "thingB",
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNotFoundForInfo(tt.args.info, tt.args.err); got != tt.want {
+				t.Errorf("isNotFoundForInfo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/oc/admin/migrate/storage/storage.go
+++ b/pkg/oc/admin/migrate/storage/storage.go
@@ -202,7 +202,11 @@ func (o *MigrateAPIStorageOptions) save(info *resource.Info, reporter migrate.Re
 			Name(info.Name).Do()
 		data, err := get.Raw()
 		if err != nil {
-			return migrate.DefaultRetriable(info, err)
+			// since we have an error, processing the body is safe because we are not going
+			// to send it back to the server.  Thus we can safely call Result.Error().
+			// This is required because we want to make sure we pass an errors.APIStatus so
+			// that DefaultRetriable can correctly determine if the error is safe to retry.
+			return migrate.DefaultRetriable(info, get.Error())
 		}
 		update := info.Client.Put().
 			Resource(info.Mapping.Resource).


### PR DESCRIPTION
This change makes it so that the migrate storage command will now reprocess the body of a failed GET request to follow the standard path of extracting a status error.  This normalizes the structure of the errors the code must handle.

When comparing the resource.Info to an error, the info's REST mapping is now used to extract group kind information since the associated runtime.Object is not guaranteed to have valid type meta data.  This is combined with relaxed case-insensitive matching to make sure that we only fail the migrate storage command on NotFound errors that we know do not match the info.

When a NotFound error occurs, the migrate command now correctly reports that it did not change the resource.  Previously it reported that it had successfully migrated the resource, which is not true since it is impossible to migrate a resource that does not exist.

Bug 1506006

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add timestamps to migration command's reporting

This change adds glog style timestamps to the reporting output of the migration tracker.  This will aid in debugging migration errors by making it easier to correlate client errors with master logs.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @smarterclayton

/kind bug

xref https://bugzilla.redhat.com/show_bug.cgi?id=1506006

@sdodson @jupierce