### PR TITLE
Fix cross build

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -190,6 +190,19 @@
 
   {
     "checkedPackages": [
+      "github.com/openshift/origin/pkg/network/master",
+      "github.com/openshift/origin/pkg/network/common"
+    ],
+    "forbiddenImportPackageRoots": [
+      "vendor/github.com/vishvananda/netlink"
+    ],
+    "allowedImportPackageRoots": [
+      ""
+    ]
+  },
+
+  {
+    "checkedPackages": [
       "github.com/openshift/origin/pkg/network/apis/network",
       "github.com/openshift/origin/pkg/network/apis/network/v1"
     ],

--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -22,8 +22,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
-
-	"github.com/vishvananda/netlink"
 )
 
 func HostSubnetToString(subnet *networkapi.HostSubnet) string {
@@ -279,35 +277,4 @@ func RegisterSharedInformerEventHandlers(kubeInformers kinternalinformers.Shared
 			delFunc(obj)
 		},
 	})
-}
-
-var (
-	ErrorNetworkInterfaceNotFound = fmt.Errorf("could not find network interface")
-)
-
-func GetLinkDetails(ip string) (netlink.Link, *net.IPNet, error) {
-	links, err := netlink.LinkList()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	for _, link := range links {
-		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
-		if err != nil {
-			glog.Warningf("Could not get addresses of interface %q: %v", link.Attrs().Name, err)
-			continue
-		}
-
-		for _, addr := range addrs {
-			if addr.IP.String() == ip {
-				_, ipNet, err := net.ParseCIDR(addr.IPNet.String())
-				if err != nil {
-					return nil, nil, fmt.Errorf("could not parse CIDR network from address %q: %v", ip, err)
-				}
-				return link, ipNet, nil
-			}
-		}
-	}
-
-	return nil, nil, ErrorNetworkInterfaceNotFound
 }

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -72,7 +72,7 @@ func newEgressIPWatcher(localIP string, oc *ovsController) *egressIPWatcher {
 
 func (eip *egressIPWatcher) Start(networkClient networkclient.Interface, iptables *NodeIPTables) error {
 	var err error
-	if eip.localEgressLink, eip.localEgressNet, err = common.GetLinkDetails(eip.localIP); err != nil {
+	if eip.localEgressLink, eip.localEgressNet, err = GetLinkDetails(eip.localIP); err != nil {
 		// Not expected, should already be caught by node.New()
 		return err
 	}


### PR DESCRIPTION
#17043 broke the cross build by depending on netlink from pkg/network/common. This fixes that (by just moving the new function since it wasn't needed outside of pkg/network/node anyway).
