### PR TITLE
[release-3.7] UPSTREAM: 55631: Parse and return the last line in the log even if it is partial

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_logs.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_logs.go
@@ -154,6 +154,27 @@ func (m *kubeGenericRuntimeManager) ReadLogs(path, containerID string, apiOpts *
 				// Return directly when reading to the end if not follow.
 				if len(l) > 0 {
 					glog.Warningf("Incomplete line in log file %q: %q", path, l)
+					if parse == nil {
+						// Intialize the log parsing function.
+						parse, err = getParseFunc(l)
+						if err != nil {
+							return fmt.Errorf("failed to get parse function: %v", err)
+						}
+					}
+					// Log a warning and exit if we can't parse the partial line.
+					if err := parse(l, msg); err != nil {
+						glog.Warningf("Failed with err %v when parsing partial line for log file %q: %q", err, path, l)
+						return nil
+					}
+					// Write the log line into the stream.
+					if err := writer.write(msg); err != nil {
+						if err == errMaximumWrite {
+							glog.V(2).Infof("Finish parsing log file %q, hit bytes limit %d(bytes)", path, opts.bytes)
+							return nil
+						}
+						glog.Errorf("Failed with err %v when writing partial log for log file %q: %+v", err, path, msg)
+						return err
+					}
 				}
 				glog.V(2).Infof("Finish parsing log file %q", path)
 				return nil


### PR DESCRIPTION
Same as https://github.com/openshift/origin/pull/17198 but for `release-3.7`.

@derekwaynecarr @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>