### PR TITLE
Stabilize observe test

### DIFF
--- a/test/cmd/observe.sh
+++ b/test/cmd/observe.sh
@@ -30,8 +30,8 @@ os::cmd::expect_failure_and_text 'oc observe services --exit-after=1m --all-name
 # argument templates
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{ .spec.clusterIP }"' '172.30.0.1'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{{ .spec.clusterIP }}" --output=gotemplate' '172.30.0.1'
-os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{ .metadata.annotations.unset }key"' 'badkey'
-os::cmd::expect_failure_and_text 'oc observe services --once --all-namespaces -a "bad{ .metadata.annotations.unset }key" --strict-templates' 'annotations is not found'
+os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{ .missingkey }key"' 'badkey'
+os::cmd::expect_failure_and_text 'oc observe services --once --all-namespaces -a "bad{ .missingkey }key" --strict-templates' 'missingkey is not found'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{{ .unknown }}" --output=gotemplate' '""'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{{ or (.unknown) \"\" }}key" --output=gotemplate' 'badkey'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{{ .unknown }}key" --output=gotemplate --strict-templates' '\<no value\>'


### PR DESCRIPTION
Stabilize the observe cmd test by removing the assumption that all services lack
annotations.

Fixes https://github.com/openshift/origin/issues/17811.