### PR TITLE
Pick UPSTREAM 53830: perform nil check before iterating over keys

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -539,6 +539,10 @@ func (f *DeltaFIFO) Resync() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.knownObjects == nil {
+		return nil
+	}
+
 	keys := f.knownObjects.ListKeys()
 	for _, k := range keys {
 		if err := f.syncKeyLocked(k); err != nil {


### PR DESCRIPTION
Picks https://github.com/kubernetes/kubernetes/pull/53830 in order to fix an `oc observe` panic when `--names` is not provided

cc @openshift/cli-review @pweil- 