### PR TITLE
remove subjectlocator shim and divide responsibility

### DIFF
--- a/pkg/authorization/apiserver/apiserver.go
+++ b/pkg/authorization/apiserver/apiserver.go
@@ -14,9 +14,9 @@ import (
 	rbacclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	authorizationapiv1 "github.com/openshift/api/authorization/v1"
-	"github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/authorization/registry/clusterrole"
 	"github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding"
 	"github.com/openshift/origin/pkg/authorization/registry/localresourceaccessreview"
@@ -34,7 +34,7 @@ type ExtraConfig struct {
 	CoreAPIServerClientConfig *restclient.Config
 	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 	RuleResolver              rbacregistryvalidation.AuthorizationRuleResolver
-	SubjectLocator            authorizer.SubjectLocator
+	SubjectLocator            rbac.SubjectLocator
 
 	// TODO these should all become local eventually
 	Scheme   *runtime.Scheme

--- a/pkg/authorization/authorizer/interfaces.go
+++ b/pkg/authorization/authorizer/interfaces.go
@@ -1,13 +1,8 @@
 package authorizer
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
-
-type SubjectLocator interface {
-	GetAllowedSubjects(attributes authorizer.Attributes) (sets.String, sets.String, error)
-}
 
 // ForbiddenMessageMaker creates a forbidden message from Attributes
 type ForbiddenMessageMaker interface {

--- a/pkg/authorization/registry/localresourceaccessreview/rest_test.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest_test.go
@@ -11,10 +11,12 @@ import (
 	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	apiserverrest "k8s.io/apiserver/pkg/registry/rest"
+	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
+	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 )
 
 type resourceAccessTest struct {
@@ -23,9 +25,8 @@ type resourceAccessTest struct {
 }
 
 type testAuthorizer struct {
-	users  sets.String
-	groups sets.String
-	err    string
+	subjects []rbacapi.Subject
+	err      string
 
 	actualAttributes kauthorizer.Attributes
 }
@@ -38,12 +39,12 @@ func (a *testAuthorizer) Authorize(attributes kauthorizer.Attributes) (decision 
 
 	return kauthorizer.DecisionNoOpinion, "", errors.New("Unsupported")
 }
-func (a *testAuthorizer) GetAllowedSubjects(passedAttributes kauthorizer.Attributes) (sets.String, sets.String, error) {
-	a.actualAttributes = passedAttributes
+func (a *testAuthorizer) AllowedSubjects(attributes kauthorizer.Attributes) ([]rbacapi.Subject, error) {
+	a.actualAttributes = attributes
 	if len(a.err) == 0 {
-		return a.users, a.groups, nil
+		return a.subjects, nil
 	}
-	return a.users, a.groups, errors.New(a.err)
+	return a.subjects, errors.New(a.err)
 }
 
 func TestNoNamespace(t *testing.T) {
@@ -86,10 +87,7 @@ func TestConflictingNamespace(t *testing.T) {
 
 func TestEmptyReturn(t *testing.T) {
 	test := &resourceAccessTest{
-		authorizer: &testAuthorizer{
-			users:  sets.String{},
-			groups: sets.String{},
-		},
+		authorizer: &testAuthorizer{},
 		reviewRequest: &authorizationapi.LocalResourceAccessReview{
 			Action: authorizationapi.Action{
 				Namespace: "unittest",
@@ -105,8 +103,12 @@ func TestEmptyReturn(t *testing.T) {
 func TestNoErrors(t *testing.T) {
 	test := &resourceAccessTest{
 		authorizer: &testAuthorizer{
-			users:  sets.NewString("one", "two"),
-			groups: sets.NewString("three", "four"),
+			subjects: []rbacapi.Subject{
+				{APIGroup: rbacapi.GroupName, Kind: rbacapi.UserKind, Name: "one"},
+				{APIGroup: rbacapi.GroupName, Kind: rbacapi.UserKind, Name: "two"},
+				{APIGroup: rbacapi.GroupName, Kind: rbacapi.GroupKind, Name: "three"},
+				{APIGroup: rbacapi.GroupName, Kind: rbacapi.GroupKind, Name: "four"},
+			},
 		},
 		reviewRequest: &authorizationapi.LocalResourceAccessReview{
 			Action: authorizationapi.Action{
@@ -123,10 +125,11 @@ func TestNoErrors(t *testing.T) {
 func (r *resourceAccessTest) runTest(t *testing.T) {
 	storage := NewREST(resourceaccessreview.NewRegistry(resourceaccessreview.NewREST(r.authorizer, r.authorizer)))
 
+	users, groups := authorizationutil.RBACSubjectsToUsersAndGroups(r.authorizer.subjects, r.reviewRequest.Action.Namespace)
 	expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 		Namespace: r.reviewRequest.Action.Namespace,
-		Users:     r.authorizer.users,
-		Groups:    r.authorizer.groups,
+		Users:     sets.NewString(users...),
+		Groups:    sets.NewString(groups...),
 	}
 
 	expectedAttributes := util.ToDefaultAuthorizationAttributes(nil, r.reviewRequest.Action.Namespace, r.reviewRequest.Action)

--- a/pkg/authorization/util/subject.go
+++ b/pkg/authorization/util/subject.go
@@ -23,3 +23,34 @@ func BuildRBACSubjects(users, groups []string) []rbac.Subject {
 
 	return subjects
 }
+
+func RBACSubjectsToUsersAndGroups(subjects []rbac.Subject, defaultNamespace string) (users []string, groups []string) {
+	for _, subject := range subjects {
+
+		switch {
+		case subject.APIGroup == rbac.GroupName && subject.Kind == rbac.GroupKind:
+			groups = append(groups, subject.Name)
+		case subject.APIGroup == rbac.GroupName && subject.Kind == rbac.UserKind:
+			users = append(users, subject.Name)
+		case subject.APIGroup == "" && subject.Kind == rbac.ServiceAccountKind:
+			// default the namespace to namespace we're working in if
+			// it's available. This allows rolebindings that reference
+			// SAs in the local namespace to avoid having to qualify
+			// them.
+			ns := defaultNamespace
+			if len(subject.Namespace) > 0 {
+				ns = subject.Namespace
+			}
+			if len(ns) > 0 {
+				name := serviceaccount.MakeUsername(ns, subject.Name)
+				users = append(users, name)
+			} else {
+				// maybe error?  this fails safe at any rate
+			}
+		default:
+			// maybe error?  This fails safe at any rate
+		}
+	}
+
+	return users, groups
+}

--- a/pkg/cmd/server/origin/authorizer.go
+++ b/pkg/cmd/server/origin/authorizer.go
@@ -2,73 +2,65 @@ package origin
 
 import (
 	"k8s.io/apiserver/pkg/authentication/user"
-	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
-	coreinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion"
 	rbacinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/rbac/internalversion"
-	rbaclisters "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/node"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 	kbootstrappolicy "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 
-	"github.com/openshift/origin/pkg/authorization/authorizer"
+	openshiftauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
 	"github.com/openshift/origin/pkg/authorization/authorizer/browsersafe"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 )
 
-func NewAuthorizer(informers InformerAccess, projectRequestMessage string) (kauthorizer.Authorizer, authorizer.SubjectLocator, rbacregistryvalidation.AuthorizationRuleResolver) {
-	kubeAuthorizer, ruleResolver, kubeSubjectLocator := buildKubeAuth(informers.GetInternalKubeInformers().Rbac().InternalVersion())
-	authorizer, subjectLocator := newAuthorizer(
-		kubeAuthorizer,
-		kubeSubjectLocator,
-		informers.GetInternalKubeInformers().Rbac().InternalVersion().ClusterRoles().Lister(),
-		informers.GetInternalKubeInformers().Core().InternalVersion().Pods(),
-		informers.GetInternalKubeInformers().Core().InternalVersion().PersistentVolumes(),
-		projectRequestMessage,
+func NewAuthorizer(informers InformerAccess, projectRequestDenyMessage string) authorizer.Authorizer {
+	messageMaker := openshiftauthorizer.NewForbiddenMessageResolver(projectRequestDenyMessage)
+	rbacInformers := informers.GetInternalKubeInformers().Rbac().InternalVersion()
+
+	kubeAuthorizer := rbacauthorizer.New(
+		&rbacauthorizer.RoleGetter{Lister: rbacInformers.Roles().Lister()},
+		&rbacauthorizer.RoleBindingLister{Lister: rbacInformers.RoleBindings().Lister()},
+		&rbacauthorizer.ClusterRoleGetter{Lister: rbacInformers.ClusterRoles().Lister()},
+		&rbacauthorizer.ClusterRoleBindingLister{Lister: rbacInformers.ClusterRoleBindings().Lister()},
 	)
+	prettyMessageKubeAuthorizer := openshiftauthorizer.NewAuthorizer(kubeAuthorizer, messageMaker)
 
-	return authorizer, subjectLocator, ruleResolver
-}
-
-func buildKubeAuth(r rbacinformers.Interface) (kauthorizer.Authorizer, rbacregistryvalidation.AuthorizationRuleResolver, rbacauthorizer.SubjectLocator) {
-	roles := &rbacauthorizer.RoleGetter{Lister: r.Roles().Lister()}
-	roleBindings := &rbacauthorizer.RoleBindingLister{Lister: r.RoleBindings().Lister()}
-	clusterRoles := &rbacauthorizer.ClusterRoleGetter{Lister: r.ClusterRoles().Lister()}
-	clusterRoleBindings := &rbacauthorizer.ClusterRoleBindingLister{Lister: r.ClusterRoleBindings().Lister()}
-	kubeAuthorizer := rbacauthorizer.New(roles, roleBindings, clusterRoles, clusterRoleBindings)
-	ruleResolver := rbacregistryvalidation.NewDefaultRuleResolver(roles, roleBindings, clusterRoles, clusterRoleBindings)
-	kubeSubjectLocator := rbacauthorizer.NewSubjectAccessEvaluator(roles, roleBindings, clusterRoles, clusterRoleBindings, "")
-	return kubeAuthorizer, ruleResolver, kubeSubjectLocator
-}
-
-func newAuthorizer(
-	kubeAuthorizer kauthorizer.Authorizer,
-	kubeSubjectLocator rbacauthorizer.SubjectLocator,
-	clusterRoleGetter rbaclisters.ClusterRoleLister,
-	podInformer coreinformers.PodInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
-	projectRequestDenyMessage string,
-) (kauthorizer.Authorizer, authorizer.SubjectLocator) {
-	messageMaker := authorizer.NewForbiddenMessageResolver(projectRequestDenyMessage)
-	roleBasedAuthorizer := authorizer.NewAuthorizer(kubeAuthorizer, messageMaker)
-	subjectLocator := authorizer.NewSubjectLocator(kubeSubjectLocator)
-
-	scopeLimitedAuthorizer := scope.NewAuthorizer(roleBasedAuthorizer, clusterRoleGetter, messageMaker)
+	scopeLimitedAuthorizer := scope.NewAuthorizer(prettyMessageKubeAuthorizer, rbacInformers.ClusterRoles().Lister(), messageMaker)
 	// Wrap with an authorizer that detects unsafe requests and modifies verbs/resources appropriately so policy can address them separately
 	browserSafeAuthorizer := browsersafe.NewBrowserSafeAuthorizer(scopeLimitedAuthorizer, user.AllAuthenticated)
 
 	graph := node.NewGraph()
-	node.AddGraphEventHandlers(graph, podInformer, pvInformer)
+	node.AddGraphEventHandlers(graph, informers.GetInternalKubeInformers().Core().InternalVersion().Pods(), informers.GetInternalKubeInformers().Core().InternalVersion().PersistentVolumes())
 	nodeAuthorizer := node.NewAuthorizer(graph, nodeidentifier.NewDefaultNodeIdentifier(), kbootstrappolicy.NodeRules())
 
-	authorizer := authorizerunion.New(
+	openshiftAuthorizer := authorizerunion.New(
 		authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup), // authorizes system:masters to do anything, just like upstream
 		nodeAuthorizer,
 		browserSafeAuthorizer,
 	)
 
-	return authorizer, subjectLocator
+	return openshiftAuthorizer
+}
+
+func NewRuleResolver(informers rbacinformers.Interface) rbacregistryvalidation.AuthorizationRuleResolver {
+	return rbacregistryvalidation.NewDefaultRuleResolver(
+		&rbacauthorizer.RoleGetter{Lister: informers.Roles().Lister()},
+		&rbacauthorizer.RoleBindingLister{Lister: informers.RoleBindings().Lister()},
+		&rbacauthorizer.ClusterRoleGetter{Lister: informers.ClusterRoles().Lister()},
+		&rbacauthorizer.ClusterRoleBindingLister{Lister: informers.ClusterRoleBindings().Lister()},
+	)
+}
+
+func NewSubjectLocator(informers rbacinformers.Interface) rbacauthorizer.SubjectLocator {
+	return rbacauthorizer.NewSubjectAccessEvaluator(
+		&rbacauthorizer.RoleGetter{Lister: informers.Roles().Lister()},
+		&rbacauthorizer.RoleBindingLister{Lister: informers.RoleBindings().Lister()},
+		&rbacauthorizer.ClusterRoleGetter{Lister: informers.ClusterRoles().Lister()},
+		&rbacauthorizer.ClusterRoleBindingLister{Lister: informers.ClusterRoleBindings().Lister()},
+		"",
+	)
 }

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -28,13 +28,13 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	oappsapiv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/origin/pkg/api"
 	"github.com/openshift/origin/pkg/api/v1"
 	oappsapiserver "github.com/openshift/origin/pkg/apps/apiserver"
 	authorizationapiserver "github.com/openshift/origin/pkg/authorization/apiserver"
-	"github.com/openshift/origin/pkg/authorization/authorizer"
 	buildapiserver "github.com/openshift/origin/pkg/build/apiserver"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -85,7 +85,7 @@ type OpenshiftAPIExtraConfig struct {
 
 	// these are all required to build our storage
 	RuleResolver   rbacregistryvalidation.AuthorizationRuleResolver
-	SubjectLocator authorizer.SubjectLocator
+	SubjectLocator rbacauthorizer.SubjectLocator
 
 	// for Images
 	LimitVerifier imageadmission.LimitVerifier


### PR DESCRIPTION
This removes an unnecessary shim interface, makes construction of separate things separate, makes an existing bug obvious (RAR doesn't take into account node authorizer), and will ease rebases.

@openshift/sig-security 
/assign enj
/assign simo5
/assign soltysh

Fixes #15816