### PR TITLE
Switch to use .DeepCopy() instead of kapi.Scheme.DeepCopy()

### DIFF
--- a/pkg/apps/controller/deployer/deployer_controller.go
+++ b/pkg/apps/controller/deployer/deployer_controller.go
@@ -490,16 +490,7 @@ func (c *DeploymentController) setDeployerPodsOwnerRef(deployment *v1.Replicatio
 			continue
 		}
 		glog.V(4).Infof("setting ownerRef for pod %s/%s to deployment %s/%s", pod.Namespace, pod.Name, deployment.Namespace, deployment.Name)
-		objCopy, err := kapi.Scheme.DeepCopy(pod)
-		if err != nil {
-			errors = append(errors, err)
-			continue
-		}
-		newPod, ok := objCopy.(*v1.Pod)
-		if !ok {
-			errors = append(errors, fmt.Errorf("object %#+v is not a pod", objCopy))
-			continue
-		}
+		newPod := pod.DeepCopy()
 		newPod.SetOwnerReferences([]metav1.OwnerReference{{
 			APIVersion: "v1",
 			Name:       deployment.Name,

--- a/pkg/apps/strategy/support/lifecycle.go
+++ b/pkg/apps/strategy/support/lifecycle.go
@@ -381,20 +381,8 @@ func makeHookPod(hook *deployapi.LifecycleHook, rc *kapi.ReplicationController, 
 	}
 
 	gracePeriod := int64(10)
-
-	var podSecurityContextCopy *kapi.PodSecurityContext
-	if ctx, err := kapi.Scheme.DeepCopy(rc.Spec.Template.Spec.SecurityContext); err != nil {
-		return nil, fmt.Errorf("unable to copy pod securityContext: %v", err)
-	} else {
-		podSecurityContextCopy = ctx.(*kapi.PodSecurityContext)
-	}
-
-	var securityContextCopy *kapi.SecurityContext
-	if ctx, err := kapi.Scheme.DeepCopy(baseContainer.SecurityContext); err != nil {
-		return nil, fmt.Errorf("unable to copy securityContext: %v", err)
-	} else {
-		securityContextCopy = ctx.(*kapi.SecurityContext)
-	}
+	podSecurityContextCopy := rc.Spec.Template.Spec.SecurityContext.DeepCopy()
+	securityContextCopy := baseContainer.SecurityContext.DeepCopy()
 
 	pod := &kapi.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apps/strategy/support/lifecycle_test.go
+++ b/pkg/apps/strategy/support/lifecycle_test.go
@@ -109,8 +109,7 @@ func TestHookExecutor_executeExecNewPodSucceeded(t *testing.T) {
 	go func() {
 		<-podCreated
 		podsWatch.Add(createdPod)
-		podCopy, _ := kapi.Scheme.Copy(createdPod)
-		updatedPod := podCopy.(*kapi.Pod)
+		updatedPod := createdPod.DeepCopy()
 		updatedPod.Status.Phase = kapi.PodSucceeded
 		podsWatch.Modify(updatedPod)
 	}()
@@ -175,8 +174,7 @@ func TestHookExecutor_executeExecNewPodFailed(t *testing.T) {
 	go func() {
 		<-podCreated
 		podsWatch.Add(createdPod)
-		podCopy, _ := kapi.Scheme.Copy(createdPod)
-		updatedPod := podCopy.(*kapi.Pod)
+		updatedPod := createdPod.DeepCopy()
 		updatedPod.Status.Phase = kapi.PodFailed
 		podsWatch.Modify(updatedPod)
 	}()

--- a/pkg/authorization/rulevalidation/compact_rules_test.go
+++ b/pkg/authorization/rulevalidation/compact_rules_test.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
@@ -106,10 +105,9 @@ func TestCompactRules(t *testing.T) {
 
 	for k, tc := range testcases {
 		rules := tc.Rules
-		originalRules, err := kapi.Scheme.DeepCopy(tc.Rules)
-		if err != nil {
-			t.Errorf("%s: couldn't copy rules: %v", k, err)
-			continue
+		originalRules := make([]authorizationapi.PolicyRule, len(tc.Rules))
+		for i, r := range tc.Rules {
+			r.DeepCopyInto(&originalRules[i])
 		}
 		compacted, err := CompactRules(tc.Rules)
 		if err != nil {

--- a/pkg/build/apis/build/validation/validation.go
+++ b/pkg/build/apis/build/validation/validation.go
@@ -44,11 +44,7 @@ func ValidateBuildUpdate(build *buildapi.Build, older *buildapi.Build) field.Err
 	}
 
 	// lie about the old build's pushsecret value so we can allow it to be updated.
-	olderCopy, err := buildutil.BuildDeepCopy(older)
-	if err != nil {
-		glog.V(2).Infof("Error copying build for update validation: %v", err)
-		allErrs = append(allErrs, field.InternalError(field.NewPath(""), fmt.Errorf("Unable to copy build for update validation: %v", err)))
-	}
+	olderCopy := older.DeepCopy()
 	olderCopy.Spec.Output.PushSecret = build.Spec.Output.PushSecret
 
 	if !kapihelper.Semantic.DeepEqual(build.Spec, olderCopy.Spec) {

--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -748,10 +748,9 @@ func (bc *BuildController) createBuildPod(build *buildapi.Build) (*buildUpdate, 
 
 	// image reference resolution requires a copy of the build
 	var err error
-	build, err = buildutil.BuildDeepCopy(build)
-	if err != nil {
-		return nil, fmt.Errorf("unable to copy build %s: %v", buildDesc(build), err)
-	}
+
+	// TODO: Rename this to buildCopy
+	build = build.DeepCopy()
 
 	// Resolve all Docker image references to valid values.
 	if err := bc.resolveImageReferences(build, update); err != nil {
@@ -1085,10 +1084,7 @@ func (bc *BuildController) handleBuildConfig(bcNamespace string, bcName string) 
 // and applies that patch using the REST client
 func (bc *BuildController) patchBuild(build *buildapi.Build, update *buildUpdate) (*buildapi.Build, error) {
 	// Create a patch using the buildUpdate object
-	updatedBuild, err := buildutil.BuildDeepCopy(build)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create a deep copy of build %s: %v", buildDesc(build), err)
-	}
+	updatedBuild := build.DeepCopy()
 	update.apply(updatedBuild)
 
 	patch, err := validation.CreateBuildPatch(build, updatedBuild)

--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -371,10 +371,7 @@ func TestHandleBuild(t *testing.T) {
 					t.Errorf("%s: did not get an update. Expected: %v", tc.name, tc.expectUpdate)
 					return
 				}
-				expectedBuild, err := buildutil.BuildDeepCopy(tc.build)
-				if err != nil {
-					t.Fatalf("unexpected: %v", err)
-				}
+				expectedBuild := tc.build.DeepCopy()
 				tc.expectUpdate.apply(expectedBuild)
 
 				// For start/completion/duration fields, simply validate that they are set/not set

--- a/pkg/build/controller/policy/policy.go
+++ b/pkg/build/controller/policy/policy.go
@@ -3,8 +3,6 @@ package policy
 import (
 	"github.com/golang/glog"
 
-	kapi "k8s.io/kubernetes/pkg/api"
-
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	buildlister "github.com/openshift/origin/pkg/build/generated/listers/build/internalversion"
@@ -106,12 +104,4 @@ func GetNextConfigBuild(lister buildlister.BuildLister, namespace, buildConfigNa
 		nextBuilds = append(nextBuilds, nextBuild)
 	}
 	return nextBuilds, hasRunningBuilds, nil
-}
-
-func copyOrDie(build *buildapi.Build) *buildapi.Build {
-	obj, err := kapi.Scheme.Copy(build)
-	if err != nil {
-		panic(err)
-	}
-	return obj.(*buildapi.Build)
 }

--- a/pkg/build/controller/policy/serial_latest_only.go
+++ b/pkg/build/controller/policy/serial_latest_only.go
@@ -80,7 +80,7 @@ func (s *SerialLatestOnlyPolicy) cancelPreviousBuilds(build *buildapi.Build) []e
 	var result = []error{}
 	for _, b := range builds {
 		err := wait.Poll(500*time.Millisecond, 5*time.Second, func() (bool, error) {
-			b = copyOrDie(b)
+			b = b.DeepCopy()
 			b.Status.Cancelled = true
 			err := s.BuildUpdater.Update(b.Namespace, b)
 			if err != nil && errors.IsConflict(err) {

--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -458,8 +458,7 @@ func (g *BuildGenerator) generateBuildFromConfig(ctx apirequest.Context, bc *bui
 	// Need to copy the buildConfig here so that it doesn't share pointers with
 	// the build object which could be (will be) modified later.
 	buildName := getNextBuildName(bc)
-	obj, _ := kapi.Scheme.Copy(bc)
-	bcCopy := obj.(*buildapi.BuildConfig)
+	bcCopy := bc.DeepCopy()
 	serviceAccount := getServiceAccount(bcCopy, g.DefaultServiceAccountName)
 	t := true
 	build := &buildapi.Build{
@@ -791,8 +790,7 @@ func UpdateCustomImageEnv(strategy *buildapi.CustomBuildStrategy, newImage strin
 
 // generateBuildFromBuild creates a new build based on a given Build.
 func generateBuildFromBuild(build *buildapi.Build, buildConfig *buildapi.BuildConfig) *buildapi.Build {
-	obj, _ := kapi.Scheme.Copy(build)
-	buildCopy := obj.(*buildapi.Build)
+	buildCopy := build.DeepCopy()
 
 	newBuild := &buildapi.Build{
 		Spec: buildCopy.Spec,

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -165,24 +165,8 @@ func VersionForBuild(build *buildapi.Build) int {
 	return version
 }
 
-func BuildDeepCopy(build *buildapi.Build) (*buildapi.Build, error) {
-	objCopy, err := kapi.Scheme.DeepCopy(build)
-	if err != nil {
-		return nil, err
-	}
-	copied, ok := objCopy.(*buildapi.Build)
-	if !ok {
-		return nil, fmt.Errorf("expected Build, got %#v", objCopy)
-	}
-	return copied, nil
-}
-
 func CopyApiResourcesToV1Resources(in *kapi.ResourceRequirements) corev1.ResourceRequirements {
-	copied, err := kapi.Scheme.DeepCopy(in)
-	if err != nil {
-		panic(err)
-	}
-	in = copied.(*kapi.ResourceRequirements)
+	in = in.DeepCopy()
 	out := corev1.ResourceRequirements{}
 	if err := kapiv1.Convert_api_ResourceRequirements_To_v1_ResourceRequirements(in, &out, nil); err != nil {
 		panic(err)
@@ -191,14 +175,10 @@ func CopyApiResourcesToV1Resources(in *kapi.ResourceRequirements) corev1.Resourc
 }
 
 func CopyApiEnvVarToV1EnvVar(in []kapi.EnvVar) []corev1.EnvVar {
-	copied, err := kapi.Scheme.DeepCopy(in)
-	if err != nil {
-		panic(err)
-	}
-	in = copied.([]kapi.EnvVar)
 	out := make([]corev1.EnvVar, len(in))
 	for i := range in {
-		if err := kapiv1.Convert_api_EnvVar_To_v1_EnvVar(&in[i], &out[i], nil); err != nil {
+		item := in[i].DeepCopy()
+		if err := kapiv1.Convert_api_EnvVar_To_v1_EnvVar(item, &out[i], nil); err != nil {
 			panic(err)
 		}
 	}

--- a/pkg/diagnostics/cluster/route_validation.go
+++ b/pkg/diagnostics/cluster/route_validation.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
-	kapi "k8s.io/kubernetes/pkg/api"
 	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	"k8s.io/kubernetes/pkg/apis/authorization"
 	authorizationtypedclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
@@ -79,13 +78,7 @@ func (d *RouteCertificateValidation) Check() types.DiagnosticResult {
 	}
 
 	for _, route := range routes.Items {
-		copied, err := kapi.Scheme.Copy(&route)
-		if err != nil {
-			r.Error("DRouCert2003", err, fmt.Errorf("unable to copy route: %v", err).Error())
-			return r
-		}
-		original := copied.(*routeapi.Route)
-
+		original := route.DeepCopy()
 		errs := validation.ExtendedValidateRoute(&route)
 
 		if len(errs) == 0 {

--- a/pkg/image/controller/imagestream_controller_test.go
+++ b/pkg/image/controller/imagestream_controller_test.go
@@ -233,10 +233,7 @@ func TestHandleImageStream(t *testing.T) {
 
 	for i, test := range testCases {
 		fake := imageclient.NewSimpleClientset()
-		other, err := kapi.Scheme.DeepCopy(test.stream)
-		if err != nil {
-			t.Fatal(err)
-		}
+		other = test.stream.DeepCopy()
 
 		if err := handleImageStream(test.stream, fake.Image(), nil); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)

--- a/pkg/image/controller/imagestream_controller_test.go
+++ b/pkg/image/controller/imagestream_controller_test.go
@@ -233,7 +233,7 @@ func TestHandleImageStream(t *testing.T) {
 
 	for i, test := range testCases {
 		fake := imageclient.NewSimpleClientset()
-		other = test.stream.DeepCopy()
+		other := test.stream.DeepCopy()
 
 		if err := handleImageStream(test.stream, fake.Image(), nil); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)

--- a/pkg/image/controller/scheduled_image_controller.go
+++ b/pkg/image/controller/scheduled_image_controller.go
@@ -9,7 +9,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/flowcontrol"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
@@ -169,11 +168,7 @@ func (s *ScheduledImageStreamController) syncTimedByName(namespace, name string)
 		return ErrNotImportable
 	}
 
-	copy, err := kapi.Scheme.DeepCopy(sharedStream)
-	if err != nil {
-		return err
-	}
-	stream := copy.(*imageapi.ImageStream)
+	stream := sharedStream.DeepCopy()
 	resetScheduledTags(stream)
 
 	glog.V(3).Infof("Scheduled import of stream %s/%s...", stream.Namespace, stream.Name)

--- a/pkg/image/controller/signature/signature_import_controller.go
+++ b/pkg/image/controller/signature/signature_import_controller.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/controller"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -154,12 +153,7 @@ func (s *SignatureImportController) syncImageSignatures(key string) error {
 		return nil
 	}
 
-	t, err := kapi.Scheme.DeepCopy(image)
-	if err != nil {
-		return err
-	}
-	newImage := t.(*imageapi.Image)
-
+	newImage := image.DeepCopy()
 	shouldUpdate := false
 
 	// Only add new signatures, do not override existing stored signatures as that

--- a/pkg/image/controller/trigger/image_trigger_controller.go
+++ b/pkg/image/controller/trigger/image_trigger_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -373,5 +374,5 @@ func (c *TriggerController) syncResource(key string) error {
 		return nil
 	}
 
-	return source.Reactor.ImageChanged(obj, c.tagRetriever)
+	return source.Reactor.ImageChanged(obj.(runtime.Object), c.tagRetriever)
 }

--- a/pkg/image/controller/trigger/image_trigger_controller_test.go
+++ b/pkg/image/controller/trigger/image_trigger_controller_test.go
@@ -956,12 +956,7 @@ func updateBuildConfigImages(bc *buildapi.BuildConfig, tagRetriever trigger.TagR
 			continue
 		}
 		if updated == nil {
-			copied, err := kapi.Scheme.Copy(bc)
-			if err != nil {
-				return nil, err
-			}
-			bc = copied.(*buildapi.BuildConfig)
-			updated = bc
+			updated = bc.DeepCopy()
 		}
 		p = bc.Spec.Triggers[i].ImageChange
 		p.LastTriggeredImageID = latest

--- a/pkg/image/controller/trigger/image_trigger_controller_test.go
+++ b/pkg/image/controller/trigger/image_trigger_controller_test.go
@@ -973,8 +973,7 @@ func updateBuildConfigImages(bc *buildapi.BuildConfig, tagRetriever trigger.TagR
 // changes passed to it and send it back on the watch as a modification.
 func alterBuildConfigFromTriggers(bcWatch *consistentWatch) imageReactorFunc {
 	return imageReactorFunc(func(obj interface{}, tagRetriever trigger.TagRetriever) error {
-		obj, _ = kapi.Scheme.DeepCopy(obj)
-		bc := obj.(*buildapi.BuildConfig)
+		bc := obj.DeepCopy()
 
 		updated, err := updateBuildConfigImages(bc, tagRetriever)
 		if err != nil {
@@ -989,8 +988,7 @@ func alterBuildConfigFromTriggers(bcWatch *consistentWatch) imageReactorFunc {
 
 func alterDeploymentConfigFromTriggers(dcWatch *consistentWatch) imageReactorFunc {
 	return imageReactorFunc(func(obj interface{}, tagRetriever trigger.TagRetriever) error {
-		obj, _ = kapi.Scheme.DeepCopy(obj)
-		dc := obj.(*deployapi.DeploymentConfig)
+		dc := obj.DeepCopy()
 		updated, resolvable, err := deploymentconfigs.UpdateDeploymentConfigImages(dc, tagRetriever)
 		if err != nil {
 			return err
@@ -1007,8 +1005,7 @@ func alterDeploymentConfigFromTriggers(dcWatch *consistentWatch) imageReactorFun
 func alterPodFromTriggers(podWatch *watch.RaceFreeFakeWatcher) imageReactorFunc {
 	count := 2
 	return imageReactorFunc(func(obj interface{}, tagRetriever trigger.TagRetriever) error {
-		obj, _ = kapi.Scheme.DeepCopy(obj)
-		pod := obj.(*kapi.Pod)
+		pod := obj.DeepCopy()
 
 		updated, err := annotations.UpdateObjectFromImages(pod, kapi.Scheme, tagRetriever)
 		if err != nil {
@@ -1227,8 +1224,7 @@ func TestTriggerController(t *testing.T) {
 				if len(items) == 0 {
 					continue
 				}
-				obj, _ := kapi.Scheme.DeepCopy(items[rnd.Int31n(int32(len(items)))])
-				bc := obj.(*buildapi.BuildConfig)
+				bc := items[rnd.Int31n(int32(len(items)))].DeepCopy()
 				if len(bc.Spec.Triggers) > 0 {
 					index := rnd.Int31n(int32(len(bc.Spec.Triggers)))
 					trigger := &bc.Spec.Triggers[index]

--- a/pkg/image/registry/image/strategy_test.go
+++ b/pkg/image/registry/image/strategy_test.go
@@ -68,11 +68,7 @@ func TestStrategyPrepareForCreate(t *testing.T) {
 
 	seed := int64(2703387474910584091) //rand.Int63()
 	fuzzed := fuzzImage(t, &original, seed)
-	obj, err := kapi.Scheme.DeepCopy(fuzzed)
-	if err != nil {
-		t.Fatalf("faild to deep copy fuzzed image: %v", err)
-	}
-	image := obj.(*imageapi.Image)
+	image := fuzzed.DeepCopy()
 
 	if len(image.Signatures) == 0 {
 		t.Fatalf("fuzzifier failed to generate signatures")

--- a/pkg/image/registry/imagestream/strategy_test.go
+++ b/pkg/image/registry/imagestream/strategy_test.go
@@ -1108,8 +1108,11 @@ func TestTagsChanged(t *testing.T) {
 		// we can't reuse the same map twice, it causes both to be modified during updates
 		var previousTagHistory = test.existingTagHistory
 		if previousTagHistory != nil {
-			obj, _ := kapi.Scheme.DeepCopy(previousTagHistory)
-			previousTagHistory, _ = obj.(map[string]imageapi.TagEventList)
+			previousTagHistoryCopy := map[string]imageapi.TagEventList{}
+			for k, v := range previousTagHistory {
+				previousTagHistory[k] = *v.DeepCopy()
+			}
+			previousTagHistory = previousTagHistoryCopy
 		}
 		previousStream := &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/image/trigger/annotations/annotations.go
+++ b/pkg/image/trigger/annotations/annotations.go
@@ -261,8 +261,8 @@ type AnnotationReactor struct {
 	Copier  runtime.ObjectCopier
 }
 
-func (r *AnnotationReactor) ImageChanged(obj interface{}, tagRetriever trigger.TagRetriever) error {
-	changed, err := UpdateObjectFromImages(obj.(runtime.Object), r.Copier, tagRetriever)
+func (r *AnnotationReactor) ImageChanged(obj runtime.Object, tagRetriever trigger.TagRetriever) error {
+	changed, err := UpdateObjectFromImages(obj, r.Copier, tagRetriever)
 	if err != nil {
 		return err
 	}

--- a/pkg/image/trigger/annotations/annotations_test.go
+++ b/pkg/image/trigger/annotations/annotations_test.go
@@ -284,11 +284,8 @@ func TestAnnotationsReactor(t *testing.T) {
 	for i, test := range testCases {
 		u := &fakeUpdater{}
 		r := AnnotationReactor{Copier: kapi.Scheme, Updater: u}
-		initial, err := kapi.Scheme.DeepCopy(test.obj)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = r.ImageChanged(test.obj, fakeTagRetriever(test.tags))
+		initial := test.obj.DeepCopy()
+		err := r.ImageChanged(test.obj, fakeTagRetriever(test.tags))
 		if !kapihelper.Semantic.DeepEqual(initial, test.obj) {
 			t.Errorf("%d: should not have mutated: %s", i, diff.ObjectReflectDiff(initial, test.obj))
 		}

--- a/pkg/image/trigger/buildconfigs/buildconfigs.go
+++ b/pkg/image/trigger/buildconfigs/buildconfigs.go
@@ -6,6 +6,7 @@ import (
 
 	clientv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -131,7 +132,7 @@ func NewBuildConfigReactor(instantiator BuildConfigInstantiator, restclient rest
 
 // ImageChanged is passed a build config and a set of changes and updates the object if
 // necessary.
-func (r *buildConfigReactor) ImageChanged(obj interface{}, tagRetriever trigger.TagRetriever) error {
+func (r *buildConfigReactor) ImageChanged(obj runtime.Object, tagRetriever trigger.TagRetriever) error {
 	bc := obj.(*buildapi.BuildConfig)
 
 	var request *buildapi.BuildRequest

--- a/pkg/image/trigger/buildconfigs/buildconfigs_test.go
+++ b/pkg/image/trigger/buildconfigs/buildconfigs_test.go
@@ -247,11 +247,8 @@ func TestBuildConfigReactor(t *testing.T) {
 	for i, test := range testCases {
 		instantiator := &instantiator{build: test.response}
 		r := buildConfigReactor{instantiator: instantiator}
-		initial, err := kapi.Scheme.DeepCopy(test.obj)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = r.ImageChanged(test.obj, fakeTagRetriever(test.tags))
+		initial := test.obj.DeepCopy()
+		err := r.ImageChanged(test.obj, fakeTagRetriever(test.tags))
 		if !kapihelper.Semantic.DeepEqual(initial, test.obj) {
 			t.Errorf("%d: should not have mutated: %s", i, diff.ObjectReflectDiff(initial, test.obj))
 		}

--- a/pkg/image/trigger/deploymentconfigs/deploymentconfigs.go
+++ b/pkg/image/trigger/deploymentconfigs/deploymentconfigs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/api"
 
@@ -226,7 +227,7 @@ func UpdateDeploymentConfigImages(dc *appsapi.DeploymentConfig, tagRetriever tri
 }
 
 // ImageChanged is passed a deployment config and a set of changes.
-func (r *DeploymentConfigReactor) ImageChanged(obj interface{}, tagRetriever trigger.TagRetriever) error {
+func (r *DeploymentConfigReactor) ImageChanged(obj runtime.Object, tagRetriever trigger.TagRetriever) error {
 	dc := obj.(*appsapi.DeploymentConfig)
 	newDC := dc.DeepCopy()
 

--- a/pkg/image/trigger/deploymentconfigs/deploymentconfigs.go
+++ b/pkg/image/trigger/deploymentconfigs/deploymentconfigs.go
@@ -164,11 +164,7 @@ func UpdateDeploymentConfigImages(dc *appsapi.DeploymentConfig, tagRetriever tri
 		if updated != nil {
 			return
 		}
-		copied, err := kapi.Scheme.Copy(dc)
-		if err != nil {
-			return
-		}
-		dc = copied.(*appsapi.DeploymentConfig)
+		dc = dc.DeepCopy()
 		updated = dc
 	}
 

--- a/pkg/image/trigger/deploymentconfigs/deploymentconfigs.go
+++ b/pkg/image/trigger/deploymentconfigs/deploymentconfigs.go
@@ -228,11 +228,7 @@ func UpdateDeploymentConfigImages(dc *appsapi.DeploymentConfig, tagRetriever tri
 // ImageChanged is passed a deployment config and a set of changes.
 func (r *DeploymentConfigReactor) ImageChanged(obj interface{}, tagRetriever trigger.TagRetriever) error {
 	dc := obj.(*appsapi.DeploymentConfig)
-	copied, err := kapi.Scheme.DeepCopy(dc)
-	if err != nil {
-		return err
-	}
-	newDC := copied.(*appsapi.DeploymentConfig)
+	newDC := dc.DeepCopy()
 
 	updated, resolvable, err := UpdateDeploymentConfigImages(newDC, tagRetriever)
 	if err != nil {

--- a/pkg/image/trigger/deploymentconfigs/deploymentconfigs_test.go
+++ b/pkg/image/trigger/deploymentconfigs/deploymentconfigs_test.go
@@ -398,11 +398,8 @@ func TestDeploymentConfigReactor(t *testing.T) {
 				})
 			}
 			r := DeploymentConfigReactor{Client: c.Apps()}
-			initial, err := kapi.Scheme.DeepCopy(test.obj)
-			if err != nil {
-				t.Fatal(err)
-			}
-			err = r.ImageChanged(test.obj, fakeTagRetriever(test.tags))
+			initial := test.obj.DeepCopy()
+			err := r.ImageChanged(test.obj, fakeTagRetriever(test.tags))
 			if !kapihelper.Semantic.DeepEqual(initial, test.obj) {
 				t.Errorf("should not have mutated: %s", diff.ObjectReflectDiff(initial, test.obj))
 			}

--- a/pkg/image/trigger/interfaces.go
+++ b/pkg/image/trigger/interfaces.go
@@ -1,6 +1,7 @@
 package trigger
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openshift/origin/pkg/image/apis/image/v1/trigger"
@@ -27,5 +28,5 @@ type TagRetriever interface {
 }
 
 type ImageReactor interface {
-	ImageChanged(obj interface{}, tagRetriever TagRetriever) error
+	ImageChanged(obj runtime.Object, tagRetriever TagRetriever) error
 }

--- a/pkg/oc/admin/groups/sync/groupsyncer_test.go
+++ b/pkg/oc/admin/groups/sync/groupsyncer_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/origin/pkg/auth/ldaputil"
 	"github.com/openshift/origin/pkg/oc/admin/groups/sync/interfaces"
@@ -243,8 +242,7 @@ func checkClientForGroups(tc *userfakeclient.Clientset, expectedGroups []*userap
 
 func groupExists(haystack []*userapi.Group, needle *userapi.Group) bool {
 	for _, actual := range haystack {
-		t, _ := kapi.Scheme.DeepCopy(actual)
-		actualGroup := t.(*userapi.Group)
+		actualGroup := actual.DeepCopy()
 		delete(actualGroup.Annotations, ldaputil.LDAPSyncTimeAnnotation)
 
 		if reflect.DeepEqual(needle, actualGroup) {

--- a/pkg/oc/cli/cmd/newapp.go
+++ b/pkg/oc/cli/cmd/newapp.go
@@ -651,12 +651,7 @@ func setLabels(labels map[string]string, result *newcmd.AppResult) error {
 
 func hasLabel(labels map[string]string, result *newcmd.AppResult) (bool, error) {
 	for _, obj := range result.List.Items {
-		objCopy, err := kapi.Scheme.DeepCopy(obj)
-		if err != nil {
-			return false, err
-		}
-		err = util.AddObjectLabelsWithFlags(objCopy.(runtime.Object), labels, util.ErrorOnExistingDstKey)
-		if err != nil {
+		if err := util.AddObjectLabelsWithFlags(obj.DeepCopyObject(), labels, util.ErrorOnExistingDstKey); err != nil {
 			return true, nil
 		}
 	}

--- a/pkg/quota/admission/clusterresourcequota/accessor.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor.go
@@ -63,13 +63,9 @@ func (e *clusterQuotaAccessor) UpdateQuotaStatus(newQuota *kapi.ResourceQuota) e
 	}
 	clusterQuota = e.checkCache(clusterQuota)
 
-	// make a copy
-	obj, err := kapi.Scheme.Copy(clusterQuota)
-	if err != nil {
-		return err
-	}
 	// re-assign objectmeta
-	clusterQuota = obj.(*quotaapi.ClusterResourceQuota)
+	// make a copy
+	clusterQuota = clusterQuota.DeepCopy()
 	clusterQuota.ObjectMeta = newQuota.ObjectMeta
 	clusterQuota.Namespace = ""
 

--- a/pkg/quota/admission/clusterresourcequota/accessor.go
+++ b/pkg/quota/admission/clusterresourcequota/accessor.go
@@ -81,11 +81,8 @@ func (e *clusterQuotaAccessor) UpdateQuotaStatus(newQuota *kapi.ResourceQuota) e
 
 	// update per namespace totals
 	oldNamespaceTotals, _ := clusterQuota.Status.Namespaces.Get(newQuota.Namespace)
-	namespaceTotalCopy, err := kapi.Scheme.DeepCopy(oldNamespaceTotals)
-	if err != nil {
-		return err
-	}
-	newNamespaceTotals := namespaceTotalCopy.(kapi.ResourceQuotaStatus)
+	namespaceTotalCopy := oldNamespaceTotals.DeepCopy()
+	newNamespaceTotals := *namespaceTotalCopy
 	newNamespaceTotals.Used = utilquota.Add(oldNamespaceTotals.Used, usageDiff)
 	clusterQuota.Status.Namespaces.Insert(newQuota.Namespace, newNamespaceTotals)
 

--- a/pkg/quota/apis/quota/types.go
+++ b/pkg/quota/apis/quota/types.go
@@ -136,11 +136,8 @@ func (o ResourceQuotasStatusByNamespace) DeepCopy() ResourceQuotasStatusByNamesp
 	for e := o.OrderedKeys().Front(); e != nil; e = e.Next() {
 		namespace := e.Value.(string)
 		instatus, _ := o.Get(namespace)
-		if outstatus, err := kapi.Scheme.DeepCopy(instatus); err != nil {
-			panic(err) // should never happen
-		} else {
-			out.Insert(namespace, outstatus.(kapi.ResourceQuotaStatus))
-		}
+		outstatus := instatus.DeepCopy()
+		out.Insert(namespace, *outstatus)
 	}
 	return out
 }

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
@@ -110,10 +110,7 @@ func runFuzzer(t *testing.T) {
 
 			quota := NewQuota(name)
 			finalQuotas[name] = quota
-			copied, err := kapi.Scheme.Copy(quota)
-			if err != nil {
-				t.Fatal(err)
-			}
+			copied := quota.DeepCopy()
 			if exists {
 				quotaActions[name] = append(quotaActions[name], fmt.Sprintf("updating %v to %v", name, quota.Spec.Selector))
 				quotaWatch.Modify(copied)
@@ -149,10 +146,7 @@ func runFuzzer(t *testing.T) {
 
 			ns := NewNamespace(name)
 			finalNamespaces[name] = ns
-			copied, err := kapi.Scheme.Copy(ns)
-			if err != nil {
-				t.Fatal(err)
-			}
+			copied := ns.DeepCopy()
 			if exists {
 				namespaceActions[name] = append(namespaceActions[name], fmt.Sprintf("updating %v to %v", name, ns.Labels))
 				nsWatch.Modify(copied)

--- a/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller.go
+++ b/pkg/quota/controller/clusterquotareconciliation/reconciliation_controller.go
@@ -248,11 +248,7 @@ func (c *ClusterQuotaReconcilationController) worker() {
 
 // syncResourceQuotaFromKey syncs a quota key
 func (c *ClusterQuotaReconcilationController) syncQuotaForNamespaces(originalQuota *quotaapi.ClusterResourceQuota, workItems []workItem) (error, []workItem /* to retry */) {
-	obj, err := kapi.Scheme.Copy(originalQuota)
-	if err != nil {
-		return err, workItems
-	}
-	quota := obj.(*quotaapi.ClusterResourceQuota)
+	quota := originalQuota.DeepCopy()
 
 	// get the list of namespaces that match this cluster quota
 	matchingNamespaceNamesList, quotaSelector := c.clusterQuotaMapper.GetNamespacesFor(quota.Name)

--- a/pkg/route/apis/route/validation/validation_test.go
+++ b/pkg/route/apis/route/validation/validation_test.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	kapi "k8s.io/kubernetes/pkg/api"
 
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 )
@@ -1291,11 +1290,7 @@ func TestValidateRouteUpdate(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		copied, err := kapi.Scheme.Copy(tc.route)
-		if err != nil {
-			t.Fatal(err)
-		}
-		newRoute := copied.(*routeapi.Route)
+		newRoute := tc.route.DeepCopy()
 		tc.change(newRoute)
 		errs := ValidateRouteUpdate(newRoute, tc.route)
 		if len(errs) != tc.expectedErrors {

--- a/pkg/route/registry/route/strategy_test.go
+++ b/pkg/route/registry/route/strategy_test.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	kapi "k8s.io/kubernetes/pkg/api"
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
@@ -88,21 +87,21 @@ func TestEmptyDefaultCACertificate(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
-		copied, _ := kapi.Scheme.Copy(testCase.route)
-		if err := DecorateLegacyRouteWithEmptyDestinationCACertificates(copied.(*routeapi.Route)); err != nil {
+		copied := testCase.route.DeepCopy()
+		if err := DecorateLegacyRouteWithEmptyDestinationCACertificates(copied); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
 		}
-		routeStrategy{}.PrepareForCreate(nil, copied.(*routeapi.Route))
+		routeStrategy{}.PrepareForCreate(nil, copied)
 		if !reflect.DeepEqual(testCase.route, copied) {
 			t.Errorf("%d: unexpected change: %#v", i, copied)
 			continue
 		}
-		if err := DecorateLegacyRouteWithEmptyDestinationCACertificates(copied.(*routeapi.Route)); err != nil {
+		if err := DecorateLegacyRouteWithEmptyDestinationCACertificates(copied); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 			continue
 		}
-		routeStrategy{}.PrepareForUpdate(nil, copied.(*routeapi.Route), &routeapi.Route{})
+		routeStrategy{}.PrepareForUpdate(nil, copied, &routeapi.Route{})
 		if !reflect.DeepEqual(testCase.route, copied) {
 			t.Errorf("%d: unexpected change: %#v", i, copied)
 			continue

--- a/pkg/route/registry/route/strategy_test.go
+++ b/pkg/route/registry/route/strategy_test.go
@@ -61,8 +61,7 @@ func TestEmptyHostDefaulting(t *testing.T) {
 			Host: "myhost.com",
 		},
 	}
-	obj, _ := kapi.Scheme.DeepCopy(persistedRoute)
-	hostlessUpdatedRoute := obj.(*routeapi.Route)
+	hostlessUpdatedRoute := persistedRoute.DeepCopy()
 	hostlessUpdatedRoute.Spec.Host = ""
 	strategy.PrepareForUpdate(ctx, hostlessUpdatedRoute, persistedRoute)
 	if hostlessUpdatedRoute.Spec.Host != "myhost.com" {

--- a/pkg/router/controller/status_test.go
+++ b/pkg/router/controller/status_test.go
@@ -576,15 +576,10 @@ func makePass(t *testing.T, host string, admitter *StatusAdmitter, srcObj *route
 
 	admitter.client = c.Route()
 
-	inputObjRaw, err := kapi.Scheme.DeepCopy(srcObj)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	inputObj := inputObjRaw.(*routeapi.Route)
+	inputObj := srcObj.DeepCopy()
 	inputObj.Spec.Host = host
 
-	err = admitter.HandleRoute(watch.Modified, inputObj)
+	err := admitter.HandleRoute(watch.Modified, inputObj)
 
 	if expectUpdate {
 		now := nowFn()

--- a/pkg/service/controller/servingcert/secret_creating_controller.go
+++ b/pkg/service/controller/servingcert/secret_creating_controller.go
@@ -19,7 +19,6 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
@@ -224,11 +223,7 @@ func (sc *ServiceServingCertController) syncService(key string) error {
 	}
 
 	// make a copy to avoid mutating cache state
-	t, err := kapi.Scheme.DeepCopy(sharedService)
-	if err != nil {
-		return err
-	}
-	serviceCopy := t.(*v1.Service)
+	serviceCopy := sharedService.DeepCopy()
 	if serviceCopy.Annotations == nil {
 		serviceCopy.Annotations = map[string]string{}
 	}

--- a/pkg/service/controller/servingcert/secret_updating_controller.go
+++ b/pkg/service/controller/servingcert/secret_updating_controller.go
@@ -16,7 +16,6 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
@@ -181,11 +180,7 @@ func (sc *ServiceServingCertUpdateController) syncSecret(key string) error {
 	}
 
 	// make a copy to avoid mutating cache state
-	t, err := kapi.Scheme.DeepCopy(sharedSecret)
-	if err != nil {
-		return err
-	}
-	secretCopy := t.(*v1.Secret)
+	secretCopy := sharedSecret.DeepCopy()
 
 	dnsName := service.Name + "." + secretCopy.Namespace + ".svc"
 	fqDNSName := dnsName + "." + sc.dnsSuffix

--- a/pkg/template/apis/template/validation/validation.go
+++ b/pkg/template/apis/template/validation/validation.go
@@ -9,7 +9,6 @@ import (
 	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	"k8s.io/kubernetes/pkg/api/validation"
 
-	"github.com/golang/glog"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
 
@@ -62,22 +61,16 @@ func ValidateTemplateInstance(templateInstance *templateapi.TemplateInstance) (a
 
 	// Allow the nested template name and namespace to be empty.  If not empty,
 	// the fields should pass validation.
-	templateCopy, err := kapi.Scheme.DeepCopy(&templateInstance.Spec.Template)
-	if err != nil {
-		glog.V(2).Infof("Error copying template for validation: %v", err)
-		allErrs = append(allErrs, field.InternalError(field.NewPath(""), fmt.Errorf("Unable to copy template validation: %v", err)))
-	} else {
-		templateCopy := templateCopy.(*templateapi.Template)
-		if templateCopy.Name == "" {
-			templateCopy.Name = "dummy"
-		}
-		if templateCopy.Namespace == "" {
-			templateCopy.Namespace = "dummy"
-		}
-		for _, err := range ValidateTemplate(templateCopy) {
-			err.Field = "spec.template." + err.Field
-			allErrs = append(allErrs, err)
-		}
+	templateCopy := templateInstance.Spec.Template.DeepCopy()
+	if templateCopy.Name == "" {
+		templateCopy.Name = "dummy"
+	}
+	if templateCopy.Namespace == "" {
+		templateCopy.Namespace = "dummy"
+	}
+	for _, err := range ValidateTemplate(templateCopy) {
+		err.Field = "spec.template." + err.Field
+		allErrs = append(allErrs, err)
 	}
 	if templateInstance.Spec.Secret != nil {
 		if templateInstance.Spec.Secret.Name != "" {

--- a/pkg/template/apis/template/validation/validation_test.go
+++ b/pkg/template/apis/template/validation/validation_test.go
@@ -442,12 +442,9 @@ func TestValidateTemplateInstanceUpdate(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		newTemplateInstance, err := kapi.Scheme.DeepCopy(oldTemplateInstance)
-		if err != nil {
-			t.Fatal(err)
-		}
-		test.modifyTemplateInstance(newTemplateInstance.(*templateapi.TemplateInstance))
-		errs := ValidateTemplateInstanceUpdate(newTemplateInstance.(*templateapi.TemplateInstance), oldTemplateInstance)
+		newTemplateInstance := oldTemplateInstance.DeepCopy()
+		test.modifyTemplateInstance(newTemplateInstance)
+		errs := ValidateTemplateInstanceUpdate(newTemplateInstance, oldTemplateInstance)
 		if test.expectedErrorType == "" {
 			if len(errs) != 0 {
 				t.Errorf("%d: Unexpected non-empty error list", i)
@@ -842,12 +839,9 @@ func TestValidateBrokerTemplateInstanceUpdate(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		newBrokerTemplateInstance, err := kapi.Scheme.DeepCopy(oldBrokerTemplateInstance)
-		if err != nil {
-			t.Fatal(err)
-		}
-		test.modifyBrokerTemplateInstance(newBrokerTemplateInstance.(*templateapi.BrokerTemplateInstance))
-		errs := ValidateBrokerTemplateInstanceUpdate(newBrokerTemplateInstance.(*templateapi.BrokerTemplateInstance), oldBrokerTemplateInstance)
+		newBrokerTemplateInstance := oldBrokerTemplateInstance.DeepCopy()
+		test.modifyBrokerTemplateInstance(newBrokerTemplateInstance)
+		errs := ValidateBrokerTemplateInstanceUpdate(newBrokerTemplateInstance, oldBrokerTemplateInstance)
 		if test.expectedErrorType == "" {
 			if len(errs) != 0 {
 				t.Errorf("%d: Unexpected non-empty error list", i)

--- a/pkg/template/controller/templateinstance_controller.go
+++ b/pkg/template/controller/templateinstance_controller.go
@@ -108,26 +108,6 @@ func (c *TemplateInstanceController) getTemplateInstance(key string) (*templatea
 	return c.lister.TemplateInstances(namespace).Get(name)
 }
 
-// copyTemplateInstance returns a deep copy of a TemplateInstance object.
-func (c *TemplateInstanceController) copyTemplateInstance(templateInstance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
-	templateInstanceCopy, err := kapi.Scheme.DeepCopy(templateInstance)
-	if err != nil {
-		return nil, err
-	}
-
-	return templateInstanceCopy.(*templateapi.TemplateInstance), nil
-}
-
-// copyTemplate returns a deep copy of a Template object.
-func (c *TemplateInstanceController) copyTemplate(template *templateapi.Template) (*templateapi.Template, error) {
-	templateCopy, err := kapi.Scheme.DeepCopy(template)
-	if err != nil {
-		return nil, err
-	}
-
-	return templateCopy.(*templateapi.Template), nil
-}
-
 // sync is the actual controller worker function.
 func (c *TemplateInstanceController) sync(key string) error {
 	templateInstance, err := c.getTemplateInstance(key)
@@ -145,10 +125,8 @@ func (c *TemplateInstanceController) sync(key string) error {
 
 	glog.V(4).Infof("TemplateInstance controller: syncing %s", key)
 
-	templateInstance, err = c.copyTemplateInstance(templateInstance)
-	if err != nil {
-		return err
-	}
+	// TODO: Rename this to templateInstanceCopy
+	templateInstance = templateInstance.DeepCopy()
 
 	if len(templateInstance.Status.Objects) != len(templateInstance.Spec.Template.Objects) {
 		err = c.instantiate(templateInstance)
@@ -391,10 +369,8 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 		}
 	}
 
-	template, err := c.copyTemplate(&templateInstance.Spec.Template)
-	if err != nil {
-		return err
-	}
+	templatePtr := &templateInstance.Spec.Template
+	template := templatePtr.DeepCopy()
 
 	if secret != nil {
 		for i, param := range template.Parameters {
@@ -418,7 +394,7 @@ func (c *TemplateInstanceController) instantiate(templateInstance *templateapi.T
 	glog.V(4).Infof("TemplateInstance controller: creating TemplateConfig for %s/%s", templateInstance.Namespace, templateInstance.Name)
 
 	tc := templateinternalclient.NewTemplateProcessorClient(c.templateClient.Template().RESTClient(), templateInstance.Namespace)
-	template, err = tc.Process(template)
+	template, err := tc.Process(template)
 	if err != nil {
 		return err
 	}

--- a/pkg/template/registry/templateinstance/strategy.go
+++ b/pkg/template/registry/templateinstance/strategy.go
@@ -104,22 +104,22 @@ func (s *templateInstanceStrategy) ValidateUpdate(ctx apirequest.Context, obj, o
 	// place where this happens is in the garbage collector, which uses
 	// Unstructureds via the dynamic client.
 
-	objcopy, err := kapi.Scheme.DeepCopy(obj)
-	if err != nil {
-		return field.ErrorList{field.InternalError(field.NewPath(""), err)}
+	if obj == nil {
+		return field.ErrorList{field.InternalError(field.NewPath(""), errors.New("input object is nil"))}
 	}
-	templateInstance := objcopy.(*templateapi.TemplateInstance)
+	templateInstanceCopy := obj.DeepCopyObject()
+	templateInstance := templateInstanceCopy.(*templateapi.TemplateInstance)
 
 	errs := runtime.DecodeList(templateInstance.Spec.Template.Objects, unstructured.UnstructuredJSONScheme)
 	if len(errs) != 0 {
 		return field.ErrorList{field.InternalError(field.NewPath(""), kutilerrors.NewAggregate(errs))}
 	}
 
-	oldcopy, err := kapi.Scheme.DeepCopy(old)
-	if err != nil {
-		return field.ErrorList{field.InternalError(field.NewPath(""), err)}
+	if old == nil {
+		return field.ErrorList{field.InternalError(field.NewPath(""), errors.New("input object is nil"))}
 	}
-	oldTemplateInstance := oldcopy.(*templateapi.TemplateInstance)
+	oldTemplateInstanceCopy := old.DeepCopyObject()
+	oldTemplateInstance := oldTemplateInstanceCopy.(*templateapi.TemplateInstance)
 
 	errs = runtime.DecodeList(oldTemplateInstance.Spec.Template.Objects, unstructured.UnstructuredJSONScheme)
 	if len(errs) != 0 {

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -234,9 +234,8 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 		for _, test := range tests {
 			setUser(cli, test.user)
 
-			templateinstancecopy, err := kapi.Scheme.DeepCopy(dummytemplateinstance)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			templateinstance, err := cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstancecopy.(*templateapi.TemplateInstance))
+			templateinstancecopy := dummytemplateinstance.DeepCopy()
+			templateinstance, err := cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstancecopy)
 
 			if !test.expectCreateSuccess {
 				o.Expect(err).To(o.HaveOccurred())
@@ -355,9 +354,8 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 		for _, test := range tests {
 			setUser(cli, test.user)
 
-			templateinstancecopy, err := kapi.Scheme.DeepCopy(dummytemplateinstance)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			templateinstance, err := cli.AdminTemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstancecopy.(*templateapi.TemplateInstance))
+			templateinstancecopy := dummytemplateinstance.DeepCopy()
+			templateinstance, err := cli.AdminTemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstancecopy)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			err = cli.TemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)


### PR DESCRIPTION
The later will not work in k8s 1.9 (@sttts to confirm). The first commit is just mechanical update.
The second commit is needed because image trigger controller used DeepCopy on interface{}.

@smarterclayton I switched that to be `runtime.Object` and nothing seems to be complaining. PTAL.