### PR TITLE
properly default to the builder SA if no SA is specified on the build

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -40,7 +40,6 @@ import (
 	buildlister "github.com/openshift/origin/pkg/build/generated/listers/build/internalversion"
 	buildgenerator "github.com/openshift/origin/pkg/build/generator"
 	buildutil "github.com/openshift/origin/pkg/build/util"
-	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageinformers "github.com/openshift/origin/pkg/image/generated/informers/internalversion/image/internalversion"
 	imagelister "github.com/openshift/origin/pkg/image/generated/listers/image/internalversion"
@@ -493,7 +492,7 @@ func (bc *BuildController) createPodSpec(build *buildapi.Build) (*v1.Pod, error)
 func (bc *BuildController) resolveImageSecretAsReference(build *buildapi.Build, imagename string) (*kapi.LocalObjectReference, error) {
 	serviceAccount := build.Spec.ServiceAccount
 	if len(serviceAccount) == 0 {
-		serviceAccount = bootstrappolicy.BuilderServiceAccountName
+		serviceAccount = buildutil.BuilderServiceAccountName
 	}
 	builderSecrets, err := buildgenerator.FetchServiceAccountSecrets(bc.kubeClient.Core(), bc.kubeClient.Core(), build.Namespace, serviceAccount)
 	if err != nil {

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -42,6 +42,11 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 		buildutil.MergeTrustedEnvWithoutDuplicates(buildutil.CopyApiEnvVarToV1EnvVar(strategy.Env), &containerEnv, true)
 	}
 
+	serviceAccount := build.Spec.ServiceAccount
+	if len(serviceAccount) == 0 {
+		serviceAccount = buildutil.BuilderServiceAccountName
+	}
+
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildapi.GetBuildPodName(build),
@@ -49,7 +54,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 			Labels:    getPodLabels(build),
 		},
 		Spec: v1.PodSpec{
-			ServiceAccountName: build.Spec.ServiceAccount,
+			ServiceAccountName: serviceAccount,
 			Containers: []v1.Container{
 				{
 					Name:    "docker-build",

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -64,6 +64,11 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 		containerEnv = append(containerEnv, v1.EnvVar{Name: buildapi.DropCapabilities, Value: strings.Join(DefaultDropCaps, ",")})
 	}
 
+	serviceAccount := build.Spec.ServiceAccount
+	if len(serviceAccount) == 0 {
+		serviceAccount = buildutil.BuilderServiceAccountName
+	}
+
 	privileged := true
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +77,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 			Labels:    getPodLabels(build),
 		},
 		Spec: v1.PodSpec{
-			ServiceAccountName: build.Spec.ServiceAccount,
+			ServiceAccountName: serviceAccount,
 			Containers: []v1.Container{
 				{
 					Name:    "sti-build",

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -30,6 +30,9 @@ const (
 
 	// WorkDir is the working directory within the build pod, mounted as a volume.
 	BuildWorkDirMount = "/tmp/build"
+
+	// BuilderServiceAccountName is the name of the account used to run build pods by default.
+	BuilderServiceAccountName = "builder"
 )
 
 var (


### PR DESCRIPTION
this brings us into alignment with what we were already doing when looking up the secrets to use for the build:
https://github.com/openshift/origin/blob/959bc67c903d1bbc81f298c76a9d75252e573120/pkg/build/controller/build/build_controller.go#L494-L497

it also aligns us with what is done when you create a build from a buildconfig that has no SA specified:
https://github.com/openshift/origin/blob/959bc67c903d1bbc81f298c76a9d75252e573120/pkg/build/generator/generator.go#L461
https://github.com/openshift/origin/blob/959bc67c903d1bbc81f298c76a9d75252e573120/pkg/build/generator/generator.go#L881-L890
