### PR TITLE
dind: Create certs for additional network interface

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -125,6 +125,7 @@ function start() {
 
   if [[ -n "${ADDITIONAL_NETWORK_INTERFACE}" ]]; then
     add-network-interface-to-nodes
+    update-node-config
   fi
 
   local rc_file="dind-${cluster_id}.rc"
@@ -193,6 +194,22 @@ function add-network-interface-to-nodes () {
     (( bridge_num += 1 ))
     (( ipam_num += 1 ))
   done
+}
+
+function update-node-config() {
+  local config_path="/data/openshift.local.config"
+  local host="$(hostname)"
+  local node_config_path="${config_path}/node-${host}"
+  local node_config_file="${node_config_path}/node-config.yaml"
+
+  # Remove node config file to trigger node config regeneration
+  #
+  # openshift-generate-node-config.sh script repopulates node config
+  # with certs for both eth0 and eth1 IP addrs.
+  #
+  # openshift-node service executes openshift-generate-node-config.sh
+  # as pre start hook.
+  rm -f "${node_config_file}"
 }
 
 function add-node () {

--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -17,19 +17,33 @@ function ensure-master-config() {
     return
   fi
 
-  local ip_addr
-  ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
   local name
   name="$(hostname)"
+
+  local ip_addr1
+  ip_addr1="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+
+  local ip_addr2
+  ip_addr2="$(ip addr | grep inet | (grep eth1 || true) | awk '{print $2}' | sed -e 's+/.*++')"
+
+  local ip_addrs
+  local serving_ip_addr
+  if [[ -n "${ip_addr2}" ]]; then
+    ip_addrs="${ip_addr1},${ip_addr2}"
+    serving_ip_addr="${ip_addr2}"
+  else
+    ip_addrs="${ip_addr1}"
+    serving_ip_addr="${ip_addr1}"
+  fi
 
   /usr/local/bin/oc adm ca create-master-certs \
     --overwrite=false \
     --cert-dir="${master_path}" \
-    --master="https://${ip_addr}:8443" \
-    --hostnames="${ip_addr},${name}"
+    --master="https://${serving_ip_addr}:8443" \
+    --hostnames="${ip_addrs},${name}"
 
   /usr/local/bin/openshift start master --write-config="${master_path}" \
-    --master="https://${ip_addr}:8443" \
+    --master="https://${serving_ip_addr}:8443" \
     --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
     ${OPENSHIFT_ADDITIONAL_ARGS}
 

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -38,8 +38,18 @@ function ensure-node-config() {
     local master_host
     master_host="$(grep server "${master_config_file}" | grep -v localhost | awk '{print $2}')"
 
-    local ip_addr
-    ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+    local ip_addr1
+    ip_addr1="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+
+    local ip_addr2
+    ip_addr2="$(ip addr | grep inet | (grep eth1 || true) | awk '{print $2}' | sed -e 's+/.*++')"
+
+    local ip_addrs
+    if [[ -n "${ip_addr2}" ]]; then
+      ip_addrs="${ip_addr1},${ip_addr2}"
+    else
+      ip_addrs="${ip_addr1}"
+    fi
 
     # Hold a lock on the shared volume to ensure cert generation is
     # performed serially.  Cert generation is not compatible with
@@ -50,7 +60,7 @@ function ensure-node-config() {
        --node-dir="${node_config_path}" \
        --node="${host}" \
        --master="${master_host}" \
-       --hostnames="${host},${ip_addr}" \
+       --hostnames="${host},${ip_addrs}" \
        --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
        --node-client-certificate-authority="${master_config_path}/ca.crt" \
        --certificate-authority="${master_config_path}/ca.crt" \


### PR DESCRIPTION
- This enables openshift master to communicate with openshift node
through node's eth0 or eth1 interface (additional network interface on the node)
- Regenerate certs for both eth0 and eth1 interfaces on the master.
  This will enable nodes to communicate with master on any interface.
- Previous implementation has single bridge per node to support additional
interface but that requires creating veth pair between the bridges for
node to master communication. To simplify this, only one additional bridge
is created for the cluster and all the additional interfaces on nodes and
master are linked to this bridge.  