### PR TITLE
 run openshift and kube controllers on different leases

### DIFF
--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -391,10 +391,6 @@ func (m *Master) Start() error {
 		if err != nil {
 			return err
 		}
-		kubeControllerInformers, err := NewInformers(*m.config)
-		if err != nil {
-			return err
-		}
 
 		_, config, err := configapi.GetExternalKubeClient(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
 		if err != nil {
@@ -470,38 +466,42 @@ func (m *Master) Start() error {
 			glog.Fatalf("Controller graceful shutdown requested")
 		}()
 
+		go runEmbeddedScheduler(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.KubernetesMasterConfig.SchedulerConfigFile, m.config.KubernetesMasterConfig.SchedulerArguments)
+
+		kubeControllerInformers, err := NewInformers(*m.config)
+		if err != nil {
+			return err
+		}
+		go runEmbeddedKubeControllerManager(
+			m.config.MasterClients.OpenShiftLoopbackKubeConfig,
+			m.config.ServiceAccountConfig.PrivateKeyFile,
+			m.config.ServiceAccountConfig.MasterCA,
+			m.config.KubernetesMasterConfig.PodEvictionTimeout,
+			m.config.VolumeConfig.DynamicProvisioningEnabled,
+			m.config.KubernetesMasterConfig.ControllerArguments,
+			recyclerImage,
+			kubeControllerInformers)
+
 		go func() {
 			controllerPlug.WaitForStart()
 			if err := waitForHealthyAPIServer(kubeExternal.Discovery().RESTClient()); err != nil {
 				glog.Fatal(err)
 			}
 
-			// continuously run the scheduler while we have the primary lease
-			go runEmbeddedScheduler(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.KubernetesMasterConfig.SchedulerConfigFile, m.config.KubernetesMasterConfig.SchedulerArguments)
-
-			go runEmbeddedKubeControllerManager(
-				m.config.MasterClients.OpenShiftLoopbackKubeConfig,
-				m.config.ServiceAccountConfig.PrivateKeyFile,
-				m.config.ServiceAccountConfig.MasterCA,
-				m.config.KubernetesMasterConfig.PodEvictionTimeout,
-				m.config.VolumeConfig.DynamicProvisioningEnabled,
-				m.config.KubernetesMasterConfig.ControllerArguments,
-				recyclerImage,
-				kubeControllerInformers)
-
 			openshiftControllerOptions, err := getOpenshiftControllerOptions(m.config.KubernetesMasterConfig.ControllerArguments)
 			if err != nil {
 				glog.Fatal(err)
 			}
 
-			controllerContext := newControllerContext(openshiftControllerOptions, m.config.ControllerConfig.Controllers, privilegedLoopbackConfig, kubeExternal, openshiftControllerInformers, utilwait.NeverStop, make(chan struct{}))
+			stopCh := utilwait.NeverStop
+			informersStarted := make(chan struct{})
+			controllerContext := newControllerContext(openshiftControllerOptions, m.config.ControllerConfig.Controllers, privilegedLoopbackConfig, kubeExternal, openshiftControllerInformers, stopCh, informersStarted)
 			if err := startControllers(*m.config, allocationController, controllerContext); err != nil {
 				glog.Fatal(err)
 			}
 
-			openshiftControllerInformers.Start(utilwait.NeverStop)
-			close(controllerContext.InformersStarted)
-
+			openshiftControllerInformers.Start(stopCh)
+			close(informersStarted)
 		}()
 	}
 

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -157,11 +157,7 @@ func Run(s *options.CMServer) error {
 			glog.Fatalf("error starting controllers: %v", err)
 		}
 
-		if StartInformers == nil {
-			ctx.InformerFactory.Start(ctx.Stop)
-		} else {
-			StartInformers(ctx.Stop)
-		}
+		ctx.InformerFactory.Start(ctx.Stop)
 		close(ctx.InformersStarted)
 
 		select {}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
@@ -7,6 +7,3 @@ import (
 
 // This allows overriding from inside the same process.  It's not pretty, but its fairly easy to maintain because conflicts are small.
 var CreateControllerContext func(s *options.CMServer, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (ControllerContext, error) = createControllerContext
-
-// StartInformers allows overriding inside of the same process.
-var StartInformers func(stop <-chan struct{}) = nil


### PR DESCRIPTION
In 3.7, we started using secondary leases for the scheduler and the kube controllers.  In the 3.9 rebase, we separate informers.  This pull completes the leasing and running separation.

@smarterclayton @soltysh 
/assign @soltysh 