### PR TITLE
 Deprecated NodeConfig.NodeIP in favor of NodeConfig.KubeletArguments["node-ip"]

### DIFF
--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -256,6 +256,16 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 		},
 		func(obj *configapi.NodeConfig, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
+
+			if len(obj.DeprecatedNodeIP) != 0 {
+				if obj.KubeletArguments == nil {
+					obj.KubeletArguments = configapi.ExtendedArguments{}
+				}
+				if ips, ok := obj.KubeletArguments["node-ip"]; !ok || (len(ips) == 0) {
+					obj.KubeletArguments["node-ip"] = []string{obj.DeprecatedNodeIP}
+				}
+			}
+
 			// Defaults/migrations for NetworkConfig
 			if len(obj.NetworkConfig.NetworkPluginName) == 0 {
 				obj.NetworkConfig.NetworkPluginName = "plugin-name"

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -176,9 +176,9 @@ type NodeConfig struct {
 	// If you're describing a set of static nodes to the master, this value must match one of the values in the list
 	NodeName string
 
-	// Node may have multiple IPs, specify the IP to use for pod traffic routing
-	// If not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
-	NodeIP string
+	// Deprecated in favor of 'node-ip' under kubeletArguments section
+	// Node may have multiple IPs, specify the IP to used by kubelet
+	DeprecatedNodeIP string
 
 	// ServingInfo describes how to start serving
 	ServingInfo ServingInfo

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -178,6 +178,15 @@ func SetDefaults_NodeConfig(obj *NodeConfig) {
 	}
 	SetDefaults_ClientConnectionOverrides(obj.MasterClientConnectionOverrides)
 
+	if len(obj.DeprecatedNodeIP) != 0 {
+		if obj.KubeletArguments == nil {
+			obj.KubeletArguments = ExtendedArguments{}
+		}
+		if ips, ok := obj.KubeletArguments["node-ip"]; !ok || (len(ips) == 0) {
+			obj.KubeletArguments["node-ip"] = []string{obj.DeprecatedNodeIP}
+		}
+	}
+
 	// Defaults/migrations for NetworkConfig
 	if len(obj.NetworkConfig.NetworkPluginName) == 0 {
 		obj.NetworkConfig.NetworkPluginName = obj.DeprecatedNetworkPluginName

--- a/pkg/cmd/server/apis/config/v1/testdata/node-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/node-config.yaml
@@ -29,7 +29,6 @@ masterKubeConfig: ""
 networkConfig:
   mtu: 1450
   networkPluginName: ""
-nodeIP: ""
 nodeName: ""
 podManifestConfig:
   fileCheckIntervalSeconds: 0

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -18,9 +18,9 @@ type NodeConfig struct {
 	// If you're describing a set of static nodes to the master, this value must match one of the values in the list
 	NodeName string `json:"nodeName"`
 
-	// Node may have multiple IPs, specify the IP to use for pod traffic routing
-	// If not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
-	NodeIP string `json:"nodeIP"`
+	// Deprecated in favor of 'node-ip' under kubeletArguments section
+	// Node may have multiple IPs, specify the IP to used by kubelet
+	DeprecatedNodeIP string `json:"nodeIP,omitempty"`
 
 	// ServingInfo describes how to start serving
 	ServingInfo ServingInfo `json:"servingInfo"`

--- a/pkg/cmd/server/kubernetes/network/sdn_linux.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_linux.go
@@ -54,10 +54,17 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 	eventBroadcaster.StartRecordingToSink(&kv1core.EventSinkImpl{Interface: kubeClientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, kclientv1.EventSource{Component: "openshift-sdn", Host: options.NodeName})
 
+	nodeIP := ""
+	if options.KubeletArguments != nil {
+		if ips, ok := options.KubeletArguments["node-ip"]; ok && (len(ips) > 0) {
+			nodeIP = ips[0]
+		}
+	}
+
 	node, err := sdnnode.New(&sdnnode.OsdnNodeConfig{
 		PluginName:         options.NetworkConfig.NetworkPluginName,
 		Hostname:           options.NodeName,
-		SelfIP:             options.NodeIP,
+		SelfIP:             nodeIP,
 		RuntimeEndpoint:    runtimeEndpoint,
 		CNIBinDir:          cniBinDir,
 		CNIConfDir:         cniConfDir,

--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -53,7 +53,6 @@ func ComputeKubeletFlags(startingArgs map[string][]string, options configapi.Nod
 	setIfUnset(args, "kubeconfig", options.MasterKubeConfig)
 	setIfUnset(args, "pod-manifest-path", path)
 	setIfUnset(args, "root-dir", options.VolumeDirectory)
-	setIfUnset(args, "node-ip", options.NodeIP)
 	setIfUnset(args, "hostname-override", options.NodeName)
 	setIfUnset(args, "allow-privileged", "true")
 	setIfUnset(args, "register-node", "true")

--- a/pkg/cmd/server/start/bootstrap_node.go
+++ b/pkg/cmd/server/start/bootstrap_node.go
@@ -139,7 +139,9 @@ func overrideNodeConfigForBootstrap(nodeConfig *configapi.NodeConfig, bootstrapK
 	// Set impliict defaults the same as the kubelet (until this entire code path is removed)
 	nodeConfig.NodeName = nodeutil.GetHostname(nodeConfig.NodeName)
 	if nodeConfig.DNSIP == "0.0.0.0" {
-		nodeConfig.DNSIP = nodeConfig.NodeIP
+		if ips, ok := nodeConfig.KubeletArguments["node-ip"]; ok && (len(ips) > 0) {
+			nodeConfig.DNSIP = ips[0]
+		}
 		// TODO: the Kubelet should do this defaulting (to the IP it recognizes)
 		if len(nodeConfig.DNSIP) == 0 {
 			if ip, err := cmdutil.DefaultLocalIP4(); err == nil {


### PR DESCRIPTION
- Both NodeConfig.NodeIP and NodeConfig.KubeletArguments["node-ip"] optional params
  does the same job of setting Kubelet reported node address as given IP.
  When we have different node IP values for these params NodeConfig.KubeletArguments
  gets the precedence. Deprecating NodeConfig.NodeIP will avoid this confusion and
  it retains the same fuctionality.

- This also helps when we introduce PodTrafficNodeIP and MasterTrafficNodeIP for this
  card: https://trello.com/c/sCNKKYCz

Docs pr: https://github.com/openshift/openshift-docs/pull/6708