### PR TITLE
Add node system-container ADDLT_MOUNTS

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -491,6 +491,7 @@
 		"size=65536k"
 	    ]
 	}
+        $ADDTL_MOUNTS
     ],
     "hooks": {},
     "linux": {

--- a/images/node/system-container/manifest.json
+++ b/images/node/system-container/manifest.json
@@ -6,6 +6,7 @@
         "ORIGIN_DATA_DIR": "/var/lib/origin",
         "MASTER_SERVICE": "atomic-openshift-master.service",
         "DOCKER_SERVICE": "docker.service",
-        "OPENVSWITCH_SERVICE": "openvswitch.service"
+        "OPENVSWITCH_SERVICE": "openvswitch.service",
+        "ADDTL_MOUNTS": ""
     }
 }


### PR DESCRIPTION
This commit allows system-container based nodes
to accept additional mounts during creation.

This implements the same interface as the etcd
system container: https://github.com/projectatomic/atomic-system-containers/blob/master/etcd/config.json.template#L219

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1534933