### PR TITLE
Implement a ranked set based on key and rank

### DIFF
--- a/pkg/util/rankedset/rankedset.go
+++ b/pkg/util/rankedset/rankedset.go
@@ -1,0 +1,162 @@
+package rankedset
+
+import "github.com/google/btree"
+
+// Item represents a single object in a RankedSet.
+type Item interface {
+	// Key returns the unique identifier for this item.
+	Key() string
+	// Rank is used to sort items.
+	// Items with the same rank are sorted lexicographically based on Key.
+	Rank() int64
+}
+
+// RankedSet stores Items based on Key (uniqueness) and Rank (sorting).
+type RankedSet struct {
+	rank *btree.BTree
+	set  map[string]*treeItem
+}
+
+// StringItem implements Item using a string.
+// It has two main uses:
+// 1. If all items in a RankedSet are StringItems, the set becomes a store of unique strings sorted lexicographically.
+// 2. It serves as a Key item that can be passed into methods that ignore Rank such as RankedSet.Delete.
+type StringItem string
+
+func (s StringItem) Key() string {
+	return string(s)
+}
+
+func (s StringItem) Rank() int64 {
+	return 0
+}
+
+func New() *RankedSet {
+	return &RankedSet{
+		rank: btree.New(32),
+		set:  make(map[string]*treeItem),
+	}
+}
+
+// Insert adds the item into the set.
+// If an item with the same Key existed in the set, it is deleted and returned.
+func (s *RankedSet) Insert(item Item) Item {
+	old := s.Delete(item)
+
+	key := item.Key()
+	value := &treeItem{item: item}
+
+	s.rank.ReplaceOrInsert(value) // should always return nil because we call Delete first
+	s.set[key] = value
+
+	return old
+}
+
+// Delete removes the item from the set based on Key (Rank is ignored).
+// The removed item is returned if it existed in the set.
+func (s *RankedSet) Delete(item Item) Item {
+	key := item.Key()
+	value, ok := s.set[key]
+	if !ok {
+		return nil
+	}
+
+	s.rank.Delete(value) // should always return the same data as value (non-nil)
+	delete(s.set, key)
+
+	return value.item
+}
+
+func (s *RankedSet) Min() Item {
+	if min := s.rank.Min(); min != nil {
+		return min.(*treeItem).item
+	}
+	return nil
+}
+
+func (s *RankedSet) Max() Item {
+	if max := s.rank.Max(); max != nil {
+		return max.(*treeItem).item
+	}
+	return nil
+}
+
+func (s *RankedSet) Len() int {
+	return len(s.set)
+}
+
+func (s *RankedSet) Get(item Item) Item {
+	if value, ok := s.set[item.Key()]; ok {
+		return value.item
+	}
+	return nil
+}
+
+func (s *RankedSet) Has(item Item) bool {
+	_, ok := s.set[item.Key()]
+	return ok
+}
+
+// List returns all items in the set in ranked order.
+// If delete is set to true, the returned items are removed from the set.
+func (s *RankedSet) List(delete bool) []Item {
+	return s.ascend(
+		func(item Item) bool {
+			return true
+		},
+		delete,
+	)
+}
+
+// LessThan returns all items less than the given rank in ranked order.
+// If delete is set to true, the returned items are removed from the set.
+func (s *RankedSet) LessThan(rank int64, delete bool) []Item {
+	return s.ascend(
+		func(item Item) bool {
+			return item.Rank() < rank
+		},
+		delete,
+	)
+}
+
+// setItemIterator allows callers of ascend to iterate in-order over the set.
+// When this function returns false, iteration will stop.
+type setItemIterator func(item Item) bool
+
+func (s *RankedSet) ascend(iterator setItemIterator, delete bool) []Item {
+	var items []Item
+	s.rank.Ascend(func(i btree.Item) bool {
+		item := i.(*treeItem).item
+		if !iterator(item) {
+			return false
+		}
+		items = append(items, item)
+		return true
+	})
+	// delete after Ascend since it is probably not safe to remove while iterating
+	if delete {
+		for _, item := range items {
+			s.Delete(item)
+		}
+	}
+	return items
+}
+
+var _ btree.Item = &treeItem{}
+
+type treeItem struct {
+	item Item
+}
+
+func (i *treeItem) Less(than btree.Item) bool {
+	other := than.(*treeItem).item
+
+	selfRank := i.item.Rank()
+	otherRank := other.Rank()
+
+	if selfRank == otherRank {
+		return i.item.Key() < other.Key()
+	}
+
+	return selfRank < otherRank
+}

--- a/pkg/util/rankedset/rankedset_test.go
+++ b/pkg/util/rankedset/rankedset_test.go
@@ -1,0 +1,273 @@
+package rankedset
+
+import "testing"
+
+func TestRankedSet(t *testing.T) {
+	s := New()
+	a := newTestSetItem("A", 5, "AD")
+	b := newTestSetItem("B", 6, "BD")
+	c := newTestSetItem("C", 4, "CD")
+	d := newTestSetItem("D", 6, "DD")
+	e := newTestSetItem("E", 1, "ED")
+
+	for _, tc := range []struct {
+		name string
+		f    func(*testing.T)
+	}{
+		{
+			name: "insert",
+			f: func(t *testing.T) {
+				assertLen(s, 0, t)
+				s.Insert(a)
+				assertLen(s, 1, t)
+				s.Insert(b)
+				assertLen(s, 2, t)
+				s.Insert(c)
+				assertLen(s, 3, t)
+				s.Insert(d)
+				assertLen(s, 4, t)
+				s.Insert(e)
+				assertLen(s, 5, t)
+			},
+		},
+		{
+			name: "list order",
+			f: func(t *testing.T) {
+				assertOrder(s.List(false), t, e, c, a, b, d)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "delete list order 1",
+			f: func(t *testing.T) {
+				assertItem(a, s.Delete(a), t)
+				assertOrder(s.List(false), t, e, c, b, d)
+				assertLen(s, 4, t)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "delete list order 2",
+			f: func(t *testing.T) {
+				assertItem(b, s.Delete(b), t)
+				assertOrder(s.List(false), t, e, c, d)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "has",
+			f: func(t *testing.T) {
+				assertHas("A", false, s, t)
+				assertHas("B", false, s, t)
+				assertHas("C", true, s, t)
+				assertHas("D", true, s, t)
+				assertHas("E", true, s, t)
+				assertHas("F", false, s, t)
+			},
+		},
+		{
+			name: "get",
+			f: func(t *testing.T) {
+				assertItem(nil, s.Get(StringItem("A")), t)
+				assertItem(nil, s.Get(StringItem("B")), t)
+				assertItem(c, s.Get(StringItem("C")), t)
+				assertItem(d, s.Get(StringItem("D")), t)
+				assertItem(e, s.Get(StringItem("E")), t)
+				assertItem(nil, s.Get(StringItem("F")), t)
+			},
+		},
+		{
+			name: "delete list order 3",
+			f: func(t *testing.T) {
+				assertItem(nil, s.Delete(b), t)
+				assertOrder(s.List(false), t, e, c, d)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "delete list order 4",
+			f: func(t *testing.T) {
+				assertItem(c, s.Delete(c), t)
+				assertOrder(s.List(false), t, e, d)
+				assertLen(s, 2, t)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "insert list order",
+			f: func(t *testing.T) {
+				assertItem(nil, s.Insert(a), t)
+				assertOrder(s.List(false), t, e, a, d)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "less than order",
+			f: func(t *testing.T) {
+				assertOrder(s.LessThan(6, false), t, e, a)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "less than order delete",
+			f: func(t *testing.T) {
+				assertOrder(s.LessThan(6, true), t, e, a)
+				assertLen(s, 1, t)
+				assertItem(d, s.Min(), t)
+				assertItem(d, s.Max(), t)
+			},
+		},
+		{
+			name: "list order delete",
+			f: func(t *testing.T) {
+				assertOrder(s.List(true), t, d)
+				assertLen(s, 0, t)
+				assertItem(nil, s.Min(), t)
+				assertItem(nil, s.Max(), t)
+			},
+		},
+		{
+			name: "insert min max",
+			f: func(t *testing.T) {
+				assertItem(nil, s.Insert(b), t)
+				assertItem(nil, s.Insert(a), t)
+				assertItem(nil, s.Insert(e), t)
+				assertOrder(s.List(false), t, e, a, b)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(b, s.Max(), t)
+				assertItem(e, s.Delete(e), t)
+				assertLen(s, 2, t)
+				assertItem(a, s.Min(), t)
+				assertItem(b, s.Max(), t)
+			},
+		},
+		{
+			name: "insert replace",
+			f: func(t *testing.T) {
+				a0 := newTestSetItem("A", 1, "AD0")
+				a1 := newTestSetItem("A", 2, "AD1")
+				a2 := newTestSetItem("A", 3, "AD2")
+
+				assertItem(nil, s.Insert(e), t)
+				assertOrder(s.List(false), t, e, a, b)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(b, s.Max(), t)
+
+				assertItem(a, s.Insert(a0), t)
+				assertOrder(s.List(false), t, a0, e, b)
+				assertLen(s, 3, t)
+				assertItem(a0, s.Min(), t)
+				assertItem(b, s.Max(), t)
+
+				assertItem(a0, s.Insert(a1), t)
+				assertOrder(s.List(false), t, e, a1, b)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(b, s.Max(), t)
+
+				assertItem(a1, s.Insert(a2), t)
+				assertOrder(s.List(false), t, e, a2, b)
+				assertLen(s, 3, t)
+				assertItem(e, s.Min(), t)
+				assertItem(b, s.Max(), t)
+			},
+		},
+	} {
+		t.Run(tc.name, tc.f)
+	}
+}
+
+func assertLen(s *RankedSet, length int, t *testing.T) {
+	if s.Len() != length {
+		t.Errorf("%s expected len: %d got %d for %v", t.Name(), length, s.Len(), noPointerItems(s.List(false)))
+	}
+}
+
+func assertOrder(actual []Item, t *testing.T, items ...*testSetItem) {
+	if len(items) != len(actual) {
+		t.Errorf("%s expected len: %d got %d for %v and %v", t.Name(), len(items), len(actual), noPointers(items), noPointerItems(actual))
+		return
+	}
+	for i, item := range items {
+		if actualItem := actual[i].(*testSetItem); *item != *actualItem {
+			t.Errorf("%s expected item: %v got %v for idx %d", t.Name(), *item, *actualItem, i)
+		}
+	}
+}
+
+func assertItem(item *testSetItem, actual Item, t *testing.T) {
+	itemNil := item == nil
+	actualNil := actual == nil
+
+	if itemNil != actualNil {
+		t.Errorf("%s expected or actual is nil: %v vs %v", t.Name(), item, actual)
+		return
+	}
+
+	if itemNil {
+		return
+	}
+
+	if actualItem := actual.(*testSetItem); *item != *actualItem {
+		t.Errorf("%s expected item: %v got %v", t.Name(), *item, *actualItem)
+	}
+}
+
+func assertHas(key string, expected bool, s *RankedSet, t *testing.T) {
+	if expected != s.Has(StringItem(key)) {
+		t.Errorf("%s expected %v for %s with %v", t.Name(), expected, key, noPointerItems(s.List(false)))
+	}
+}
+
+func newTestSetItem(key string, rank int64, data string) *testSetItem {
+	return &testSetItem{
+		key:  key,
+		rank: rank,
+		data: data,
+	}
+}
+
+type testSetItem struct {
+	key  string
+	rank int64
+	data string
+}
+
+func (i *testSetItem) Key() string {
+	return i.key
+}
+
+func (i *testSetItem) Rank() int64 {
+	return i.rank
+}
+
+// funcs below make the printing of these slices better
+
+func noPointers(items []*testSetItem) []testSetItem {
+	var out []testSetItem
+	for _, item := range items {
+		out = append(out, *item)
+	}
+	return out
+}
+
+func noPointerItems(items []Item) []testSetItem {
+	var out []testSetItem
+	for _, item := range items {
+		out = append(out, *(item.(*testSetItem)))
+	}
+	return out
+}


### PR DESCRIPTION
This change adds a ranked set that uses a key (string) to determine uniqueness and a rank (int64) to determine ordering.  For example, a structure with a name and time could be ranked based on the time and deduped based on the name.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @simo5

In regards to using this in the token timeout PR:

1. Implement Key using token.Name and Rank using token.timeout().Unix()
2. Use RankedSet.Insert to add tokens
3. Use RankedSet.LessThan(flushInterval.Unix(), true) to get all tokens that are about to expire (and remove them from the set)
4. Process the tokens as needed