### PR TITLE
NetworkPolicy RBAC fixes

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -279,7 +279,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(readWrite...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(appsGroup, extensionsGroup).Resources("replicationcontrollers/scale",
-					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback", "networkpolicies").RuleOrDie(),
+					"replicasets", "replicasets/scale", "deployments", "deployments/scale", "deployments/rollback").RuleOrDie(),
 				rbac.NewRule(read...).Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(appsGroup).Resources("statefulsets", "deployments", "deployments/scale", "deployments/status").RuleOrDie(),
@@ -321,6 +321,8 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("update").Groups(routeGroup, legacyRouteGroup).Resources("routes/status").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
+
+				rbac.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
 				// backwards compatibility
 				rbac.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
@@ -380,6 +382,8 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(read...).Groups(routeGroup, legacyRouteGroup).Resources("routes/status").RuleOrDie(),
 
 				rbac.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
+
+				rbac.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
 				// backwards compatibility
 				rbac.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
@@ -720,6 +724,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(read...).Groups(networkGroup, legacyNetworkGroup).Resources("egressnetworkpolicies", "hostsubnets", "netnamespaces").RuleOrDie(),
 				rbac.NewRule(read...).Groups(kapiGroup).Resources("nodes", "namespaces").RuleOrDie(),
 				rbac.NewRule(read...).Groups(extensionsGroup).Resources("networkpolicies").RuleOrDie(),
+				rbac.NewRule(read...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbac.NewRule("get").Groups(networkGroup, legacyNetworkGroup).Resources("clusternetworks").RuleOrDie(),
 			},
 		},

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -703,7 +703,6 @@ items:
     - deployments
     - deployments/rollback
     - deployments/scale
-    - networkpolicies
     - replicasets
     - replicasets/scale
     - replicationcontrollers/scale
@@ -992,6 +991,20 @@ items:
     - templateconfigs
     - templateinstances
     - templates
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    - networking.k8s.io
+    resources:
+    - networkpolicies
     verbs:
     - create
     - delete
@@ -1351,6 +1364,20 @@ items:
     - templateconfigs
     - templateinstances
     - templates
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    - networking.k8s.io
+    resources:
+    - networkpolicies
     verbs:
     - create
     - delete
@@ -2356,6 +2383,14 @@ items:
     - watch
   - apiGroups:
     - extensions
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - networking.k8s.io
     resources:
     - networkpolicies
     verbs:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -765,7 +765,6 @@ items:
     - deployments
     - deployments/rollback
     - deployments/scale
-    - networkpolicies
     - replicasets
     - replicasets/scale
     - replicationcontrollers/scale
@@ -1081,6 +1080,21 @@ items:
     - templateconfigs
     - templateinstances
     - templates
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    - networking.k8s.io
+    attributeRestrictions: null
+    resources:
+    - networkpolicies
     verbs:
     - create
     - delete
@@ -1470,6 +1484,21 @@ items:
     - templateconfigs
     - templateinstances
     - templates
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    - networking.k8s.io
+    attributeRestrictions: null
+    resources:
+    - networkpolicies
     verbs:
     - create
     - delete
@@ -2578,6 +2607,15 @@ items:
     - watch
   - apiGroups:
     - extensions
+    attributeRestrictions: null
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - networking.k8s.io
     attributeRestrictions: null
     resources:
     - networkpolicies


### PR DESCRIPTION
As part of the k8s 1.8 rebase, the NetworkPolicy code was changed to use networking.NetworkPolicy rather than extensions.NetworkPolicy, but the roles weren't updated to have the right permissions.. (This wasn't caught because only extended-networking-minimal gets run on PRs by default, and that only tests multitenant.)

Fixes test_branch_origin_extended_networking 

(https://github.com/kubernetes/kubernetes/pull/56650 hasn't actually merged yet.)