### PR TITLE
UPSTREAM: <carry>: use DeepCopy when syncing service to prevent concurrent map access

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/endpoint/endpoints_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/endpoint/endpoints_controller.go
@@ -438,8 +438,12 @@ func (e *EndpointController) syncService(key string) error {
 	readyEps := 0
 	notReadyEps := 0
 	for i := range pods {
-		// TODO: Do we need to copy here?
-		pod := &(*pods[i])
+		podObj, err := api.Scheme.DeepCopy(pods[i])
+		if err != nil {
+			glog.V(5).Infof("Failed to deep copy pod %s/%s: %v", pods[i].Namespace, pods[i].Name, err)
+			continue
+		}
+		pod := podObj.(*v1.Pod)
 
 		for i := range service.Spec.Ports {
 			servicePort := &service.Spec.Ports[i]


### PR DESCRIPTION
Attempt to fix https://bugzilla.redhat.com/show_bug.cgi?id=1530368

@deads2k @smarterclayton will need sanity check on this, but my theory is that this:

```
commit d5d8b8a24cd4f6bfe72e1bb40177aa9ae5c8afc3
Author: Avesh Agarwal <avagarwa@redhat.com>
Date:   Wed Jul 5 18:14:57 2017 -0400

    UPSTREAM: 47731: Use endpoints informer for the endpoint controller.
```

made endpoints controller use the shared informer and the weak copy stop working as you accessing the annotations on pod inside `getHostname(...)` which can result in panic reported in the BZ.
  
FYI: @tnozicka found https://github.com/kubernetes/kubernetes/pull/46761 which I have hard time to believe is the right thing to do, but my mind is open ;-)

Also https://github.com/kubernetes/kubernetes/pull/47731/files#r122846364 we deep-copied the endpoints, but seems like we missed to deep copy the pods?
  