### PR TITLE
calculate patches using input version

### DIFF
--- a/pkg/oc/cli/cmd/set/helper.go
+++ b/pkg/oc/cli/cmd/set/helper.go
@@ -141,7 +141,9 @@ func CalculatePatches(infos []*resource.Info, encoder runtime.Encoder, mutateFn 
 	var patches []*Patch
 	for _, info := range infos {
 		patch := &Patch{Info: info}
-		patch.Before, patch.Err = runtime.Encode(encoder, info.Object)
+
+		versionedEncoder := kapi.Codecs.EncoderForVersion(encoder, patch.Info.Mapping.GroupVersionKind.GroupVersion())
+		patch.Before, patch.Err = runtime.Encode(versionedEncoder, info.Object)
 
 		ok, err := mutateFn(info)
 		if !ok {
@@ -155,7 +157,7 @@ func CalculatePatches(infos []*resource.Info, encoder runtime.Encoder, mutateFn 
 			continue
 		}
 
-		patch.After, patch.Err = runtime.Encode(encoder, info.Object)
+		patch.After, patch.Err = runtime.Encode(versionedEncoder, info.Object)
 		if patch.Err != nil {
 			continue
 		}

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -14,6 +14,7 @@ os::test::junit::declare_suite_start "cmd/volumes"
 # This test validates the 'volume' command
 
 os::cmd::expect_success 'oc create -f test/integration/testdata/test-deployment-config.yaml'
+os::cmd::expect_success 'oc create -f test/testdata/rollingupdate-daemonset.yaml'
 
 os::cmd::expect_success_and_text 'oc volume dc/test-deployment-config --list' 'vol1'
 os::cmd::expect_success 'oc volume dc/test-deployment-config --add --name=vol0 -m /opt5'
@@ -35,6 +36,11 @@ os::cmd::expect_success 'oc set volume dc/test-deployment-config --remove --name
 os::cmd::expect_success_and_not_text 'oc set volume dc/test-deployment-config --list' 'vol2'
 os::cmd::expect_success 'oc set volume dc/test-deployment-config --remove --confirm'
 os::cmd::expect_success_and_not_text 'oc set volume dc/test-deployment-config --list' 'vol1'
+
+# ensure that resources not present in all versions of a target group
+# are still able to be encoded and patched accordingly
+os::cmd::expect_success 'oc set volume ds/bind --add --name=vol2 --type=emptydir -m /opt'
+os::cmd::expect_success 'oc set volume ds/bind --remove --name=vol2'
 
 os::cmd::expect_success "oc volume dc/test-deployment-config --add -t 'secret' --secret-name='asdf' --default-mode '765'"
 os::cmd::expect_success_and_text 'oc get dc/test-deployment-config -o jsonpath={.spec.template.spec.volumes[0]}' '501'

--- a/test/testdata/rollingupdate-daemonset.yaml
+++ b/test/testdata/rollingupdate-daemonset.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: bind
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        service: bind
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: "service"
+                  operator: "In"
+                  values: ["bind"]
+              topologyKey: "kubernetes.io/hostname"
+              namespaces: []
+      containers:
+      - name: kubernetes-pause
+        image: gcr.io/google-containers/pause:2.0


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518325

Wrap an encoder to first convert to the same version used to read the
object (based on the mapping's GroupVersion)

cc @openshift/cli-review @liggitt 