### PR TITLE
UPSTREAM: 58533: add suggestion to describe pod for container names

### DIFF
--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -263,6 +263,17 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 	o.AsNonRoot = !o.AsRoot && cmd.Flag("as-root").Changed
 
 	if len(o.Attach.ContainerName) == 0 && len(pod.Spec.Containers) > 0 {
+		fullCmdName := ""
+		cmdParent := cmd.Parent()
+		if cmdParent != nil {
+			fullCmdName = cmdParent.CommandPath()
+		}
+
+		if len(fullCmdName) > 0 && kcmdutil.IsSiblingCommandExists(cmd, "describe") {
+			fmt.Fprintf(o.Attach.Err, "Defaulting container name to %s.\n", pod.Spec.Containers[0].Name)
+			fmt.Fprintf(o.Attach.Err, "Use '%s describe pod/%s -n %s' to see all of the containers in this pod.\n", fullCmdName, pod.Name, pod.Namespace)
+		}
+
 		glog.V(4).Infof("Defaulting container name to %s", pod.Spec.Containers[0].Name)
 		o.Attach.ContainerName = pod.Spec.Containers[0].Name
 	}

--- a/pkg/oc/cli/cmd/rsh.go
+++ b/pkg/oc/cli/cmd/rsh.go
@@ -147,6 +147,15 @@ func (o *RshOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 	o.PodClient = client.Core()
 
 	o.PodName, err = f.PodForResource(resource, time.Duration(o.Timeout)*time.Second)
+
+	fullCmdName := ""
+	cmdParent := cmd.Parent()
+	if cmdParent != nil {
+		fullCmdName = cmdParent.CommandPath()
+	}
+	if len(fullCmdName) > 0 && kcmdutil.IsSiblingCommandExists(cmd, "describe") {
+		o.ExecOptions.SuggestedCmdUsage = fmt.Sprintf("Use '%s describe pod/%s -n %s' to see all of the containers in this pod.", fullCmdName, o.PodName, o.Namespace)
+	}
 	return err
 }
 

--- a/pkg/oc/cli/cmd/rsync/execremote.go
+++ b/pkg/oc/cli/cmd/rsync/execremote.go
@@ -14,11 +14,12 @@ import (
 
 // remoteExecutor will execute commands on a given pod/container by using the kube Exec command
 type remoteExecutor struct {
-	Namespace     string
-	PodName       string
-	ContainerName string
-	Client        kclientset.Interface
-	Config        *restclient.Config
+	Namespace         string
+	PodName           string
+	ContainerName     string
+	SuggestedCmdUsage string
+	Client            kclientset.Interface
+	Config            *restclient.Config
 }
 
 // Ensure it implements the executor interface
@@ -37,10 +38,11 @@ func (e *remoteExecutor) Execute(command []string, in io.Reader, out, errOut io.
 			Err:           errOut,
 			Stdin:         in != nil,
 		},
-		Executor:  &kubecmd.DefaultRemoteExecutor{},
-		PodClient: e.Client.Core(),
-		Config:    e.Config,
-		Command:   command,
+		SuggestedCmdUsage: e.SuggestedCmdUsage,
+		Executor:          &kubecmd.DefaultRemoteExecutor{},
+		PodClient:         e.Client.Core(),
+		Config:            e.Config,
+		Command:           command,
 	}
 	err := execOptions.Validate()
 	if err != nil {
@@ -66,10 +68,11 @@ func newRemoteExecutor(f *clientcmd.Factory, o *RsyncOptions) (executor, error) 
 	}
 
 	return &remoteExecutor{
-		Namespace:     o.Namespace,
-		PodName:       o.PodName(),
-		ContainerName: o.ContainerName,
-		Config:        config,
-		Client:        client,
+		Namespace:         o.Namespace,
+		PodName:           o.PodName(),
+		ContainerName:     o.ContainerName,
+		SuggestedCmdUsage: o.SuggestedCmdUsage,
+		Config:            config,
+		Client:            client,
 	}, nil
 }

--- a/pkg/oc/cli/cmd/rsync/rsync.go
+++ b/pkg/oc/cli/cmd/rsync/rsync.go
@@ -70,15 +70,16 @@ type podChecker interface {
 
 // RsyncOptions holds the options to execute the sync command
 type RsyncOptions struct {
-	Namespace     string
-	ContainerName string
-	Source        *pathSpec
-	Destination   *pathSpec
-	Strategy      copyStrategy
-	StrategyName  string
-	Quiet         bool
-	Delete        bool
-	Watch         bool
+	Namespace         string
+	ContainerName     string
+	Source            *pathSpec
+	Destination       *pathSpec
+	Strategy          copyStrategy
+	StrategyName      string
+	Quiet             bool
+	Delete            bool
+	Watch             bool
+	SuggestedCmdUsage string
 
 	RsyncInclude  []string
 	RsyncExclude  []string
@@ -212,6 +213,16 @@ func (o *RsyncOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args [
 	o.Destination, err = parsePathSpec(parsedDestPath)
 	if err != nil {
 		return err
+	}
+
+	fullCmdName := ""
+	cmdParent := cmd.Parent()
+	if cmdParent != nil {
+		fullCmdName = cmdParent.CommandPath()
+	}
+
+	if len(fullCmdName) > 0 && kcmdutil.IsSiblingCommandExists(cmd, "describe") {
+		o.SuggestedCmdUsage = fmt.Sprintf("Use '%s describe pod/%s -n %s' to see all of the containers in this pod.", fullCmdName, o.PodName(), o.Namespace)
 	}
 
 	o.Strategy, err = o.determineStrategy(f, cmd, o.StrategyName)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
@@ -114,7 +114,8 @@ func (*DefaultRemoteAttach) Attach(method string, url *url.URL, config *restclie
 type AttachOptions struct {
 	StreamOptions
 
-	CommandName string
+	CommandName       string
+	SuggestedCmdUsage string
 
 	Pod *api.Pod
 
@@ -166,6 +167,15 @@ func (p *AttachOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn [
 
 	p.PodName = attachablePod.Name
 	p.Namespace = namespace
+
+	fullCmdName := ""
+	cmdParent := cmd.Parent()
+	if cmdParent != nil {
+		fullCmdName = cmdParent.CommandPath()
+	}
+	if len(fullCmdName) > 0 && cmdutil.IsSiblingCommandExists(cmd, "describe") {
+		p.SuggestedCmdUsage = fmt.Sprintf("Use '%s describe pod/%s -n %s' to see all of the containers in this pod.", fullCmdName, p.PodName, p.Namespace)
+	}
 
 	config, err := f.ClientConfig()
 	if err != nil {
@@ -310,6 +320,11 @@ func (p *AttachOptions) containerToAttachTo(pod *api.Pod) (*api.Container, error
 			}
 		}
 		return nil, fmt.Errorf("container not found (%s)", p.ContainerName)
+	}
+
+	if len(p.SuggestedCmdUsage) > 0 {
+		fmt.Fprintf(p.Err, "Defaulting container name to %s.\n", pod.Spec.Containers[0].Name)
+		fmt.Fprintf(p.Err, "%s\n", p.SuggestedCmdUsage)
 	}
 
 	glog.V(4).Infof("defaulting container name to %s", pod.Spec.Containers[0].Name)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1389208

Usability improvement: Suggest using `oc describe <pod>` to retrieve all pod containers to use with cmds that stream to/from pods.

cc @soltysh 