### PR TITLE
Fix a race condition in the multicast test

### DIFF
--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -156,7 +156,7 @@ func launchTestMulticastPod(f *e2e.Framework, nodeName string, podName string) (
 	podIP := ""
 	err = waitForPodCondition(f.ClientSet, f.Namespace.Name, podName, "running", podStartTimeout, func(pod *kapiv1.Pod) (bool, error) {
 		podIP = pod.Status.PodIP
-		return podIP != "", nil
+		return (podIP != "" && pod.Status.Phase != kapiv1.PodPending), nil
 	})
 	return podIP, err
 }


### PR DESCRIPTION
We wait for each test pod to get assigned an IP, but given bad timing, we could potentially reach the "oc exec" part of the test before the non-infra container in a pod is running.

Seen in https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/test_branch_origin_extended_networking/1362/