### PR TITLE
UPSTREAM: 58478: support comma delimited env arg oc run

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/run.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/run.go
@@ -916,20 +916,26 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 func parseEnvs(envArray []string) ([]v1.EnvVar, error) {
 	envs := make([]v1.EnvVar, 0, len(envArray))
 	for _, env := range envArray {
-		pos := strings.Index(env, "=")
-		if pos == -1 {
-			return nil, fmt.Errorf("invalid env: %v", env)
+		// parse a list of envs delimited by commas
+		pieces := strings.Split(env, ",")
+		for _, envPiece := range pieces {
+			envPiece = strings.TrimSpace(envPiece)
+
+			pos := strings.Index(envPiece, "=")
+			if pos == -1 {
+				return nil, fmt.Errorf("invalid env: %v", envPiece)
+			}
+			name := envPiece[:pos]
+			value := envPiece[pos+1:]
+			if len(name) == 0 {
+				return nil, fmt.Errorf("invalid env: %v", envPiece)
+			}
+			if len(validation.IsEnvVarName(name)) != 0 {
+				return nil, fmt.Errorf("invalid env: %v", envPiece)
+			}
+			envVar := v1.EnvVar{Name: name, Value: value}
+			envs = append(envs, envVar)
 		}
-		name := env[:pos]
-		value := env[pos+1:]
-		if len(name) == 0 {
-			return nil, fmt.Errorf("invalid env: %v", env)
-		}
-		if len(validation.IsEnvVarName(name)) != 0 {
-			return nil, fmt.Errorf("invalid env: %v", env)
-		}
-		envVar := v1.EnvVar{Name: name, Value: value}
-		envs = append(envs, envVar)
 	}
 	return envs, nil
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1523069

**Before**
```
$ oc run myrun-pod  --image=my-image --generator=run-pod/v1 --env=MYENV1=v1,MYENV2=v2
pod "myrun-pod" created

$ oc get pod myrun-pod -o json
...
"containers": [
            {
                "env": [
                    {
                        "name": "MYENV1",
                        "value": "v1,MYENV2=v2"
                    }
                ],
...
```

**After**
```
$ oc run myrun-pod  --image=my-image --generator=run-pod/v1 --env=MYENV1=v1,MYENV2=v2
pod "myrun-pod" created

$ oc get pod myrun-pod -o json
...
"containers": [
            {
                "env": [
                    {
                        "name": "MYENV1",
                        "value": "v1"
                    },
                    {
                        "name": "MYENV2",
                        "value": "v2"
                    }
                ],
...
```
cc @soltysh 