### PR TITLE
Remove min-block-duration option from standalone Prometheus

### DIFF
--- a/examples/prometheus/prometheus-standalone.yaml
+++ b/examples/prometheus/prometheus-standalone.yaml
@@ -129,7 +129,6 @@ objects:
         - name: prometheus
           args:
           - --storage.tsdb.retention=6h
-          - --storage.tsdb.min-block-duration=2m
           - --config.file=/etc/prometheus/prometheus.yml
           - --web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}


### PR DESCRIPTION
This flag causes more troubles than good.