### PR TITLE
Fix networking tests after 1.9 rebase

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -241,14 +241,8 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 		addRoleToE2EServiceAccounts(authorizationClient, []kapiv1.Namespace{*ns}, bootstrappolicy.ViewRoleName)
 	}
 
-	// some test suites assume they can schedule to all nodes
-	switch {
-	case isPackage("/kubernetes/test/e2e/scheduler_predicates.go"),
-		isPackage("/kubernetes/test/e2e/rescheduler.go"),
-		isPackage("/kubernetes/test/e2e/kubelet.go"),
-		isPackage("/kubernetes/test/e2e/common/networking.go"),
-		isPackage("/kubernetes/test/e2e/daemon_set.go"),
-		isPackage("/kubernetes/test/e2e/statefulset.go"):
+	// some tests assume they can schedule to all nodes
+	if testNameContains("Granular Checks: Pods") {
 		allowAllNodeScheduling(c, ns.Name)
 	}
 
@@ -257,10 +251,6 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 
 var (
 	excludedTests = []string{
-		// these broke in the rebase, but everything else is working
-		`should function for intra-pod communication`,
-		`should function for node-pod communication`,
-
 		`\[Skipped\]`,
 		`\[Slow\]`,
 		`\[Flaky\]`,


### PR DESCRIPTION
extended.test has some code to fix up certain tests that assume that all nodes are available to ordinary users, but that code was now failing for two different reasons:
- It was identifying tests based on filenames, but most of the files in question were later moved, so the filenames were no longer correct.
- Many of the tests are now declared using a `ConformanceIt()` wrapper aroung `ginkgo.It()`, which causes ginkgo's idea of what file the test is in to be wrong anyway (it thinks they're all in kubernetes/test/e2e/framework/framework.go now).

This fixes it by matching on test name rather than filename (and dropping all the apparently-unnecessary checks for other tests).

Fixes #17754 
