### PR TITLE
Tag and run qualified image names for gssapi tests

### DIFF
--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -76,15 +76,15 @@ for os_image in "${os_images[@]}"; do
             os::cmd::expect_success 'cp ../../scripts/test-wrapper.sh .'
             os::cmd::expect_success 'cp ../../scripts/gssapi-tests.sh .'
             os::cmd::expect_success 'cp ../../config/kubeconfig .'
-            os::cmd::expect_success "docker build --build-arg REALM='${realm}' --build-arg HOST='${host}' -t '${project_name}/${os_image}-gssapi-base:latest' ."
+            os::cmd::expect_success "docker build --build-arg REALM='${realm}' --build-arg HOST='${host}' -t 'docker.io/${project_name}/${os_image}-gssapi-base:latest' ."
         popd > /dev/null
 
         pushd kerberos > /dev/null
-            os::cmd::expect_success "docker build -t '${project_name}/${os_image}-gssapi-kerberos:latest' ."
+            os::cmd::expect_success "docker build -t 'docker.io/${project_name}/${os_image}-gssapi-kerberos:latest' ."
         popd > /dev/null
 
         pushd kerberos_configured > /dev/null
-            os::cmd::expect_success "docker build -t '${project_name}/${os_image}-gssapi-kerberos-configured:latest' ."
+            os::cmd::expect_success "docker build -t 'docker.io/${project_name}/${os_image}-gssapi-kerberos-configured:latest' ."
         popd > /dev/null
 
     popd > /dev/null
@@ -106,11 +106,11 @@ function run_gssapi_tests() {
     local server_config="${2}"
     local container_exit_code_jsonpath='{.status.containerStatuses[0].state.terminated.exitCode}'
     local pod_log_location="${LOG_DIR}/${image_name}-${server_config}.log"
-    oc run "${image_name}"                                  \
-            --image="${project_name}/${image_name}"         \
-            --generator=run-pod/v1 --restart=Never --attach \
-            --env=SERVER="${server_config}"                 \
-            1> "${pod_log_location}"                        \
+    oc run "${image_name}"                                    \
+            --image="docker.io/${project_name}/${image_name}" \
+            --generator=run-pod/v1 --restart=Never --attach   \
+            --env=SERVER="${server_config}"                   \
+            1> "${pod_log_location}"                          \
             2>> "${junit_gssapi_output}"
     # Lots of checks to really make sure that the tests ran successfully
     os::cmd::expect_success_and_text "cat ${pod_log_location}" 'SUCCESS'


### PR DESCRIPTION
caused by mismatch in local docker builds and fully-qualified pull expectations

fixes #17481