### PR TITLE
Backport PVC Protection Feature Scheduler Changes

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/BUILD
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/BUILD
@@ -64,6 +64,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/trace:go_default_library",
+        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",

--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/extender_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/extender_test.go
@@ -317,7 +317,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		}
 		queue := NewSchedulingQueue()
 		scheduler := NewGenericScheduler(
-			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders, nil)
+			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders, nil, schedulertesting.FakePersistentVolumeClaimLister{})
 		podIgnored := &v1.Pod{}
 		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {

--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/generic_scheduler.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/core/generic_scheduler.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 	utiltrace "k8s.io/apiserver/pkg/util/trace"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
@@ -101,6 +102,7 @@ type genericScheduler struct {
 
 	cachedNodeInfoMap map[string]*schedulercache.NodeInfo
 	volumeBinder      *volumebinder.VolumeBinder
+	pvcLister         corelisters.PersistentVolumeClaimLister
 }
 
 // Schedule tries to schedule the given pod to one of node in the node list.
@@ -109,6 +111,10 @@ type genericScheduler struct {
 func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister) (string, error) {
 	trace := utiltrace.New(fmt.Sprintf("Scheduling %s/%s", pod.Namespace, pod.Name))
 	defer trace.LogIfLong(100 * time.Millisecond)
+
+	if err := podPassesBasicChecks(pod, g.pvcLister); err != nil {
+		return "", err
+	}
 
 	nodes, err := nodeLister.List()
 	if err != nil {
@@ -995,6 +1001,32 @@ func podEligibleToPreemptOthers(pod *v1.Pod, nodeNameToInfo map[string]*schedule
 	return true
 }
 
+// podPassesBasicChecks makes sanity checks on the pod if it can be scheduled.
+func podPassesBasicChecks(pod *v1.Pod, pvcLister corelisters.PersistentVolumeClaimLister) error {
+	// Check PVCs used by the pod
+	namespace := pod.Namespace
+	manifest := &(pod.Spec)
+	for i := range manifest.Volumes {
+		volume := &manifest.Volumes[i]
+		if volume.PersistentVolumeClaim == nil {
+			// Volume is not a PVC, ignore
+			continue
+		}
+		pvcName := volume.PersistentVolumeClaim.ClaimName
+		pvc, err := pvcLister.PersistentVolumeClaims(namespace).Get(pvcName)
+		if err != nil {
+			// The error has already enough context ("persistentvolumeclaim "myclaim" not found")
+			return err
+		}
+
+		if pvc.DeletionTimestamp != nil {
+			return fmt.Errorf("persistentvolumeclaim %q is being deleted", pvc.Name)
+		}
+	}
+
+	return nil
+}
+
 func NewGenericScheduler(
 	cache schedulercache.Cache,
 	eCache *EquivalenceCache,
@@ -1004,7 +1036,8 @@ func NewGenericScheduler(
 	prioritizers []algorithm.PriorityConfig,
 	priorityMetaProducer algorithm.MetadataProducer,
 	extenders []algorithm.SchedulerExtender,
-	volumeBinder *volumebinder.VolumeBinder) algorithm.ScheduleAlgorithm {
+	volumeBinder *volumebinder.VolumeBinder,
+	pvcLister corelisters.PersistentVolumeClaimLister) algorithm.ScheduleAlgorithm {
 	return &genericScheduler{
 		cache:                 cache,
 		equivalenceCache:      eCache,
@@ -1016,5 +1049,6 @@ func NewGenericScheduler(
 		extenders:             extenders,
 		cachedNodeInfoMap:     make(map[string]*schedulercache.NodeInfo),
 		volumeBinder:          volumeBinder,
+		pvcLister:             pvcLister,
 	}
 }

--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/factory/factory.go
@@ -933,7 +933,7 @@ func (f *configFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 		glog.Info("Created equivalence class cache")
 	}
 
-	algo := core.NewGenericScheduler(f.schedulerCache, f.equivalencePodCache, f.podQueue, predicateFuncs, predicateMetaProducer, priorityConfigs, priorityMetaProducer, extenders, f.volumeBinder)
+	algo := core.NewGenericScheduler(f.schedulerCache, f.equivalencePodCache, f.podQueue, predicateFuncs, predicateMetaProducer, priorityConfigs, priorityMetaProducer, extenders, f.volumeBinder, f.pVCLister)
 
 	podBackoff := util.CreateDefaultPodBackoff()
 	return &scheduler.Config{

--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/scheduler_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/scheduler_test.go
@@ -532,7 +532,8 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.
 		[]algorithm.PriorityConfig{},
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.SchedulerExtender{},
-		nil)
+		nil,
+		schedulertesting.FakePersistentVolumeClaimLister{})
 	bindingChan := make(chan *v1.Binding, 1)
 	errChan := make(chan error, 1)
 	configurator := &FakeConfigurator{
@@ -575,7 +576,8 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		[]algorithm.PriorityConfig{},
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.SchedulerExtender{},
-		nil)
+		nil,
+		schedulertesting.FakePersistentVolumeClaimLister{})
 	bindingChan := make(chan *v1.Binding, 2)
 	configurator := &FakeConfigurator{
 		Config: &Config{

--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/testing/BUILD
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/testing/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/testing/fake_lister.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/scheduler/testing/fake_lister.go
@@ -24,6 +24,7 @@ import (
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	. "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
@@ -175,4 +176,39 @@ func (f FakeStatefulSetLister) GetPodStatefulSets(pod *v1.Pod) (sss []*apps.Stat
 		err = fmt.Errorf("Could not find StatefulSet for pod %s in namespace %s with labels: %v", pod.Name, pod.Namespace, pod.Labels)
 	}
 	return
+}
+
+// FakePersistentVolumeClaimLister implements PersistentVolumeClaimLister on []*v1.PersistentVolumeClaim for test purposes.
+type FakePersistentVolumeClaimLister []*v1.PersistentVolumeClaim
+
+var _ corelisters.PersistentVolumeClaimLister = FakePersistentVolumeClaimLister{}
+
+func (f FakePersistentVolumeClaimLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f FakePersistentVolumeClaimLister) PersistentVolumeClaims(namespace string) corelisters.PersistentVolumeClaimNamespaceLister {
+	return &fakePersistentVolumeClaimNamespaceLister{
+		pvcs:      f,
+		namespace: namespace,
+	}
+}
+
+// fakePersistentVolumeClaimNamespaceLister is implementation of PersistentVolumeClaimNamespaceLister returned by List() above.
+type fakePersistentVolumeClaimNamespaceLister struct {
+	pvcs      []*v1.PersistentVolumeClaim
+	namespace string
+}
+
+func (f *fakePersistentVolumeClaimNamespaceLister) Get(name string) (*v1.PersistentVolumeClaim, error) {
+	for _, pvc := range f.pvcs {
+		if pvc.Name == name && pvc.Namespace == f.namespace {
+			return pvc, nil
+		}
+	}
+	return nil, fmt.Errorf("persistentvolumeclaim %q not found", name)
+}
+
+func (f fakePersistentVolumeClaimNamespaceLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
+	return nil, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
Fixes bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1533081
Trello card: https://trello.com/c/cRyaIf5E/566-8-product-quality-prevent-pvc-deletion-if-pvc-in-use-by-a-pod

Backport of the K8s PR: https://github.com/kubernetes/kubernetes/pull/55957

K8s documentation: https://github.com/kubernetes/website/pull/6415