### PR TITLE
Allow egress-router EGRESS_SOURCE to specify the local subnet length

### DIFF
--- a/images/egress/router/egress_router_test.go
+++ b/images/egress/router/egress_router_test.go
@@ -24,6 +24,15 @@ func TestEgressRouter(t *testing.T) {
 `,
 		},
 		{
+			source:  "1.2.3.4/24",
+			gateway: "1.1.1.1",
+			dest:    "10.1.2.3",
+			output: `
+-A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
+-A POSTROUTING -j SNAT --to-source 1.2.3.4
+`,
+		},
+		{
 			source:  "1.2.3.4",
 			gateway: "1.1.1.1",
 			dest:    "10.1.2.3",


### PR DESCRIPTION
Currently the egress-router always sets the macvlan0 address as a `/32`. This apparently causes problems with some wacky networking setups. This changes the script to let you specify EGRESS_SOURCE as something like `192.168.1.99/24`, so it will add it as a `/24` and then also add the corresponding subnet route, fixing things.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1527602