### PR TITLE
tweak failing-dc e2e test with sleep so docker have time to get the hook container logs

### DIFF
--- a/test/testdata/failing-dc.yaml
+++ b/test/testdata/failing-dc.yaml
@@ -22,8 +22,14 @@ spec:
         execNewPod:
           containerName: myapp
           command:
-          - /bin/echo
-          - test pre hook executed
+            - /bin/sh
+            - -c
+            - |
+              echo test pre hook executed
+              # FIXME: The sleep here is needed so the Docker have time to acquire the
+              # logs from this hook. This is a bug and this sleep should be removed
+              # when the Docker bug is fixed.
+              sleep 1
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
This tweaks the fixture for e2e test where the hook pod is executing really fast and Docker daemon seems to not have enough time to gather the container logs. This is NOT fixing the issue with Docker, but unblocking the queue as this is flaking hard... We should still continue to investigate the issue in Docker.

@tnozicka @deads2k 