### PR TITLE
use version tagged jenkins for imagestreamtag

### DIFF
--- a/examples/image-streams/image-streams-centos7.json
+++ b/examples/image-streams/image-streams-centos7.json
@@ -961,7 +961,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "openshift/jenkins-2-centos7:latest"
+              "name": "openshift/jenkins-2-centos7:v3.9"
             }
           }
         ]

--- a/examples/image-streams/image-streams-rhel7.json
+++ b/examples/image-streams/image-streams-rhel7.json
@@ -863,7 +863,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:latest"
+              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.9"
             }
           }
         ]

--- a/examples/jenkins/jenkins-ephemeral-template.json
+++ b/examples/jenkins/jenkins-ephemeral-template.json
@@ -278,7 +278,7 @@
       "name": "JENKINS_IMAGE_STREAM_TAG",
       "displayName": "Jenkins ImageStreamTag",
       "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "value": "jenkins:2"
     }
   ],
   "labels": {

--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -302,7 +302,7 @@
       "name": "JENKINS_IMAGE_STREAM_TAG",
       "displayName": "Jenkins ImageStreamTag",
       "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "value": "jenkins:2"
     }
   ],
   "labels": {

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -1047,7 +1047,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "openshift/jenkins-2-centos7:latest"
+              "name": "openshift/jenkins-2-centos7:v3.9"
             }
           }
         ]
@@ -1937,7 +1937,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:latest"
+              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.9"
             }
           }
         ]
@@ -5035,7 +5035,7 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "name": "JENKINS_IMAGE_STREAM_TAG",
       "displayName": "Jenkins ImageStreamTag",
       "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "value": "jenkins:2"
     }
   ],
   "labels": {
@@ -5363,7 +5363,7 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "name": "JENKINS_IMAGE_STREAM_TAG",
       "displayName": "Jenkins ImageStreamTag",
       "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "value": "jenkins:2"
     }
   ],
   "labels": {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -15445,7 +15445,7 @@ var _examplesImageStreamsImageStreamsCentos7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "openshift/jenkins-2-centos7:latest"
+              "name": "openshift/jenkins-2-centos7:v3.9"
             }
           }
         ]
@@ -16335,7 +16335,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:latest"
+              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.9"
             }
           }
         ]
@@ -25865,7 +25865,7 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "name": "JENKINS_IMAGE_STREAM_TAG",
       "displayName": "Jenkins ImageStreamTag",
       "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "value": "jenkins:2"
     }
   ],
   "labels": {
@@ -26193,7 +26193,7 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "name": "JENKINS_IMAGE_STREAM_TAG",
       "displayName": "Jenkins ImageStreamTag",
       "description": "Name of the ImageStreamTag to be used for the Jenkins image.",
-      "value": "jenkins:latest"
+      "value": "jenkins:2"
     }
   ],
   "labels": {


### PR DESCRIPTION
depends on https://github.com/openshift/aos-cd-jobs/pull/897 being delivered and run to create the jenkins:v3.9 image on dockerhub.

and https://github.com/openshift/jenkins/pull/431 to consume the new env var.

Note that this PR introduces rhel imagestreams that cannot actually be successfully imported until after v3.9 GAs.  We're going to have to communicate this to QE to ensure they update the imagestreams to use internal registries when testing.
