### PR TITLE
Use written node config in 'openshift start'

### DIFF
--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -295,7 +295,10 @@ func (o NodeOptions) resolveNodeConfig() (*configapi.NodeConfig, string, error) 
 		if err != nil {
 			return nil, "", err
 		}
-		cfg, err := o.NodeArgs.BuildSerializeableNodeConfig()
+		cfg, err := configapilatest.ReadAndResolveNodeConfig(configFile)
+		if err != nil {
+			return nil, "", err
+		}
 		return cfg, configFile, err
 	}
 }


### PR DESCRIPTION
The generated node config file was correct, but the returned config struct used for `openshift start` was using a separate in-memory construction used only by tests

This unifies the config written by `openshift start --write-config` and `openshift start`