### PR TITLE
Exclude local tests from conformance

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -261,6 +261,7 @@ var (
 		`\[Slow\]`,
 		`\[Flaky\]`,
 		`\[Disruptive\]`,
+		`\[local\]`,
 
 		// not enabled in Origin yet
 		//`\[Feature:GarbageCollector\]`,


### PR DESCRIPTION
Excludes local tests from extended test suite. 
Tests that are also tagged with conformance should be reworked to not be local.