### PR TITLE
kubelet completely from flags

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node.go
+++ b/pkg/cmd/server/kubernetes/node/node.go
@@ -3,16 +3,12 @@ package node
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/golang/glog"
 
 	kapiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kclientsetexternal "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/pkg/volume"
 
@@ -143,90 +139,4 @@ func PatchUpstreamVolumePluginsForLocalQuota(nodeConfig configapi.NodeConfig) fu
 
 		return ret
 	}
-}
-
-func GetClusterDNS(dnsClient kclientsetexternal.Interface, currClusterDNS []string) []string {
-	var clusterDNS net.IP
-	if len(currClusterDNS) == 0 {
-		if service, err := dnsClient.Core().Services(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{}); err == nil {
-			if includesServicePort(service.Spec.Ports, 53, "dns") {
-				// Use master service if service includes "dns" port 53.
-				clusterDNS = net.ParseIP(service.Spec.ClusterIP)
-			}
-		}
-	}
-	if clusterDNS == nil {
-		if endpoint, err := dnsClient.Core().Endpoints(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{}); err == nil {
-			if endpointIP, ok := firstEndpointIPWithNamedPort(endpoint, 53, "dns"); ok {
-				// Use first endpoint if endpoint includes "dns" port 53.
-				clusterDNS = net.ParseIP(endpointIP)
-			} else if endpointIP, ok := firstEndpointIP(endpoint, 53); ok {
-				// Test and use first endpoint if endpoint includes any port 53.
-				if err := cmdutil.WaitForSuccessfulDial(false, "tcp", fmt.Sprintf("%s:%d", endpointIP, 53), 50*time.Millisecond, 0, 2); err == nil {
-					clusterDNS = net.ParseIP(endpointIP)
-				}
-			}
-		}
-	}
-	if clusterDNS != nil && !clusterDNS.IsUnspecified() {
-		return []string{clusterDNS.String()}
-	}
-
-	return currClusterDNS
-}
-
-// TODO: more generic location
-func includesServicePort(ports []kapiv1.ServicePort, port int, portName string) bool {
-	for _, p := range ports {
-		if p.Port == int32(port) && p.Name == portName {
-			return true
-		}
-	}
-	return false
-}
-
-// TODO: more generic location
-func includesEndpointPort(ports []kapiv1.EndpointPort, port int) bool {
-	for _, p := range ports {
-		if p.Port == int32(port) {
-			return true
-		}
-	}
-	return false
-}
-
-// TODO: more generic location
-func firstEndpointIP(endpoints *kapiv1.Endpoints, port int) (string, bool) {
-	for _, s := range endpoints.Subsets {
-		if !includesEndpointPort(s.Ports, port) {
-			continue
-		}
-		for _, a := range s.Addresses {
-			return a.IP, true
-		}
-	}
-	return "", false
-}
-
-// TODO: more generic location
-func firstEndpointIPWithNamedPort(endpoints *kapiv1.Endpoints, port int, portName string) (string, bool) {
-	for _, s := range endpoints.Subsets {
-		if !includesNamedEndpointPort(s.Ports, port, portName) {
-			continue
-		}
-		for _, a := range s.Addresses {
-			return a.IP, true
-		}
-	}
-	return "", false
-}
-
-// TODO: more generic location
-func includesNamedEndpointPort(ports []kapiv1.EndpointPort, port int, portName string) bool {
-	for _, p := range ports {
-		if p.Port == int32(port) && p.Name == portName {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/cmd/server/kubernetes/node/node.go
+++ b/pkg/cmd/server/kubernetes/node/node.go
@@ -25,8 +25,7 @@ import (
 // EnsureKubeletAccess performs a number of test operations that the Kubelet requires to properly function.
 // All errors here are fatal.
 func EnsureKubeletAccess() {
-	containerized := cmdutil.Env("OPENSHIFT_CONTAINERIZED", "") == "true"
-	if containerized {
+	if cmdutil.Env("OPENSHIFT_CONTAINERIZED", "") == "true" {
 		if _, err := os.Stat("/rootfs"); os.IsPermission(err) || os.IsNotExist(err) {
 			glog.Fatal("error: Running in containerized mode, but cannot find the /rootfs directory - be sure to mount the host filesystem at /rootfs (read-only) in the container.")
 		}

--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	kubeletoptions "k8s.io/kubernetes/cmd/kubelet/app/options"
+	kclientsetexternal "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
 	kubeletcni "k8s.io/kubernetes/pkg/kubelet/network/cni"
@@ -17,14 +19,13 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/network"
 )
 
 // computeKubeletFlags returns the flags to use when starting the kubelet
 // TODO this needs to return a []string and be passed to cobra, but as an intermediate step, we'll compute the map and run it through the existing paths
-func computeKubeletFlags(startingArgs map[string][]string, options configapi.NodeConfig) (map[string][]string, error) {
+func ComputeKubeletFlagsAsMap(startingArgs map[string][]string, options configapi.NodeConfig) (map[string][]string, error) {
 	args := map[string][]string{}
 	for key, slice := range startingArgs {
 		for _, val := range slice {
@@ -101,60 +102,51 @@ func computeKubeletFlags(startingArgs map[string][]string, options configapi.Nod
 	setIfUnset(args, "tls-cipher-suites", crypto.CipherSuitesToNamesOrDie(crypto.CipherSuitesOrDie(options.ServingInfo.CipherSuites))...)
 	setIfUnset(args, "tls-min-version", crypto.TLSVersionToNameOrDie(crypto.TLSVersionOrDie(options.ServingInfo.MinTLSVersion)))
 
+	// Server cert rotation is ineffective if a cert is hardcoded.
+	if len(args["feature-gates"]) > 0 {
+		// TODO this affects global state, but it matches what happens later.  Need a less side-effecty way to do it
+		if err := utilfeature.DefaultFeatureGate.Set(args["feature-gates"][0]); err != nil {
+			return nil, err
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
+			// Server cert rotation is ineffective if a cert is hardcoded.
+			setIfUnset(args, "tls-cert-file", "")
+			setIfUnset(args, "tls-private-key-file", "")
+		}
+	}
+
+	// we sometimes have different clusterdns options.  I really don't understand why
+	externalKubeClient, _, err := configapi.GetExternalKubeClient(options.MasterKubeConfig, options.MasterClientConnectionOverrides)
+	if err != nil {
+		return nil, err
+	}
+	args["cluster-dns"] = getClusterDNS(externalKubeClient, args["cluster-dns"])
+
 	return args, nil
+}
+
+func KubeletArgsMapToArgs(argsMap map[string][]string) []string {
+	args := []string{}
+	for key, value := range argsMap {
+		for _, token := range value {
+			args = append(args, fmt.Sprintf("--%s=%v", key, token))
+		}
+	}
+
+	// there is a special case.  If you set `--cgroups-per-qos=false` and `--enforce-node-allocatable` is
+	// an empty string, `--enforce-node-allocatable=""` needs to be explicitly set
+	// cgroups-per-qos defaults to true
+	if cgroupArg, enforceAllocatable := argsMap["cgroups-per-qos"], argsMap["enforce-node-allocatable"]; len(cgroupArg) == 1 && cgroupArg[0] == "false" && len(enforceAllocatable) == 0 {
+		args = append(args, `--enforce-node-allocatable=`)
+	}
+
+	return args
 }
 
 func setIfUnset(cmdLineArgs map[string][]string, key string, value ...string) {
 	if _, ok := cmdLineArgs[key]; !ok {
 		cmdLineArgs[key] = value
 	}
-}
-
-// Build creates the core Kubernetes component configs for a given NodeConfig, or returns
-// an error
-func Build(options configapi.NodeConfig) (*kubeletoptions.KubeletServer, error) {
-	kubeletFlags, err := computeKubeletFlags(options.KubeletArguments, options)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create kubelet args: %v", err)
-	}
-
-	// Defaults are tested in TestKubeletDefaults
-	server, err := kubeletoptions.NewKubeletServer()
-	if err != nil {
-		return nil, fmt.Errorf("cannot create kubelet server: %v", err)
-	}
-	if err := cmdflags.Resolve(kubeletFlags, server.AddFlags); len(err) > 0 {
-		return nil, kerrors.NewAggregate(err)
-	}
-
-	// terminate early if feature gate is incorrect on the node
-	if len(server.FeatureGates) > 0 {
-		if err := utilfeature.DefaultFeatureGate.SetFromMap(server.FeatureGates); err != nil {
-			return nil, err
-		}
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
-		// Server cert rotation is ineffective if a cert is hardcoded.
-		if len(server.CertDirectory) > 0 {
-			server.TLSCertFile = ""
-			server.TLSPrivateKeyFile = ""
-		}
-	}
-
-	return server, nil
-}
-
-func ToFlags(config *kubeletoptions.KubeletServer) []string {
-	server, _ := kubeletoptions.NewKubeletServer()
-	args := cmdflags.AsArgs(config.AddFlags, server.AddFlags)
-
-	// there is a special case.  If you set `--cgroups-per-qos=false` and `--enforce-node-allocatable` is
-	// an empty string, `--enforce-node-allocatable=""` needs to be explicitly set
-	if !config.CgroupsPerQOS && len(config.EnforceNodeAllocatable) == 0 {
-		args = append(args, `--enforce-node-allocatable=`)
-	}
-
-	return args
 }
 
 // Some flags are *required* to be set when running from openshift start node.  This ensures they are set.
@@ -187,5 +179,91 @@ func hasArgPrefix(needle string, haystack []string) bool {
 		}
 	}
 
+	return false
+}
+
+func getClusterDNS(dnsClient kclientsetexternal.Interface, currClusterDNS []string) []string {
+	var clusterDNS net.IP
+	if len(currClusterDNS) == 0 {
+		if service, err := dnsClient.Core().Services(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{}); err == nil {
+			if includesServicePort(service.Spec.Ports, 53, "dns") {
+				// Use master service if service includes "dns" port 53.
+				clusterDNS = net.ParseIP(service.Spec.ClusterIP)
+			}
+		}
+	}
+	if clusterDNS == nil {
+		if endpoint, err := dnsClient.Core().Endpoints(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{}); err == nil {
+			if endpointIP, ok := firstEndpointIPWithNamedPort(endpoint, 53, "dns"); ok {
+				// Use first endpoint if endpoint includes "dns" port 53.
+				clusterDNS = net.ParseIP(endpointIP)
+			} else if endpointIP, ok := firstEndpointIP(endpoint, 53); ok {
+				// Test and use first endpoint if endpoint includes any port 53.
+				if err := cmdutil.WaitForSuccessfulDial(false, "tcp", fmt.Sprintf("%s:%d", endpointIP, 53), 50*time.Millisecond, 0, 2); err == nil {
+					clusterDNS = net.ParseIP(endpointIP)
+				}
+			}
+		}
+	}
+	if clusterDNS != nil && !clusterDNS.IsUnspecified() {
+		return []string{clusterDNS.String()}
+	}
+
+	return currClusterDNS
+}
+
+// TODO: more generic location
+func includesEndpointPort(ports []kapiv1.EndpointPort, port int) bool {
+	for _, p := range ports {
+		if p.Port == int32(port) {
+			return true
+		}
+	}
+	return false
+}
+
+// TODO: more generic location
+func includesServicePort(ports []kapiv1.ServicePort, port int, portName string) bool {
+	for _, p := range ports {
+		if p.Port == int32(port) && p.Name == portName {
+			return true
+		}
+	}
+	return false
+}
+
+// TODO: more generic location
+func firstEndpointIP(endpoints *kapiv1.Endpoints, port int) (string, bool) {
+	for _, s := range endpoints.Subsets {
+		if !includesEndpointPort(s.Ports, port) {
+			continue
+		}
+		for _, a := range s.Addresses {
+			return a.IP, true
+		}
+	}
+	return "", false
+}
+
+// TODO: more generic location
+func firstEndpointIPWithNamedPort(endpoints *kapiv1.Endpoints, port int, portName string) (string, bool) {
+	for _, s := range endpoints.Subsets {
+		if !includesNamedEndpointPort(s.Ports, port, portName) {
+			continue
+		}
+		for _, a := range s.Addresses {
+			return a.IP, true
+		}
+	}
+	return "", false
+}
+
+// TODO: more generic location
+func includesNamedEndpointPort(ports []kapiv1.EndpointPort, port int, portName string) bool {
+	for _, p := range ports {
+		if p.Port == int32(port) && p.Name == portName {
+			return true
+		}
+	}
 	return false
 }


### PR DESCRIPTION
Endgame.  This completes the change to stop building intermediate internal kubelet types to get to flags.  This builds the flags directly from the openshift config.

I think this is good enough (minus some package updates perhaps), to hold for 3.9.

/assign @sjenning 
/assign soltysh
/assign mfojtik