### PR TITLE
ClusterResourceOverride annotates pod with original resources

### DIFF
--- a/pkg/quota/admission/clusterresourceoverride/admission_test.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission_test.go
@@ -254,11 +254,13 @@ func testBestEffortPod() *kapi.Pod {
 		Spec: kapi.PodSpec{
 			InitContainers: []kapi.Container{
 				{
+					Name:      "ctr-1",
 					Resources: kapi.ResourceRequirements{},
 				},
 			},
 			Containers: []kapi.Container{
 				{
+					Name:      "ctr-2",
 					Resources: kapi.ResourceRequirements{},
 				},
 			},
@@ -271,6 +273,7 @@ func testPod(memLimit string, memRequest string, cpuLimit string, cpuRequest str
 		Spec: kapi.PodSpec{
 			InitContainers: []kapi.Container{
 				{
+					Name: "ctr-1",
 					Resources: kapi.ResourceRequirements{
 						Limits: kapi.ResourceList{
 							kapi.ResourceCPU:    resource.MustParse(cpuLimit),
@@ -285,6 +288,7 @@ func testPod(memLimit string, memRequest string, cpuLimit string, cpuRequest str
 			},
 			Containers: []kapi.Container{
 				{
+					Name: "ctr-2",
 					Resources: kapi.ResourceRequirements{
 						Limits: kapi.ResourceList{
 							kapi.ResourceCPU:    resource.MustParse(cpuLimit),


### PR DESCRIPTION
Add an annotation to record original input resource requirements when they differ from modified values.

The requirements are keyed by the container name.

Example:
```yaml
kind: Pod
metadata:
  annotations:
    cluster-resource-override.openshift.io/original-resource-requirements: '{"cakephp-ex":{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}}}'
```

