### PR TITLE
OVS parsing improvements

### DIFF
--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -44,7 +44,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestEgressIP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}

--- a/pkg/network/node/metrics.go
+++ b/pkg/network/node/metrics.go
@@ -123,7 +123,7 @@ func gatherPeriodicMetrics(ovs ovs.Interface) {
 }
 
 func updateOVSMetrics(ovs ovs.Interface) {
-	flows, err := ovs.DumpFlows()
+	flows, err := ovs.DumpFlows("")
 	if err == nil {
 		OVSFlows.Set(float64(len(flows)))
 	} else {

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -25,7 +25,7 @@ func setupOVSController(t *testing.T) (ovs.Interface, *ovsController, []string) 
 		t.Fatalf("Unexpected error setting up OVS: %v", err)
 	}
 
-	origFlows, err := ovsif.DumpFlows()
+	origFlows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestOVSHostSubnet(t *testing.T) {
 		t.Fatalf("Unexpected error adding HostSubnet rules: %v", err)
 	}
 
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestOVSHostSubnet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error deleting HostSubnet rules: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestOVSService(t *testing.T) {
 		t.Fatalf("Unexpected error adding service rules: %v", err)
 	}
 
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestOVSService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error deleting service rules: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestOVSPod(t *testing.T) {
 		t.Fatalf("Unexpected error adding pod rules: %v", err)
 	}
 
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestOVSPod(t *testing.T) {
 		t.Fatalf("Unexpected error adding pod rules: %v", err)
 	}
 
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestOVSPod(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error deleting pod rules: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -378,7 +378,7 @@ func TestOVSMulticast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestOVSMulticast(t *testing.T) {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}
 	lastFlows := flows
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestOVSMulticast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestOVSMulticast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -451,7 +451,7 @@ func TestOVSMulticast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -475,7 +475,7 @@ func TestOVSMulticast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -615,7 +615,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -639,7 +639,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -667,7 +667,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -695,7 +695,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -719,7 +719,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -743,7 +743,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -769,7 +769,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpected lack of error updating egress network policy")
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -793,7 +793,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpected lack of error updating egress network policy")
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -821,7 +821,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpected lack of error updating egress network policy")
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}
@@ -881,7 +881,7 @@ func TestOVSEgressNetworkPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error updating egress network policy: %v", err)
 	}
-	flows, err = ovsif.DumpFlows()
+	flows, err = ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error dumping flows: %v", err)
 	}

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -321,8 +321,6 @@ func TestOVSPod(t *testing.T) {
 func TestGetPodDetails(t *testing.T) {
 	type testcase struct {
 		sandboxID string
-		flows     []string
-		ofport    int
 		ip        string
 		mac       string
 		note      string
@@ -332,71 +330,20 @@ func TestGetPodDetails(t *testing.T) {
 	testcases := []testcase{
 		{
 			sandboxID: sandboxID,
-			flows: []string{
-				"cookie=0x0, duration=12.243s, table=0, n_packets=0, n_bytes=0, priority=250,ip,in_port=2,nw_dst=224.0.0.0/4 actions=drop",
-				"cookie=0x0, duration=12.258s, table=0, n_packets=0, n_bytes=0, priority=200,arp,in_port=1,arp_spa=10.128.0.0/14,arp_tpa=10.130.0.0/23 actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-				"cookie=0x0, duration=12.255s, table=0, n_packets=0, n_bytes=0, priority=200,ip,in_port=1,nw_src=10.128.0.0/14,nw_dst=10.130.0.0/23 actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-				"cookie=0x0, duration=12.252s, table=0, n_packets=0, n_bytes=0, priority=200,ip,in_port=1,nw_src=10.128.0.0/14,nw_dst=224.0.0.0/4 actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10",
-				"cookie=0x0, duration=12.237s, table=0, n_packets=0, n_bytes=0, priority=200,arp,in_port=2,arp_spa=10.130.0.1,arp_tpa=10.128.0.0/14 actions=goto_table:30",
-				"cookie=0x0, duration=12.234s, table=0, n_packets=0, n_bytes=0, priority=200,ip,in_port=2 actions=goto_table:30",
-				"cookie=0x0, duration=12.248s, table=0, n_packets=0, n_bytes=0, priority=150,in_port=1 actions=drop",
-				"cookie=0x0, duration=12.230s, table=0, n_packets=7, n_bytes=586, priority=150,in_port=2 actions=drop",
-				"cookie=0x0, duration=12.222s, table=0, n_packets=0, n_bytes=0, priority=100,arp actions=goto_table:20",
-				"cookie=0x0, duration=12.218s, table=0, n_packets=0, n_bytes=0, priority=100,ip actions=goto_table:20",
-				"cookie=0x0, duration=12.215s, table=0, n_packets=5, n_bytes=426, priority=0 actions=drop",
-				"cookie=0x0, duration=12.063s, table=10, n_packets=0, n_bytes=0, priority=100,tun_src=172.17.0.3 actions=goto_table:30",
-				"cookie=0x0, duration=12.041s, table=10, n_packets=0, n_bytes=0, priority=100,tun_src=172.17.0.4 actions=goto_table:30",
-				"cookie=0x0, duration=12.211s, table=10, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=3.202s, table=20, n_packets=0, n_bytes=0, priority=100,arp,in_port=3,arp_spa=10.130.0.2,arp_sha=4a:77:32:e4:ab:9d actions=load:0->NXM_NX_REG0[],note:bc.b5.d8.d2.87.fc.f9.74.58.c4.8a.d6.43.b1.01.07.9e.3b.c2.65.a9.4e.09.7e.74.07.44.07.16.11.2f.69.00.00.00.00.00.00,goto_table:21",
-				"cookie=0x0, duration=3.197s, table=20, n_packets=0, n_bytes=0, priority=100,ip,in_port=3,nw_src=10.130.0.2 actions=load:0->NXM_NX_REG0[],goto_table:21",
-				"cookie=0x0, duration=12.205s, table=20, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.201s, table=21, n_packets=0, n_bytes=0, priority=0 actions=goto_table:30",
-				"cookie=0x0, duration=12.196s, table=30, n_packets=0, n_bytes=0, priority=300,arp,arp_tpa=10.130.0.1 actions=output:2",
-				"cookie=0x0, duration=12.182s, table=30, n_packets=0, n_bytes=0, priority=300,ip,nw_dst=10.130.0.1 actions=output:2",
-				"cookie=0x0, duration=12.190s, table=30, n_packets=0, n_bytes=0, priority=200,arp,arp_tpa=10.130.0.0/23 actions=goto_table:40",
-				"cookie=0x0, duration=12.173s, table=30, n_packets=0, n_bytes=0, priority=200,ip,nw_dst=10.130.0.0/23 actions=goto_table:70",
-				"cookie=0x0, duration=12.186s, table=30, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.128.0.0/14 actions=goto_table:50",
-				"cookie=0x0, duration=12.169s, table=30, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.128.0.0/14 actions=goto_table:90",
-				"cookie=0x0, duration=12.178s, table=30, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=172.30.0.0/16 actions=goto_table:60",
-				"cookie=0x0, duration=12.165s, table=30, n_packets=0, n_bytes=0, priority=50,ip,in_port=1,nw_dst=224.0.0.0/4 actions=goto_table:120",
-				"cookie=0x0, duration=12.160s, table=30, n_packets=0, n_bytes=0, priority=25,ip,nw_dst=224.0.0.0/4 actions=goto_table:110",
-				"cookie=0x0, duration=12.154s, table=30, n_packets=0, n_bytes=0, priority=0,ip actions=goto_table:100",
-				"cookie=0x0, duration=12.150s, table=30, n_packets=0, n_bytes=0, priority=0,arp actions=drop",
-				"cookie=0x0, duration=3.190s, table=40, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.130.0.2 actions=output:3",
-				"cookie=0x0, duration=12.147s, table=40, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.058s, table=50, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.128.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.3->tun_dst,output:1",
-				"cookie=0x0, duration=12.037s, table=50, n_packets=0, n_bytes=0, priority=100,arp,arp_tpa=10.129.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.4->tun_dst,output:1",
-				"cookie=0x0, duration=12.143s, table=50, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.139s, table=60, n_packets=0, n_bytes=0, priority=200,reg0=0 actions=output:2",
-				"cookie=0x0, duration=11.938s, table=60, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=172.30.0.1,nw_frag=later actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
-				"cookie=0x0, duration=11.929s, table=60, n_packets=0, n_bytes=0, priority=100,tcp,nw_dst=172.30.0.1,tp_dst=443 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
-				"cookie=0x0, duration=11.926s, table=60, n_packets=0, n_bytes=0, priority=100,udp,nw_dst=172.30.0.1,tp_dst=53 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
-				"cookie=0x0, duration=11.922s, table=60, n_packets=0, n_bytes=0, priority=100,tcp,nw_dst=172.30.0.1,tp_dst=53 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
-				"cookie=0x0, duration=12.136s, table=60, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=3.179s, table=70, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.130.0.2 actions=load:0->NXM_NX_REG1[],load:0x3->NXM_NX_REG2[],goto_table:80",
-				"cookie=0x0, duration=12.133s, table=70, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.129s, table=80, n_packets=0, n_bytes=0, priority=300,ip,nw_src=10.130.0.1 actions=output:NXM_NX_REG2[]",
-				"cookie=0x0, duration=12.062s, table=80, n_packets=0, n_bytes=0, priority=200,reg0=0 actions=output:NXM_NX_REG2[]",
-				"cookie=0x0, duration=12.055s, table=80, n_packets=0, n_bytes=0, priority=200,reg1=0 actions=output:NXM_NX_REG2[]",
-				"cookie=0x0, duration=12.124s, table=80, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.053s, table=90, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.128.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.3->tun_dst,output:1",
-				"cookie=0x0, duration=12.030s, table=90, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=10.129.0.0/23 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.4->tun_dst,output:1",
-				"cookie=0x0, duration=12.120s, table=90, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.116s, table=100, n_packets=0, n_bytes=0, priority=0 actions=output:2",
-				"cookie=0x0, duration=12.112s, table=110, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.024s, table=111, n_packets=0, n_bytes=0, priority=100 actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:172.17.0.3->tun_dst,output:1,set_field:172.17.0.4->tun_dst,output:1,goto_table:120",
-				"cookie=0x0, duration=12.105s, table=120, n_packets=0, n_bytes=0, priority=0 actions=drop",
-				"cookie=0x0, duration=12.101s, table=253, n_packets=0, n_bytes=0, actions=note:01.03.00.00.00.00",
-			},
-			ofport: 3,
-			ip:     "10.130.0.2",
-			mac:    "4a:77:32:e4:ab:9d",
-			note:   sandboxNote,
+			ip:        "10.130.0.2",
+			mac:       "4a:77:32:e4:ab:9d",
+			note:      sandboxNote,
 		},
 	}
 
 	for _, tc := range testcases {
-		ofport, ip, mac, note, err := getPodDetailsBySandboxID(tc.flows, tc.sandboxID)
+		_, oc, _ := setupOVSController(t)
+		tcOFPort, err := oc.SetUpPod("veth1", tc.ip, tc.mac, tc.sandboxID, 42)
+		if err != nil {
+			t.Fatalf("Unexpected error adding pod rules: %v", err)
+		}
+
+		ofport, ip, mac, note, err := oc.getPodDetailsBySandboxID(tc.sandboxID)
 		if err != nil {
 			if tc.errStr != "" {
 				if !strings.Contains(err.Error(), tc.errStr) {
@@ -408,8 +355,8 @@ func TestGetPodDetails(t *testing.T) {
 		} else if tc.errStr != "" {
 			t.Fatalf("expected error %q", tc.errStr)
 		}
-		if ofport != tc.ofport {
-			t.Fatalf("unexpected ofport %d (expected %d)", ofport, tc.ofport)
+		if ofport != tcOFPort {
+			t.Fatalf("unexpected ofport %d (expected %d)", ofport, tcOFPort)
 		}
 		if ip != tc.ip {
 			t.Fatalf("unexpected ip %q (expected %q)", ip, tc.ip)

--- a/pkg/util/ovs/fake_ovs.go
+++ b/pkg/util/ovs/fake_ovs.go
@@ -169,7 +169,7 @@ func (tx *ovsFakeTx) AddFlow(flow string, args ...interface{}) {
 
 	// If there is already an exact match for this flow, then the new flow replaces it.
 	for i := range tx.fake.flows {
-		if FlowMatches(&tx.fake.flows[i], parsed, true) {
+		if FlowMatches(&tx.fake.flows[i], parsed) {
 			tx.fake.flows[i] = *parsed
 			return
 		}
@@ -183,7 +183,7 @@ func (tx *ovsFakeTx) DeleteFlows(flow string, args ...interface{}) {
 	if tx.err != nil {
 		return
 	}
-	parsed, err := ParseFlow(ParseForDelete, flow, args...)
+	parsed, err := ParseFlow(ParseForFilter, flow, args...)
 	if err != nil {
 		tx.err = err
 		return
@@ -192,7 +192,7 @@ func (tx *ovsFakeTx) DeleteFlows(flow string, args ...interface{}) {
 
 	newFlows := make([]OvsFlow, 0, len(tx.fake.flows))
 	for _, flow := range tx.fake.flows {
-		if !FlowMatches(&flow, parsed, false) {
+		if !FlowMatches(&flow, parsed) {
 			newFlows = append(newFlows, flow)
 		}
 	}

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -63,8 +63,8 @@ type Interface interface {
 	Clear(table, record string, columns ...string) error
 
 	// DumpFlows dumps the flow table for the bridge and returns it as an array of
-	// strings, one per flow.
-	DumpFlows() ([]string, error)
+	// strings, one per flow. If flow is not "" then it describes the flows to dump.
+	DumpFlows(flow string, args ...interface{}) ([]string, error)
 
 	// NewTransaction begins a new OVS transaction. If an error occurs at
 	// any step in the transaction, it will be recorded until
@@ -287,8 +287,11 @@ func (tx *ovsExecTx) EndTransaction() error {
 	return err
 }
 
-func (ovsif *ovsExec) DumpFlows() ([]string, error) {
-	out, err := ovsif.exec(OVS_OFCTL, "dump-flows", ovsif.bridge)
+func (ovsif *ovsExec) DumpFlows(flow string, args ...interface{}) ([]string, error) {
+	if len(args) > 0 {
+		flow = fmt.Sprintf(flow, args...)
+	}
+	out, err := ovsif.exec(OVS_OFCTL, "dump-flows", ovsif.bridge, flow)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/ovs/ovs_test.go
+++ b/pkg/util/ovs/ovs_test.go
@@ -94,7 +94,7 @@ func TestTransactionFailure(t *testing.T) {
 
 func TestDumpFlows(t *testing.T) {
 	fexec := normalSetup()
-	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 dump-flows br0", `OFPST_FLOW reply (OF1.3) (xid=0x2):
+	addTestResult(t, fexec, "ovs-ofctl -O OpenFlow13 dump-flows br0 ", `OFPST_FLOW reply (OF1.3) (xid=0x2):
  cookie=0x0, duration=13271.779s, table=0, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=192.168.1.0/24 actions=set_field:0a:7b:e6:19:11:cf->eth_dst,output:2
  cookie=0x0, duration=13271.776s, table=0, n_packets=1, n_bytes=42, priority=100,arp,arp_tpa=192.168.1.0/24 actions=set_field:10.19.17.34->tun_dst,output:1
  cookie=0x3, duration=13267.277s, table=0, n_packets=788539827, n_bytes=506520926762, priority=100,ip,nw_dst=192.168.2.2 actions=output:3
@@ -108,7 +108,7 @@ func TestDumpFlows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error from ovs.New(): %v", err)
 	}
-	flows, err := ovsif.DumpFlows()
+	flows, err := ovsif.DumpFlows("")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/util/ovs/parse_test.go
+++ b/pkg/util/ovs/parse_test.go
@@ -93,7 +93,7 @@ func TestParseFlows(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error from ParseFlow: %v", err)
 		}
-		if !FlowMatches(parsed, &test.match, true) {
+		if !FlowMatches(parsed, &test.match) {
 			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
 		}
 	}
@@ -120,7 +120,7 @@ func TestParseFlowsDefaults(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error from ParseFlow: %v", err)
 		}
-		if !FlowMatches(parsed, &test.match, true) {
+		if !FlowMatches(parsed, &test.match) {
 			t.Fatalf("parsed flow %d (%#v) does not match expected output (%#v)", i, parsed, &test.match)
 		}
 	}
@@ -286,7 +286,7 @@ func TestFlowMatchesBad(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error from ParseFlow: %v", err)
 		}
-		if FlowMatches(parsed, &test.match, false) {
+		if FlowMatches(parsed, &test.match) {
 			t.Fatalf("parsed flow %d (%#v) unexpectedly matches output (%#v)", i, parsed, &test.match)
 		}
 	}


### PR DESCRIPTION
The more-complicated version of #17313. This takes advantage of the fact that "ovs-ofctl dump-flows" lets you pass a filter, so rather than getting back the whole list of flows and parsing each one, we can just ask for a much smaller set of flows to begin with.

In particular:
- in AlreadySetUp() we can `DumpFlows("table=%d", ruleVersionTable)` and get back only the single flow we're looking for
- in getPodDetailsBySandboxID(), we can `DumpFlows("table=20,arp")` and only get back the flows that *might* be the one we're looking for. (You can't match on the `actions` field, so there's no way to request only the flow that has the specific `note` that we're looking for. We *could* store the first 4 bytes of the sandbox ID in the cookie and then add that to the filter, I guess, but this code doesn't get run much anyway...)