### PR TITLE
Fix scale subresource type for apps.openshift.io/deploymentconfigs/scale

### DIFF
--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -229,6 +229,13 @@ func installAPIs(c *OpenshiftAPIConfig, server *genericapiserver.GenericAPIServe
 			if isPreferredGroupVersion(gv) {
 				apiGroupInfo.GroupMeta.GroupVersion = gv
 			}
+
+			if group == "apps.openshift.io" && version == "v1" {
+				if apiGroupInfo.SubresourceGroupVersionKind == nil {
+					apiGroupInfo.SubresourceGroupVersionKind = map[string]schema.GroupVersionKind{}
+				}
+				apiGroupInfo.SubresourceGroupVersionKind["deploymentconfigs/scale"] = v1beta1extensions.SchemeGroupVersion.WithKind("Scale")
+			}
 		}
 
 		if err := server.InstallAPIGroup(&apiGroupInfo); err != nil {

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -1,10 +1,12 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	extensionsv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 
@@ -51,6 +53,40 @@ func TestDeployScale(t *testing.T) {
 		t.Fatalf("Couldn't create DeploymentConfig: %v %#v", err, config)
 	}
 	generation := dc.Generation
+
+	{
+		// Get scale subresource
+		legacyPath := fmt.Sprintf("/oapi/v1/namespaces/%s/deploymentconfigs/%s/scale", dc.Namespace, dc.Name)
+		legacyScale := &unstructured.Unstructured{}
+		if err := clusterAdminClient.RESTClient.Get().AbsPath(legacyPath).Do().Into(legacyScale); err != nil {
+			t.Fatal(err)
+		}
+		// Ensure correct type
+		if legacyScale.GetAPIVersion() != "extensions/v1beta1" {
+			t.Fatalf("Expected extensions/v1beta1, got %v", legacyScale.GetAPIVersion())
+		}
+		// Ensure we can submit the same type back
+		if err := clusterAdminClient.RESTClient.Put().AbsPath(legacyPath).Body(legacyScale).Do().Error(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	{
+		// Get scale subresource
+		scalePath := fmt.Sprintf("/apis/apps.openshift.io/v1/namespaces/%s/deploymentconfigs/%s/scale", dc.Namespace, dc.Name)
+		scale := &unstructured.Unstructured{}
+		if err := clusterAdminClient.RESTClient.Get().AbsPath(scalePath).Do().Into(scale); err != nil {
+			t.Fatal(err)
+		}
+		// Ensure correct type
+		if scale.GetAPIVersion() != "extensions/v1beta1" {
+			t.Fatalf("Expected extensions/v1beta1, got %v", scale.GetAPIVersion())
+		}
+		// Ensure we can submit the same type back
+		if err := clusterAdminClient.RESTClient.Put().AbsPath(scalePath).Body(scale).Do().Error(); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	condition := func() (bool, error) {
 		config, err := osClient.DeploymentConfigs(namespace).Get(dc.Name, metav1.GetOptions{})


### PR DESCRIPTION
Fixes the Scale subresource returned from apps.openshift.io/v1/deploymentconfigs/scale to match oapi/v1/deploymentconfigs/scale, and to be usable by HPA