### PR TITLE
UPSTREAM: google/cadvisor: 1847: Skip getVfsStats when file does not exist

### DIFF
--- a/vendor/github.com/google/cadvisor/fs/fs.go
+++ b/vendor/github.com/google/cadvisor/fs/fs.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/golang/glog"
 	"github.com/google/cadvisor/devicemapper"
+	"github.com/google/cadvisor/utils"
 	dockerutil "github.com/google/cadvisor/utils/docker"
 	zfs "github.com/mistifyio/go-zfs"
 )
@@ -409,10 +410,14 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
 				fs.Type = ZFS
 			default:
 				var inodes, inodesFree uint64
-				fs.Capacity, fs.Free, fs.Available, inodes, inodesFree, err = getVfsStats(partition.mountpoint)
-				fs.Inodes = &inodes
-				fs.InodesFree = &inodesFree
-				fs.Type = VFS
+				if utils.FileExists(partition.mountpoint) {
+					fs.Capacity, fs.Free, fs.Available, inodes, inodesFree, err = getVfsStats(partition.mountpoint)
+					fs.Inodes = &inodes
+					fs.InodesFree = &inodesFree
+					fs.Type = VFS
+				} else {
+					glog.V(4).Infof("unable to determine file system type, partition mountpoint does not exist: %v", partition.mountpoint)
+				}
 			}
 			if err != nil {
 				glog.Errorf("Stat fs failed. Error: %v", err)


### PR DESCRIPTION
https://github.com/google/cadvisor/pull/1847

xref https://bugzilla.redhat.com/show_bug.cgi?id=1511576

@eparis @derekwaynecarr 

**Reviewer note**
Drops two copyright year changes included in the upstream commit.