### PR TITLE
Allow assign-macvlan annotation to specify an interface

### DIFF
--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -377,8 +377,8 @@ func getVethInfo(netns, containerIfname string) (string, string, string, error) 
 
 // Adds a macvlan interface to a container, if requested, for use with the egress router feature
 func maybeAddMacvlan(pod *kapi.Pod, netns string) error {
-	val, ok := pod.Annotations[networkapi.AssignMacvlanAnnotation]
-	if !ok || val != "true" {
+	annotation, ok := pod.Annotations[networkapi.AssignMacvlanAnnotation]
+	if !ok || annotation == "false" {
 		return nil
 	}
 
@@ -393,23 +393,31 @@ func maybeAddMacvlan(pod *kapi.Pod, netns string) error {
 		return fmt.Errorf("pod has %q annotation but is not privileged", networkapi.AssignMacvlanAnnotation)
 	}
 
-	// Find interface with the default route
-	var defIface netlink.Link
-	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
-	if err != nil {
-		return fmt.Errorf("failed to read routes: %v", err)
-	}
+	var iface netlink.Link
+	var err error
+	if annotation == "true" {
+		// Find interface with the default route
+		routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("failed to read routes: %v", err)
+		}
 
-	for _, r := range routes {
-		if r.Dst == nil {
-			defIface, err = netlink.LinkByIndex(r.LinkIndex)
-			if err != nil {
-				return fmt.Errorf("failed to get default route interface: %v", err)
+		for _, r := range routes {
+			if r.Dst == nil {
+				iface, err = netlink.LinkByIndex(r.LinkIndex)
+				if err != nil {
+					return fmt.Errorf("failed to get default route interface: %v", err)
+				}
 			}
 		}
-	}
-	if defIface == nil {
-		return fmt.Errorf("failed to find default route interface")
+		if iface == nil {
+			return fmt.Errorf("failed to find default route interface")
+		}
+	} else {
+		iface, err = netlink.LinkByName(annotation)
+		if err != nil {
+			return fmt.Errorf("pod annotation %q is neither 'true' nor the name of a local network interface", networkapi.AssignMacvlanAnnotation)
+		}
 	}
 
 	podNs, err := ns.GetNS(netns)
@@ -420,9 +428,9 @@ func maybeAddMacvlan(pod *kapi.Pod, netns string) error {
 
 	err = netlink.LinkAdd(&netlink.Macvlan{
 		LinkAttrs: netlink.LinkAttrs{
-			MTU:         defIface.Attrs().MTU,
+			MTU:         iface.Attrs().MTU,
 			Name:        "macvlan0",
-			ParentIndex: defIface.Attrs().Index,
+			ParentIndex: iface.Attrs().Index,
 			Namespace:   netlink.NsFd(podNs.Fd()),
 		},
 		Mode: netlink.MACVLAN_MODE_PRIVATE,


### PR DESCRIPTION
If the `assign-macvlan` interface is a string other than "true", assume that it's the name of a network interface and hang the macvlan off that rather than the default interface. This lets you egress-route out a non-default interface (without forcing OpenShift itself to parse the `EGRESS_SOURCE` environment variable in the pod definition).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1513764. Needs to be backported to 3.7 and 3.6 quickly for a customer, so we went with a simple solution here.

@openshift/networking PTAL