### PR TITLE
UPSTREAM: 57276: Fix vsphere cloudprovider naming

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -217,7 +217,7 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 
 	// Only on controller node it is required to register listeners.
 	// Register callbacks for node updates
-	client := clientBuilder.ClientOrDie("vSphere-cloud-provider")
+	client := clientBuilder.ClientOrDie("vsphere-cloud-provider")
 	factory := informers.NewSharedInformerFactory(client, 5*time.Minute)
 	nodeInformer := factory.Core().V1().Nodes()
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530225

cc @childsb @rootfs 
 

NOTE: I have not personally verified if the PR works as intended but the issue appears clear cut that, it will fix the cloudprovider naming bug as expected. 