### PR TITLE
hack/lib/init.sh: minor shell and readme improvement 

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -137,7 +137,7 @@ $ hack/env make release
 In order to make use of the binaries from your shell, add the build output
 directory to the `$PATH`:
 ----
-$ export PATH="${PATH}:$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::build::host_platform )/" )"
+$ export PATH="$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::build::host_platform )/" ):${PATH}"
 ----
 
 See more information in https://github.com/openshift/origin/blob/master/HACKING.md#building-on-non-linux-systems[`HACKING.md`]

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -30,7 +30,7 @@ function os::util::absolute_path() {
 readonly -f os::util::absolute_path
 
 # find the absolute path to the root of the Origin source tree
-init_source="$( dirname "${BASH_SOURCE}" )/../.."
+init_source="$( dirname "${BASH_SOURCE[0]}" )/../.."
 OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
 cd "${OS_ROOT}"
@@ -51,14 +51,14 @@ os::log::stacktrace::install
 os::util::environment::update_path_var
 
 if [[ -z "${OS_TMP_ENV_SET-}" ]]; then
-    if [[ "$0" =~ *.sh ]]; then
-       os::util::environment::setup_tmpdir_vars "$( basename "$0" ".sh" )"
-    else
-        os::util::environment::setup_tmpdir_vars "shell"
-    fi
+	if [[ "${BASH_SOURCE[0]}" =~ .*\.sh ]]; then
+		os::util::environment::setup_tmpdir_vars "$( basename "${BASH_SOURCE[0]}" ".sh" )"
+	else
+		os::util::environment::setup_tmpdir_vars "shell"
+	fi
 fi
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then
-  export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
+	export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 fi


### PR DESCRIPTION
 hack/lib/init.sh: minor shell and readme improvement

Use ${BASH_SOURCE[0]} instead of $0 for consistent behavior when
script is run directly or using 'source hack/lib/init.sh', and
fix regex.

Use tabs instead of spaces for indenting in shell scripts.

The example in the CONTRIBUTING doc adds the locally built
oc binary dir at the end of the PATH.  If the user already has oc
in the path then this command won't override it.  This just
changes the example to add the local build to the beginning of the PATH