### PR TITLE
Optionally enforce that `$ETCD_DATA_DIR` is on tmpfs

### DIFF
--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -189,3 +189,33 @@ function os::util::curl_etcd() {
 		     --cert "${etcd_client_cert}" --key "${etcd_client_key}" "${full_url}"
 	fi
 }
+
+# os::util::ensure_tmpfs ensures that the target dir is mounted on tmpfs
+#
+# Globals:
+#  OS_TMPFS_REQUIRED
+# Arguments:
+#  - 1: target to check
+# Returns:
+#  None
+function os::util::ensure_tmpfs() {
+	local target="$1"
+	if [[ ! -d "${target}" ]]; then
+		os::log::fatal "Target dir ${target} does not exist, cannot perform fstype check."
+	fi
+
+	os::log::debug "Filesystem information:
+$( df -h -T )"
+
+	local fstype
+	fstype="$( df --output=fstype "${target}" | tail -n 1 )"
+	if [[ "${fstype}" != "tmpfs" ]]; then
+		local message="Expected \`${target}\` to be mounted on \`tmpfs\` but found \`${fstype}\` instead."
+		if [[ -n "${OS_TMPFS_REQUIRED:-}" ]]; then
+			os::log::fatal "${message}"
+		else
+			os::log::warning "${message}
+Running in permissive mode, this will be ignored."
+		fi
+	fi
+}

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -44,6 +44,7 @@ export NETWORK_PLUGIN='redhat/openshift-ovs-multitenant'
 
 os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
+os::util::ensure_tmpfs "${ETCD_DATA_DIR}"
 
 echo "Logging to ${LOG_DIR}..."
 

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -3,6 +3,7 @@
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+os::util::ensure_tmpfs "${ETCD_DATA_DIR}"
 
 os::util::environment::setup_time_vars
 trap os::test::junit::reconcile_output EXIT
@@ -379,7 +380,7 @@ os::cmd::expect_success 'oc project test'
 os::cmd::expect_success 'oc whoami'
 
 # FIXME: Disabled because in Jenkins it seems like the --attach does not print the required output or the output is stripped which is causing
-#        this test case to flake massively. 
+#        this test case to flake massively.
 #
 #os::log::info "Running a CLI command in a container using the service account"
 #os::cmd::expect_success 'oc policy add-role-to-user view -z default'


### PR DESCRIPTION
In AWS EC2, we must use `tmpfs` instead of the default EBS volumes for
etcd data, or long fsyncs can kill our server. When `$OS_TMPFS_REQUIRED`
is set, we can be stringent about this check but otherwise we will
default to being permissive.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @deads2k @bparees @smarterclayton 
Supersedes https://github.com/openshift/origin/pull/18160