### PR TITLE
increase the podLogTimeout for downward volume test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go
@@ -32,7 +32,7 @@ import (
 
 var _ = framework.KubeDescribe("Downward API volume", func() {
 	// How long to wait for a log pod to be displayed
-	const podLogTimeout = 2 * time.Minute
+	const podLogTimeout = 3 * time.Minute
 	f := framework.NewDefaultFramework("downward-api")
 	var podClient *framework.PodClient
 	BeforeEach(func() {


### PR DESCRIPTION
Increase timeout for the test based on https://github.com/kubernetes/kubernetes/pull/33165

