### PR TITLE
Remove api-version from documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,6 @@ CLI commands support both local (specific to the given command) and global (work
 |`--client-key` *filename*   | Look in *filename* for the TLS client key. |
 |`--certificate-authority` *filename* | Look in *filename* for the CA certificate. |
 |`--auth-path` *filename*    | Look in *filename* for the auth info (for HTTPS). |
-|`--api-version` *version*   | Specify API version *version* to use against the server. |
 |`--insecure-skip-tls-verify` | Skip SSL certificate validation (makes HTTPS insecure). |
 |`--help` (`-h`)             | Display help for the specified command. |
 


### PR DESCRIPTION
## Motivation 

Cleanup repository documentation from invalid global parameters
Resolves: https://github.com/openshift/origin/issues/14053

## Notes

Additional parameters that seem to be removed (tested using local build)

- [ ] ` --ns-path` (Error: unknown flag:  --ns-path)
- [ ]  `--auth-path` (Error: unknown flag: --auth-path)

I will be happy to remove them as well in this PR if approved.