### PR TITLE
Avoid compiling all of kube twice for images

### DIFF
--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -69,10 +69,11 @@ if [[ -n "${OS_ONLY_BUILD_PLATFORMS-}" ]]; then
 fi
 
 # Build image binaries for a subset of platforms. Image binaries are currently
-# linux-only, and are compiled with flags to make them static for use in Docker
-# images "FROM scratch".
+# linux-only, and a subset of them are compiled with flags to make them static
+# for use in Docker images "FROM scratch".
 OS_BUILD_PLATFORMS=("${image_platforms[@]+"${image_platforms[@]}"}")
-os::build::build_static_binaries "${OS_IMAGE_COMPILE_TARGETS_LINUX[@]-}" "${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]-}"
+os::build::build_static_binaries "${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]-}"
+os::build::build_binaries "${OS_IMAGE_COMPILE_TARGETS_LINUX[@]-}"
 
 # Build the primary client/server for all platforms
 OS_BUILD_PLATFORMS=("${platforms[@]+"${platforms[@]}"}")

--- a/hack/lib/build/constants.sh
+++ b/hack/lib/build/constants.sh
@@ -24,13 +24,13 @@ readonly OS_SDN_COMPILE_TARGETS_LINUX=(
   vendor/github.com/containernetworking/cni/plugins/main/loopback
 )
 readonly OS_IMAGE_COMPILE_TARGETS_LINUX=(
-  images/pod
   cmd/dockerregistry
   cmd/gitserver
   vendor/k8s.io/kubernetes/cmd/hyperkube
   "${OS_SDN_COMPILE_TARGETS_LINUX[@]}"
 )
 readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX=(
+  images/pod
   examples/hello-openshift
 )
 readonly OS_IMAGE_COMPILE_BINARIES=("${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]##*/}" "${OS_IMAGE_COMPILE_TARGETS_LINUX[@]##*/}")


### PR DESCRIPTION
CGO_ENABLED=1/0 causes common packages to be rebuilt. Build the small
static binaries first, then the others (which are not placed inside of
scratch images) second.