### PR TITLE
unit-tests: fixed flake and race in image pruning 

### DIFF
--- a/pkg/oc/admin/prune/images_test.go
+++ b/pkg/oc/admin/prune/images_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -97,6 +98,7 @@ func TestImagePruneErrOnBadReference(t *testing.T) {
 		ImageClient:     imageFake.Image(),
 		KubeClient:      kFake,
 		DiscoveryClient: fakeDiscovery,
+		Timeout:         time.Millisecond,
 		Out:             ioutil.Discard,
 		ErrOut:          errBuf,
 	}


### PR DESCRIPTION
Resolves: https://github.com/openshift/origin/pull/16821#issuecomment-340758624