### PR TITLE
use cluster role aggregation for admin, edit, and view

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy_test.go
+++ b/pkg/cmd/server/bootstrappolicy/policy_test.go
@@ -142,9 +142,9 @@ func testObjects(t *testing.T, list *api.List, fixtureFilename string) {
 // Some roles should always cover others
 func TestCovers(t *testing.T) {
 	allRoles := bootstrappolicy.GetBootstrapClusterRoles()
-	var admin *rbac.ClusterRole
-	var editor *rbac.ClusterRole
-	var viewer *rbac.ClusterRole
+	var admin []rbac.PolicyRule
+	var editor []rbac.PolicyRule
+	var viewer []rbac.PolicyRule
 	var registryAdmin *rbac.ClusterRole
 	var registryEditor *rbac.ClusterRole
 	var registryViewer *rbac.ClusterRole
@@ -158,12 +158,12 @@ func TestCovers(t *testing.T) {
 	for i := range allRoles {
 		role := allRoles[i]
 		switch role.Name {
-		case bootstrappolicy.AdminRoleName:
-			admin = &role
-		case bootstrappolicy.EditRoleName:
-			editor = &role
-		case bootstrappolicy.ViewRoleName:
-			viewer = &role
+		case "system:openshift:aggregate-to-admin", "system:aggregate-to-admin":
+			admin = append(admin, role.Rules...)
+		case "system:openshift:aggregate-to-edit", "system:aggregate-to-edit":
+			editor = append(editor, role.Rules...)
+		case "system:openshift:aggregate-to-view", "system:aggregate-to-view":
+			viewer = append(viewer, role.Rules...)
 		case bootstrappolicy.RegistryAdminRoleName:
 			registryAdmin = &role
 		case bootstrappolicy.RegistryEditorRoleName:
@@ -185,16 +185,16 @@ func TestCovers(t *testing.T) {
 		}
 	}
 
-	if covers, miss := rulevalidation.Covers(admin.Rules, editor.Rules); !covers {
+	if covers, miss := rulevalidation.Covers(admin, editor); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
-	if covers, miss := rulevalidation.Covers(admin.Rules, editor.Rules); !covers {
+	if covers, miss := rulevalidation.Covers(admin, editor); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
-	if covers, miss := rulevalidation.Covers(admin.Rules, viewer.Rules); !covers {
+	if covers, miss := rulevalidation.Covers(admin, viewer); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
-	if covers, miss := rulevalidation.Covers(admin.Rules, registryAdmin.Rules); !covers {
+	if covers, miss := rulevalidation.Covers(admin, registryAdmin.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 	if covers, miss := rulevalidation.Covers(clusterAdmin.Rules, storageAdmin.Rules); !covers {
@@ -208,10 +208,10 @@ func TestCovers(t *testing.T) {
 	}
 
 	// admin and editor should cover imagebuilder
-	if covers, miss := rulevalidation.Covers(admin.Rules, imageBuilder.Rules); !covers {
+	if covers, miss := rulevalidation.Covers(admin, imageBuilder.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
-	if covers, miss := rulevalidation.Covers(editor.Rules, imageBuilder.Rules); !covers {
+	if covers, miss := rulevalidation.Covers(editor, imageBuilder.Rules); !covers {
 		t.Errorf("failed to cover: %#v", miss)
 	}
 

--- a/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
+++ b/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
@@ -60,6 +60,9 @@ var rolesToHide = sets.NewString(
 	"system:aggregate-to-edit",
 	"system:aggregate-to-view",
 	"system:aws-cloud-provider",
+	"system:openshift:aggregate-to-admin",
+	"system:openshift:aggregate-to-edit",
+	"system:openshift:aggregate-to-view",
 )
 
 func TestSystemOnlyRoles(t *testing.T) {

--- a/test/integration/ingressip_test.go
+++ b/test/integration/ingressip_test.go
@@ -32,7 +32,7 @@ func TestIngressIPAllocation(t *testing.T) {
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
 	masterConfig.NetworkConfig.ExternalIPNetworkCIDRs = []string{"172.16.0.0/24"}
 	masterConfig.NetworkConfig.IngressIPNetworkCIDR = "172.16.1.0/24"
-	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterWithOptions(masterConfig, testserver.TestOptions{})
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMasterWithOptions(masterConfig)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -619,161 +619,16 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: A user that has edit rights within the project and
-        can change the project's membership.
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: admin
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    name: system:openshift:aggregate-to-admin
   rules:
   - apiGroups:
     - ""
-    resources:
-    - pods
-    - pods/attach
-    - pods/exec
-    - pods/portforward
-    - pods/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
-    - replicationcontrollers
-    - replicationcontrollers/scale
-    - secrets
-    - serviceaccounts
-    - services
-    - services/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - bindings
-    - events
-    - limitranges
-    - namespaces
-    - namespaces/status
-    - pods/log
-    - pods/status
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - serviceaccounts
-    verbs:
-    - impersonate
-  - apiGroups:
-    - autoscaling
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - batch
-    resources:
-    - cronjobs
-    - jobs
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - deployments
-    - deployments/rollback
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    - replicationcontrollers/scale
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
     - authorization.openshift.io
-    resources:
-    - rolebindings
-    - roles
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - rbac.authorization.k8s.io
     resources:
     - rolebindings
     - roles
@@ -802,12 +657,6 @@ items:
     - podsecuritypolicyreviews
     - podsecuritypolicyselfsubjectreviews
     - podsecuritypolicysubjectreviews
-    verbs:
-    - create
-  - apiGroups:
-    - authorization.k8s.io
-    resources:
-    - localsubjectaccessreviews
     verbs:
     - create
   - apiGroups:
@@ -1018,7 +867,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - extensions
     - networking.k8s.io
     resources:
     - networkpolicies
@@ -1065,144 +913,13 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: A user that can create and edit most objects in a
-        project, but can not update the project's membership.
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: edit
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    name: system:openshift:aggregate-to-edit
   rules:
-  - apiGroups:
-    - ""
-    resources:
-    - pods
-    - pods/attach
-    - pods/exec
-    - pods/portforward
-    - pods/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
-    - replicationcontrollers
-    - replicationcontrollers/scale
-    - secrets
-    - serviceaccounts
-    - services
-    - services/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - bindings
-    - events
-    - limitranges
-    - namespaces
-    - namespaces/status
-    - pods/log
-    - pods/status
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - serviceaccounts
-    verbs:
-    - impersonate
-  - apiGroups:
-    - autoscaling
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - batch
-    resources:
-    - cronjobs
-    - jobs
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - deployments
-    - deployments/rollback
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    - replicationcontrollers/scale
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
   - apiGroups:
     - ""
     - build.openshift.io
@@ -1391,7 +1108,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - extensions
     - networking.k8s.io
     resources:
     - networkpolicies
@@ -1430,91 +1146,13 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: A user who can view but not edit any resources within
-        the project. They can not view secrets or membership.
+      authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: view
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-view: "true"
+    name: system:openshift:aggregate-to-view
   rules:
-  - apiGroups:
-    - ""
-    resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
-    - pods
-    - replicationcontrollers
-    - serviceaccounts
-    - services
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - bindings
-    - events
-    - limitranges
-    - namespaces
-    - namespaces/status
-    - pods/log
-    - pods/status
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - autoscaling
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - batch
-    resources:
-    - cronjobs
-    - jobs
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - deployments
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    resources:
-    - deployments
-    - deployments/scale
-    - statefulsets
-    verbs:
-    - get
-    - list
-    - watch
   - apiGroups:
     - ""
     - build.openshift.io
@@ -5040,6 +4678,54 @@ items:
     - selfsubjectrulesreviews
     verbs:
     - create
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      openshift.io/description: A user that has edit rights within the project and
+        can change the project's membership.
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: admin
+  rules: null
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      openshift.io/description: A user that can create and edit most objects in a
+        project, but can not update the project's membership.
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: edit
+  rules: null
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+  apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      openshift.io/description: A user who can view but not edit any resources within
+        the project. They can not view secrets or membership.
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: view
+  rules: null
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -676,171 +676,16 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: A user that has edit rights within the project and
-        can change the project's membership.
+      authorization.openshift.io/system-only: "true"
       openshift.io/reconcile-protect: "false"
     creationTimestamp: null
-    name: admin
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    name: system:openshift:aggregate-to-admin
   rules:
   - apiGroups:
     - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    - pods/attach
-    - pods/exec
-    - pods/portforward
-    - pods/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
-    - replicationcontrollers
-    - replicationcontrollers/scale
-    - secrets
-    - serviceaccounts
-    - services
-    - services/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - bindings
-    - events
-    - limitranges
-    - namespaces
-    - namespaces/status
-    - pods/log
-    - pods/status
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - serviceaccounts
-    verbs:
-    - impersonate
-  - apiGroups:
-    - autoscaling
-    attributeRestrictions: null
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - batch
-    attributeRestrictions: null
-    resources:
-    - cronjobs
-    - jobs
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/rollback
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    - replicationcontrollers/scale
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
     - authorization.openshift.io
-    attributeRestrictions: null
-    resources:
-    - rolebindings
-    - roles
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - rbac.authorization.k8s.io
     attributeRestrictions: null
     resources:
     - rolebindings
@@ -872,13 +717,6 @@ items:
     - podsecuritypolicyreviews
     - podsecuritypolicyselfsubjectreviews
     - podsecuritypolicysubjectreviews
-    verbs:
-    - create
-  - apiGroups:
-    - authorization.k8s.io
-    attributeRestrictions: null
-    resources:
-    - localsubjectaccessreviews
     verbs:
     - create
   - apiGroups:
@@ -1109,7 +947,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - extensions
     - networking.k8s.io
     attributeRestrictions: null
     resources:
@@ -1160,153 +997,13 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: A user that can create and edit most objects in a
-        project, but can not update the project's membership.
+      authorization.openshift.io/system-only: "true"
       openshift.io/reconcile-protect: "false"
     creationTimestamp: null
-    name: edit
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    name: system:openshift:aggregate-to-edit
   rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - pods
-    - pods/attach
-    - pods/exec
-    - pods/portforward
-    - pods/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
-    - replicationcontrollers
-    - replicationcontrollers/scale
-    - secrets
-    - serviceaccounts
-    - services
-    - services/proxy
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - bindings
-    - events
-    - limitranges
-    - namespaces
-    - namespaces/status
-    - pods/log
-    - pods/status
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - serviceaccounts
-    verbs:
-    - impersonate
-  - apiGroups:
-    - autoscaling
-    attributeRestrictions: null
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - batch
-    attributeRestrictions: null
-    resources:
-    - cronjobs
-    - jobs
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/rollback
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    - replicationcontrollers/scale
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - deployments/status
-    - statefulsets
-    verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
   - apiGroups:
     - ""
     - build.openshift.io
@@ -1513,7 +1210,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - extensions
     - networking.k8s.io
     attributeRestrictions: null
     resources:
@@ -1555,98 +1251,13 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: A user who can view but not edit any resources within
-        the project. They can not view secrets or membership.
+      authorization.openshift.io/system-only: "true"
       openshift.io/reconcile-protect: "false"
     creationTimestamp: null
-    name: view
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-view: "true"
+    name: system:openshift:aggregate-to-view
   rules:
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - configmaps
-    - endpoints
-    - persistentvolumeclaims
-    - pods
-    - replicationcontrollers
-    - serviceaccounts
-    - services
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    attributeRestrictions: null
-    resources:
-    - bindings
-    - events
-    - limitranges
-    - namespaces
-    - namespaces/status
-    - pods/log
-    - pods/status
-    - replicationcontrollers/status
-    - resourcequotas
-    - resourcequotas/status
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - autoscaling
-    attributeRestrictions: null
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - batch
-    attributeRestrictions: null
-    resources:
-    - cronjobs
-    - jobs
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - replicasets
-    - replicasets/scale
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    - extensions
-    attributeRestrictions: null
-    resources:
-    - daemonsets
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - apps
-    attributeRestrictions: null
-    resources:
-    - deployments
-    - deployments/scale
-    - statefulsets
-    verbs:
-    - get
-    - list
-    - watch
   - apiGroups:
     - ""
     - build.openshift.io
@@ -5518,6 +5129,54 @@ items:
     - selfsubjectrulesreviews
     verbs:
     - create
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      openshift.io/description: A user that has edit rights within the project and
+        can change the project's membership.
+      openshift.io/reconcile-protect: "false"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: admin
+  rules: []
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      openshift.io/description: A user that can create and edit most objects in a
+        project, but can not update the project's membership.
+      openshift.io/reconcile-protect: "false"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: edit
+  rules: []
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+  apiVersion: v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      openshift.io/description: A user who can view but not edit any resources within
+        the project. They can not view secrets or membership.
+      openshift.io/reconcile-protect: "false"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: view
+  rules: []
 - apiVersion: v1
   kind: ClusterRole
   metadata:

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -402,14 +403,6 @@ func CleanupMasterEtcd(t *testing.T, config *configapi.MasterConfig) {
 	}
 }
 
-type TestOptions struct {
-	EnableControllers bool
-}
-
-func DefaultTestOptions() TestOptions {
-	return TestOptions{EnableControllers: true}
-}
-
 func StartConfiguredNode(nodeConfig *configapi.NodeConfig, components *utilflags.ComponentFlag) error {
 	guardNode()
 	kubernetes.SetFakeCadvisorInterfaceForIntegrationTest()
@@ -433,21 +426,25 @@ func StartConfiguredNode(nodeConfig *configapi.NodeConfig, components *utilflags
 }
 
 func StartConfiguredMaster(masterConfig *configapi.MasterConfig) (string, error) {
-	return StartConfiguredMasterWithOptions(masterConfig, DefaultTestOptions())
+	return StartConfiguredMasterWithOptions(masterConfig)
 }
 
 func StartConfiguredMasterAPI(masterConfig *configapi.MasterConfig) (string, error) {
-	options := DefaultTestOptions()
-	options.EnableControllers = false
-	return StartConfiguredMasterWithOptions(masterConfig, options)
+	// we need to unconditionally start this controller for rbac permissions to work
+	if masterConfig.KubernetesMasterConfig.ControllerArguments == nil {
+		masterConfig.KubernetesMasterConfig.ControllerArguments = map[string][]string{}
+	}
+	masterConfig.KubernetesMasterConfig.ControllerArguments["controllers"] = append(masterConfig.KubernetesMasterConfig.ControllerArguments["controllers"], "clusterrole-aggregation")
+
+	return StartConfiguredMasterWithOptions(masterConfig)
 }
 
-func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig, testOptions TestOptions) (string, error) {
+func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig) (string, error) {
 	guardMaster()
 	if masterConfig.EtcdConfig != nil && len(masterConfig.EtcdConfig.StorageDir) > 0 {
 		os.RemoveAll(masterConfig.EtcdConfig.StorageDir)
 	}
-	if err := start.NewMaster(masterConfig, testOptions.EnableControllers, true).Start(); err != nil {
+	if err := start.NewMaster(masterConfig, true /* always needed for cluster role aggregation */, true).Start(); err != nil {
 		return "", err
 	}
 	adminKubeConfigFile := util.KubeConfigPath()
@@ -473,6 +470,47 @@ func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig, test
 			return false, err
 		}
 		return healthy, nil
+	})
+	if err == wait.ErrWaitTimeout {
+		return "", fmt.Errorf("server did not become healthy: %v", healthzResponse)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// wait until the cluster roles have been aggregated
+	clusterAdminClientConfig, err := util.GetClusterAdminClientConfig(adminKubeConfigFile)
+	if err != nil {
+		return "", err
+	}
+	err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		kubeClient, err := kubeclient.NewForConfig(clusterAdminClientConfig)
+		if err != nil {
+			return false, err
+		}
+		admin, err := kubeClient.RbacV1().ClusterRoles().Get("admin", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(admin.Rules) == 0 {
+			return false, nil
+		}
+		edit, err := kubeClient.RbacV1().ClusterRoles().Get("edit", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(edit.Rules) == 0 {
+			return false, nil
+		}
+		view, err := kubeClient.RbacV1().ClusterRoles().Get("view", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(view.Rules) == 0 {
+			return false, nil
+		}
+
+		return true, nil
 	})
 	if err == wait.ErrWaitTimeout {
 		return "", fmt.Errorf("server did not become healthy: %v", healthzResponse)


### PR DESCRIPTION
Update to use the aggregated admin, edit, and view from upstream.

@openshift/sig-security 
@sub-mod fyi

/assign simo5
/assign enj