### PR TITLE
Follow tag reference when imagestream has the alias as image:tag format

### DIFF
--- a/pkg/oc/cli/cmd/importimage_test.go
+++ b/pkg/oc/cli/cmd/importimage_test.go
@@ -285,7 +285,27 @@ func TestCreateImageImport(t *testing.T) {
 				To:   &kapi.LocalObjectReference{Name: "mytag"},
 			}},
 		},
-		"import tag from .spec.tags with Kind != DockerImage": {
+		"use tag aliases": {
+			name: "testis:mytag",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testis",
+					Namespace: "other",
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"mytag":  {From: &kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"}},
+						"other1": {From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "testis:mytag"}},
+						"other2": {From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "mytag"}},
+					},
+				},
+			},
+			expectedImages: []imageapi.ImageImportSpec{{
+				From: kapi.ObjectReference{Kind: "DockerImage", Name: "repo.com/somens/someimage:mytag"},
+				To:   &kapi.LocalObjectReference{Name: "mytag"},
+			}},
+		},
+		"import tag from alias of cross-image-stream": {
 			name: "testis:mytag",
 			stream: &imageapi.ImageStream{
 				ObjectMeta: metav1.ObjectMeta{
@@ -295,12 +315,46 @@ func TestCreateImageImport(t *testing.T) {
 				Spec: imageapi.ImageStreamSpec{
 					Tags: map[string]imageapi.TagReference{
 						"mytag": {
-							From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "someimage:mytag"},
+							From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "otherimage:mytag"},
 						},
 					},
 				},
 			},
-			err: "tag \"mytag\" points to existing ImageStreamTag \"someimage:mytag\", it cannot be re-imported",
+			err: "tag \"mytag\" points to an imagestreamtag from another ImageStream",
+		},
+		"import tag from alias of circular reference": {
+			name: "testis:mytag",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testis",
+					Namespace: "other",
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"mytag": {
+							From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "mytag"},
+						},
+					},
+				},
+			},
+			err: "tag \"mytag\" on the image stream is a reference to same tag",
+		},
+		"import tag from non existing alias": {
+			name: "testis:mytag",
+			stream: &imageapi.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testis",
+					Namespace: "other",
+				},
+				Spec: imageapi.ImageStreamSpec{
+					Tags: map[string]imageapi.TagReference{
+						"mytag": {
+							From: &kapi.ObjectReference{Kind: "ImageStreamTag", Name: "nonexisting"},
+						},
+					},
+				},
+			},
+			err: "the tag \"mytag\" does not exist on the image stream - choose an existing tag to import or use the 'tag' command to create a new tag",
 		},
 		"use insecure annotation": {
 			name: "testis",

--- a/pkg/oc/cli/describe/helpers.go
+++ b/pkg/oc/cli/describe/helpers.go
@@ -242,7 +242,7 @@ func formatImageStreamTags(out *tabwriter.Writer, stream *imageapi.ImageStream) 
 	var localReferences sets.String
 	var referentialTags map[string]sets.String
 	for k := range stream.Spec.Tags {
-		if target, _, ok, multiple := imageapi.FollowTagReference(stream, k); ok && multiple {
+		if target, _, multiple, err := imageapi.FollowTagReference(stream, k); err == nil && multiple {
 			if referentialTags == nil {
 				referentialTags = make(map[string]sets.String)
 			}


### PR DESCRIPTION
As reported here https://github.com/openshift/origin/pull/17377#issuecomment-347740468, when `oc tag` creates the alias with `image:tag` format like:

~~~
oc tag registry.access.redhat.com/rhscl/perl-520-rhel7:latest perl:5.20 --source=docker
oc tag perl:5.20 perl:latest --source=istag --alias
~~~

`oc describe is` displays the tag separately.

~~~
# oc describe is perl
 ... snip ...
latest
  tagged from perl:5.20

5.20
  tagged from registry.access.redhat.com/rhscl/perl-520-rhel7:latest
~~~

This expects to display as:

~~~
# oc describe is perl
 ... snip ...
5.20 (latest)
  tagged from registry.access.redhat.com/rhscl/perl-520-rhel7:latest
~~~

This patch fixes the issue.