### PR TITLE
UPSTREAM: 49885: Ignore UDP metrics in kubelet

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -105,7 +105,7 @@ func New(port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string) (I
 	sysFs := sysfs.NewRealSysFs()
 
 	// Create and start the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}}, http.DefaultClient)
+	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}, cadvisormetrics.NetworkUdpUsageMetrics: struct{}{}}, http.DefaultClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
openshift-node seems to have high CPU usage during tests. This patch should fix that.

Upstream PR: https://github.com/kubernetes/kubernetes/pull/49885
Upstream issue: https://github.com/kubernetes/kubernetes/issues/54448

@sjug PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>