### PR TITLE
fix args passed to exec syscall

### DIFF
--- a/cmd/oadm/main.go
+++ b/cmd/oadm/main.go
@@ -24,7 +24,15 @@ func main() {
 
 	fmt.Fprintf(os.Stderr, "DEPRECATED: The 'oadm' command is deprecated, please use '%s adm' instead.\n", baseCommand)
 
-	if err := syscall.Exec(path, append([]string{"adm"}, os.Args[1:]...), os.Environ()); err != nil {
+	admCmd := ""
+
+	// there is no `oc adm version` command.
+	// special-case it here.
+	if os.Args[1] != "version" {
+		admCmd = "adm"
+	}
+
+	if err := syscall.Exec(path, append([]string{baseCommand, admCmd}, os.Args[1:]...), os.Environ()); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534315

The `oadm` top-level cmd made exec calls to `oc`, relaying its arguments to it.
It failed to pass a "base" command argument, which meant that the first argument
that it passed to `oc` was ignored/treated as the binary name in `oc`.

This meant that every command relayed from `oadm` to `oc adm` would be
executed without the `adm` arg, causing every command except `oadm version`
to fail.

What this also means is that this fix would break `oadm version` as there is no
`oc adm version` sub-command:

```
$ oadm version
DEPRECATED: The 'oadm' command is deprecated, please use 'oc adm' instead.
error: unknown command "version"
See 'oc adm -h' for help and examples.
```

cc @deads2k @soltysh 