### PR TITLE
UPSTREAM: 58466: tolerate more than one gvklist item

### DIFF
--- a/test/cmd/explain.sh
+++ b/test/cmd/explain.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all,templates --all
+  exit 0
+) &>/dev/null
+
+
+os::test::junit::declare_suite_start "cmd/explain"
+# This test validates that the explain command works with openshift resources
+
+os::cmd::expect_success 'oc explain dc'
+os::cmd::expect_success_and_text 'oc explain dc.status.replicas' 'FIELD\: replicas'
+
+os::cmd::expect_success 'oc explain routes'
+os::cmd::expect_success_and_text 'oc explain route.metadata.name' 'string'
+
+os::cmd::expect_success 'oc explain bc'
+os::cmd::expect_success 'oc explain image'
+os::cmd::expect_success 'oc explain is'
+
+echo "explain: ok"
+os::test::junit::declare_suite_end
+


### PR DESCRIPTION
Fixes #17872
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536845
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1529447

Origin resources, like deployment configs, are part of two api groups -
the legacy "empty" group, and, in cases like deploymentconfigs, the
"apps.openshift.io" group.

**Before**
```
$ oc explain dc
error: Couldn't find resource for "/v1, Kind=DeploymentConfig"
```

**After**
```
$ oc explain dc
DESCRIPTION:
     Deployment Configs define the template for a pod and manages deploying new
     images or configuration changes. A single deployment configuration is
     usually analogous to a single micro-service. Can support many different
     deployment patterns, including full restart, customizable rolling updates,
...
```

cc @deads2k @soltysh 