### PR TITLE
Pull haproxy from the right place

### DIFF
--- a/images/base/cbs-paas7-openshift-multiarch-el7-build.repo
+++ b/images/base/cbs-paas7-openshift-multiarch-el7-build.repo
@@ -4,5 +4,5 @@ baseurl = http://cbs.centos.org/kojifiles/repos/paas7-openshift-multiarch-el7-bu
 enabled = 1
 gpgcheck = 0
 sslverify = 0
-skip_if_unavailable = 1
-includepkgs = golang* protobuf* goversioninfo* openvswitch*
+skip_if_unavailable = 0
+includepkgs = golang* protobuf* goversioninfo* openvswitch* haproxy*

--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -6,9 +6,7 @@
 FROM openshift/origin
 
 RUN INSTALL_PKGS="haproxy18" && \
-    yum install yum-utils && \
-    yum-config-manager --add http://cbs.centos.org/repos/paas7-openshift-origin38-testing/x86_64/os/ && \
-    yum install --nogpgcheck -y $INSTALL_PKGS && \
+    yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \


### PR DESCRIPTION
This reverts the hack that we added to pull directly from a testing repo.  Once the image rolls out to the mirrors the hack is not needed.  This reverts it.