### PR TITLE
track deployment scaleRefs for hpas

### DIFF
--- a/pkg/api/kubegraph/edges.go
+++ b/pkg/api/kubegraph/edges.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
@@ -242,6 +243,8 @@ func AddHPAScaleRefEdges(g osgraph.Graph) {
 			syntheticNode = kubegraph.FindOrCreateSyntheticReplicationControllerNode(g, &kapi.ReplicationController{ObjectMeta: syntheticMeta})
 		case appsapi.IsResourceOrLegacy("deploymentconfigs", r):
 			syntheticNode = appsgraph.FindOrCreateSyntheticDeploymentConfigNode(g, &appsapi.DeploymentConfig{ObjectMeta: syntheticMeta})
+		case r == kapisext.Resource("deployments"):
+			syntheticNode = appsgraph.FindOrCreateSyntheticDeploymentNode(g, &kapisext.Deployment{ObjectMeta: syntheticMeta})
 		default:
 			continue
 		}

--- a/pkg/oc/cli/describe/projectstatus.go
+++ b/pkg/oc/cli/describe/projectstatus.go
@@ -16,10 +16,12 @@ import (
 	kapps "k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kappsclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion"
 	kautoscalingclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	kapisextclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	"github.com/openshift/origin/pkg/api/graph/graphview"
@@ -93,6 +95,7 @@ func (d *ProjectStatusDescriber) MakeGraph(namespace string) (osgraph.Graph, set
 		&podLoader{namespace: namespace, lister: d.K.Core()},
 		&statefulSetLoader{namespace: namespace, lister: d.K.Apps()},
 		&horizontalPodAutoscalerLoader{namespace: namespace, lister: d.K.Autoscaling()},
+		&deploymentLoader{namespace: namespace, lister: d.K.Extensions()},
 		// TODO check swagger for feature enablement and selectively add bcLoader and buildLoader
 		// then remove errors.TolerateNotFoundError method.
 		&bcLoader{namespace: namespace, lister: d.BuildClient},
@@ -1376,6 +1379,30 @@ func (l *horizontalPodAutoscalerLoader) Load() error {
 func (l *horizontalPodAutoscalerLoader) AddToGraph(g osgraph.Graph) error {
 	for i := range l.items {
 		kubegraph.EnsureHorizontalPodAutoscalerNode(g, &l.items[i])
+	}
+
+	return nil
+}
+
+type deploymentLoader struct {
+	namespace string
+	lister    kapisextclient.DeploymentsGetter
+	items     []kapisext.Deployment
+}
+
+func (l *deploymentLoader) Load() error {
+	list, err := l.lister.Deployments(l.namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	l.items = list.Items
+	return nil
+}
+
+func (l *deploymentLoader) AddToGraph(g osgraph.Graph) error {
+	for i := range l.items {
+		appsgraph.EnsureDeploymentNode(g, &l.items[i])
 	}
 
 	return nil


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534956

A `ScalingEdgeKind` was not being added between hpas and scaling refs of type `extensions.Deployment`

cc @deads2k @soltysh 