### PR TITLE
Limit Prometheus discovery to relevant namespaces

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -469,6 +469,9 @@ objects:
 
         kubernetes_sd_configs:
         - role: endpoints
+          namespaces:
+            names:
+            - default
 
         scheme: https
         tls_config:
@@ -479,9 +482,9 @@ objects:
         # will add targets for each API server which Kubernetes adds an endpoint to
         # the default/kubernetes service.
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;kubernetes;https
+          regex: kubernetes;https
 
       # Scrape config for controllers.
       #
@@ -499,14 +502,17 @@ objects:
 
         kubernetes_sd_configs:
         - role: endpoints
+          namespaces:
+            names:
+            - default
 
         # Keep only the default/kubernetes service endpoints for the https port, and then
         # set the port to 8444. This is the default configuration for the controllers on OpenShift
         # masters.
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;kubernetes;https
+          regex: kubernetes;https
         - source_labels: [__address__]
           action: replace
           target_label: __address__
@@ -680,10 +686,12 @@ objects:
           namespaces:
             names:
             - openshift-template-service-broker
+
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: openshift-template-service-broker;apiserver;https
+          regex: api-server;https
+
       # Scrape config for the router
       - job_name: 'openshift-router'
         scheme: https
@@ -697,9 +705,9 @@ objects:
             names:
             - default
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;router;1936-tcp
+          regex: router;1936-tcp
 
       alerting:
         alertmanagers:

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14424,6 +14424,9 @@ objects:
 
         kubernetes_sd_configs:
         - role: endpoints
+          namespaces:
+            names:
+            - default
 
         scheme: https
         tls_config:
@@ -14434,9 +14437,9 @@ objects:
         # will add targets for each API server which Kubernetes adds an endpoint to
         # the default/kubernetes service.
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;kubernetes;https
+          regex: kubernetes;https
 
       # Scrape config for controllers.
       #
@@ -14454,14 +14457,17 @@ objects:
 
         kubernetes_sd_configs:
         - role: endpoints
+          namespaces:
+            names:
+            - default
 
         # Keep only the default/kubernetes service endpoints for the https port, and then
         # set the port to 8444. This is the default configuration for the controllers on OpenShift
         # masters.
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;kubernetes;https
+          regex: kubernetes;https
         - source_labels: [__address__]
           action: replace
           target_label: __address__
@@ -14635,10 +14641,12 @@ objects:
           namespaces:
             names:
             - openshift-template-service-broker
+
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: openshift-template-service-broker;apiserver;https
+          regex: api-server;https
+
       # Scrape config for the router
       - job_name: 'openshift-router'
         scheme: https
@@ -14652,9 +14660,9 @@ objects:
             names:
             - default
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;router;1936-tcp
+          regex: router;1936-tcp
 
       alerting:
         alertmanagers:

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -25980,6 +25980,9 @@ objects:
 
         kubernetes_sd_configs:
         - role: endpoints
+          namespaces:
+            names:
+            - default
 
         scheme: https
         tls_config:
@@ -25990,9 +25993,9 @@ objects:
         # will add targets for each API server which Kubernetes adds an endpoint to
         # the default/kubernetes service.
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;kubernetes;https
+          regex: kubernetes;https
 
       # Scrape config for controllers.
       #
@@ -26010,14 +26013,17 @@ objects:
 
         kubernetes_sd_configs:
         - role: endpoints
+          namespaces:
+            names:
+            - default
 
         # Keep only the default/kubernetes service endpoints for the https port, and then
         # set the port to 8444. This is the default configuration for the controllers on OpenShift
         # masters.
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;kubernetes;https
+          regex: kubernetes;https
         - source_labels: [__address__]
           action: replace
           target_label: __address__
@@ -26191,10 +26197,12 @@ objects:
           namespaces:
             names:
             - openshift-template-service-broker
+
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: openshift-template-service-broker;apiserver;https
+          regex: api-server;https
+
       # Scrape config for the router
       - job_name: 'openshift-router'
         scheme: https
@@ -26208,9 +26216,9 @@ objects:
             names:
             - default
         relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
-          regex: default;router;1936-tcp
+          regex: router;1936-tcp
 
       alerting:
         alertmanagers:


### PR DESCRIPTION
This change tweaks the Prometheus example configuration to avoid
watching all the namespaces when only one is effectively of interest.