### PR TITLE
switch migrate storage to unstructured builder

### DIFF
--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -63,6 +63,7 @@ type ResourceOptions struct {
 	In          io.Reader
 	Out, ErrOut io.Writer
 
+	Unstructured  bool
 	AllNamespaces bool
 	Include       []string
 	Filenames     []string
@@ -222,7 +223,6 @@ func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error
 	}
 
 	o.Builder = f.NewBuilder().
-		Internal().
 		AllNamespaces(allNamespaces).
 		FilenameParam(false, &resource.FilenameOptions{Recursive: false, Filenames: o.Filenames}).
 		ContinueOnError().
@@ -230,6 +230,13 @@ func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error
 		RequireObject(true).
 		SelectAllParam(true).
 		Flatten()
+
+	if o.Unstructured {
+		o.Builder = o.Builder.Unstructured()
+	} else {
+		o.Builder = o.Builder.Internal()
+	}
+
 	if !allNamespaces {
 		o.Builder.NamespaceParam(namespace)
 	}

--- a/pkg/oc/admin/migrate/storage/storage.go
+++ b/pkg/oc/admin/migrate/storage/storage.go
@@ -6,13 +6,10 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
-	apiextensioninstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	apiregistrationinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -68,7 +65,8 @@ func NewCmdMigrateAPIStorage(name, fullName string, f *clientcmd.Factory, in io.
 			Out:    out,
 			ErrOut: errout,
 
-			Include: []string{"*"},
+			Unstructured: true,
+			Include:      []string{"*"},
 			DefaultExcludes: []schema.GroupResource{
 				// openshift resources:
 				{Resource: "appliedclusterresourcequotas"},
@@ -164,9 +162,6 @@ func NewCmdMigrateAPIStorage(name, fullName string, f *clientcmd.Factory, in io.
 		Long:    internalMigrateStorageLong,
 		Example: fmt.Sprintf(internalMigrateStorageExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
-			apiextensioninstall.Install(legacyscheme.GroupFactoryRegistry, legacyscheme.Registry, legacyscheme.Scheme)
-			apiregistrationinstall.Install(legacyscheme.GroupFactoryRegistry, legacyscheme.Registry, legacyscheme.Scheme)
-
 			kcmdutil.CheckErr(options.Complete(f, cmd, args))
 			kcmdutil.CheckErr(options.Validate())
 			kcmdutil.CheckErr(options.Run())


### PR DESCRIPTION
Switch `oc adm migrate storage` to use unstructure builder to avoid having to keep up to date with schemes.