### PR TITLE
Add template support for Jenkins INSTALL_PLUGINS env variable

### DIFF
--- a/examples/jenkins/jenkins-ephemeral-template.json
+++ b/examples/jenkins/jenkins-ephemeral-template.json
@@ -123,6 +123,10 @@
                     "value": "true"
                   },
                   {
+                    "name": "INSTALL_PLUGINS",
+                    "value": "${INSTALL_PLUGINS}"
+                  },
+                  {
                     "name": "JENKINS_SERVICE_NAME",
                     "value": "${JENKINS_SERVICE_NAME}"
                   },
@@ -261,6 +265,12 @@
       "displayName": "Enable OAuth in Jenkins",
       "description": "Whether to enable OAuth OpenShift integration. If false, the static account 'admin' will be initialized with the password 'password'.",
       "value": "true"
+    },
+    {
+      "name": "INSTALL_PLUGINS",
+      "displayName": "Additional Jenkins plugins to install",
+      "description": "Comma-separated list of additional plugins to install on startup. The format of each plugin spec is 'plugin-id:version'",
+      "value": ""
     },
     {
       "name": "MEMORY_LIMIT",

--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -140,6 +140,10 @@
                     "value": "true"
                   },
                   {
+                    "name": "INSTALL_PLUGINS",
+                    "value": "${INSTALL_PLUGINS}"
+                  },
+                  {
                     "name": "JENKINS_SERVICE_NAME",
                     "value": "${JENKINS_SERVICE_NAME}"
                   },
@@ -278,6 +282,12 @@
       "displayName": "Enable OAuth in Jenkins",
       "description": "Whether to enable OAuth OpenShift integration. If false, the static account 'admin' will be initialized with the password 'password'.",
       "value": "true"
+    },
+    {
+      "name": "INSTALL_PLUGINS",
+      "displayName": "Additional Jenkins plugins to install",
+      "description": "Comma-separated list of additional plugins to install on startup. The format of each plugin spec is 'plugin-id:version'",
+      "value": ""
     },
     {
       "name": "MEMORY_LIMIT",

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -4881,6 +4881,10 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
                     "value": "true"
                   },
                   {
+                    "name": "INSTALL_PLUGINS",
+                    "value": "${INSTALL_PLUGINS}"
+                  },
+                  {
                     "name": "JENKINS_SERVICE_NAME",
                     "value": "${JENKINS_SERVICE_NAME}"
                   },
@@ -5019,6 +5023,12 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "displayName": "Enable OAuth in Jenkins",
       "description": "Whether to enable OAuth OpenShift integration. If false, the static account 'admin' will be initialized with the password 'password'.",
       "value": "true"
+    },
+    {
+      "name": "INSTALL_PLUGINS",
+      "displayName": "Additional Jenkins plugins to install",
+      "description": "Comma-separated list of additional plugins to install on startup. The format of each plugin spec is 'plugin-id:version'",
+      "value": ""
     },
     {
       "name": "MEMORY_LIMIT",
@@ -5202,6 +5212,10 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
                     "value": "true"
                   },
                   {
+                    "name": "INSTALL_PLUGINS",
+                    "value": "${INSTALL_PLUGINS}"
+                  },
+                  {
                     "name": "JENKINS_SERVICE_NAME",
                     "value": "${JENKINS_SERVICE_NAME}"
                   },
@@ -5340,6 +5354,12 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "displayName": "Enable OAuth in Jenkins",
       "description": "Whether to enable OAuth OpenShift integration. If false, the static account 'admin' will be initialized with the password 'password'.",
       "value": "true"
+    },
+    {
+      "name": "INSTALL_PLUGINS",
+      "displayName": "Additional Jenkins plugins to install",
+      "description": "Comma-separated list of additional plugins to install on startup. The format of each plugin spec is 'plugin-id:version'",
+      "value": ""
     },
     {
       "name": "MEMORY_LIMIT",

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -25711,6 +25711,10 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
                     "value": "true"
                   },
                   {
+                    "name": "INSTALL_PLUGINS",
+                    "value": "${INSTALL_PLUGINS}"
+                  },
+                  {
                     "name": "JENKINS_SERVICE_NAME",
                     "value": "${JENKINS_SERVICE_NAME}"
                   },
@@ -25849,6 +25853,12 @@ var _examplesJenkinsJenkinsEphemeralTemplateJson = []byte(`{
       "displayName": "Enable OAuth in Jenkins",
       "description": "Whether to enable OAuth OpenShift integration. If false, the static account 'admin' will be initialized with the password 'password'.",
       "value": "true"
+    },
+    {
+      "name": "INSTALL_PLUGINS",
+      "displayName": "Additional Jenkins plugins to install",
+      "description": "Comma-separated list of additional plugins to install on startup. The format of each plugin spec is 'plugin-id:version'",
+      "value": ""
     },
     {
       "name": "MEMORY_LIMIT",
@@ -26032,6 +26042,10 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
                     "value": "true"
                   },
                   {
+                    "name": "INSTALL_PLUGINS",
+                    "value": "${INSTALL_PLUGINS}"
+                  },
+                  {
                     "name": "JENKINS_SERVICE_NAME",
                     "value": "${JENKINS_SERVICE_NAME}"
                   },
@@ -26170,6 +26184,12 @@ var _examplesJenkinsJenkinsPersistentTemplateJson = []byte(`{
       "displayName": "Enable OAuth in Jenkins",
       "description": "Whether to enable OAuth OpenShift integration. If false, the static account 'admin' will be initialized with the password 'password'.",
       "value": "true"
+    },
+    {
+      "name": "INSTALL_PLUGINS",
+      "displayName": "Additional Jenkins plugins to install",
+      "description": "Comma-separated list of additional plugins to install on startup. The format of each plugin spec is 'plugin-id:version'",
+      "value": ""
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
This will let you specify additional Jenkins plugins to install through the supported `INSTALL_PLUGINS` [environment variable](https://github.com/openshift/jenkins/blob/master/README.md#environment-variables).
```
$ oc env dc/jenkins --list
# deploymentconfigs jenkins, container jenkins
OPENSHIFT_ENABLE_OAUTH=true
OPENSHIFT_ENABLE_REDIRECT_PROMPT=true
KUBERNETES_MASTER=https://kubernetes.default:443
KUBERNETES_TRUST_CERTIFICATES=true
INSTALL_PLUGINS=cobertura:1.12
JENKINS_SERVICE_NAME=jenkins
JNLP_SERVICE_NAME=jenkins-jnlp
```
Might require a rebase after https://github.com/openshift/origin/pull/17813 is merged.