### PR TITLE
Log OVS errors at a better level

### DIFF
--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -140,7 +140,7 @@ func (ovsif *ovsExec) exec(cmd string, args ...string) (string, error) {
 
 	output, err := ovsif.execer.Command(cmd, args...).CombinedOutput()
 	if err != nil {
-		glog.V(5).Infof("Error executing %s: %s", cmd, string(output))
+		glog.V(2).Infof("Error executing %s: %s", cmd, string(output))
 		return "", err
 	}
 


### PR DESCRIPTION
Since dind runs at --loglevel=4 now, we're missing out on OVS errors when things fail