### PR TITLE
handle non generic printer panic

### DIFF
--- a/pkg/cmd/cli/describe/printer.go
+++ b/pkg/cmd/cli/describe/printer.go
@@ -75,6 +75,11 @@ var (
 	securityContextConstraintsColumns = []string{"NAME", "PRIV", "CAPS", "SELINUX", "RUNASUSER", "FSGROUP", "SUPGROUP", "PRIORITY", "READONLYROOTFS", "VOLUMES"}
 )
 
+func init() {
+	// TODO this should be eliminated
+	kprinters.NewHumanReadablePrinterFn = NewHumanReadablePrinter
+}
+
 // NewHumanReadablePrinter returns a new HumanReadablePrinter
 func NewHumanReadablePrinter(encoder runtime.Encoder, decoder runtime.Decoder, printOptions kprinters.PrintOptions) *kprinters.HumanReadablePrinter {
 	// TODO: support cross namespace listing

--- a/pkg/cmd/experimental/config/patch.go
+++ b/pkg/cmd/experimental/config/patch.go
@@ -88,7 +88,12 @@ func (o *PatchOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 	var err error
 	mapper, typer := f.Object()
 	decoders := []runtime.Decoder{f.Decoder(true), unstructured.UnstructuredJSONScheme}
-	o.Printer, _, err = kprinters.GetStandardPrinter("yaml", "", false, false, mapper, typer, decoders)
+	o.Printer, _, err = kprinters.GetStandardPrinter(
+		"yaml",
+		"",
+		false,
+		false,
+		mapper, typer, nil, decoders, kprinters.PrintOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util/gendocs/gendocs.go
+++ b/pkg/cmd/util/gendocs/gendocs.go
@@ -43,7 +43,7 @@ func GenDocs(cmd *cobra.Command, filename string) error {
 		items = append(items, example)
 	}
 
-	printer, _, err := printers.GetStandardPrinter("template", string(template), false, false, nil, nil, nil)
+	printer, _, err := printers.GetStandardPrinter("template", string(template), false, false, nil, nil, nil, nil, printers.PrintOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -253,7 +253,7 @@ echo "admin-reconcile-cluster-role-bindings: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/admin/role-reapers"
-os::cmd::expect_success "oc process -f test/extended/testdata/roles/policy-roles.yaml -v NAMESPACE='${project}' | oc create -f -"
+os::cmd::expect_success "oc process -f test/extended/testdata/roles/policy-roles.yaml -p NAMESPACE='${project}' | oc create -f -"
 os::cmd::expect_success "oc get rolebinding/basic-users"
 os::cmd::expect_success "oc delete role/basic-user"
 os::cmd::expect_failure "oc get rolebinding/basic-users"

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/config/view.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/config/view.go
@@ -81,7 +81,7 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 				cmd.Flags().Set("output", defaultOutputFormat)
 			}
 
-			printer, _, err := cmdutil.PrinterForCommand(cmd, meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, []runtime.Decoder{latest.Codec})
+			printer, _, err := cmdutil.PrinterForCommand(cmd, meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, nil, []runtime.Decoder{latest.Codec})
 			cmdutil.CheckErr(err)
 			printer = printers.NewVersionedPrinter(printer, latest.Scheme, latest.ExternalVersion)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_builder.go
@@ -49,7 +49,7 @@ func (f *ring2Factory) PrinterForCommand(cmd *cobra.Command) (printers.ResourceP
 	mapper, typer := f.objectMappingFactory.Object()
 	// TODO: used by the custom column implementation and the name implementation, break this dependency
 	decoders := []runtime.Decoder{f.clientAccessFactory.Decoder(true), unstructured.UnstructuredJSONScheme}
-	return PrinterForCommand(cmd, mapper, typer, decoders)
+	return PrinterForCommand(cmd, mapper, typer, f.clientAccessFactory.JSONEncoder(), decoders)
 }
 
 func (f *ring2Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (printers.ResourcePrinter, error) {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
@@ -107,7 +107,7 @@ func ValidateOutputArgs(cmd *cobra.Command) error {
 
 // PrinterForCommand returns the default printer for this command.
 // Requires that printer flags have been added to cmd (see AddPrinterFlags).
-func PrinterForCommand(cmd *cobra.Command, mapper meta.RESTMapper, typer runtime.ObjectTyper, decoders []runtime.Decoder) (printers.ResourcePrinter, bool, error) {
+func PrinterForCommand(cmd *cobra.Command, mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder) (printers.ResourcePrinter, bool, error) {
 	outputFormat := GetFlagString(cmd, "output")
 
 	// templates are logically optional for specifying a format.
@@ -139,7 +139,7 @@ func PrinterForCommand(cmd *cobra.Command, mapper meta.RESTMapper, typer runtime
 	}
 	printer, generic, err := printers.GetStandardPrinter(
 		outputFormat, templateFile, noHeaders, allowMissingTemplateKeys,
-		mapper, typer, decoders,
+		mapper, typer, encoder, decoders, printers.PrintOptions{},
 	)
 	if err != nil {
 		return nil, generic, err

--- a/vendor/k8s.io/kubernetes/pkg/printers/internalversion/printers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/internalversion/printers_test.go
@@ -81,7 +81,7 @@ func TestVersionedPrinter(t *testing.T) {
 }
 
 func TestPrintDefault(t *testing.T) {
-	printer, found, err := printers.GetStandardPrinter("", "", false, false, nil, nil, nil)
+	printer, found, err := printers.GetStandardPrinter("", "", false, false, nil, nil, api.Codecs.LegacyCodec(api.Registry.EnabledVersions()...), []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme}, printers.PrintOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %#v", err)
 	}
@@ -136,7 +136,7 @@ func TestPrinter(t *testing.T) {
 	}
 	for _, test := range printerTests {
 		buf := bytes.NewBuffer([]byte{})
-		printer, generic, err := printers.GetStandardPrinter(test.Format, test.FormatArgument, false, true, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme})
+		printer, generic, err := printers.GetStandardPrinter(test.Format, test.FormatArgument, false, true, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, nil, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme}, printers.PrintOptions{})
 		if err != nil {
 			t.Errorf("in %s, unexpected error: %#v", test.Name, err)
 		}
@@ -166,7 +166,7 @@ func TestBadPrinter(t *testing.T) {
 		{"bad jsonpath", "jsonpath", "{.Name", fmt.Errorf("error parsing jsonpath {.Name, unclosed action\n")},
 	}
 	for _, test := range badPrinterTests {
-		_, _, err := printers.GetStandardPrinter(test.Format, test.FormatArgument, false, false, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme})
+		_, _, err := printers.GetStandardPrinter(test.Format, test.FormatArgument, false, false, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, nil, []runtime.Decoder{api.Codecs.UniversalDecoder(), nil, unstructured.UnstructuredJSONScheme}, printers.PrintOptions{})
 		if err == nil || err.Error() != test.Error.Error() {
 			t.Errorf("in %s, expect %s, got %s", test.Name, test.Error, err)
 		}
@@ -359,7 +359,7 @@ func TestNamePrinter(t *testing.T) {
 			},
 			"pods/foo\npods/bar\n"},
 	}
-	printer, _, _ := printers.GetStandardPrinter("name", "", false, false, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme})
+	printer, _, _ := printers.GetStandardPrinter("name", "", false, false, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, nil, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme}, printers.PrintOptions{})
 	for name, item := range tests {
 		buff := &bytes.Buffer{}
 		err := printer.PrintObj(item.obj, buff)
@@ -2198,7 +2198,7 @@ func TestAllowMissingKeys(t *testing.T) {
 	}
 	for _, test := range tests {
 		buf := bytes.NewBuffer([]byte{})
-		printer, _, err := printers.GetStandardPrinter(test.Format, test.Template, false, test.AllowMissingTemplateKeys, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme})
+		printer, _, err := printers.GetStandardPrinter(test.Format, test.Template, false, test.AllowMissingTemplateKeys, api.Registry.RESTMapper(api.Registry.EnabledVersions()...), api.Scheme, nil, []runtime.Decoder{api.Codecs.UniversalDecoder(), unstructured.UnstructuredJSONScheme}, printers.PrintOptions{})
 		if err != nil {
 			t.Errorf("in %s, unexpected error: %#v", test.Name, err)
 		}

--- a/vendor/k8s.io/kubernetes/pkg/printers/printers.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/printers.go
@@ -30,7 +30,7 @@ import (
 // is agnostic to schema versions, so you must send arguments to PrintObj in the
 // version you wish them to be shown using a VersionedPrinter (typically when
 // generic is true).
-func GetStandardPrinter(format, formatArgument string, noHeaders, allowMissingTemplateKeys bool, mapper meta.RESTMapper, typer runtime.ObjectTyper, decoders []runtime.Decoder) (ResourcePrinter, bool, error) {
+func GetStandardPrinter(format, formatArgument string, noHeaders, allowMissingTemplateKeys bool, mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder, options PrintOptions) (ResourcePrinter, bool, error) {
 	var printer ResourcePrinter
 	switch format {
 	case "json":
@@ -108,7 +108,7 @@ func GetStandardPrinter(format, formatArgument string, noHeaders, allowMissingTe
 	case "wide":
 		fallthrough
 	case "":
-		return nil, false, nil
+		return NewHumanReadablePrinterFn(encoder, decoders[0], options), false, nil
 	default:
 		return nil, false, fmt.Errorf("output format %q not recognized", format)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/printers/printers_patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/printers_patch.go
@@ -1,0 +1,11 @@
+package printers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// we have this here so that we can provide the human readable printer since this bypasses the factory.
+
+type NewHumanReadablePrinterFunc func(encoder runtime.Encoder, decoder runtime.Decoder, options PrintOptions) *HumanReadablePrinter
+
+var NewHumanReadablePrinterFn NewHumanReadablePrinterFunc = NewHumanReadablePrinter


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/17163

Partially picks changes introduced in upstream PR https://github.com/kubernetes/kubernetes/pull/46265
in order to avoid a panic caused by calling `PrintObject` on a `nil` printer, after calling [vendor/k8s.io/kubernetes/pkg/printers/printers.go#GetStandardPrinter](https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/pkg/printers/printers.go#L32)

**Before**
```
$ oc export <resource> -o wide
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x5ace72]

goroutine 1 [running]:
panic(0x37ffd80, 0xc420014100)
        /usr/lib/golang/src/runtime/panic.go:500 +0x1a1
...
```

**After**
```
$ oc export pod -o wide
NAME              READY     STATUS    RESTARTS   AGE         IP        NODE
podname-1-build   0/1       Pending   0          <unknown>   <none>
```


/kind bug

cc @openshift/cli-review