### PR TITLE
Update gitignore for vendored build output files

### DIFF
--- a/cmd/cluster-capacity/.gitignore
+++ b/cmd/cluster-capacity/.gitignore
@@ -1,0 +1,1 @@
+/go/src/github.com/kubernetes-incubator/cluster-capacity/_output

--- a/cmd/service-catalog/.gitignore
+++ b/cmd/service-catalog/.gitignore
@@ -1,0 +1,1 @@
+/go/src/github.com/kubernetes-incubator/service-catalog/_output


### PR DESCRIPTION
Ignoring any directory named `_output` regardless of whether it occurs
at the project root will ignore build output from vendored projects and
is safe as no real project source will ever live under such a directory.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton @csrwng 