### PR TITLE
verify-signature: fixed (in)secure transport

### DIFF
--- a/pkg/oc/admin/image/manifest.go
+++ b/pkg/oc/admin/image/manifest.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/docker/distribution/digest"
 
+	"k8s.io/client-go/rest"
+
 	"github.com/openshift/origin/pkg/image/importer"
 )
 
@@ -18,7 +20,12 @@ func getImageManifestByIDFromRegistry(registry *url.URL, repositoryName, imageID
 	credentials := importer.NewBasicCredentials()
 	credentials.Add(registry, username, password)
 
-	repo, err := importer.NewContext(http.DefaultTransport, http.DefaultTransport).
+	insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}})
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := importer.NewContext(http.DefaultTransport, insecureRT).
 		WithCredentials(credentials).
 		Repository(ctx, registry, repositoryName, insecure)
 	if err != nil {

--- a/pkg/oc/admin/image/verify-signature.go
+++ b/pkg/oc/admin/image/verify-signature.go
@@ -256,7 +256,7 @@ func (o *VerifyImageSignatureOptions) getImageManifest(img *imageapi.Image) ([]b
 	if len(o.RegistryURL) > 0 {
 		registryURL = &url.URL{Host: o.RegistryURL, Scheme: "https"}
 		if o.Insecure {
-			registryURL.Scheme = "http"
+			registryURL.Scheme = ""
 		}
 	}
 	return getImageManifestByIDFromRegistry(registryURL, parsed.RepositoryName(), img.Name, o.CurrentUser, o.CurrentUserToken, o.Insecure)


### PR DESCRIPTION
And reenabled image signature workflow extended test.

Resolves #15809