### PR TITLE
`oc image mirror` was accidentally broken during dependency updating

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -75,6 +75,10 @@ import:
 - package: github.com/opencontainers/runc
   repo:    git@github.com:openshift/opencontainers-runc
   version: openshift-3.9
+# cli
+- package: github.com/docker/distribution
+  repo:    git@github.com:openshift/docker-distribution
+  version: release-2.6.0
 
 # ours: shared with kube, but forced by openshift
 # master

--- a/pkg/oc/cli/cmd/image/mirror/mirror.go
+++ b/pkg/oc/cli/cmd/image/mirror/mirror.go
@@ -101,6 +101,12 @@ type pushOptions struct {
 	AttemptS3BucketCopy []string
 }
 
+// schema2ManifestOnly specifically requests a manifest list first
+var schema2ManifestOnly = distribution.WithManifestMediaTypes([]string{
+	manifestlist.MediaTypeManifestList,
+	schema2.MediaTypeManifest,
+})
+
 // NewCommandMirrorImage copies images from one location to another.
 func NewCmdMirrorImage(name string, out, errOut io.Writer) *cobra.Command {
 	o := &pushOptions{}
@@ -398,8 +404,7 @@ func (o *pushOptions) Run() error {
 		for srcDigestString, pushTargets := range src.digests {
 			// load the manifest
 			srcDigest := godigest.Digest(srcDigestString)
-			// var contentDigest godigest.Digest / client.ReturnContentDigest(&contentDigest),
-			srcManifest, err := manifests.Get(ctx, godigest.Digest(srcDigest), distribution.WithTag(manifestlist.MediaTypeManifestList), distribution.WithTag(schema2.MediaTypeManifest))
+			srcManifest, err := manifests.Get(ctx, godigest.Digest(srcDigest), schema2ManifestOnly)
 			if err != nil {
 				digestErrs = append(digestErrs, retrieverError{src: src.ref, err: fmt.Errorf("unable to retrieve source image %s manifest: %v", src.ref, err)})
 				continue

--- a/vendor/github.com/docker/distribution/registry.go
+++ b/vendor/github.com/docker/distribution/registry.go
@@ -72,6 +72,21 @@ func (o WithTagOption) Apply(m ManifestService) error {
 	return nil
 }
 
+// WithManifestMediaTypes lists the media types the client wishes
+// the server to provide.
+func WithManifestMediaTypes(mediaTypes []string) ManifestServiceOption {
+	return WithManifestMediaTypesOption{mediaTypes}
+}
+
+// WithManifestMediaTypesOption holds a list of accepted media types
+type WithManifestMediaTypesOption struct{ MediaTypes []string }
+
+// Apply conforms to the ManifestServiceOption interface
+func (o WithManifestMediaTypesOption) Apply(m ManifestService) error {
+	// no implementation
+	return nil
+}
+
 // Repository is a named collection of manifests and layers.
 type Repository interface {
 	// Named returns the name of the repository.

--- a/vendor/github.com/docker/distribution/registry/client/repository_test.go
+++ b/vendor/github.com/docker/distribution/registry/client/repository_test.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -781,6 +783,65 @@ func TestManifestFetchWithEtag(t *testing.T) {
 	_, err = clientManifestService.Get(ctx, d1, distribution.WithTag("latest"), AddEtagToTag("latest", d1.String()))
 	if err != distribution.ErrManifestNotModified {
 		t.Fatal(err)
+	}
+}
+
+func TestManifestFetchWithAccept(t *testing.T) {
+	ctx := context.Background()
+	repo, _ := reference.WithName("test.example.com/repo")
+	_, dgst, _ := newRandomSchemaV1Manifest(repo, "latest", 6)
+	headers := make(chan []string, 1)
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		headers <- req.Header["Accept"]
+	}))
+	defer close(headers)
+	defer s.Close()
+
+	r, err := NewRepository(context.Background(), repo, s.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms, err := r.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		// the media types we send
+		mediaTypes []string
+		// the expected Accept headers the server should receive
+		expect []string
+		// whether to sort the request and response values for comparison
+		sort bool
+	}{
+		{
+			mediaTypes: []string{},
+			expect:     distribution.ManifestMediaTypes(),
+			sort:       true,
+		},
+		{
+			mediaTypes: []string{"test1", "test2"},
+			expect:     []string{"test1", "test2"},
+		},
+		{
+			mediaTypes: []string{"test1"},
+			expect:     []string{"test1"},
+		},
+		{
+			mediaTypes: []string{""},
+			expect:     []string{""},
+		},
+	}
+	for _, testCase := range testCases {
+		ms.Get(ctx, dgst, distribution.WithManifestMediaTypes(testCase.mediaTypes))
+		actual := <-headers
+		if testCase.sort {
+			sort.Strings(actual)
+			sort.Strings(testCase.expect)
+		}
+		if !reflect.DeepEqual(actual, testCase.expect) {
+			t.Fatalf("unexpected Accept header values: %v", actual)
+		}
 	}
 }
 


### PR DESCRIPTION
An upstream cherry-pick was dropped and the wrong values were passed to the manifest Get call.

@liggitt