### PR TITLE
fix basename: illegal option -- b issue with upstream filenames starting with -

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -51,7 +51,11 @@ os::log::stacktrace::install
 os::util::environment::update_path_var
 
 if [[ -z "${OS_TMP_ENV_SET-}" ]]; then
-	os::util::environment::setup_tmpdir_vars "$( basename "$0" ".sh" )"
+    if [[ "$0" =~ *.sh ]]; then
+       os::util::environment::setup_tmpdir_vars "$( basename "$0" ".sh" )"
+    else
+        os::util::environment::setup_tmpdir_vars "shell"
+    fi
 fi
 
 # Allow setting $JUNIT_REPORT to toggle output behavior


### PR DESCRIPTION
issue:
```
$ git branch -vv
* devel  3ea2451f08 Merge pull request #17120 from joelsmith/master
  master 3ae44301f9 [origin/master] fix basename: illegal option -- b issue with upstream filenames starting with -
xiaods at XiaoTommydeMacBook-Pro in ~/go/src/github.com/openshift/origin on devel*
$ export PATH="${PATH}:$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::build::host_platform )/" )"
basename: illegal option -- b
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
```
caused by :

The -- (dash dash) stops basename from processing any options in the argument.
Always quote $0 in case there are spaces in the name.


