### PR TITLE
Re-pick Upstream 53916: update .dockercfg content to config.json

### DIFF
--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -27,6 +27,8 @@ os::cmd::expect_success_and_text 'oc secrets new-dockercfg dockercfg --docker-us
 os::cmd::expect_success_and_text 'oc secrets new from-file .dockercfg=${HOME}/dockerconfig -o yaml' 'kubernetes.io/dockercfg'
 # check to make sure malformed names fail as expected
 os::cmd::expect_failure_and_text 'oc secrets new bad-name .docker=cfg=${HOME}/dockerconfig' "error: Key names or file paths cannot contain '='."
+# ensure the docker-registry helper stores secret data in the "config.json" format under the .dockerfg field
+os::cmd::expect_success_and_text "oc create secret docker-registry dockercfg --docker-username=sample-user --docker-password=sample-password --docker-email=fake@example.org -o go-template='{{range \$key, \$value := .data}}{{ \$value }}{{end}}' --dry-run | base64 --decode" '"auths"\:'
 
 workingdir="$( mktemp -d )"
 os::cmd::try_until_success "oc get secret/dockercfg"

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry.go
@@ -141,7 +141,9 @@ func handleDockercfgContent(username, password, email, server string) ([]byte, e
 		Email:    email,
 	}
 
-	dockerCfg := map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth}
+	dockerCfg := credentialprovider.DockerConfigJson{
+		Auths: map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth},
+	}
 
 	return json.Marshal(dockerCfg)
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry_test.go
@@ -70,7 +70,7 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expected: &api.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-gb4kftc655",
+					Name: "foo-94759gc65b",
 				},
 				Data: map[string][]byte{
 					api.DockerConfigKey: secretData,


### PR DESCRIPTION
This change was introduced in https://github.com/openshift/origin/pull/16868 and lost during the 1.8.1 rebase: https://github.com/openshift/origin/pull/17115/commits/c4b40b3f401472203fcef1927f3c5ce40da07056

cc @bparees @openshift/cli-review 