### PR TITLE
Fix segv error for usage error of oc set env command

### DIFF
--- a/pkg/oc/cli/cmd/set/env.go
+++ b/pkg/oc/cli/cmd/set/env.go
@@ -170,7 +170,7 @@ func keyToEnvName(key string) string {
 func (o *EnvOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []string) error {
 	resources, envArgs, ok := cmdutil.SplitEnvironmentFromResources(args)
 	if !ok {
-		return kcmdutil.UsageErrorf(o.Cmd, "all resources must be specified before environment changes: %s", strings.Join(args, " "))
+		return kcmdutil.UsageErrorf(cmd, "all resources must be specified before environment changes: %s", strings.Join(args, " "))
 	}
 	if len(o.Filenames) == 0 && len(resources) < 1 {
 		return kcmdutil.UsageErrorf(cmd, "one or more resources must be specified as <resource> <name> or <resource>/<name>")


### PR DESCRIPTION
When oc set env had wrong argments, oc command failed with segv
error.

This patch fixes the issue by passing valid cmd object to
`kcmdutil.UsageErrorf`.

Note, this segv error could be reproduced by following command.

~~~
# ./oc set env foo=bar router
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x100e116]

goroutine 1 [running]:
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Name(0x0, 0xc421353b58, 0x4ea8c4)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:918 +0x26
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).CommandPath(0x0, 0x3e, 0xc421353c88)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:853 +0x2f
github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util.UsageErrorf(0x0, 0x4d46e38, 0x3e, 0xc421353c88, 0x1, 0x1, 0xe, 0x0)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go:296 +0x8e
github.com/openshift/origin/pkg/oc/cli/cmd/set.(*EnvOptions).Complete(0xc420af38c0, 0xc4211e13b0, 0xc42046e000, 0xc42058d4c0, 0x2, 0x2, 0x4, 0x4ee6158)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/cmd/set/env.go:173 +0x774
github.com/openshift/origin/pkg/oc/cli/cmd/set.NewCmdEnv.func1(0xc42046e000, 0xc42058d4c0, 0x2, 0x2)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/cmd/set/env.go:126 +0x6f
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc42046e000, 0xc42058d320, 0x2, 0x2, 0xc42046e000, 0xc42058d320)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:603 +0x234
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4204d0900, 0x202d071, 0xc4204d0900, 0xc420374a20)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:689 +0x2fe
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4204d0900, 0x2, 0xc4204d0900)
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:648 +0x2b
main.main()
	/home/knakayam/dev/origin/_output/local/go/src/github.com/openshift/origin/cmd/oc/oc.go:41 +0x293
~~~