### PR TITLE
fix deploymentStrategy validation panic

### DIFF
--- a/pkg/apps/apis/apps/validation/validation.go
+++ b/pkg/apps/apis/apps/validation/validation.go
@@ -39,7 +39,12 @@ func ValidateDeploymentConfigSpec(spec appsapi.DeploymentConfigSpec) field.Error
 		podSpec = &spec.Template.Spec
 	}
 
-	allErrs = append(allErrs, validateDeploymentStrategy(&spec.Strategy, podSpec, specPath.Child("strategy"))...)
+	// gate calls to validation functions that depend on a podSpec
+	// if we have don't have an actual podSpec here.
+	if podSpec != nil {
+		allErrs = append(allErrs, validateDeploymentStrategy(&spec.Strategy, podSpec, specPath.Child("strategy"))...)
+	}
+
 	if spec.RevisionHistoryLimit != nil {
 		allErrs = append(allErrs, kapivalidation.ValidateNonnegativeField(int64(*spec.RevisionHistoryLimit), specPath.Child("revisionHistoryLimit"))...)
 	}


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/18069

A server-side validation panic was occurring when 
attempting to validate deployment strategies for 
any deployment config which matched *all of* the following criteria:

- **had a nil or no `spec.Template` field**
- had a deployment strategy of type `Recreate`
- had a non-nil `spec.strategy.recreateParams` field
- had a non-nil `pre`, `mid`, or `post` hook
- had a non-nil `spec.strategy.recreateParams(pre|mid|post).failurePolicy` field
- had a `nil` `spec.strategy.recreateParams.(pre|mid|post).execNewPod` field
- had at least one tag image as part of its recreateParams

Validation for a dc matching the above criteria would attempt to use a nil podSpec (due to a nil spec.Template) and panic after calling  https://github.com/openshift/origin/blob/master/pkg/apps/apis/apps/validation/validation.go#L311 which  attempts to make use of podSpec data.

cc @mfojtik @soltysh 