### PR TITLE
Move constant where it is used.

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -47,8 +47,6 @@ const (
 	// This is a special constant which maps to the service account name used by the underlying
 	// Kubernetes code, so that we can build out the extra policy required to scale OpenShift resources.
 	InfraHorizontalPodAutoscalerControllerServiceAccountName = "horizontal-pod-autoscaler"
-
-	InfraNodeBootstrapServiceAccountName = "node-bootstrapper"
 )
 
 var (

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -41,6 +41,8 @@ const (
 	roleSystemOnly = "authorization.openshift.io/system-only"
 	// roleIsSystemOnly is an annotation value that denotes roleSystemOnly, and thus excludes the role from the UI
 	roleIsSystemOnly = "true"
+	// InfraNodeBootstrapServiceAccountName is the SA used to bootstrap nodes
+	InfraNodeBootstrapServiceAccountName = "node-bootstrapper"
 )
 
 var (


### PR DESCRIPTION
The node-bootstrapper is not a controller and does not belong to
the controller policy. Move it where it is actually used.

Fixes #15937