### PR TITLE
etcdhelper: no kind "Image" is registered for version "v1"

### DIFF
--- a/tools/etcdhelper/etcdhelper.go
+++ b/tools/etcdhelper/etcdhelper.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
+	scheme "k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"


### PR DESCRIPTION
Import `_ "github.com/openshift/origin/pkg/api/install"` installs API into legacyscheme, but etcdhelper uses different scheme, which doesn't have our types.