### PR TITLE
Switch idling over to using owner references.

### DIFF
--- a/pkg/oc/cli/cmd/idle.go
+++ b/pkg/oc/cli/cmd/idle.go
@@ -514,7 +514,7 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 		return err
 	}
 
-	externalKubeExtensionClient := kextensionsclient.New(kclient.Core().RESTClient())
+	externalKubeExtensionClient := kextensionsclient.New(kclient.Extensions().RESTClient())
 	delegScaleGetter := appsmanualclient.NewDelegatingScaleNamespacer(appsV1Client, externalKubeExtensionClient)
 	scaleAnnotater := utilunidling.NewScaleAnnotater(delegScaleGetter, appClient.Apps(), kclient.Core(), func(currentReplicas int32, annotations map[string]string) {
 		annotations[unidlingapi.IdledAtAnnotation] = nowTime.UTC().Format(time.RFC3339)


### PR DESCRIPTION
This commit switches the `oc idle` code over to using owner references
instead of the created-by annotation and the OpenShift-specific
deployment config annotations.

Closes #17798