### PR TITLE
[3.7] UPSTREAM: 51634: Revert to using isolated PID namespaces in Docker

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config_test.go
+++ b/pkg/cmd/server/kubernetes/node/node_config_test.go
@@ -31,6 +31,7 @@ func TestKubeletDefaults(t *testing.T) {
 			ContainerRuntimeOptions: kubeletoptions.ContainerRuntimeOptions{
 				DockershimRootDirectory:   "/var/lib/dockershim",
 				DockerExecHandlerName:     "native",
+				DockerDisableSharedPID:    true,
 				DockerEndpoint:            "unix:///var/run/docker.sock",
 				ImagePullProgressDeadline: metav1.Duration{Duration: 1 * time.Minute},
 				RktAPIEndpoint:            rkt.DefaultRktAPIServiceEndpoint,

--- a/vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go
@@ -108,6 +108,7 @@ func NewContainerRuntimeOptions() *ContainerRuntimeOptions {
 		DockerEndpoint:            dockerEndpoint,
 		DockershimRootDirectory:   "/var/lib/dockershim",
 		DockerExecHandlerName:     "native",
+		DockerDisableSharedPID:    true,
 		PodSandboxImage:           defaultPodSandboxImage,
 		ImagePullProgressDeadline: metav1.Duration{Duration: 1 * time.Minute},
 		RktAPIEndpoint:            defaultRktAPIServiceEndpoint,


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/51634

fixes https://github.com/openshift/openshift-ansible/issues/6431

The upstream pick is a revert the shared PID namespacing being on by default.  Unfortunately, it made the change for kube 1.8 and later but not 1.7 and therefore it is on by default in Origin 3.7 when using docker 1.13.  This causes issues for glusterfs https://github.com/kubernetes/kubernetes/issues/48937

@derekwaynecarr @dustymabe @sdodson 