### PR TITLE
Fix rollout cancel and retry bugs

### DIFF
--- a/pkg/oc/cli/cmd/rollout/cancel.go
+++ b/pkg/oc/cli/cmd/rollout/cancel.go
@@ -17,12 +17,12 @@ import (
 	units "github.com/docker/go-units"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
+	"github.com/openshift/origin/pkg/oc/cli/cmd/set"
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/kubectl/cmd/set"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
@@ -130,10 +130,10 @@ func (o CancelOptions) Run() error {
 				return false
 			}
 
-			patches := set.CalculatePatches([]*resource.Info{{Object: rc, Mapping: mapping}}, o.Encoder, func(*resource.Info) ([]byte, error) {
+			patches := set.CalculatePatches([]*resource.Info{{Object: rc, Mapping: mapping}}, o.Encoder, func(info *resource.Info) (bool, error) {
 				rc.Annotations[appsapi.DeploymentCancelledAnnotation] = appsapi.DeploymentCancelledAnnotationValue
 				rc.Annotations[appsapi.DeploymentStatusReasonAnnotation] = appsapi.DeploymentCancelledByUser
-				return runtime.Encode(o.Encoder, rc)
+				return true, nil
 			})
 
 			allPatchesEmpty := true

--- a/pkg/oc/cli/cmd/rollout/retry.go
+++ b/pkg/oc/cli/cmd/rollout/retry.go
@@ -15,12 +15,12 @@ import (
 
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
+	"github.com/openshift/origin/pkg/oc/cli/cmd/set"
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/kubectl/cmd/set"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -169,11 +169,11 @@ func (o RetryOptions) Run() error {
 			continue
 		}
 
-		patches := set.CalculatePatches([]*resource.Info{{Object: rc, Mapping: mapping}}, o.Encoder, func(*resource.Info) ([]byte, error) {
+		patches := set.CalculatePatches([]*resource.Info{{Object: rc, Mapping: mapping}}, o.Encoder, func(info *resource.Info) (bool, error) {
 			rc.Annotations[appsapi.DeploymentStatusAnnotation] = string(appsapi.DeploymentStatusNew)
 			delete(rc.Annotations, appsapi.DeploymentStatusReasonAnnotation)
 			delete(rc.Annotations, appsapi.DeploymentCancelledAnnotation)
-			return runtime.Encode(o.Encoder, rc)
+			return true, nil
 		})
 
 		if len(patches) == 0 {


### PR DESCRIPTION
Fix rollout cancel and retry command failures resulting from use of
internal types passed to strategic merge patch generation. Other CLI
commands already use an internal adapter to support this use case; the
deployment rollout commands are now in line with the existing wrapper
usages.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530750