### PR TITLE
Never evict pods on dind nodes

### DIFF
--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -64,6 +64,8 @@ kubeletArguments:
   cgroups-per-qos: ["false"]
   enforce-node-allocatable: [""]
   fail-swap-on: ["false"]
+  eviction-soft: [""]
+  eviction-hard: [""]
 EOF
 
     if [[ "${OPENSHIFT_CONTAINER_RUNTIME}" != "dockershim" ]]; then


### PR DESCRIPTION
#15480 got closed, with the comment:

> So we don't need this anymore, it seems. Kube 1.8-something changed:
> 
>     -temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%"
>     +temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"
> 
> and no longer cares about how much imagefs is available.

But imagefs and nodefs are both the same filesystem on a dind node, so this is just changing things from "root partition must have at least 15% free" to "root partition must have at least 10% free" (which I guess was enough to put @dcbw on the happy side of the line, but not me).

The attached patch disables eviction completely, which is maybe too big a hammer? We could set a limit in terms of MB rather than %, but if we don't actually know what the provably correct lower limit is then it doesn't seem worth it to figure that out for something only used for dev/test environments anyway.

cc @knobunc 