### PR TITLE
Adding additional persistent volumes for image_ecosystem tests

### DIFF
--- a/test/extended/image_ecosystem/helper.go
+++ b/test/extended/image_ecosystem/helper.go
@@ -54,3 +54,9 @@ func CheckPageContains(oc *exutil.CLI, endpoint, path, contents string) (bool, e
 	}
 	return success, nil
 }
+
+func cleanup(oc *exutil.CLI) {
+	if err := exutil.CleanupHostPathVolumes(oc.AdminKubeClient().Core().PersistentVolumes(), oc.Namespace()); err != nil {
+		ginkgolog("WARNING: couldn't cleanup persistent volumes: %v", err)
+	}
+}

--- a/test/extended/image_ecosystem/mongodb_replica_statefulset.go
+++ b/test/extended/image_ecosystem/mongodb_replica_statefulset.go
@@ -50,15 +50,7 @@ var _ = g.Describe("[Conformance][image_ecosystem][mongodb][Slow] openshift mong
 					3,
 				)
 				o.Expect(err).NotTo(o.HaveOccurred())
-
-				defer func() {
-					// We're removing only PVs because all other things will be removed
-					// together with namespace.
-					err := exutil.CleanupHostPathVolumes(oc.AdminKubeClient().Core().PersistentVolumes(), oc.Namespace())
-					if err != nil {
-						ginkgolog("WARNING: couldn't cleanup persistent volumes: %v", err)
-					}
-				}()
+				defer cleanup(oc)
 
 				g.By("creating a new app")
 				o.Expect(

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -62,16 +62,12 @@ func CreateMySQLReplicationHelpers(c kcoreclient.PodInterface, masterDeployment,
 	return master, slaves, helper
 }
 
-func cleanup(oc *exutil.CLI) {
-	exutil.CleanupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace())
-}
-
 func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 	return func() {
 		oc.SetOutputDir(exutil.TestContext.OutputDir)
 		defer cleanup(oc)
 
-		_, err := exutil.SetupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace(), "1Gi", 2)
+		_, err := exutil.SetupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace(), "1Gi", 5)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = testutil.WaitForPolicyUpdate(oc.InternalKubeClient().Authorization(), oc.Namespace(), "create", templateapi.Resource("templates"), true)

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -81,7 +81,7 @@ func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string) func() {
 		oc.SetOutputDir(exutil.TestContext.OutputDir)
 		defer cleanup(oc)
 
-		_, err := exutil.SetupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace(), "512Mi", 1)
+		_, err := exutil.SetupHostPathVolumes(oc.AdminKubeClient().CoreV1().PersistentVolumes(), oc.Namespace(), "512Mi", 3)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = testutil.WaitForPolicyUpdate(oc.InternalKubeClient().Authorization(), oc.Namespace(), "create", templateapi.Resource("templates"), true)


### PR DESCRIPTION
Should resolve: #17714 & #17651 