### PR TITLE
Adding synchronization and other features to extended test cluster loader.

### DIFF
--- a/test/extended/cluster/context.go
+++ b/test/extended/cluster/context.go
@@ -13,17 +13,20 @@ type ContextType struct {
 	ClusterLoader struct {
 		Cleanup    bool
 		Projects   []ClusterLoaderType
+		Sync       SyncObjectType
 		TuningSets []TuningSetType
 	}
 }
 
 // ClusterLoaderType struct only used for Cluster Loader test config
 type ClusterLoaderType struct {
-	Number    int `mapstructure:"num"`
-	Basename  string
-	Tuning    string
-	Pods      []ClusterLoaderObjectType
-	Templates []ClusterLoaderObjectType
+	Number     int `mapstructure:"num"`
+	Basename   string
+	Tuning     string
+	Configmaps map[string]interface{}
+	Secrets    map[string]interface{}
+	Pods       []ClusterLoaderObjectType
+	Templates  []ClusterLoaderObjectType
 }
 
 // ClusterLoaderObjectType is nested object type for cluster loader struct
@@ -33,7 +36,20 @@ type ClusterLoaderObjectType struct {
 	Image      string
 	Basename   string
 	File       string
+	Sync       SyncObjectType
 	Parameters map[string]interface{}
+}
+
+// SyncObjectType is nested object type for cluster loader synchronisation functionality
+type SyncObjectType struct {
+	Server struct {
+		Enabled bool
+		Port    int
+	}
+	Running   bool
+	Succeeded bool
+	Selectors map[string]string
+	Timeout   string
 }
 
 // TuningSetType is nested type for controlling Cluster Loader deployment pattern


### PR DESCRIPTION
Fixes:
- number of templates no longer ignored
- tuningsets no longer ignored for templates
- maxRetries reflected the number of all tries, not retries

New features:
- label-based pod post deployment synchronization at pod, template
  or global level
- creation of config maps and secrets from files
- support for getting parameter values from the environment