### PR TITLE
Revert "UPSTREAM: 53916: update .dockercfg data to config.json format

### DIFF
--- a/pkg/oc/cli/secrets/dockercfg.go
+++ b/pkg/oc/cli/secrets/dockercfg.go
@@ -125,9 +125,7 @@ func (o CreateDockerConfigOptions) NewDockerSecret() (*api.Secret, error) {
 		Email:    o.EmailAddress,
 	}
 
-	dockerCfg := credentialprovider.DockerConfigJson{
-		Auths: map[string]credentialprovider.DockerConfigEntry{o.RegistryLocation: dockercfgAuth},
-	}
+	dockerCfg := map[string]credentialprovider.DockerConfigEntry{o.RegistryLocation: dockercfgAuth}
 
 	dockercfgContent, err := json.Marshal(dockerCfg)
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry.go
@@ -122,9 +122,7 @@ func handleDockercfgContent(username, password, email, server string) ([]byte, e
 		Email:    email,
 	}
 
-	dockerCfg := credentialprovider.DockerConfigJson{
-		Auths: map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth},
-	}
+	dockerCfg := map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth}
 
 	return json.Marshal(dockerCfg)
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/secret_for_docker_registry_test.go
@@ -59,26 +59,6 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expectErr: false,
 		},
-		"test-valid-use-append-hash": {
-			params: map[string]interface{}{
-				"name":            "foo-94759gc65b",
-				"docker-server":   server,
-				"docker-username": username,
-				"docker-password": password,
-				"docker-email":    email,
-				"append-hash":     "true",
-			},
-			expected: &api.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-94759gc65b",
-				},
-				Data: map[string][]byte{
-					api.DockerConfigKey: secretData,
-				},
-				Type: api.SecretTypeDockercfg,
-			},
-			expectErr: false,
-		},
 		"test-valid-use-no-email": {
 			params: map[string]interface{}{
 				"name":            "foo",


### PR DESCRIPTION
Addresses problem described in https://bugzilla.redhat.com/show_bug.cgi?id=1531511 and https://bugzilla.redhat.com/show_bug.cgi?id=1476330

This reverts commit 836369773b13156a4ce53974c4749936d961fcfe, to make it compatible with `kubectl create secret docker-registry`  from k8s 1.7.

@juanvallejo ptal