### PR TITLE
reencrypt route without verification of client side cert 

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -400,9 +400,15 @@ backend be_secure:{{$cfgIdx}}
           {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
             {{- end }}
-            {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }} verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem
+            {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }}
+              {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/verifyCACertificate")) }} verify required ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem
+              {{- else }} verify none ca-file {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem
+              {{- end}}
             {{- else }}
-              {{- if gt (len $defaultDestinationCA) 0 }} verify required ca-file {{ $defaultDestinationCA }}
+              {{- if gt (len $defaultDestinationCA) 0 }}
+                {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/verifyCACertificate")) }} verify required ca-file {{ $defaultDestinationCA }}
+                {{- else }} verify none ca-file {{ $defaultDestinationCA }}
+                {{- end }}
               {{- else }} verify none
               {{- end }}
             {{- end }}


### PR DESCRIPTION
allow an openshift administrator to create a reencrypt route that does not verify the client side cert. 

Using the annotation haproxy.router.openshift.io/verifyCACertificate allows to create a route with an empty destinationCACertificate

[Trello card](https://trello.com/c/YoihDIlt/191-option-to-re-encrypt-without-certificate-validation-ingress)
Bugzilla RFE: [1306533](https://bugzilla.redhat.com/show_bug.cgi?id=1306533)

@knobunc PTAL