### PR TITLE
admission_test.go(TestAdmit): compare SecurityContexts instead of particular members

### DIFF
--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -497,18 +497,8 @@ func TestAdmit(t *testing.T) {
 			v.pod.Spec.Containers, v.pod.Spec.InitContainers = v.pod.Spec.InitContainers, v.pod.Spec.Containers
 
 			if !v.shouldAdmit {
-				attrs := kadmission.NewAttributesRecord(v.pod, nil, kapi.Kind("Pod").WithVersion("version"), v.pod.Namespace, v.pod.Name, kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
-				err := p.Admit(attrs)
-				if err != nil {
-					t.Errorf("Expected %s to pass with escalated scc but got error %v", k, err)
-				}
-				validatedSCC, ok := v.pod.Annotations[allocator.ValidatedSCCAnnotation]
-				if !ok {
-					t.Errorf("%s expected to find the validated annotation on the pod for the scc but found none", k)
-				}
-				if validatedSCC != adminSCC.Name {
-					t.Errorf("%s should have validated against %s but found %s", k, adminSCC.Name, validatedSCC)
-				}
+				// pods that were rejected by strict SCC, should pass with relaxed SCC
+				testSCCAdmission(v.pod, p, adminSCC.Name, k, t)
 			}
 		}
 	}

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -532,30 +532,8 @@ func TestAdmitFailure(t *testing.T) {
 
 	// now add an escalated scc to the group and re-run the cases that expected failure, they should
 	// now pass by validating against the escalated scc.
-	adminSCC := &securityapi.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "scc-admin",
-		},
-		AllowPrivilegedContainer: true,
-		AllowHostNetwork:         true,
-		AllowHostPorts:           true,
-		AllowHostPID:             true,
-		AllowHostIPC:             true,
-		RunAsUser: securityapi.RunAsUserStrategyOptions{
-			Type: securityapi.RunAsUserStrategyRunAsAny,
-		},
-		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
-			Type: securityapi.SELinuxStrategyRunAsAny,
-		},
-		FSGroup: securityapi.FSGroupStrategyOptions{
-			Type: securityapi.FSGroupStrategyRunAsAny,
-		},
-		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-			Type: securityapi.SupplementalGroupsStrategyRunAsAny,
-		},
-		Groups: []string{"system:serviceaccounts"},
-	}
-
+	adminSCC := laxSCC()
+	adminSCC.Name = "scc-admin"
 	indexer.Add(adminSCC)
 
 	for i := 0; i < 2; i++ {
@@ -1141,6 +1119,11 @@ func laxSCC() *securityapi.SecurityContextConstraints {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "lax",
 		},
+		AllowPrivilegedContainer: true,
+		AllowHostNetwork:         true,
+		AllowHostPorts:           true,
+		AllowHostPID:             true,
+		AllowHostIPC:             true,
 		RunAsUser: securityapi.RunAsUserStrategyOptions{
 			Type: securityapi.RunAsUserStrategyRunAsAny,
 		},

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -939,16 +939,16 @@ func TestAdmitWithPrioritizedSCC(t *testing.T) {
 
 	// create the admission plugin
 	plugin := NewTestAdmission(cache, tc)
-	// match the restricted SCC
-	testSCCAdmission(goodPod(), plugin, restricted.Name, t)
-	// match matchingPrioritySCCOne by setting RunAsUser to 5
+
+	testSCCAdmission(goodPod(), plugin, restricted.Name, "match the restricted SCC", t)
+
 	matchingPrioritySCCOnePod := goodPod()
 	matchingPrioritySCCOnePod.Spec.Containers[0].SecurityContext.RunAsUser = &uidFive
-	testSCCAdmission(matchingPrioritySCCOnePod, plugin, matchingPrioritySCCOne.Name, t)
-	// match matchingPriorityAndScoreSCCOne by setting RunAsUser to 6
+	testSCCAdmission(matchingPrioritySCCOnePod, plugin, matchingPrioritySCCOne.Name, "match matchingPrioritySCCOne by setting RunAsUser to 5", t)
+
 	matchingPriorityAndScoreSCCOnePod := goodPod()
 	matchingPriorityAndScoreSCCOnePod.Spec.Containers[0].SecurityContext.RunAsUser = &uidSix
-	testSCCAdmission(matchingPriorityAndScoreSCCOnePod, plugin, matchingPriorityAndScoreSCCOne.Name, t)
+	testSCCAdmission(matchingPriorityAndScoreSCCOnePod, plugin, matchingPriorityAndScoreSCCOne.Name, "match matchingPriorityAndScoreSCCOne by setting RunAsUser to 6", t)
 }
 
 func TestAdmitSeccomp(t *testing.T) {
@@ -1064,21 +1064,21 @@ func TestAdmitSeccomp(t *testing.T) {
 
 // testSCCAdmission is a helper to admit the pod and ensure it was validated against the expected
 // SCC.
-func testSCCAdmission(pod *kapi.Pod, plugin kadmission.Interface, expectedSCC string, t *testing.T) {
+func testSCCAdmission(pod *kapi.Pod, plugin kadmission.Interface, expectedSCC, testName string, t *testing.T) {
 	attrs := kadmission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 	err := plugin.Admit(attrs)
 	if err != nil {
-		t.Errorf("error admitting pod: %v", err)
+		t.Errorf("%s error admitting pod: %v", testName, err)
 		return
 	}
 
 	validatedSCC, ok := pod.Annotations[allocator.ValidatedSCCAnnotation]
 	if !ok {
-		t.Errorf("expected to find the validated annotation on the pod for the scc but found none")
+		t.Errorf("expected %q to find the validated annotation on the pod for the scc but found none", testName)
 		return
 	}
 	if validatedSCC != expectedSCC {
-		t.Errorf("should have validated against %s but found %s", expectedSCC, validatedSCC)
+		t.Errorf("%q should have validated against %s but found %s", testName, expectedSCC, validatedSCC)
 	}
 }
 

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -201,35 +201,7 @@ func TestAdmitSuccess(t *testing.T) {
 	// service accounts to test that even though this has matching priorities (0) and a
 	// lower point value score (which will cause it to be sorted in front of scc-sa) it should not
 	// validate the requests so we should try scc-sa.
-	var exactUID int64 = 999
-	saExactSCC := &securityapi.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "scc-sa-exact",
-		},
-		RunAsUser: securityapi.RunAsUserStrategyOptions{
-			Type: securityapi.RunAsUserStrategyMustRunAs,
-			UID:  &exactUID,
-		},
-		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
-			Type: securityapi.SELinuxStrategyMustRunAs,
-			SELinuxOptions: &kapi.SELinuxOptions{
-				Level: "s9:z0,z1",
-			},
-		},
-		FSGroup: securityapi.FSGroupStrategyOptions{
-			Type: securityapi.FSGroupStrategyMustRunAs,
-			Ranges: []securityapi.IDRange{
-				{Min: 999, Max: 999},
-			},
-		},
-		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
-			Ranges: []securityapi.IDRange{
-				{Min: 999, Max: 999},
-			},
-		},
-		Groups: []string{"system:serviceaccounts"},
-	}
+	saExactSCC := saExactSCC()
 
 	lister := createSCCLister(t, []*securityapi.SecurityContextConstraints{
 		saExactSCC,
@@ -387,35 +359,7 @@ func TestAdmitFailure(t *testing.T) {
 	// service accounts to test that even though this has matching priorities (0) and a
 	// lower point value score (which will cause it to be sorted in front of scc-sa) it should not
 	// validate the requests so we should try scc-sa.
-	var exactUID int64 = 999
-	saExactSCC := &securityapi.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "scc-sa-exact",
-		},
-		RunAsUser: securityapi.RunAsUserStrategyOptions{
-			Type: securityapi.RunAsUserStrategyMustRunAs,
-			UID:  &exactUID,
-		},
-		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
-			Type: securityapi.SELinuxStrategyMustRunAs,
-			SELinuxOptions: &kapi.SELinuxOptions{
-				Level: "s9:z0,z1",
-			},
-		},
-		FSGroup: securityapi.FSGroupStrategyOptions{
-			Type: securityapi.FSGroupStrategyMustRunAs,
-			Ranges: []securityapi.IDRange{
-				{Min: 999, Max: 999},
-			},
-		},
-		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
-			Ranges: []securityapi.IDRange{
-				{Min: 999, Max: 999},
-			},
-		},
-		Groups: []string{"system:serviceaccounts"},
-	}
+	saExactSCC := saExactSCC()
 
 	lister, indexer := createSCCListerAndIndexer(t, []*securityapi.SecurityContextConstraints{
 		saExactSCC,
@@ -1112,6 +1056,38 @@ func restrictiveSCC() *securityapi.SecurityContextConstraints {
 	return &securityapi.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "restrictive",
+		},
+		RunAsUser: securityapi.RunAsUserStrategyOptions{
+			Type: securityapi.RunAsUserStrategyMustRunAs,
+			UID:  &exactUID,
+		},
+		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Type: securityapi.SELinuxStrategyMustRunAs,
+			SELinuxOptions: &kapi.SELinuxOptions{
+				Level: "s9:z0,z1",
+			},
+		},
+		FSGroup: securityapi.FSGroupStrategyOptions{
+			Type: securityapi.FSGroupStrategyMustRunAs,
+			Ranges: []securityapi.IDRange{
+				{Min: 999, Max: 999},
+			},
+		},
+		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
+			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
+			Ranges: []securityapi.IDRange{
+				{Min: 999, Max: 999},
+			},
+		},
+		Groups: []string{"system:serviceaccounts"},
+	}
+}
+
+func saExactSCC() *securityapi.SecurityContextConstraints {
+	var exactUID int64 = 999
+	return &securityapi.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "scc-sa-exact",
 		},
 		RunAsUser: securityapi.RunAsUserStrategyOptions{
 			Type: securityapi.RunAsUserStrategyMustRunAs,

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -173,7 +173,13 @@ func testSCCAdmit(testCaseName string, sccs []*securityapi.SecurityContextConstr
 }
 
 func TestAdmitSuccess(t *testing.T) {
-	tc := setupClientSet()
+	// create the annotated namespace and add it to the fake client
+	namespace := admissiontesting.CreateNamespaceForTest()
+
+	serviceAccount := admissiontesting.CreateSAForTest()
+	serviceAccount.Namespace = namespace.Name
+
+	tc := clientsetfake.NewSimpleClientset(namespace, serviceAccount)
 
 	// used for cases where things are preallocated
 	defaultGroup := int64(2)
@@ -223,8 +229,7 @@ func TestAdmitSuccess(t *testing.T) {
 		Level: "s0:c1,c0",
 	}
 
-	// level matches a value from namespace (see CreateNamespaceForTest())
-	seLinuxLevelFromNamespace := "s0:c1,c0"
+	seLinuxLevelFromNamespace := namespace.Annotations[allocator.MCSAnnotation]
 
 	testCases := map[string]struct {
 		pod                 *kapi.Pod

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -179,24 +179,8 @@ func TestAdmitSuccess(t *testing.T) {
 	defaultGroup := int64(2)
 
 	// create scc that requires allocation retrieval
-	saSCC := &securityapi.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "scc-sa",
-		},
-		RunAsUser: securityapi.RunAsUserStrategyOptions{
-			Type: securityapi.RunAsUserStrategyMustRunAsRange,
-		},
-		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
-			Type: securityapi.SELinuxStrategyMustRunAs,
-		},
-		FSGroup: securityapi.FSGroupStrategyOptions{
-			Type: securityapi.FSGroupStrategyMustRunAs,
-		},
-		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
-		},
-		Groups: []string{"system:serviceaccounts"},
-	}
+	saSCC := saSCC()
+
 	// create scc that has specific requirements that shouldn't match but is permissioned to
 	// service accounts to test that even though this has matching priorities (0) and a
 	// lower point value score (which will cause it to be sorted in front of scc-sa) it should not
@@ -337,24 +321,8 @@ func TestAdmitFailure(t *testing.T) {
 	tc := setupClientSet()
 
 	// create scc that requires allocation retrieval
-	saSCC := &securityapi.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "scc-sa",
-		},
-		RunAsUser: securityapi.RunAsUserStrategyOptions{
-			Type: securityapi.RunAsUserStrategyMustRunAsRange,
-		},
-		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
-			Type: securityapi.SELinuxStrategyMustRunAs,
-		},
-		FSGroup: securityapi.FSGroupStrategyOptions{
-			Type: securityapi.FSGroupStrategyMustRunAs,
-		},
-		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
-		},
-		Groups: []string{"system:serviceaccounts"},
-	}
+	saSCC := saSCC()
+
 	// create scc that has specific requirements that shouldn't match but is permissioned to
 	// service accounts to test that even though this has matching priorities (0) and a
 	// lower point value score (which will cause it to be sorted in front of scc-sa) it should not
@@ -1078,6 +1046,27 @@ func restrictiveSCC() *securityapi.SecurityContextConstraints {
 			Ranges: []securityapi.IDRange{
 				{Min: 999, Max: 999},
 			},
+		},
+		Groups: []string{"system:serviceaccounts"},
+	}
+}
+
+func saSCC() *securityapi.SecurityContextConstraints {
+	return &securityapi.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "scc-sa",
+		},
+		RunAsUser: securityapi.RunAsUserStrategyOptions{
+			Type: securityapi.RunAsUserStrategyMustRunAsRange,
+		},
+		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Type: securityapi.SELinuxStrategyMustRunAs,
+		},
+		FSGroup: securityapi.FSGroupStrategyOptions{
+			Type: securityapi.FSGroupStrategyMustRunAs,
+		},
+		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
+			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
 		},
 		Groups: []string{"system:serviceaccounts"},
 	}

--- a/pkg/security/admission/admission_test.go
+++ b/pkg/security/admission/admission_test.go
@@ -179,13 +179,204 @@ func testSCCAdmit(testCaseName string, sccs []*securityapi.SecurityContextConstr
 	}
 }
 
-func TestAdmit(t *testing.T) {
+func TestAdmitSuccess(t *testing.T) {
 	// create the annotated namespace and add it to the fake client
 	namespace := admissiontesting.CreateNamespaceForTest()
 	serviceAccount := admissiontesting.CreateSAForTest()
 
 	// used for cases where things are preallocated
 	defaultGroup := int64(2)
+
+	tc := clientsetfake.NewSimpleClientset(namespace, serviceAccount)
+
+	// create scc that requires allocation retrieval
+	saSCC := &securityapi.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "scc-sa",
+		},
+		RunAsUser: securityapi.RunAsUserStrategyOptions{
+			Type: securityapi.RunAsUserStrategyMustRunAsRange,
+		},
+		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Type: securityapi.SELinuxStrategyMustRunAs,
+		},
+		FSGroup: securityapi.FSGroupStrategyOptions{
+			Type: securityapi.FSGroupStrategyMustRunAs,
+		},
+		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
+			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
+		},
+		Groups: []string{"system:serviceaccounts"},
+	}
+	// create scc that has specific requirements that shouldn't match but is permissioned to
+	// service accounts to test that even though this has matching priorities (0) and a
+	// lower point value score (which will cause it to be sorted in front of scc-sa) it should not
+	// validate the requests so we should try scc-sa.
+	var exactUID int64 = 999
+	saExactSCC := &securityapi.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "scc-sa-exact",
+		},
+		RunAsUser: securityapi.RunAsUserStrategyOptions{
+			Type: securityapi.RunAsUserStrategyMustRunAs,
+			UID:  &exactUID,
+		},
+		SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Type: securityapi.SELinuxStrategyMustRunAs,
+			SELinuxOptions: &kapi.SELinuxOptions{
+				Level: "s9:z0,z1",
+			},
+		},
+		FSGroup: securityapi.FSGroupStrategyOptions{
+			Type: securityapi.FSGroupStrategyMustRunAs,
+			Ranges: []securityapi.IDRange{
+				{Min: 999, Max: 999},
+			},
+		},
+		SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
+			Type: securityapi.SupplementalGroupsStrategyMustRunAs,
+			Ranges: []securityapi.IDRange{
+				{Min: 999, Max: 999},
+			},
+		},
+		Groups: []string{"system:serviceaccounts"},
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	cache := securitylisters.NewSecurityContextConstraintsLister(indexer)
+
+	indexer.Add(saExactSCC)
+	indexer.Add(saSCC)
+
+	// create the admission plugin
+	p := NewTestAdmission(cache, tc)
+
+	// specifies a UID in the range of the preallocated UID annotation
+	specifyUIDInRange := goodPod()
+	var goodUID int64 = 3
+	specifyUIDInRange.Spec.Containers[0].SecurityContext.RunAsUser = &goodUID
+
+	// specifies an mcs label that matches the preallocated mcs annotation
+	specifyLabels := goodPod()
+	specifyLabels.Spec.Containers[0].SecurityContext.SELinuxOptions = &kapi.SELinuxOptions{
+		Level: "s0:c1,c0",
+	}
+
+	// specifies an FSGroup in the range of preallocated sup group annotation
+	specifyFSGroupInRange := goodPod()
+	// group in the range of a preallocated fs group which, by default is a single digit range
+	// based on the first value of the ns annotation.
+	goodFSGroup := int64(2)
+	specifyFSGroupInRange.Spec.SecurityContext.FSGroup = &goodFSGroup
+
+	// specifies a sup group in the range of preallocated sup group annotation
+	specifySupGroup := goodPod()
+	// group is not the default but still in the range
+	specifySupGroup.Spec.SecurityContext.SupplementalGroups = []int64{3}
+
+	specifyPodLevelSELinux := goodPod()
+	specifyPodLevelSELinux.Spec.SecurityContext.SELinuxOptions = &kapi.SELinuxOptions{
+		Level: "s0:c1,c0",
+	}
+
+	testCases := map[string]struct {
+		pod               *kapi.Pod
+		expectedUID       int64
+		expectedLevel     string
+		expectedFSGroup   int64
+		expectedSupGroups []int64
+		expectedPriv      bool
+	}{
+		"specifyUIDInRange": {
+			pod:               specifyUIDInRange,
+			expectedUID:       *specifyUIDInRange.Spec.Containers[0].SecurityContext.RunAsUser,
+			expectedLevel:     "s0:c1,c0",
+			expectedFSGroup:   defaultGroup,
+			expectedSupGroups: []int64{defaultGroup},
+		},
+		"specifyLabels": {
+			pod:               specifyLabels,
+			expectedUID:       1,
+			expectedLevel:     specifyLabels.Spec.Containers[0].SecurityContext.SELinuxOptions.Level,
+			expectedFSGroup:   defaultGroup,
+			expectedSupGroups: []int64{defaultGroup},
+		},
+		"specifyFSGroup": {
+			pod:               specifyFSGroupInRange,
+			expectedUID:       1,
+			expectedLevel:     "s0:c1,c0",
+			expectedFSGroup:   *specifyFSGroupInRange.Spec.SecurityContext.FSGroup,
+			expectedSupGroups: []int64{defaultGroup},
+		},
+		"specifySupGroup": {
+			pod:               specifySupGroup,
+			expectedUID:       1,
+			expectedLevel:     "s0:c1,c0",
+			expectedFSGroup:   defaultGroup,
+			expectedSupGroups: []int64{specifySupGroup.Spec.SecurityContext.SupplementalGroups[0]},
+		},
+		"specifyPodLevelSELinuxLevel": {
+			pod:               specifyPodLevelSELinux,
+			expectedUID:       1,
+			expectedLevel:     "s0:c1,c0",
+			expectedFSGroup:   defaultGroup,
+			expectedSupGroups: []int64{defaultGroup},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		for k, v := range testCases {
+			v.pod.Spec.Containers, v.pod.Spec.InitContainers = v.pod.Spec.InitContainers, v.pod.Spec.Containers
+			containers := v.pod.Spec.Containers
+			if i == 0 {
+				containers = v.pod.Spec.InitContainers
+			}
+			attrs := kadmission.NewAttributesRecord(v.pod, nil, kapi.Kind("Pod").WithVersion("version"), v.pod.Namespace, v.pod.Name, kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
+			err := p.Admit(attrs)
+
+			if err != nil {
+				t.Fatalf("%s expected no errors but received %v", k, err)
+			}
+
+			validatedSCC, ok := v.pod.Annotations[allocator.ValidatedSCCAnnotation]
+			if !ok {
+				t.Errorf("%s expected to find the validated annotation on the pod for the scc but found none", k)
+			}
+			if validatedSCC != saSCC.Name {
+				t.Errorf("%s should have validated against %s but found %s", k, saSCC.Name, validatedSCC)
+			}
+
+			// ensure anything we expected to be defaulted on the container level is set
+			if *containers[0].SecurityContext.RunAsUser != v.expectedUID {
+				t.Errorf("%s expected UID %d but found %d", k, v.expectedUID, *containers[0].SecurityContext.RunAsUser)
+			}
+			if containers[0].SecurityContext.SELinuxOptions.Level != v.expectedLevel {
+				t.Errorf("%s expected Level %s but found %s", k, v.expectedLevel, containers[0].SecurityContext.SELinuxOptions.Level)
+			}
+
+			// ensure anything we expected to be defaulted on the pod level is set
+			if v.pod.Spec.SecurityContext.SELinuxOptions.Level != v.expectedLevel {
+				t.Errorf("%s expected pod level SELinux Level %s but found %s", k, v.expectedLevel, v.pod.Spec.SecurityContext.SELinuxOptions.Level)
+			}
+			if *v.pod.Spec.SecurityContext.FSGroup != v.expectedFSGroup {
+				t.Errorf("%s expected fsgroup %d but found %d", k, v.expectedFSGroup, *v.pod.Spec.SecurityContext.FSGroup)
+			}
+			if len(v.pod.Spec.SecurityContext.SupplementalGroups) != len(v.expectedSupGroups) {
+				t.Errorf("%s found unexpected supplemental groups.  Expected: %v, actual %v", k, v.expectedSupGroups, v.pod.Spec.SecurityContext.SupplementalGroups)
+			}
+			for _, g := range v.expectedSupGroups {
+				if !hasSupGroup(g, v.pod.Spec.SecurityContext.SupplementalGroups) {
+					t.Errorf("%s expected sup group %d", k, g)
+				}
+			}
+		}
+	}
+}
+
+func TestAdmitFailure(t *testing.T) {
+	// create the annotated namespace and add it to the fake client
+	namespace := admissiontesting.CreateNamespaceForTest()
+	serviceAccount := admissiontesting.CreateSAForTest()
 
 	tc := clientsetfake.NewSimpleClientset(namespace, serviceAccount)
 
@@ -265,45 +456,17 @@ func TestAdmit(t *testing.T) {
 	var priv bool = true
 	disallowedPriv.Spec.Containers[0].SecurityContext.Privileged = &priv
 
-	// specifies a UID in the range of the preallocated UID annotation
-	specifyUIDInRange := goodPod()
-	var goodUID int64 = 3
-	specifyUIDInRange.Spec.Containers[0].SecurityContext.RunAsUser = &goodUID
-
-	// specifies an mcs label that matches the preallocated mcs annotation
-	specifyLabels := goodPod()
-	specifyLabels.Spec.Containers[0].SecurityContext.SELinuxOptions = &kapi.SELinuxOptions{
-		Level: "s0:c1,c0",
-	}
-
-	// specifies an FSGroup in the range of preallocated sup group annotation
-	specifyFSGroupInRange := goodPod()
-	// group in the range of a preallocated fs group which, by default is a single digit range
-	// based on the first value of the ns annotation.
-	goodFSGroup := int64(2)
-	specifyFSGroupInRange.Spec.SecurityContext.FSGroup = &goodFSGroup
-
-	// specifies a sup group in the range of preallocated sup group annotation
-	specifySupGroup := goodPod()
-	// group is not the default but still in the range
-	specifySupGroup.Spec.SecurityContext.SupplementalGroups = []int64{3}
-
-	specifyPodLevelSELinux := goodPod()
-	specifyPodLevelSELinux.Spec.SecurityContext.SELinuxOptions = &kapi.SELinuxOptions{
-		Level: "s0:c1,c0",
-	}
-
 	requestsHostNetwork := goodPod()
 	requestsHostNetwork.Spec.SecurityContext.HostNetwork = true
+
+	requestsHostPorts := goodPod()
+	requestsHostPorts.Spec.Containers[0].Ports = []kapi.ContainerPort{{HostPort: 1}}
 
 	requestsHostPID := goodPod()
 	requestsHostPID.Spec.SecurityContext.HostPID = true
 
 	requestsHostIPC := goodPod()
 	requestsHostIPC.Spec.SecurityContext.HostIPC = true
-
-	requestsHostPorts := goodPod()
-	requestsHostPorts.Spec.Containers[0].Ports = []kapi.ContainerPort{{HostPort: 1}}
 
 	requestsSupplementalGroup := goodPod()
 	requestsSupplementalGroup.Spec.SecurityContext.SupplementalGroups = []int64{1}
@@ -321,145 +484,48 @@ func TestAdmit(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		pod               *kapi.Pod
-		shouldAdmit       bool
-		expectedUID       int64
-		expectedLevel     string
-		expectedFSGroup   int64
-		expectedSupGroups []int64
-		expectedPriv      bool
+		pod *kapi.Pod
 	}{
 		"uidNotInRange": {
-			pod:         uidNotInRange,
-			shouldAdmit: false,
+			pod: uidNotInRange,
 		},
 		"invalidMCSLabels": {
-			pod:         invalidMCSLabels,
-			shouldAdmit: false,
+			pod: invalidMCSLabels,
 		},
 		"disallowedPriv": {
-			pod:         disallowedPriv,
-			shouldAdmit: false,
-		},
-		"specifyUIDInRange": {
-			pod:               specifyUIDInRange,
-			shouldAdmit:       true,
-			expectedUID:       *specifyUIDInRange.Spec.Containers[0].SecurityContext.RunAsUser,
-			expectedLevel:     "s0:c1,c0",
-			expectedFSGroup:   defaultGroup,
-			expectedSupGroups: []int64{defaultGroup},
-		},
-		"specifyLabels": {
-			pod:               specifyLabels,
-			shouldAdmit:       true,
-			expectedUID:       1,
-			expectedLevel:     specifyLabels.Spec.Containers[0].SecurityContext.SELinuxOptions.Level,
-			expectedFSGroup:   defaultGroup,
-			expectedSupGroups: []int64{defaultGroup},
-		},
-		"specifyFSGroup": {
-			pod:               specifyFSGroupInRange,
-			shouldAdmit:       true,
-			expectedUID:       1,
-			expectedLevel:     "s0:c1,c0",
-			expectedFSGroup:   *specifyFSGroupInRange.Spec.SecurityContext.FSGroup,
-			expectedSupGroups: []int64{defaultGroup},
-		},
-		"specifySupGroup": {
-			pod:               specifySupGroup,
-			shouldAdmit:       true,
-			expectedUID:       1,
-			expectedLevel:     "s0:c1,c0",
-			expectedFSGroup:   defaultGroup,
-			expectedSupGroups: []int64{specifySupGroup.Spec.SecurityContext.SupplementalGroups[0]},
-		},
-		"specifyPodLevelSELinuxLevel": {
-			pod:               specifyPodLevelSELinux,
-			shouldAdmit:       true,
-			expectedUID:       1,
-			expectedLevel:     "s0:c1,c0",
-			expectedFSGroup:   defaultGroup,
-			expectedSupGroups: []int64{defaultGroup},
+			pod: disallowedPriv,
 		},
 		"requestsHostNetwork": {
-			pod:         requestsHostNetwork,
-			shouldAdmit: false,
+			pod: requestsHostNetwork,
 		},
 		"requestsHostPorts": {
-			pod:         requestsHostPorts,
-			shouldAdmit: false,
+			pod: requestsHostPorts,
 		},
 		"requestsHostPID": {
-			pod:         requestsHostPID,
-			shouldAdmit: false,
+			pod: requestsHostPID,
 		},
 		"requestsHostIPC": {
-			pod:         requestsHostIPC,
-			shouldAdmit: false,
+			pod: requestsHostIPC,
 		},
 		"requestsSupplementalGroup": {
-			pod:         requestsSupplementalGroup,
-			shouldAdmit: false,
+			pod: requestsSupplementalGroup,
 		},
 		"requestsFSGroup": {
-			pod:         requestsFSGroup,
-			shouldAdmit: false,
+			pod: requestsFSGroup,
 		},
 		"requestsPodLevelMCS": {
-			pod:         requestsPodLevelMCS,
-			shouldAdmit: false,
+			pod: requestsPodLevelMCS,
 		},
 	}
 
 	for i := 0; i < 2; i++ {
 		for k, v := range testCases {
 			v.pod.Spec.Containers, v.pod.Spec.InitContainers = v.pod.Spec.InitContainers, v.pod.Spec.Containers
-			containers := v.pod.Spec.Containers
-			if i == 0 {
-				containers = v.pod.Spec.InitContainers
-			}
 			attrs := kadmission.NewAttributesRecord(v.pod, nil, kapi.Kind("Pod").WithVersion("version"), v.pod.Namespace, v.pod.Name, kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 			err := p.Admit(attrs)
 
-			if v.shouldAdmit && err != nil {
-				t.Fatalf("%s expected no errors but received %v", k, err)
-			}
-			if !v.shouldAdmit && err == nil {
+			if err == nil {
 				t.Errorf("%s expected errors but received none", k)
-			}
-
-			if v.shouldAdmit {
-				validatedSCC, ok := v.pod.Annotations[allocator.ValidatedSCCAnnotation]
-				if !ok {
-					t.Errorf("%s expected to find the validated annotation on the pod for the scc but found none", k)
-				}
-				if validatedSCC != saSCC.Name {
-					t.Errorf("%s should have validated against %s but found %s", k, saSCC.Name, validatedSCC)
-				}
-
-				// ensure anything we expected to be defaulted on the container level is set
-				if *containers[0].SecurityContext.RunAsUser != v.expectedUID {
-					t.Errorf("%s expected UID %d but found %d", k, v.expectedUID, *containers[0].SecurityContext.RunAsUser)
-				}
-				if containers[0].SecurityContext.SELinuxOptions.Level != v.expectedLevel {
-					t.Errorf("%s expected Level %s but found %s", k, v.expectedLevel, containers[0].SecurityContext.SELinuxOptions.Level)
-				}
-
-				// ensure anything we expected to be defaulted on the pod level is set
-				if v.pod.Spec.SecurityContext.SELinuxOptions.Level != v.expectedLevel {
-					t.Errorf("%s expected pod level SELinux Level %s but found %s", k, v.expectedLevel, v.pod.Spec.SecurityContext.SELinuxOptions.Level)
-				}
-				if *v.pod.Spec.SecurityContext.FSGroup != v.expectedFSGroup {
-					t.Errorf("%s expected fsgroup %d but found %d", k, v.expectedFSGroup, *v.pod.Spec.SecurityContext.FSGroup)
-				}
-				if len(v.pod.Spec.SecurityContext.SupplementalGroups) != len(v.expectedSupGroups) {
-					t.Errorf("%s found unexpected supplemental groups.  Expected: %v, actual %v", k, v.expectedSupGroups, v.pod.Spec.SecurityContext.SupplementalGroups)
-				}
-				for _, g := range v.expectedSupGroups {
-					if !hasSupGroup(g, v.pod.Spec.SecurityContext.SupplementalGroups) {
-						t.Errorf("%s expected sup group %d", k, g)
-					}
-				}
 			}
 		}
 	}
@@ -496,10 +562,8 @@ func TestAdmit(t *testing.T) {
 		for k, v := range testCases {
 			v.pod.Spec.Containers, v.pod.Spec.InitContainers = v.pod.Spec.InitContainers, v.pod.Spec.Containers
 
-			if !v.shouldAdmit {
-				// pods that were rejected by strict SCC, should pass with relaxed SCC
-				testSCCAdmission(v.pod, p, adminSCC.Name, k, t)
-			}
+			// pods that were rejected by strict SCC, should pass with relaxed SCC
+			testSCCAdmission(v.pod, p, adminSCC.Name, k, t)
 		}
 	}
 }


### PR DESCRIPTION
This makes the test close to the upstream implementation.

Extracted from https://github.com/openshift/origin/pull/16934#discussion_r145748837

PTAL @liggitt @pweil- @adelton @simo5
