### PR TITLE
Validate 'nodeName' config against cloud provider node name if needed

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node.go
+++ b/pkg/cmd/server/kubernetes/node/node.go
@@ -216,6 +216,28 @@ func (c *NodeConfig) EnsureLocalQuota(nodeConfig configapi.NodeConfig) {
 	}
 }
 
+// EnsureCloudProviderName checks cloud provider perceived node name matches with
+// OpenShift configured node name.
+func (c *NodeConfig) EnsureCloudProviderName(nodeConfig configapi.NodeConfig) {
+	if c.KubeletDeps.Cloud == nil {
+		return
+	}
+
+	instances, ok := c.KubeletDeps.Cloud.Instances()
+	if !ok {
+		glog.Fatalf("Could not get instances from cloud provider")
+	}
+
+	nodeName, err := instances.CurrentNodeName(nodeConfig.NodeName)
+	if err != nil {
+		glog.Fatalf("Unable to fetch node name from cloud provider: %v", err)
+	}
+
+	if nodeConfig.NodeName != string(nodeName) {
+		glog.Fatalf("Configured node name %q does not match with cloud provider node name: %q", nodeConfig.NodeName, string(nodeName))
+	}
+}
+
 // RunKubelet starts the Kubelet.
 func (c *NodeConfig) RunKubelet() {
 	var clusterDNS net.IP

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -475,6 +475,7 @@ func StartNode(nodeConfig configapi.NodeConfig, components *utilflags.ComponentF
 		}
 		glog.Infof("Starting node %s (%s)", config.KubeletServer.HostnameOverride, version.Get().String())
 
+		config.EnsureCloudProviderName(nodeConfig)
 		config.EnsureKubeletAccess()
 		config.EnsureVolumeDir()
 		config.EnsureDocker(docker.NewHelper())


### PR DESCRIPTION
- When cloud provider is set, kubelet ignores given node name and
   fetches the node name from corresponding cloud provider. This may
   not match with node name used in openshift SDN and other places
   which causes problems similar to https://github.com/openshift/origin/issues/15910

- So bail out early when we know given nodeNome does not match with
   cloud provider node name.
  