### PR TITLE
Bug 1508061: Fix panic during openshift controller options initialization

### DIFF
--- a/pkg/cmd/server/start/start_kube_controller_manager.go
+++ b/pkg/cmd/server/start/start_kube_controller_manager.go
@@ -49,9 +49,11 @@ func kubeControllerManagerAddFlags(cmserver *controlleroptions.CMServer) func(fl
 	}
 }
 
-func newKubeControllerManager(kubeconfigFile, saPrivateKeyFile, saRootCAFile, podEvictionTimeout, recyclerImage string, dynamicProvisioningEnabled bool, cmdLineArgs map[string][]string) (*controlleroptions.CMServer, []func(), error) {
-	if cmdLineArgs == nil {
-		cmdLineArgs = map[string][]string{}
+func newKubeControllerManager(kubeconfigFile, saPrivateKeyFile, saRootCAFile, podEvictionTimeout, recyclerImage string, dynamicProvisioningEnabled bool, controllerArgs map[string][]string) (*controlleroptions.CMServer, []func(), error) {
+	cmdLineArgs := map[string][]string{}
+	// deep-copy the input args to avoid mutation conflict.
+	for k, v := range controllerArgs {
+		cmdLineArgs[k] = append([]string{}, v...)
 	}
 	cleanupFunctions := []func(){}
 

--- a/pkg/cmd/server/start/start_kube_scheduler.go
+++ b/pkg/cmd/server/start/start_kube_scheduler.go
@@ -11,9 +11,11 @@ import (
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 )
 
-func newScheduler(kubeconfigFile, schedulerConfigFile string, cmdLineArgs map[string][]string) (*scheduleroptions.SchedulerServer, error) {
-	if cmdLineArgs == nil {
-		cmdLineArgs = map[string][]string{}
+func newScheduler(kubeconfigFile, schedulerConfigFile string, schedulerArgs map[string][]string) (*scheduleroptions.SchedulerServer, error) {
+	cmdLineArgs := map[string][]string{}
+	// deep-copy the input args to avoid mutation conflict.
+	for k, v := range schedulerArgs {
+		cmdLineArgs[k] = append([]string{}, v...)
 	}
 	if len(cmdLineArgs["kubeconfig"]) == 0 {
 		cmdLineArgs["kubeconfig"] = []string{kubeconfigFile}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1508061

Basically `newKubeControllerManager` mutates the cmdLineArgs in parallel to `getOpenshiftControllerOptions` which is trying to read it.

@deads2k @sttts PTAL, i consider this 3.7 blocker.