### PR TITLE
bump godeps for kube version reporting

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -4001,1788 +4001,1788 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/admission/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/admissionregistration/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/apps/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/apps/v1beta2",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/authentication/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/authentication/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/authorization/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/authorization/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/autoscaling/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/autoscaling/v2beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/batch/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/batch/v2alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/certificates/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/imagepolicy/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/networking/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/policy/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/rbac/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/rbac/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/rbac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/scheduling/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/settings/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/storage/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/storage/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/internalinterfaces",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/equality",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/errors",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/meta",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/resource",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/testing/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validation/path",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apimachinery",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/conversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/fields",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/labels",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/schema",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/selection",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/types",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/clock",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/framer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/httpstream",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/initialization",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/intstr",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/json",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/mergepatch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/net",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/proxy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/rand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/remotecommand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/sets",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/uuid",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/validation/field",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/yaml",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/version",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/watch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/third_party/forked/golang/json",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/initializer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/audit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/audit/policy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/union",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/union",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/user",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/authorizer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/union",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/discovery",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/openapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/request",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/features",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/httplog",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/mux",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes/data/swagger",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/errors",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcdtest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing/testingcert",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd3/preflight",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/names",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/value",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/secretbox",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/feature",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/flag",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/flushwriter",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/proxy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/trace",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/wsstream",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/audit/log",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/keystone",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/cached",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/dynamic",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/admissionregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/apps",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/apps/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/apps/v1beta2",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/autoscaling",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/autoscaling/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/autoscaling/v2beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/batch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/batch/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/batch/v2alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/certificates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/certificates/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/core",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/extensions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/internalinterfaces",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/networking",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/networking/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/policy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/policy/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/rbac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/rbac/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/rbac/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/rbac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/scheduling",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/settings",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/settings/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/storage/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/storage/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/apps/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/apps/v1beta2",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/autoscaling/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/autoscaling/v2beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/batch/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/batch/v2alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/certificates/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/networking/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/policy/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/rbac/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/rbac/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/rbac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/settings/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/storage/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/storage/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/pkg/version",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/plugin/pkg/client/auth",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/watch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/third_party/forked/golang/template",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/auth",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/api",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/api/latest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/api/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/leaderelection",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/pager",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/portforward",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/record",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/reference",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/remotecommand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/transport",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/spdy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/cert",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/cert/triple",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/certificate",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/certificate/csr",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/exec",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/flowcontrol",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/homedir",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/integer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/jsonpath",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/workqueue",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/args",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/path",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/types",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/args",
@@ -5831,113 +5831,113 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/internalinterfaces",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/aggregator",
@@ -5965,4568 +5965,4568 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/genutils",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-apiserver/app",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-apiserver/app/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-controller-manager/app",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-controller-manager/app/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kube-proxy/app",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubeadm/app/constants",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubelet/app",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/cmd/kubelet/app/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/apis/federation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/apis/federation/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/apis/federation/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/typed/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/typed/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/dnsprovider",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns/stubs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federatedtypes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federatedtypes/crudtester",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federation-controller/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federation-controller/util/hpa",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federation-controller/util/planner",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federation-controller/util/podanalyzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/federation-controller/util/replicapreferences",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/kubefed",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/kubefed/init",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/federation/pkg/kubefed/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/endpoints",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/events",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/helper",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/helper/qos",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/persistentvolume",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/pod",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/ref",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/resource",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/service",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/testapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/testing/compat",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/endpoints",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/helper",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/helper/qos",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/node",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/pod",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/resource",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/service",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/v1/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac/latest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac/v0",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/abac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admission",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admission/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admission/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/admissionregistration/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/v1beta2",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/apps/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authentication/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/autoscaling/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/batch/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/certificates/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/imagepolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/imagepolicy/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/networking/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/policy/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/rbac/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/scheduling/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/settings/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/storage/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/auth/authorizer/abac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/auth/nodeidentifier",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/bootstrap/api",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/capabilities",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/chaosclient",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/conditions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/admissionregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/apps",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/apps/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/autoscaling",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/autoscaling/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/batch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/batch/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/certificates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/certificates/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/extensions",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/extensions/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/internalinterfaces",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/networking",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/networking/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/policy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/policy/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/rbac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/rbac/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/scheduling",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/scheduling/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/settings",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/settings/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/storage/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/leaderelectionconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/admissionregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/apps/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/autoscaling/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/batch/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/certificates/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/core/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/extensions/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/networking/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/policy/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/scheduling/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/settings/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/listers/storage/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/metrics/prometheus",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/aws",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/cloudstack",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/photon",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/bootstrap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/certificates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/certificates/approver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/certificates/signer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/cronjob",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/daemon",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/daemon/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/deployment",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/deployment/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/disruption",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/endpoint",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/garbagecollector",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/garbagecollector/metaonly",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/history",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/job",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/namespace",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/namespace/deletion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/node",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/node/ipam",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/node/ipam/cidrset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/node/ipam/sync",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/node/scheduler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/node/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/podautoscaler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/podautoscaler/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/podgc",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/replicaset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/replication",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/resourcequota",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/route",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/service",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/serviceaccount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/statefulset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/ttl",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/attachdetach",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/attachdetach/populator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/attachdetach/statusupdater",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/attachdetach/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/events",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/expand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/expand/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/expand/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/volume/persistentvolume",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/aws",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/azure",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/gcp",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider/rancher",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/features",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/fieldpath",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/generated",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/generated/openapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/admission",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/admission/configuration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/admission/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/authenticator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/authorizer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubeapiserver/server",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/auth",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/config",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/rollout",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/set",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/templates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util/editor",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util/env",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/metricsutil",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/plugins",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/proxy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/resource",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/crlf",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/hash",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/i18n",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/logs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/slice",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/util/term",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/cri",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cadvisor",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/certificate",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/client",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/cpuset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/cm/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/config",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/configmap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/container",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/container/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/deviceplugin",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/cm",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/errors",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/dockershim/remote",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/envvars",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/events",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/eviction",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/eviction/api",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/gpu",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/gpu/nvidia",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/images",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/checkpoint/store",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/configfiles",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/status",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/codec",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/equal",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/files",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/log",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/panic",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/kuberuntime",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/leaky",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/lifecycle",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/cni",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/hairpin",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/hostport",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/network/kubenet",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/pleg",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/pod",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/preemption",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/prober",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/prober/results",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/qos",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/remote",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/rkt",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/secret",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/portforward",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/remotecommand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/stats",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/server/streaming",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/stats",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/status",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/sysctl",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/types",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/format",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/ioutils",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/queue",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/util/sliceutils",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager/populator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubemark",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/master",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/master/controller/crdregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/master/ports",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/master/tunneler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/printers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/printers/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/printers/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe/exec",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe/http",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/probe/tcp",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/config",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/healthcheck",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/iptables",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/ipvs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/userspace",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/winkernel",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/proxy/winuserspace",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/quota",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/quota/evaluator/core",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/quota/generic",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/quota/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/admissionregistration/externaladmissionhookconfiguration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/admissionregistration/initializerconfiguration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/admissionregistration/initializerconfiguration/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/admissionregistration/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/apps/controllerrevision",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/apps/controllerrevision/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/apps/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/apps/statefulset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authentication/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authentication/tokenreview",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authorization/localsubjectaccessreview",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authorization/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authorization/selfsubjectaccessreview",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authorization/selfsubjectrulesreview",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authorization/subjectaccessreview",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/authorization/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/autoscaling/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/batch/cronjob",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/batch/cronjob/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/batch/job",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/batch/job/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/batch/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/cachesize",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/certificates/certificates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/certificates/certificates/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/certificates/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/componentstatus",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/configmap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/configmap/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/endpoint",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/endpoint/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/event",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/event/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/limitrange",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/limitrange/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/namespace",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/namespace/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/node",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/node/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/node/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/persistentvolume",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/persistentvolume/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/pod",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/pod/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/pod/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/podtemplate",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/podtemplate/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/rangeallocation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/replicationcontroller",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/resourcequota",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/resourcequota/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/secret",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/secret/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/allocator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/allocator/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/ipallocator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/ipallocator/controller",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/portallocator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/portallocator/controller",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/service/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/serviceaccount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/core/serviceaccount/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/controller/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/daemonset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/daemonset/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/deployment",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/deployment/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/ingress",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/ingress/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/podsecuritypolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/podsecuritypolicy/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/replicaset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/replicaset/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/extensions/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/networking/networkpolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/networking/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/policy/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/clusterrole",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/clusterrole/policybased",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/policybased",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/reconciliation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/role",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/role/policybased",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/role/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/rolebinding",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/rolebinding/policybased",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/rolebinding/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/rbac/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/registrytest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/scheduling/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/settings/podpreset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/settings/podpreset/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/settings/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/storage/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/storage/storageclass",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/registry/storage/storageclass/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/routes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/apparmor",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/apparmor",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/capabilities",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/group",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/seccomp",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/selinux",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/sysctl",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/user",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/security/podsecuritypolicy/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/securitycontext",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/serviceaccount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/ssh",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/async",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/bandwidth",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/config",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/configz",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/dbus",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ebtables",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/env",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/file",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/filesystem",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/flock",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/goroutinemap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/goroutinemap/exponentialbackoff",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/hash",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/interrupt",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/io",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ipconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/iptables",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/ipvs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/keymutex",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/labels",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/limitwriter",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/maps",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/mount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/net/sets",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/netsh",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/node",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/oom",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/parsers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/pointer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/procfs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/reflector/prometheus",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/removeall",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/resourcecontainer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/rlimit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/selinux",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/slice",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/strings",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/sysctl",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/system",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/tail",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/taints",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/term",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/tolerations",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/version",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/workqueue/prometheus",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version/prometheus",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version/verflag",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/aws_ebs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/azure_dd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/azure_file",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/cephfs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/cinder",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/configmap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/downwardapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/empty_dir",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/fc",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/flexvolume",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/flocker",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/gce_pd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/git_repo",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/glusterfs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/host_path",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/iscsi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/local",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/nfs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/photon_pd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/portworx",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/projected",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/quobyte",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/rbd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/scaleio",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/secret",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/storageos",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/operationexecutor",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/types",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/util/volumehelper",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/volume/vsphere_volume",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/watch/json",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/admit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/antiaffinity",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/deny",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/exec",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/gc",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/imagepolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/initialization",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/initialresources",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/limitranger",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/namespace/exists",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/noderestriction",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/label",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/resize",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podnodeselector",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podpreset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/priority",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/resourcequota",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/security/podsecuritypolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/storageclass/setdefault",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/admission/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authorizer/node",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api/latest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/api/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/core",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/factory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/plugin/pkg/scheduler/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/apps/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/apps/v1beta2",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/authentication/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/authorization/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/batch/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/batch/v2alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/rbac/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/api/storage/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/equality",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/errors",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/meta",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/resource",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/testing/fuzzer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validation/path",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apimachinery",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/conversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/fields",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/labels",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/schema",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/selection",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/types",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/errors",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/intstr",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/net",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/rand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/runtime",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/sets",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/uuid",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/validation/field",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/yaml",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/version",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/watch",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/initializer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/apis/audit/validation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/audit",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/audit/policy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/union",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/union",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/user",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/authorizer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/union",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/discovery",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/openapi",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/request",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/features",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/mux",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcdtest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/etcd/util",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/names",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/feature",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/flag",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/logs",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/util/wsstream",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/audit/log",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/cached",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/dynamic",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/informers/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/listers/core/v1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/rest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/fake",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/clientcmd/api",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/leaderelection",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/portforward",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/record",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/remotecommand",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/transport",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/spdy",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/cert",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/certificate",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/flowcontrol",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/homedir",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/integer",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/jsonpath",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/testing",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/client-go/util/workqueue",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/install",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/chaosmonkey",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/common",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/framework",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/framework/ginkgowrapper",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/framework/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/generated",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/manifest",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e/perftype",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e_federation",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e_federation/framework",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/e2e_federation/upgrades",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/utils",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/test/utils/image",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/golang/expansion",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/gonum/graph",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/gonum/graph/internal/linear",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/gonum/graph/simple",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/gonum/graph/traverse",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/apis/custom_metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/apis/metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/scheme",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1beta1",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/staging/src/k8s.io/metrics/pkg/client/custom_metrics",
-			"Comment": "v1.9.0-beta1",
-			"Rev": "3258431ac4f8e0f1425711b140de793ce20702e3"
+			"Comment": "v1.9.1-57-ga0ce1bc657",
+			"Rev": "a0ce1bc657faa48c85731dcca6a613d91224dea0"
 		},
 		{
 			"ImportPath": "k8s.io/utils/exec",


### PR DESCRIPTION
reports kube at the correct version after the 1.9.1 rebase. related to https://bugzilla.redhat.com/show_bug.cgi?id=1533433