### PR TITLE
bug 1492562. Add etcd section to logging and metrics inventory for 'o…

### DIFF
--- a/pkg/bootstrap/docker/openshift/ansible.go
+++ b/pkg/bootstrap/docker/openshift/ansible.go
@@ -50,6 +50,9 @@ openshift_metrics_hawkular_hostname={{.HawkularHostName}}
 
 [nodes]
 {{.MasterIP}}
+
+[etcd]
+{{.MasterIP}}
 `
 
 const defaultLoggingInventory = `
@@ -80,6 +83,9 @@ openshift_logging_kibana_hostname={{.KibanaHostName}}
 {{.MasterIP}} ansible_connection=local
 
 [nodes]
+{{.MasterIP}}
+
+[etcs]
 {{.MasterIP}}
 `
 


### PR DESCRIPTION
…c cluster up'

This is a 3.6 backport for #17036 