### PR TITLE
Use $0 and not $BASH_SOURCE to detect the executable

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -51,8 +51,8 @@ os::log::stacktrace::install
 os::util::environment::update_path_var
 
 if [[ -z "${OS_TMP_ENV_SET-}" ]]; then
-	if [[ "${BASH_SOURCE[0]}" =~ .*\.sh ]]; then
-		os::util::environment::setup_tmpdir_vars "$( basename "${BASH_SOURCE[0]}" ".sh" )"
+	if [[ "${0}" =~ .*\.sh ]]; then
+		os::util::environment::setup_tmpdir_vars "$( basename "${0}" ".sh" )"
 	else
 		os::util::environment::setup_tmpdir_vars "shell"
 	fi


### PR DESCRIPTION
When we are called by a shell sourcing `hack/lib/init.sh`, only `$0`
reflects that. `"${BASH_SOURCE[0]}"` is always going to point to the top
of the call-stack within the shell, which will be the shell script being
run.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @pgier 
/assign @smarterclayton 
fixes #17560 