### PR TITLE
Fix parse error for multiple OPTIONS to run node

### DIFF
--- a/images/node/scripts/origin-node-run.sh
+++ b/images/node/scripts/origin-node-run.sh
@@ -3,9 +3,8 @@
 set -eu
 
 conf=${CONFIG_FILE:-/etc/origin/node/node-config.yaml}
-opts=${OPTIONS:---loglevel=2}
-if [ "$#" -ne 0 ]; then
-  opts=""
+if [[ "$#" -eq 0 ]]; then
+  eval "set -- ${OPTIONS:---loglevel=2}"
 fi
 
-exec /usr/bin/openshift start node "--config=${conf}" ${opts} $@
+exec /usr/bin/openshift start node "--config=${conf}" "$@"

--- a/images/node/scripts/origin-node-run.sh
+++ b/images/node/scripts/origin-node-run.sh
@@ -8,4 +8,4 @@ if [ "$#" -ne 0 ]; then
   opts=""
 fi
 
-exec /usr/bin/openshift start node "--config=${conf}" "${opts}" $@
+exec /usr/bin/openshift start node "--config=${conf}" ${opts} $@


### PR DESCRIPTION
bash env variables put single quotation (`''`) when the variable has
`""`. Due to this and behavior of golang's parse mechanism,
containerized OpenShift Node cannot start if OPTIONS contains multiple
variables.

This patch removes the double quotations from the start script of
OpenShift Node.

You can simulate the issue with following steps:

1. Start running containerized OpenShift Node image

~~~
# /usr/bin/docker run -it --entrypoint=/bin/bash  \
-v /etc/origin/node:/etc/origin/node -e OPTIONS="--loglevel=3 --disable=proxy" \
registry.access.redhat.com/openshift3/node:v3.6.173.0.49
~~~

2. Run `/usr/local/bin/origin-node-run.sh` or `openshift start node '--loglevel=3 --disable=proxy'`

~~~
[root@20de90d3c238 origin]# /usr/local/bin/origin-node-run.sh
Error: invalid argument "3 --disable=proxy" for --loglevel=3 --disable=proxy: strconv.ParseInt: parsing "3 --disable=proxy": invalid syntax
~~~

~~~
[root@eb7e4d9cea08 origin]# exec /usr/bin/openshift start node --config=/etc/origin/node/node-config.yaml '--loglevel=3 --disable=proxy'
Error: invalid argument "3 --disable=proxy" for --loglevel=3 --disable=proxy: strconv.ParseInt: parsing "3 --disable=proxy": invalid syntax
~~~