### PR TITLE
Openshift rails+postgres template fix.

### DIFF
--- a/examples/quickstarts/rails-postgresql-persistent.json
+++ b/examples/quickstarts/rails-postgresql-persistent.json
@@ -422,7 +422,7 @@
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
-                    "mountPath": "/var/lib/pgsql/data"
+                    "mountPath": "/var/lib/postgresql/data"
                   }
                 ],
                 "env": [

--- a/examples/quickstarts/rails-postgresql.json
+++ b/examples/quickstarts/rails-postgresql.json
@@ -403,7 +403,7 @@
                 "volumeMounts": [
                   {
                     "name": "data",
-                    "mountPath": "/var/lib/pgsql/data"
+                    "mountPath": "/var/lib/postgresql/data"
                   }
                 ],
                 "env": [

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -11923,7 +11923,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
-                    "mountPath": "/var/lib/pgsql/data"
+                    "mountPath": "/var/lib/postgresql/data"
                   }
                 ],
                 "env": [
@@ -12528,7 +12528,7 @@ var _examplesQuickstartsRailsPostgresqlJson = []byte(`{
                 "volumeMounts": [
                   {
                     "name": "data",
-                    "mountPath": "/var/lib/pgsql/data"
+                    "mountPath": "/var/lib/postgresql/data"
                   }
                 ],
                 "env": [

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -23697,7 +23697,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
                 "volumeMounts": [
                   {
                     "name": "${DATABASE_SERVICE_NAME}-data",
-                    "mountPath": "/var/lib/pgsql/data"
+                    "mountPath": "/var/lib/postgresql/data"
                   }
                 ],
                 "env": [
@@ -24302,7 +24302,7 @@ var _examplesQuickstartsRailsPostgresqlJson = []byte(`{
                 "volumeMounts": [
                   {
                     "name": "data",
-                    "mountPath": "/var/lib/pgsql/data"
+                    "mountPath": "/var/lib/postgresql/data"
                   }
                 ],
                 "env": [


### PR DESCRIPTION
Fix error "mkdir: cannot create directory '/var/lib/pgsql/data': Permission denied" while
deploying rails+postgres from openshift template.