### PR TITLE
Add prometheus.io/port to avoid unreachable targets

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -66,6 +66,7 @@ objects:
   metadata:
     annotations:
       prometheus.io/scrape: "true"
+      prometheus.io/port: "8443"
       prometheus.io/scheme: https
       service.alpha.openshift.io/serving-cert-secret-name: prometheus-tls
     labels:


### PR DESCRIPTION
Without this PR, a target for each port exported by containers in the prometheus pod is created in Prometheus (8443, 9090, 9443, 9099 and 9093). But only the only target reachable by prometheus is 8443, so this PR removes unreachable targets from the prometheus configuration.