### PR TITLE
Force removal of temporary build containers [3.7]

### DIFF
--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -298,13 +298,14 @@ func (d *DockerBuilder) dockerBuild(dir string, tag string, secrets []buildapi.S
 	}
 
 	opts := docker.BuildImageOptions{
-		Name:           tag,
-		RmTmpContainer: true,
-		OutputStream:   os.Stdout,
-		Dockerfile:     dockerfilePath,
-		NoCache:        noCache,
-		Pull:           forcePull,
-		BuildArgs:      buildArgs,
+		Name:                tag,
+		RmTmpContainer:      true,
+		ForceRmTmpContainer: true,
+		OutputStream:        os.Stdout,
+		Dockerfile:          dockerfilePath,
+		NoCache:             noCache,
+		Pull:                forcePull,
+		BuildArgs:           buildArgs,
 	}
 	network, resolvConfHostPath, err := getContainerNetworkConfig()
 	if err != nil {


### PR DESCRIPTION
Currently temporary Docker build containers will only be removed from the node if the build succeeds. This change will force build containers to be removed whether the build fails or succeeds.

Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1512679