### PR TITLE
Trivial fix to do fewer allocations in OVS healthcheck

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -58,10 +58,11 @@ func (oc *ovsController) AlreadySetUp() bool {
 		return false
 	}
 	expectedVersionNote := oc.getVersionNote()
-	for _, flow := range flows {
-		parsed, err := ovs.ParseFlow(ovs.ParseForDump, flow)
-		if err == nil && parsed.Table == ruleVersionTable && parsed.NoteHasPrefix(expectedVersionNote) {
-			return true
+	// The "version" flow should be the last one, so scan from the end
+	for i := len(flows) - 1; i >= 0; i-- {
+		parsed, err := ovs.ParseFlow(ovs.ParseForDump, flows[i])
+		if err == nil && parsed.Table == ruleVersionTable {
+			return parsed.NoteHasPrefix(expectedVersionNote)
 		}
 	}
 	return false


### PR DESCRIPTION
Make `ovsController.AlreadySetUp()` scan the flows in reverse order; the flow we're looking for is in the highest-numbered table, and `ovs-ofctl dump-flows` returns the flows sorted by table number, so if we parse them in forward order, we'll end up unnecessarily parsing every single flow, while parsing them in reverse means we only parse one.

(Also stop parsing further flows once we found the one we were looking for, even if it has the wrong value.)

Fixes #17312

(We can also make improvements to ParseFlow itself later, but this just seemed like the simplest fix for the immediate problem.)