### PR TITLE
disable SchedulerPredicates validates that NodeSelector is respected

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -352,8 +352,9 @@ var (
 		`validates resource limits of pods that are allowed to run`, // can't schedule to master due to node label limits, also fiddly
 
 		// TODO undisable:
-		`should provide basic identity`,                         // needs a persistent volume provisioner in single node, host path not working
-		`should idle the service and DeploymentConfig properly`, // idling with a single service and DeploymentConfig [Conformance]
+		`should provide basic identity`,                            // needs a persistent volume provisioner in single node, host path not working
+		`should idle the service and DeploymentConfig properly`,    // idling with a single service and DeploymentConfig [Conformance]
+		"validates that NodeSelector is respected if not matching", // https://github.com/openshift/origin/issues/17682
 
 		// slow as sin and twice as ugly (11m each)
 		"Pod should avoid to schedule to node that have avoidPod annotation",


### PR DESCRIPTION
Unblocks the queue as https://github.com/openshift/origin/issues/17682 is flaking hard. We still have to investigate why the timeout is hit and this should be reverted when we have fix.