### PR TITLE
break dependency on version cmd for non-cli pkgs

### DIFF
--- a/pkg/cmd/infra/builder/builder.go
+++ b/pkg/cmd/infra/builder/builder.go
@@ -9,7 +9,8 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/openshift/origin/pkg/build/builder/cmd"
-	ocmd "github.com/openshift/origin/pkg/oc/cli/cmd"
+	cmdversion "github.com/openshift/origin/pkg/cmd/version"
+	"github.com/openshift/origin/pkg/version"
 )
 
 var (
@@ -56,7 +57,7 @@ func NewCommandS2IBuilder(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 	return cmd
 }
 
@@ -71,7 +72,7 @@ func NewCommandDockerBuilder(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 	return cmd
 }
 
@@ -87,7 +88,7 @@ func NewCommandGitClone(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 	return cmd
 }
 
@@ -101,7 +102,7 @@ func NewCommandManageDockerfile(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 	return cmd
 }
 
@@ -115,6 +116,6 @@ func NewCommandExtractImageContent(name string) *cobra.Command {
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 	return cmd
 }

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -24,8 +24,9 @@ import (
 	"github.com/openshift/origin/pkg/apps/strategy/rolling"
 	deployutil "github.com/openshift/origin/pkg/apps/util"
 	"github.com/openshift/origin/pkg/cmd/util"
+	cmdversion "github.com/openshift/origin/pkg/cmd/version"
 	imageclientinternal "github.com/openshift/origin/pkg/image/generated/internalclientset"
-	ocmd "github.com/openshift/origin/pkg/oc/cli/cmd"
+	"github.com/openshift/origin/pkg/version"
 )
 
 var (
@@ -81,7 +82,7 @@ func NewCommandDeployer(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 
 	flag := cmd.Flags()
 	flag.StringVar(&cfg.rcName, "deployment", util.Env("OPENSHIFT_DEPLOYMENT_NAME", ""), "The deployment name to start")

--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -14,12 +14,13 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	ocmd "github.com/openshift/origin/pkg/oc/cli/cmd"
+	cmdversion "github.com/openshift/origin/pkg/cmd/version"
 	projectinternalclientset "github.com/openshift/origin/pkg/project/generated/internalclientset"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	routeinternalclientset "github.com/openshift/origin/pkg/route/generated/internalclientset"
 	"github.com/openshift/origin/pkg/router/controller"
 	f5plugin "github.com/openshift/origin/pkg/router/f5"
+	"github.com/openshift/origin/pkg/version"
 )
 
 var (
@@ -152,7 +153,7 @@ func NewCommandF5Router(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 
 	flag := cmd.Flags()
 	options.Config.Bind(flag)

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -30,7 +30,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	ocmd "github.com/openshift/origin/pkg/oc/cli/cmd"
+	cmdversion "github.com/openshift/origin/pkg/cmd/version"
 	projectinternalclientset "github.com/openshift/origin/pkg/project/generated/internalclientset"
 	routeinternalclientset "github.com/openshift/origin/pkg/route/generated/internalclientset"
 	"github.com/openshift/origin/pkg/router"
@@ -160,7 +160,7 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ocmd.NewCmdVersion(name, nil, os.Stdout, ocmd.VersionOptions{}))
+	cmd.AddCommand(cmdversion.NewCmdVersion(name, version.Get(), os.Stdout))
 
 	flag := cmd.Flags()
 	options.Config.Bind(flag)

--- a/pkg/cmd/server/start/kubernetes/kubernetes.go
+++ b/pkg/cmd/server/start/kubernetes/kubernetes.go
@@ -13,7 +13,6 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	"github.com/openshift/origin/pkg/oc/cli/cmd"
 )
 
 const kubernetesLong = `
@@ -36,9 +35,6 @@ func NewCommand(name, fullName string, out, errOut io.Writer) *cobra.Command {
 	cmds.AddCommand(NewKubeletCommand("kubelet", fullName+" kubelet", out))
 	cmds.AddCommand(proxyapp.NewProxyCommand())
 	cmds.AddCommand(NewSchedulerCommand("scheduler", fullName+" scheduler", out))
-	if "hyperkube" == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, nil, out, cmd.VersionOptions{}))
-	}
 
 	return cmds
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,0 +1,30 @@
+package version
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// VersionInfo provides semantic version information
+// in a human-friendly format
+// TODO: may be expanded for various short and formatting options if necessary.
+type VersionInfo interface {
+	String() string
+}
+
+// NewCmdVersion provides a shim around version for
+// non-client packages that require version information
+func NewCmdVersion(fullName string, versionInfo VersionInfo, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display client and server versions",
+		Long:  "Display client and server versions",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(out, "%s %v\n", fullName, versionInfo)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/federation/kubefed/kubefed.go
+++ b/pkg/federation/kubefed/kubefed.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 
 	osclientcmd "github.com/openshift/origin/pkg/cmd/util/clientcmd"
-	"github.com/openshift/origin/pkg/oc/cli/cmd"
 	"github.com/openshift/origin/pkg/version"
 )
 
@@ -75,8 +74,6 @@ func NewKubeFedCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
 	// Use the openshift-specific version command
-	cmds.AddCommand(cmd.NewCmdVersion("kubefed", f, out, cmd.VersionOptions{PrintClientFeatures: true}))
-
 	cmds.AddCommand(kubectl.NewCmdOptions(out))
 
 	return cmds


### PR DESCRIPTION
This patch solves a few of the items (currently checked) from #17309 
Removes dependency on `pkg/cli/cmd/version` for packages outside
of the `pkg/oc` subtree.

cc @deads2k @liggitt @openshift/cli-review 