### PR TITLE
Additional cluster up version logging

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -668,9 +668,8 @@ func (h *Helper) ServerPrereleaseVersion() (semver.Version, error) {
 			break
 		}
 	}
-
 	if len(versionStr) == 0 {
-		return semver.Version{}, fmt.Errorf("did not find version in command output")
+		return semver.Version{}, fmt.Errorf("did not find version in command output: %s", versionText)
 	}
 	return parseOpenshiftVersion(versionStr)
 }


### PR DESCRIPTION
Output the the oc version command as part of the error string

In reference to: https://ci.openshift.redhat.com/jenkins/job/test_pull_request_origin_extended_clusterup/227/consoleFull#158781393258b6e51eb7608a5981914356