### PR TITLE
extended tests: label idling test that depends on local services local

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -251,7 +251,7 @@ var _ = g.Describe("idling and unidling", func() {
 		os.Remove(idlingFile)
 	})
 
-	g.Describe("idling", func() {
+	g.Describe("idling [local]", func() {
 		g.Context("with a single service and DeploymentConfig [Conformance]", func() {
 			g.BeforeEach(func() {
 				framework.BeforeEach()


### PR DESCRIPTION
both tests under "idling" call checkSingleIdle which relies on local service access