### PR TITLE
Automated cherry pick of #15213 #16219 #16340 #17080 #18221 on release-3.6

### DIFF
--- a/pkg/cmd/admin/admin.go
+++ b/pkg/cmd/admin/admin.go
@@ -69,7 +69,7 @@ func NewCommandAdmin(name, fullName string, in io.Reader, out io.Writer, errout 
 				policy.NewCmdPolicy(policy.PolicyRecommendedName, fullName+" "+policy.PolicyRecommendedName, f, out, errout),
 				groups.NewCmdGroups(groups.GroupsRecommendedName, fullName+" "+groups.GroupsRecommendedName, f, out, errout),
 				cert.NewCmdCert(cert.CertRecommendedName, fullName+" "+cert.CertRecommendedName, out, errout),
-				admin.NewCommandOverwriteBootstrapPolicy(admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.CreateBootstrapPolicyFileCommand, out),
+				admin.NewCommandOverwriteBootstrapPolicy(admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.OverwriteBootstrapPolicyCommandName, fullName+" "+admin.CreateBootstrapPolicyFileCommand, f, out),
 				kubecmd.NewCmdCertificate(f, out),
 			},
 		},

--- a/pkg/cmd/admin/migrate/authorization/authorization.go
+++ b/pkg/cmd/admin/migrate/authorization/authorization.go
@@ -84,12 +84,12 @@ func (o *MigrateAuthorizationOptions) Complete(name string, f *clientcmd.Factory
 		return err
 	}
 
-	client, kclient, err := f.Clients()
+	_, kclient, err := f.Clients()
 	if err != nil {
 		return err
 	}
 
-	if err := clientcmd.Gate(client, "", "3.7.0"); err != nil {
+	if err := clientcmd.LegacyPolicyResourceGate(kclient.Discovery()); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/admin/migrate/authorization/authorization.go
+++ b/pkg/cmd/admin/migrate/authorization/authorization.go
@@ -84,10 +84,15 @@ func (o *MigrateAuthorizationOptions) Complete(name string, f *clientcmd.Factory
 		return err
 	}
 
-	_, kclient, err := f.Clients()
+	client, kclient, err := f.Clients()
 	if err != nil {
 		return err
 	}
+
+	if err := clientcmd.Gate(client, "", "3.7.0"); err != nil {
+		return err
+	}
+
 	o.rbac = kclient.Rbac()
 
 	return nil

--- a/pkg/cmd/admin/migrate/authorization/authorization.go
+++ b/pkg/cmd/admin/migrate/authorization/authorization.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"io"
 
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -39,7 +40,8 @@ var (
 
 		No resources are mutated.`)
 
-	errOutOfSync = errors.New("is not in sync with RBAC")
+	// errOutOfSync is retriable since it could be caused by the controller lagging behind
+	errOutOfSync = migrate.ErrRetriable{errors.New("is not in sync with RBAC")}
 )
 
 type MigrateAuthorizationOptions struct {
@@ -54,6 +56,7 @@ func NewCmdMigrateAuthorization(name, fullName string, f *clientcmd.Factory, in 
 			Out:           out,
 			ErrOut:        errout,
 			AllNamespaces: true,
+			Confirm:       true, // force our save function to always run (it is read only)
 			Include: []string{
 				"clusterroles.authorization.openshift.io",
 				"roles.authorization.openshift.io",
@@ -80,20 +83,40 @@ func (o *MigrateAuthorizationOptions) Complete(name string, f *clientcmd.Factory
 		return fmt.Errorf("%s takes no positional arguments", name)
 	}
 
+	o.ResourceOptions.SaveFn = o.checkParity
 	if err := o.ResourceOptions.Complete(f, c); err != nil {
 		return err
 	}
 
-	_, kclient, err := f.Clients()
+	discovery, err := f.DiscoveryClient()
 	if err != nil {
 		return err
 	}
 
-	if err := clientcmd.LegacyPolicyResourceGate(kclient.Discovery()); err != nil {
+	if err := clientcmd.LegacyPolicyResourceGate(discovery); err != nil {
 		return err
 	}
 
-	o.rbac = kclient.Rbac()
+	config, err := f.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	// do not rate limit this client because it has to scan all RBAC data across the cluster
+	// this is safe because only a cluster admin will have the ability to read these objects
+	configShallowCopy := *config
+	configShallowCopy.RateLimiter = flowcontrol.NewFakeAlwaysRateLimiter()
+
+	// This command is only compatible with a 3.6 server, which only supported RBAC v1beta1
+	// Thus we must force that GV otherwise the client will default to v1
+	gv := v1beta1.SchemeGroupVersion
+	configShallowCopy.GroupVersion = &gv
+
+	rbac, err := rbacinternalversion.NewForConfig(&configShallowCopy)
+	if err != nil {
+		return err
+	}
+	o.rbac = rbac
 
 	return nil
 }
@@ -103,130 +126,159 @@ func (o MigrateAuthorizationOptions) Validate() error {
 }
 
 func (o MigrateAuthorizationOptions) Run() error {
-	return o.ResourceOptions.Visitor().Visit(func(info *resource.Info) (migrate.Reporter, error) {
-		return o.checkParity(info.Object)
-	})
+	// we lie and say this object has changed so our save function will run
+	return o.ResourceOptions.Visitor().Visit(migrate.AlwaysRequiresMigration)
 }
 
 // checkParity confirms that Openshift authorization objects are in sync with Kubernetes RBAC
 // and returns an error if they are out of sync or if it encounters a conversion error
-func (o *MigrateAuthorizationOptions) checkParity(obj runtime.Object) (migrate.Reporter, error) {
-	var errlist []error
-	switch t := obj.(type) {
+func (o *MigrateAuthorizationOptions) checkParity(info *resource.Info, _ migrate.Reporter) error {
+	var err migrate.TemporaryError
+
+	switch t := info.Object.(type) {
 	case *authorizationapi.ClusterRole:
-		errlist = append(errlist, o.checkClusterRole(t)...)
+		err = o.checkClusterRole(t)
 	case *authorizationapi.Role:
-		errlist = append(errlist, o.checkRole(t)...)
+		err = o.checkRole(t)
 	case *authorizationapi.ClusterRoleBinding:
-		errlist = append(errlist, o.checkClusterRoleBinding(t)...)
+		err = o.checkClusterRoleBinding(t)
 	case *authorizationapi.RoleBinding:
-		errlist = append(errlist, o.checkRoleBinding(t)...)
+		err = o.checkRoleBinding(t)
 	default:
-		return nil, nil // indicate that we ignored the object
+		// this should never happen unless o.Include or the server is broken
+		return fmt.Errorf("impossible type %T for checkParity info=%#v object=%#v", t, info, t)
 	}
-	return migrate.NotChanged, utilerrors.NewAggregate(errlist) // we only perform read operations
+
+	// We encountered no error, so this object is in sync.
+	if err == nil {
+		// we only perform read operations so we return this error to signal that we did not change anything
+		return migrate.ErrUnchanged
+	}
+
+	// At this point we know that we have some non-nil TemporaryError.
+	// If it has the possibility of being transient, we need to sync ourselves with the current state of the object.
+	if err.Temporary() {
+		// The most likely cause is that an authorization object was deleted after we initially fetched it,
+		// and the controller deleted the associated RBAC object, which caused our RBAC GET to fail.
+		// We can confirm this by refetching the authorization object.
+		refreshErr := info.Get()
+		if refreshErr != nil {
+			// Our refresh GET for this authorization object failed.
+			// The default logic for migration errors is appropriate in this case (refreshErr is most likely a NotFound).
+			return migrate.DefaultRetriable(info, refreshErr)
+		}
+		// We had no refreshErr, but encountered some other possibly transient error.
+		// No special handling is required in this case, we just pass it through below.
+	}
+
+	// All of the check* funcs return an appropriate TemporaryError based on the failure,
+	// so we can pass that through to the default migration logic which will retry as needed.
+	return err
 }
 
-func (o *MigrateAuthorizationOptions) checkClusterRole(originClusterRole *authorizationapi.ClusterRole) []error {
-	var errlist []error
+// handleRBACGetError signals for a retry on NotFound (handles deletion and sync lag)
+// and ServerTimeout (handles heavy load against the server).
+func handleRBACGetError(err error) migrate.TemporaryError {
+	switch {
+	case kerrs.IsNotFound(err), kerrs.IsServerTimeout(err):
+		return migrate.ErrRetriable{err}
+	default:
+		return migrate.ErrNotRetriable{err}
+	}
+}
 
+func (o *MigrateAuthorizationOptions) checkClusterRole(originClusterRole *authorizationapi.ClusterRole) migrate.TemporaryError {
 	// convert the origin role to a rbac role
 	convertedClusterRole, err := authorizationsync.ConvertToRBACClusterRole(originClusterRole)
 	if err != nil {
-		errlist = append(errlist, err)
+		// conversion errors should basically never happen, so we do not attempt to retry on those
+		return migrate.ErrNotRetriable{err}
 	}
 
 	// try to get the equivalent rbac role from the api
 	rbacClusterRole, err := o.rbac.ClusterRoles().Get(originClusterRole.Name, v1.GetOptions{})
 	if err != nil {
-		errlist = append(errlist, err)
+		// it is possible that the controller has not synced this yet
+		return handleRBACGetError(err)
 	}
 
-	// compare the results if there have been no errors so far
-	if len(errlist) == 0 {
-		// if they are not equal, something has gone wrong and the two objects are not in sync
-		if authorizationsync.PrepareForUpdateClusterRole(convertedClusterRole, rbacClusterRole) {
-			errlist = append(errlist, errOutOfSync)
-		}
+	// if they are not equal, something has gone wrong and the two objects are not in sync
+	if authorizationsync.PrepareForUpdateClusterRole(convertedClusterRole, rbacClusterRole) {
+		// we retry on this since it could be caused by the controller lagging behind
+		return errOutOfSync
 	}
 
-	return errlist
+	return nil
 }
 
-func (o *MigrateAuthorizationOptions) checkRole(originRole *authorizationapi.Role) []error {
-	var errlist []error
-
+func (o *MigrateAuthorizationOptions) checkRole(originRole *authorizationapi.Role) migrate.TemporaryError {
 	// convert the origin role to a rbac role
 	convertedRole, err := authorizationsync.ConvertToRBACRole(originRole)
 	if err != nil {
-		errlist = append(errlist, err)
+		// conversion errors should basically never happen, so we do not attempt to retry on those
+		return migrate.ErrNotRetriable{err}
 	}
 
 	// try to get the equivalent rbac role from the api
 	rbacRole, err := o.rbac.Roles(originRole.Namespace).Get(originRole.Name, v1.GetOptions{})
 	if err != nil {
-		errlist = append(errlist, err)
+		// it is possible that the controller has not synced this yet
+		return handleRBACGetError(err)
 	}
 
-	// compare the results if there have been no errors so far
-	if len(errlist) == 0 {
-		// if they are not equal, something has gone wrong and the two objects are not in sync
-		if authorizationsync.PrepareForUpdateRole(convertedRole, rbacRole) {
-			errlist = append(errlist, errOutOfSync)
-		}
+	// if they are not equal, something has gone wrong and the two objects are not in sync
+	if authorizationsync.PrepareForUpdateRole(convertedRole, rbacRole) {
+		// we retry on this since it could be caused by the controller lagging behind
+		return errOutOfSync
 	}
 
-	return errlist
+	return nil
 }
 
-func (o *MigrateAuthorizationOptions) checkClusterRoleBinding(originRoleBinding *authorizationapi.ClusterRoleBinding) []error {
-	var errlist []error
-
+func (o *MigrateAuthorizationOptions) checkClusterRoleBinding(originRoleBinding *authorizationapi.ClusterRoleBinding) migrate.TemporaryError {
 	// convert the origin role binding to a rbac role binding
 	convertedRoleBinding, err := authorizationsync.ConvertToRBACClusterRoleBinding(originRoleBinding)
 	if err != nil {
-		errlist = append(errlist, err)
+		// conversion errors should basically never happen, so we do not attempt to retry on those
+		return migrate.ErrNotRetriable{err}
 	}
 
 	// try to get the equivalent rbac role binding from the api
 	rbacRoleBinding, err := o.rbac.ClusterRoleBindings().Get(originRoleBinding.Name, v1.GetOptions{})
 	if err != nil {
-		errlist = append(errlist, err)
+		// it is possible that the controller has not synced this yet
+		return handleRBACGetError(err)
 	}
 
-	// compare the results if there have been no errors so far
-	if len(errlist) == 0 {
-		// if they are not equal, something has gone wrong and the two objects are not in sync
-		if authorizationsync.PrepareForUpdateClusterRoleBinding(convertedRoleBinding, rbacRoleBinding) {
-			errlist = append(errlist, errOutOfSync)
-		}
+	// if they are not equal, something has gone wrong and the two objects are not in sync
+	if authorizationsync.PrepareForUpdateClusterRoleBinding(convertedRoleBinding, rbacRoleBinding) {
+		// we retry on this since it could be caused by the controller lagging behind
+		return errOutOfSync
 	}
 
-	return errlist
+	return nil
 }
 
-func (o *MigrateAuthorizationOptions) checkRoleBinding(originRoleBinding *authorizationapi.RoleBinding) []error {
-	var errlist []error
-
+func (o *MigrateAuthorizationOptions) checkRoleBinding(originRoleBinding *authorizationapi.RoleBinding) migrate.TemporaryError {
 	// convert the origin role binding to a rbac role binding
 	convertedRoleBinding, err := authorizationsync.ConvertToRBACRoleBinding(originRoleBinding)
 	if err != nil {
-		errlist = append(errlist, err)
+		// conversion errors should basically never happen, so we do not attempt to retry on those
+		return migrate.ErrNotRetriable{err}
 	}
 
 	// try to get the equivalent rbac role binding from the api
 	rbacRoleBinding, err := o.rbac.RoleBindings(originRoleBinding.Namespace).Get(originRoleBinding.Name, v1.GetOptions{})
 	if err != nil {
-		errlist = append(errlist, err)
+		// it is possible that the controller has not synced this yet
+		return handleRBACGetError(err)
 	}
 
-	// compare the results if there have been no errors so far
-	if len(errlist) == 0 {
-		// if they are not equal, something has gone wrong and the two objects are not in sync
-		if authorizationsync.PrepareForUpdateRoleBinding(convertedRoleBinding, rbacRoleBinding) {
-			errlist = append(errlist, errOutOfSync)
-		}
+	// if they are not equal, something has gone wrong and the two objects are not in sync
+	if authorizationsync.PrepareForUpdateRoleBinding(convertedRoleBinding, rbacRoleBinding) {
+		// we retry on this since it could be caused by the controller lagging behind
+		return errOutOfSync
 	}
 
-	return errlist
+	return nil
 }

--- a/pkg/cmd/admin/migrate/migrator.go
+++ b/pkg/cmd/admin/migrate/migrator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -46,6 +47,11 @@ func (r ReporterBool) Changed() bool {
 
 func AlwaysRequiresMigration(_ *resource.Info) (Reporter, error) {
 	return ReporterBool(true), nil
+}
+
+// timeStampNow returns the current time in the same format as glog
+func timeStampNow() string {
+	return time.Now().Format("0102 15:04:05.000000")
 }
 
 // NotChanged is a Reporter returned by operations that are guaranteed to be read-only
@@ -396,9 +402,9 @@ func (t *migrateTracker) report(prefix string, info *resource.Info, err error) {
 		ns = "-n " + ns
 	}
 	if err != nil {
-		fmt.Fprintf(t.out, "%-10s %s %s/%s: %v\n", prefix, ns, info.Mapping.Resource, info.Name, err)
+		fmt.Fprintf(t.out, "E%s %-10s %s %s/%s: %v\n", timeStampNow(), prefix, ns, info.Mapping.Resource, info.Name, err)
 	} else {
-		fmt.Fprintf(t.out, "%-10s %s %s/%s\n", prefix, ns, info.Mapping.Resource, info.Name)
+		fmt.Fprintf(t.out, "I%s %-10s %s %s/%s\n", timeStampNow(), prefix, ns, info.Mapping.Resource, info.Name)
 	}
 }
 

--- a/pkg/cmd/admin/migrate/migrator.go
+++ b/pkg/cmd/admin/migrate/migrator.go
@@ -483,11 +483,13 @@ func canRetry(err error) bool {
 // All other errors are left in their natural state - they will not be retried unless
 // they define a Temporary() method that returns true.
 func DefaultRetriable(info *resource.Info, err error) error {
-	// tolerate the deletion of resources during migration
-	if err == nil || isNotFoundForInfo(info, err) {
-		return nil
-	}
 	switch {
+	case err == nil:
+		return nil
+	case isNotFoundForInfo(info, err):
+		// tolerate the deletion of resources during migration
+		// report unchanged since we did not actually migrate this object
+		return ErrUnchanged
 	case errors.IsMethodNotSupported(err):
 		return ErrNotRetriable{err}
 	case errors.IsConflict(err):
@@ -497,8 +499,9 @@ func DefaultRetriable(info *resource.Info, err error) error {
 		return ErrRetriable{err}
 	case errors.IsServerTimeout(err):
 		return ErrRetriable{err}
+	default:
+		return err
 	}
-	return err
 }
 
 // isNotFoundForInfo returns true iff the error is a not found for the specific info object.
@@ -514,6 +517,11 @@ func isNotFoundForInfo(info *resource.Info, err error) bool {
 	if details == nil {
 		return false
 	}
-	gvk := info.Object.GetObjectKind().GroupVersionKind()
-	return details.Name == info.Name && details.Kind == gvk.Kind && (details.Group == "" || details.Group == gvk.Group)
+	// get schema.GroupKind from the mapping since the actual object may not have type meta filled out
+	gk := info.Mapping.GroupVersionKind.GroupKind()
+	// based on case-insensitive string comparisons, the error matches info iff
+	// the name and kind match
+	// the group match, but only if both the error and info specify a group
+	return strings.EqualFold(details.Name, info.Name) && strings.EqualFold(details.Kind, gk.Kind) &&
+		(len(details.Group) == 0 || len(gk.Group) == 0 || strings.EqualFold(details.Group, gk.Group))
 }

--- a/pkg/cmd/admin/migrate/migrator_test.go
+++ b/pkg/cmd/admin/migrate/migrator_test.go
@@ -1,0 +1,345 @@
+package migrate
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+func TestIsNotFoundForInfo(t *testing.T) {
+	type args struct {
+		info *resource.Info
+		err  error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil err does not match",
+			args: args{
+				info: nil,
+				err:  nil,
+			},
+			want: false,
+		},
+		{
+			name: "simple not found match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "group1",
+					Resource: "kind1", // this is the kind
+				},
+					"name1",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "simple not found match from generic 404 response",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "group1",
+						Resource: "kind1", // this is the kind
+					},
+					"name1",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "simple not match from generic 400 response",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusBadRequest,
+					"",
+					schema.GroupResource{
+						Group:    "group1",
+						Resource: "kind1", // this is the kind
+					},
+					"name1",
+					"",
+					0,
+					false,
+				),
+			},
+			want: false,
+		},
+		{
+			name: "different status error does not match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: errors.NewAlreadyExists(schema.GroupResource{
+					Group:    "group1",
+					Resource: "kind1", // this is the kind
+				},
+					"name1",
+				),
+			},
+			want: false,
+		},
+		{
+			name: "non status error does not match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "name1",
+				},
+				err: fmt.Errorf("%v",
+					schema.GroupVersionKind{
+						Group: "group1",
+						Kind:  "kind1",
+					},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "case-insensitive not found match",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "GROUPA",
+							Kind:  "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "groupA",
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match from generic 404 response",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "ThisGroup",
+							Kind:  "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "thisgroup",
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match, no group in info",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Kind: "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "groupA",
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match, no group in error",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "GROUPA",
+							Kind:  "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not match due to different groups",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "KINDB",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "group2",
+					Resource: "Kindb", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: false,
+		},
+		{
+			name: "case-insensitive not found match from generic 404 response, no group in info",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Kind: "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "thisgroup",
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not found match from generic 404 response, no group in error",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "ThisGroup",
+							Kind:  "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not match from generic 404 response due to different groups",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "thingA",
+							Kind:  "HasKinds",
+						},
+					},
+					Name: "AndAName",
+				},
+				err: errors.NewGenericServerResponse(
+					http.StatusNotFound,
+					"",
+					schema.GroupResource{
+						Group:    "thingB",
+						Resource: "haskinds", // this is the kind
+					},
+					"andaname",
+					"",
+					0,
+					false,
+				),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNotFoundForInfo(tt.args.info, tt.args.err); got != tt.want {
+				t.Errorf("isNotFoundForInfo() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/admin/migrate/storage/storage.go
+++ b/pkg/cmd/admin/migrate/storage/storage.go
@@ -206,7 +206,11 @@ func (o *MigrateAPIStorageOptions) save(info *resource.Info, reporter migrate.Re
 			Name(info.Name).Do()
 		data, err := get.Raw()
 		if err != nil {
-			return migrate.DefaultRetriable(info, err)
+			// since we have an error, processing the body is safe because we are not going
+			// to send it back to the server.  Thus we can safely call Result.Error().
+			// This is required because we want to make sure we pass an errors.APIStatus so
+			// that DefaultRetriable can correctly determine if the error is safe to retry.
+			return migrate.DefaultRetriable(info, get.Error())
 		}
 		update := info.Client.Put().
 			Resource(info.Mapping.Resource).

--- a/pkg/cmd/cli/cmd/create/policy_binding.go
+++ b/pkg/cmd/cli/cmd/create/policy_binding.go
@@ -71,12 +71,16 @@ func (o *CreatePolicyBindingOptions) Complete(cmd *cobra.Command, f *clientcmd.F
 	}
 	o.BindingNamespace = namespace
 
-	client, kclient, err := f.Clients()
+	discovery, err := f.DiscoveryClient()
 	if err != nil {
 		return err
 	}
 
-	if err := clientcmd.LegacyPolicyResourceGate(kclient.Discovery()); err != nil {
+	if err := clientcmd.LegacyPolicyResourceGate(discovery); err != nil {
+		return err
+	}
+	client, _, err := f.Clients()
+	if err != nil {
 		return err
 	}
 

--- a/pkg/cmd/cli/cmd/create/policy_binding.go
+++ b/pkg/cmd/cli/cmd/create/policy_binding.go
@@ -75,6 +75,11 @@ func (o *CreatePolicyBindingOptions) Complete(cmd *cobra.Command, f *clientcmd.F
 	if err != nil {
 		return err
 	}
+
+	if err := clientcmd.Gate(client, "", "3.7.0"); err != nil {
+		return err
+	}
+
 	o.BindingClient = client
 
 	o.Mapper, _ = f.Object()

--- a/pkg/cmd/cli/cmd/create/policy_binding.go
+++ b/pkg/cmd/cli/cmd/create/policy_binding.go
@@ -71,12 +71,12 @@ func (o *CreatePolicyBindingOptions) Complete(cmd *cobra.Command, f *clientcmd.F
 	}
 	o.BindingNamespace = namespace
 
-	client, _, err := f.Clients()
+	client, kclient, err := f.Clients()
 	if err != nil {
 		return err
 	}
 
-	if err := clientcmd.Gate(client, "", "3.7.0"); err != nil {
+	if err := clientcmd.LegacyPolicyResourceGate(kclient.Discovery()); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -83,12 +83,12 @@ func (o OverwriteBootstrapPolicyOptions) Validate(args []string) error {
 }
 
 func (o OverwriteBootstrapPolicyOptions) Complete(f *clientcmd.Factory) error {
-	oClient, _, err := f.Clients()
+	_, kclient, err := f.Clients()
 	if err != nil {
 		return err
 	}
 
-	return clientcmd.Gate(oClient, "", "3.7.0")
+	return clientcmd.LegacyPolicyResourceGate(kclient.Discovery())
 }
 
 func (o OverwriteBootstrapPolicyOptions) OverwriteBootstrapPolicy() error {

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -83,12 +83,12 @@ func (o OverwriteBootstrapPolicyOptions) Validate(args []string) error {
 }
 
 func (o OverwriteBootstrapPolicyOptions) Complete(f *clientcmd.Factory) error {
-	_, kclient, err := f.Clients()
+	discovery, err := f.DiscoveryClient()
 	if err != nil {
 		return err
 	}
 
-	return clientcmd.LegacyPolicyResourceGate(kclient.Discovery())
+	return clientcmd.LegacyPolicyResourceGate(discovery)
 }
 
 func (o OverwriteBootstrapPolicyOptions) OverwriteBootstrapPolicy() error {

--- a/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
+++ b/pkg/cmd/server/admin/overwrite_bootstrappolicy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/cli/describe"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/api/latest"
 	originrest "github.com/openshift/origin/pkg/cmd/server/origin/rest"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -38,7 +39,7 @@ type OverwriteBootstrapPolicyOptions struct {
 	CreateBootstrapPolicyCommand string
 }
 
-func NewCommandOverwriteBootstrapPolicy(commandName string, fullName string, createBootstrapPolicyCommand string, out io.Writer) *cobra.Command {
+func NewCommandOverwriteBootstrapPolicy(commandName string, fullName string, createBootstrapPolicyCommand string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
 	options := &OverwriteBootstrapPolicyOptions{Out: out}
 	options.CreateBootstrapPolicyCommand = createBootstrapPolicyCommand
 
@@ -46,13 +47,11 @@ func NewCommandOverwriteBootstrapPolicy(commandName string, fullName string, cre
 		Use:   commandName,
 		Short: "Reset the policy to the default values",
 		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(options.Complete(f))
 			if err := options.Validate(args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
 			}
-
-			if err := options.OverwriteBootstrapPolicy(); err != nil {
-				kcmdutil.CheckErr(err)
-			}
+			kcmdutil.CheckErr(options.OverwriteBootstrapPolicy())
 		},
 	}
 
@@ -81,6 +80,15 @@ func (o OverwriteBootstrapPolicyOptions) Validate(args []string) error {
 	}
 
 	return nil
+}
+
+func (o OverwriteBootstrapPolicyOptions) Complete(f *clientcmd.Factory) error {
+	oClient, _, err := f.Clients()
+	if err != nil {
+		return err
+	}
+
+	return clientcmd.Gate(oClient, "", "3.7.0")
 }
 
 func (o OverwriteBootstrapPolicyOptions) OverwriteBootstrapPolicy() error {

--- a/pkg/cmd/util/clientcmd/gating.go
+++ b/pkg/cmd/util/clientcmd/gating.go
@@ -1,0 +1,64 @@
+package clientcmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/blang/semver"
+
+	"github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/version"
+)
+
+// Gate returns an error if the server is below minServerVersion or above/equal maxServerVersion.
+// To test only for min or only max version, set the other string to the empty value.
+func Gate(ocClient *client.Client, minServerVersion, maxServerVersion string) error {
+	if len(minServerVersion) == 0 && len(maxServerVersion) == 0 {
+		return fmt.Errorf("No version info passed to gate command")
+	}
+
+	ocVersionBody, err := ocClient.Get().AbsPath("/version/openshift").Do().Raw()
+	if err != nil {
+		return err
+	}
+	ocServerInfo := &version.Info{}
+	if err := json.Unmarshal(ocVersionBody, ocServerInfo); err != nil {
+		return err
+	}
+	ocVersion := ocServerInfo.String()
+	// skip first chracter as Openshift returns a 'v' preceding the actual
+	// version string which semver does not grok
+	semVersion, err := semver.Parse(ocVersion[1:])
+	if err != nil {
+		return fmt.Errorf("Failed to parse server version %s: %v", ocVersion, err)
+	}
+	// ignore pre-release version info
+	semVersion.Pre = nil
+
+	if len(minServerVersion) > 0 {
+		min, err := semver.Parse(minServerVersion)
+		if err != nil {
+			return fmt.Errorf("Failed to parse min gate version %s: %v", minServerVersion, err)
+		}
+		// ignore pre-release version info
+		min.Pre = nil
+		if semVersion.LT(min) {
+			return fmt.Errorf("This command works only with server versions > %s, found %s", minServerVersion, ocVersion)
+		}
+	}
+
+	if len(maxServerVersion) > 0 {
+		max, err := semver.Parse(maxServerVersion)
+		if err != nil {
+			return fmt.Errorf("Failed to parse max gate version %s: %v", maxServerVersion, err)
+		}
+		// ignore pre-release version info
+		max.Pre = nil
+		if semVersion.GTE(max) {
+			return fmt.Errorf("This command works only with server versions < %s, found %s", maxServerVersion, ocVersion)
+		}
+	}
+
+	// OK this is within min/max all good!
+	return nil
+}

--- a/pkg/cmd/util/clientcmd/gating.go
+++ b/pkg/cmd/util/clientcmd/gating.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 
-	"github.com/openshift/origin/pkg/authorization/apis/authorization"
+	authorization "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 )
 
 // LegacyPolicyResourceGate returns err if the server does not support the set of legacy policy objects (< 3.7)

--- a/pkg/cmd/util/clientcmd/gating_test.go
+++ b/pkg/cmd/util/clientcmd/gating_test.go
@@ -1,0 +1,360 @@
+package clientcmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/authorization/apis/authorization"
+)
+
+// TestDiscoveryResourceGate tests the legacy policy gate and GVR resource discovery
+func TestDiscoveryResourceGate(t *testing.T) {
+	resources := map[string][]metav1.APIResource{
+		"allLegacy": {
+			{Name: "clusterpolicies", Kind: "ClusterPolicies"},
+			{Name: "clusterpolicybindings", Kind: "ClusterPolicyBindings"},
+			{Name: "policies", Kind: "Policies"},
+			{Name: "policybindings", Kind: "PolicyBindings"},
+			{Name: "foo", Kind: "Foo"},
+		},
+		"partialLegacy": {
+			{Name: "clusterpolicies", Kind: "ClusterPolicies"},
+			{Name: "clusterpolicybindings", Kind: "ClusterPolicyBindings"},
+			{Name: "foo", Kind: "Foo"},
+		},
+		"noLegacy": {
+			{Name: "foo", Kind: "Foo"},
+			{Name: "bar", Kind: "Bar"},
+		},
+	}
+
+	legacyTests := map[string]struct {
+		existingResources *metav1.APIResourceList
+		expectErrStr      string
+	}{
+		"scheme-legacy-all-supported": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: authorization.LegacySchemeGroupVersion.String(),
+				APIResources: resources["allLegacy"],
+			},
+			expectErrStr: "",
+		},
+		"scheme-legacy-some-supported": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: authorization.LegacySchemeGroupVersion.String(),
+				APIResources: resources["partialLegacy"],
+			},
+			expectErrStr: "the server does not support legacy policy resources",
+		},
+		"scheme-legacy-none-supported": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: authorization.LegacySchemeGroupVersion.String(),
+				APIResources: resources["noLegacy"],
+			},
+			expectErrStr: "the server does not support legacy policy resources",
+		},
+		"scheme-all-supported": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: authorization.SchemeGroupVersion.String(),
+				APIResources: resources["allLegacy"],
+			},
+			expectErrStr: "",
+		},
+		"scheme-some-supported": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: authorization.SchemeGroupVersion.String(),
+				APIResources: resources["partialLegacy"],
+			},
+			expectErrStr: "the server does not support legacy policy resources",
+		},
+		"scheme-none-supported": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: authorization.SchemeGroupVersion.String(),
+				APIResources: resources["noLegacy"],
+			},
+			expectErrStr: "the server does not support legacy policy resources",
+		},
+	}
+
+	discoveryTests := map[string]struct {
+		existingResources *metav1.APIResourceList
+		inputGVR          []schema.GroupVersionResource
+		expectedGVR       []schema.GroupVersionResource
+		expectedAll       bool
+	}{
+		"discovery-subset": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: "v1",
+				APIResources: resources["noLegacy"],
+			},
+			inputGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "bar",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "noexist",
+				},
+			},
+			expectedGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "bar",
+				},
+			},
+		},
+		"discovery-none": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: "v1",
+				APIResources: resources["noLegacy"],
+			},
+			inputGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "noexist",
+				},
+			},
+			expectedGVR: []schema.GroupVersionResource{},
+		},
+		"discovery-all": {
+			existingResources: &metav1.APIResourceList{
+				GroupVersion: "v1",
+				APIResources: resources["noLegacy"],
+			},
+			inputGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "bar",
+				},
+			},
+			expectedGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "bar",
+				},
+			},
+			expectedAll: true,
+		},
+	}
+
+	for tcName, tc := range discoveryTests {
+		func() {
+			server := testServer(t, tc.existingResources)
+			defer server.Close()
+			client := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+
+			got, all, err := DiscoverGroupVersionResources(client, tc.inputGVR...)
+			if err != nil {
+				t.Fatalf("myerr %s", err.Error())
+			}
+			if !reflect.DeepEqual(got, tc.expectedGVR) {
+				t.Fatalf("%s got %v, expected %v", tcName, got, tc.expectedGVR)
+			}
+			if tc.expectedAll && !all {
+				t.Fatalf("%s expected all", tcName)
+			}
+		}()
+	}
+
+	for tcName, tc := range legacyTests {
+		func() {
+			server := testServer(t, tc.existingResources)
+			defer server.Close()
+			client := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
+
+			err := LegacyPolicyResourceGate(client)
+			if err != nil {
+				if len(tc.expectErrStr) == 0 {
+					t.Fatalf("%s unexpected err %s\n", tcName, err.Error())
+				}
+				if tc.expectErrStr != err.Error() {
+					t.Fatalf("%s expected err %s, got %s", tcName, tc.expectErrStr, err.Error())
+				}
+			}
+			if err == nil && len(tc.expectErrStr) != 0 {
+				t.Fatalf("%s expected err %s, got none\n", tcName, tc.expectErrStr)
+			}
+		}()
+	}
+}
+
+func testServer(t *testing.T, inputList *metav1.APIResourceList) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var list interface{}
+		switch req.URL.Path {
+		case "/apis/" + authorization.LegacySchemeGroupVersion.String():
+			list = inputList
+		case "/apis/" + authorization.SchemeGroupVersion.String():
+			list = inputList
+		case "/api/v1":
+			list = inputList
+		default:
+			t.Logf("unexpected request: %s", req.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		output, err := json.Marshal(list)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+}
+
+// TestCountResourceDiscoveryCache tests the DiscoverGroupVersionResources() in-function GroupVersion cache.
+func TestCountResourceDiscoveryCache(t *testing.T) {
+	discoveryTests := map[string]struct {
+		inputGVR     []schema.GroupVersionResource
+		expectedGVR  []schema.GroupVersionResource
+		expectedHits int
+	}{
+		"discovery-cache-gv": {
+			inputGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "bar",
+				},
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "baz",
+				},
+			},
+			expectedGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "bar",
+				},
+			},
+			expectedHits: 1,
+		},
+		"discovery-cache-separate-gv": {
+			inputGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "bar",
+				},
+				{
+					Group:    "",
+					Version:  "foobar2",
+					Resource: "baz",
+				},
+			},
+			expectedGVR: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "foo",
+				},
+				{
+					Group:    "",
+					Version:  "foobar",
+					Resource: "bar",
+				},
+			},
+			expectedHits: 2,
+		},
+	}
+
+	for tcName, tc := range discoveryTests {
+		client := &countDiscoveryClient{}
+		got, _, err := DiscoverGroupVersionResources(client, tc.inputGVR...)
+		if err != nil {
+			t.Fatalf("myerr %s", err.Error())
+		}
+		if tc.expectedHits != client.hits {
+			t.Fatalf("%s wrong number of round trips, expected %v, got %v", tcName, tc.expectedHits, client.hits)
+		}
+		if !reflect.DeepEqual(got, tc.expectedGVR) {
+			t.Fatalf("%s got %v, expected %v", tcName, got, tc.expectedGVR)
+		}
+	}
+}
+
+type countDiscoveryClient struct {
+	hits int
+}
+
+func (c *countDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (resources *metav1.APIResourceList, err error) {
+	if groupVersion == "foobar" || groupVersion == "foobar2" {
+		c.hits++
+		return &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+			},
+		}, nil
+	}
+	return nil, nil
+}
+
+func (c *countDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	panic("Unexpected call to ServerResources() in mock implementation")
+}
+func (c *countDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	panic("Unexpected call to ServerPreferredResources() in mock implementation")
+}
+func (c *countDiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	panic("Unexpected call to ServerPreferredNamespacedResources() in mock implementation")
+}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -173,6 +173,10 @@ os::cmd::expect_success_and_not_text 'oc get scc/privileged -o yaml' 'fake-group
 echo "admin-scc: ok"
 os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/admin/overwrite-policy"
+os::cmd::expect_failure_and_not_text 'oc adm overwrite-policy --filename file_does_not_exist' 'error: the server does not support legacy policy resources'
+os::test::junit::declare_suite_end
+
 os::test::junit::declare_suite_start "cmd/admin/reconcile-cluster-roles"
 os::cmd::expect_success 'oc delete clusterrole/cluster-status --cascade=false'
 os::cmd::expect_failure 'oc get clusterrole/cluster-status'

--- a/test/cmd/migrate.sh
+++ b/test/cmd/migrate.sh
@@ -27,6 +27,11 @@ os::cmd::expect_success_and_not_text 'oadm migrate storage --loglevel=2 --includ
 os::cmd::expect_success_and_text     'oadm migrate storage --loglevel=2 --confirm' 'unchanged:'
 os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "cmd/migrate/authorization"
+os::cmd::expect_success_and_not_text 'oc adm migrate authorization' 'error: the server does not support legacy policy resources'
+os::cmd::expect_success_and_text     'oc adm migrate authorization' 'summary: total=[0-9]+ errors=[0-9]+ ignored=[0-9]+ unchanged=[0-9]+ migrated=[0-9]+'
+os::test::junit::declare_suite_end
+
 os::test::junit::declare_suite_start "cmd/migrate/storage_oauthclientauthorizations"
 # Create valid OAuth client
 os::cmd::expect_success_and_text     'oc create -f test/testdata/oauth/client.yaml' 'oauthclient "test-oauth-client" created'

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -23,7 +23,7 @@ os::cmd::expect_success_and_text 'oc whoami --as=system:serviceaccount:policy-lo
 os::cmd::expect_failure 'oc whoami --as=system:serviceaccount:another:default'
 os::cmd::expect_success "oc login -u system:admin -n '${project}'"
 os::cmd::expect_success 'oc delete project policy-login'
-
+os::cmd::expect_failure_and_not_text 'oc create policybinding default -n some_nonexistent_project' 'error: the server does not support legacy policy resources'
 
 # This test validates user level policy
 os::cmd::expect_failure_and_text 'oc policy add-role-to-user' 'you must specify a role'


### PR DESCRIPTION
Cherry pick of #15213 #16219 #16340 #17080 #18221 on release-3.6.

#15213: Not found errors must match object in migration
#16219: Use discovery based version gating for policy commands
#16340: Decrement retries count during migration
#17080: Correctly handle NotFound errors during migration
#18221: Fix issues with oc adm migrate authorization