### PR TITLE
Support oc tag to add alias of ImageStreamTag in the same ImageStream

### DIFF
--- a/pkg/oc/cli/cmd/tag.go
+++ b/pkg/oc/cli/cmd/tag.go
@@ -202,7 +202,7 @@ func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 				ref.Namespace = o.namespace
 			}
 			if sourceKind == "ImageStreamTag" {
-				if len(ref.Tag) == 0 {
+				if len(ref.Tag) == 0 && !o.aliasTag {
 					return fmt.Errorf("--source=ImageStreamTag requires a valid <name>:<tag> in SOURCE")
 				}
 			} else {
@@ -349,7 +349,7 @@ func (o TagOptions) Validate() error {
 		if err != nil {
 			return err
 		}
-		if cross {
+		if cross && o.ref.Tag != "" {
 			return errors.New("cannot set alias across different Image Streams")
 		}
 	}

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -218,6 +218,9 @@ os::cmd::expect_success_and_text "oc get is/mysql --template='{{(index .spec.tag
 
 os::cmd::expect_failure_and_text 'oc tag mysql:latest tagtest:tag1 --alias' 'cannot set alias across'
 
+os::cmd::expect_success 'oc tag --source=istag alias1 mysql:alias1 --alias'
+os::cmd::expect_success_and_text "oc get is/mysql --template='{{(index .spec.tags 15).from.kind}}'" 'ImageStreamTag'
+
 # tag labeled image
 os::cmd::expect_success 'oc label is/mysql labelA=value'
 os::cmd::expect_success 'oc tag mysql:latest mysql:labeled'


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514907

oc tag: Support oc tag to add alias of ImageStreamTag

Current `oc tag` command allows only `<name>:<tag>` format to add tag
from ImageStreamTag source. Due to this, if users want to create an
alias of ImageStreamTag in same ImageStream by `oc tag <tag> --alias` 
after omitting the name,  they encounter following validation error:

```
# oc tag registry.access.redhat.com/rhscl/perl-520-rhel7:latest perl:latest --source=docker
# oc tag perl:latest perl:5.20 --source=istag 
# oc tag 5.20 perl:latest --source=istag --alias
error: --source=ImageStreamTag requires a valid <name>:<tag> in SOURCE
```
Note, these command could create this
[ImageStream](https://gist.githubusercontent.com/nak3/223bf3bd7d59bfcc6eb63fa981a691ba/raw/c4705d82157c72caf13f91c4540bd504c965b47c/perl_imagestream.yaml)
and we know that it is possible to create this ImageStream(Tags) by
`oc create -f`.

This patch removes the validation check of <name>:<tag> only when
`--alias` specified and allow users to create ImageStreamTag alias in
the same ImageStream by `oc tag`.