### PR TITLE
Partially revert node IP startup check

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -74,7 +74,7 @@ func (eip *egressIPWatcher) Start(networkClient networkclient.Interface, iptable
 	var err error
 	if eip.localEgressLink, eip.localEgressNet, err = GetLinkDetails(eip.localIP); err != nil {
 		// Not expected, should already be caught by node.New()
-		return err
+		return nil
 	}
 
 	eip.iptables = iptables

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -224,10 +224,9 @@ func (c *OsdnNodeConfig) setNodeIP() error {
 
 	if _, _, err := GetLinkDetails(c.SelfIP); err != nil {
 		if err == ErrorNetworkInterfaceNotFound {
-			return fmt.Errorf("node IP %q is not a local/private address (hostname %q)", c.SelfIP, c.Hostname)
-		} else {
-			return err
+			err = fmt.Errorf("node IP %q is not a local/private address (hostname %q)", c.SelfIP, c.Hostname)
 		}
+		glog.Errorf("Unable to find network interface for node IP; some features will not work! (%v)", err)
 	}
 
 	return nil


### PR DESCRIPTION
Forcing the node to have a valid nodeIP/nodeName is breaking a bunch of QE tests (that set an invalid nodeIP but don't depend on any of the features that get broken by doing that). Rather than force them to fix them all right when they need to be doing actual 3.7 testing, we'll revert the check until after 3.7 branches.
