### PR TITLE
Allow registry-admin to manage RBAC roles and bindings

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -778,6 +778,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("create").Groups(imageGroup, legacyImageGroup).Resources("imagestreamimports").RuleOrDie(),
 				rbac.NewRule("get", "update").Groups(imageGroup, legacyImageGroup).Resources("imagestreams/layers").RuleOrDie(),
 				rbac.NewRule(readWrite...).Groups(authzGroup, legacyAuthzGroup).Resources("rolebindings", "roles").RuleOrDie(),
+				rbac.NewRule(readWrite...).Groups(rbacGroup).Resources("roles", "rolebindings").RuleOrDie(),
 				rbac.NewRule("create").Groups(authzGroup, legacyAuthzGroup).Resources("localresourceaccessreviews", "localsubjectaccessreviews", "subjectrulesreviews").RuleOrDie(),
 				rbac.NewRule("create").Groups(kAuthzGroup).Resources("localsubjectaccessreviews").RuleOrDie(),
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2561,6 +2561,20 @@ items:
     - update
     - watch
   - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - rolebindings
+    - roles
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - ""
     - authorization.openshift.io
     resources:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -2801,6 +2801,21 @@ items:
     - update
     - watch
   - apiGroups:
+    - rbac.authorization.k8s.io
+    attributeRestrictions: null
+    resources:
+    - rolebindings
+    - roles
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - ""
     - authorization.openshift.io
     attributeRestrictions: null


### PR DESCRIPTION
`registry-admin` can already manage these resources via the proxied origin authorization endpoints.  This just allows it to perform these actions directly.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @simo5 @deads2k

/kind bug