### PR TITLE
Alerts-proxy points to wrong container (to buffer instead to manager)…

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -167,7 +167,7 @@ objects:
           - -https-address=:9443
           - -http-address=
           - -email-domain=*
-          - -upstream=http://localhost:9099
+          - -upstream=http://localhost:9093
           - -client-id=system:serviceaccount:${NAMESPACE}:prometheus
           - -openshift-ca=/etc/pki/tls/cert.pem
           - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
Change the port there alert-proxy points. Now, alert-manager route gives 404. 