### PR TITLE
UPSTREAM: 55248: increase iptables max wait from 2 seconds to 5 (fix)

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/util/iptables/iptables.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/iptables/iptables.go
@@ -567,7 +567,7 @@ func getIPTablesRestoreWaitFlag(exec utilexec.Interface) []string {
 		return nil
 	}
 
-	return []string{"--wait=2"}
+	return []string{WaitSecondsString}
 }
 
 // getIPTablesRestoreVersionString runs "iptables-restore --version" to get the version string

--- a/vendor/k8s.io/kubernetes/pkg/util/iptables/iptables_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/iptables/iptables_test.go
@@ -1051,7 +1051,7 @@ func TestRestoreAllWait(t *testing.T) {
 	}
 
 	commandSet := sets.NewString(fcmd.CombinedOutputLog[2]...)
-	if !commandSet.HasAll("iptables-restore", "--wait=2", "--counters", "--noflush") {
+	if !commandSet.HasAll("iptables-restore", WaitSecondsString, "--counters", "--noflush") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 
@@ -1100,8 +1100,8 @@ func TestRestoreAllWaitOldIptablesRestore(t *testing.T) {
 	if !commandSet.HasAll("iptables-restore", "--counters", "--noflush") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
-	if commandSet.HasAny("--wait=2") {
-		t.Errorf("wrong CombinedOutput() log (unexpected --wait=2 option), got %s", fcmd.CombinedOutputLog[2])
+	if commandSet.HasAny(WaitSecondsString) {
+		t.Errorf("wrong CombinedOutput() log (unexpected %s option), got %s", WaitSecondsString, fcmd.CombinedOutputLog[2])
 	}
 
 	if fcmd.CombinedOutputCalls != 3 {


### PR DESCRIPTION
There were a few more places that had a different form of the wait argument.  This catches those places and makes them use the same constant.

https://bugzilla.redhat.com/show_bug.cgi?id=1506396

Upstream PR https://github.com/kubernetes/kubernetes/pull/55248