### PR TITLE
Support pod and master traffic segregation on the node

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -125,6 +125,7 @@ function start() {
 
   if [[ -n "${ADDITIONAL_NETWORK_INTERFACE}" ]]; then
     add-network-interface-to-nodes
+    update-node-config
   fi
 
   local rc_file="dind-${cluster_id}.rc"
@@ -193,6 +194,22 @@ function add-network-interface-to-nodes () {
     (( bridge_num += 1 ))
     (( ipam_num += 1 ))
   done
+}
+
+function update-node-config() {
+  local config_path="/data/openshift.local.config"
+  local host="$(hostname)"
+  local node_config_path="${config_path}/node-${host}"
+  local node_config_file="${node_config_path}/node-config.yaml"
+
+  # Remove node config file to trigger node config regeneration
+  #
+  # openshift-generate-node-config.sh script repopulates node config
+  # with certs for both eth0 and eth1 IP addrs.
+  #
+  # openshift-node service executes openshift-generate-node-config.sh
+  # as pre start hook.
+  rm -f "${node_config_file}"
 }
 
 function add-node () {

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -163,18 +163,16 @@ cluster's rc file to configure the bash environment:
 }
 
 function add-network-interface-to-nodes () {
-  local bridge_num=${BRIDGE_START_NUM}
-  local ipam_num=${IPAM_START_NUM}
-  local netns_path="/var/run/netns"
+  # Create new bridge
+  sudo brctl addbr "${ADDITIONAL_BRIDGE_NAME}"
+  # Assign IPAM to the bridge
+  sudo ifconfig "${ADDITIONAL_BRIDGE_NAME}" "172.${IPAM_START_NUM}.0.1/16"
 
+  local netns_path="/var/run/netns"
   sudo mkdir -p "${netns_path}"
 
+  local num=3
   for pid in $( ${DOCKER_CMD} ps -q --filter "name=${MASTER_NAME}|${NODE_PREFIX}" | xargs ${DOCKER_CMD} inspect --format '{{.State.Pid}}' ); do
-    local bridge="${BRIDGE_PREFIX}${bridge_num}"
-    # Create new bridge
-    sudo brctl addbr "${bridge}"
-    # Assign IPAM to the bridge
-    sudo ifconfig "${bridge}" "172.${ipam_num}.0.1/16"
     # Link container network namespace so that 'ip netns' can recognize
     sudo ln -s /proc/"${pid}"/ns/net "${netns_path}/ns-${pid}"
     # Create veth pair
@@ -184,16 +182,15 @@ function add-network-interface-to-nodes () {
     # Rename interface name inside the container
     sudo ip netns exec ns-"${pid}" ip link set veth1-ns-"${pid}" name "${ADDITIONAL_IFACE_NAME}"
     # Assign address to the added interface in the container
-    sudo ip netns exec ns-"${pid}" ifconfig "${ADDITIONAL_IFACE_NAME}" "172.${ipam_num}.0.3/16"
+    sudo ip netns exec ns-"${pid}" ifconfig "${ADDITIONAL_IFACE_NAME}" "172.${IPAM_START_NUM}.0.${num}/24"
     # Bring up the link connected to the container
     sudo ip netns exec ns-"${pid}" ip link set "${ADDITIONAL_IFACE_NAME}" up
     # Move other end of the veth pair to the bridge
-    sudo brctl addif "${bridge}" veth2-ns-"${pid}"
+    sudo brctl addif "${ADDITIONAL_BRIDGE_NAME}" veth2-ns-"${pid}"
     # Bring up the link connected to the bridge
     sudo ip link set dev veth2-ns-"${pid}" up
 
-    (( bridge_num += 1 ))
-    (( ipam_num += 1 ))
+    (( num += 1 ))
   done
 }
 
@@ -305,16 +302,9 @@ function stop() {
   echo "Stopping dind cluster '${cluster_id}'"
   sudo echo -n
 
-  # Delete additional network interface on the nodes if needed
-  local bridge_num=${BRIDGE_START_NUM}
-  for (( i=1; i<=NODE_COUNT; i++ )); do
-    local bridge="${BRIDGE_PREFIX}${bridge_num}"
-
-    sudo ip link set "${bridge}" down 2> /dev/null || "true"
-    sudo brctl delbr "${bridge}" 2> /dev/null || "true"
-
-    (( bridge_num += 1 ))
-  done
+  # Delete additional bridge if present
+  sudo ip link set "${ADDITIONAL_BRIDGE_NAME}" down 2> /dev/null || "true"
+  sudo brctl delbr "${ADDITIONAL_BRIDGE_NAME}" 2> /dev/null || "true"
 
   # Delete the containers
   for cid in $( ${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}|${NODE_PREFIX}" ); do
@@ -699,8 +689,7 @@ NODE_PREFIX="${CLUSTER_ID}-node-"
 NODE_COUNT=2
 NODE_NAMES=()
 
-BRIDGE_PREFIX="docker"
-BRIDGE_START_NUM=10
+ADDITIONAL_BRIDGE_NAME="${ADDITIONAL_BRIDGE_NAME:-docker10}"
 IPAM_START_NUM=100
 ADDITIONAL_IFACE_NAME="${ADDITIONAL_IFACE_NAME:-eth1}"
 

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -38,8 +38,18 @@ function ensure-node-config() {
     local master_host
     master_host="$(grep server "${master_config_file}" | grep -v localhost | awk '{print $2}')"
 
-    local ip_addr
-    ip_addr="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+    local ip_addr1
+    ip_addr1="$(ip addr | grep inet | grep eth0 | awk '{print $2}' | sed -e 's+/.*++')"
+
+    local ip_addr2
+    ip_addr2="$(ip addr | grep inet | (grep eth1 || true) | awk '{print $2}' | sed -e 's+/.*++')"
+
+    local ip_addrs
+    if [[ ! -z "${ip_addr2}" ]]; then
+      ip_addrs="${ip_addr1},${ip_addr2}"
+    else
+      ip_addrs="${ip_addr1}"
+    fi
 
     # Hold a lock on the shared volume to ensure cert generation is
     # performed serially.  Cert generation is not compatible with
@@ -50,7 +60,7 @@ function ensure-node-config() {
        --node-dir="${node_config_path}" \
        --node="${host}" \
        --master="${master_host}" \
-       --hostnames="${host},${ip_addr}" \
+       --hostnames="${host},${ip_addrs}" \
        --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
        --node-client-certificate-authority="${master_config_path}/ca.crt" \
        --certificate-authority="${master_config_path}/ca.crt" \

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -174,9 +174,9 @@ type NodeConfig struct {
 	// If you're describing a set of static nodes to the master, this value must match one of the values in the list
 	NodeName string
 
-	// Node may have multiple IPs, specify the IP to use for pod traffic routing
-	// If not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
-	NodeIP string
+	// Deprecated in favor of 'node-ip' under kubeletArguments section
+	// Node may have multiple IPs, specify the IP to used by kubelet
+	DeprecatedNodeIP string
 
 	// ServingInfo describes how to start serving
 	ServingInfo ServingInfo

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -292,6 +292,12 @@ type NodeNetworkConfig struct {
 	// PodTrafficNodeIP is the node IP to use for pod traffic routing
 	// If PodTrafficNodeIP is not set and PodTrafficNodeInterface is set, then first non-loopback IPv4 addr from PodTrafficNodeInterface is used.
 	PodTrafficNodeIP string
+
+	// MasterTrafficNodeInterface is the network interface to be used for master traffic
+	MasterTrafficNodeInterface string
+
+	// If MasterTrafficNodeIP is not set and MasterTrafficNodeInterface is set, then first non-loopback IPv4 addr from MasterTrafficNodeInterface is used.
+	MasterTrafficNodeIP string
 }
 
 // NodeAuthConfig holds authn/authz configuration options

--- a/pkg/cmd/server/api/types.go
+++ b/pkg/cmd/server/api/types.go
@@ -282,8 +282,16 @@ type LocalQuota struct {
 type NodeNetworkConfig struct {
 	// NetworkPluginName is a string specifying the networking plugin
 	NetworkPluginName string
+
 	// Maximum transmission unit for the network packets
 	MTU uint32
+
+	// PodTrafficNodeInterface is the network interface to be used for pod traffic
+	PodTrafficNodeInterface string
+
+	// PodTrafficNodeIP is the node IP to use for pod traffic routing
+	// If PodTrafficNodeIP is not set and PodTrafficNodeInterface is set, then first non-loopback IPv4 addr from PodTrafficNodeInterface is used.
+	PodTrafficNodeIP string
 }
 
 // NodeAuthConfig holds authn/authz configuration options

--- a/pkg/cmd/server/api/v1/conversions.go
+++ b/pkg/cmd/server/api/v1/conversions.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"github.com/golang/glog"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -157,6 +159,18 @@ func SetDefaults_NodeConfig(obj *NodeConfig) {
 		}
 	}
 	SetDefaults_ClientConnectionOverrides(obj.MasterClientConnectionOverrides)
+
+	if len(obj.DeprecatedNodeIP) != 0 {
+		if obj.KubeletArguments == nil {
+			obj.KubeletArguments = ExtendedArguments{}
+		}
+
+		if _, ok := obj.KubeletArguments["node-ip"]; ok {
+			glog.Warning("nodeIP config is ignored in favor of kubeletArguments[\"node-ip\"]")
+		} else {
+			obj.KubeletArguments["node-ip"] = []string{obj.DeprecatedNodeIP}
+		}
+	}
 
 	// Defaults/migrations for NetworkConfig
 	if len(obj.NetworkConfig.NetworkPluginName) == 0 {

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -18,9 +18,9 @@ type NodeConfig struct {
 	// If you're describing a set of static nodes to the master, this value must match one of the values in the list
 	NodeName string `json:"nodeName"`
 
-	// Node may have multiple IPs, specify the IP to use for pod traffic routing
-	// If not specified, network parse/lookup on the nodeName is performed and the first non-loopback address is used
-	NodeIP string `json:"nodeIP"`
+	// Deprecated in favor of 'node-ip' under kubeletArguments section
+	// Node may have multiple IPs, specify the IP to used by kubelet
+	DeprecatedNodeIP string `json:"nodeIP,omitempty"`
 
 	// ServingInfo describes how to start serving
 	ServingInfo ServingInfo `json:"servingInfo"`

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -156,6 +156,12 @@ type NodeNetworkConfig struct {
 	// PodTrafficNodeIP is the node IP to use for pod traffic routing
 	// If PodTrafficNodeIP is not set and PodTrafficNodeInterface is set, then first non-loopback IPv4 addr from PodTrafficNodeInterface is used.
 	PodTrafficNodeIP string `json:"podTrafficNodeIP"`
+
+	// MasterTrafficNodeInterface is the network interface to be used for master traffic
+	MasterTrafficNodeInterface string `json:"masterTrafficNodeInterface,omitempty"`
+
+	// If MasterTrafficNodeIP is not set and MasterTrafficNodeInterface is set, then first non-loopback IPv4 addr from MasterTrafficNodeInterface is used.
+	MasterTrafficNodeIP string `json:"masterTrafficNodeIP"`
 }
 
 // DockerConfig holds Docker related configuration options.

--- a/pkg/cmd/server/api/v1/types.go
+++ b/pkg/cmd/server/api/v1/types.go
@@ -146,8 +146,16 @@ type NodeAuthConfig struct {
 type NodeNetworkConfig struct {
 	// NetworkPluginName is a string specifying the networking plugin
 	NetworkPluginName string `json:"networkPluginName"`
+
 	// Maximum transmission unit for the network packets
 	MTU uint32 `json:"mtu"`
+
+	// PodTrafficNodeInterface is the network interface to be used for pod traffic
+	PodTrafficNodeInterface string `json:"podTrafficNodeInterface,omitempty"`
+
+	// PodTrafficNodeIP is the node IP to use for pod traffic routing
+	// If PodTrafficNodeIP is not set and PodTrafficNodeInterface is set, then first non-loopback IPv4 addr from PodTrafficNodeInterface is used.
+	PodTrafficNodeIP string `json:"podTrafficNodeIP"`
 }
 
 // DockerConfig holds Docker related configuration options.

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -51,6 +51,7 @@ masterKubeConfig: ""
 networkConfig:
   mtu: 0
   networkPluginName: ""
+  podTrafficNodeIP: ""
 nodeName: ""
 podManifestConfig:
   fileCheckIntervalSeconds: 0

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -52,6 +52,7 @@ networkConfig:
   mtu: 0
   networkPluginName: ""
   podTrafficNodeIP: ""
+  masterTrafficNodeIP: ""
 nodeName: ""
 podManifestConfig:
   fileCheckIntervalSeconds: 0

--- a/pkg/cmd/server/api/v1/types_test.go
+++ b/pkg/cmd/server/api/v1/types_test.go
@@ -51,7 +51,6 @@ masterKubeConfig: ""
 networkConfig:
   mtu: 0
   networkPluginName: ""
-nodeIP: ""
 nodeName: ""
 podManifestConfig:
   fileCheckIntervalSeconds: 0

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	kubeletoptions "k8s.io/kubernetes/cmd/kubelet/app/options"
 
 	"github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/util/netutils"
 )
 
 func ValidateNodeConfig(config *api.NodeConfig, fldPath *field.Path) ValidationResults {
@@ -106,6 +108,11 @@ func ValidateNetworkConfig(config api.NodeNetworkConfig, fldPath *field.Path) fi
 	if config.MTU == 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("mtu"), config.MTU, fmt.Sprintf("must be greater than zero")))
 	}
+
+	if len(config.PodTrafficNodeInterface) > 0 || len(config.PodTrafficNodeIP) > 0 {
+		allErrs = append(allErrs, ValidatePodTrafficParams(config.PodTrafficNodeInterface, config.PodTrafficNodeIP, fldPath)...)
+	}
+
 	return allErrs
 }
 
@@ -135,5 +142,47 @@ func ValidateVolumeConfig(config api.NodeVolumeConfig, fldPath *field.Path) fiel
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("localQuota", "perFSGroup"), config.LocalQuota.PerFSGroup,
 			"must be a positive integer"))
 	}
+	return allErrs
+}
+
+func ValidatePodTrafficParams(nodeIface, nodeIP string, fldPath *field.Path) field.ErrorList {
+	return validateNetworkInterfaceAndIP(nodeIface, nodeIP, fldPath.Child("podTrafficNodeInterface"), fldPath.Child("podTrafficNodeIP"))
+}
+
+func validateNetworkInterfaceAndIP(iface, ip string, ifaceFieldPath, ipFieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	var ipv4Addrs []net.IP
+	if len(iface) > 0 {
+		var err error
+		if ipv4Addrs, err = netutils.GetIPAddrsFromNetworkInterface(iface); err != nil {
+			allErrs = append(allErrs, field.Invalid(ifaceFieldPath, iface, err.Error()))
+		}
+	}
+
+	if len(ip) > 0 {
+		ipObj := net.ParseIP(ip)
+		if ipObj == nil {
+			allErrs = append(allErrs, field.Invalid(ipFieldPath, ip, "must be a valid IP"))
+		} else if ipObj.IsUnspecified() {
+			allErrs = append(allErrs, field.Invalid(ipFieldPath, ip, "cannot be an unspecified IP"))
+		} else if ipObj.To4() == nil {
+			allErrs = append(allErrs, field.Invalid(ipFieldPath, ip, "must be IPv4 address"))
+		}
+
+		if len(iface) > 0 {
+			found := false
+			for _, addr := range ipv4Addrs {
+				if addr.Equal(ipObj) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allErrs = append(allErrs, field.Invalid(ipFieldPath, ip, fmt.Sprintf("IP %q not found in network interface %q", ip, iface)))
+			}
+		}
+	}
+
 	return allErrs
 }

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -27,9 +27,6 @@ func ValidateInClusterNodeConfig(config *api.NodeConfig, fldPath *field.Path) Va
 	if len(config.NodeName) == 0 {
 		validationResults.AddErrors(field.Required(fldPath.Child("nodeName"), ""))
 	}
-	if len(config.NodeIP) > 0 {
-		validationResults.AddErrors(ValidateSpecifiedIP(config.NodeIP, fldPath.Child("nodeIP"))...)
-	}
 
 	servingInfoPath := fldPath.Child("servingInfo")
 	hasCertDir := len(config.KubeletArguments["cert-dir"]) > 0

--- a/pkg/cmd/server/api/validation/node.go
+++ b/pkg/cmd/server/api/validation/node.go
@@ -113,6 +113,10 @@ func ValidateNetworkConfig(config api.NodeNetworkConfig, fldPath *field.Path) fi
 		allErrs = append(allErrs, ValidatePodTrafficParams(config.PodTrafficNodeInterface, config.PodTrafficNodeIP, fldPath)...)
 	}
 
+	if len(config.MasterTrafficNodeInterface) > 0 || len(config.MasterTrafficNodeIP) > 0 {
+		allErrs = append(allErrs, ValidateMasterTrafficParams(config.MasterTrafficNodeInterface, config.MasterTrafficNodeIP, fldPath)...)
+	}
+
 	return allErrs
 }
 
@@ -147,6 +151,10 @@ func ValidateVolumeConfig(config api.NodeVolumeConfig, fldPath *field.Path) fiel
 
 func ValidatePodTrafficParams(nodeIface, nodeIP string, fldPath *field.Path) field.ErrorList {
 	return validateNetworkInterfaceAndIP(nodeIface, nodeIP, fldPath.Child("podTrafficNodeInterface"), fldPath.Child("podTrafficNodeIP"))
+}
+
+func ValidateMasterTrafficParams(nodeIface, nodeIP string, fldPath *field.Path) field.ErrorList {
+	return validateNetworkInterfaceAndIP(nodeIface, nodeIP, fldPath.Child("masterTrafficNodeInterface"), fldPath.Child("masterTrafficNodeIP"))
 }
 
 func validateNetworkInterfaceAndIP(iface, ip string, ifaceFieldPath, ipFieldPath *field.Path) field.ErrorList {

--- a/pkg/cmd/server/kubernetes/network/sdn_linux.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_linux.go
@@ -38,10 +38,17 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 	eventBroadcaster.StartRecordingToSink(&kv1core.EventSinkImpl{Interface: kubeClientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, kclientv1.EventSource{Component: "openshift-sdn", Host: options.NodeName})
 
+	nodeIP := ""
+	if options.KubeletArguments != nil {
+		if ips, ok := options.KubeletArguments["node-ip"]; ok {
+			nodeIP = ips[0]
+		}
+	}
+
 	node, err := sdnnode.New(&sdnnode.OsdnNodeConfig{
 		PluginName:         options.NetworkConfig.NetworkPluginName,
 		Hostname:           options.NodeName,
-		SelfIP:             options.NodeIP,
+		SelfIP:             nodeIP,
 		RuntimeEndpoint:    runtimeEndpoint,
 		MTU:                options.NetworkConfig.MTU,
 		NetworkClient:      networkClient,

--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -6,8 +6,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/golang/glog"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	kubeutilnet "k8s.io/apimachinery/pkg/util/net"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kubeletoptions "k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/features"
@@ -20,6 +23,7 @@ import (
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/network"
+	"github.com/openshift/origin/pkg/util/netutils"
 )
 
 // Build creates the core Kubernetes component configs for a given NodeConfig, or returns
@@ -144,6 +148,15 @@ func Build(options configapi.NodeConfig) (*kubeletoptions.KubeletServer, error) 
 		server.CNIConfDir = kubeletcni.DefaultNetDir
 		server.CNIBinDir = kubeletcni.DefaultCNIDir
 		server.HairpinMode = kubeletconfig.HairpinNone
+
+		// For openshift SDN plugin, always set valid node IP.
+		// This ensures same node IP is used by both kubelet and SDN.
+		nodeIP, err := GetPodTrafficNodeIP(options)
+		if err != nil {
+			return nil, err
+		}
+		glog.Infof("Resolved kubelet node IP to %q", nodeIP)
+		server.NodeIP = nodeIP
 	}
 
 	return server, nil
@@ -152,4 +165,50 @@ func Build(options configapi.NodeConfig) (*kubeletoptions.KubeletServer, error) 
 func ToFlags(config *kubeletoptions.KubeletServer) []string {
 	server, _ := kubeletoptions.NewKubeletServer()
 	return cmdflags.AsArgs(config.AddFlags, server.AddFlags)
+}
+
+func GetPodTrafficNodeIP(options configapi.NodeConfig) (string, error) {
+	podTrafficNodeIP, err := GetIPFromIface(options.NetworkConfig.PodTrafficNodeIP, options.NetworkConfig.PodTrafficNodeInterface)
+	if err != nil {
+		return "", err
+	}
+
+	if len(podTrafficNodeIP) == 0 {
+		if options.KubeletArguments != nil {
+			if ips, ok := options.KubeletArguments["node-ip"]; ok {
+				podTrafficNodeIP = ips[0]
+			}
+		}
+
+		if len(podTrafficNodeIP) == 0 {
+			var err error
+			podTrafficNodeIP, err = netutils.GetNodeIP(options.NodeName)
+			if err != nil {
+				glog.V(5).Infof("Failed to determine node address from hostname %s; using default interface (%v)", options.NodeName, err)
+
+				var defaultIP net.IP
+				defaultIP, err = kubeutilnet.ChooseHostInterface()
+				if err != nil {
+					return "", err
+				}
+				podTrafficNodeIP = defaultIP.String()
+			}
+		}
+	}
+
+	return podTrafficNodeIP, nil
+}
+
+func GetIPFromIface(nodeIP, nodeIface string) (string, error) {
+	if len(nodeIP) == 0 {
+		if len(nodeIface) > 0 {
+			ips, err := netutils.GetIPAddrsFromNetworkInterface(nodeIface)
+			if err != nil {
+				return "", err
+			}
+			nodeIP = ips[0].String()
+		}
+	}
+
+	return nodeIP, nil
 }

--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -55,7 +55,6 @@ func Build(options configapi.NodeConfig) (*kubeletoptions.KubeletServer, error) 
 	server.KubeConfig.Default(options.MasterKubeConfig)
 	server.PodManifestPath = path
 	server.RootDirectory = options.VolumeDirectory
-	server.NodeIP = options.NodeIP
 	server.HostnameOverride = options.NodeName
 	server.AllowPrivileged = true
 	server.RegisterNode = true

--- a/pkg/cmd/server/start/bootstrap_node.go
+++ b/pkg/cmd/server/start/bootstrap_node.go
@@ -139,7 +139,9 @@ func overrideNodeConfigForBootstrap(nodeConfig *configapi.NodeConfig, bootstrapK
 	// Set impliict defaults the same as the kubelet (until this entire code path is removed)
 	nodeConfig.NodeName = nodeutil.GetHostname(nodeConfig.NodeName)
 	if nodeConfig.DNSIP == "0.0.0.0" {
-		nodeConfig.DNSIP = nodeConfig.NodeIP
+		if ips, ok := nodeConfig.KubeletArguments["node-ip"]; ok {
+			nodeConfig.DNSIP = ips[0]
+		}
 		// TODO: the Kubelet should do this defaulting (to the IP it recognizes)
 		if len(nodeConfig.DNSIP) == 0 {
 			if ip, err := cmdutil.DefaultLocalIP4(); err == nil {

--- a/pkg/network/apis/network/plugin.go
+++ b/pkg/network/apis/network/plugin.go
@@ -12,4 +12,7 @@ const (
 
 	// NetNamespace annotations
 	MulticastEnabledAnnotation = "netnamespace.network.openshift.io/multicast-enabled"
+
+	// Node annotations
+	MasterTrafficNodeIPAnnotation = "network.openshift.io/master-traffic-node-ip"
 )

--- a/pkg/network/apis/network/plugin.go
+++ b/pkg/network/apis/network/plugin.go
@@ -12,7 +12,4 @@ const (
 
 	// NetNamespace annotations
 	MulticastEnabledAnnotation = "netnamespace.network.openshift.io/multicast-enabled"
-
-	// Node annotations
-	MasterTrafficNodeIPAnnotation = "network.openshift.io/master-traffic-node-ip"
 )

--- a/pkg/network/node/master_nodeip.go
+++ b/pkg/network/node/master_nodeip.go
@@ -1,0 +1,141 @@
+package node
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	kapi "k8s.io/kubernetes/pkg/apis/core"
+
+	networkapi "github.com/openshift/origin/pkg/network/apis/network"
+	"github.com/openshift/origin/pkg/util/netutils"
+)
+
+// AnnotateMasterTrafficNodeIP assigns master traffic node IP as annotation on the local node object.
+// We use exponential back off polling on the local node object instead of node shared informers
+// because kube informers will not be started until all the openshift controllers are started.
+func (plugin *OsdnNode) AnnotateMasterTrafficNodeIP() error {
+	backoff := utilwait.Backoff{
+		// A bit under 2 minutes total
+		Duration: time.Second,
+		Factor:   1.5,
+		Steps:    11,
+	}
+
+	var node *kapi.Node
+	err := utilwait.ExponentialBackoff(backoff, func() (bool, error) {
+		var err error
+		node, err = plugin.kClient.Core().Nodes().Get(plugin.hostName, metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		} else if kapierrors.IsNotFound(err) {
+			glog.Warningf("Could not find local node object: %s, Waiting...", plugin.hostName)
+			return false, nil
+		} else {
+			return false, err
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get node object for this host: %s, error: %v", plugin.hostName, err)
+	}
+
+	if err := plugin.handleLocalNode(node); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (plugin *OsdnNode) handleLocalNode(node *kapi.Node) error {
+	if len(plugin.masterTrafficIP) == 0 {
+		// Unset master traffic node IP if needed
+		return plugin.unsetMasterTrafficNodeIPAnnotation(node)
+	}
+
+	nodeIP, err := getMasterTrafficNodeIPAnnotation(node)
+	if (err == nil) && (nodeIP == plugin.masterTrafficIP) {
+		return nil
+	}
+
+	isLocal, err := plugin.isNodeIPLocal(plugin.masterTrafficIP)
+	if err != nil {
+		return fmt.Errorf("failed to check if master traffic node IP %q is local or not, %v", plugin.masterTrafficIP, err)
+	}
+	if !isLocal {
+		return fmt.Errorf("master traffic node IP %q is not local", plugin.masterTrafficIP)
+	}
+
+	if err := plugin.setMasterTrafficNodeIPAnnotation(node); err != nil {
+		return fmt.Errorf("unable to set master traffic node IP annotation for node %q, %v", node.Name, err)
+	}
+
+	return nil
+}
+
+func (plugin *OsdnNode) isNodeIPLocal(nodeIP string) (bool, error) {
+	_, hostIPs, err := netutils.GetHostIPNetworks([]string{Tun0})
+	if err != nil {
+		return false, err
+	}
+
+	for _, ip := range hostIPs {
+		if nodeIP == ip.String() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func getMasterTrafficNodeIPAnnotation(node *kapi.Node) (string, error) {
+	if len(node.Annotations) > 0 {
+		if nodeIP, ok := node.Annotations[networkapi.MasterTrafficNodeIPAnnotation]; ok {
+			return nodeIP, nil
+		}
+	}
+
+	return "", fmt.Errorf("master traffic node IP not found for node %q", node.Name)
+}
+
+func (plugin *OsdnNode) setMasterTrafficNodeIPAnnotation(node *kapi.Node) error {
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	node.Annotations[networkapi.MasterTrafficNodeIPAnnotation] = plugin.masterTrafficIP
+
+	return plugin.updateNode(node)
+}
+
+func (plugin *OsdnNode) unsetMasterTrafficNodeIPAnnotation(node *kapi.Node) error {
+	if node.Annotations != nil {
+		if _, ok := node.Annotations[networkapi.MasterTrafficNodeIPAnnotation]; ok {
+			delete(node.Annotations, networkapi.MasterTrafficNodeIPAnnotation)
+			return plugin.updateNode(node)
+		}
+	}
+
+	return nil
+}
+
+func (plugin *OsdnNode) updateNode(node *kapi.Node) error {
+	// A bit over 1 minute total
+	backoff := utilwait.Backoff{
+		Duration: time.Second,
+		Factor:   1.5,
+		Steps:    10,
+	}
+
+	return utilwait.ExponentialBackoff(backoff, func() (bool, error) {
+		_, err := plugin.kClient.Core().Nodes().Update(node)
+		if err == nil {
+			return true, nil
+		} else if kapierrors.IsNotFound(err) {
+			return false, fmt.Errorf("could not find local node for host: %s", plugin.hostName)
+		} else {
+			return false, nil
+		}
+	})
+}

--- a/pkg/network/node/master_nodeip.go
+++ b/pkg/network/node/master_nodeip.go
@@ -31,7 +31,14 @@ func (plugin *OsdnNode) AnnotateMasterTrafficNodeIP() error {
 		var err error
 		node, err = plugin.kClient.Core().Nodes().Get(plugin.hostName, metav1.GetOptions{})
 		if err == nil {
-			return true, nil
+			if len(node.Status.Addresses) > 0 &&
+				node.Status.Addresses[0].Address != "" &&
+				node.Status.Addresses[0].Address == plugin.localIP {
+				return true, nil
+			} else {
+				glog.Warningf("Found local node object: %s, Waiting for node address to be updated...", plugin.hostName)
+				return false, nil
+			}
 		} else if kapierrors.IsNotFound(err) {
 			glog.Warningf("Could not find local node object: %s, Waiting...", plugin.hostName)
 			return false, nil

--- a/pkg/network/node/master_nodeip.go
+++ b/pkg/network/node/master_nodeip.go
@@ -10,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
-	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/util/netutils"
 )
 
@@ -99,7 +99,7 @@ func (plugin *OsdnNode) isNodeIPLocal(nodeIP string) (bool, error) {
 
 func getMasterTrafficNodeIPAnnotation(node *kapi.Node) (string, error) {
 	if len(node.Annotations) > 0 {
-		if nodeIP, ok := node.Annotations[networkapi.MasterTrafficNodeIPAnnotation]; ok {
+		if nodeIP, ok := node.Annotations[kubeletclient.MasterTrafficNodeIPAnnotation]; ok {
 			return nodeIP, nil
 		}
 	}
@@ -111,15 +111,15 @@ func (plugin *OsdnNode) setMasterTrafficNodeIPAnnotation(node *kapi.Node) error 
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}
-	node.Annotations[networkapi.MasterTrafficNodeIPAnnotation] = plugin.masterTrafficIP
+	node.Annotations[kubeletclient.MasterTrafficNodeIPAnnotation] = plugin.masterTrafficIP
 
 	return plugin.updateNode(node)
 }
 
 func (plugin *OsdnNode) unsetMasterTrafficNodeIPAnnotation(node *kapi.Node) error {
 	if node.Annotations != nil {
-		if _, ok := node.Annotations[networkapi.MasterTrafficNodeIPAnnotation]; ok {
-			delete(node.Annotations, networkapi.MasterTrafficNodeIPAnnotation)
+		if _, ok := node.Annotations[kubeletclient.MasterTrafficNodeIPAnnotation]; ok {
+			delete(node.Annotations, kubeletclient.MasterTrafficNodeIPAnnotation)
 			return plugin.updateNode(node)
 		}
 	}

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	kubeutilnet "k8s.io/apimachinery/pkg/util/net"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/record"
@@ -151,8 +150,13 @@ func New(c *OsdnNodeConfig) (network.NodeInterface, error) {
 	// we're ready yet
 	os.Remove(filepath.Join(cniDirPath, openshiftCNIFile))
 
-	if err := c.setNodeIP(); err != nil {
-		return nil, err
+	if _, _, err := GetLinkDetails(c.SelfIP); err != nil {
+		if err == ErrorNetworkInterfaceNotFound {
+			err = fmt.Errorf("node IP %q is not a local/private address (hostname %q)", c.SelfIP, c.Hostname)
+		}
+		// TODO: We should eventually return an error here
+		// Currently we are ignoring the error so that it won't block the merge queue and QE can fix their test cases.
+		glog.Errorf("Unable to find network interface for node IP; some features will not work! (%v)", err)
 	}
 
 	ovsif, err := ovs.New(kexec.New(), Br0, minOvsVersion)
@@ -189,42 +193,6 @@ func New(c *OsdnNodeConfig) (network.NodeInterface, error) {
 	RegisterMetrics()
 
 	return plugin, nil
-}
-
-// Set node IP if required
-func (c *OsdnNodeConfig) setNodeIP() error {
-	if len(c.Hostname) == 0 {
-		output, err := kexec.New().Command("uname", "-n").CombinedOutput()
-		if err != nil {
-			return err
-		}
-		c.Hostname = strings.TrimSpace(string(output))
-		glog.Infof("Resolved hostname to %q", c.Hostname)
-	}
-
-	if len(c.SelfIP) == 0 {
-		var err error
-		c.SelfIP, err = netutils.GetNodeIP(c.Hostname)
-		if err != nil {
-			glog.V(5).Infof("Failed to determine node address from hostname %s; using default interface (%v)", c.Hostname, err)
-			var defaultIP net.IP
-			defaultIP, err = kubeutilnet.ChooseHostInterface()
-			if err != nil {
-				return err
-			}
-			c.SelfIP = defaultIP.String()
-			glog.Infof("Resolved IP address to %q", c.SelfIP)
-		}
-	}
-
-	if _, _, err := GetLinkDetails(c.SelfIP); err != nil {
-		if err == ErrorNetworkInterfaceNotFound {
-			err = fmt.Errorf("node IP %q is not a local/private address (hostname %q)", c.SelfIP, c.Hostname)
-		}
-		glog.Errorf("Unable to find network interface for node IP; some features will not work! (%v)", err)
-	}
-
-	return nil
 }
 
 var (

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -303,6 +303,10 @@ func (node *OsdnNode) Start() error {
 		glog.Errorf("Local networks conflict with SDN; this will eventually cause problems: %v", err)
 	}
 
+	if err := node.AnnotateMasterTrafficNodeIP(); err != nil {
+		return err
+	}
+
 	node.localSubnetCIDR, err = node.getLocalSubnet()
 	if err != nil {
 		return err

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -70,6 +70,7 @@ type OsdnNodeConfig struct {
 	PluginName      string
 	Hostname        string
 	SelfIP          string
+	MasterTrafficIP string
 	RuntimeEndpoint string
 	MTU             uint32
 	EnableHostports bool
@@ -94,6 +95,7 @@ type OsdnNode struct {
 	podManager         *podManager
 	localSubnetCIDR    string
 	localIP            string
+	masterTrafficIP    string
 	hostName           string
 	useConnTrack       bool
 	iptablesSyncPeriod time.Duration
@@ -167,6 +169,7 @@ func New(c *OsdnNodeConfig) (network.NodeInterface, error) {
 		oc:                 oc,
 		podManager:         newPodManager(c.KClient, policy, c.MTU, oc, c.EnableHostports),
 		localIP:            c.SelfIP,
+		masterTrafficIP:    c.MasterTrafficIP,
 		hostName:           c.Hostname,
 		useConnTrack:       useConnTrack,
 		iptablesSyncPeriod: c.IPTablesSyncPeriod,


### PR DESCRIPTION
Trello card: https://trello.com/c/sCNKKYCz

- Allows pod to pod traffic on eth0 interface and node to master traffic on eth1 interface.

Depends on https://github.com/openshift/origin/pull/17907 and https://github.com/openshift/origin/pull/17719