### PR TITLE
Fail fast when request to /.well-known/oauth-authorization-server fails

### DIFF
--- a/pkg/cmd/util/tokencmd/request_token.go
+++ b/pkg/cmd/util/tokencmd/request_token.go
@@ -108,11 +108,18 @@ func (o *RequestTokenOptions) SetDefaultOsinConfig() error {
 	if err != nil {
 		return err
 	}
-	resp, err := request(rt, strings.TrimRight(o.ClientConfig.Host, "/")+oauthMetadataEndpoint, nil)
+
+	requestURL := strings.TrimRight(o.ClientConfig.Host, "/") + oauthMetadataEndpoint
+	resp, err := request(rt, requestURL, nil)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("couldn't get %v: unexpected response status %v", requestURL, resp.StatusCode)
+	}
+
 	metadata := &util.OauthAuthorizationServerMetadata{}
 	if err := json.NewDecoder(resp.Body).Decode(metadata); err != nil {
 		return err


### PR DESCRIPTION
Improves error reporting. See here for more details: https://github.com/openshift/origin/issues/17574#issuecomment-349108861

Prior this change `hack/test-cmd.sh` could fail with the error:

> error: Missing configuration - verify you have provided the correct host and port and that the server is currently running.

Now, the message has more details:

> error: couldn't get https://10.34.129.148:28443/.well-known/oauth-authorization-server: unexpected status 403 were returned - verify you have provided the correct host and port and that the server is currently running.

PTAL @enj @simo5 