### PR TITLE
UPSTREAM: 57967: Fixed TearDown of NFS with root squash.

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
@@ -19,6 +19,7 @@ limitations under the License.
 package mount
 
 import (
+	"os"
 	"path/filepath"
 )
 
@@ -208,6 +209,12 @@ func IsNotMountPoint(mounter Interface, file string) (bool, error) {
 	// IsLikelyNotMountPoint provides a quick check
 	// to determine whether file IS A mountpoint
 	notMnt, notMntErr := mounter.IsLikelyNotMountPoint(file)
+	if notMntErr != nil && os.IsPermission(notMntErr) {
+		// We were not allowed to do the simple stat() check, e.g. on NFS with
+		// root_squash. Fall back to /proc/mounts check below.
+		notMnt = true
+		notMntErr = nil
+	}
 	if notMntErr != nil {
 		return notMnt, notMntErr
 	}

--- a/vendor/k8s.io/kubernetes/pkg/volume/nfs/nfs.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/nfs/nfs.go
@@ -233,7 +233,7 @@ func (b *nfsMounter) SetUp(fsGroup *int64) error {
 }
 
 func (b *nfsMounter) SetUpAt(dir string, fsGroup *int64) error {
-	notMnt, err := b.mounter.IsLikelyNotMountPoint(dir)
+	notMnt, err := b.mounter.IsNotMountPoint(dir)
 	glog.V(4).Infof("NFS mount set up: %s %v %v", dir, !notMnt, err)
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -252,7 +252,7 @@ func (b *nfsMounter) SetUpAt(dir string, fsGroup *int64) error {
 	mountOptions := volume.JoinMountOptions(b.mountOptions, options)
 	err = b.mounter.Mount(source, dir, "nfs", mountOptions)
 	if err != nil {
-		notMnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
+		notMnt, mntErr := b.mounter.IsNotMountPoint(dir)
 		if mntErr != nil {
 			glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 			return err
@@ -262,7 +262,7 @@ func (b *nfsMounter) SetUpAt(dir string, fsGroup *int64) error {
 				glog.Errorf("Failed to unmount: %v", mntErr)
 				return err
 			}
-			notMnt, mntErr := b.mounter.IsLikelyNotMountPoint(dir)
+			notMnt, mntErr := b.mounter.IsNotMountPoint(dir)
 			if mntErr != nil {
 				glog.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
 				return err
@@ -290,7 +290,10 @@ func (c *nfsUnmounter) TearDown() error {
 }
 
 func (c *nfsUnmounter) TearDownAt(dir string) error {
-	return util.UnmountPath(dir, c.mounter)
+	// Use extensiveMountPointCheck to consult /proc/mounts. We can't use faster
+	// IsLikelyNotMountPoint (lstat()), since there may be root_squash on the
+	// NFS server and kubelet may not be able to do lstat/stat() there.
+	return util.UnmountMountPoint(dir, c.mounter, true /* extensiveMountPointCheck */)
 }
 
 func getVolumeSource(spec *volume.Spec) (*v1.NFSVolumeSource, bool, error) {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518237

/assign @rootfs @gnufied 