### PR TITLE
exempt default namespace from CRO

### DIFF
--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -80,7 +80,7 @@ func (r *REST) NewList() runtime.Object {
 var _ = rest.Creater(&REST{})
 
 var (
-	ForbiddenNames    = []string{"openshift", "kubernetes", "kube"}
+	ForbiddenNames    = []string{"openshift", "kubernetes", "kube", "default"}
 	ForbiddenPrefixes = []string{"openshift-", "kubernetes-", "kube-"}
 )
 


### PR DESCRIPTION
so the CRO doesn't apply to router and docker-registry

also removes `kubernetes` and `kube` from the `ForbiddenNames` like @smarterclayton wanted in https://github.com/openshift/origin/pull/16845/files#r144452808 since they are not reserved namespaces.

@smarterclayton @eparis @derekwaynecarr @portante 