### PR TITLE
Fix indentation in egress-router.sh

### DIFF
--- a/images/egress/router/egress-router.sh
+++ b/images/egress/router/egress-router.sh
@@ -31,12 +31,12 @@ function setup_network() {
     # The pod may die and get restarted; only try to add the
     # address/route/rules if they are not already there.
     if ! ip route get "${EGRESS_GATEWAY}" | grep -q macvlan0; then
-    ip addr add "${EGRESS_SOURCE}"/32 dev macvlan0
-    ip link set up dev macvlan0
+        ip addr add "${EGRESS_SOURCE}"/32 dev macvlan0
+        ip link set up dev macvlan0
 
-    ip route add "${EGRESS_GATEWAY}"/32 dev macvlan0
-    ip route del default
-    ip route add default via "${EGRESS_GATEWAY}" dev macvlan0
+        ip route add "${EGRESS_GATEWAY}"/32 dev macvlan0
+        ip route del default
+        ip route add default via "${EGRESS_GATEWAY}" dev macvlan0
     fi
 
     # Update neighbor ARP caches in case another node previously had the IP. (This is


### PR DESCRIPTION
One clause got misindented in the tabs->spaces migration