### PR TITLE
Update web console template labels

### DIFF
--- a/install/origin-web-console/OWNERS
+++ b/install/origin-web-console/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - spadgett
+  - jwforres
+  - deads2k
+approvers:
+  - spadgett
+  - jwforres
+  - deads2k

--- a/install/origin-web-console/console-template.yaml
+++ b/install/origin-web-console/console-template.yaml
@@ -42,6 +42,7 @@ objects:
       metadata:
         name: webconsole
         labels:
+          app: openshift-web-console
           webconsole: "true"
       spec:
         serviceAccountName: webconsole

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -15069,6 +15069,7 @@ objects:
       metadata:
         name: webconsole
         labels:
+          app: openshift-web-console
           webconsole: "true"
       spec:
         serviceAccountName: webconsole

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -29264,6 +29264,7 @@ objects:
       metadata:
         name: webconsole
         labels:
+          app: openshift-web-console
           webconsole: "true"
       spec:
         serviceAccountName: webconsole


### PR DESCRIPTION
Consistently use `app: openshift-web-console` for labels in the web console template.

Per https://github.com/openshift/openshift-ansible/pull/6359#issuecomment-359279922

> Also, the labels for the deployment should be app: openshift-web-console across the board.

/assign @smarterclayton 
/cc @deads2k @jwforres