### PR TITLE
prevent err message when removing env vars

### DIFF
--- a/pkg/oc/cli/cmd/set/env.go
+++ b/pkg/oc/cli/cmd/set/env.go
@@ -478,7 +478,7 @@ updates:
 
 		// make sure arguments to set or replace environment variables are set
 		// before returning a successful message
-		if len(env) == 0 && len(o.EnvArgs) == 0 {
+		if len(env) == 0 && len(o.EnvArgs) == 0 && len(remove) == 0 {
 			return fmt.Errorf("at least one environment variable must be provided")
 		}
 

--- a/test/cmd/env.sh
+++ b/test/cmd/env.sh
@@ -13,6 +13,12 @@ os::cmd::expect_failure_and_text 'oc set env dc --all --containers="node"' 'erro
 os::cmd::expect_failure_and_not_text 'oc set env --from=secret/mysecret dc/node' 'error: at least one environment variable must be provided'
 os::cmd::expect_failure_and_text 'oc set env dc/node test#abc=1234' 'environment variables must be of the form key=value'
 
+# ensure deleting a var through --env does not result in an error message
+os::cmd::expect_success_and_text 'oc set env dc/node key=value' 'deploymentconfig "node" updated'
+os::cmd::expect_success_and_text 'oc set env dc --all --containers="node" --env=key-' 'deploymentconfig "node" updated'
+# ensure deleting a var through --env actually deletes the env var
+os::cmd::expect_success_and_not_text "oc get dc/node -o jsonpath='{ .spec.template.spec.containers[?(@.name==\"node\")].env }'" 'name\:key'
+
 # check that env vars are not split at commas
 os::cmd::expect_success_and_text 'oc set env -o yaml dc/node PASS=x,y=z' 'value: x,y=z'
 os::cmd::expect_success_and_text 'oc set env -o yaml dc/node --env PASS=x,y=z' 'value: x,y=z'


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/17041

This patch updates `oc set env ...` to avoid returning an error message
when removing environment variables via the `--env` flag.

cc @openshift/cli-review 