### PR TITLE
UPSTREAM: 54921: rename metric reflector_xx_last_resource_version

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/util/reflector/prometheus/prometheus.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/reflector/prometheus/prometheus.go
@@ -68,6 +68,12 @@ var (
 		Name:      "items_per_watch",
 		Help:      "How many items an API watch returns to the reflectors",
 	}, []string{"name"})
+
+	lastResourceVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: reflectorSubsystem,
+		Name:      "last_resource_version",
+		Help:      "Last resource version seen for the reflectors",
+	}, []string{"name"})
 )
 
 func init() {
@@ -78,6 +84,7 @@ func init() {
 	prometheus.MustRegister(shortWatchesTotal)
 	prometheus.MustRegister(watchDuration)
 	prometheus.MustRegister(itemsPerWatch)
+	prometheus.MustRegister(lastResourceVersion)
 
 	cache.SetReflectorMetricsProvider(prometheusMetricsProvider{})
 }
@@ -117,11 +124,5 @@ func (prometheusMetricsProvider) NewItemsInWatchMetric(name string) cache.Summar
 }
 
 func (prometheusMetricsProvider) NewLastResourceVersionMetric(name string) cache.GaugeMetric {
-	rv := prometheus.NewGauge(prometheus.GaugeOpts{
-		Subsystem: name,
-		Name:      "last_resource_version",
-		Help:      "last resource version seen for the reflectors",
-	})
-	prometheus.MustRegister(rv)
-	return rv
+	return lastResourceVersion.WithLabelValues(name)
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -109,7 +109,7 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	r := &Reflector{
 		name: name,
 		// we need this to be unique per process (some names are still the same)but obvious who it belongs to
-		metrics:       newReflectorMetrics(makeValidPromethusMetricName(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
+		metrics:       newReflectorMetrics(makeValidPromethusMetricLabel(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
 		listerWatcher: lw,
 		store:         store,
 		expectedType:  reflect.TypeOf(expectedType),
@@ -120,9 +120,9 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	return r
 }
 
-func makeValidPromethusMetricName(in string) string {
+func makeValidPromethusMetricLabel(in string) string {
 	// this isn't perfect, but it removes our common characters
-	return strings.NewReplacer("/", "_", ".", "_", "-", "_").Replace(in)
+	return strings.NewReplacer("/", "_", ".", "_", "-", "_", ":", "_").Replace(in)
 }
 
 // internalPackages are packages that ignored when creating a default reflector name. These packages are in the common


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1509341
xref https://github.com/kubernetes/kubernetes/pull/54921