### PR TITLE
Update cluster up for console config API changes

### DIFF
--- a/install/origin-web-console/console-config.yaml
+++ b/install/origin-web-console/console-config.yaml
@@ -1,5 +1,34 @@
-kind: WebConsoleConfiguration
 apiVersion: webconsole.config.openshift.io/v1
+kind: WebConsoleConfiguration
+clusterInfo:
+  consolePublicURL: https://127.0.0.1:8443/console/
+  loggingPublicURL: ""
+  logoutPublicURL: ""
+  masterPublicURL: https://127.0.0.1:8443
+  metricsPublicURL: ""
+# TODO: The new extensions properties cannot be set until
+# origin-web-console-server has been updated with the API changes since
+# `extensions` in the old asset config was an array.
+#extensions:
+#  scriptURLs: []
+#  stylesheetURLs: []
+#  properties: null
+features:
+  inactivityTimeoutMinutes: 0
+servingInfo:
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: /var/serving-cert/tls.crt
+  clientCA: ""
+  keyFile: /var/serving-cert/tls.key
+  maxRequestsInFlight: 0
+  namedCertificates: null
+  requestTimeoutSeconds: 0
+
+# START deprecated properties
+# These properties have been renamed and will be removed from the install
+# in a future pull. Keep both the old and new properties for now so that
+# the install is not broken while the origin-web-console image is updated.
 extensionDevelopment: false
 extensionProperties: null
 extensionScripts: null
@@ -10,12 +39,4 @@ logoutURL: ""
 masterPublicURL: https://127.0.0.1:8443
 metricsPublicURL: ""
 publicURL: https://127.0.0.1:8443/console/
-servingInfo:
-  bindAddress: 0.0.0.0:8443
-  bindNetwork: tcp4
-  certFile: /var/serving-cert/tls.crt
-  clientCA: ""
-  keyFile: /var/serving-cert/tls.key
-  maxRequestsInFlight: 0
-  namedCertificates: null
-  requestTimeoutSeconds: 0
+# END deprecated properties

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14894,8 +14894,37 @@ func examplesServiceCatalogServiceCatalogYaml() (*asset, error) {
 	return a, nil
 }
 
-var _installOriginWebConsoleConsoleConfigYaml = []byte(`kind: WebConsoleConfiguration
-apiVersion: webconsole.config.openshift.io/v1
+var _installOriginWebConsoleConsoleConfigYaml = []byte(`apiVersion: webconsole.config.openshift.io/v1
+kind: WebConsoleConfiguration
+clusterInfo:
+  consolePublicURL: https://127.0.0.1:8443/console/
+  loggingPublicURL: ""
+  logoutPublicURL: ""
+  masterPublicURL: https://127.0.0.1:8443
+  metricsPublicURL: ""
+# TODO: The new extensions properties cannot be set until
+# origin-web-console-server has been updated with the API changes since
+# `+"`"+`extensions`+"`"+` in the old asset config was an array.
+#extensions:
+#  scriptURLs: []
+#  stylesheetURLs: []
+#  properties: null
+features:
+  inactivityTimeoutMinutes: 0
+servingInfo:
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: /var/serving-cert/tls.crt
+  clientCA: ""
+  keyFile: /var/serving-cert/tls.key
+  maxRequestsInFlight: 0
+  namedCertificates: null
+  requestTimeoutSeconds: 0
+
+# START deprecated properties
+# These properties have been renamed and will be removed from the install
+# in a future pull. Keep both the old and new properties for now so that
+# the install is not broken while the origin-web-console image is updated.
 extensionDevelopment: false
 extensionProperties: null
 extensionScripts: null
@@ -14906,15 +14935,7 @@ logoutURL: ""
 masterPublicURL: https://127.0.0.1:8443
 metricsPublicURL: ""
 publicURL: https://127.0.0.1:8443/console/
-servingInfo:
-  bindAddress: 0.0.0.0:8443
-  bindNetwork: tcp4
-  certFile: /var/serving-cert/tls.crt
-  clientCA: ""
-  keyFile: /var/serving-cert/tls.key
-  maxRequestsInFlight: 0
-  namedCertificates: null
-  requestTimeoutSeconds: 0
+# END deprecated properties
 `)
 
 func installOriginWebConsoleConsoleConfigYamlBytes() ([]byte, error) {

--- a/pkg/oc/bootstrap/docker/openshift/webconsole.go
+++ b/pkg/oc/bootstrap/docker/openshift/webconsole.go
@@ -23,7 +23,7 @@ const (
 	consoleNamespace             = "openshift-web-console"
 	consoleRBACTemplateName      = "web-console-server-rbac"
 	consoleAPIServerTemplateName = "openshift-web-console"
-	consoleAssetConfigFile       = "install/origin-web-console/console-config.yaml"
+	consoleConfigFile            = "install/origin-web-console/console-config.yaml"
 )
 
 // InstallWebConsole installs the web console server into the openshift-web-console namespace and waits for it to become ready
@@ -46,32 +46,51 @@ func (h *Helper) InstallWebConsole(f *clientcmd.Factory, imageFormat string, ser
 		return errors.NewError("cannot instantiate template service broker permissions").WithCause(err)
 	}
 
-	// read in the asset config YAML file like the installer
-	assetConfigYaml, err := bootstrap.Asset(consoleAssetConfigFile)
+	// read in the config YAML file like the installer
+	consoleConfigYaml, err := bootstrap.Asset(consoleConfigFile)
 	if err != nil {
-		return errors.NewError("cannot read web console asset config file").WithCause(err)
+		return errors.NewError("cannot read web console config file").WithCause(err)
 	}
 
 	// prase the YAML to edit
-	var assetConfig map[string]interface{}
-	if err := yaml.Unmarshal(assetConfigYaml, &assetConfig); err != nil {
-		return errors.NewError("cannot parse web console asset config as YAML").WithCause(err)
+	var consoleConfig map[string]interface{}
+	if err := yaml.Unmarshal(consoleConfigYaml, &consoleConfig); err != nil {
+		return errors.NewError("cannot parse web console config as YAML").WithCause(err)
 	}
 
-	// update asset config values
-	assetConfig["publicURL"] = publicURL
-	assetConfig["masterPublicURL"] = masterURL
+	// update config values
+	clusterInfo, ok := consoleConfig["clusterInfo"].(map[interface{}]interface{})
+	if !ok {
+		return errors.NewError("cannot read clusterInfo in web console config")
+	}
+
+	clusterInfo["consolePublicURL"] = publicURL
+	clusterInfo["masterPublicURL"] = masterURL
 	if len(loggingURL) > 0 {
-		assetConfig["loggingPublicURL"] = loggingURL
+		clusterInfo["loggingPublicURL"] = loggingURL
 	}
 	if len(metricsURL) > 0 {
-		assetConfig["metricsPublicURL"] = metricsURL
+		clusterInfo["metricsPublicURL"] = metricsURL
 	}
 
+	// START deprecated properties
+	// These properties have been renamed and will be removed from cluster up
+	// in a future pull. Keep both the old and new properties for now so that
+	// the cluster up is not broken while the origin-web-console image is updated.
+	consoleConfig["publicURL"] = publicURL
+	consoleConfig["masterPublicURL"] = masterURL
+	if len(loggingURL) > 0 {
+		consoleConfig["loggingPublicURL"] = loggingURL
+	}
+	if len(metricsURL) > 0 {
+		consoleConfig["metricsPublicURL"] = metricsURL
+	}
+	// END deprecated properties
+
 	// serialize it back out as a string to use as a template parameter
-	updatedAssetConfig, err := yaml.Marshal(assetConfig)
+	updatedConfig, err := yaml.Marshal(consoleConfig)
 	if err != nil {
-		return errors.NewError("cannot serialize web console asset config").WithCause(err)
+		return errors.NewError("cannot serialize web console config").WithCause(err)
 	}
 
 	imageTemplate := variable.NewDefaultImageTemplate()
@@ -79,7 +98,7 @@ func (h *Helper) InstallWebConsole(f *clientcmd.Factory, imageFormat string, ser
 	imageTemplate.Latest = false
 
 	params := map[string]string{
-		"API_SERVER_CONFIG": string(updatedAssetConfig),
+		"API_SERVER_CONFIG": string(updatedConfig),
 		"IMAGE":             imageTemplate.ExpandOrDie("web-console"),
 		"LOGLEVEL":          fmt.Sprint(serverLogLevel),
 		"NAMESPACE":         consoleNamespace,

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -28794,8 +28794,37 @@ func examplesQuickstartsCakephpMysqlJsonCakephpMysqlJson() (*asset, error) {
 	return a, nil
 }
 
-var _installOriginWebConsoleConsoleConfigYaml = []byte(`kind: WebConsoleConfiguration
-apiVersion: webconsole.config.openshift.io/v1
+var _installOriginWebConsoleConsoleConfigYaml = []byte(`apiVersion: webconsole.config.openshift.io/v1
+kind: WebConsoleConfiguration
+clusterInfo:
+  consolePublicURL: https://127.0.0.1:8443/console/
+  loggingPublicURL: ""
+  logoutPublicURL: ""
+  masterPublicURL: https://127.0.0.1:8443
+  metricsPublicURL: ""
+# TODO: The new extensions properties cannot be set until
+# origin-web-console-server has been updated with the API changes since
+# `+"`"+`extensions`+"`"+` in the old asset config was an array.
+#extensions:
+#  scriptURLs: []
+#  stylesheetURLs: []
+#  properties: null
+features:
+  inactivityTimeoutMinutes: 0
+servingInfo:
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: /var/serving-cert/tls.crt
+  clientCA: ""
+  keyFile: /var/serving-cert/tls.key
+  maxRequestsInFlight: 0
+  namedCertificates: null
+  requestTimeoutSeconds: 0
+
+# START deprecated properties
+# These properties have been renamed and will be removed from the install
+# in a future pull. Keep both the old and new properties for now so that
+# the install is not broken while the origin-web-console image is updated.
 extensionDevelopment: false
 extensionProperties: null
 extensionScripts: null
@@ -28806,15 +28835,7 @@ logoutURL: ""
 masterPublicURL: https://127.0.0.1:8443
 metricsPublicURL: ""
 publicURL: https://127.0.0.1:8443/console/
-servingInfo:
-  bindAddress: 0.0.0.0:8443
-  bindNetwork: tcp4
-  certFile: /var/serving-cert/tls.crt
-  clientCA: ""
-  keyFile: /var/serving-cert/tls.key
-  maxRequestsInFlight: 0
-  namedCertificates: null
-  requestTimeoutSeconds: 0
+# END deprecated properties
 `)
 
 func installOriginWebConsoleConsoleConfigYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Adopt API changes from https://github.com/openshift/api/pull/31

For now, both the new and old config need to be written to avoid breaking cluster up until origin-web-console-server is updated.

/assign @deads2k 
@jwforres FYI