### PR TITLE
fix admission usage test and add missing plugins

### DIFF
--- a/pkg/cmd/server/origin/admission/chain_builder.go
+++ b/pkg/cmd/server/origin/admission/chain_builder.go
@@ -49,7 +49,11 @@ var (
 
 	// kubeAdmissionPlugins gives the in-order default admission chain for kube resources.
 	kubeAdmissionPlugins = []string{
+		"AlwaysAdmit",
+		"NamespaceAutoProvision",
+		"NamespaceExists",
 		lifecycle.PluginName,
+		"EventRateLimit",
 		"RunOnceDuration",
 		"PodNodeConstraints",
 		"OriginPodNodeEnvironment",
@@ -61,10 +65,15 @@ var (
 		imagequalify.PluginName,
 		"ImagePolicyWebhook",
 		"PodPreset",
+		"InitialResources",
 		"LimitRanger",
 		"ServiceAccount",
 		noderestriction.PluginName,
+		"SecurityContextDeny",
 		sccadmission.PluginName,
+		"PodSecurityPolicy",
+		"DenyEscalatingExec",
+		"DenyExecOnPrivileged",
 		storageclassdefaultadmission.PluginName,
 		expandpvcadmission.PluginName,
 		"AlwaysPullImages",
@@ -73,6 +82,7 @@ var (
 		"PersistentVolumeLabel",
 		"OwnerReferencesPermissionEnforcement",
 		ingressadmission.IngressAdmission,
+		"Priority",
 		"ExtendedResourceToleration",
 		"DefaultTolerationSeconds",
 		"PVCProtection",
@@ -80,6 +90,7 @@ var (
 		"MutatingAdmissionWebhook",
 		"ValidatingAdmissionWebhook",
 		"PodTolerationRestriction",
+		"AlwaysDeny",
 		// NOTE: ResourceQuota and ClusterResourceQuota must be the last 2 plugins.
 		// DO NOT ADD ANY PLUGINS AFTER THIS LINE!
 		"ResourceQuota",
@@ -90,7 +101,11 @@ var (
 	// When possible, this list is used.  The set of openshift+kube chains must exactly match this set.  In addition,
 	// the order specified in the openshift and kube chains must match the order here.
 	combinedAdmissionControlPlugins = []string{
+		"AlwaysAdmit",
+		"NamespaceAutoProvision",
+		"NamespaceExists",
 		lifecycle.PluginName,
+		"EventRateLimit",
 		"ProjectRequestLimit",
 		"OriginNamespaceLifecycle",
 		"openshift.io/RestrictSubjectBindings",
@@ -109,10 +124,15 @@ var (
 		imagequalify.PluginName,
 		"ImagePolicyWebhook",
 		"PodPreset",
+		"InitialResources",
 		"LimitRanger",
 		"ServiceAccount",
 		noderestriction.PluginName,
+		"SecurityContextDeny",
 		sccadmission.PluginName,
+		"PodSecurityPolicy",
+		"DenyEscalatingExec",
+		"DenyExecOnPrivileged",
 		storageclassdefaultadmission.PluginName,
 		expandpvcadmission.PluginName,
 		"AlwaysPullImages",
@@ -121,6 +141,7 @@ var (
 		"PersistentVolumeLabel",
 		"OwnerReferencesPermissionEnforcement",
 		ingressadmission.IngressAdmission,
+		"Priority",
 		"ExtendedResourceToleration",
 		"DefaultTolerationSeconds",
 		"PVCProtection",
@@ -128,6 +149,7 @@ var (
 		"MutatingAdmissionWebhook",
 		"ValidatingAdmissionWebhook",
 		"PodTolerationRestriction",
+		"AlwaysDeny",
 		// NOTE: ResourceQuota and ClusterResourceQuota must be the last 2 plugins.
 		// DO NOT ADD ANY PLUGINS AFTER THIS LINE!
 		"ResourceQuota",

--- a/pkg/cmd/server/origin/admission/register.go
+++ b/pkg/cmd/server/origin/admission/register.go
@@ -52,6 +52,10 @@ func init() {
 func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	kubeapiserver.RegisterAllAdmissionPlugins(plugins)
 	genericapiserver.RegisterAllAdmissionPlugins(plugins)
+	registerOpenshiftAdmissionPlugins(plugins)
+}
+
+func registerOpenshiftAdmissionPlugins(plugins *admission.Plugins) {
 	authorizationrestrictusers.Register(plugins)
 	buildjenkinsbootstrapper.Register(plugins)
 	buildsecretinjector.Register(plugins)
@@ -114,8 +118,9 @@ var (
 		"LimitPodHardAntiAffinityTopology",
 		"DefaultTolerationSeconds",
 		"PodPreset", // default to off while PodPreset is alpha
-
-		// these are new, reassess post-rebase
+		"EventRateLimit",
+		"PodSecurityPolicy",
+		"Priority",
 		"Initializers",
 		"ValidatingAdmissionWebhook",
 		"MutatingAdmissionWebhook",
@@ -123,6 +128,16 @@ var (
 		"ExtendedResourceToleration",
 		"PVCProtection",
 		expandpvcadmission.PluginName,
+
+		// these should usually be off.
+		"AlwaysAdmit",
+		"AlwaysDeny",
+		"DenyEscalatingExec",
+		"DenyExecOnPrivileged",
+		"InitialResources",
+		"NamespaceAutoProvision",
+		"NamespaceExists",
+		"SecurityContextDeny",
 	)
 )
 

--- a/pkg/cmd/server/origin/admission/sync_test.go
+++ b/pkg/cmd/server/origin/admission/sync_test.go
@@ -69,8 +69,8 @@ func TestAdmissionOnOffCoverage(t *testing.T) {
 
 	if !configuredAdmissionPlugins.Equal(allCoveredAdmissionPlugins) {
 		t.Errorf("every admission plugin must be default on or default off. differences: %v and %v",
-			configuredAdmissionPlugins.Difference(allCoveredAdmissionPlugins),
-			allCoveredAdmissionPlugins.Difference(configuredAdmissionPlugins))
+			configuredAdmissionPlugins.Difference(allCoveredAdmissionPlugins).List(),
+			allCoveredAdmissionPlugins.Difference(configuredAdmissionPlugins).List())
 	}
 
 	for plugin := range DefaultOnPlugins {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536288

Our test for including upstream admission plugins wasn't good.  I fixed it to run based on the upstream registration functions.  I also added the EventRateLimiter to fix the perceived problem.

/assign soltysh
/assign sttts
@mfojtik 