### PR TITLE
dind-ovn: use golang binaries instead of python ones

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -551,13 +551,11 @@ function copy-ovn-runtime() {
   local ovn_go_controller_built_binaries_path="${ovn_root}/go-controller/_output/go/bin"
   cp "${ovn_go_controller_built_binaries_path}/ovnkube" "${target}"
   cp "${ovn_go_controller_built_binaries_path}/ovn-kube-util" "${target}"
+  cp "${ovn_go_controller_built_binaries_path}/ovn-k8s-overlay" "${target}"
+  cp "${ovn_go_controller_built_binaries_path}/ovn-k8s-cni-overlay" "${target}"
 
   local ovn_k8s_binaries_path="${ovn_root}/bin"
-  cp "${ovn_k8s_binaries_path}/ovn-k8s-cni-overlay" "${target}"
   cp "${ovn_k8s_binaries_path}/ovn-k8s-gateway-helper" "${target}"
-  cp "${ovn_k8s_binaries_path}/ovn-k8s-overlay" "${target}"
-  cp "${ovn_k8s_binaries_path}/ovn-k8s-util" "${target}"
-  cp "${ovn_k8s_binaries_path}/ovn-k8s-watcher" "${target}"
 
   local ovn_k8s_python_module_path="${ovn_root}/ovn_k8s"
   cp -R "${ovn_k8s_python_module_path}" "${target}/"

--- a/images/dind/node/ovn-kubernetes-node-setup.sh
+++ b/images/dind/node/ovn-kubernetes-node-setup.sh
@@ -22,7 +22,7 @@ function ovn-kubernetes-node-setup() {
 
   ln -sf /data/ovnkube /usr/local/bin/
   ln -sf /data/ovn-kube-util /usr/local/bin/
-  ln -sf /data/ovn-k8s-cni-overlay /usr/local/bin/
+  ln -sf /data/ovn-k8s-cni-overlay /opt/cni/bin/
   ln -sf /data/ovn-k8s-gateway-helper /usr/local/bin/
   ln -sf /data/ovn-k8s-overlay /usr/local/bin
   ln -sf /data/ovn-k8s-util /usr/local/bin/

--- a/images/dind/node/ovn-kubernetes-node.sh
+++ b/images/dind/node/ovn-kubernetes-node.sh
@@ -30,7 +30,7 @@ function ovn-kubernetes-node() {
 
   cat >"/etc/openvswitch/ovn_k8s.conf" <<EOF
 [default]
-k8s_ca_certificate=${config_dir}/ca.crt
+k8s-ca-certificate=${config_dir}/ca.crt
 EOF
 
   local host


### PR DESCRIPTION

Dependent on upstream PR: https://github.com/openvswitch/ovn-kubernetes/pull/173

Signed-off-by: Rajat Chopra <rchopra@redhat.com>


@dcbw PTAL. Thanks.
