### PR TITLE
WIP - Preserve router state across restarts

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -10,7 +10,7 @@ RUN INSTALL_PKGS="haproxy18" && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
-    mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
+    mkdir -p /var/lib/haproxy/{conf,run/state,bin,log} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_route_http_insecure,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
     chown -R :0 /var/lib/haproxy && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -43,6 +43,9 @@ global
   stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
   stats timeout 2m
 
+  server-state-file global
+  server-state-base /var/lib/haproxy/run/state
+
   # Increase the default request size to be comparable to modern cloud load balancers (ALB: 64kb), affects
   # total memory use when large numbers of connections are open.
   tune.maxrewrite 8192
@@ -83,6 +86,8 @@ global
 
 defaults
   maxconn {{env "ROUTER_MAX_CONNECTIONS" "20000"}}
+
+  load-server-state-from-file global
 
   # Add x-forwarded-for header.
 {{- if ne (env "ROUTER_SYSLOG_ADDRESS") "" }}
@@ -329,6 +334,7 @@ backend be_edge_http:{{$cfgIdx}}
 # Secure backend which requires re-encryption
 backend be_secure:{{$cfgIdx}}
     {{- end }}{{/* end chceck for router type */}}
+  id {{ .InternalID }}
   mode http
   option redispatch
   option forwardfor
@@ -396,7 +402,7 @@ backend be_secure:{{$cfgIdx}}
     {{- if ne $weight 0 }}
       {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
         {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
-  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
+  server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}} id {{$endpoint.InternalID}}
           {{- if (eq $cfg.TLSTermination "reencrypt") }} ssl
             {{- if $cfg.VerifyServiceHostname }} verifyhost {{ $serviceUnit.Hostname }}
             {{- end }}
@@ -423,6 +429,7 @@ backend be_secure:{{$cfgIdx}}
 
 # Secure backend, pass through
 backend be_tcp:{{$cfgIdx}}
+  id {{ .InternalID }}
 {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
   option tcplog
 {{- end }}

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -66,11 +66,14 @@ function haproxyHealthCheck() {
   done
 }
 
+# Preserve server state
+if [[ -S /var/lib/haproxy/run/haproxy.sock && -d /var/lib/haproxy/run/state ]]; then
+  socat /var/lib/haproxy/run/haproxy.sock - <<< "show servers state" > /var/lib/haproxy/run/state/global
+fi
 
 # How many times to retry removal of the iptables rules (if requested at all)
 # It will sleep for 1/2 a second between attempts, so the time is retries / 2 secs
 retries=20
-
 
 # sort the path based map files for the haproxy map_beg function
 for mapfile in "$haproxy_conf_dir"/*.map; do

--- a/pkg/router/template/fake.go
+++ b/pkg/router/template/fake.go
@@ -9,6 +9,7 @@ func NewFakeTemplateRouter() *templateRouter {
 		serviceUnits:              make(map[string]ServiceUnit),
 		certManager:               fakeCertManager,
 		rateLimitedCommitFunction: nil,
+		uniqueIds:                 make(map[uint32]struct{}),
 	}
 }
 

--- a/pkg/router/template/router_test.go
+++ b/pkg/router/template/router_test.go
@@ -24,23 +24,6 @@ func TestCreateServiceUnit(t *testing.T) {
 	}
 }
 
-// TestDeleteServiceUnit tests that deleted service units no longer exist in state
-func TestDeleteServiceUnit(t *testing.T) {
-	router := NewFakeTemplateRouter()
-	suKey := "ns/test"
-	router.CreateServiceUnit(suKey)
-
-	if _, ok := router.FindServiceUnit(suKey); !ok {
-		t.Errorf("Unable to find serivce unit %s after creation", suKey)
-	}
-
-	router.DeleteServiceUnit(suKey)
-
-	if _, ok := router.FindServiceUnit(suKey); ok {
-		t.Errorf("Service unit %s was found in state after delete", suKey)
-	}
-}
-
 // TestAddEndpoints test adding endpoints to service units
 func TestAddEndpoints(t *testing.T) {
 	router := NewFakeTemplateRouter()
@@ -315,7 +298,7 @@ func TestCreateServiceAliasConfig(t *testing.T) {
 		},
 	}
 
-	config := *router.createServiceAliasConfig(route, "foo")
+	config := *createServiceAliasConfig(route, "foo", router.allowWildcardRoutes, router.defaultDestinationCAPath)
 
 	suName := endpointsKeyFromParts(namespace, serviceName)
 	expectedSUs := map[string]int32{

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -48,6 +48,10 @@ type ServiceAliasConfig struct {
 	// Hash of the route name - used to obscure cookieId
 	RoutingKeyName string
 
+	// A unique internal ID that is stable across router reloads and is mostly stable across restarts.
+	// No other object exposed to the router configuration will have this same value.
+	InternalID uint32
+
 	// IsWildcard indicates this service unit needs wildcarding support.
 	IsWildcard bool
 
@@ -95,6 +99,9 @@ type Endpoint struct {
 	PortName      string
 	IdHash        string
 	NoHealthCheck bool
+	// A unique internal ID that is stable across router reloads and is mostly stable across restarts.
+	// No other object exposed to the router configuration will have this same value.
+	InternalID uint32
 }
 
 // certificateManager provides the ability to write certificates for a ServiceAliasConfig


### PR DESCRIPTION
Exploration of the plumbing necessary for server-state to be stored in
haproxy across reloads. Tracks down backends.

May be useful/requried for dynamic reload.