### PR TITLE
Fix up destination MAC of auto-egress-ip packets

### DIFF
--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -160,7 +160,7 @@ func TestEgressIP(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=100", "reg0=44", "0xac110066->pkt_mark", "output:2"},
+			match: []string{"table=100", "reg0=44", "0xac110066->pkt_mark", "goto_table:101"},
 		},
 	)
 	if err != nil {
@@ -195,7 +195,7 @@ func TestEgressIP(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=100", "reg0=45", "0xac110067->pkt_mark", "output:2"},
+			match: []string{"table=100", "reg0=45", "0xac110067->pkt_mark", "goto_table:101"},
 		},
 	)
 	if err != nil {
@@ -216,7 +216,7 @@ func TestEgressIP(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowRemoved,
-			match: []string{"table=100", "reg0=44", "0xac110066->pkt_mark", "output:2"},
+			match: []string{"table=100", "reg0=44", "0xac110066->pkt_mark", "goto_table:101"},
 		},
 	)
 	if err != nil {
@@ -262,7 +262,7 @@ func TestEgressIP(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowRemoved,
-			match: []string{"table=100", "reg0=45", "0xac110067->pkt_mark", "output:2"},
+			match: []string{"table=100", "reg0=45", "0xac110067->pkt_mark", "goto_table:101"},
 		},
 		flowChange{
 			kind:  flowAdded,

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -704,7 +704,7 @@ func (oc *ovsController) UpdateNamespaceEgressRules(vnid uint32, nodeIP, egressH
 		otx.AddFlow("table=100, priority=100, reg0=%d, actions=drop", vnid)
 	} else if nodeIP == oc.localIP {
 		// Local Egress IP
-		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=set_field:%s->eth_dst,set_field:%s->pkt_mark,output:2", vnid, oc.tunMAC, egressHex)
+		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=set_field:%s->eth_dst,set_field:%s->pkt_mark,goto_table:101", vnid, oc.tunMAC, egressHex)
 	} else {
 		// Remote Egress IP; send via VXLAN
 		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", vnid, nodeIP)

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -18,6 +18,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/api"
+
+	"github.com/vishvananda/netlink"
 )
 
 type ovsController struct {
@@ -25,6 +27,7 @@ type ovsController struct {
 	pluginId     int
 	useConnTrack bool
 	localIP      string
+	tunMAC       string
 }
 
 const (
@@ -83,6 +86,13 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	if err != nil {
 		return err
 	}
+	if oc.tunMAC == "" {
+		link, err := netlink.LinkByName(Tun0)
+		if err != nil {
+			return err
+		}
+		oc.tunMAC = link.Attrs().HardwareAddr.String()
+	}
 
 	otx := oc.ovs.NewTransaction()
 
@@ -94,6 +104,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	for _, clusterCIDR := range clusterNetworkCIDR {
 		otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterCIDR, localSubnetCIDR)
 		otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_src=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterCIDR)
+		otx.AddFlow("table=0, priority=200, in_port=1, ip, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterCIDR)
 	}
 	otx.AddFlow("table=0, priority=150, in_port=1, actions=drop")
 	// tun0
@@ -693,7 +704,7 @@ func (oc *ovsController) UpdateNamespaceEgressRules(vnid uint32, nodeIP, egressH
 		otx.AddFlow("table=100, priority=100, reg0=%d, actions=drop", vnid)
 	} else if nodeIP == oc.localIP {
 		// Local Egress IP
-		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=set_field:%s->pkt_mark,output:2", vnid, egressHex)
+		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=set_field:%s->eth_dst,set_field:%s->pkt_mark,output:2", vnid, oc.tunMAC, egressHex)
 	} else {
 		// Remote Egress IP; send via VXLAN
 		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", vnid, nodeIP)

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -19,6 +19,7 @@ import (
 func setupOVSController(t *testing.T) (ovs.Interface, *ovsController, []string) {
 	ovsif := ovs.NewFake(Br0)
 	oc := NewOVSController(ovsif, 0, true, "172.17.0.4")
+	oc.tunMAC = "c6:ac:2c:13:48:4b"
 	err := oc.SetupOVS([]string{"10.128.0.0/14"}, "172.30.0.0/16", "10.128.0.0/23", "10.128.0.1")
 	if err != nil {
 		t.Fatalf("Unexpected error setting up OVS: %v", err)


### PR DESCRIPTION
Auto egress packets from pods on nodes other than the one with the egress IP were getting dropped. This turns out to be because the packets will be ignored if you output them on tun0 but they don't have tun0's MAC address as the destination MAC. (For local pods, the default route is via tun0, so the MAC is correct, but for remote pods, the default route is via the tun0 on their node, so the MAC was wrong for the node it eventually ended up on.) 

Also includes two other auto-egress-ip OVS flow fixes.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1501876
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1507871