### PR TITLE
cluster up: install console after template service broker

### DIFF
--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -430,12 +430,6 @@ func (c *ClientStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command)
 	// Import internal templates
 	c.addTask(conditionalTask("Importing internal templates", c.ImportInternalTemplates, c.ShouldInitializeData))
 
-	// Install the web console
-	c.addTask(conditionalTask("Installing web console", c.InstallWebConsole, func() bool {
-		serverVersion, _ := c.OpenShiftHelper().ServerVersion()
-		return clusterVersionIsCurrent(serverVersion) && c.ShouldInitializeData()
-	}))
-
 	// Import logging templates
 	c.addTask(conditionalTask("Importing logging templates", c.ImportLoggingTemplates, func() bool {
 		return c.ShouldInstallLogging && c.ShouldInitializeData()
@@ -460,6 +454,13 @@ func (c *ClientStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command)
 	// the TSB registration is not persisted.
 	c.addTask(conditionalTask("Registering template service broker with service catalog", c.RegisterTemplateServiceBroker, func() bool {
 		return c.ShouldInstallServiceCatalog
+	}))
+
+	// Install the web console. Do this after the template service broker is installed so that
+	// the console can discover that the broker is running on startup.
+	c.addTask(conditionalTask("Installing web console", c.InstallWebConsole, func() bool {
+		serverVersion, _ := c.OpenShiftHelper().ServerVersion()
+		return clusterVersionIsCurrent(serverVersion) && c.ShouldInitializeData()
 	}))
 
 	// Login with an initial default user


### PR DESCRIPTION
The console will check if the template service broker is running, but
only on startup. Install the console after the broker so that this check
works for `oc cluster up --service-catalog`.

/assign @deads2k 
cc @jwforres 

See https://github.com/openshift/origin-web-console-server/pull/18
See https://bugzilla.redhat.com/show_bug.cgi?id=1534316