### PR TITLE
sdn: fix locking of egress DNS policy updates

### DIFF
--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -106,6 +106,12 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsHandler) error {
 	return nil
 }
 
+func (proxy *OsdnProxy) updateEgressNetworkPolicyLocked(policy networkapi.EgressNetworkPolicy) {
+	proxy.lock.Lock()
+	defer proxy.lock.Unlock()
+	proxy.updateEgressNetworkPolicy(policy)
+}
+
 func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
 	common.RunEventQueue(proxy.networkClient.Network().RESTClient(), common.EgressNetworkPolicies, func(delta cache.Delta) error {
 		policy := delta.Object.(*networkapi.EgressNetworkPolicy)
@@ -117,11 +123,7 @@ func (proxy *OsdnProxy) watchEgressNetworkPolicies() {
 			proxy.egressDNS.Add(*policy)
 		}
 
-		func() {
-			proxy.lock.Lock()
-			defer proxy.lock.Unlock()
-			proxy.updateEgressNetworkPolicy(*policy)
-		}()
+		proxy.updateEgressNetworkPolicyLocked(*policy)
 		return nil
 	})
 }
@@ -360,10 +362,7 @@ func (proxy *OsdnProxy) syncEgressDNSProxyFirewall() {
 			}
 		}
 
-		proxy.lock.Lock()
-		defer proxy.lock.Unlock()
-
-		proxy.updateEgressNetworkPolicy(policy)
+		proxy.updateEgressNetworkPolicyLocked(policy)
 	}
 }
 


### PR DESCRIPTION
When a DNS query resulted in changed data for an egress DNS policy
and the signal was processed by the code that actually applied
the policy, a lock was not correctly released leading to a deadlock
in the proxy, and failure to handle any endpoint changes.

Concrete effects included started/stopped pods not having their
endpoint changes reflected in iptables output.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1502602

@knobunc @eparis @openshift/networking 