### PR TITLE
Diagnostics: Catch an error if failed to count network test pods

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics/network/setup.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/network/setup.go
@@ -171,6 +171,8 @@ func (d *NetworkDiagnostic) waitForTestPodAndService(nsList []string) error {
 				errList = append(errList, fmt.Errorf("Failed to run network diags test pods, failed: %d, total: %d", (totalPods-runningPods), totalPods))
 			}
 		}
+	} else {
+		errList = append(errList, fmt.Errorf("Failed to count test pods: %v ", err))
 	}
 	return kerrors.NewAggregate(errList)
 }


### PR DESCRIPTION
This patch changes to add error handling to append error when
d.getCountOfTestPods(nsList) retruns error.