### PR TITLE
apps: record lastFailedRollout metric only for presently failed DC

### DIFF
--- a/pkg/apps/metrics/prometheus/metrics_test.go
+++ b/pkg/apps/metrics/prometheus/metrics_test.go
@@ -124,7 +124,7 @@ func TestCollect(t *testing.T) {
 		},
 		{
 			name:          "single failed deployment within successful deployments",
-			count:         4,
+			count:         3,
 			available:     2,
 			failed:        1,
 			cancelled:     0,


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/17493

@tnozicka @smarterclayton this should cause that we only track the DC that has the latest deployment in failed state and not all deployments that were failed for a given DC.

PTAL