### PR TITLE
Don't use a container volume for `/tmp` in hack/env

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -44,6 +44,7 @@ export NETWORK_PLUGIN='redhat/openshift-ovs-multitenant'
 
 os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
+export OS_TMPFS_REQUIRED='true'
 os::util::ensure_tmpfs "${ETCD_DATA_DIR}"
 
 echo "Logging to ${LOG_DIR}..."

--- a/test/end-to-end/core.sh
+++ b/test/end-to-end/core.sh
@@ -3,6 +3,7 @@
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+export OS_TMPFS_REQUIRED='true'
 os::util::ensure_tmpfs "${ETCD_DATA_DIR}"
 
 os::util::environment::setup_time_vars


### PR DESCRIPTION
Don't use a container volume for `/tmp` in hack/env

Instead of creating a volume for temporary files in the `hack/env`
environment, we should just pass through the host's `/tmp` and keep
whatever special setup (like fstype) the host has for that mount.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>


/cc @deads2k @mfojtik @smarterclayton 