### PR TITLE
Fix BuildConfigInstantiateFailed warning when lastVersion == 0

### DIFF
--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -318,7 +318,7 @@ func (g *BuildGenerator) instantiate(ctx apirequest.Context, request *buildapi.B
 	return g.createBuild(ctx, newBuild)
 }
 
-// checkBuildConfigLastVersion will return an error if the BuildConfig's LastVersion doesn't match the passed in lastVersion
+// checkLastVersion will return an error if the BuildConfig's LastVersion doesn't match the passed in lastVersion
 // when lastVersion is not nil
 func (g *BuildGenerator) checkLastVersion(bc *buildapi.BuildConfig, lastVersion *int64) error {
 	if lastVersion != nil && bc.Status.LastVersion != *lastVersion {

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -42,6 +42,12 @@ os::cmd::expect_success 'oc delete all -l app=expose-output'
 os::cmd::expect_success_and_text 'oc new-app mysql --as-test' 'Application is not exposed'
 os::cmd::expect_success 'oc delete all -l app=mysql'
 
+# ensure that oc new-app does not emit a BuildConfigInstantiateFailed event when creating
+# a new application
+os::cmd::expect_success 'oc new-app https://github.com/sclorg/ruby-ex'
+os::cmd::expect_success_and_not_text 'oc describe bc/ruby-ex' 'BuildConfigInstantiateFailed'
+os::cmd::expect_success 'oc delete all -l app=ruby-ex'
+
 # test that imagestream references across imagestreams do not cause an error
 os::cmd::try_until_success 'oc get imagestreamtags ruby:2.3'
 os::cmd::expect_success 'oc create -f test/testdata/newapp/imagestream-ref.yaml'


### PR DESCRIPTION
Build config instatiate should not emit a warning when
bc.Status.LastVersion != lastVersion and lastVersion == 0
Fixes #16557