### PR TITLE
Improve the documentation for oc rollout

### DIFF
--- a/pkg/oc/cli/cmd/rollout/rollout.go
+++ b/pkg/oc/cli/cmd/rollout/rollout.go
@@ -136,7 +136,7 @@ var (
     Any image triggers present in the rolled back configuration will be disabled
     with a warning. This is to help prevent your rolled back deployment from being
     replaced by a triggered deployment soon after your rollback. To re-enable the
-    triggers, use the 'deploy --enable-triggers' command.
+    triggers, use the 'oc set triggers --auto' command.
 
     If you would like to review the outcome of the rollback, pass '--dry-run' to print
     a human-readable representation of the updated deployment configuration instead of


### PR DESCRIPTION
Since the 'oc deploy' is deprecated. It is better for providing usag  'oc set trigger'. Forgetting the 'oc deploy'