### PR TITLE
Avoid creating release archives in RPM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,6 @@ official-release: build-images build-cross
 # Example:
 #   make release
 release: build-images
-	hack/extract-release.sh
 .PHONY: release
 
 # Build the cross compiled release binaries

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -82,17 +82,25 @@ os::build::build_binaries "${OS_CROSS_COMPILE_TARGETS[@]}"
 OS_BUILD_PLATFORMS=("${test_platforms[@]+"${test_platforms[@]}"}")
 os::build::build_binaries "${OS_TEST_TARGETS[@]}"
 
-# Make the primary client/server release.
-OS_BUILD_PLATFORMS=("${platforms[@]+"${platforms[@]}"}")
-OS_RELEASE_ARCHIVE="openshift-origin" \
-  os::build::place_bins "${OS_CROSS_COMPILE_BINARIES[@]}"
+if [[ "${OS_BUILD_RELEASE_ARCHIVES-}" != "n" ]]; then
+  # Make the primary client/server release.
+  OS_BUILD_PLATFORMS=("${platforms[@]+"${platforms[@]}"}")
+  OS_RELEASE_ARCHIVE="openshift-origin" \
+    os::build::place_bins "${OS_CROSS_COMPILE_BINARIES[@]}"
 
-# Make the image binaries release.
-OS_BUILD_PLATFORMS=("${image_platforms[@]+"${image_platforms[@]}"}")
-OS_RELEASE_ARCHIVE="openshift-origin-image" \
-  os::build::place_bins "${OS_IMAGE_COMPILE_BINARIES[@]}"
+  # Make the image binaries release.
+  OS_BUILD_PLATFORMS=("${image_platforms[@]+"${image_platforms[@]}"}")
+  OS_RELEASE_ARCHIVE="openshift-origin-image" \
+    os::build::place_bins "${OS_IMAGE_COMPILE_BINARIES[@]}"
 
-os::build::release_sha
+  os::build::release_sha
+else
+  # Place binaries only
+  OS_BUILD_PLATFORMS=("${platforms[@]+"${platforms[@]}"}") \
+    os::build::place_bins "${OS_CROSS_COMPILE_BINARIES[@]}"
+  OS_BUILD_PLATFORMS=("${image_platforms[@]+"${image_platforms[@]}"}") \
+    os::build::place_bins "${OS_IMAGE_COMPILE_BINARIES[@]}"
+fi
 
 if [[ "${OS_GIT_TREE_STATE:-dirty}" == "clean"  ]]; then
 	# only when we are building from a clean state can we claim to

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -97,6 +97,7 @@ os::build::release_sha
 if [[ "${OS_GIT_TREE_STATE:-dirty}" == "clean"  ]]; then
 	# only when we are building from a clean state can we claim to
 	# have created a valid set of binaries that can resemble a release
+  mkdir -p "${OS_OUTPUT_RELEASEPATH}"
 	echo "${OS_GIT_COMMIT}" > "${OS_OUTPUT_RELEASEPATH}/.commit"
 fi
 

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -18,8 +18,6 @@ trap "cleanup" EXIT
 os::util::ensure::gopath_binary_exists imagebuilder
 # image builds require RPMs to have been built
 os::build::release::check_for_rpms
-# OS_RELEASE_COMMIT is required by image-build
-os::build::archive::detect_local_release_tars $(os::build::host_platform_friendly)
 
 # we need to mount RPMs into the container builds for installation
 OS_BUILD_IMAGE_ARGS="${OS_BUILD_IMAGE_ARGS:-} -mount ${OS_OUTPUT_RPMPATH}/:/srv/origin-local-release/"

--- a/hack/build-rpm-release.sh
+++ b/hack/build-rpm-release.sh
@@ -60,7 +60,6 @@ if [[ -z "${tito_output_directory}" ]]; then
         os::log::fatal 'No _output artifact directory found in tito rpmbuild artifacts!'
 fi
 
-# clean up our local state so we can unpack the tito artifacts cleanly
 make clean
 
 # migrate the tito artifacts to the Origin directory
@@ -78,9 +77,12 @@ else
   cp -R "${tito_output_directory}"/* "${OS_OUTPUT}"
   rm -rf "${tito_output_directory}"/*
 fi
+
 mkdir -p "${OS_OUTPUT_RPMPATH}"
-mv "${tito_tmp_dir}"/*src.rpm "${OS_OUTPUT_RPMPATH}"
-mv "${tito_tmp_dir}"/*/*.rpm "${OS_OUTPUT_RPMPATH}"
+mv -f "${tito_tmp_dir}"/*src.rpm "${OS_OUTPUT_RPMPATH}"
+mv -f "${tito_tmp_dir}"/*/*.rpm "${OS_OUTPUT_RPMPATH}"
+mkdir -p "${OS_OUTPUT_RELEASEPATH}"
+echo "${OS_GIT_COMMIT}" > "${OS_OUTPUT_RELEASEPATH}/.commit"
 
 repo_path="$( os::util::absolute_path "${OS_OUTPUT_RPMPATH}" )"
 createrepo "${repo_path}"

--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -25,7 +25,13 @@ function os::build::image() {
 		# available, falling back to the last commit
 		# if no release commit is recorded
 		local release_commit
-		release_commit="${OS_RELEASE_COMMIT:-"$( git log -1 --pretty=%h )"}"
+		release_commit="${OS_RELEASE_COMMIT-}"
+		if [[ -z "${release_commit}" && -f "${OS_OUTPUT_RELEASEPATH}/.commit" ]]; then
+			release_commit="$( cat "${OS_OUTPUT_RELEASEPATH}/.commit" )"
+		fi
+		if [[ -z "${release_commit}" ]]; then
+			release_commit="$( git log -1 --pretty=%h )"
+		fi
 		extra_tag="${tag}:${release_commit}"
 
 		tag="${tag}:latest"

--- a/hack/lib/build/release.sh
+++ b/hack/lib/build/release.sh
@@ -4,7 +4,7 @@
 
 # os::build::release::check_for_rpms checks that an RPM release has been built
 function os::build::release::check_for_rpms() {
-	if [[ ! -d "${OS_OUTPUT_RPMPATH}" || ! -s "${OS_OUTPUT_RELEASEPATH}/CHECKSUM" ]]; then
+	if [[ ! -d "${OS_OUTPUT_RPMPATH}" || ! -d "${OS_OUTPUT_RPMPATH}/repodata" ]]; then
 		relative_release_path="$( os::util::repository_relative_path "${OS_OUTPUT_RELEASEPATH}" )"
 		relative_bin_path="$( os::util::repository_relative_path "${OS_OUTPUT_BINPATH}" )"
 		os::log::fatal "No release RPMs have been built! RPMs are necessary to build container images.

--- a/origin.spec
+++ b/origin.spec
@@ -240,7 +240,7 @@ of docker.  Exclude those versions of docker.
 %if 0%{do_build}
 %if 0%{make_redistributable}
 # Create Binaries for all supported arches
-%{os_git_vars} hack/build-cross.sh
+%{os_git_vars} OS_BUILD_RELEASE_ARCHIVES=n hack/build-cross.sh
 %{os_git_vars} hack/build-go.sh vendor/github.com/onsi/ginkgo/ginkgo
 %{os_git_vars} unset GOPATH; cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/build-cross.sh
 %{os_git_vars} unset GOPATH; cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/hack/build-cross.sh
@@ -261,7 +261,7 @@ of docker.  Exclude those versions of docker.
 %ifarch s390x
   BUILD_PLATFORM="linux/s390x"
 %endif
-OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} hack/build-cross.sh
+OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} OS_BUILD_RELEASE_ARCHIVES=n hack/build-cross.sh
 OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} hack/build-go.sh vendor/github.com/onsi/ginkgo/ginkgo
 OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} unset GOPATH; cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/hack/build-cross.sh
 OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} unset GOPATH; cmd/cluster-capacity/go/src/github.com/kubernetes-incubator/cluster-capacity/hack/build-cross.sh


### PR DESCRIPTION
It saves time copying binaries, and we don't actually use the release binary downstream anymore.