### PR TITLE
stop overriding cache control tags

### DIFF
--- a/pkg/cmd/server/origin/handlers.go
+++ b/pkg/cmd/server/origin/handlers.go
@@ -3,6 +3,7 @@ package origin
 import (
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -13,9 +14,29 @@ import (
 	serverhandlers "github.com/openshift/origin/pkg/cmd/server/handlers"
 )
 
+// cacheExcludedPaths is small and simple until the handlers include the cache headers they need
+var cacheExcludedPathPrefixes = []string{
+	"/swagger-2.0.0.json",
+	"/swagger-2.0.0.pb-v1",
+	"/swagger-2.0.0.pb-v1.gz",
+	"/swagger.json",
+	"/swaggerapi",
+}
+
 // cacheControlFilter sets the Cache-Control header to the specified value.
 func cacheControlFilter(handler http.Handler, value string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if _, ok := w.Header()["Cache-Control"]; ok {
+			handler.ServeHTTP(w, req)
+			return
+		}
+		for _, prefix := range cacheExcludedPathPrefixes {
+			if strings.HasPrefix(req.URL.Path, prefix) {
+				handler.ServeHTTP(w, req)
+				return
+			}
+		}
+
 		w.Header().Set("Cache-Control", value)
 		handler.ServeHTTP(w, req)
 	})


### PR DESCRIPTION
Overriding the cache control header messes with endpoints that are trying to set appropriate tags.  I have no memory of which one of us did it or why.

@juanvallejo @smarterclayton @liggitt 