### PR TITLE
Deal with auto-egress-ip mark conflicting with kube-proxy's masqueradeBit

### DIFF
--- a/pkg/cmd/server/kubernetes/network/sdn_linux.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_linux.go
@@ -55,6 +55,7 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 		KubeInformers:      internalKubeInformers,
 		NetworkInformers:   internalNetworkInformers,
 		IPTablesSyncPeriod: proxyconfig.IPTables.SyncPeriod.Duration,
+		MasqueradeBit:      proxyconfig.IPTables.MasqueradeBit,
 		ProxyMode:          proxyconfig.Mode,
 		EnableHostports:    enableHostports,
 		Recorder:           recorder,

--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -170,7 +170,7 @@ func TestEgressIP(t *testing.T) {
 
 	// Assign HostSubnet.EgressIP first, then NetNamespace.EgressIP, with a local EgressIP
 	eip.updateNodeEgress("172.17.0.4", []string{"172.17.0.102", "172.17.0.103"})
-	err = assertNetlinkChange(eip, "claim 172.17.0.103")
+	err = assertNoNetlinkChanges(eip)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -184,7 +184,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	eip.updateNamespaceEgress(45, "172.17.0.103")
-	err = assertNoNetlinkChanges(eip)
+	err = assertNetlinkChange(eip, "claim 172.17.0.103")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -205,7 +205,7 @@ func TestEgressIP(t *testing.T) {
 
 	// Drop namespace EgressIP
 	eip.deleteNamespaceEgress(44)
-	err = assertNoNetlinkChanges(eip)
+	err = assertNetlinkChange(eip, "release 172.17.0.102")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -213,9 +213,9 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 	return chainArray
 }
 
-func (n *NodeIPTables) AddEgressIPRules(egressIP, egressHex string) error {
+func (n *NodeIPTables) AddEgressIPRules(egressIP, mark string) error {
 	for _, cidr := range n.clusterNetworkCIDR {
-		_, err := n.ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-m", "mark", "--mark", egressHex, "-j", "SNAT", "--to-source", egressIP)
+		_, err := n.ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-m", "mark", "--mark", mark, "-j", "SNAT", "--to-source", egressIP)
 		if err != nil {
 			return err
 		}
@@ -224,9 +224,9 @@ func (n *NodeIPTables) AddEgressIPRules(egressIP, egressHex string) error {
 	return err
 }
 
-func (n *NodeIPTables) DeleteEgressIPRules(egressIP, egressHex string) error {
+func (n *NodeIPTables) DeleteEgressIPRules(egressIP, mark string) error {
 	for _, cidr := range n.clusterNetworkCIDR {
-		err := n.ipt.DeleteRule(iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-m", "mark", "--mark", egressHex, "-j", "SNAT", "--to-source", egressIP)
+		err := n.ipt.DeleteRule(iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-m", "mark", "--mark", mark, "-j", "SNAT", "--to-source", egressIP)
 		if err != nil {
 			return err
 		}

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -85,6 +85,7 @@ type OsdnNodeConfig struct {
 
 	IPTablesSyncPeriod time.Duration
 	ProxyMode          kubeproxyconfig.ProxyMode
+	MasqueradeBit      *int32
 }
 
 type OsdnNode struct {
@@ -182,7 +183,7 @@ func New(c *OsdnNodeConfig) (network.NodeInterface, error) {
 		hostSubnetMap:      make(map[string]*networkapi.HostSubnet),
 		kubeInformers:      c.KubeInformers,
 		networkInformers:   c.NetworkInformers,
-		egressIP:           newEgressIPWatcher(c.SelfIP, oc),
+		egressIP:           newEgressIPWatcher(oc, c.SelfIP, c.MasqueradeBit),
 
 		runtimeEndpoint: c.RuntimeEndpoint,
 		// 2 minutes is the current default value used in kubelet


### PR DESCRIPTION
auto-egress-ip uses the skb mark (OVS `pkt_mark`, iptables `mark`) to communicate information from OVS rules to iptables rules. Normally this works fine, but if the iptables rules get flushed and recreated, it's possible that the OpenShift and kube-proxy rules will get added back in the "wrong" order, and then the kube-proxy rules will start matching some of the auto-egress-ip packets, causing the wrong thing to happen.

Forcibly fixing the iptables rule order is difficult and fragile. Changing the implementation to not use the mark would also not be easy (and would be a lot of code to backport to 3.7). So I fixed it by just changing the code to use mark values that don't conflict with the bit that kube-proxy is using.

This means we only have 31 bits of mark to work with, so we can't reliably use the IP address as the mark value any more. So I switched to using the namespace's VNID instead, since those are only 24 bits. But this required reorganizing the code a bit because previously we were setting up the iptables rules for egress IPs before we knew what namespaces they were associated with.

First commit ("Make sure oc.tunMAC gets set even if AlreadySetUp()") is from #18049

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527642

@openshift/sig-networking PTAL