### PR TITLE
Minor: When using netlink library, use netlink.FAMILY_V4 instead of syscall.AF_INET

### DIFF
--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
@@ -357,7 +356,7 @@ func getVethInfo(netns, containerIfname string) (string, string, string, error) 
 		}
 		peerIfindex = contVeth.Attrs().ParentIndex
 
-		addrs, err := netlink.AddrList(contVeth, syscall.AF_INET)
+		addrs, err := netlink.AddrList(contVeth, netlink.FAMILY_V4)
 		if err != nil {
 			return fmt.Errorf("failed to get container IP addresses: %v", err)
 		}

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -5,7 +5,6 @@ package node
 import (
 	"fmt"
 	"net"
-	"syscall"
 	"time"
 
 	"github.com/golang/glog"
@@ -67,7 +66,7 @@ func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR string, clusterNetwo
 		return false
 	}
 
-	addrs, err := netlink.AddrList(l, syscall.AF_INET)
+	addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
 	if err != nil {
 		return false
 	}
@@ -82,7 +81,7 @@ func (plugin *OsdnNode) alreadySetUp(localSubnetGatewayCIDR string, clusterNetwo
 		return false
 	}
 
-	routes, err := netlink.RouteList(l, syscall.AF_INET)
+	routes, err := netlink.RouteList(l, netlink.FAMILY_V4)
 	if err != nil {
 		return false
 	}
@@ -117,7 +116,7 @@ func deleteLocalSubnetRoute(device, localSubnetCIDR string) {
 		if err != nil {
 			return false, fmt.Errorf("could not get interface %s: %v", device, err)
 		}
-		routes, err := netlink.RouteList(l, syscall.AF_INET)
+		routes, err := netlink.RouteList(l, netlink.FAMILY_V4)
 		if err != nil {
 			return false, fmt.Errorf("could not get routes: %v", err)
 		}


### PR DESCRIPTION
- netlink.AddrLink expects FAMILY_* constants and internally FAMILY_V4 is set to syscall.AF_INET
  It will be nice not to assume internals of external library.