### PR TITLE
Install openshift-diagnostics binary in dind and vagrant environments

### DIFF
--- a/contrib/vagrant/provision-util.sh
+++ b/contrib/vagrant/provision-util.sh
@@ -57,7 +57,7 @@ os::provision::install-cmds() {
   local deployed_root=$1
 
   local output_path="$(os::build::get-bin-output-path "${deployed_root}")"
-  cp ${output_path}/{openshift,oc} /usr/bin
+  cp ${output_path}/{openshift,openshift-diagnostics,oc} /usr/bin
 }
 
 os::provision::add-to-hosts-file() {

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -487,6 +487,7 @@ function copy-runtime() {
   local target=$2
 
   cp "$(os::util::find::built_binary openshift)" "${target}"
+  cp "$(os::util::find::built_binary openshift-diagnostics)" "${target}"
   cp "$(os::util::find::built_binary oc)" "${target}"
   cp "$(os::util::find::built_binary host-local)" "${target}"
   cp "$(os::util::find::built_binary loopback)" "${target}"

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -70,6 +70,7 @@ RUN mkdir -p /opt/cni/bin
 # make reloading easy.  Revisit if/when dind becomes useful for more
 # than dev/test.
 RUN ln -sf /data/openshift /usr/local/bin/ && \
+    ln -sf /data/openshift-diagnostics /usr/local/bin/ && \
     ln -sf /data/oc        /usr/local/bin/ && \
     ln -sf /data/openshift /usr/local/bin/openshift-deploy && \
     ln -sf /data/openshift /usr/local/bin/openshift-docker-build && \


### PR DESCRIPTION
- https://github.com/openshift/origin/pull/17482 removed 'openshift infra'
command and diagnostic-pod/network-diagnostic-pod subcommands now are
moved under openshift-diagnostics command.