### PR TITLE
Add retry import with no auth for IS if we get 401 error (public images case) 

### DIFF
--- a/pkg/image/importer/importer.go
+++ b/pkg/image/importer/importer.go
@@ -340,6 +340,8 @@ func formatRepositoryError(ref imageapi.DockerImageReference, err error) error {
 		err = kapierrors.NewUnauthorized(fmt.Sprintf("you may not have access to the Docker image %q", ref.Exact()))
 	case strings.HasSuffix(err.Error(), "no basic auth credentials"):
 		err = kapierrors.NewUnauthorized(fmt.Sprintf("you may not have access to the Docker image %q", ref.Exact()))
+	case strings.HasSuffix(err.Error(), "incorrect username or password"):
+		err = kapierrors.NewUnauthorized(fmt.Sprintf("incorrect username or password for image %q", ref.Exact()))
 	}
 	return err
 }

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -309,4 +309,14 @@ os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"
 os::test::junit::declare_suite_end
 
+# test importing images with wrong docker secrets
+os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/import-public-images-with-fake-secret"
+os::cmd::expect_success 'oc new-project import-images'
+os::cmd::expect_success 'oc create secret docker-registry dummy-secret1 --docker-server=docker.io --docker-username=dummy1 --docker-password=dummy1 --docker-email==dummy1@example.com'
+os::cmd::expect_success 'oc create secret docker-registry dummy-secret2 --docker-server=docker.io --docker-username=dummy2 --docker-password=dummy2 --docker-email==dummy2@example.com'
+os::cmd::expect_success_and_text 'oc import-image example --from=openshift/hello-openshift --confirm' 'The import completed successfully'
+os::cmd::expect_success 'oc delete project import-images'
+echo "import public images with fake secret ok"
+os::test::junit::declare_suite_end
+
 os::test::junit::declare_suite_end


### PR DESCRIPTION
If we try to import any image (even public ones) and we have a bad secret (wrong password or expired cloud token) in our project imports are failing. 

This leads to all imports in the same project to fail with a random unclear error. 
This could be fixed in [RoundTripper and Smarter Authenticator](https://github.com/openshift/origin/blob/master/pkg/image/importer/client.go#L150). This might end up bigger change than this fix...

This fix just retries import with empty authentication. 

If you know better place for this fix let me know :)

https://bugzilla.redhat.com/show_bug.cgi?id=1506175