### PR TITLE
Reduce TestProjectRequestError flakiness

### DIFF
--- a/test/integration/project_request_test.go
+++ b/test/integration/project_request_test.go
@@ -101,7 +101,7 @@ func TestProjectRequestError(t *testing.T) {
 				case watch.Deleted:
 					deleted++
 				}
-			case <-time.After(10 * time.Second):
+			case <-time.After(30 * time.Second):
 				return added, deleted, events
 			}
 


### PR DESCRIPTION
A processing delay between the projectrequest DELETE of a
namespace and the namespace controller's handling of the event combined
with the deletion grace period often adds up to more time than the test
allows for namespace deletion. Increase the timeout to reduce flakiness.

Fixes https://github.com/openshift/origin/issues/17780
  