### PR TITLE
remove Categories from /oapi resources

### DIFF
--- a/pkg/apps/registry/deployconfig/etcd/etcd.go
+++ b/pkg/apps/registry/deployconfig/etcd/etcd.go
@@ -31,12 +31,6 @@ type REST struct {
 
 var _ rest.StandardStorage = &REST{}
 var _ rest.ShortNamesProvider = &REST{}
-var _ rest.CategoriesProvider = &REST{}
-
-// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
-func (r *REST) Categories() []string {
-	return []string{"all"}
-}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {

--- a/pkg/build/registry/build/etcd/etcd.go
+++ b/pkg/build/registry/build/etcd/etcd.go
@@ -18,12 +18,6 @@ type REST struct {
 }
 
 var _ rest.StandardStorage = &REST{}
-var _ rest.CategoriesProvider = &REST{}
-
-// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
-func (r *REST) Categories() []string {
-	return []string{"all"}
-}
 
 // NewREST returns a RESTStorage object that will work against Build objects.
 func NewREST(optsGetter restoptions.Getter) (*REST, *DetailsREST, error) {

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -17,12 +17,6 @@ type REST struct {
 
 var _ rest.StandardStorage = &REST{}
 var _ rest.ShortNamesProvider = &REST{}
-var _ rest.CategoriesProvider = &REST{}
-
-// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
-func (r *REST) Categories() []string {
-	return []string{"all"}
-}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -23,12 +23,6 @@ type REST struct {
 
 var _ rest.StandardStorage = &REST{}
 var _ rest.ShortNamesProvider = &REST{}
-var _ rest.CategoriesProvider = &REST{}
-
-// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
-func (r *REST) Categories() []string {
-	return []string{"all"}
-}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -21,12 +21,6 @@ type REST struct {
 }
 
 var _ rest.StandardStorage = &REST{}
-var _ rest.CategoriesProvider = &REST{}
-
-// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
-func (r *REST) Categories() []string {
-	return []string{"all"}
-}
 
 // NewREST returns a RESTStorage object that will work against routes.
 func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarClient routeregistry.SubjectAccessReviewInterface) (*REST, *StatusREST, error) {

--- a/test/integration/category_builder_test.go
+++ b/test/integration/category_builder_test.go
@@ -1,0 +1,172 @@
+package integration
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+var expectedGroups = map[string]bool{
+	"apiregistration.k8s.io/v1beta1":       false,
+	"extensions/v1beta1":                   false,
+	"apps/v1":                              false,
+	"apps/v1beta1":                         false,
+	"apps/v1beta2":                         false,
+	"events.k8s.io/v1beta1":                false,
+	"authentication.k8s.io/v1":             false,
+	"authentication.k8s.io/v1beta1":        false,
+	"authorization.k8s.io/v1":              false,
+	"authorization.k8s.io/v1beta1":         false,
+	"autoscaling/v1":                       false,
+	"autoscaling/v2beta1":                  false,
+	"batch/v1":                             false,
+	"batch/v1beta1":                        false,
+	"batch/v2alpha1":                       false,
+	"certificates.k8s.io/v1beta1":          false,
+	"networking.k8s.io/v1":                 false,
+	"policy/v1beta1":                       false,
+	"authorization.openshift.io/v1":        false,
+	"rbac.authorization.k8s.io/v1":         false,
+	"rbac.authorization.k8s.io/v1beta1":    false,
+	"storage.k8s.io/v1":                    false,
+	"storage.k8s.io/v1beta1":               false,
+	"admissionregistration.k8s.io/v1beta1": false,
+	"apiextensions.k8s.io/v1beta1":         false,
+	"apps.openshift.io/v1":                 false,
+	"build.openshift.io/v1":                false,
+	"image.openshift.io/v1":                false,
+	"network.openshift.io/v1":              false,
+	"oauth.openshift.io/v1":                false,
+	"project.openshift.io/v1":              false,
+	"quota.openshift.io/v1":                false,
+	"route.openshift.io/v1":                false,
+	"security.openshift.io/v1":             false,
+	"template.openshift.io/v1":             false,
+	"user.openshift.io/v1":                 false,
+	"/v1": false,
+}
+
+var expectedCategories = map[string][]string{
+	"DaemonSet/extensions/v1beta1":                {"all"},
+	"Deployment/extensions/v1beta1":               {"all"},
+	"ReplicaSet/extensions/v1beta1":               {"all"},
+	"DaemonSet/apps/v1":                           {"all"},
+	"Deployment/apps/v1":                          {"all"},
+	"ReplicaSet/apps/v1":                          {"all"},
+	"StatefulSet/apps/v1":                         {"all"},
+	"Deployment/apps/v1beta1":                     {"all"},
+	"StatefulSet/apps/v1beta1":                    {"all"},
+	"DaemonSet/apps/v1beta2":                      {"all"},
+	"Deployment/apps/v1beta2":                     {"all"},
+	"ReplicaSet/apps/v1beta2":                     {"all"},
+	"StatefulSet/apps/v1beta2":                    {"all"},
+	"HorizontalPodAutoscaler/autoscaling/v1":      {"all"},
+	"HorizontalPodAutoscaler/autoscaling/v2beta1": {"all"},
+	"Job/batch/v1":                                {"all"},
+	"Pod/v1":                                      {"all"},
+	"CronJob/batch/v1beta1":                       {"all"},
+	"CronJob/batch/v2alpha1":                      {"all"},
+	"ReplicationController/v1":                    {"all"},
+	"Service/v1":                                  {"all"},
+	"BuildConfig/v1":                              {"all"},
+	"Build/v1":                                    {"all"},
+	"DeploymentConfig/v1":                         {"all"},
+	"ImageStream/v1":                              {"all"},
+	"Route/v1":                                    {"all"},
+}
+
+func TestDiscoveryCategoriesContainExpectedResources(t *testing.T) {
+	masterConfig, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+	masterConfig.OAuthConfig = nil
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterAPI(masterConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
+	kclientset, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resources, err := kclientset.Discovery().ServerResources()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualCategories := map[string][]string{}
+
+	for _, resourceList := range resources {
+		gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		groupVersion := ""
+		if len(gv.Group) > 0 {
+			groupVersion += gv.Group
+		}
+		if len(gv.Version) > 0 {
+			groupVersion += "/" + gv.Version
+		}
+
+		if _, exists := expectedGroups[groupVersion]; exists {
+			expectedGroups[groupVersion] = true
+		} else {
+			t.Fatalf("unexpected discoverable resource group %q", groupVersion)
+		}
+
+		for _, resource := range resourceList.APIResources {
+			if len(resource.Categories) == 0 {
+				continue
+			}
+
+			kindGroupVersion := resource.Kind
+			if len(gv.Group) > 0 {
+				kindGroupVersion += "/" + gv.Group
+			}
+			if len(gv.Version) > 0 {
+				kindGroupVersion += "/" + gv.Version
+			}
+
+			actualCategories[kindGroupVersion] = resource.Categories
+		}
+	}
+
+	for groupVersion, seen := range expectedGroups {
+		if !seen {
+			t.Fatalf("expected group/version %q to be discoverable", groupVersion)
+		}
+	}
+
+	if len(actualCategories) != len(expectedCategories) {
+		t.Fatalf("expected\n\n %v\n to contain categories, but got\n\n %v", expectedCategories, actualCategories)
+	}
+
+	for expected, expectedAliases := range expectedCategories {
+		actualAliases, exists := actualCategories[expected]
+		if !exists {
+			t.Fatalf("expected resource %v to contain at least one category", expected)
+		}
+
+		if len(actualAliases) != len(expectedAliases) {
+			t.Fatalf("expected %v to contain categories %v but got %v", expected, expectedAliases, actualAliases)
+		}
+
+		for _, actualAlias := range actualAliases {
+			for _, expectedAlias := range expectedAliases {
+				if actualAlias != expectedAlias {
+					t.Fatalf("expected category for %v to be %v, but got %v", expectedAlias, expected, actualAlias)
+				}
+			}
+		}
+	}
+}

--- a/test/integration/category_builder_test.go
+++ b/test/integration/category_builder_test.go
@@ -66,16 +66,21 @@ var expectedCategories = map[string][]string{
 	"HorizontalPodAutoscaler/autoscaling/v1":      {"all"},
 	"HorizontalPodAutoscaler/autoscaling/v2beta1": {"all"},
 	"Job/batch/v1":                                {"all"},
+	"DeploymentConfig/apps.openshift.io/v1":       {"all"}, // FIX: discovered with no categories
+	"BuildConfig/build.openshift.io/v1":           {"all"}, // FIX: discovered with no categories
+	"Build/build.openshift.io/v1":                 {"all"}, // FIX: discovered with no categories
+	"ImageStream/image.openshift.io/v1":           {"all"}, // FIX: discovered with no categories
+	"Route/route.openshift.io/v1":                 {"all"}, // FIX: discovered with no categories
 	"Pod/v1":                                      {"all"},
 	"CronJob/batch/v1beta1":                       {"all"},
 	"CronJob/batch/v2alpha1":                      {"all"},
 	"ReplicationController/v1":                    {"all"},
 	"Service/v1":                                  {"all"},
-	"BuildConfig/v1":                              {"all"},
-	"Build/v1":                                    {"all"},
-	"DeploymentConfig/v1":                         {"all"},
-	"ImageStream/v1":                              {"all"},
-	"Route/v1":                                    {"all"},
+	"BuildConfig/v1":                              {"all"}, // FIX: discovered with no categories
+	"Build/v1":                                    {"all"}, // FIX: discovered with no categories
+	"DeploymentConfig/v1":                         {"all"}, // FIX: discovered with no categories
+	"ImageStream/v1":                              {"all"}, // FIX: discovered with no categories
+	"Route/v1":                                    {"all"}, // FIX: discovered with no categories
 }
 
 func TestDiscoveryCategoriesContainExpectedResources(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/17446

Removes the `Categories` method from `/oapi` resources, introduced in https://github.com/openshift/origin/pull/16823

Suggested in https://github.com/openshift/origin/issues/17446#issuecomment-348503231

cc @deads2k @openshift/cli-review @mfojtik @smarterclayton 