### PR TITLE
dockergc: storage driver support limited to overlay2

### DIFF
--- a/pkg/oc/experimental/dockergc/dockergc.go
+++ b/pkg/oc/experimental/dockergc/dockergc.go
@@ -56,8 +56,10 @@ var (
 		If the OpenShift node is configured to use a container runtime other than docker,
 		docker will still be used to do builds.  However OpenShift itself may not
 		manage the docker storage since it is not the container runtime for pods.
-		
-		This utility allows garbage collection to do be done on the docker storage.`)
+
+		This utility allows garbage collection to do be done on the docker storage.
+
+		Only the overlay2 docker storage driver is supported at this time.`)
 
 	dockerGC_example = templates.Examples(`
 	  # Perform garbage collection with the default settings
@@ -251,6 +253,9 @@ func Run(f *clientcmd.Factory, options *dockerGCConfigCmdOptions, cmd *cobra.Com
 	info, err := client.Info(ctx)
 	if err != nil {
 		return err
+	}
+	if info.Driver != "overlay2" {
+		return fmt.Errorf("%s storage driver is not supported", info.Driver)
 	}
 	rootDir := info.DockerRootDir
 	if rootDir == "" {


### PR DESCRIPTION
document and enforce that overlay2 is the only currently supported docker storage driver for this command

xref https://bugzilla.redhat.com/show_bug.cgi?id=1511400

@derekwaynecarr 