### PR TITLE
Limit fail-on-swap override to cluster-up

### DIFF
--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -82,10 +82,6 @@ func Build(options configapi.NodeConfig) (*kubeletoptions.KubeletServer, error) 
 	server.RemoteImageEndpoint = options.DockerConfig.DockerShimSocket
 	server.DockershimRootDirectory = options.DockerConfig.DockershimRootDirectory
 
-	// TODO: check/warn/fail in setup instead?
-	// allows kubelet to continue to start in swap environments
-	server.FailSwapOn = false
-
 	// prevents kube from generating certs
 	server.TLSCertFile = options.ServingInfo.ServerCert.CertFile
 	server.TLSPrivateKeyFile = options.ServingInfo.ServerCert.KeyFile

--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -887,6 +887,9 @@ func (h *Helper) updateConfig(configDir string, opt *StartOptions) error {
 		nodeCfg.DNSIP = ""
 	}
 	nodeCfg.DNSBindAddress = ""
+	if nodeCfg.KubeletArguments == nil {
+		nodeCfg.KubeletArguments = configapi.ExtendedArguments{}
+	}
 
 	if h.supportsCgroupDriver() {
 		// Set the cgroup driver from the current docker
@@ -895,11 +898,9 @@ func (h *Helper) updateConfig(configDir string, opt *StartOptions) error {
 			return err
 		}
 		glog.V(5).Infof("cgroup driver from Docker: %s", cgroupDriver)
-		if nodeCfg.KubeletArguments == nil {
-			nodeCfg.KubeletArguments = configapi.ExtendedArguments{}
-		}
 		nodeCfg.KubeletArguments["cgroup-driver"] = []string{cgroupDriver}
 	}
+	nodeCfg.KubeletArguments["fail-swap-on"] = []string{"false"}
 
 	cfgBytes, err = configapilatest.WriteYAML(nodeCfg)
 	if err != nil {


### PR DESCRIPTION
Follow up from rebase. Ansible disables swap, so we only need to prevent the "crash on start" behavior for cluster-up