### PR TITLE
Bring the base Dockerfiles into sync

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -7,6 +7,8 @@
 FROM openshift/origin-source
 
 RUN INSTALL_PKGS="bsdtar ceph-common device-mapper device-mapper-persistent-data e2fsprogs ethtool findutils git hostname iptables lsof nmap-ncat socat sysvinit-tools tar tree util-linux wget which xfsprogs" && \
+    yum install -y centos-release-ceph-luminous && \
+    rpm -V centos-release-ceph-luminous && \
     yum install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all && \

--- a/images/base/Dockerfile.centos7
+++ b/images/base/Dockerfile.centos7
@@ -7,9 +7,9 @@
 FROM openshift/origin-source
 
 RUN INSTALL_PKGS="bsdtar ceph-common device-mapper device-mapper-persistent-data e2fsprogs ethtool findutils git hostname iptables lsof nmap-ncat socat sysvinit-tools tar tree util-linux wget which xfsprogs" && \
-    yum --disablerepo=origin-local-release install -y centos-release-ceph && \
-    rpm -V centos-release-ceph && \
-    yum --disablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
+    yum install -y centos-release-ceph-luminous && \
+    rpm -V centos-release-ceph-luminous && \
+    yum install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all && \
     mkdir -p /var/lib/origin


### PR DESCRIPTION
We need the Dockerfile and Dockerfile.centos7 to be in sync.
Furthermore, the package that is installed has the `-luminous` suffix,
so we need to explicitly provide it or `rpm -V` will fail.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Follow-up to https://github.com/openshift/origin/pull/17350
/cc @rootfs 
/assign @csrwng 