### PR TITLE
allow webconsole to discover cluster information

### DIFF
--- a/install/origin-web-console/rbac-template.yaml
+++ b/install/origin-web-console/rbac-template.yaml
@@ -1,0 +1,38 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: web-console-server-rbac
+parameters:
+- name: NAMESPACE
+  # This namespace cannot be changed. Only `openshift-web-console` is supported.
+  value: openshift-web-console
+objects:
+
+
+# allow grant powers to the webconsole server for cluster inspection
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    name: system:openshift:web-console-server
+  rules:
+  - apiGroups:
+    - "servicecatalog.k8s.io"
+    resources:
+    - clusterservicebrokers
+    verbs:
+    - get
+    - list
+    - watch
+
+# Grant the service account for the web console
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:web-console-server
+  roleRef:
+    kind: ClusterRole
+    name: system:openshift:web-console-server
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: webconsole

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -37,6 +37,7 @@
 // examples/service-catalog/service-catalog.yaml
 // install/origin-web-console/console-config.yaml
 // install/origin-web-console/console-template.yaml
+// install/origin-web-console/rbac-template.yaml
 // install/service-catalog-broker-resources/template-service-broker-registration.yaml
 // install/templateservicebroker/apiserver-config.yaml
 // install/templateservicebroker/apiserver-template.yaml
@@ -14360,6 +14361,61 @@ func installOriginWebConsoleConsoleTemplateYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installOriginWebConsoleRbacTemplateYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: web-console-server-rbac
+parameters:
+- name: NAMESPACE
+  # This namespace cannot be changed. Only `+"`"+`openshift-web-console`+"`"+` is supported.
+  value: openshift-web-console
+objects:
+
+
+# allow grant powers to the webconsole server for cluster inspection
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    name: system:openshift:web-console-server
+  rules:
+  - apiGroups:
+    - "servicecatalog.k8s.io"
+    resources:
+    - clusterservicebrokers
+    verbs:
+    - get
+    - list
+    - watch
+
+# Grant the service account for the web console
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:web-console-server
+  roleRef:
+    kind: ClusterRole
+    name: system:openshift:web-console-server
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: webconsole
+`)
+
+func installOriginWebConsoleRbacTemplateYamlBytes() ([]byte, error) {
+	return _installOriginWebConsoleRbacTemplateYaml, nil
+}
+
+func installOriginWebConsoleRbacTemplateYaml() (*asset, error) {
+	bytes, err := installOriginWebConsoleRbacTemplateYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/origin-web-console/rbac-template.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -14943,6 +14999,7 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/service-catalog/service-catalog.yaml": examplesServiceCatalogServiceCatalogYaml,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
 	"install/origin-web-console/console-template.yaml": installOriginWebConsoleConsoleTemplateYaml,
+	"install/origin-web-console/rbac-template.yaml": installOriginWebConsoleRbacTemplateYaml,
 	"install/service-catalog-broker-resources/template-service-broker-registration.yaml": installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml,
 	"install/templateservicebroker/apiserver-config.yaml": installTemplateservicebrokerApiserverConfigYaml,
 	"install/templateservicebroker/apiserver-template.yaml": installTemplateservicebrokerApiserverTemplateYaml,
@@ -15050,6 +15107,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"origin-web-console": &bintree{nil, map[string]*bintree{
 			"console-config.yaml": &bintree{installOriginWebConsoleConsoleConfigYaml, map[string]*bintree{}},
 			"console-template.yaml": &bintree{installOriginWebConsoleConsoleTemplateYaml, map[string]*bintree{}},
+			"rbac-template.yaml": &bintree{installOriginWebConsoleRbacTemplateYaml, map[string]*bintree{}},
 		}},
 		"service-catalog-broker-resources": &bintree{nil, map[string]*bintree{
 			"template-service-broker-registration.yaml": &bintree{installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml, map[string]*bintree{}},

--- a/pkg/oc/bootstrap/docker/openshift/webconsole.go
+++ b/pkg/oc/bootstrap/docker/openshift/webconsole.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	consoleNamespace             = "openshift-web-console"
+	consoleRBACTemplateName      = "web-console-server-rbac"
 	consoleAPIServerTemplateName = "openshift-web-console"
 	consoleAssetConfigFile       = "install/origin-web-console/console-config.yaml"
 )
@@ -39,6 +40,10 @@ func (h *Helper) InstallWebConsole(f *clientcmd.Factory, imageFormat string, ser
 	// create the namespace if needed.  This is a reserved namespace, so you can't do it with the create project request
 	if _, err := kubeClient.Core().Namespaces().Create(&kapi.Namespace{ObjectMeta: metav1.ObjectMeta{Name: consoleNamespace}}); err != nil && !kapierrors.IsAlreadyExists(err) {
 		return errors.NewError("cannot create web console project").WithCause(err)
+	}
+
+	if err = instantiateTemplate(templateClient.Template(), f, OpenshiftInfraNamespace, consoleRBACTemplateName, consoleNamespace, map[string]string{}, true); err != nil {
+		return errors.NewError("cannot instantiate template service broker permissions").WithCause(err)
 	}
 
 	// read in the asset config YAML file like the installer

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -127,6 +127,7 @@ var (
 	// the cluster version.
 	internalCurrentTemplateLocations = map[string]string{
 		"web console server template":       "install/origin-web-console/console-template.yaml",
+		"web console server rbac":           "install/origin-web-console/rbac-template.yaml",
 		"template service broker apiserver": "install/templateservicebroker/apiserver-template.yaml",
 	}
 	// internalPreviousTemplateLocations are templates that will be registered in an internal namespace.

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -245,6 +245,7 @@
 // examples/quickstarts/cakephp-mysql.json
 // install/origin-web-console/console-config.yaml
 // install/origin-web-console/console-template.yaml
+// install/origin-web-console/rbac-template.yaml
 // install/service-catalog-broker-resources/template-service-broker-registration.yaml
 // install/templateservicebroker/apiserver-config.yaml
 // install/templateservicebroker/apiserver-template.yaml
@@ -28263,6 +28264,61 @@ func installOriginWebConsoleConsoleTemplateYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installOriginWebConsoleRbacTemplateYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: web-console-server-rbac
+parameters:
+- name: NAMESPACE
+  # This namespace cannot be changed. Only `+"`"+`openshift-web-console`+"`"+` is supported.
+  value: openshift-web-console
+objects:
+
+
+# allow grant powers to the webconsole server for cluster inspection
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRole
+  metadata:
+    name: system:openshift:web-console-server
+  rules:
+  - apiGroups:
+    - "servicecatalog.k8s.io"
+    resources:
+    - clusterservicebrokers
+    verbs:
+    - get
+    - list
+    - watch
+
+# Grant the service account for the web console
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:web-console-server
+  roleRef:
+    kind: ClusterRole
+    name: system:openshift:web-console-server
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: webconsole
+`)
+
+func installOriginWebConsoleRbacTemplateYamlBytes() ([]byte, error) {
+	return _installOriginWebConsoleRbacTemplateYaml, nil
+}
+
+func installOriginWebConsoleRbacTemplateYaml() (*asset, error) {
+	bytes, err := installOriginWebConsoleRbacTemplateYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/origin-web-console/rbac-template.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -29018,6 +29074,7 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/quickstarts/cakephp-mysql.json/cakephp-mysql.json": examplesQuickstartsCakephpMysqlJsonCakephpMysqlJson,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
 	"install/origin-web-console/console-template.yaml": installOriginWebConsoleConsoleTemplateYaml,
+	"install/origin-web-console/rbac-template.yaml": installOriginWebConsoleRbacTemplateYaml,
 	"install/service-catalog-broker-resources/template-service-broker-registration.yaml": installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml,
 	"install/templateservicebroker/apiserver-config.yaml": installTemplateservicebrokerApiserverConfigYaml,
 	"install/templateservicebroker/apiserver-template.yaml": installTemplateservicebrokerApiserverTemplateYaml,
@@ -29132,6 +29189,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"origin-web-console": &bintree{nil, map[string]*bintree{
 			"console-config.yaml": &bintree{installOriginWebConsoleConsoleConfigYaml, map[string]*bintree{}},
 			"console-template.yaml": &bintree{installOriginWebConsoleConsoleTemplateYaml, map[string]*bintree{}},
+			"rbac-template.yaml": &bintree{installOriginWebConsoleRbacTemplateYaml, map[string]*bintree{}},
 		}},
 		"service-catalog-broker-resources": &bintree{nil, map[string]*bintree{
 			"template-service-broker-registration.yaml": &bintree{installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml, map[string]*bintree{}},


### PR DESCRIPTION
Adds permissions to the webconsole to inspect what clusterservicebrokers are present.

@pmorie please confirm this is a non-escalating resource which can be generally viewed.
@openshift/sig-security 
@spadgett @jwforres you'll need this before merging https://github.com/openshift/origin-web-console-server/pull/18