### PR TITLE
Check all headers in TestOAuthServerHeaders

### DIFF
--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -335,7 +335,7 @@ var DefaultFormRenderer = grantTemplateRenderer{}
 type grantTemplateRenderer struct{}
 
 func (r grantTemplateRenderer) Render(form Form, w http.ResponseWriter, req *http.Request) {
-	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
+	w.Header().Add("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 
 	if err := defaultGrantTemplate.Execute(w, form); err != nil {

--- a/pkg/auth/server/headers/headers.go
+++ b/pkg/auth/server/headers/headers.go
@@ -5,7 +5,6 @@ import (
 )
 
 func SetStandardHeaders(w http.ResponseWriter) {
-
 	// We cannot set HSTS by default, it has too many drawbacks in environments
 	// that use self-signed certs
 	standardHeaders := map[string]string{


### PR DESCRIPTION
This change makes it so that all headers are verified in TestOAuthServerHeaders.  This prevents any situations in which a new header is added to the OAuth HTML pages without causing this test to fail.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/kind bug
/assign @simo5