### PR TITLE
cli: update existing image trigger instead of appending

### DIFF
--- a/test/cmd/triggers.sh
+++ b/test/cmd/triggers.sh
@@ -116,6 +116,8 @@ os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world --auto' 'u
 os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'config.*true'
 os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world --from-image=ruby-hello-world:latest -c ruby-hello-world' 'updated'
 os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'image.*ruby-hello-world:latest \(ruby-hello-world\).*true'
+os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world --from-image=ruby-hello-world:stage -c ruby-hello-world' 'updated'
+os::cmd::expect_success_and_text 'oc set triggers dc/ruby-hello-world' 'image.*ruby-hello-world:stage \(ruby-hello-world\).*true'
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/triggers/annotations"


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/18025

This will override the existing image trigger per container instead of appending new triggers.
This makes updating to new image version a one-liner instead of removing all triggers and setting new
trigger. It is not clear what is the use-case for appending new image triggers for a single containers other than playing roulette with "what image will my container gonna be deployed with".

The behavior now is:

```console
# Initially there is one trigger
→ oc set triggers dc/test-deployment
NAME                               TYPE    VALUE                       AUTO
deploymentconfigs/test-deployment  config                              true
deploymentconfigs/test-deployment  image   image:v1 (test-deployment)  true

# User want to update to next version
→ oc set triggers dc/test-deployment --containers=test-deployment --from-image=image:v2
→ oc set triggers dc/test-deployment
NAME                               TYPE    VALUE                       AUTO
deploymentconfigs/test-deployment  config                              true
deploymentconfigs/test-deployment  image   image:v2 (test-deployment)  true
```

The change here is, that without `--append` flag, the `set triggers` will simply append a new trigger for image:v2 into the list, so the DC will end up with 2 image triggers for image:v1 and image:v2 which I consider as a dangerous bug.