### PR TITLE
Fix panic in extended deployment test

### DIFF
--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -24,13 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kapiv1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	appsapiv1 "github.com/openshift/api/apps/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
-	appsconversionsv1 "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 	appstypedclientset "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -200,7 +199,7 @@ func deploymentReachedCompletion(dc *appsapi.DeploymentConfig, rcs []*corev1.Rep
 	}
 	rcv1 := rcs[len(rcs)-1]
 	rc := &kapi.ReplicationController{}
-	kapiv1.Convert_v1_ReplicationController_To_core_ReplicationController(rcv1, rc, nil)
+	legacyscheme.Scheme.Convert(rcv1, rc, nil)
 	version := appsutil.DeploymentVersionFor(rc)
 	if version != dc.Status.LatestVersion {
 		return false, nil
@@ -234,7 +233,7 @@ func deploymentFailed(dc *appsapi.DeploymentConfig, rcs []*corev1.ReplicationCon
 	}
 	rcv1 := rcs[len(rcs)-1]
 	rc := &kapi.ReplicationController{}
-	kapiv1.Convert_v1_ReplicationController_To_core_ReplicationController(rcv1, rc, nil)
+	legacyscheme.Scheme.Convert(rcv1, rc, nil)
 	version := appsutil.DeploymentVersionFor(rc)
 	if version != dc.Status.LatestVersion {
 		return false, nil
@@ -252,7 +251,7 @@ func deploymentRunning(dc *appsapi.DeploymentConfig, rcs []*corev1.ReplicationCo
 	}
 	rcv1 := rcs[len(rcs)-1]
 	rc := &kapi.ReplicationController{}
-	kapiv1.Convert_v1_ReplicationController_To_core_ReplicationController(rcv1, rc, nil)
+	legacyscheme.Scheme.Convert(rcv1, rc, nil)
 	version := appsutil.DeploymentVersionFor(rc)
 	if version != dc.Status.LatestVersion {
 		//e2e.Logf("deployment %s is not the latest version on DC: %d", rc.Name, version)
@@ -634,7 +633,7 @@ func readDCFixture(path string) (*appsapi.DeploymentConfig, error) {
 	}
 
 	dc := new(appsapi.DeploymentConfig)
-	err = appsconversionsv1.Convert_v1_DeploymentConfig_To_apps_DeploymentConfig(dcv1, dc, nil)
+	err = legacyscheme.Scheme.Convert(dcv1, dc, nil)
 	return dc, err
 }
 


### PR DESCRIPTION
Fixes https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/17539/test_pull_request_origin_extended_conformance_gce/13371/?log#log

```
 Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /usr/local/go/src/runtime/panic.go:491

    Full Stack Trace
    	/usr/local/go/src/runtime/panic.go:491 +0x283
    github.com/openshift/origin/pkg/apps/apis/apps/v1.Convert_v1_DeploymentTriggerImageChangeParams_To_apps_DeploymentTriggerImageChangeParams(0xc42118cf00, 0xc42118d180, 0x0, 0x0, 0x7f31c61e36c8, 0x0)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/conversion.go:16 +0x26
    github.com/openshift/origin/pkg/apps/apis/apps/v1.autoConvert_v1_DeploymentTriggerPolicy_To_apps_DeploymentTriggerPolicy(0xc421374960, 0xc4205f5d40, 0x0, 0x0, 0x1, 0xc4205f5d40)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/zz_generated.conversion.go:709 +0xff
    github.com/openshift/origin/pkg/apps/apis/apps/v1.Convert_v1_DeploymentTriggerPolicy_To_apps_DeploymentTriggerPolicy(0xc421374960, 0xc4205f5d40, 0x0, 0x0, 0x1, 0x1)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/zz_generated.conversion.go:720 +0x49
    github.com/openshift/origin/pkg/apps/apis/apps/v1.autoConvert_v1_DeploymentConfigSpec_To_apps_DeploymentConfigSpec(0xc421883308, 0xc421883508, 0x0, 0x0, 0x1e8, 0xc421883400)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/zz_generated.conversion.go:355 +0x366
    github.com/openshift/origin/pkg/apps/apis/apps/v1.Convert_v1_DeploymentConfigSpec_To_apps_DeploymentConfigSpec(0xc421883308, 0xc421883508, 0x0, 0x0, 0x0, 0x0)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/zz_generated.conversion.go:381 +0x49
    github.com/openshift/origin/pkg/apps/apis/apps/v1.autoConvert_v1_DeploymentConfig_To_apps_DeploymentConfig(0xc421883200, 0xc421883400, 0x0, 0x0, 0xc421883201, 0xc421883400)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/zz_generated.conversion.go:212 +0x98
    github.com/openshift/origin/pkg/apps/apis/apps/v1.Convert_v1_DeploymentConfig_To_apps_DeploymentConfig(0xc421883200, 0xc421883400, 0x0, 0x0, 0xc421883200, 0x0)
    	/tmp/openshift/build-rpms/rpm/BUILD/origin-3.9.0/_output/local/go/src/github.com/openshift/origin/pkg/apps/apis/apps/v1/zz_generated.conversion.go:223 +0x49
    github.com/openshift/origin/test/extended/deployments.readDCFixture(0xc4200dd140, 0x5d, 0x0, 0x0, 0x0)
    	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/deployments/util.go:637 +0x126
    github.com/openshift/origin/test/extended/deployments.glob..func1.24.3()
    	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/deployments/deployments.go:1384 +0xfb
    github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc4210f14a0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/test.go:160 +0x40c
    github.com/openshift/origin/test/extended.TestExtended(0xc420768870)
    	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/extended_test.go:34 +0x40
    testing.tRunner(0xc420768870, 0x42227e0)
    	/usr/local/go/src/testing/testing.go:746 +0xd0
    created by testing.(*T).Run
    	/usr/local/go/src/testing/testing.go:789 +0x2de
    
```