### PR TITLE
Fix passing container to pod logs from dc

### DIFF
--- a/pkg/apps/apis/apps/helpers.go
+++ b/pkg/apps/apis/apps/helpers.go
@@ -16,6 +16,7 @@ import (
 // so it shouldn't be included here.
 func DeploymentToPodLogOptions(opts *DeploymentLogOptions) *kapi.PodLogOptions {
 	return &kapi.PodLogOptions{
+		Container:    opts.Container,
 		Follow:       opts.Follow,
 		SinceSeconds: opts.SinceSeconds,
 		SinceTime:    opts.SinceTime,

--- a/pkg/oc/cli/cmd/logs.go
+++ b/pkg/oc/cli/cmd/logs.go
@@ -168,6 +168,7 @@ func (o *OpenShiftLogsOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command
 
 	case appsapi.IsResourceOrLegacy("deploymentconfig", gr):
 		dopts := &appsapi.DeploymentLogOptions{
+			Container:    podLogOptions.Container,
 			Follow:       podLogOptions.Follow,
 			Previous:     podLogOptions.Previous,
 			SinceSeconds: podLogOptions.SinceSeconds,


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/17999

@kargakis FYI
  
```
~/.../openshift/origin → oc logs dc/docker-registry -c second
openshift v3.9.0-alpha.1+5643835
kubernetes v1.9.0-beta1
etcd 3.2.8
~/.../openshift/origin → oc logs dc/docker-registry
Error from server (BadRequest): a container name must be specified for pod docker-registry-3-f6grl, choose one of: [second registry]
```