### PR TITLE
examples/prometheus: remove tsdb block duration setting

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -143,7 +143,6 @@ objects:
         - name: prometheus
           args:
           - --storage.tsdb.retention=6h
-          - --storage.tsdb.min-block-duration=2m
           - --config.file=/etc/prometheus/prometheus.yml
           - --web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13430,7 +13430,6 @@ objects:
         - name: prometheus
           args:
           - --storage.tsdb.retention=6h
-          - --storage.tsdb.min-block-duration=2m
           - --config.file=/etc/prometheus/prometheus.yml
           - --web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -24696,7 +24696,6 @@ objects:
         - name: prometheus
           args:
           - --storage.tsdb.retention=6h
-          - --storage.tsdb.min-block-duration=2m
           - --config.file=/etc/prometheus/prometheus.yml
           - --web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}


### PR DESCRIPTION
The storage.tsdb.min-block-duration cli option is only meant to be used
for testing.  Production environments should use the default 2h min block
duration.
See also: https://github.com/prometheus/prometheus/pull/3618