### PR TITLE
oc set probe err message improvements

### DIFF
--- a/pkg/oc/cli/cmd/set/probe.go
+++ b/pkg/oc/cli/cmd/set/probe.go
@@ -336,12 +336,12 @@ func (o *ProbeOptions) Run() error {
 
 		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch)
 		if err != nil {
-			handlePodUpdateError(o.Err, err, "probes")
-
 			// if no port was specified, inform that one must be provided
 			if len(o.HTTPGet) > 0 && len(o.HTTPGetAction.Port.String()) == 0 {
-				fmt.Fprintf(o.Err, "\nA port must be specified as part of a url (http://127.0.0.1:3306).\nSee 'oc set probe -h' for help and examples.\n")
+				fmt.Fprintf(o.Err, "A port must be specified as part of a url (http://127.0.0.1:3306).\n\nSee 'oc set probe -h' for help and examples.\n")
 			}
+			handlePodUpdateError(o.Err, err, "probes")
+
 			failed = true
 			continue
 		}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1332871

Low-sev bugfix. Improves error message of `oc set probe` to display
the main error cause at the top of the message, when a port is not
given as part of a --liveness url.

```
$ oc set probe -f test/testdata/simple-deployment.yaml --liveness --get-url="http://test.url"
A port must be specified as part of a url (http://127.0.0.1:3306).

See 'oc set probe -h' for help and examples.
error: DeploymentConfig "simple-deployment" is invalid

* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
* spec.template.spec.containers[0].livenessProbe.httpGet.port: Invalid value: "": must contain at least one letter or number (a-z, 0-9)
```

cc @openshift/cli-review 