### PR TITLE
UPSTREAM: 56971: LimitRange ignores objects previously marked for deletion

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission.go
@@ -113,6 +113,18 @@ func (l *LimitRanger) runLimitFunc(a admission.Attributes, limitFn func(limitRan
 		}
 	}
 
+	// ignore all objects marked for deletion
+	oldObj := a.GetOldObject()
+	if oldObj != nil {
+		oldAccessor, err := meta.Accessor(oldObj)
+		if err != nil {
+			return admission.NewForbidden(a, err)
+		}
+		if oldAccessor.GetDeletionTimestamp() != nil {
+			return nil
+		}
+	}
+
 	items, err := l.GetLimitRanges(a)
 	if err != nil {
 		return err

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/limitranger/admission_test.go
@@ -733,6 +733,15 @@ func TestLimitRangerAdmitPod(t *testing.T) {
 	if err != nil {
 		t.Errorf("Should have ignored calls to any subresource of pod %v", err)
 	}
+
+	// a pod that is undergoing termination should never be blocked
+	terminatingPod := validPod("terminatingPod", 1, api.ResourceRequirements{})
+	now := metav1.Now()
+	terminatingPod.DeletionTimestamp = &now
+	err = handler.Validate(admission.NewAttributesRecord(&terminatingPod, &terminatingPod, api.Kind("Pod").WithVersion("version"), limitRange.Namespace, "terminatingPod", api.Resource("pods").WithVersion("version"), "", admission.Update, nil))
+	if err != nil {
+		t.Errorf("LimitRange should ignore a pod marked for termination")
+	}
 }
 
 // newMockClientForTest creates a mock client that returns a client configured for the specified list of limit ranges


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/56971

xref https://bugzilla.redhat.com/show_bug.cgi?id=1509309

@derekwaynecarr 