### PR TITLE
origin.spec: add openshift-diagnostics

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -534,6 +534,7 @@ fi
 %{_bindir}/oc
 %{_bindir}/kubectl
 %{_bindir}/oadm
+%{_bindir}/openshift-diagnostics
 %{_sysconfdir}/bash_completion.d/oc
 %{_mandir}/man1/oc*
 


### PR DESCRIPTION
One method of fixing https://github.com/openshift/origin/issues/18141 -- add the binary into the origin RPM so it gets into the images.