### PR TITLE
images: run observe image as root for ease of use

### DIFF
--- a/images/observe/Dockerfile
+++ b/images/observe/Dockerfile
@@ -10,6 +10,4 @@ FROM openshift/origin
 
 LABEL io.k8s.display-name="OpenShift Observer" \
       io.k8s.description="This image runs the oc observe command to watch and react to changes on your cluster."
-# The observer doesn't require a root user.
-USER 1001
 ENTRYPOINT ["/usr/bin/oc", "observe"]


### PR DESCRIPTION
When running the observe image from the master, this is the easiest way:

`docker run -u root -v /etc/origin/master/admin.kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig openshift/observe:latest services`

https://github.com/openshift/openshift-docs/pull/6082#discussion_r162156167

The `-u root` is needed to access the `admin.kubeconfig` in its default location.  If we remove the `USER` line from the `Dockerfile` then users won't need to do that.

A usability improvement in my mind.

@smarterclayton @mburke5678 