### PR TITLE
[3.7] image: only allow to import signatures for RH images

### DIFF
--- a/pkg/image/controller/signature/container_image_downloader_test.go
+++ b/pkg/image/controller/signature/container_image_downloader_test.go
@@ -1,0 +1,49 @@
+package signature
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+)
+
+func TestDownloadImageSignatures(t *testing.T) {
+	tests := []struct {
+		reference            string
+		expectSignatureCount int
+		expectError          bool
+	}{
+		{
+			reference:            "registry.access.redhat.com/rhel7:latest",
+			expectSignatureCount: 0,
+			expectError:          false,
+		},
+		{
+			reference:            "docker-registry:5000/foo/bar",
+			expectSignatureCount: 0,
+			expectError:          false,
+		},
+		{
+			reference:            "test",
+			expectSignatureCount: 0,
+			expectError:          false,
+		},
+	}
+
+	for _, c := range tests {
+		d := NewContainerImageSignatureDownloader(context.Background(), 1*time.Second)
+		image := &imageapi.Image{DockerImageReference: c.reference}
+		signatures, err := d.DownloadImageSignatures(image)
+		if len(signatures) != c.expectSignatureCount {
+			t.Errorf("[%s] expected %d signatures, got %d", c.reference, c.expectSignatureCount, len(signatures))
+		}
+		if err != nil && !c.expectError {
+			t.Errorf("[%s] unexpected error: %v", c.reference, err)
+		}
+		if err == nil && c.expectError {
+			t.Errorf("[%s] expected error, got no error", c.reference)
+		}
+	}
+
+}


### PR DESCRIPTION
@smarterclayton @bparees variant 1).

This is fairly simple change and should be easy to pick for 3.7. However, this basically disallow to import signatures from anything else than RH registry...

[Alternative](https://github.com/openshift/origin/pull/17626) could be to use the import whitelist and only allow automatic import for registries listed there (excluding internal registry which I think is not in the list anyway).