### PR TITLE
 re-enable networking tests 58f0681

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -257,10 +257,6 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 
 var (
 	excludedTests = []string{
-		// these broke in the rebase, but everything else is working
-		`should function for intra-pod communication`,
-		`should function for node-pod communication`,
-
 		`\[Skipped\]`,
 		`\[Slow\]`,
 		`\[Flaky\]`,


### PR DESCRIPTION
Fixes #17754

alternative to https://github.com/openshift/origin/pull/17759

Based on the information from @ironcladlou and the shape of the node selector in these tests, it may be breaking on our project creation rules.