### PR TITLE
show disk types for proof during tests

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -5,6 +5,9 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 os::util::environment::setup_time_vars
 
+echo "Disk Types"
+df -T
+
 function cleanup() {
   return_code=$?
   os::test::junit::generate_report

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -7,6 +7,9 @@ source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 os::util::environment::setup_time_vars
 trap os::test::junit::reconcile_output EXIT
 
+echo "Disk Types"
+df -T
+
 export VERBOSE=true
 
 function wait_for_app() {


### PR DESCRIPTION
Dump all the disk types during test-cmd and test-end-to-end so that we can be sure that we're getting the ramdisk we expect.