### PR TITLE
fix metrics auth failure so that it gives 401 instead of 500

### DIFF
--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -64,7 +64,7 @@ func (l Listener) authorizeHandler(protected http.Handler) http.Handler {
 		user, ok, err := l.Authenticator.AuthenticateRequest(req)
 		if err != nil {
 			glog.V(3).Infof("Unable to authenticate: %v", err)
-			http.Error(w, "Unable to authenticate due to an error", http.StatusInternalServerError)
+			http.Error(w, "Unable to authenticate due to an error", http.StatusUnauthorized)
 			return
 		}
 		scopedRecord := l.Record


### PR DESCRIPTION
@knobunc @stevekuznetsov @smarterclayton 

Clayton, not sure the sequence of events that changed the code, but the tests use empty username passwd, and that gives 500, instead of 401.