### PR TITLE
Suppress sync errors in project authorization cache

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -21,6 +21,8 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+
+	"github.com/golang/glog"
 )
 
 // Lister enforces ability to enumerate a resource based on role
@@ -292,7 +294,7 @@ func (ac *AuthorizationCache) synchronizeNamespaces(userSubjectRecordStore cache
 			namespaceResourceVersion: namespace.ResourceVersion,
 		}
 		if err := ac.syncHandler(reviewRequest, userSubjectRecordStore, groupSubjectRecordStore, reviewRecordStore); err != nil {
-			utilruntime.HandleError(fmt.Errorf("error synchronizing: %v", err))
+			glog.V(5).Infof("project authorization cache: error synchronizing namespaces: %v", err)
 		}
 	}
 	return namespaceSet
@@ -311,7 +313,7 @@ func (ac *AuthorizationCache) synchronizePolicies(userSubjectRecordStore cache.S
 			roleUIDToResourceVersion: map[types.UID]string{role.UID: role.ResourceVersion},
 		}
 		if err := ac.syncHandler(reviewRequest, userSubjectRecordStore, groupSubjectRecordStore, reviewRecordStore); err != nil {
-			utilruntime.HandleError(fmt.Errorf("error synchronizing: %v", err))
+			glog.V(5).Infof("project authorization cache: error synchronizing roles: %v", err)
 		}
 	}
 }
@@ -329,7 +331,7 @@ func (ac *AuthorizationCache) synchronizeRoleBindings(userSubjectRecordStore cac
 			roleBindingUIDToResourceVersion: map[types.UID]string{roleBinding.UID: roleBinding.ResourceVersion},
 		}
 		if err := ac.syncHandler(reviewRequest, userSubjectRecordStore, groupSubjectRecordStore, reviewRecordStore); err != nil {
-			utilruntime.HandleError(fmt.Errorf("error synchronizing: %v", err))
+			glog.V(5).Infof("project authorization cache: error synchronizing role bindings: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
synchronizeRoleBindings is causing a lot of noise in the logs.  This change replaces HandleError with a conservative glog to avoid spam in the logs.

[Bug 1531938](https://bugzilla.redhat.com/show_bug.cgi?id=1531938)

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @eparis @deads2k @simo5

@eparis I would like to look at these logs when I return from PTO to make sure they are safe to ignore and not indicative of a larger problem.