### PR TITLE
Use double-dashes for AlertManager CLI parameters

### DIFF
--- a/examples/prometheus/prometheus-standalone.yaml
+++ b/examples/prometheus/prometheus-standalone.yaml
@@ -175,7 +175,7 @@ objects:
 
         - name: alertmanager
           args:
-          - -config.file=/etc/alertmanager/alertmanager.yml
+          - --config.file=/etc/alertmanager/alertmanager.yml
           image: ${IMAGE_ALERTMANAGER}
           imagePullPolicy: IfNotPresent
           ports:

--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -301,7 +301,7 @@ objects:
 
         - name: alertmanager
           args:
-          - -config.file=/etc/alertmanager/alertmanager.yml
+          - --config.file=/etc/alertmanager/alertmanager.yml
           image: ${IMAGE_ALERTMANAGER}
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
Alertmanager >= v0.13.0  will only support double-dashes. Previous versions
support single and double dashes.

@aweiteka you probably want the same modification for the Ansible installer.