### PR TITLE
make assetconfig a top level type

### DIFF
--- a/pkg/cmd/server/api/install/install.go
+++ b/pkg/cmd/server/api/install/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
@@ -29,14 +30,18 @@ var accessor = meta.NewAccessor()
 var availableVersions = []schema.GroupVersion{configapiv1.SchemeGroupVersion}
 
 func init() {
-	configapi.AddToScheme(configapi.Scheme)
-	configapiv1.AddToScheme(configapi.Scheme)
+	AddToScheme(configapi.Scheme)
+}
+
+func AddToScheme(scheme *runtime.Scheme) {
+	configapi.AddToScheme(scheme)
+	configapiv1.AddToScheme(scheme)
 	// we additionally need to enable audit versions, since we embed the audit
 	// policy file inside master-config.yaml
-	audit.AddToScheme(configapi.Scheme)
-	auditv1alpha1.AddToScheme(configapi.Scheme)
-	apiserver.AddToScheme(configapi.Scheme)
-	apiserverv1alpha1.AddToScheme(configapi.Scheme)
+	audit.AddToScheme(scheme)
+	auditv1alpha1.AddToScheme(scheme)
+	apiserver.AddToScheme(scheme)
+	apiserverv1alpha1.AddToScheme(scheme)
 }
 
 func interfacesFor(version schema.GroupVersion) (*meta.VersionInterfaces, error) {

--- a/pkg/cmd/server/api/register.go
+++ b/pkg/cmd/server/api/register.go
@@ -39,6 +39,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&MasterConfig{},
 		&NodeConfig{},
+		&AssetConfig{},
 		&SessionSecrets{},
 
 		&BasicAuthPasswordIdentityProvider{},

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -823,7 +823,11 @@ type DNSConfig struct {
 	AllowRecursiveQueries bool
 }
 
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type AssetConfig struct {
+	metav1.TypeMeta
+
 	ServingInfo HTTPServingInfo
 
 	// PublicURL is where you can find the asset server (TODO do we really need this?)

--- a/pkg/cmd/server/api/v1/register.go
+++ b/pkg/cmd/server/api/v1/register.go
@@ -20,6 +20,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&MasterConfig{},
 		&NodeConfig{},
+		&AssetConfig{},
 		&SessionSecrets{},
 
 		&BasicAuthPasswordIdentityProvider{},

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -713,8 +713,12 @@ type DNSConfig struct {
 	AllowRecursiveQueries bool `json:"allowRecursiveQueries"`
 }
 
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // AssetConfig holds the necessary configuration options for serving assets
 type AssetConfig struct {
+	metav1.TypeMeta `json:",inline"`
+
 	// ServingInfo is the HTTP serving information for these assets
 	ServingInfo HTTPServingInfo `json:"servingInfo"`
 

--- a/pkg/cmd/server/api/v1/zz_generated.defaults.go
+++ b/pkg/cmd/server/api/v1/zz_generated.defaults.go
@@ -12,9 +12,14 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&AssetConfig{}, func(obj interface{}) { SetObjectDefaults_AssetConfig(obj.(*AssetConfig)) })
 	scheme.AddTypeDefaultingFunc(&MasterConfig{}, func(obj interface{}) { SetObjectDefaults_MasterConfig(obj.(*MasterConfig)) })
 	scheme.AddTypeDefaultingFunc(&NodeConfig{}, func(obj interface{}) { SetObjectDefaults_NodeConfig(obj.(*NodeConfig)) })
 	return nil
+}
+
+func SetObjectDefaults_AssetConfig(in *AssetConfig) {
+	SetDefaults_ServingInfo(&in.ServingInfo.ServingInfo)
 }
 
 func SetObjectDefaults_MasterConfig(in *MasterConfig) {
@@ -36,7 +41,7 @@ func SetObjectDefaults_MasterConfig(in *MasterConfig) {
 		SetDefaults_GrantConfig(&in.OAuthConfig.GrantConfig)
 	}
 	if in.AssetConfig != nil {
-		SetDefaults_ServingInfo(&in.AssetConfig.ServingInfo.ServingInfo)
+		SetObjectDefaults_AssetConfig(in.AssetConfig)
 	}
 	if in.DNSConfig != nil {
 		SetDefaults_DNSConfig(in.DNSConfig)


### PR DESCRIPTION
@liggitt @smarterclayton API change need to split the webconsole out.  This never went into openshift/api, so I'd like to see it merged.

@spadgett fyi