### PR TITLE
[3.7] image: allow to disable signature import controller

### DIFF
--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -9,9 +9,10 @@ import (
 
 // A new entry shall be added to FeatureAliases for every change to following values.
 const (
-	FeatureBuilder    = `Builder`
-	FeatureS2I        = `S2IBuilder`
-	FeatureWebConsole = `WebConsole`
+	FeatureBuilder         = `Builder`
+	FeatureS2I             = `S2IBuilder`
+	FeatureWebConsole      = `WebConsole`
+	FeatureSignatureImport = `SignatureImport`
 
 	AllVersions = "*"
 )

--- a/pkg/cmd/server/api/util.go
+++ b/pkg/cmd/server/api/util.go
@@ -4,3 +4,7 @@ package api
 func IsBuildEnabled(config *MasterConfig) bool {
 	return !config.DisabledFeatures.Has(FeatureBuilder)
 }
+
+func IsSignatureImportEnabled(config *MasterConfig) bool {
+	return !config.DisabledFeatures.Has(FeatureSignatureImport)
+}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -701,6 +701,9 @@ func getExcludedControllers(options configapi.MasterConfig) sets.String {
 		excludedControllers.Insert("openshift.io/build")
 		excludedControllers.Insert("openshift.io/build-config-change")
 	}
+	if !configapi.IsSignatureImportEnabled(&options) {
+		excludedControllers.Insert("openshift.io/image-signature-import")
+	}
 	return excludedControllers
 }
 


### PR DESCRIPTION
Alternative for https://github.com/openshift/origin/pull/17625

@smarterclayton @bparees adds gate feature similar to s2i and builders. Allow us to disable the controller via master config.

@deads2k this and the "build" feature gate will be deprecated in 3.9 (since we can use the controllers flag...)