### PR TITLE
fix authorization to use no opinion where possible

### DIFF
--- a/pkg/authorization/authorizer/authorizer.go
+++ b/pkg/authorization/authorizer/authorizer.go
@@ -29,15 +29,15 @@ func NewSubjectLocator(delegate authorizerrbac.SubjectLocator) SubjectLocator {
 
 func (a *openshiftAuthorizer) Authorize(attributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	if attributes.GetUser() == nil {
-		return authorizer.DecisionDeny, "", errors.New("no user available on context")
+		return authorizer.DecisionNoOpinion, "", errors.New("no user available on context")
 	}
-	authorized, delegateReason, err := a.delegate.Authorize(attributes)
-	if authorized == authorizer.DecisionAllow {
+	authorizationDecision, delegateReason, err := a.delegate.Authorize(attributes)
+	if authorizationDecision == authorizer.DecisionAllow {
 		return authorizer.DecisionAllow, reason(attributes), nil
 	}
 	// errors are allowed to occur
 	if err != nil {
-		return authorizer.DecisionDeny, "", err
+		return authorizationDecision, "", err
 	}
 
 	denyReason, err := a.forbiddenMessageMaker.MakeMessage(attributes)
@@ -48,7 +48,7 @@ func (a *openshiftAuthorizer) Authorize(attributes authorizer.Attributes) (autho
 		denyReason += ": " + delegateReason
 	}
 
-	return authorizer.DecisionDeny, denyReason, nil
+	return authorizationDecision, denyReason, nil
 }
 
 // GetAllowedSubjects returns the subjects it knows can perform the action.

--- a/pkg/authorization/authorizer/browsersafe/authorizer_test.go
+++ b/pkg/authorization/authorizer/browsersafe/authorizer_test.go
@@ -71,5 +71,5 @@ type recordingAuthorizer struct {
 
 func (t *recordingAuthorizer) Authorize(a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	t.attributes = a
-	return authorizer.DecisionDeny, "", nil
+	return authorizer.DecisionNoOpinion, "", nil
 }

--- a/pkg/authorization/authorizer/scope/authorizer.go
+++ b/pkg/authorization/authorizer/scope/authorizer.go
@@ -26,7 +26,7 @@ func NewAuthorizer(delegate authorizer.Authorizer, clusterRoleGetter rbaclisters
 func (a *scopeAuthorizer) Authorize(attributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	user := attributes.GetUser()
 	if user == nil {
-		return authorizer.DecisionDeny, "", fmt.Errorf("user missing from context")
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("user missing from context")
 	}
 
 	scopes := user.GetExtra()[authorizationapi.ScopesKey]
@@ -52,5 +52,6 @@ func (a *scopeAuthorizer) Authorize(attributes authorizer.Attributes) (authorize
 		denyReason = err.Error()
 	}
 
+	// the scope prevent this.  We need to authoritatively deny
 	return authorizer.DecisionDeny, fmt.Sprintf("scopes %v prevent this action; %v", scopes, denyReason), kerrors.NewAggregate(nonFatalErrors)
 }

--- a/pkg/authorization/registry/localresourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest_test.go
@@ -36,7 +36,7 @@ func (a *testAuthorizer) Authorize(attributes kauthorizer.Attributes) (decision 
 		return kauthorizer.DecisionAllow, "", nil
 	}
 
-	return kauthorizer.DecisionDeny, "", errors.New("Unsupported")
+	return kauthorizer.DecisionNoOpinion, "", errors.New("Unsupported")
 }
 func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attributes) (sets.String, sets.String, error) {
 	a.actualAttributes = passedAttributes

--- a/pkg/authorization/registry/localsubjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/localsubjectaccessreview/rest_test.go
@@ -54,7 +54,7 @@ func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attribu
 func TestNoNamespace(t *testing.T) {
 	test := &subjectAccessTest{
 		authorizer: &testAuthorizer{
-			allowed: kauthorizer.DecisionDeny,
+			allowed: kauthorizer.DecisionNoOpinion,
 		},
 		reviewRequest: &authorizationapi.LocalSubjectAccessReview{
 			Action: authorizationapi.Action{
@@ -73,7 +73,7 @@ func TestNoNamespace(t *testing.T) {
 
 func TestConflictingNamespace(t *testing.T) {
 	authorizer := &testAuthorizer{
-		allowed: kauthorizer.DecisionDeny,
+		allowed: kauthorizer.DecisionNoOpinion,
 	}
 	reviewRequest := &authorizationapi.LocalSubjectAccessReview{
 		Action: authorizationapi.Action{
@@ -99,7 +99,7 @@ func TestConflictingNamespace(t *testing.T) {
 func TestEmptyReturn(t *testing.T) {
 	test := &subjectAccessTest{
 		authorizer: &testAuthorizer{
-			allowed: kauthorizer.DecisionDeny,
+			allowed: kauthorizer.DecisionNoOpinion,
 			reason:  "because reasons",
 		},
 		reviewRequest: &authorizationapi.LocalSubjectAccessReview{

--- a/pkg/authorization/registry/resourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest_test.go
@@ -35,13 +35,13 @@ func (a *testAuthorizer) Authorize(attributes kauthorizer.Attributes) (allowed k
 	// allow the initial check for "can I run this RAR at all"
 	if attributes.GetResource() == "localresourceaccessreviews" {
 		if len(a.deniedNamespaces) != 0 && a.deniedNamespaces.Has(attributes.GetNamespace()) {
-			return kauthorizer.DecisionDeny, "denied initial check", nil
+			return kauthorizer.DecisionNoOpinion, "no decision on initial check", nil
 		}
 
 		return kauthorizer.DecisionAllow, "", nil
 	}
 
-	return kauthorizer.DecisionDeny, "", errors.New("unsupported")
+	return kauthorizer.DecisionNoOpinion, "", errors.New("unsupported")
 }
 func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attributes) (sets.String, sets.String, error) {
 	a.actualAttributes = passedAttributes
@@ -56,7 +56,7 @@ func TestDeniedNamespace(t *testing.T) {
 		authorizer: &testAuthorizer{
 			users:            sets.String{},
 			groups:           sets.String{},
-			err:              "denied initial check",
+			err:              "no decision on initial check",
 			deniedNamespaces: sets.NewString("foo"),
 		},
 		reviewRequest: &authorizationapi.ResourceAccessReview{

--- a/pkg/authorization/registry/subjectaccessreview/rest_test.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest_test.go
@@ -39,7 +39,7 @@ func (a *testAuthorizer) Authorize(passedAttributes kauthorizer.Attributes) (all
 	// allow the initial check for "can I run this SAR at all"
 	if passedAttributes.GetResource() == "localsubjectaccessreviews" {
 		if len(a.deniedNamespaces) != 0 && a.deniedNamespaces.Has(passedAttributes.GetNamespace()) {
-			return kauthorizer.DecisionDeny, "denied initial check", nil
+			return kauthorizer.DecisionNoOpinion, "no decision on initial check", nil
 		}
 
 		return kauthorizer.DecisionAllow, "", nil
@@ -59,7 +59,7 @@ func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attribu
 func TestDeniedNamespace(t *testing.T) {
 	test := &subjectAccessTest{
 		authorizer: &testAuthorizer{
-			allowed:          kauthorizer.DecisionDeny,
+			allowed:          kauthorizer.DecisionNoOpinion,
 			err:              "denied initial check",
 			deniedNamespaces: sets.NewString("foo"),
 		},
@@ -81,7 +81,7 @@ func TestDeniedNamespace(t *testing.T) {
 func TestEmptyReturn(t *testing.T) {
 	test := &subjectAccessTest{
 		authorizer: &testAuthorizer{
-			allowed: kauthorizer.DecisionDeny,
+			allowed: kauthorizer.DecisionNoOpinion,
 			reason:  "because reasons",
 		},
 		reviewRequest: &authorizationapi.SubjectAccessReview{

--- a/pkg/ingress/admission/ingress_admission_test.go
+++ b/pkg/ingress/admission/ingress_admission_test.go
@@ -95,7 +95,7 @@ func TestAdmission(t *testing.T) {
 		},
 		{
 			admit:    false,
-			allow:    authorizer.DecisionDeny,
+			allow:    authorizer.DecisionNoOpinion,
 			config:   emptyConfig(),
 			op:       admission.Create,
 			newHost:  "foo.com",

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -425,14 +425,14 @@ func fakeAuthorizer(t *testing.T) authorizer.Authorizer {
 func (a *fakeTestAuthorizer) Authorize(attributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	ui := attributes.GetUser()
 	if ui == nil {
-		return authorizer.DecisionDeny, "", fmt.Errorf("No valid UserInfo for Context")
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("No valid UserInfo for Context")
 	}
 	// User with pods/bindings. permission:
 	if ui.GetName() == "system:serviceaccount:openshift-infra:daemonset-controller" {
 		return authorizer.DecisionAllow, "", nil
 	}
 	// User without pods/bindings. permission:
-	return authorizer.DecisionDeny, "", nil
+	return authorizer.DecisionNoOpinion, "", nil
 }
 
 func reviewResponse(allowed bool, msg string) *authorizationapi.SubjectAccessReviewResponse {


### PR DESCRIPTION
Followup to the rebase.  NoOpinion matches previous behavior.

/assign @liggitt 
/assign @simo5 

@openshift/sig-security 