### PR TITLE
dind: set fail-swap-on=false

### DIFF
--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -63,6 +63,7 @@ function ensure-node-config() {
 kubeletArguments:
   cgroups-per-qos: ["false"]
   enforce-node-allocatable: [""]
+  fail-swap-on: ["false"]
 EOF
 
     if [[ "${OPENSHIFT_CONTAINER_RUNTIME}" != "dockershim" ]]; then


### PR DESCRIPTION
Docker-In-Docker is used on a local machine for openshift development,
and since it's containerized much of /proc is available in the openshift
master/node containers.  Thus if your development machine has swap (which
is pretty common) kubelet will complain.  But since this isn't production,
having swap shouldn't matter.

@openshift/networking @knobunc 