### PR TITLE
pin the go-openapi/loads level

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -78,3 +78,7 @@ import:
   version: openshift-3.8
 - package: github.com/vjeantet/ldapserver
   version: v1.0
+
+# ours because of genapidocs.  This is the current kube level
+- package: github.com/go-openapi/loads
+  version: 18441dfa706d924a39a030ee2c3b1d8d81917b38


### PR DESCRIPTION
This is a shared dependency that is trying to bump itself.

@jim-minter I think you added this dep
/assign jim-minter
/assign bparees