### PR TITLE
Clean policy

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -274,15 +274,19 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
 				rbac.NewRule("impersonate").Groups(kapiGroup).Resources("serviceaccounts").RuleOrDie(),
 
+				rbac.NewRule(readWrite...).Groups(appsGroup).Resources("statefulsets",
+					"deployments", "deployments/scale", "deployments/status",
+					"replicasets", "replicasets/scale").RuleOrDie(),
+
 				rbac.NewRule(readWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
-				rbac.NewRule(readWrite...).Groups(appsGroup, extensionsGroup).Resources("replicationcontrollers/scale",
-					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback", "networkpolicies").RuleOrDie(),
-				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
+				rbac.NewRule(readWrite...).Groups(extensionsGroup).Resources(
+					"deployments", "deployments/scale", "deployments/rollback",
+					"replicasets", "replicasets/scale", "replicationcontrollers/scale").RuleOrDie(),
 
-				rbac.NewRule(readWrite...).Groups(appsGroup).Resources("statefulsets", "deployments", "deployments/scale", "deployments/status").RuleOrDie(),
+				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(authzGroup, legacyAuthzGroup).Resources("roles", "rolebindings").RuleOrDie(),
 				rbac.NewRule(readWrite...).Groups(rbacGroup).Resources("roles", "rolebindings").RuleOrDie(),
@@ -343,15 +347,19 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
 				rbac.NewRule("impersonate").Groups(kapiGroup).Resources("serviceaccounts").RuleOrDie(),
 
+				rbac.NewRule(readWrite...).Groups(appsGroup).Resources("statefulsets",
+					"deployments", "deployments/scale", "deployments/rollback",
+					"replicasets", "replicasets/scale").RuleOrDie(),
+
 				rbac.NewRule(readWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
-				rbac.NewRule(readWrite...).Groups(appsGroup, extensionsGroup).Resources("replicationcontrollers/scale",
-					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback").RuleOrDie(),
-				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
+				rbac.NewRule(readWrite...).Groups(extensionsGroup).Resources(
+					"deployments", "deployments/scale", "deployments/rollback",
+					"replicasets", "replicasets/scale", "replicationcontrollers/scale").RuleOrDie(),
 
-				rbac.NewRule(readWrite...).Groups(appsGroup).Resources("statefulsets", "deployments", "deployments/scale", "deployments/status").RuleOrDie(),
+				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				rbac.NewRule(read...).Groups(buildGroup, legacyBuildGroup).Resources("builds/log").RuleOrDie(),
@@ -400,14 +408,17 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(read...).Groups(kapiGroup).Resources("limitranges", "resourcequotas", "bindings", "events",
 					"namespaces", "pods/status", "resourcequotas/status", "namespaces/status", "replicationcontrollers/status", "pods/log").RuleOrDie(),
 
+				rbac.NewRule(read...).Groups(appsGroup).Resources("statefulsets",
+					"daemonsets",
+					"deployments", "deployments/scale",
+					"replicasets", "replicasets/scale").RuleOrDie(),
+
 				rbac.NewRule(read...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				rbac.NewRule(read...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
-				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("deployments", "deployments/scale", "replicasets", "replicasets/scale").RuleOrDie(),
-				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
-
-				rbac.NewRule(read...).Groups(appsGroup).Resources("statefulsets", "deployments", "deployments/scale").RuleOrDie(),
+				rbac.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets", "deployments", "deployments/scale",
+					"replicasets", "replicasets/scale", "replicationcontrollers/scale").RuleOrDie(),
 
 				rbac.NewRule(read...).Groups(buildGroup, legacyBuildGroup).Resources("builds", "buildconfigs", "buildconfigs/webhooks").RuleOrDie(),
 				rbac.NewRule(read...).Groups(buildGroup, legacyBuildGroup).Resources("builds/log").RuleOrDie(),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -670,6 +670,24 @@ items:
     verbs:
     - impersonate
   - apiGroups:
+    - apps
+    resources:
+    - deployments
+    - deployments/scale
+    - deployments/status
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - autoscaling
     resources:
     - horizontalpodautoscalers
@@ -697,13 +715,11 @@ items:
     - update
     - watch
   - apiGroups:
-    - apps
     - extensions
     resources:
     - deployments
     - deployments/rollback
     - deployments/scale
-    - networkpolicies
     - replicasets
     - replicasets/scale
     - replicationcontrollers/scale
@@ -724,22 +740,6 @@ items:
     verbs:
     - get
     - list
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
     - watch
   - apiGroups:
     - ""
@@ -1103,6 +1103,24 @@ items:
     verbs:
     - impersonate
   - apiGroups:
+    - apps
+    resources:
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - autoscaling
     resources:
     - horizontalpodautoscalers
@@ -1130,7 +1148,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - apps
     - extensions
     resources:
     - deployments
@@ -1156,22 +1173,6 @@ items:
     verbs:
     - get
     - list
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
     - watch
   - apiGroups:
     - ""
@@ -1424,6 +1425,19 @@ items:
     - list
     - watch
   - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
     - autoscaling
     resources:
     - horizontalpodautoscalers
@@ -1441,32 +1455,14 @@ items:
     - list
     - watch
   - apiGroups:
-    - apps
     - extensions
     resources:
+    - daemonsets
     - deployments
     - deployments/scale
     - replicasets
     - replicasets/scale
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - deployments/scale
-    - statefulsets
+    - replicationcontrollers/scale
     verbs:
     - get
     - list

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -729,6 +729,25 @@ items:
     verbs:
     - impersonate
   - apiGroups:
+    - apps
+    attributeRestrictions: null
+    resources:
+    - deployments
+    - deployments/scale
+    - deployments/status
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - autoscaling
     attributeRestrictions: null
     resources:
@@ -758,14 +777,12 @@ items:
     - update
     - watch
   - apiGroups:
-    - apps
     - extensions
     attributeRestrictions: null
     resources:
     - deployments
     - deployments/rollback
     - deployments/scale
-    - networkpolicies
     - replicasets
     - replicasets/scale
     - replicationcontrollers/scale
@@ -787,23 +804,6 @@ items:
     verbs:
     - get
     - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
     - watch
   - apiGroups:
     - ""
@@ -1199,6 +1199,25 @@ items:
     verbs:
     - impersonate
   - apiGroups:
+    - apps
+    attributeRestrictions: null
+    resources:
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - autoscaling
     attributeRestrictions: null
     resources:
@@ -1228,7 +1247,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - apps
     - extensions
     attributeRestrictions: null
     resources:
@@ -1256,23 +1274,6 @@ items:
     verbs:
     - get
     - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
     - watch
   - apiGroups:
     - ""
@@ -1547,6 +1548,20 @@ items:
     - list
     - watch
   - apiGroups:
+    - apps
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    - deployments
+    - deployments/scale
+    - replicasets
+    - replicasets/scale
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
     - autoscaling
     attributeRestrictions: null
     resources:
@@ -1566,35 +1581,15 @@ items:
     - list
     - watch
   - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
     - extensions
     attributeRestrictions: null
     resources:
     - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
     - deployments
     - deployments/scale
-    - statefulsets
+    - replicasets
+    - replicasets/scale
+    - replicationcontrollers/scale
     verbs:
     - get
     - list


### PR DESCRIPTION
This is one of 1.8 post-rebase tasks. It includes:

- reformatting so it's easier to compare with upstream roles
- removes networkpolicies from extensions, since they moved to own group. What worries me here is that I don't see any networkpolicy-related role in upstream, so I'm not sure if we might be bitten by it  @openshift/sig-networking any ideas why we had read/write access for extensions.networkpolicies?

@deads2k || @liggitt ptal
/cc @openshift/sig-security 