### PR TITLE
merge imagestreamtag list on patch

### DIFF
--- a/api/protobuf-spec/github_com_openshift_origin_pkg_image_apis_image_v1.proto
+++ b/api/protobuf-spec/github_com_openshift_origin_pkg_image_apis_image_v1.proto
@@ -270,6 +270,8 @@ message ImageStreamSpec {
   optional string dockerImageRepository = 1;
 
   // tags map arbitrary string values to specific image locators
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated TagReference tags = 2;
 }
 
@@ -286,6 +288,8 @@ message ImageStreamStatus {
 
   // Tags are a historical record of images associated with each tag. The first entry in the
   // TagEvent array is the currently tagged image.
+  // +patchMergeKey=tag
+  // +patchStrategy=merge
   repeated NamedTagEventList tags = 2;
 }
 

--- a/api/swagger-spec/openshift-openapi-spec.json
+++ b/api/swagger-spec/openshift-openapi-spec.json
@@ -90333,7 +90333,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/com.github.openshift.origin.pkg.image.apis.image.v1.TagReference"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      }
     }
    },
@@ -90356,7 +90358,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/com.github.openshift.origin.pkg.image.apis.image.v1.NamedTagEventList"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "tag",
+      "x-kubernetes-patch-strategy": "merge"
      }
     }
    },

--- a/pkg/image/apis/image/v1/generated.proto
+++ b/pkg/image/apis/image/v1/generated.proto
@@ -270,6 +270,8 @@ message ImageStreamSpec {
   optional string dockerImageRepository = 1;
 
   // tags map arbitrary string values to specific image locators
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated TagReference tags = 2;
 }
 
@@ -286,6 +288,8 @@ message ImageStreamStatus {
 
   // Tags are a historical record of images associated with each tag. The first entry in the
   // TagEvent array is the currently tagged image.
+  // +patchMergeKey=tag
+  // +patchStrategy=merge
   repeated NamedTagEventList tags = 2;
 }
 

--- a/pkg/image/apis/image/v1/types.go
+++ b/pkg/image/apis/image/v1/types.go
@@ -184,7 +184,9 @@ type ImageStreamSpec struct {
 	// Specify the source for the tags to be imported in each tag via the spec.tags.from reference instead.
 	DockerImageRepository string `json:"dockerImageRepository,omitempty" protobuf:"bytes,1,opt,name=dockerImageRepository"`
 	// tags map arbitrary string values to specific image locators
-	Tags []TagReference `json:"tags,omitempty" protobuf:"bytes,2,rep,name=tags"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Tags []TagReference `json:"tags,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=tags"`
 }
 
 // ImageLookupPolicy describes how an image stream can be used to override the image references
@@ -272,7 +274,9 @@ type ImageStreamStatus struct {
 	PublicDockerImageRepository string `json:"publicDockerImageRepository,omitempty" protobuf:"bytes,3,opt,name=publicDockerImageRepository"`
 	// Tags are a historical record of images associated with each tag. The first entry in the
 	// TagEvent array is the currently tagged image.
-	Tags []NamedTagEventList `json:"tags,omitempty" protobuf:"bytes,2,rep,name=tags"`
+	// +patchMergeKey=tag
+	// +patchStrategy=merge
+	Tags []NamedTagEventList `json:"tags,omitempty" patchStrategy:"merge" patchMergeKey:"tag" protobuf:"bytes,2,rep,name=tags"`
 }
 
 // NamedTagEventList relates a tag to its image history.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -6136,6 +6136,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"tags": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "tags map arbitrary string values to specific image locators",
 								Type:        []string{"array"},
@@ -6174,6 +6180,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"tags": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "tag",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Tags are a historical record of images associated with each tag. The first entry in the TagEvent array is the currently tagged image.",
 								Type:        []string{"array"},

--- a/test/testdata/images/modified-ruby-imagestream.json
+++ b/test/testdata/images/modified-ruby-imagestream.json
@@ -1,0 +1,38 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "ruby",
+    "annotations": {
+      "openshift.io/display-name": "Ruby"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "2.4",
+        "annotations": {
+          "openshift.io/display-name": "Ruby Patched",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Ruby 2.4 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-ruby",
+          "tags": "builder,ruby",
+          "supports": "ruby:2.4,ruby",
+          "version": "2.4 patched",
+          "sampleRepo": "https://github.com/openshift/ruby-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-24-centos7:latest"
+        }
+      },
+      {
+        "name": "newtag",
+        "from": {
+          "kind": "DockerImage",
+          "name": "centos/ruby-24-centos7:latest"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This will ensure we don't drop spec tags when applying a new set of imagestreams that is not a superset of the existing spec tags.

related to https://bugzilla.redhat.com/show_bug.cgi?id=1507031
