### PR TITLE
Fix deploymentconfig scale

### DIFF
--- a/pkg/apps/apis/apps/types.go
+++ b/pkg/apps/apis/apps/types.go
@@ -138,7 +138,6 @@ const (
 // +genclient:method=Instantiate,verb=create,subresource=instantiate,input=DeploymentRequest
 // +genclient:method=Rollback,verb=create,subresource=rollback,input=DeploymentConfigRollback
 // +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/extensions/v1beta1.Scale
-// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/extensions/v1beta1.Scale,result=k8s.io/api/extensions/v1beta1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DeploymentConfig represents a configuration for a single deployment (represented as a

--- a/pkg/apps/apiserver/apiserver.go
+++ b/pkg/apps/apiserver/apiserver.go
@@ -13,6 +13,7 @@ import (
 	kclientsetexternal "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	kapi "k8s.io/kubernetes/pkg/api"
+	v1beta1extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
@@ -89,6 +90,12 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(appsapiv1.GroupName, c.ExtraConfig.Registry, c.ExtraConfig.Scheme, parameterCodec, c.ExtraConfig.Codecs)
 	apiGroupInfo.GroupMeta.GroupVersion = appsapiv1.SchemeGroupVersion
 	apiGroupInfo.VersionedResourcesStorageMap[appsapiv1.SchemeGroupVersion.Version] = v1Storage
+
+	if apiGroupInfo.SubresourceGroupVersionKind == nil {
+		apiGroupInfo.SubresourceGroupVersionKind = map[string]schema.GroupVersionKind{}
+	}
+	apiGroupInfo.SubresourceGroupVersionKind["deploymentconfigs/scale"] = v1beta1extensions.SchemeGroupVersion.WithKind("Scale")
+
 	if err := s.GenericAPIServer.InstallAPIGroup(&apiGroupInfo); err != nil {
 		return nil, err
 	}

--- a/pkg/apps/generated/internalclientset/scheme/register_expansion.go
+++ b/pkg/apps/generated/internalclientset/scheme/register_expansion.go
@@ -1,0 +1,10 @@
+package scheme
+
+import (
+	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+func init() {
+	// Needed for GetScale/UpdateScale
+	extensionsv1beta1.AddToScheme(Scheme)
+}

--- a/pkg/apps/generated/internalclientset/typed/apps/internalversion/deploymentconfig.go
+++ b/pkg/apps/generated/internalclientset/typed/apps/internalversion/deploymentconfig.go
@@ -30,7 +30,6 @@ type DeploymentConfigInterface interface {
 	Instantiate(deploymentConfigName string, deploymentRequest *apps.DeploymentRequest) (*apps.DeploymentConfig, error)
 	Rollback(deploymentConfigName string, deploymentConfigRollback *apps.DeploymentConfigRollback) (*apps.DeploymentConfig, error)
 	GetScale(deploymentConfigName string, options v1.GetOptions) (*v1beta1.Scale, error)
-	UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (*v1beta1.Scale, error)
 
 	DeploymentConfigExpansion
 }
@@ -198,20 +197,6 @@ func (c *deploymentConfigs) GetScale(deploymentConfigName string, options v1.Get
 		Name(deploymentConfigName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *deploymentConfigs) UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
-	result = &v1beta1.Scale{}
-	err = c.client.Put().
-		Namespace(c.ns).
-		Resource("deploymentconfigs").
-		Name(deploymentConfigName).
-		SubResource("scale").
-		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/pkg/apps/generated/internalclientset/typed/apps/internalversion/deploymentconfig_expansion.go
+++ b/pkg/apps/generated/internalclientset/typed/apps/internalversion/deploymentconfig_expansion.go
@@ -1,0 +1,33 @@
+package internalversion
+
+import (
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+type DeploymentConfigExpansion interface {
+	UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error)
+}
+
+var scaleCodec = kapi.Codecs.LegacyCodec(v1beta1.SchemeGroupVersion)
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *deploymentConfigs) UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	// FIXME: make non-homogenous subresource GV client generation work
+	data, err := runtime.Encode(scaleCodec, scale)
+	if err != nil {
+		return nil, err
+	}
+
+	result = &v1beta1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("deploymentconfigs").
+		Name(deploymentConfigName).
+		SubResource("scale").
+		Body(data).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/apps/generated/internalclientset/typed/apps/internalversion/fake/fake_deploymentconfig.go
+++ b/pkg/apps/generated/internalclientset/typed/apps/internalversion/fake/fake_deploymentconfig.go
@@ -154,14 +154,3 @@ func (c *FakeDeploymentConfigs) GetScale(deploymentConfigName string, options v1
 	}
 	return obj.(*v1beta1.Scale), err
 }
-
-// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *FakeDeploymentConfigs) UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(deploymentconfigsResource, "scale", c.ns, scale), &v1beta1.Scale{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Scale), err
-}

--- a/pkg/apps/generated/internalclientset/typed/apps/internalversion/fake/fake_deploymentconfig_expansion.go
+++ b/pkg/apps/generated/internalclientset/typed/apps/internalversion/fake/fake_deploymentconfig_expansion.go
@@ -1,0 +1,17 @@
+package fake
+
+import (
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	testing "k8s.io/client-go/testing"
+)
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if t
+func (c *FakeDeploymentConfigs) UpdateScale(deploymentConfigName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentconfigsResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}

--- a/pkg/apps/generated/internalclientset/typed/apps/internalversion/generated_expansion.go
+++ b/pkg/apps/generated/internalclientset/typed/apps/internalversion/generated_expansion.go
@@ -1,3 +1,1 @@
 package internalversion
-
-type DeploymentConfigExpansion interface{}


### PR DESCRIPTION
3.6 and 3.7 shipped with the /apis/apps.openshift.io/deploymentconfigs/scale subresource returning apps.openshift.io/v1 Scale objects

This is a non-standard Scale object that the HPA will never be able to make use of.

The intent was to continue send the same thing as /oapi/v1/deploymentconfigs/scale: extensions/v1beta1 Scale objects

This PR fixes the groupified API to send/receive the correct type.

It also updates the internal UpdateScale() client method to send extensions/v1beta1 Scale objects