### PR TITLE
add support for JenkinsPipeline strategy env update

### DIFF
--- a/pkg/cmd/util/clientcmd/factory.go
+++ b/pkg/cmd/util/clientcmd/factory.go
@@ -124,6 +124,9 @@ func (f *Factory) UpdateObjectEnvironment(obj runtime.Object, fn func(*[]api.Env
 		if t.Spec.Strategy.DockerStrategy != nil {
 			return true, fn(&t.Spec.Strategy.DockerStrategy.Env)
 		}
+		if t.Spec.Strategy.JenkinsPipelineStrategy != nil {
+			return true, fn(&t.Spec.Strategy.JenkinsPipelineStrategy.Env)
+		}
 	}
 	return false, fmt.Errorf("object does not contain any environment variables")
 }


### PR DESCRIPTION
Pick of https://github.com/openshift/origin/pull/17203

Adds support for updating environment variables on buildConfigs
that use the JenkinsPipeline strategy.

/kind bug

cc @openshift/cli-review @bparees