### PR TITLE
fix off by one error in oc adm top images edge creation

### DIFF
--- a/pkg/oc/admin/top/graph.go
+++ b/pkg/oc/admin/top/graph.go
@@ -82,7 +82,7 @@ func addImageStreamsToGraph(g graph.Graph, streams *imageapi.ImageStreamList) {
 				}
 				glog.V(4).Infof("Adding edge from %q to %q", imageStreamNode.UniqueName(), imageNode.UniqueName())
 				edgeKind := ImageStreamImageEdgeKind
-				if i > 1 {
+				if i > 0 {
 					edgeKind = HistoricImageStreamImageEdgeKind
 				}
 				g.AddEdge(imageStreamNode, imageNode, edgeKind)


### PR DESCRIPTION
before, the second image in the history is reported with an imagestream reference (though no actual tag value).

```
$ oc adm top images -n test
NAME                                                                    IMAGESTREAMTAG                    PARENTS              USAGE                                                    METADATA STORAGE   
sha256:a39050fbf26335a80876dfbafb47a6c0df8e9a728141cfc7723d506d1fc42acb test/origin-ruby-sample (latest)  sha256:cf44f7a05f... Deployment: test/frontend-3, Deployment: test/frontend-3 no       188.7 MiB 
sha256:30d3c1dd270158b7909c50f7dee5e92a43fbe7df300d673ab10cf8f3c7b27475 test/origin-ruby-sample ()        sha256:cf44f7a05f... <none>                                                   no       188.7 MiB 
```

after, it is correctly reported with an IST of "none"

```
$ oc adm top images -n test 
NAME                                                                    IMAGESTREAMTAG                    PARENTS              USAGE                                                    METADATA STORAGE   
sha256:a39050fbf26335a80876dfbafb47a6c0df8e9a728141cfc7723d506d1fc42acb test/origin-ruby-sample (latest)  sha256:cf44f7a05f... Deployment: test/frontend-3, Deployment: test/frontend-3 no       188.7 MiB 
sha256:30d3c1dd270158b7909c50f7dee5e92a43fbe7df300d673ab10cf8f3c7b27475 <none>                            sha256:cf44f7a05f... <none>                                                   no       188.7 MiB 
```
