### PR TITLE
Apps: raise failing-dc timeout to avoid flakes

### DIFF
--- a/test/testdata/failing-dc.yaml
+++ b/test/testdata/failing-dc.yaml
@@ -15,7 +15,7 @@ spec:
       intervalSeconds: 1
       maxSurge: 25%
       maxUnavailable: 25%
-      timeoutSeconds: 5
+      timeoutSeconds: 10
       updatePeriodSeconds: 1
       pre:
         failurePolicy: Abort


### PR DESCRIPTION
@mfojtik fix for the flake you saw earlier (https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/17576/test_pull_request_origin_end_to_end/6624/)