### PR TITLE
fix multiarch import tests

### DIFF
--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -143,12 +143,12 @@ os::cmd::expect_success_and_text "oc describe ${imagename}" 'Image Created:'
 os::cmd::expect_success_and_text "oc describe ${imagename}" 'Image Name:'
 
 # test prefer-os and prefer-arch annotations
-os::cmd::expect_success 'oc create -f test/testdata/test-nginx-multiarch-stream.yaml'
-os::cmd::try_until_success 'oc get istag test-nginx-multiarch-stream:linux-amd64'
-os::cmd::try_until_success 'oc get istag test-nginx-multiarch-stream:linux-ppc64le'
-os::cmd::expect_success_and_text 'oc get istag test-nginx-multiarch-stream:linux-amd64 --template={{.image.dockerImageMetadata.Architecture}}' 'amd64'
-os::cmd::expect_success_and_text 'oc get istag test-nginx-multiarch-stream:linux-ppc64le --template={{.image.dockerImageMetadata.Architecture}}' 'ppc64le'
-os::cmd::expect_success 'oc delete is test-nginx-multiarch-stream'
+os::cmd::expect_success 'oc create -f test/testdata/test-multiarch-stream.yaml'
+os::cmd::try_until_success 'oc get istag test-multiarch-stream:linux-amd64'
+os::cmd::try_until_success 'oc get istag test-multiarch-stream:linux-s390x'
+os::cmd::expect_success_and_text 'oc get istag test-multiarch-stream:linux-amd64 --template={{.image.dockerImageMetadata.Architecture}}' 'amd64'
+os::cmd::expect_success_and_text 'oc get istag test-multiarch-stream:linux-s390x --template={{.image.dockerImageMetadata.Architecture}}' 's390x'
+os::cmd::expect_success 'oc delete is test-multiarch-stream'
 echo "imageStreams: ok"
 os::test::junit::declare_suite_end
 

--- a/test/testdata/test-multiarch-stream.yaml
+++ b/test/testdata/test-multiarch-stream.yaml
@@ -1,20 +1,20 @@
 apiVersion: v1
 kind: ImageStream
 metadata:
-  name: test-nginx-multiarch-stream
+  name: test-multiarch-stream
 spec:
   tags:
   - name: linux-amd64
     from:
       kind: DockerImage
-      name: nginx:latest
+      name: bparees/multiplatformtest:latest
     annotations:
       importer.image.openshift.io/prefer-os: linux
       importer.image.openshift.io/prefer-arch: amd64
-  - name: linux-ppc64le
+  - name: linux-s390x
     from:
       kind: DockerImage
-      name: nginx:latest
+      name: bparees/multiplatformtest:latest
     annotations:
       importer.image.openshift.io/prefer-os: linux
-      importer.image.openshift.io/prefer-arch: ppc64le
+      importer.image.openshift.io/prefer-arch: s390x


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/17436

updated this to use an image under our control to which i've pushed amd64, ppc64le, and s390x image versions in a manifestlist.

I didn't do it under the openshift org to avoid confusion if someone stumbles upon them.

for reference I used this tool:
https://github.com/estesp/manifest-tool

and these images:
s390x/busybox
ppc64le/busybox
busybox

pushed to my own repository and this manifest yaml input to the manifest-tool.
```
image: bparees/multiplatformtest:latest
manifests:
   -
     image: bparees/multiplatformtest:amd64
     platform:
       architecture: amd64
       os: linux
   -
     image: bparees/multiplatformtest:ppc64le
     platform:
       architecture: ppc64le
       os: linux
   -
     image: bparees/multiplatformtest:s390x
     platform:
       architecture: s390x
       os: linux
```