### PR TITLE
newapp - retain ordering of env vars

### DIFF
--- a/pkg/generate/app/cmd/newapp.go
+++ b/pkg/generate/app/cmd/newapp.go
@@ -491,7 +491,7 @@ func (c *AppConfig) buildTemplates(components app.ComponentReferences, parameter
 		if len(c.ContextDir) > 0 {
 			return "", nil, fmt.Errorf("--context-dir is not supported when using a template")
 		}
-		result, err := TransformTemplate(tpl, templateProcessor, c.OriginNamespace, parameters, c.IgnoreUnknownParameters)
+		result, err := TransformTemplate(tpl, templateProcessor, c.OriginNamespace, parameters.Map(), c.IgnoreUnknownParameters)
 		if err != nil {
 			return name, nil, err
 		}

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -141,7 +141,7 @@ func TestValidate(t *testing.T) {
 		if len(env) != len(c.env) {
 			t.Errorf("%s: Environment variables don't match. Expected: %v, Got: %v", n, c.env, env)
 		}
-		for e, v := range env {
+		for e, v := range env.Map() {
 			if c.env[e] != v {
 				t.Errorf("%s: Environment variables don't match. Expected: %v, Got: %v", n, c.env, env)
 				break
@@ -150,7 +150,7 @@ func TestValidate(t *testing.T) {
 		if len(buildEnv) != len(c.buildEnv) {
 			t.Errorf("%s: Environment variables don't match. Expected: %v, Got: %v", n, c.buildEnv, buildEnv)
 		}
-		for e, v := range buildEnv {
+		for e, v := range buildEnv.Map() {
 			if c.buildEnv[e] != v {
 				t.Errorf("%s: Environment variables don't match. Expected: %v, Got: %v", n, c.buildEnv, buildEnv)
 				break
@@ -159,7 +159,7 @@ func TestValidate(t *testing.T) {
 		if len(parms) != len(c.parms) {
 			t.Errorf("%s: Template parameters don't match. Expected: %v, Got: %v", n, c.parms, parms)
 		}
-		for p, v := range parms {
+		for p, v := range parms.Map() {
 			if c.parms[p] != v {
 				t.Errorf("%s: Template parameters don't match. Expected: %v, Got: %v", n, c.parms, parms)
 				break
@@ -217,7 +217,7 @@ func TestBuildTemplates(t *testing.T) {
 			t.Errorf("%s: Unexpected error: %v", n, err)
 			continue
 		}
-		_, _, err = appCfg.buildTemplates(components, app.Environment(parms), app.Environment(map[string]string{}), app.Environment(map[string]string{}), fakeTemplateProcessor{})
+		_, _, err = appCfg.buildTemplates(components, app.Environment(parms), app.Environment{}, app.Environment{}, fakeTemplateProcessor{})
 		if err != nil {
 			t.Errorf("%s: Unexpected error: %v", n, err)
 		}
@@ -232,7 +232,7 @@ func TestBuildTemplates(t *testing.T) {
 			if len(parms) != len(c.parms) {
 				t.Errorf("%s: Template parameters don't match. Expected: %v, Got: %v", n, c.parms, parms)
 			}
-			for p, v := range parms {
+			for p, v := range parms.Map() {
 				if c.parms[p] != v {
 					t.Errorf("%s: Template parameters don't match. Expected: %v, Got: %v", n, c.parms, parms)
 					break

--- a/pkg/generate/appjson/appjson.go
+++ b/pkg/generate/appjson/appjson.go
@@ -103,10 +103,10 @@ func (g *Generator) Generate(body []byte) (*templateapi.Template, error) {
 	template.Annotations["iconURL"] = appJSON.Logo
 
 	// create parameters and environment for containers
-	allEnv := make(app.Environment)
+	allEnv := make(app.Environment, 0)
 	for k, v := range appJSON.Env {
 		if v.EnvVar != nil {
-			allEnv[k] = fmt.Sprintf("${%s}", k)
+			allEnv.Add(k, fmt.Sprintf("${%s}", k))
 		}
 	}
 	envVars := allEnv.List()

--- a/pkg/ipfailover/keepalived/generator.go
+++ b/pkg/ipfailover/keepalived/generator.go
@@ -22,10 +22,7 @@ func generateEnvEntries(name string, options *ipfailover.IPFailoverConfigCmdOpti
 	replicas := strconv.FormatInt(int64(options.Replicas), 10)
 	interval := strconv.Itoa(options.CheckInterval)
 	VRRPIDOffset := strconv.Itoa(options.VRRPIDOffset)
-	env := app.Environment{}
-
-	env.Add(app.Environment{
-
+	env := map[string]string{
 		"OPENSHIFT_HA_CONFIG_NAME":       name,
 		"OPENSHIFT_HA_VIRTUAL_IPS":       options.VirtualIPs,
 		"OPENSHIFT_HA_NETWORK_INTERFACE": options.NetworkInterface,
@@ -39,8 +36,8 @@ func generateEnvEntries(name string, options *ipfailover.IPFailoverConfigCmdOpti
 		"OPENSHIFT_HA_PREEMPTION":        options.Preemption,
 		"OPENSHIFT_HA_CHECK_INTERVAL":    interval,
 		// "OPENSHIFT_HA_UNICAST_PEERS":     "127.0.0.1",
-	})
-	return env
+	}
+	return app.NewEnvironmentFromMap(env)
 }
 
 //  Generate the IP failover monitor (keepalived) container configuration.

--- a/pkg/oc/admin/registry/registry.go
+++ b/pkg/oc/admin/registry/registry.go
@@ -336,14 +336,14 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 	healthzPort := defaultPort
 	if len(opts.ports) > 0 {
 		healthzPort = int(opts.ports[0].ContainerPort)
-		env["REGISTRY_HTTP_ADDR"] = fmt.Sprintf(":%d", healthzPort)
-		env["REGISTRY_HTTP_NET"] = "tcp"
+		env.Add("REGISTRY_HTTP_ADDR", fmt.Sprintf(":%d", healthzPort))
+		env.Add("REGISTRY_HTTP_NET", "tcp")
 	}
 	secrets, volumes, mounts, extraEnv, tls, err := generateSecretsConfig(opts.Config, servingCert, servingKey)
 	if err != nil {
 		return err
 	}
-	env.Add(extraEnv)
+	env.AddEnvs(extraEnv)
 
 	livenessProbe := generateLivenessProbeConfig(healthzPort, tls)
 	readinessProbe := generateReadinessProbeConfig(healthzPort, tls)
@@ -555,10 +555,8 @@ func generateSecretsConfig(
 		}
 		mounts = append(mounts, mount)
 
-		extraEnv.Add(app.Environment{
-			"REGISTRY_HTTP_TLS_CERTIFICATE": path.Join(defaultCertificateDir, kapi.TLSCertKey),
-			"REGISTRY_HTTP_TLS_KEY":         path.Join(defaultCertificateDir, kapi.TLSPrivateKeyKey),
-		})
+		extraEnv.Add("REGISTRY_HTTP_TLS_CERTIFICATE", path.Join(defaultCertificateDir, kapi.TLSCertKey))
+		extraEnv.Add("REGISTRY_HTTP_TLS_KEY", path.Join(defaultCertificateDir, kapi.TLSPrivateKeyKey))
 	}
 
 	secretBytes := make([]byte, randomSecretSize)
@@ -566,7 +564,7 @@ func generateSecretsConfig(
 		return nil, nil, nil, nil, false, fmt.Errorf("registry does not exist; could not generate random bytes for HTTP secret: %v", err)
 	}
 	httpSecretString := base64.StdEncoding.EncodeToString(secretBytes)
-	extraEnv["REGISTRY_HTTP_SECRET"] = httpSecretString
+	extraEnv.Add("REGISTRY_HTTP_SECRET", httpSecretString)
 
 	return secrets, volumes, mounts, extraEnv, len(defaultCrt) > 0, nil
 }

--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -638,39 +638,39 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 		}
 	}
 
-	env := app.Environment{
-		"ROUTER_SUBDOMAIN":                      cfg.Subdomain,
-		"ROUTER_SERVICE_NAME":                   name,
-		"ROUTER_SERVICE_NAMESPACE":              namespace,
-		"ROUTER_SERVICE_HTTP_PORT":              "80",
-		"ROUTER_SERVICE_HTTPS_PORT":             "443",
-		"ROUTER_EXTERNAL_HOST_HOSTNAME":         cfg.ExternalHost,
-		"ROUTER_EXTERNAL_HOST_USERNAME":         cfg.ExternalHostUsername,
-		"ROUTER_EXTERNAL_HOST_PASSWORD":         cfg.ExternalHostPassword,
-		"ROUTER_EXTERNAL_HOST_HTTP_VSERVER":     cfg.ExternalHostHttpVserver,
-		"ROUTER_EXTERNAL_HOST_HTTPS_VSERVER":    cfg.ExternalHostHttpsVserver,
-		"ROUTER_EXTERNAL_HOST_INSECURE":         strconv.FormatBool(cfg.ExternalHostInsecure),
-		"ROUTER_EXTERNAL_HOST_PARTITION_PATH":   cfg.ExternalHostPartitionPath,
-		"ROUTER_EXTERNAL_HOST_PRIVKEY":          privkeyPath,
-		"ROUTER_EXTERNAL_HOST_INTERNAL_ADDRESS": cfg.ExternalHostInternalIP,
-		"ROUTER_EXTERNAL_HOST_VXLAN_GW_CIDR":    cfg.ExternalHostVxLANGateway,
-		"ROUTER_CIPHERS":                        cfg.Ciphers,
-		"STATS_PORT":                            strconv.Itoa(cfg.StatsPort),
-		"STATS_USERNAME":                        cfg.StatsUsername,
-		"STATS_PASSWORD":                        cfg.StatsPassword,
-	}
+	env := app.Environment{}
+	env.Add("ROUTER_SUBDOMAIN", cfg.Subdomain)
+	env.Add("ROUTER_SERVICE_NAME", name)
+	env.Add("ROUTER_SERVICE_NAMESPACE", namespace)
+	env.Add("ROUTER_SERVICE_HTTP_PORT", "80")
+	env.Add("ROUTER_SERVICE_HTTPS_PORT", "443")
+	env.Add("ROUTER_EXTERNAL_HOST_HOSTNAME", cfg.ExternalHost)
+	env.Add("ROUTER_EXTERNAL_HOST_USERNAME", cfg.ExternalHostUsername)
+	env.Add("ROUTER_EXTERNAL_HOST_PASSWORD", cfg.ExternalHostPassword)
+	env.Add("ROUTER_EXTERNAL_HOST_HTTP_VSERVER", cfg.ExternalHostHttpVserver)
+	env.Add("ROUTER_EXTERNAL_HOST_HTTPS_VSERVER", cfg.ExternalHostHttpsVserver)
+	env.Add("ROUTER_EXTERNAL_HOST_INSECURE", strconv.FormatBool(cfg.ExternalHostInsecure))
+	env.Add("ROUTER_EXTERNAL_HOST_PARTITION_PATH", cfg.ExternalHostPartitionPath)
+	env.Add("ROUTER_EXTERNAL_HOST_PRIVKEY", privkeyPath)
+	env.Add("ROUTER_EXTERNAL_HOST_INTERNAL_ADDRESS", cfg.ExternalHostInternalIP)
+	env.Add("ROUTER_EXTERNAL_HOST_VXLAN_GW_CIDR", cfg.ExternalHostVxLANGateway)
+	env.Add("ROUTER_CIPHERS", cfg.Ciphers)
+	env.Add("STATS_PORT", strconv.Itoa(cfg.StatsPort))
+	env.Add("STATS_USERNAME", cfg.StatsUsername)
+	env.Add("STATS_PASSWORD", cfg.StatsPassword)
+
 	if len(cfg.MaxConnections) > 0 {
-		env["ROUTER_MAX_CONNECTIONS"] = cfg.MaxConnections
+		env.Add("ROUTER_MAX_CONNECTIONS", cfg.MaxConnections)
 	}
 	if len(cfg.ForceSubdomain) > 0 {
-		env["ROUTER_SUBDOMAIN"] = cfg.ForceSubdomain
-		env["ROUTER_OVERRIDE_HOSTNAME"] = "true"
+		env.Add("ROUTER_SUBDOMAIN", cfg.ForceSubdomain)
+		env.Add("ROUTER_OVERRIDE_HOSTNAME", "true")
 	}
 	if cfg.DisableNamespaceOwnershipCheck {
-		env["ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK"] = "true"
+		env.Add("ROUTER_DISABLE_NAMESPACE_OWNERSHIP_CHECK", "true")
 	}
 	if cfg.StrictSNI {
-		env["ROUTER_STRICT_SNI"] = "true"
+		env.Add("ROUTER_STRICT_SNI", "true")
 	}
 	if len(cfg.RouterCanonicalHostname) > 0 {
 		if errs := validation.IsDNS1123Subdomain(cfg.RouterCanonicalHostname); len(errs) != 0 {
@@ -679,22 +679,22 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 		if errs := validation.IsValidIP(cfg.RouterCanonicalHostname); len(errs) == 0 {
 			return fmt.Errorf("canonical hostname must not be an IP address: %s", cfg.RouterCanonicalHostname)
 		}
-		env["ROUTER_CANONICAL_HOSTNAME"] = cfg.RouterCanonicalHostname
+		env.Add("ROUTER_CANONICAL_HOSTNAME", cfg.RouterCanonicalHostname)
 	}
 	// automatically start the internal metrics agent if we are handling a known type
 	if cfg.Type == "haproxy-router" && cfg.StatsPort != 0 {
-		env["ROUTER_LISTEN_ADDR"] = fmt.Sprintf("0.0.0.0:%d", cfg.StatsPort)
-		env["ROUTER_METRICS_TYPE"] = "haproxy"
+		env.Add("ROUTER_LISTEN_ADDR", fmt.Sprintf("0.0.0.0:%d", cfg.StatsPort))
+		env.Add("ROUTER_METRICS_TYPE", "haproxy")
 	}
-	env.Add(secretEnv)
+	env.AddEnvs(secretEnv)
 	if len(defaultCert) > 0 {
 		if cfg.SecretsAsEnv {
-			env.Add(app.Environment{"DEFAULT_CERTIFICATE": string(defaultCert)})
+			env.Add("DEFAULT_CERTIFICATE", string(defaultCert))
 		} else {
-			env.Add(app.Environment{"DEFAULT_CERTIFICATE_PATH": defaultCertificatePath})
+			env.Add("DEFAULT_CERTIFICATE_PATH", defaultCertificatePath)
 		}
 	}
-	env.Add(app.Environment{"DEFAULT_CERTIFICATE_DIR": defaultCertificateDir})
+	env.Add("DEFAULT_CERTIFICATE_DIR", defaultCertificateDir)
 	var certName = fmt.Sprintf("%s-certs", cfg.Name)
 	secrets, volumes, mounts, err := generateSecretsConfig(cfg, namespace, defaultCert, certName)
 	if err != nil {

--- a/pkg/oc/cli/cmd/process.go
+++ b/pkg/oc/cli/cmd/process.go
@@ -353,7 +353,7 @@ func RunProcess(f *clientcmd.Factory, in io.Reader, out, errout io.Writer, cmd *
 // injectUserVars injects user specified variables into the Template
 func injectUserVars(values app.Environment, t *templateapi.Template, ignoreUnknownParameters bool) []error {
 	var errors []error
-	for param, val := range values {
+	for param, val := range values.Map() {
 		v := template.GetParameterByName(t, param)
 		if v != nil {
 			v.Value = val

--- a/pkg/oc/cli/cmd/process_test.go
+++ b/pkg/oc/cli/cmd/process_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	"testing"
+
+	"github.com/openshift/origin/pkg/generate/app"
+	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
 
 func TestInjectUserVars(t *testing.T) {
@@ -19,7 +21,7 @@ func TestInjectUserVars(t *testing.T) {
 		"parameter_foo_bar_error":    "value_foo_bar_error=value_foo_bar_error",
 	}
 
-	errors := injectUserVars(testParam, template, false)
+	errors := injectUserVars(app.NewEnvironmentFromMap(testParam), template, false)
 	if len(errors) != 2 {
 		for index, err := range errors {
 			fmt.Printf("errors[%d] : %v\n", index, err)


### PR DESCRIPTION
Changes the underlying structure of the Environment type to
a slice instead of a map.

Fixes bz 1430277