### PR TITLE
Allow '-n none' for the dind to set up no network plugin

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -460,6 +460,8 @@ function get-network-plugin() {
     echo "${ovn_plugin}"
   elif [[ "${plugin}" = "cni" ]]; then
     echo "cni"
+  elif [[ "${plugin}" = "none" ]]; then
+    echo ""
   elif [[ -n "${plugin}" ]]; then
     >&2 echo "Invalid network plugin: ${plugin}"
     exit 1
@@ -826,7 +828,7 @@ Commands:
 
 start accepts the following options:
 
- -n [net plugin]   the name of the network plugin to deploy
+ -n [net plugin]   the name of the network plugin to deploy (or "none" for none)
  -N                number of nodes in the cluster
  -b                build origin before starting the cluster
  -c [runtime name] use the specified container runtime instead of dockershim (eg, "crio")


### PR DESCRIPTION
In order to diagnose some problems when there was no network plugin enabled, it was necessary to set up a DinD environment with no network plugin.

Once this is enabled you can do:
  hack/dind-cluster.sh start -n "none" -N 1

I used -N 1 above to set up a single node (since no networking between nodes will work anyway).