### PR TITLE
cluster up: use server version to detect whether to use cgroup flag

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -888,7 +888,7 @@ func (h *Helper) updateConfig(configDir string, opt *StartOptions) error {
 	}
 	nodeCfg.DNSBindAddress = ""
 
-	if h.supportsCgroupDriver() {
+	if h.supportsCgroupDriver(version) {
 		// Set the cgroup driver from the current docker
 		cgroupDriver, err := h.dockerHelper.CgroupDriver()
 		if err != nil {
@@ -956,7 +956,10 @@ func getUsedPorts(data string) map[int]struct{} {
 	return ports
 }
 
-func (h *Helper) supportsCgroupDriver() bool {
+func (h *Helper) supportsCgroupDriver(version semver.Version) bool {
+	if version.GTE(version37) {
+		return true
+	}
 	script := `#!/bin/bash
 
 # Exit with an error

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -315,6 +315,10 @@ ORIGIN_COMMIT=${ORIGIN_COMMIT:-latest}
 
 echo "Running cluster up tests using tag $ORIGIN_COMMIT"
 
+# Tag the docker registry image with the same tag as the other origin images
+docker pull openshift/origin-docker-registry:latest
+docker tag openshift/origin-docker-registry:latest openshift/origin-docker-registry:${ORIGIN_COMMIT}
+
 # Ensure that KUBECONFIG is not set
 unset KUBECONFIG
 for test in "${tests[@]}"; do


### PR DESCRIPTION
The latest origin image no longer includes the kubelet binary and does not support running the openshift binary as a kubelet. This shortcuts detection of the cgroup flag by simply looking at the server version. If 3.7 or newer, then we should just use the flag.

Fixes #17474