### PR TITLE
add loadavg to node exporter whitelist.  this is not in cadvisor either.

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -571,10 +571,10 @@ objects:
         - source_labels: [__name__]
           action: drop
           regex: 'node_cpu|node_(disk|scrape_collector)_.+'
-        # preserve a subset of the network, netstat, vmstat, and filesystem series
+        # preserve a subset of the network, netstat, vmstat, load and filesystem series
         - source_labels: [__name__]
           action: replace
-          regex: '(node_(netstat_Ip_.+|vmstat_(nr|thp)_.+|filesystem_(free|size|device_error)|network_(transmit|receive)_(drop|errs)))'
+          regex: '(node_(node_load.+|netstat_Ip_.+|vmstat_(nr|thp)_.+|filesystem_(free|size|device_error)|network_(transmit|receive)_(drop|errs)))'
           target_label: __name__
           replacement: renamed_$1
         - source_labels: [__name__]

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14401,10 +14401,10 @@ objects:
         - source_labels: [__name__]
           action: drop
           regex: 'node_cpu|node_(disk|scrape_collector)_.+'
-        # preserve a subset of the network, netstat, vmstat, and filesystem series
+        # preserve a subset of the network, netstat, vmstat, load and filesystem series
         - source_labels: [__name__]
           action: replace
-          regex: '(node_(netstat_Ip_.+|vmstat_(nr|thp)_.+|filesystem_(free|size|device_error)|network_(transmit|receive)_(drop|errs)))'
+          regex: '(node_(node_load.+|netstat_Ip_.+|vmstat_(nr|thp)_.+|filesystem_(free|size|device_error)|network_(transmit|receive)_(drop|errs)))'
           target_label: __name__
           replacement: renamed_$1
         - source_labels: [__name__]

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -25697,10 +25697,10 @@ objects:
         - source_labels: [__name__]
           action: drop
           regex: 'node_cpu|node_(disk|scrape_collector)_.+'
-        # preserve a subset of the network, netstat, vmstat, and filesystem series
+        # preserve a subset of the network, netstat, vmstat, load and filesystem series
         - source_labels: [__name__]
           action: replace
-          regex: '(node_(netstat_Ip_.+|vmstat_(nr|thp)_.+|filesystem_(free|size|device_error)|network_(transmit|receive)_(drop|errs)))'
+          regex: '(node_(node_load.+|netstat_Ip_.+|vmstat_(nr|thp)_.+|filesystem_(free|size|device_error)|network_(transmit|receive)_(drop|errs)))'
           target_label: __name__
           replacement: renamed_$1
         - source_labels: [__name__]


### PR DESCRIPTION
There's no way to get loadavg at the moment.