### PR TITLE
UPSTREAM: 52616: Temporarily disable flaky unit test

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/deviceplugin/manager_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/deviceplugin/manager_test.go
@@ -56,6 +56,7 @@ func TestNewManagerImplStart(t *testing.T) {
 // making sure that after registration, devices are correctly updated and if a re-registration
 // happens, we will NOT delete devices; and no orphaned devices left.
 func TestDevicePluginReRegistration(t *testing.T) {
+	t.SkipNow()
 	devs := []*pluginapi.Device{
 		{ID: "Dev1", Health: pluginapi.Healthy},
 		{ID: "Dev2", Health: pluginapi.Healthy},


### PR DESCRIPTION
Currently this test is not 100% race proof. A better implementation
is already under review upstream:
https://github.com/kubernetes/kubernetes/pull/52616

Disable this unit test till above mentioned PR gets merged upstream.

/cc @sjenning @enj 