### PR TITLE
don't expose oapi types as 'all'

### DIFF
--- a/pkg/apps/registry/deployconfig/etcd/etcd.go
+++ b/pkg/apps/registry/deployconfig/etcd/etcd.go
@@ -178,3 +178,12 @@ func (r *StatusREST) Get(ctx apirequest.Context, name string, options *metav1.Ge
 func (r *StatusREST) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
 }
+
+// LegacyREST allows us to wrap and alter some behavior
+type LegacyREST struct {
+	*REST
+}
+
+func (r *LegacyREST) Categories() []string {
+	return []string{}
+}

--- a/pkg/build/registry/build/etcd/etcd.go
+++ b/pkg/build/registry/build/etcd/etcd.go
@@ -66,3 +66,12 @@ func (r *DetailsREST) New() runtime.Object {
 func (r *DetailsREST) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
 }
+
+// LegacyREST allows us to wrap and alter some behavior
+type LegacyREST struct {
+	*REST
+}
+
+func (r *LegacyREST) Categories() []string {
+	return []string{}
+}

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -48,3 +48,12 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 
 	return &REST{store}, nil
 }
+
+// LegacyREST allows us to wrap and alter some behavior
+type LegacyREST struct {
+	*REST
+}
+
+func (r *LegacyREST) Categories() []string {
+	return []string{}
+}

--- a/pkg/cmd/server/origin/legacy.go
+++ b/pkg/cmd/server/origin/legacy.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/openshift/origin/pkg/apps/registry/deployconfig"
 	deploymentconfigetcd "github.com/openshift/origin/pkg/apps/registry/deployconfig/etcd"
+	buildetcd "github.com/openshift/origin/pkg/build/registry/build/etcd"
 	buildconfig "github.com/openshift/origin/pkg/build/registry/buildconfig"
 	buildconfigetcd "github.com/openshift/origin/pkg/build/registry/buildconfig/etcd"
+	imagestreametcd "github.com/openshift/origin/pkg/image/registry/imagestream/etcd"
 	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
 	routeetcd "github.com/openshift/origin/pkg/route/registry/route/etcd"
 )
@@ -197,29 +199,33 @@ func LegacyStorage(storage map[schema.GroupVersion]map[string]rest.Storage) map[
 				// Kube only did this for a select few resources which were controller managed and established links
 				// via a workload controller.  In openshift, these will all conform to registry.Store so we
 				// can actually wrap the "normal" storage here.
-				switch resource {
-				case "buildConfigs":
-					restStorage := s.(*buildconfigetcd.REST)
-					store := *restStorage.Store
+				switch storage := s.(type) {
+				case *buildetcd.REST:
+					legacyStorage[resource] = &buildetcd.LegacyREST{REST: storage}
+
+				case *buildconfigetcd.REST:
+					store := *storage.Store
 					store.DeleteStrategy = buildconfig.LegacyStrategy
 					store.CreateStrategy = buildconfig.LegacyStrategy
-					legacyStorage[resource] = &buildconfigetcd.REST{Store: &store}
-				case "deploymentConfigs":
-					restStorage := s.(*deploymentconfigetcd.REST)
-					store := *restStorage.Store
+					legacyStorage[resource] = &buildconfigetcd.LegacyREST{REST: &buildconfigetcd.REST{Store: &store}}
+
+				case *deploymentconfigetcd.REST:
+					store := *storage.Store
 					store.CreateStrategy = deployconfig.LegacyStrategy
 					store.DeleteStrategy = deployconfig.LegacyStrategy
-					legacyStorage[resource] = &deploymentconfigetcd.REST{Store: &store}
-				case "routes":
-					restStorage := s.(*routeetcd.REST)
-					store := *restStorage.Store
+					legacyStorage[resource] = &deploymentconfigetcd.LegacyREST{REST: &deploymentconfigetcd.REST{Store: &store}}
+
+				case *imagestreametcd.REST:
+					legacyStorage[resource] = &imagestreametcd.LegacyREST{REST: storage}
+
+				case *routeetcd.REST:
+					store := *storage.Store
 					store.Decorator = routeregistry.DecorateLegacyRouteWithEmptyDestinationCACertificates
-					legacyStorage[resource] = &routeetcd.REST{Store: &store}
+					legacyStorage[resource] = &routeetcd.LegacyREST{REST: &routeetcd.REST{Store: &store}}
 
 				default:
 					legacyStorage[resource] = s
 				}
-
 			}
 		}
 	}

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -125,3 +125,12 @@ func (r *InternalREST) Create(ctx apirequest.Context, obj runtime.Object, create
 func (r *InternalREST) Update(ctx apirequest.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
 }
+
+// LegacyREST allows us to wrap and alter some behavior
+type LegacyREST struct {
+	*REST
+}
+
+func (r *LegacyREST) Categories() []string {
+	return []string{}
+}

--- a/pkg/oc/cli/util/clientcmd/factory_object_mapping.go
+++ b/pkg/oc/cli/util/clientcmd/factory_object_mapping.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	restclient "k8s.io/client-go/rest"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
@@ -62,34 +61,7 @@ func (f *ring1Factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 }
 
 func (f *ring1Factory) CategoryExpander() categories.CategoryExpander {
-	upstreamExpander := f.kubeObjectMappingFactory.CategoryExpander()
-
-	var openshiftCategoryExpander categories.CategoryExpander
-	openshiftCategoryExpander = legacyOpeshiftCategoryExpander
-	discoveryClient, err := f.clientAccessFactory.DiscoveryClient()
-	if err == nil {
-		// wrap with discovery based filtering
-		openshiftCategoryExpander, err = categories.NewDiscoveryFilteredExpander(openshiftCategoryExpander, discoveryClient)
-		// you only have an error on missing discoveryClient, so this shouldn't fail.  Check anyway.
-		kcmdutil.CheckErr(err)
-	}
-
-	return categories.UnionCategoryExpander{legacyOpeshiftCategoryExpander, upstreamExpander}
-}
-
-var legacyOpenshiftUserResources = []schema.GroupResource{
-	{Group: "", Resource: "buildconfigs"},
-	{Group: "", Resource: "builds"},
-	{Group: "", Resource: "imagestreams"},
-	{Group: "", Resource: "deploymentconfigs"},
-	{Group: "", Resource: "routes"},
-}
-
-// legacyOpeshiftCategoryExpander is the old hardcoded expansion for servers without listed categories
-var legacyOpeshiftCategoryExpander categories.CategoryExpander = categories.SimpleCategoryExpander{
-	Expansions: map[string][]schema.GroupResource{
-		"all": legacyOpenshiftUserResources,
-	},
+	return f.kubeObjectMappingFactory.CategoryExpander()
 }
 
 func (f *ring1Factory) ClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -78,3 +78,12 @@ func (r *StatusREST) Get(ctx apirequest.Context, name string, options *metav1.Ge
 func (r *StatusREST) Update(ctx apirequest.Context, name string, objInfo kapirest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation)
 }
+
+// LegacyREST allows us to wrap and alter some behavior
+type LegacyREST struct {
+	*REST
+}
+
+func (r *LegacyREST) Categories() []string {
+	return []string{}
+}

--- a/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
+++ b/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
@@ -45,3 +45,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	}
 	return &REST{store}
 }
+
+// LegacyREST allows us to wrap and alter some behavior
+type LegacyREST struct {
+	*REST
+}
+
+func (r *LegacyREST) Categories() []string {
+	return []string{}
+}


### PR DESCRIPTION
/assign @juanvallejo 

golang didn't let this come out as clean as I may have hoped.