### PR TITLE
Bump the haproxy version to 1.8

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -5,7 +5,7 @@
 #
 FROM openshift/origin
 
-RUN INSTALL_PKGS="haproxy" && \
+RUN INSTALL_PKGS="haproxy18" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
This just uses the new OpenShift repo RPMs for haproxy 1.8.  There should be no features changed by this.  All follow-on work making use of the new features in haproxy will happen in subsequent commits.

@openshift/networking PTAL