### PR TITLE
Additional registry whitelisting

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -68,7 +68,7 @@ fi
 # profile the web
 export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
 
-export ADDITIONAL_ALLOWED_REGISTRIES=( "172.30.30.30:5000" "myregistry.com" )
+export ADDITIONAL_ALLOWED_REGISTRIES=( "172.30.30.30:5000" "myregistry.com" "registry.centos.org" )
 
 os::start::configure_server
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -68,6 +68,8 @@ fi
 # profile the web
 export OPENSHIFT_PROFILE="${WEB_PROFILE-}"
 
+export ADDITIONAL_ALLOWED_REGISTRIES=( "172.30.30.30:5000" "myregistry.com" )
+
 os::start::configure_server
 
 os::test::junit::declare_suite_start "cmd/version"

--- a/pkg/image/admission/fake/fake.go
+++ b/pkg/image/admission/fake/fake.go
@@ -1,0 +1,17 @@
+package fake
+
+import (
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+)
+
+type ImageStreamLimitVerifier struct {
+	ImageStreamEvaluator func(ns string, is *imageapi.ImageStream) error
+	Err                  error
+}
+
+func (f *ImageStreamLimitVerifier) VerifyLimits(ns string, is *imageapi.ImageStream) error {
+	if f.ImageStreamEvaluator != nil {
+		return f.ImageStreamEvaluator(ns, is)
+	}
+	return f.Err
+}

--- a/pkg/image/admission/testutil/util.go
+++ b/pkg/image/admission/testutil/util.go
@@ -30,18 +30,6 @@ func MakeDockerImageReference(ns, isName, imageID string) string {
 	return fmt.Sprintf("%s/%s/%s@%s", InternalRegistryURL, ns, isName, imageID)
 }
 
-type FakeImageStreamLimitVerifier struct {
-	ImageStreamEvaluator func(ns string, is *imageapi.ImageStream) error
-	Err                  error
-}
-
-func (f *FakeImageStreamLimitVerifier) VerifyLimits(ns string, is *imageapi.ImageStream) error {
-	if f.ImageStreamEvaluator != nil {
-		return f.ImageStreamEvaluator(ns, is)
-	}
-	return f.Err
-}
-
 // GetFakeImageStreamListHandler creates a test handler that lists given image streams matching requested
 // namespace. Additionally, a shared image stream will be listed if the requested namespace is "shared".
 func GetFakeImageStreamListHandler(t *testing.T, iss ...imageapi.ImageStream) clientgotesting.ReactionFunc {

--- a/pkg/image/apis/image/test/conversion_test.go
+++ b/pkg/image/apis/image/test/conversion_test.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
+	"github.com/openshift/api/image/v1"
 	newer "github.com/openshift/origin/pkg/image/apis/image"
-	"github.com/openshift/origin/pkg/image/apis/image/v1"
 
 	_ "github.com/openshift/origin/pkg/image/apis/image/install"
 )

--- a/pkg/image/apis/image/validation/fake/fake.go
+++ b/pkg/image/apis/image/validation/fake/fake.go
@@ -1,0 +1,25 @@
+package fake
+
+import (
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
+)
+
+type RegistryWhitelister struct{}
+
+func (rw *RegistryWhitelister) AdmitHostname(host string, transport whitelist.WhitelistTransport) error {
+	return nil
+}
+func (rw *RegistryWhitelister) AdmitPullSpec(pullSpec string, transport whitelist.WhitelistTransport) error {
+	return nil
+}
+func (rw *RegistryWhitelister) AdmitDockerImageReference(ref *imageapi.DockerImageReference, transport whitelist.WhitelistTransport) error {
+	return nil
+}
+func (rw *RegistryWhitelister) WhitelistRegistry(hostPortGlob string, transport whitelist.WhitelistTransport) error {
+	return nil
+}
+func (rw *RegistryWhitelister) WhitelistPullSpecs(pullSpec ...string) {}
+func (rw *RegistryWhitelister) Copy() whitelist.RegistryWhitelister {
+	return &RegistryWhitelister{}
+}

--- a/pkg/image/apis/image/validation/validation.go
+++ b/pkg/image/apis/image/validation/validation.go
@@ -3,20 +3,24 @@ package validation
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
 	"github.com/docker/distribution/reference"
+	"github.com/golang/glog"
 
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/validation/path"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 
-	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
-	stringsutil "github.com/openshift/origin/pkg/util/strings"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 )
 
 // RepositoryNameComponentRegexp restricts registry path component names to
@@ -153,6 +157,15 @@ func ValidateImageSignatureUpdate(newImageSignature, oldImageSignature *imageapi
 
 // ValidateImageStream tests required fields for an ImageStream.
 func ValidateImageStream(stream *imageapi.ImageStream) field.ErrorList {
+	return ValidateImageStreamWithWhitelister(nil, stream)
+}
+
+// ValidateImageStreamWithWhitelister tests required fields for an ImageStream. Additionally, it validates
+// each new image reference against registry whitelist.
+func ValidateImageStreamWithWhitelister(
+	whitelister whitelist.RegistryWhitelister,
+	stream *imageapi.ImageStream,
+) field.ErrorList {
 	result := validation.ValidateObjectMeta(&stream.ObjectMeta, true, ValidateImageStreamName, field.NewPath("metadata"))
 
 	// Ensure we can generate a valid docker image repository from namespace/name
@@ -160,27 +173,55 @@ func ValidateImageStream(stream *imageapi.ImageStream) field.ErrorList {
 		result = append(result, field.Invalid(field.NewPath("metadata", "name"), stream.Name, fmt.Sprintf("'namespace/name' cannot be longer than %d characters", reference.NameTotalLengthMax)))
 	}
 
+	insecureRepository := isRepositoryInsecure(stream)
+
 	if len(stream.Spec.DockerImageRepository) != 0 {
 		dockerImageRepositoryPath := field.NewPath("spec", "dockerImageRepository")
-		if ref, err := imageapi.ParseDockerImageReference(stream.Spec.DockerImageRepository); err != nil {
+		isValid := true
+		ref, err := imageapi.ParseDockerImageReference(stream.Spec.DockerImageRepository)
+		if err != nil {
 			result = append(result, field.Invalid(dockerImageRepositoryPath, stream.Spec.DockerImageRepository, err.Error()))
+			isValid = false
 		} else {
 			if len(ref.Tag) > 0 {
 				result = append(result, field.Invalid(dockerImageRepositoryPath, stream.Spec.DockerImageRepository, "the repository name may not contain a tag"))
+				isValid = false
 			}
 			if len(ref.ID) > 0 {
 				result = append(result, field.Invalid(dockerImageRepositoryPath, stream.Spec.DockerImageRepository, "the repository name may not contain an ID"))
+				isValid = false
+			}
+		}
+		if isValid && whitelister != nil {
+			if err := whitelister.AdmitDockerImageReference(&ref, whitelist.GetWhitelistTransportForFlag(insecureRepository, true)); err != nil {
+				result = append(result, field.Forbidden(dockerImageRepositoryPath, err.Error()))
 			}
 		}
 	}
 	for tag, tagRef := range stream.Spec.Tags {
 		path := field.NewPath("spec", "tags").Key(tag)
-		result = append(result, ValidateImageStreamTagReference(tagRef, path)...)
+		result = append(result, ValidateImageStreamTagReference(whitelister, insecureRepository, tagRef, path)...)
 	}
 	for tag, history := range stream.Status.Tags {
 		for i, tagEvent := range history.Items {
 			if len(tagEvent.DockerImageReference) == 0 {
 				result = append(result, field.Required(field.NewPath("status", "tags").Key(tag).Child("items").Index(i).Child("dockerImageReference"), ""))
+				continue
+			}
+			ref, err := imageapi.ParseDockerImageReference(tagEvent.DockerImageReference)
+			if err != nil {
+				result = append(result, field.Invalid(field.NewPath("status", "tags").Key(tag).Child("items").Index(i).Child("dockerImageReference"), tagEvent.DockerImageReference, err.Error()))
+				continue
+			}
+			if whitelister != nil {
+				insecure := false
+				if tr, ok := stream.Spec.Tags[tag]; ok {
+					insecure = tr.ImportPolicy.Insecure
+				}
+				transport := whitelist.GetWhitelistTransportForFlag(insecure || insecureRepository, true)
+				if err := whitelister.AdmitDockerImageReference(&ref, transport); err != nil {
+					result = append(result, field.Forbidden(field.NewPath("status", "tags").Key(tag).Child("items").Index(i).Child("dockerImageReference"), err.Error()))
+				}
 			}
 		}
 	}
@@ -189,8 +230,14 @@ func ValidateImageStream(stream *imageapi.ImageStream) field.ErrorList {
 }
 
 // ValidateImageStreamTagReference ensures that a given tag reference is valid.
-func ValidateImageStreamTagReference(tagRef imageapi.TagReference, fldPath *field.Path) field.ErrorList {
-	var errs field.ErrorList
+func ValidateImageStreamTagReference(
+	whitelister whitelist.RegistryWhitelister,
+	insecureRepository bool,
+	tagRef imageapi.TagReference,
+	fldPath *field.Path,
+) field.ErrorList {
+	var errs = field.ErrorList{}
+
 	if tagRef.From != nil {
 		if len(tagRef.From.Name) == 0 {
 			errs = append(errs, field.Required(fldPath.Child("from", "name"), ""))
@@ -201,6 +248,11 @@ func ValidateImageStreamTagReference(tagRef imageapi.TagReference, fldPath *fiel
 				errs = append(errs, field.Invalid(fldPath.Child("from", "name"), tagRef.From.Name, err.Error()))
 			} else if len(ref.ID) > 0 && tagRef.ImportPolicy.Scheduled {
 				errs = append(errs, field.Invalid(fldPath.Child("from", "name"), tagRef.From.Name, "only tags can be scheduled for import"))
+			} else if whitelister != nil {
+				transport := whitelist.GetWhitelistTransportForFlag(tagRef.ImportPolicy.Insecure || insecureRepository, true)
+				if err := whitelister.AdmitDockerImageReference(&ref, transport); err != nil {
+					errs = append(errs, field.Forbidden(fldPath.Child("from", "name"), err.Error()))
+				}
 			}
 		case "ImageStreamImage", "ImageStreamTag":
 			if tagRef.ImportPolicy.Scheduled {
@@ -215,20 +267,133 @@ func ValidateImageStreamTagReference(tagRef imageapi.TagReference, fldPath *fiel
 	default:
 		errs = append(errs, field.Invalid(fldPath.Child("referencePolicy", "type"), tagRef.ReferencePolicy.Type, fmt.Sprintf("valid values are %q, %q", imageapi.SourceTagReferencePolicy, imageapi.LocalTagReferencePolicy)))
 	}
+
 	return errs
 }
 
+// ValidateImageStreamUpdate tests required fields for an ImageStream update.
 func ValidateImageStreamUpdate(newStream, oldStream *imageapi.ImageStream) field.ErrorList {
+	return ValidateImageStreamUpdateWithWhitelister(nil, newStream, oldStream)
+}
+
+// ValidateImageStreamUpdateWithWhitelister tests required fields for an ImageStream update. Additionally, it
+// validates each new image reference against registry whitelist.
+func ValidateImageStreamUpdateWithWhitelister(
+	whitelister whitelist.RegistryWhitelister,
+	newStream, oldStream *imageapi.ImageStream,
+) field.ErrorList {
 	result := validation.ValidateObjectMetaUpdate(&newStream.ObjectMeta, &oldStream.ObjectMeta, field.NewPath("metadata"))
-	result = append(result, ValidateImageStream(newStream)...)
+
+	if whitelister != nil {
+		// whitelist old pull specs no longer present on the whitelist
+		whitelister = whitelister.Copy()
+		whitelister.WhitelistPullSpecs(collectImageStreamSpecImageReferences(oldStream).List()...)
+		for ref := range collectImageStreamStatusImageReferences(oldStream) {
+			whitelister.WhitelistPullSpecs(ref)
+		}
+	}
+
+	result = append(result, ValidateImageStreamWithWhitelister(whitelister, newStream)...)
 
 	return result
 }
 
 // ValidateImageStreamStatusUpdate tests required fields for an ImageStream status update.
 func ValidateImageStreamStatusUpdate(newStream, oldStream *imageapi.ImageStream) field.ErrorList {
-	result := validation.ValidateObjectMetaUpdate(&newStream.ObjectMeta, &oldStream.ObjectMeta, field.NewPath("metadata"))
-	return result
+	return ValidateImageStreamStatusUpdateWithWhitelister(nil, newStream, oldStream)
+}
+
+// ValidateImageStreamStatusUpdateWithWhitelister tests required fields for an ImageStream status update.
+// Additionally, it validates each new image reference against registry whitelist.
+func ValidateImageStreamStatusUpdateWithWhitelister(
+	whitelister whitelist.RegistryWhitelister,
+	newStream, oldStream *imageapi.ImageStream,
+) field.ErrorList {
+	errs := validation.ValidateObjectMetaUpdate(&newStream.ObjectMeta, &oldStream.ObjectMeta, field.NewPath("metadata"))
+	insecureRepository := isRepositoryInsecure(newStream)
+
+	oldRefs := collectImageStreamStatusImageReferences(oldStream)
+	newRefs := collectImageStreamStatusImageReferences(newStream)
+
+	for refString, rfs := range newRefs {
+		// allow to manipulate not whitelisted references if already present in the image stream
+		if _, ok := oldRefs[refString]; ok {
+			continue
+		}
+		ref, err := imageapi.ParseDockerImageReference(refString)
+		if err != nil {
+			for _, rf := range rfs {
+				errs = append(errs, field.Invalid(rf.path, refString, err.Error()))
+			}
+			continue
+		}
+
+		if whitelister == nil {
+			continue
+		}
+
+		insecure := insecureRepository
+		if !insecure {
+			for _, rf := range rfs {
+				if rf.insecure {
+					insecure = true
+					break
+				}
+			}
+		}
+		transport := whitelist.GetWhitelistTransportForFlag(insecure, true)
+		if err := whitelister.AdmitDockerImageReference(&ref, transport); err != nil {
+			// TODO: should we whitelist references imported based on whitelisted/old spec?
+			// report error for each tag/history item having this reference
+			for _, rf := range rfs {
+				errs = append(errs, field.Forbidden(rf.path, err.Error()))
+			}
+		}
+	}
+
+	return errs
+}
+
+type referencePath struct {
+	path     *field.Path
+	insecure bool
+}
+
+func collectImageStreamSpecImageReferences(s *imageapi.ImageStream) sets.String {
+	res := sets.NewString()
+
+	if len(s.Spec.DockerImageRepository) > 0 {
+		res.Insert(s.Spec.DockerImageRepository)
+	}
+	for _, tagRef := range s.Spec.Tags {
+		if tagRef.From != nil && tagRef.From.Kind == "DockerImage" {
+			res.Insert(tagRef.From.Name)
+		}
+	}
+	return res
+}
+
+func collectImageStreamStatusImageReferences(s *imageapi.ImageStream) map[string][]referencePath {
+	var (
+		res      = make(map[string][]referencePath)
+		insecure = isRepositoryInsecure(s)
+	)
+
+	for tag, eventList := range s.Status.Tags {
+		tagInsecure := false
+		if tr, ok := s.Spec.Tags[tag]; ok {
+			tagInsecure = tr.ImportPolicy.Insecure
+		}
+		for i, item := range eventList.Items {
+			rfs := res[item.DockerImageReference]
+			rfs = append(rfs, referencePath{
+				path:     field.NewPath("status", "tags").Key(tag).Child("items").Index(i).Child("dockerImageReference"),
+				insecure: insecure || tagInsecure,
+			})
+			res[item.DockerImageReference] = rfs
+		}
+	}
+	return res
 }
 
 // ValidateImageStreamMapping tests required fields for an ImageStreamMapping.
@@ -260,11 +425,23 @@ func ValidateImageStreamMapping(mapping *imageapi.ImageStreamMapping) field.Erro
 	return result
 }
 
-// ValidateImageStreamTag validates a mutation of an image stream tag, which can happen on PUT
+// ValidateImageStreamTag validates a mutation of an image stream tag, which can happen on PUT.
 func ValidateImageStreamTag(ist *imageapi.ImageStreamTag) field.ErrorList {
+	return ValidateImageStreamTagWithWhitelister(nil, ist)
+}
+
+// ValidateImageStreamTag validates a mutation of an image stream tag, which can happen on PUT. Additionally,
+// it validates each new image reference against registry whitelist.
+func ValidateImageStreamTagWithWhitelister(
+	whitelister whitelist.RegistryWhitelister,
+	ist *imageapi.ImageStreamTag,
+) field.ErrorList {
 	result := validation.ValidateObjectMeta(&ist.ObjectMeta, true, path.ValidatePathSegmentName, field.NewPath("metadata"))
+
 	if ist.Tag != nil {
-		result = append(result, ValidateImageStreamTagReference(*ist.Tag, field.NewPath("tag"))...)
+		// TODO: verify that istag inherits imagestream's annotations
+		insecureRepository := isRepositoryInsecure(ist)
+		result = append(result, ValidateImageStreamTagReference(whitelister, insecureRepository, *ist.Tag, field.NewPath("tag"))...)
 		if ist.Tag.Annotations != nil && !kapihelper.Semantic.DeepEqual(ist.Tag.Annotations, ist.ObjectMeta.Annotations) {
 			result = append(result, field.Invalid(field.NewPath("tag", "annotations"), "<map>", "tag annotations must not be provided or must be equal to the object meta annotations"))
 		}
@@ -273,12 +450,26 @@ func ValidateImageStreamTag(ist *imageapi.ImageStreamTag) field.ErrorList {
 	return result
 }
 
-// ValidateImageStreamTagUpdate ensures that only the annotations of the IST have changed
+// ValidateImageStreamTagUpdate ensures that only the annotations or the image reference of the IST have changed.
 func ValidateImageStreamTagUpdate(newIST, oldIST *imageapi.ImageStreamTag) field.ErrorList {
+	return ValidateImageStreamTagUpdateWithWhitelister(nil, newIST, oldIST)
+}
+
+// ValidateImageStreamTagUpdate ensures that only the annotations or the image reference of the IST have
+// changed. Additionally, it validates image reference against registry whitelist if it changed.
+func ValidateImageStreamTagUpdateWithWhitelister(
+	whitelister whitelist.RegistryWhitelister,
+	newIST, oldIST *imageapi.ImageStreamTag,
+) field.ErrorList {
 	result := validation.ValidateObjectMetaUpdate(&newIST.ObjectMeta, &oldIST.ObjectMeta, field.NewPath("metadata"))
 
+	if whitelister != nil && oldIST.Tag != nil && oldIST.Tag.From != nil && oldIST.Tag.From.Kind == "DockerImage" {
+		whitelister = whitelister.Copy()
+		whitelister.WhitelistPullSpecs(oldIST.Tag.From.Name)
+	}
+
 	if newIST.Tag != nil {
-		result = append(result, ValidateImageStreamTagReference(*newIST.Tag, field.NewPath("tag"))...)
+		result = append(result, ValidateImageStreamTagReference(whitelister, isRepositoryInsecure(newIST), *newIST.Tag, field.NewPath("tag"))...)
 		if newIST.Tag.Annotations != nil && !kapihelper.Semantic.DeepEqual(newIST.Tag.Annotations, newIST.ObjectMeta.Annotations) {
 			result = append(result, field.Invalid(field.NewPath("tag", "annotations"), "<map>", "tag annotations must not be provided or must be equal to the object meta annotations"))
 		}
@@ -292,42 +483,19 @@ func ValidateImageStreamTagUpdate(newIST, oldIST *imageapi.ImageStreamTag) field
 	newISTCopy.LookupPolicy = oldISTCopy.LookupPolicy
 	newISTCopy.Generation = oldISTCopy.Generation
 	if !kapihelper.Semantic.Equalities.DeepEqual(&newISTCopy, &oldISTCopy) {
-		//glog.Infof("objects differ: ", diff.ObjectDiff(oldISTCopy, newISTCopy))
 		result = append(result, field.Invalid(field.NewPath("metadata"), "", "may not update fields other than metadata.annotations"))
 	}
 
 	return result
 }
 
-func ValidateRegistryAllowedForImport(path *field.Path, name, registryHost, registryPort string, allowedRegistries *serverapi.AllowedRegistries) field.ErrorList {
-	errs := field.ErrorList{}
-	if allowedRegistries == nil {
-		return errs
+func ValidateRegistryAllowedForImport(whitelister whitelist.RegistryWhitelister, path *field.Path, name, registryHost, registryPort string) field.ErrorList {
+	hostname := net.JoinHostPort(registryHost, registryPort)
+	err := whitelister.AdmitHostname(hostname, whitelist.WhitelistTransportSecure)
+	if err != nil {
+		return field.ErrorList{field.Forbidden(path, fmt.Sprintf("importing images from registry %q is forbidden: %v", hostname, err))}
 	}
-	allowedRegistriesForHumans := []string{}
-	for _, registry := range *allowedRegistries {
-		allowedRegistryHost, allowedRegistryPort := "", ""
-		parts := strings.Split(registry.DomainName, ":")
-		switch len(parts) {
-		case 1:
-			allowedRegistryHost = parts[0]
-			if registry.Insecure {
-				allowedRegistryPort = "80"
-			} else {
-				allowedRegistryPort = "443"
-			}
-		case 2:
-			allowedRegistryHost, allowedRegistryPort = parts[0], parts[1]
-		default:
-			continue
-		}
-		if stringsutil.IsWildcardMatch(registryHost, allowedRegistryHost) && stringsutil.IsWildcardMatch(registryPort, allowedRegistryPort) {
-			return errs
-		}
-		allowedRegistriesForHumans = append(allowedRegistriesForHumans, registry.DomainName)
-	}
-	return append(errs, field.Invalid(path, name,
-		fmt.Sprintf("importing images from registry %q is forbidden, only images from %q are allowed", registryHost+":"+registryPort, strings.Join(allowedRegistriesForHumans, ","))))
+	return nil
 }
 
 func ValidateImageStreamImport(isi *imageapi.ImageStreamImport) field.ErrorList {
@@ -391,4 +559,13 @@ func ValidateImageStreamImport(isi *imageapi.ImageStreamImport) field.ErrorList 
 
 	errs = append(errs, validation.ValidateObjectMeta(&isi.ObjectMeta, true, ValidateImageStreamName, field.NewPath("metadata"))...)
 	return errs
+}
+
+func isRepositoryInsecure(obj runtime.Object) bool {
+	accessor, err := kmeta.Accessor(obj)
+	if err != nil {
+		glog.V(4).Infof("Error getting accessor for %#v", obj)
+		return false
+	}
+	return accessor.GetAnnotations()[imageapi.InsecureRepositoryAnnotation] == "true"
 }

--- a/pkg/image/apis/image/validation/validation_test.go
+++ b/pkg/image/apis/image/validation/validation_test.go
@@ -630,7 +630,7 @@ func TestValidateImageStreamWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "tags").Key("fail").Child("from", "name"),
-					`registry "registry.ltd" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "registry.ltd" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 			},
 		},
 
@@ -673,11 +673,11 @@ func TestValidateImageStreamWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("status", "tags").Key("secure").Child("items").Index(0).Child("dockerImageReference"),
-					`registry "docker.io" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "docker.io" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 				field.Forbidden(field.NewPath("status", "tags").Key("secure").Child("items").Index(2).Child("dockerImageReference"),
-					`registry "example.com:80" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "example.com:80" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 				field.Forbidden(field.NewPath("status", "tags").Key("secure").Child("items").Index(3).Child("dockerImageReference"),
-					`registry "dev.null.io" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "dev.null.io" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 			},
 		},
 
@@ -720,9 +720,9 @@ func TestValidateImageStreamWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("status", "tags").Key("insecure").Child("items").Index(1).Child("dockerImageReference"),
-					`registry "example.com:80" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "example.com:80" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 				field.Forbidden(field.NewPath("status", "tags").Key("insecure").Child("items").Index(2).Child("dockerImageReference"),
-					`registry "registry.ltd" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "registry.ltd" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 			},
 		},
 
@@ -763,7 +763,7 @@ func TestValidateImageStreamWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("status", "tags").Key("securebydefault").Child("items").Index(0).Child("dockerImageReference"),
-					`registry "localhost" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "localhost" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 			},
 		},
 
@@ -804,7 +804,7 @@ func TestValidateImageStreamWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("status", "tags").Key("securebydefault").Child("items").Index(0).Child("dockerImageReference"),
-					`registry "localhost" not allowed by whitelist { "example.com:443", "localhost:5000", "dev.null.io:80" }`),
+					`registry "localhost" not allowed by whitelist: "example.com:443", "localhost:5000", "dev.null.io:80"`),
 			},
 		},
 
@@ -823,7 +823,7 @@ func TestValidateImageStreamWithWhitelister(t *testing.T) {
 			dockerImageRepository: "example.com/openshift/origin",
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "dockerImageRepository"),
-					`registry "example.com" not allowed by whitelist { "*.example.com:443" }`),
+					`registry "example.com" not allowed by whitelist: "*.example.com:443"`),
 			},
 		},
 	} {
@@ -916,9 +916,9 @@ func TestValidateImageStreamUpdateWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "tags").Key("fail").Child("from", "name"),
-					`registry "example.com" not allowed by whitelist { "docker.io:443" }`),
+					`registry "example.com" not allowed by whitelist: "docker.io:443"`),
 				field.Forbidden(field.NewPath("status", "tags").Key("fail").Child("items").Index(0).Child("dockerImageReference"),
-					`registry "example.com" not allowed by whitelist { "docker.io:443" }`),
+					`registry "example.com" not allowed by whitelist: "docker.io:443"`),
 			},
 		},
 
@@ -994,7 +994,7 @@ func TestValidateImageStreamUpdateWithWhitelister(t *testing.T) {
 			newDockerImageRepository: "example.com/my/newapp",
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "dockerImageRepository"),
-					`registry "example.com" not allowed by whitelist { "docker.io:443" }`)},
+					`registry "example.com" not allowed by whitelist: "docker.io:443"`)},
 		},
 
 		{
@@ -1148,7 +1148,7 @@ func TestValidateISTUpdateWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("tag", "from", "name"),
-					`registry "docker.io:443" not allowed by whitelist { "example.com:*" }`),
+					`registry "docker.io:443" not allowed by whitelist: "example.com:*"`),
 			},
 		},
 
@@ -1178,7 +1178,7 @@ func TestValidateISTUpdateWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("tag", "from", "name"),
-					`registry "docker.io:443" not allowed by whitelist { "example.com:*" }`),
+					`registry "docker.io:443" not allowed by whitelist: "example.com:*"`),
 			},
 		},
 
@@ -1191,7 +1191,7 @@ func TestValidateISTUpdateWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("tag", "from", "name"),
-					`registry "example.com" not allowed by whitelist { "example.com:80" }`),
+					`registry "example.com" not allowed by whitelist: "example.com:80"`),
 			},
 		},
 
@@ -1233,7 +1233,7 @@ func TestValidateISTUpdateWithWhitelister(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("tag", "from", "name"),
-					`registry "docker.io" not allowed by whitelist { "example.com:443" }`),
+					`registry "docker.io" not allowed by whitelist: "example.com:443"`),
 			},
 		},
 	} {
@@ -1288,7 +1288,7 @@ func TestValidateRegistryAllowedForImport(t *testing.T) {
 			hostname:  "example.com:443",
 			whitelist: *mkAllowed(false, "foo.bar"),
 			expected: field.ErrorList{field.Forbidden(nil,
-				`importing images from registry "example.com:443" is forbidden: registry "example.com:443" not allowed by whitelist { "foo.bar:443" }`)},
+				`importing images from registry "example.com:443" is forbidden: registry "example.com:443" not allowed by whitelist: "foo.bar:443"`)},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/image/apis/image/validation/whitelist/whitelister.go
+++ b/pkg/image/apis/image/validation/whitelist/whitelister.go
@@ -1,0 +1,268 @@
+package whitelist
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+
+	"github.com/golang/glog"
+
+	kerrutil "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	stringsutil "github.com/openshift/origin/pkg/util/strings"
+)
+
+// WhitelistTransport says whether the associated registry host shall be treated as secure or insecure.
+type WhitelistTransport string
+
+const (
+	WhitelistTransportAny      WhitelistTransport = "any"
+	WhitelistTransportSecure   WhitelistTransport = "secure"
+	WhitelistTransportInsecure WhitelistTransport = "insecure"
+)
+
+// RegistryWhitelister decides whether given image pull specs are allowed by system's image policy.
+type RegistryWhitelister interface {
+	// AdmitHostname returns error if the given host is not allowed by the whitelist.
+	AdmitHostname(host string, transport WhitelistTransport) error
+	// AdmitPullSpec returns error if the given pull spec is allowed neither by the whitelist nor by the
+	// collected whitelisted pull specs.
+	AdmitPullSpec(pullSpec string, transport WhitelistTransport) error
+	// AdmitDockerImageReference returns error if the given reference is allowed neither by the whitelist nor
+	// by the collected whitelisted pull specs.
+	AdmitDockerImageReference(ref *imageapi.DockerImageReference, transport WhitelistTransport) error
+	// WhitelistRegistry extends internal whitelist for additional registry domain name. Accepted values are:
+	//  <host>, <host>:<port>
+	// where each component can contain wildcards like '*' or '??' to match wide range of registries. If the
+	// port is omitted, the default will be appended based on the given transport. If the transport is "any",
+	// the given glob will match hosts with both :80 and :443 ports.
+	WhitelistRegistry(hostPortGlob string, transport WhitelistTransport) error
+	// WhitelistPullSpecs allows to whitelist particular pull specs. References must match exactly one of the
+	// given pull specs for it to be whitelisted.
+	// TODO: accept insecure flag
+	WhitelistPullSpecs(pullSpecs ...string)
+	// Copy returns a deep copy of the whitelister. This is useful for temporarily whitelisting additional
+	// registries/pullSpecs before a specific validation.
+	Copy() RegistryWhitelister
+}
+
+type allowedHostPortGlobs struct {
+	host string
+	port string
+}
+
+type registryWhitelister struct {
+	whitelist             []allowedHostPortGlobs
+	pullSpecs             sets.String
+	registryHostRetriever imageapi.RegistryHostnameRetriever
+}
+
+var _ RegistryWhitelister = &registryWhitelister{}
+
+// NewRegistryWhitelister creates a whitelister that admits registry domains and pull specs based on the given
+// list of allowed registries and the current domain name of the integrated Docker registry.
+func NewRegistryWhitelister(
+	whitelist serverapi.AllowedRegistries,
+	registryHostRetriever imageapi.RegistryHostnameRetriever,
+) (RegistryWhitelister, error) {
+	errs := []error{}
+	rw := registryWhitelister{
+		whitelist:             make([]allowedHostPortGlobs, 0, len(whitelist)),
+		pullSpecs:             sets.NewString(),
+		registryHostRetriever: registryHostRetriever,
+	}
+	// iterate in reversed order to make the patterns appear in the same order as given (patterns are prepended)
+	for i := len(whitelist) - 1; i >= 0; i-- {
+		registry := whitelist[i]
+		err := rw.WhitelistRegistry(registry.DomainName, GetWhitelistTransportForFlag(registry.Insecure, false))
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, kerrutil.NewAggregate(errs)
+	}
+	return &rw, nil
+}
+
+// WhitelistAllRegistries returns a whitelister that will allow any given registry host name.
+// TODO: make a new implementation of RegistryWhitelister instead that will not bother with pull specs
+func WhitelistAllRegistries() RegistryWhitelister {
+	return &registryWhitelister{
+		whitelist: []allowedHostPortGlobs{{host: "*", port: "*"}},
+		pullSpecs: sets.NewString(),
+	}
+}
+
+func (rw *registryWhitelister) AdmitHostname(hostname string, transport WhitelistTransport) error {
+	return rw.AdmitDockerImageReference(&imageapi.DockerImageReference{Registry: hostname}, transport)
+}
+
+func (rw *registryWhitelister) AdmitPullSpec(pullSpec string, transport WhitelistTransport) error {
+	ref, err := imageapi.ParseDockerImageReference(pullSpec)
+	if err != nil {
+		return err
+	}
+	return rw.AdmitDockerImageReference(&ref, transport)
+}
+
+func (rw *registryWhitelister) AdmitDockerImageReference(ref *imageapi.DockerImageReference, transport WhitelistTransport) error {
+	const showMax = 5
+	const fullWhitelistLogLevel = 5
+
+	if rw.pullSpecs.Len() > 0 {
+		if rw.pullSpecs.Has(ref.Exact()) || rw.pullSpecs.Has(ref.DockerClientDefaults().Exact()) || rw.pullSpecs.Has(ref.DaemonMinimal().Exact()) {
+			return nil
+		}
+	}
+
+	if rw.registryHostRetriever != nil {
+		if localRegistry, ok := rw.registryHostRetriever.InternalRegistryHostname(); ok {
+			rw.WhitelistRegistry(localRegistry, WhitelistTransportSecure)
+		}
+	}
+
+	var (
+		host, port string
+		err        error
+	)
+	switch transport {
+	case WhitelistTransportAny:
+		host, port, err = net.SplitHostPort(ref.Registry)
+		if err != nil || len(port) == 0 {
+			host = ref.Registry
+			port = ""
+		}
+		if len(host) == 0 {
+			host, _ = ref.RegistryHostPort(false)
+		}
+	case WhitelistTransportInsecure:
+		host, port = ref.RegistryHostPort(true)
+	default:
+		host, port = ref.RegistryHostPort(false)
+	}
+
+	matchHost := func(h string) bool {
+		for _, hp := range rw.whitelist {
+			if stringsutil.IsWildcardMatch(h, hp.host) {
+				if len(port) == 0 {
+					switch hp.port {
+					case "80", "443", "*":
+						return true
+					default:
+						continue
+					}
+				}
+				if stringsutil.IsWildcardMatch(port, hp.port) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	switch host {
+	case imageapi.DockerDefaultV1Registry, imageapi.DockerDefaultV2Registry:
+		// try to match plain docker.io first to satisfy `docker.io:*` wildcard
+		if matchHost(imageapi.DockerDefaultRegistry) {
+			return nil
+		}
+		fallthrough
+	default:
+		if matchHost(host) {
+			return nil
+		}
+	}
+
+	hostname := ref.Registry
+	if len(ref.Registry) == 0 {
+		if len(port) > 0 {
+			hostname = net.JoinHostPort(host, port)
+		} else {
+			hostname = host
+		}
+	}
+	whitelist := []string{}
+	full := []string{}
+	for i := 0; i < len(rw.whitelist); i++ {
+		if i < showMax-1 || len(rw.whitelist)-showMax == 0 {
+			whitelist = append(whitelist, fmt.Sprintf("%q", net.JoinHostPort(rw.whitelist[i].host, rw.whitelist[i].port)))
+		} else if i < showMax {
+			whitelist = append(whitelist, fmt.Sprintf("and %d more ...", len(rw.whitelist)-showMax+1))
+		} else if !glog.V(fullWhitelistLogLevel) {
+			break
+		}
+		full = append(full, fmt.Sprintf("%q", net.JoinHostPort(rw.whitelist[i].host, rw.whitelist[i].port)))
+	}
+	glog.V(fullWhitelistLogLevel).Infof("registry %q not allowed by whitelist { %s }", hostname, strings.Join(full, ", "))
+	return fmt.Errorf("registry %q not allowed by whitelist { %s }", hostname, strings.Join(whitelist, ", "))
+}
+
+func (rw *registryWhitelister) WhitelistRegistry(hostPortGlob string, transport WhitelistTransport) error {
+	hps := make([]allowedHostPortGlobs, 1, 2)
+
+	parts := strings.SplitN(hostPortGlob, ":", 3)
+	switch len(parts) {
+	case 1:
+		hps[0].host = parts[0]
+		switch transport {
+		case WhitelistTransportAny:
+			hps[0].port = "80"
+			// add two entries matching both secure and insecure ports
+			hps = append(hps, allowedHostPortGlobs{host: parts[0], port: "443"})
+		case WhitelistTransportInsecure:
+			hps[0].port = "80"
+		default:
+			hps[0].port = "443"
+		}
+	case 2:
+		hps[0].host, hps[0].port = parts[0], parts[1]
+	default:
+		return fmt.Errorf("failed to parse allowed registry %q: too many colons", hostPortGlob)
+	}
+
+addHPsLoop:
+	for i := range hps {
+		for _, item := range rw.whitelist {
+			if reflect.DeepEqual(item, hps[i]) {
+				continue addHPsLoop
+			}
+		}
+		rw.whitelist = append([]allowedHostPortGlobs{hps[i]}, rw.whitelist...)
+	}
+
+	return nil
+}
+
+func (rw *registryWhitelister) WhitelistPullSpecs(pullSpecs ...string) {
+	rw.pullSpecs.Insert(pullSpecs...)
+}
+
+func (rw *registryWhitelister) Copy() RegistryWhitelister {
+	newRW := registryWhitelister{
+		whitelist:             make([]allowedHostPortGlobs, len(rw.whitelist)),
+		pullSpecs:             sets.NewString(rw.pullSpecs.List()...),
+		registryHostRetriever: rw.registryHostRetriever,
+	}
+
+	for i, item := range rw.whitelist {
+		newRW.whitelist[i] = item
+	}
+	return &newRW
+}
+
+// GetWhitelistTransportForFlag returns transport for the given insecure flag.
+func GetWhitelistTransportForFlag(insecure, allowSecureFallback bool) WhitelistTransport {
+	if insecure {
+		if allowSecureFallback {
+			return WhitelistTransportAny
+		}
+		return WhitelistTransportInsecure
+	}
+	return WhitelistTransportSecure
+}

--- a/pkg/image/apis/image/validation/whitelist/whitelister_test.go
+++ b/pkg/image/apis/image/validation/whitelist/whitelister_test.go
@@ -1,0 +1,364 @@
+package whitelist
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+)
+
+func mkAllowed(insecure bool, regs ...string) serverapi.AllowedRegistries {
+	ret := make(serverapi.AllowedRegistries, 0, len(regs))
+	for _, reg := range regs {
+		ret = append(ret, serverapi.RegistryLocation{DomainName: reg, Insecure: insecure})
+	}
+	return ret
+}
+
+func TestRegistryWhitelister(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		transport WhitelistTransport
+		whitelist serverapi.AllowedRegistries
+		hostnames map[string]error
+		difs      map[imageapi.DockerImageReference]error
+		pullSpecs map[string]error
+	}{
+		{
+			name:      "empty whitelist",
+			transport: WhitelistTransportSecure,
+			whitelist: mkAllowed(true),
+			hostnames: map[string]error{
+				"example.com":    fmt.Errorf(`registry "example.com" not allowed by whitelist {  }`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist {  }`),
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: fmt.Errorf(`registry "docker.io" not allowed by whitelist {  }`),
+				{Name: "busybox"}:                                              fmt.Errorf(`registry "docker.io:443" not allowed by whitelist {  }`),
+			},
+		},
+
+		{
+			name:      "allow any host with secure transport",
+			transport: WhitelistTransportSecure,
+			whitelist: mkAllowed(false, "*"),
+			hostnames: map[string]error{
+				"docker.io":      nil,
+				"example.com":    nil,
+				"localhost:443":  nil,
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist { "*:443" }`),
+				"localhost:80":   fmt.Errorf(`registry "localhost:80" not allowed by whitelist { "*:443" }`),
+				"localhost":      nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+			},
+		},
+
+		{
+			name:      "allow any host with insecure transport",
+			transport: WhitelistTransportInsecure,
+			whitelist: mkAllowed(true, "*"),
+			hostnames: map[string]error{
+				"docker.io":      nil,
+				"example.com":    nil,
+				"localhost:443":  fmt.Errorf(`registry "localhost:443" not allowed by whitelist { "*:80" }`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist { "*:80" }`),
+				"localhost:80":   nil,
+				"localhost":      nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+			},
+		},
+
+		{
+			name:      "allow any host with any transport",
+			transport: WhitelistTransportAny,
+			whitelist: mkAllowed(true, "*"),
+			hostnames: map[string]error{
+				"docker.io":      nil,
+				"example.com":    nil,
+				"localhost:443":  fmt.Errorf(`registry "localhost:443" not allowed by whitelist { "*:80" }`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist { "*:80" }`),
+				"localhost:80":   nil,
+				"localhost":      nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+			},
+		},
+
+		{
+			name:      "allow any host:port with secure transport",
+			transport: WhitelistTransportSecure,
+			whitelist: mkAllowed(false, "*:*"),
+			hostnames: map[string]error{
+				"docker.io":      nil,
+				"example.com":    nil,
+				"localhost:443":  nil,
+				"localhost:5000": nil,
+				"localhost:80":   nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+				{Registry: "example.com", Namespace: "a", Name: "b"}:           nil,
+				{Registry: "localhost:80", Namespace: "ns", Name: "repo"}:      nil,
+				{Registry: "localhost:443", Namespace: "ns", Name: "repo"}:     nil,
+				{Registry: "docker.io", Name: "busybox"}:                       nil,
+				{Registry: "localhost:5000", Namespace: "my", Name: "app"}:     nil,
+			},
+		},
+
+		{
+			name:      "allow any host:port with insecure transport",
+			transport: WhitelistTransportInsecure,
+			whitelist: mkAllowed(true, "*:*"),
+			hostnames: map[string]error{
+				"localhost:5000": nil,
+				"docker.io":      nil,
+				"localhost:443":  nil,
+				"localhost:80":   nil,
+				"example.com":    nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+				{Registry: "example.com", Namespace: "a", Name: "b"}:           nil,
+				{Registry: "localhost:80", Namespace: "ns", Name: "repo"}:      nil,
+				{Registry: "localhost:443", Namespace: "ns", Name: "repo"}:     nil,
+				{Registry: "docker.io", Name: "busybox"}:                       nil,
+				{Registry: "localhost:5000", Namespace: "my", Name: "app"}:     nil,
+			},
+		},
+
+		{
+			name:      "allow any host:port with any transport",
+			transport: WhitelistTransportAny,
+			whitelist: mkAllowed(true, "*:*"),
+			hostnames: map[string]error{
+				"localhost:5000": nil,
+				"docker.io":      nil,
+				"localhost:443":  nil,
+				"localhost:80":   nil,
+				"example.com":    nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+				{Registry: "example.com", Namespace: "a", Name: "b"}:           nil,
+				{Registry: "localhost:80", Namespace: "ns", Name: "repo"}:      nil,
+				{Registry: "localhost:443", Namespace: "ns", Name: "repo"}:     nil,
+				{Registry: "docker.io", Name: "busybox"}:                       nil,
+				{Registry: "localhost:5000", Namespace: "my", Name: "app"}:     nil,
+			},
+		},
+
+		{
+			name:      "allow whitelisted with secure transport",
+			transport: WhitelistTransportSecure,
+			whitelist: mkAllowed(false, "localhost:5000", "docker.io", "example.com:*", "registry.com:80"),
+			hostnames: map[string]error{
+				"example.com:5000":         nil,
+				"example.com:80":           nil,
+				"example.com":              nil,
+				"localhost:443":            fmt.Errorf(`registry "localhost:443" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				"localhost:5000":           nil,
+				"registry-1.docker.io:443": nil,
+				"registry.com:443":         fmt.Errorf(`registry "registry.com:443" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				"registry.com:80":          nil,
+				"registry.com":             fmt.Errorf(`registry "registry.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io"}:            nil,
+				{Registry: "index.docker.io"}:      nil,
+				{Registry: "example.com"}:          nil,
+				{Registry: "docker.io"}:            nil,
+				{Registry: "localhost:5000"}:       nil,
+				{Registry: "registry.example.com"}: fmt.Errorf(`registry "registry.example.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				{Name: "busybox"}:                  nil,
+			},
+		},
+
+		{
+			name:      "allow whitelisted with insecure transport",
+			transport: WhitelistTransportInsecure,
+			whitelist: mkAllowed(true, "localhost:5000", "docker.io", "example.com:*", "registry.com:80", "*.foo.com", "*domain.ltd"),
+			hostnames: map[string]error{
+				"a.b.c.d.foo.com:80": nil,
+				"domain.ltd":         nil,
+				"example.com":        nil,
+				"foo.com":            fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"index.docker.io":    nil,
+				"localhost:5000":     nil,
+				"my.domain.ltd:443":  fmt.Errorf(`registry "my.domain.ltd:443" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"my.domain.ltd:80":   nil,
+				"my.domain.ltd":      nil,
+				"mydomain.ltd":       nil,
+				"registry.com":       nil,
+				"registry.foo.com":   nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+				{Registry: "foo.com", Namespace: "library", Name: "busybox"}:   fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				{Registry: "ffoo.com", Namespace: "library", Name: "busybox"}:  fmt.Errorf(`registry "ffoo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+			},
+		},
+
+		{
+			name:      "allow whitelisted with any transport",
+			transport: WhitelistTransportAny,
+			whitelist: mkAllowed(false, "localhost:5000", "docker.io", "example.com:*", "registry.com:80", "*.foo.com", "*domain.ltd"),
+			hostnames: map[string]error{
+				"a.b.c.d.foo.com:80": fmt.Errorf(`registry "a.b.c.d.foo.com:80" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"domain.ltd":         nil,
+				"example.com":        nil,
+				"foo.com":            fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"index.docker.io":    nil,
+				"localhost:5000":     nil,
+				"my.domain.ltd:443":  nil,
+				"my.domain.ltd:80":   fmt.Errorf(`registry "my.domain.ltd:80" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"my.domain.ltd":      nil,
+				"mydomain.ltd":       nil,
+				"registry.com:443":   fmt.Errorf(`registry "registry.com:443" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"registry.com":       nil,
+				"registry.foo.com":   nil,
+			},
+			difs: map[imageapi.DockerImageReference]error{
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
+				{Registry: "foo.com", Namespace: "library", Name: "busybox"}:   fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				{Registry: "ffoo.com", Namespace: "library", Name: "busybox"}:  fmt.Errorf(`registry "ffoo.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+			},
+		},
+
+		{
+			name:      "allow whitelisted pullspecs with any transport",
+			transport: WhitelistTransportAny,
+			whitelist: mkAllowed(true, "localhost:5000", "docker.io", "example.com:*", "registry.com:80", "*.foo.com", "*domain.ltd"),
+			pullSpecs: map[string]error{
+				"a.b.c.d.foo.com:80/repo":     nil,
+				"domain.ltd/a/b":              nil,
+				"example.com/c/d":             nil,
+				"foo.com/foo":                 fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"index.docker.io/bar":         nil,
+				"localhost:5000/repo":         nil,
+				"my.domain.ltd:443/a/b":       fmt.Errorf(`registry "my.domain.ltd:443" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"my.domain.ltd:80/foo:latest": nil,
+				"my.domain.ltd/bar:1.3.4":     nil,
+				"mydomain.ltd/my/repo/sitory": nil,
+				"registry.com:443/ab:tag":     fmt.Errorf(`registry "registry.com:443" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"registry.com/repo":           nil,
+				"registry.foo.com/123":        nil,
+				"repository:latest":           nil,
+				"nm/repo:latest":              nil,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rw, err := NewRegistryWhitelister(tc.whitelist, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for hn, expErr := range tc.hostnames {
+				t.Run("hostname "+hn, func(t *testing.T) {
+					err := rw.AdmitHostname(hn, tc.transport)
+					assertExpectedError(t, err, expErr)
+				})
+			}
+
+			for dif, expErr := range tc.difs {
+				t.Run("dockerImageReference "+dif.String(), func(t *testing.T) {
+					err := rw.AdmitDockerImageReference(&dif, tc.transport)
+					assertExpectedError(t, err, expErr)
+				})
+			}
+
+			for ps, expErr := range tc.pullSpecs {
+				t.Run("pull spec "+ps, func(t *testing.T) {
+					err := rw.AdmitPullSpec(ps, tc.transport)
+					assertExpectedError(t, err, expErr)
+				})
+
+			}
+		})
+	}
+}
+
+func TestWhitelistRegistry(t *testing.T) {
+	rwClean, err := NewRegistryWhitelister(serverapi.AllowedRegistries{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rw := rwClean.Copy()
+	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportAny); err != nil {
+		t.Fatal(err)
+	}
+	exp := fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:443", "foo.com:80" }`)
+	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
+		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
+	}
+
+	rw = rwClean.Copy()
+	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportInsecure); err != nil {
+		t.Fatal(err)
+	}
+	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:80" }`)
+	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
+		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
+	}
+	// add duplicate
+	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportInsecure); err != nil {
+		t.Fatal(err)
+	}
+	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:80" }`)
+	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
+		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
+	}
+	// add duplicate with different port
+	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportAny); err != nil {
+		t.Fatal(err)
+	}
+	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:443", "foo.com:80" }`)
+	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
+		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
+	}
+}
+
+func TestNewRegistryWhitelister(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		insecure      bool
+		whitelist     serverapi.AllowedRegistries
+		expectedError error
+	}{
+		{
+			name:      "chinese works",
+			whitelist: mkAllowed(true, "先生，先生！"),
+		},
+
+		{
+			name:          "don't try it with multiple colons though",
+			whitelist:     mkAllowed(true, "0:1:2:3"),
+			expectedError: fmt.Errorf(`failed to parse allowed registry "0:1:2:3": too many colons`),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewRegistryWhitelister(tc.whitelist, nil)
+			assertExpectedError(t, err, tc.expectedError)
+		})
+	}
+}
+
+func assertExpectedError(t *testing.T, a, e error) {
+	switch {
+	case a == nil && e != nil:
+		t.Errorf("got unexpected non-error; expected: %q", e)
+	case a != nil && e == nil:
+		t.Errorf("got unexpected error: %q", a)
+	case a != nil && e != nil && a.Error() != e.Error():
+		t.Errorf("got unexpected error: %s", diff.ObjectGoPrintDiff(a, e))
+	}
+}

--- a/pkg/image/apis/image/validation/whitelist/whitelister_test.go
+++ b/pkg/image/apis/image/validation/whitelist/whitelister_test.go
@@ -32,12 +32,12 @@ func TestRegistryWhitelister(t *testing.T) {
 			transport: WhitelistTransportSecure,
 			whitelist: mkAllowed(true),
 			hostnames: map[string]error{
-				"example.com":    fmt.Errorf(`registry "example.com" not allowed by whitelist {  }`),
-				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist {  }`),
+				"example.com":    fmt.Errorf(`registry "example.com" not allowed by empty whitelist`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by empty whitelist`),
 			},
 			difs: map[imageapi.DockerImageReference]error{
-				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: fmt.Errorf(`registry "docker.io" not allowed by whitelist {  }`),
-				{Name: "busybox"}:                                              fmt.Errorf(`registry "docker.io:443" not allowed by whitelist {  }`),
+				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: fmt.Errorf(`registry "docker.io" not allowed by empty whitelist`),
+				{Name: "busybox"}:                                              fmt.Errorf(`registry "docker.io:443" not allowed by empty whitelist`),
 			},
 		},
 
@@ -49,8 +49,8 @@ func TestRegistryWhitelister(t *testing.T) {
 				"docker.io":      nil,
 				"example.com":    nil,
 				"localhost:443":  nil,
-				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist { "*:443" }`),
-				"localhost:80":   fmt.Errorf(`registry "localhost:80" not allowed by whitelist { "*:443" }`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist: "*:443"`),
+				"localhost:80":   fmt.Errorf(`registry "localhost:80" not allowed by whitelist: "*:443"`),
 				"localhost":      nil,
 			},
 			difs: map[imageapi.DockerImageReference]error{
@@ -65,8 +65,8 @@ func TestRegistryWhitelister(t *testing.T) {
 			hostnames: map[string]error{
 				"docker.io":      nil,
 				"example.com":    nil,
-				"localhost:443":  fmt.Errorf(`registry "localhost:443" not allowed by whitelist { "*:80" }`),
-				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist { "*:80" }`),
+				"localhost:443":  fmt.Errorf(`registry "localhost:443" not allowed by whitelist: "*:80"`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist: "*:80"`),
 				"localhost:80":   nil,
 				"localhost":      nil,
 			},
@@ -82,8 +82,8 @@ func TestRegistryWhitelister(t *testing.T) {
 			hostnames: map[string]error{
 				"docker.io":      nil,
 				"example.com":    nil,
-				"localhost:443":  fmt.Errorf(`registry "localhost:443" not allowed by whitelist { "*:80" }`),
-				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist { "*:80" }`),
+				"localhost:443":  fmt.Errorf(`registry "localhost:443" not allowed by whitelist: "*:80"`),
+				"localhost:5000": fmt.Errorf(`registry "localhost:5000" not allowed by whitelist: "*:80"`),
 				"localhost:80":   nil,
 				"localhost":      nil,
 			},
@@ -163,12 +163,12 @@ func TestRegistryWhitelister(t *testing.T) {
 				"example.com:5000":         nil,
 				"example.com:80":           nil,
 				"example.com":              nil,
-				"localhost:443":            fmt.Errorf(`registry "localhost:443" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				"localhost:443":            fmt.Errorf(`registry "localhost:443" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80"`),
 				"localhost:5000":           nil,
 				"registry-1.docker.io:443": nil,
-				"registry.com:443":         fmt.Errorf(`registry "registry.com:443" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				"registry.com:443":         fmt.Errorf(`registry "registry.com:443" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80"`),
 				"registry.com:80":          nil,
-				"registry.com":             fmt.Errorf(`registry "registry.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				"registry.com":             fmt.Errorf(`registry "registry.com" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80"`),
 			},
 			difs: map[imageapi.DockerImageReference]error{
 				{Registry: "docker.io"}:            nil,
@@ -176,7 +176,7 @@ func TestRegistryWhitelister(t *testing.T) {
 				{Registry: "example.com"}:          nil,
 				{Registry: "docker.io"}:            nil,
 				{Registry: "localhost:5000"}:       nil,
-				{Registry: "registry.example.com"}: fmt.Errorf(`registry "registry.example.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80" }`),
+				{Registry: "registry.example.com"}: fmt.Errorf(`registry "registry.example.com" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80"`),
 				{Name: "busybox"}:                  nil,
 			},
 		},
@@ -189,10 +189,10 @@ func TestRegistryWhitelister(t *testing.T) {
 				"a.b.c.d.foo.com:80": nil,
 				"domain.ltd":         nil,
 				"example.com":        nil,
-				"foo.com":            fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"foo.com":            fmt.Errorf(`registry "foo.com" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
 				"index.docker.io":    nil,
 				"localhost:5000":     nil,
-				"my.domain.ltd:443":  fmt.Errorf(`registry "my.domain.ltd:443" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"my.domain.ltd:443":  fmt.Errorf(`registry "my.domain.ltd:443" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
 				"my.domain.ltd:80":   nil,
 				"my.domain.ltd":      nil,
 				"mydomain.ltd":       nil,
@@ -201,8 +201,8 @@ func TestRegistryWhitelister(t *testing.T) {
 			},
 			difs: map[imageapi.DockerImageReference]error{
 				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
-				{Registry: "foo.com", Namespace: "library", Name: "busybox"}:   fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
-				{Registry: "ffoo.com", Namespace: "library", Name: "busybox"}:  fmt.Errorf(`registry "ffoo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				{Registry: "foo.com", Namespace: "library", Name: "busybox"}:   fmt.Errorf(`registry "foo.com" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
+				{Registry: "ffoo.com", Namespace: "library", Name: "busybox"}:  fmt.Errorf(`registry "ffoo.com" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
 			},
 		},
 
@@ -211,24 +211,24 @@ func TestRegistryWhitelister(t *testing.T) {
 			transport: WhitelistTransportAny,
 			whitelist: mkAllowed(false, "localhost:5000", "docker.io", "example.com:*", "registry.com:80", "*.foo.com", "*domain.ltd"),
 			hostnames: map[string]error{
-				"a.b.c.d.foo.com:80": fmt.Errorf(`registry "a.b.c.d.foo.com:80" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"a.b.c.d.foo.com:80": fmt.Errorf(`registry "a.b.c.d.foo.com:80" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ...`),
 				"domain.ltd":         nil,
 				"example.com":        nil,
-				"foo.com":            fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"foo.com":            fmt.Errorf(`registry "foo.com" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ...`),
 				"index.docker.io":    nil,
 				"localhost:5000":     nil,
 				"my.domain.ltd:443":  nil,
-				"my.domain.ltd:80":   fmt.Errorf(`registry "my.domain.ltd:80" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"my.domain.ltd:80":   fmt.Errorf(`registry "my.domain.ltd:80" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ...`),
 				"my.domain.ltd":      nil,
 				"mydomain.ltd":       nil,
-				"registry.com:443":   fmt.Errorf(`registry "registry.com:443" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"registry.com:443":   fmt.Errorf(`registry "registry.com:443" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ...`),
 				"registry.com":       nil,
 				"registry.foo.com":   nil,
 			},
 			difs: map[imageapi.DockerImageReference]error{
 				{Registry: "docker.io", Namespace: "library", Name: "busybox"}: nil,
-				{Registry: "foo.com", Namespace: "library", Name: "busybox"}:   fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
-				{Registry: "ffoo.com", Namespace: "library", Name: "busybox"}:  fmt.Errorf(`registry "ffoo.com" not allowed by whitelist { "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ... }`),
+				{Registry: "foo.com", Namespace: "library", Name: "busybox"}:   fmt.Errorf(`registry "foo.com" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ...`),
+				{Registry: "ffoo.com", Namespace: "library", Name: "busybox"}:  fmt.Errorf(`registry "ffoo.com" not allowed by whitelist: "localhost:5000", "docker.io:443", "example.com:*", "registry.com:80", and 2 more ...`),
 			},
 		},
 
@@ -240,14 +240,14 @@ func TestRegistryWhitelister(t *testing.T) {
 				"a.b.c.d.foo.com:80/repo":     nil,
 				"domain.ltd/a/b":              nil,
 				"example.com/c/d":             nil,
-				"foo.com/foo":                 fmt.Errorf(`registry "foo.com" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"foo.com/foo":                 fmt.Errorf(`registry "foo.com" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
 				"index.docker.io/bar":         nil,
 				"localhost:5000/repo":         nil,
-				"my.domain.ltd:443/a/b":       fmt.Errorf(`registry "my.domain.ltd:443" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"my.domain.ltd:443/a/b":       fmt.Errorf(`registry "my.domain.ltd:443" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
 				"my.domain.ltd:80/foo:latest": nil,
 				"my.domain.ltd/bar:1.3.4":     nil,
 				"mydomain.ltd/my/repo/sitory": nil,
-				"registry.com:443/ab:tag":     fmt.Errorf(`registry "registry.com:443" not allowed by whitelist { "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ... }`),
+				"registry.com:443/ab:tag":     fmt.Errorf(`registry "registry.com:443" not allowed by whitelist: "localhost:5000", "docker.io:80", "example.com:*", "registry.com:80", and 2 more ...`),
 				"registry.com/repo":           nil,
 				"registry.foo.com/123":        nil,
 				"repository:latest":           nil,
@@ -296,7 +296,7 @@ func TestWhitelistRegistry(t *testing.T) {
 	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportAny); err != nil {
 		t.Fatal(err)
 	}
-	exp := fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:443", "foo.com:80" }`)
+	exp := fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist: "foo.com:443", "foo.com:80"`)
 	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
 		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
 	}
@@ -305,7 +305,7 @@ func TestWhitelistRegistry(t *testing.T) {
 	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportInsecure); err != nil {
 		t.Fatal(err)
 	}
-	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:80" }`)
+	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist: "foo.com:80"`)
 	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
 		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
 	}
@@ -313,7 +313,7 @@ func TestWhitelistRegistry(t *testing.T) {
 	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportInsecure); err != nil {
 		t.Fatal(err)
 	}
-	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:80" }`)
+	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist: "foo.com:80"`)
 	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
 		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
 	}
@@ -321,7 +321,7 @@ func TestWhitelistRegistry(t *testing.T) {
 	if err := rw.WhitelistRegistry("foo.com", WhitelistTransportAny); err != nil {
 		t.Fatal(err)
 	}
-	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist { "foo.com:443", "foo.com:80" }`)
+	exp = fmt.Errorf(`registry "sub.foo.com" not allowed by whitelist: "foo.com:443", "foo.com:80"`)
 	if err := rw.AdmitHostname("sub.foo.com", WhitelistTransportAny); err == nil || err.Error() != exp.Error() {
 		t.Fatalf("got unexpected error: %s", diff.ObjectGoPrintDiff(err, exp))
 	}

--- a/pkg/image/registry/imagestream/etcd/etcd_test.go
+++ b/pkg/image/registry/imagestream/etcd/etcd_test.go
@@ -15,8 +15,9 @@ import (
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
 	"github.com/openshift/origin/pkg/api/latest"
-	"github.com/openshift/origin/pkg/image/admission/testutil"
+	admfake "github.com/openshift/origin/pkg/image/admission/fake"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/fake"
 	"github.com/openshift/origin/pkg/util/restoptions"
 
 	// install all APIs
@@ -52,7 +53,12 @@ func (f *fakeSubjectAccessReviewRegistry) Create(subjectAccessReview *authorizat
 func newStorage(t *testing.T) (*REST, *StatusREST, *InternalREST, *etcdtesting.EtcdTestServer) {
 	etcdStorage, server := registrytest.NewEtcdStorage(t, latest.Version.Group)
 	registry := imageapi.DefaultRegistryHostnameRetriever(noDefaultRegistry, "", "")
-	imageStorage, statusStorage, internalStorage, err := NewREST(restoptions.NewSimpleGetter(etcdStorage), registry, &fakeSubjectAccessReviewRegistry{}, &testutil.FakeImageStreamLimitVerifier{})
+	imageStorage, statusStorage, internalStorage, err := NewREST(
+		restoptions.NewSimpleGetter(etcdStorage),
+		registry,
+		&fakeSubjectAccessReviewRegistry{},
+		&admfake.ImageStreamLimitVerifier{},
+		&fake.RegistryWhitelister{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/image/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/registry/imagestreamimage/rest_test.go
@@ -16,8 +16,9 @@ import (
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	"github.com/openshift/origin/pkg/image/admission/testutil"
+	admfake "github.com/openshift/origin/pkg/image/admission/fake"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/fake"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	imageetcd "github.com/openshift/origin/pkg/image/registry/image/etcd"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
@@ -45,7 +46,7 @@ func setup(t *testing.T) (etcd.KV, *etcdtesting.EtcdTestServer, *REST) {
 		t.Fatal(err)
 	}
 	defaultRegistry := imageapi.DefaultRegistryHostnameRetriever(testDefaultRegistry, "", "")
-	imageStreamStorage, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(restoptions.NewSimpleGetter(etcdStorage), defaultRegistry, &fakeSubjectAccessReviewRegistry{}, &testutil.FakeImageStreamLimitVerifier{})
+	imageStreamStorage, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(restoptions.NewSimpleGetter(etcdStorage), defaultRegistry, &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, &fake.RegistryWhitelister{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/image/registry/imagestreamimport/rest.go
+++ b/pkg/image/registry/imagestreamimport/rest.go
@@ -25,8 +25,8 @@ import (
 
 	imageapiv1 "github.com/openshift/api/image/v1"
 	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
-	serverapi "github.com/openshift/origin/pkg/cmd/server/api"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	"github.com/openshift/origin/pkg/image/importer"
 	"github.com/openshift/origin/pkg/image/importer/dockerv1client"
@@ -65,8 +65,7 @@ func NewREST(importFn ImporterFunc, streams imagestream.Registry, internalStream
 	images rest.Creater, isClient imageclient.ImageStreamsGetter,
 	transport, insecureTransport http.RoundTripper,
 	clientFn ImporterDockerRegistryFunc,
-	allowedImportRegistries *serverapi.AllowedRegistries,
-	registryFn imageapi.RegistryHostnameRetriever,
+	registryWhitelister whitelist.RegistryWhitelister,
 	sarClient authorizationclient.SubjectAccessReviewInterface,
 ) *REST {
 	return &REST{
@@ -78,7 +77,7 @@ func NewREST(importFn ImporterFunc, streams imagestream.Registry, internalStream
 		transport:         transport,
 		insecureTransport: insecureTransport,
 		clientFn:          clientFn,
-		strategy:          NewStrategy(allowedImportRegistries, registryFn),
+		strategy:          NewStrategy(registryWhitelister),
 		sarClient:         sarClient,
 	}
 }

--- a/pkg/image/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/registry/imagestreammapping/rest_test.go
@@ -26,8 +26,9 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 
-	"github.com/openshift/origin/pkg/image/admission/testutil"
+	admfake "github.com/openshift/origin/pkg/image/admission/fake"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/fake"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	imageetcd "github.com/openshift/origin/pkg/image/registry/image/etcd"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
@@ -57,7 +58,7 @@ func setup(t *testing.T) (etcd.KV, *etcdtesting.EtcdTestServer, *REST) {
 		t.Fatal(err)
 	}
 	registry := imageapi.DefaultRegistryHostnameRetriever(testDefaultRegistry, "", "")
-	imageStreamStorage, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(restoptions.NewSimpleGetter(etcdStorage), registry, &fakeSubjectAccessReviewRegistry{}, &testutil.FakeImageStreamLimitVerifier{})
+	imageStreamStorage, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(restoptions.NewSimpleGetter(etcdStorage), registry, &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, &fake.RegistryWhitelister{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/image/registry/imagestreamtag/strategy.go
+++ b/pkg/image/registry/imagestreamtag/strategy.go
@@ -14,22 +14,29 @@ import (
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/apis/image/validation"
+	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 )
 
-// strategy implements behavior for ImageStreamTags.
-type strategy struct {
+// Strategy implements behavior for ImageStreamTags.
+type Strategy struct {
 	runtime.ObjectTyper
+	registryWhitelister whitelist.RegistryWhitelister
 }
 
-var Strategy = &strategy{
-	ObjectTyper: legacyscheme.Scheme,
+// NewStrategy is the default logic that applies when creating and updating
+// ImageStreamTag objects via the REST API.
+func NewStrategy(registryWhitelister whitelist.RegistryWhitelister) Strategy {
+	return Strategy{
+		ObjectTyper:         legacyscheme.Scheme,
+		registryWhitelister: registryWhitelister,
+	}
 }
 
-func (s *strategy) NamespaceScoped() bool {
+func (s Strategy) NamespaceScoped() bool {
 	return true
 }
 
-func (s *strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
+func (s Strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) {
 	newIST := obj.(*imageapi.ImageStreamTag)
 	if newIST.Tag != nil && len(newIST.Tag.Name) == 0 {
 		_, tag, _ := imageapi.SplitImageStreamTag(newIST.Name)
@@ -39,29 +46,29 @@ func (s *strategy) PrepareForCreate(ctx apirequest.Context, obj runtime.Object) 
 	newIST.Image = imageapi.Image{}
 }
 
-func (s *strategy) GenerateName(base string) string {
+func (s Strategy) GenerateName(base string) string {
 	return base
 }
 
-func (s *strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
+func (s Strategy) Validate(ctx apirequest.Context, obj runtime.Object) field.ErrorList {
 	istag := obj.(*imageapi.ImageStreamTag)
 
-	return validation.ValidateImageStreamTag(istag)
+	return validation.ValidateImageStreamTagWithWhitelister(s.registryWhitelister, istag)
 }
 
-func (s *strategy) AllowCreateOnUpdate() bool {
+func (s Strategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (*strategy) AllowUnconditionalUpdate() bool {
+func (Strategy) AllowUnconditionalUpdate() bool {
 	return false
 }
 
 // Canonicalize normalizes the object after validation.
-func (strategy) Canonicalize(obj runtime.Object) {
+func (Strategy) Canonicalize(obj runtime.Object) {
 }
 
-func (s *strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
+func (s Strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Object) {
 	newIST := obj.(*imageapi.ImageStreamTag)
 	oldIST := old.(*imageapi.ImageStreamTag)
 
@@ -75,11 +82,11 @@ func (s *strategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime.Obj
 	newIST.Image = oldIST.Image
 }
 
-func (s *strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
+func (s Strategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
 	newIST := obj.(*imageapi.ImageStreamTag)
 	oldIST := old.(*imageapi.ImageStreamTag)
 
-	return validation.ValidateImageStreamTagUpdate(newIST, oldIST)
+	return validation.ValidateImageStreamTagUpdateWithWhitelister(s.registryWhitelister, newIST, oldIST)
 }
 
 // MatchImageStreamTag returns a generic matcher for a given label and field selector.

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -53,6 +53,7 @@ func TestConcurrentBuildControllersPodSync(t *testing.T) {
 }
 
 func TestConcurrentBuildImageChangeTriggerControllers(t *testing.T) {
+	testutil.SetAdditionalAllowedRegistries("registry:8080")
 	// Start a master with multiple ImageChangeTrigger controllers
 	buildClient, imageClient, _, fn := setupBuildControllerTest(controllerCount{ImageChangeControllers: 5}, t)
 	defer fn()

--- a/test/integration/deploy_trigger_test.go
+++ b/test/integration/deploy_trigger_test.go
@@ -103,6 +103,8 @@ func TestTriggers_manual(t *testing.T) {
 // TestTriggers_imageChange ensures that a deployment config with an ImageChange trigger
 // will start a new deployment when an image change happens.
 func TestTriggers_imageChange(t *testing.T) {
+	const registryHostname = "registry:8080"
+	testutil.SetAdditionalAllowedRegistries(registryHostname)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -142,7 +144,7 @@ func TestTriggers_imageChange(t *testing.T) {
 	defer imageWatch.Stop()
 
 	updatedImage := fmt.Sprintf("sha256:%s", appstest.ImageID)
-	updatedPullSpec := fmt.Sprintf("registry:8080/%s/%s@%s", testutil.Namespace(), appstest.ImageStreamName, updatedImage)
+	updatedPullSpec := fmt.Sprintf("%s/%s/%s@%s", registryHostname, testutil.Namespace(), appstest.ImageStreamName, updatedImage)
 	// Make a function which can create a new tag event for the image stream and
 	// then wait for the stream status to be asynchronously updated.
 	createTagEvent := func() {
@@ -206,6 +208,8 @@ waitForNewConfig:
 // TestTriggers_imageChange_nonAutomatic ensures that a deployment config with a non-automatic
 // trigger will have its image updated when a deployment is started manually.
 func TestTriggers_imageChange_nonAutomatic(t *testing.T) {
+	const registryHostname = "registry:8080"
+	testutil.SetAdditionalAllowedRegistries(registryHostname, "registry:5000")
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -324,7 +328,7 @@ out:
 
 	// Subsequent updates to the image shouldn't update the pod template image
 	mapping.Image.Name = "sha256:0000000000000000000000000000000000000000000000000000000000000321"
-	mapping.Image.DockerImageReference = fmt.Sprintf("registry:8080/%s/%s@%s", testutil.Namespace(), appstest.ImageStreamName, mapping.Image.Name)
+	mapping.Image.DockerImageReference = fmt.Sprintf("%s/%s/%s@%s", registryHostname, testutil.Namespace(), appstest.ImageStreamName, mapping.Image.Name)
 	createTagEvent(mapping)
 
 	timeout = time.After(20 * time.Second)
@@ -383,6 +387,8 @@ loop:
 // TestTriggers_MultipleICTs ensures that a deployment config with more than one ImageChange trigger
 // will start a new deployment iff all images are resolved.
 func TestTriggers_MultipleICTs(t *testing.T) {
+	const registryHostname = "registry:8080"
+	testutil.SetAdditionalAllowedRegistries(registryHostname)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("error starting master: %v", err)
@@ -430,7 +436,7 @@ func TestTriggers_MultipleICTs(t *testing.T) {
 	defer imageWatch.Stop()
 
 	updatedImage := fmt.Sprintf("sha256:%s", appstest.ImageID)
-	updatedPullSpec := fmt.Sprintf("registry:8080/%s/%s@%s", testutil.Namespace(), appstest.ImageStreamName, updatedImage)
+	updatedPullSpec := fmt.Sprintf("%s/%s/%s@%s", registryHostname, testutil.Namespace(), appstest.ImageStreamName, updatedImage)
 
 	// Make a function which can create a new tag event for the image stream and
 	// then wait for the stream status to be asynchronously updated.

--- a/test/integration/webhook_test.go
+++ b/test/integration/webhook_test.go
@@ -134,6 +134,9 @@ func TestWebhook(t *testing.T) {
 }
 
 func TestWebhookGitHubPushWithImage(t *testing.T) {
+	const registryHostname = "registry:3000"
+	testutil.SetAdditionalAllowedRegistries(registryHostname)
+
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -165,12 +168,12 @@ func TestWebhookGitHubPushWithImage(t *testing.T) {
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{Name: "image-stream"},
 		Spec: imageapi.ImageStreamSpec{
-			DockerImageRepository: "registry:3000/integration/imagestream",
+			DockerImageRepository: registryHostname + "/integration/imagestream",
 			Tags: map[string]imageapi.TagReference{
 				"validtag": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
-						Name: "registry:3000/integration/imagestream:success",
+						Name: registryHostname + "/integration/imagestream:success",
 					},
 				},
 			},
@@ -187,7 +190,7 @@ func TestWebhookGitHubPushWithImage(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "myimage",
 			},
-			DockerImageReference: "registry:3000/integration/imagestream:success",
+			DockerImageReference: registryHostname + "/integration/imagestream:success",
 		},
 	}
 	if _, err := clusterAdminImageClient.ImageStreamMappings(testutil.Namespace()).Create(ism); err != nil {
@@ -244,6 +247,8 @@ func TestWebhookGitHubPushWithImage(t *testing.T) {
 }
 
 func TestWebhookGitHubPushWithImageStream(t *testing.T) {
+	const registryHostname = "registry:3000"
+	testutil.SetAdditionalAllowedRegistries(registryHostname)
 	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -275,12 +280,12 @@ func TestWebhookGitHubPushWithImageStream(t *testing.T) {
 	imageStream := &imageapi.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{Name: "image-stream"},
 		Spec: imageapi.ImageStreamSpec{
-			DockerImageRepository: "registry:3000/integration/imagestream",
+			DockerImageRepository: registryHostname + "/integration/imagestream",
 			Tags: map[string]imageapi.TagReference{
 				"validtag": {
 					From: &kapi.ObjectReference{
 						Kind: "DockerImage",
-						Name: "registry:3000/integration/imagestream:success",
+						Name: registryHostname + "/integration/imagestream:success",
 					},
 				},
 			},
@@ -297,7 +302,7 @@ func TestWebhookGitHubPushWithImageStream(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "myimage",
 			},
-			DockerImageReference: "registry:3000/integration/imagestream:success",
+			DockerImageReference: registryHostname + "/integration/imagestream:success",
 		},
 	}
 	if _, err := clusterAdminImageClient.ImageStreamMappings(testutil.Namespace()).Create(ism); err != nil {
@@ -339,8 +344,8 @@ Loop:
 			break Loop
 		}
 	}
-	if build.Spec.Strategy.SourceStrategy.From.Name != "registry:3000/integration/imagestream:success" {
-		t.Errorf("Expected %s, got %s", "registry:3000/integration/imagestream:success", build.Spec.Strategy.SourceStrategy.From.Name)
+	if build.Spec.Strategy.SourceStrategy.From.Name != registryHostname+"/integration/imagestream:success" {
+		t.Errorf("Expected %s, got %s", registryHostname+"/integration/imagestream:success", build.Spec.Strategy.SourceStrategy.From.Name)
 	}
 }
 

--- a/test/testdata/test-stream.yaml
+++ b/test/testdata/test-stream.yaml
@@ -7,7 +7,7 @@ metadata:
   selfLink: /oapi/v1/namespaces/test/imagestreams/test-stream
   uid: 15be89a8-70db-11e5-ae32-080027c5bfa9
 spec: 
-  dockerImageRepository: 172.30.181.223:5000/test/test-stream
+  dockerImageRepository: 172.30.30.30:5000/test/test-stream
   tags:
   - name: latest
   - name: installable

--- a/test/util/helpers.go
+++ b/test/util/helpers.go
@@ -2,14 +2,20 @@ package util
 
 import (
 	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
+
+const additionalAllowedRegistriesEnvVar = "ADDITIONAL_ALLOWED_REGISTRIES"
 
 func GetTemplateFixture(filename string) (*templateapi.Template, error) {
 	data, err := ioutil.ReadFile(filename)
@@ -41,4 +47,24 @@ func GetImageFixture(filename string) (*imageapi.Image, error) {
 		return nil, err
 	}
 	return obj.(*imageapi.Image), nil
+}
+
+func SetAdditionalAllowedRegistries(hostPortGlobs ...string) {
+	os.Setenv(additionalAllowedRegistriesEnvVar, strings.Join(hostPortGlobs, ","))
+}
+
+func AddAdditionalAllowedRegistries(hostPortGlobs ...string) {
+	regs := GetAdditionalAllowedRegistries()
+	regs.Insert(hostPortGlobs...)
+	SetAdditionalAllowedRegistries(regs.List()...)
+}
+
+func GetAdditionalAllowedRegistries() sets.String {
+	regs := sets.NewString()
+	for _, r := range regexp.MustCompile(`[[:space:],]+`).Split(os.Getenv(additionalAllowedRegistriesEnvVar), -1) {
+		if len(r) > 0 {
+			regs.Insert(r)
+		}
+	}
+	return regs
 }

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -218,6 +218,9 @@ func DefaultMasterOptionsWithTweaks(startEtcd, useDefaultPort bool) (*configapi.
 		*configapi.DefaultAllowedRegistriesForImport,
 		configapi.RegistryLocation{DomainName: "127.0.0.1:*"},
 	)
+	for r := range util.GetAdditionalAllowedRegistries() {
+		allowedRegistries = append(allowedRegistries, configapi.RegistryLocation{DomainName: r})
+	}
 	masterConfig.ImagePolicyConfig.AllowedRegistriesForImport = &allowedRegistries
 
 	// force strict handling of service account secret references by default, so that all our examples and controllers will handle it.


### PR DESCRIPTION
Adds validation to imagestreams and imagestreamtags that forbids new image pull specs not present on the whitelist.

Resolves [bz#1505315](https://bugzilla.redhat.com/show_bug.cgi?id=1505315)