### PR TITLE
UPSTREAM: 58394: don't stop informer delivery on error

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1647,6 +1647,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/retry",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
 			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1675,6 +1675,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/retry",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
 			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/BUILD
@@ -83,6 +83,7 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/pager:go_default_library",
         "//vendor/k8s.io/client-go/util/buffer:go_default_library",
+        "//vendor/k8s.io/client-go/util/retry:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1631,6 +1631,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/retry",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1623,6 +1623,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/retry",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
 			"Rev": "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -979,6 +979,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/retry",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},


### PR DESCRIPTION
@derekwaynecarr @eparis this prevents the zombie controller in a running controller process that isn't getting any notifications.

This changes the symptom to skip the offending notification (the calling code can't know why the notification was rejected) until the next resync when the controller gets another shot at it.  Already merged upstream.

@openshift/sig-master 
/assign @tnozicka 