### PR TITLE
os::start::master(): use curl instead of oc get for polling /healthz/ready endpoint

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -276,7 +276,11 @@ function os::start::master() {
 
 	os::test::junit::declare_suite_start "setup/start-master"
 	os::cmd::try_until_text "oc get --raw /healthz --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 160 * second )) 0.25
-	os::cmd::try_until_text "oc get --raw /healthz/ready --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 160 * second )) 0.25
+	os::cmd::try_until_text \
+		"curl --silent --cacert '$MASTER_CONFIG_DIR/ca.crt' '$API_SCHEME://$API_HOST:$API_PORT/healthz/ready'" \
+		'ok' \
+		$(( 160 * second )) \
+		0.25
 	os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
 	os::test::junit::declare_suite_end
 


### PR DESCRIPTION
Quoting @enj:
> `oc get --raw` is not a valid way to check because it will be running as part of the `system:masters group` and will bypass the RBAC authorizer.

In case of the test framework, `os::start::master()` were returning too early and `oc login` was failing to login because in fact the server wasn't ready yet.

Fixes #17574

PTAL @enj @simo5 @juanvallejo @stevekuznetsov 