### PR TITLE
[3.7] UPSTREAM: 49128: add svc and netpol to discovery

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/registry/core/service/rest.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/service/rest.go
@@ -77,6 +77,16 @@ func NewStorage(registry Registry, endpoints endpoint.Registry, serviceIPs ipall
 	}
 }
 
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (rs *REST) ShortNames() []string {
+	return []string{"svc"}
+}
+
+// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
+func (rs *REST) Categories() []string {
+	return []string{"all"}
+}
+
 // TODO: implement includeUninitialized by refactoring this to move to store
 func (rs *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	service := obj.(*api.Service)

--- a/vendor/k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	networkingapi "k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/registry/networking/networkpolicy"
@@ -49,4 +50,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	}
 
 	return &REST{store}
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"netpol"}
 }


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/17411 and https://bugzilla.redhat.com/show_bug.cgi?id=1515878

Add svc and netpol to discovery, picking https://github.com/kubernetes/kubernetes/commit/8232778ffefe439c990ff2e5715ef26fad0510d6 into the **enterprise-3.7** branch.

PTAL @deads2k @smarterclayton 