### PR TITLE
Fix network diagnostic default image path

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics/networkpod/util/util.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/networkpod/util/util.go
@@ -37,15 +37,29 @@ const (
 	NetworkDiagDefaultTestPodPort     = 8080
 )
 
+func trimRegistryPath(image string) string {
+	// Image format could be: [<dns-name>/]openshift/origin-deployer[:<tag>]
+	// Return image without registry dns: openshift/origin-deployer[:<tag>]
+	tokens := strings.Split(image, "/")
+	sz := len(tokens)
+	trimmedImage := image
+	if sz >= 2 {
+		trimmedImage = fmt.Sprintf("%s/%s", tokens[sz-2], tokens[sz-1])
+	}
+	return trimmedImage
+}
+
 func GetNetworkDiagDefaultPodImage() string {
 	imageTemplate := variable.NewDefaultImageTemplate()
 	imageTemplate.Format = variable.DefaultImagePrefix + ":${version}"
-	return imageTemplate.ExpandOrDie("")
+	image := imageTemplate.ExpandOrDie("")
+	return trimRegistryPath(image)
 }
 
 func GetNetworkDiagDefaultTestPodImage() string {
 	imageTemplate := variable.NewDefaultImageTemplate()
-	return imageTemplate.ExpandOrDie("deployer")
+	image := imageTemplate.ExpandOrDie("deployer")
+	return trimRegistryPath(image)
 }
 
 func GetOpenShiftNetworkPlugin(clusterNetworkClient networktypedclient.ClusterNetworksGetter) (string, bool, error) {

--- a/pkg/oc/admin/diagnostics/diagnostics/networkpod/util/util_test.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/networkpod/util/util_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestTrimRegistryPath(t *testing.T) {
+	testcases := map[string]struct {
+		image         string
+		expectedImage string
+	}{
+		"Empty image": {
+			image:         "",
+			expectedImage: "",
+		},
+		"Image with no slashes, no tags": {
+			image:         "origin",
+			expectedImage: "origin",
+		},
+		"Image with no slashes": {
+			image:         "origin:v1.2.3",
+			expectedImage: "origin:v1.2.3",
+		},
+		"Image with one slash, no tags": {
+			image:         "openshift/origin",
+			expectedImage: "openshift/origin",
+		},
+		"Image with one slash": {
+			image:         "openshift/origin:v1.2.3",
+			expectedImage: "openshift/origin:v1.2.3",
+		},
+		"Image with dns path, no port, no tags": {
+			image:         "registry.access.redhat.com/openshift3/ose",
+			expectedImage: "openshift3/ose",
+		},
+		"Image with dns path, no port": {
+			image:         "registry.access.redhat.com/openshift3/ose:v1.2.3",
+			expectedImage: "openshift3/ose:v1.2.3",
+		},
+		"Image with dns path": {
+			image:         "registry.reg-aws.openshift.com:443/openshift3/ose:v1.2.3",
+			expectedImage: "openshift3/ose:v1.2.3",
+		},
+	}
+
+	for name, tc := range testcases {
+		trimmedImage := trimRegistryPath(tc.image)
+		if trimmedImage != tc.expectedImage {
+			t.Fatalf("[%s] failed: expected %s but got %s", name, tc.expectedImage, trimmedImage)
+		}
+	}
+}


### PR DESCRIPTION
- variable.DefaultImagePrefix is populated from {node,master}-config.yaml
(imageConfig.format) and if this value is not specified in the config,
openshift ansible defaults it to 'registry.access.redhat.com'.

- Network diagnostics is run as a admin CLI command so there is no config for
variable.DefaultImagePrefix and it defaults to 'registry.access.redhat.com'
which may not be true for AWS or some other openshift environments.

- This change will remove the registry path from the default image so that it
defaults to registry configured on the openshift node.

Example:
  Earlier image path: registry.access.redhat.com/openshift3/ose
  New image path: openshift3/ose
  On AWS node, this will resolve to registry.reg-aws.openshift.com:443/openshift3/ose