### PR TITLE
Clean Prometheus example

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -38,6 +38,7 @@ objects:
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prom: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus"}}'
       serviceaccounts.openshift.io/oauth-redirectreference.alerts: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alerts"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.alertmanager: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alertmanager"}}'
 - apiVersion: authorization.openshift.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -87,6 +88,81 @@ objects:
     namespace: "${NAMESPACE}"
   stringData:
     session_secret: "${SESSION_SECRET}="
+
+# Create a fully end-to-end TLS connection to the alert proxy
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: alerts
+    namespace: "${NAMESPACE}"
+  spec:
+    to:
+      name: alerts
+    tls:
+      termination: Reencrypt
+      insecureEdgeTerminationPolicy: Redirect
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: alerts-tls
+    labels:
+      name: alerts
+    name: alerts
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - name: alerts
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+    selector:
+      app: prometheus
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: alerts-proxy
+    namespace: "${NAMESPACE}"
+  stringData:
+    session_secret: "${SESSION_SECRET}="
+
+# Create a fully end-to-end TLS connection to the alertmanager proxy
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: alertmanager
+    namespace: "${NAMESPACE}"
+  spec:
+    to:
+      name: alertmanager
+    tls:
+      termination: Reencrypt
+      insecureEdgeTerminationPolicy: Redirect
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: alertmanager-tls
+    labels:
+      name: alertmanager
+    name: alertmanager
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - name: alertmanager
+      port: 443
+      protocol: TCP
+      targetPort: 10443
+    selector:
+      app: prometheus
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: alertmanager-proxy
+    namespace: "${NAMESPACE}"
+  stringData:
+    session_secret: "${SESSION_SECRET}="
+
 - apiVersion: apps/v1beta1
   kind: StatefulSet
   metadata:
@@ -134,9 +210,9 @@ objects:
           - -skip-auth-regex=^/metrics
           volumeMounts:
           - mountPath: /etc/tls/private
-            name: prometheus-tls
+            name: prometheus-tls-secret
           - mountPath: /etc/proxy/secrets
-            name: prometheus-secrets
+            name: prometheus-proxy-secret
           - mountPath: /prometheus
             name: prometheus-data
 
@@ -179,9 +255,9 @@ objects:
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
           volumeMounts:
           - mountPath: /etc/tls/private
-            name: alerts-tls
+            name: alerts-tls-secret
           - mountPath: /etc/proxy/secrets
-            name: alerts-secrets
+            name: alerts-proxy-secrets
 
         - name: alert-buffer
           args:
@@ -190,10 +266,38 @@ objects:
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - mountPath: /alert-buffer
-            name: alert-buffer-data
+            name: alerts-data
           ports:
           - containerPort: 9099
             name: alert-buf
+
+        - name: alertmanager-proxy
+          image: ${IMAGE_PROXY}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 10443
+            name: web
+          args:
+          - -provider=openshift
+          - -https-address=:10443
+          - -http-address=
+          - -email-domain=*
+          - -upstream=http://localhost:9093
+          - -client-id=system:serviceaccount:${NAMESPACE}:prometheus
+          - -openshift-ca=/etc/pki/tls/cert.pem
+          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: alertmanager-tls-secret
+          - mountPath: /etc/proxy/secrets
+            name: alertmanager-proxy-secret
 
         - name: alertmanager
           args:
@@ -211,31 +315,40 @@ objects:
 
         restartPolicy: Always
         volumes:
+
         - name: prometheus-config
           configMap:
             defaultMode: 420
             name: prometheus
-        - name: prometheus-secrets
+        - name: prometheus-proxy-secret
           secret:
             secretName: prometheus-proxy
-        - name: prometheus-tls
+        - name: prometheus-tls-secret
           secret:
             secretName: prometheus-tls
         - name: prometheus-data
           emptyDir: {}
+
         - name: alertmanager-config
           configMap:
             defaultMode: 420
-            name: prometheus-alerts
-        - name: alerts-secrets
+            name: alertmanager
+        - name: alertmanager-tls-secret
+          secret:
+            secretName: alertmanager-tls  
+        - name: alertmanager-proxy-secret
+          secret:
+            secretName: alertmanager-proxy         
+
+        - name: alerts-proxy-secrets
           secret:
             secretName: alerts-proxy
-        - name: alerts-tls
+        - name: alerts-tls-secret
           secret:
-            secretName: prometheus-alerts-tls
+            secretName: alerts-tls
         - name: alertmanager-data
           emptyDir: {}
-        - name: alert-buffer-data #TODO: make persistent
+        - name: alerts-data
           emptyDir: {}
 
 - apiVersion: v1
@@ -438,47 +551,10 @@ objects:
           - targets:
             - "localhost:9093"
 
-# Create a fully end-to-end TLS connection to the alert proxy
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    name: alerts
-    namespace: "${NAMESPACE}"
-  spec:
-    to:
-      name: alerts
-    tls:
-      termination: Reencrypt
-      insecureEdgeTerminationPolicy: Redirect
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: prometheus-alerts-tls
-    labels:
-      name: alerts
-    name: alerts
-    namespace: "${NAMESPACE}"
-  spec:
-    ports:
-    - name: alerts
-      port: 443
-      protocol: TCP
-      targetPort: 9443
-    selector:
-      app: prometheus
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: alerts-proxy
-    namespace: "${NAMESPACE}"
-  stringData:
-    session_secret: "${SESSION_SECRET}="
-
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    name: prometheus-alerts
+    name: alertmanager
     namespace: "${NAMESPACE}"
   data:
     alertmanager.yml: |

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -24591,6 +24591,7 @@ objects:
     annotations:
       serviceaccounts.openshift.io/oauth-redirectreference.prom: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus"}}'
       serviceaccounts.openshift.io/oauth-redirectreference.alerts: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alerts"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.alertmanager: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alertmanager"}}'
 - apiVersion: authorization.openshift.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -24640,6 +24641,81 @@ objects:
     namespace: "${NAMESPACE}"
   stringData:
     session_secret: "${SESSION_SECRET}="
+
+# Create a fully end-to-end TLS connection to the alert proxy
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: alerts
+    namespace: "${NAMESPACE}"
+  spec:
+    to:
+      name: alerts
+    tls:
+      termination: Reencrypt
+      insecureEdgeTerminationPolicy: Redirect
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: alerts-tls
+    labels:
+      name: alerts
+    name: alerts
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - name: alerts
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+    selector:
+      app: prometheus
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: alerts-proxy
+    namespace: "${NAMESPACE}"
+  stringData:
+    session_secret: "${SESSION_SECRET}="
+
+# Create a fully end-to-end TLS connection to the alertmanager proxy
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: alertmanager
+    namespace: "${NAMESPACE}"
+  spec:
+    to:
+      name: alertmanager
+    tls:
+      termination: Reencrypt
+      insecureEdgeTerminationPolicy: Redirect
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      service.alpha.openshift.io/serving-cert-secret-name: alertmanager-tls
+    labels:
+      name: alertmanager
+    name: alertmanager
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - name: alertmanager
+      port: 443
+      protocol: TCP
+      targetPort: 10443
+    selector:
+      app: prometheus
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: alertmanager-proxy
+    namespace: "${NAMESPACE}"
+  stringData:
+    session_secret: "${SESSION_SECRET}="
+
 - apiVersion: apps/v1beta1
   kind: StatefulSet
   metadata:
@@ -24687,9 +24763,9 @@ objects:
           - -skip-auth-regex=^/metrics
           volumeMounts:
           - mountPath: /etc/tls/private
-            name: prometheus-tls
+            name: prometheus-tls-secret
           - mountPath: /etc/proxy/secrets
-            name: prometheus-secrets
+            name: prometheus-proxy-secret
           - mountPath: /prometheus
             name: prometheus-data
 
@@ -24732,9 +24808,9 @@ objects:
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
           volumeMounts:
           - mountPath: /etc/tls/private
-            name: alerts-tls
+            name: alerts-tls-secret
           - mountPath: /etc/proxy/secrets
-            name: alerts-secrets
+            name: alerts-proxy-secrets
 
         - name: alert-buffer
           args:
@@ -24743,10 +24819,38 @@ objects:
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - mountPath: /alert-buffer
-            name: alert-buffer-data
+            name: alerts-data
           ports:
           - containerPort: 9099
             name: alert-buf
+
+        - name: alertmanager-proxy
+          image: ${IMAGE_PROXY}
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 10443
+            name: web
+          args:
+          - -provider=openshift
+          - -https-address=:10443
+          - -http-address=
+          - -email-domain=*
+          - -upstream=http://localhost:9093
+          - -client-id=system:serviceaccount:${NAMESPACE}:prometheus
+          - -openshift-ca=/etc/pki/tls/cert.pem
+          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+          - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "resourceName": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+          - -tls-cert=/etc/tls/private/tls.crt
+          - -tls-key=/etc/tls/private/tls.key
+          - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: alertmanager-tls-secret
+          - mountPath: /etc/proxy/secrets
+            name: alertmanager-proxy-secret
 
         - name: alertmanager
           args:
@@ -24764,31 +24868,40 @@ objects:
 
         restartPolicy: Always
         volumes:
+
         - name: prometheus-config
           configMap:
             defaultMode: 420
             name: prometheus
-        - name: prometheus-secrets
+        - name: prometheus-proxy-secret
           secret:
             secretName: prometheus-proxy
-        - name: prometheus-tls
+        - name: prometheus-tls-secret
           secret:
             secretName: prometheus-tls
         - name: prometheus-data
           emptyDir: {}
+
         - name: alertmanager-config
           configMap:
             defaultMode: 420
-            name: prometheus-alerts
-        - name: alerts-secrets
+            name: alertmanager
+        - name: alertmanager-tls-secret
+          secret:
+            secretName: alertmanager-tls  
+        - name: alertmanager-proxy-secret
+          secret:
+            secretName: alertmanager-proxy         
+
+        - name: alerts-proxy-secrets
           secret:
             secretName: alerts-proxy
-        - name: alerts-tls
+        - name: alerts-tls-secret
           secret:
-            secretName: prometheus-alerts-tls
+            secretName: alerts-tls
         - name: alertmanager-data
           emptyDir: {}
-        - name: alert-buffer-data #TODO: make persistent
+        - name: alerts-data
           emptyDir: {}
 
 - apiVersion: v1
@@ -24991,47 +25104,10 @@ objects:
           - targets:
             - "localhost:9093"
 
-# Create a fully end-to-end TLS connection to the alert proxy
-- apiVersion: route.openshift.io/v1
-  kind: Route
-  metadata:
-    name: alerts
-    namespace: "${NAMESPACE}"
-  spec:
-    to:
-      name: alerts
-    tls:
-      termination: Reencrypt
-      insecureEdgeTerminationPolicy: Redirect
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: prometheus-alerts-tls
-    labels:
-      name: alerts
-    name: alerts
-    namespace: "${NAMESPACE}"
-  spec:
-    ports:
-    - name: alerts
-      port: 443
-      protocol: TCP
-      targetPort: 9443
-    selector:
-      app: prometheus
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: alerts-proxy
-    namespace: "${NAMESPACE}"
-  stringData:
-    session_secret: "${SESSION_SECRET}="
-
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    name: prometheus-alerts
+    name: alertmanager
     namespace: "${NAMESPACE}"
   data:
     alertmanager.yml: |


### PR DESCRIPTION
Main changes:
1. Unified secrets, config, data volumes names to have postfix so it would be easier to read and track who is who. 
```
S: prometheus-tls		-> prometheus-tls-secret
...
C: prometheus                   -> prometheus-config
C: prometheus-alertmanage       -> prometheus-alertmanager-config
D: emptyDir		        -> prometheus-data
...
```
2. Add clear SMTP example with multiple receivers for buffer and smtp
3. Change order of elements so it would be easier to read. 
4. Add proxy for alertmanager as a 6th container. 

If/When this gets merged will update ansible deployment too to represent this change. 

Did this for client deployment for their monitoring solution evaluation. 