### PR TITLE
Allow making HPA use REST Clients

### DIFF
--- a/pkg/cmd/server/origin/controller/config.go
+++ b/pkg/cmd/server/origin/controller/config.go
@@ -244,9 +244,13 @@ func BuildOpenshiftControllerConfig(options configapi.MasterConfig) (*OpenshiftC
 		DefaultReplenishmentSyncPeriod: 12 * time.Hour,
 	}
 
-	// TODO this goes away with a truly generic autoscaler
+	// TODO: this goes away when we can get rid of the legacy Heapster metrics client
+	useRESTClientsOption := options.KubernetesMasterConfig.ControllerArguments["horizontal-pod-autoscaler-use-rest-clients"]
 	ret.HorizontalPodAutoscalerControllerConfig = HorizontalPodAutoscalerControllerConfig{
 		HeapsterNamespace: options.PolicyConfig.OpenShiftInfrastructureNamespace,
+		// TODO: we may want to turn this into a proper option, but if Heapster support just
+		// goes away, it's a bit of a moot point.
+		UseRESTClients: len(useRESTClientsOption) > 0 && useRESTClientsOption[len(useRESTClientsOption)-1] == "true",
 	}
 
 	return ret, nil


### PR DESCRIPTION
Since we have our own custom HPA setup, we have to have to do special
work to make the HPA use REST clients.  Since we don't actually have
access to the underlying Kubernetes config object, we settle for
manually checking the same flag name that's normally used.  When we
start deploying metrics-server by default, all of our custom code can
just go away.