### PR TITLE
Allow admin to specify minimum supported TLS version

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -6685,6 +6685,8 @@ _oc_adm_router()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--min-tls-version")
+    local_nonpersistent_flags+=("--min-tls-version")
     flags+=("--ciphers=")
     local_nonpersistent_flags+=("--ciphers=")
     flags+=("--create")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -6827,6 +6827,8 @@ _oc_adm_router()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--min-tls-version")
+    local_nonpersistent_flags+=("--min-tls-version")
     flags+=("--ciphers=")
     local_nonpersistent_flags+=("--ciphers=")
     flags+=("--create")

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -48,8 +48,14 @@ global
   tune.maxrewrite 8192
   tune.bufsize 32768
 
-  # Prevent vulnerability to POODLE attacks
+# SSLv3 disabled to prevent vulnerability to POODLE attacks
+{{- if eq (env "ROUTER_MINIMUM_TLS_VERSION" "") "1.2" }}
+  ssl-default-bind-options no-tlsv10 no-tlsv11 no-sslv3
+{{- else if eq (env "ROUTER_MINIMUM_TLS_VERSION" "") "1.1" }}
+  ssl-default-bind-options no-tlsv10 no-sslv3
+{{- else }}
   ssl-default-bind-options no-sslv3
+{{- end }}
 
 # The default cipher suite can be selected from the three sets recommended by https://wiki.mozilla.org/Security/Server_Side_TLS,
 # or the user can provide one using the ROUTER_CIPHERS environment variable.

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -86,6 +86,7 @@ type TemplateRouter struct {
 	MaxConnections           string
 	Ciphers                  string
 	StrictSNI                bool
+	MinimumTLSVersion        string
 	MetricsType              string
 }
 
@@ -122,7 +123,8 @@ func (o *TemplateRouter) Bind(flag *pflag.FlagSet) {
 	flag.BoolVar(&o.BindPortsAfterSync, "bind-ports-after-sync", isTrue(util.Env("ROUTER_BIND_PORTS_AFTER_SYNC", "")), "Bind ports only after route state has been synchronized")
 	flag.StringVar(&o.MaxConnections, "max-connections", util.Env("ROUTER_MAX_CONNECTIONS", ""), "Specifies the maximum number of concurrent connections.")
 	flag.StringVar(&o.Ciphers, "ciphers", util.Env("ROUTER_CIPHERS", ""), "Specifies the cipher suites to use. You can choose a predefined cipher set ('modern', 'intermediate', or 'old') or specify exact cipher suites by passing a : separated list.")
-	flag.BoolVar(&o.StrictSNI, "strict-sni", isTrue(util.Env("ROUTER_STRICT_SNI", "")), "Use strict-sni bind processing (do not use default cert).")
+	flag.BoolVar(&o.StrictSNI, "strict-sni", util.Env("ROUTER_STRICT_SNI", "") == "true", "Use strict-sni bind processing (do not use default cert).")
+	flag.StringVar(&o.MinimumTLSVersion, "min-tls-version", util.Env("ROUTER_MINIMUM_TLS_VERSION", ""), "Specifies a minimum version of the TLS protocol to support. E.g.'1.1', '1.2'")
 	flag.StringVar(&o.MetricsType, "metrics-type", util.Env("ROUTER_METRICS_TYPE", ""), "Specifies the type of metrics to gather. Supports 'haproxy'.")
 }
 
@@ -400,6 +402,7 @@ func (o *TemplateRouterOptions) Run() error {
 		MaxConnections:           o.MaxConnections,
 		Ciphers:                  o.Ciphers,
 		StrictSNI:                o.StrictSNI,
+		MinimumTLSVersion:        o.MinimumTLSVersion,
 	}
 
 	kc, err := o.Config.Clients()

--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -235,6 +235,11 @@ type RouterConfig struct {
 	StrictSNI bool
 
 	Local bool
+	// MinimumTLSVersion is the list of TLS protocols which should
+	// be rejected by the router.
+	// SSLv3 protocol not configurable and disabled by default due
+	// to poodle vulnerability.
+	MinimumTLSVersion string
 }
 
 const (
@@ -317,6 +322,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out, errout io.
 	cmd.Flags().StringVar(&cfg.Ciphers, "ciphers", cfg.Ciphers, "Specifies the cipher suites to use. You can choose a predefined cipher set ('modern', 'intermediate', or 'old') or specify exact cipher suites by passing a : separated list. Not supported for F5.")
 	cmd.Flags().BoolVar(&cfg.StrictSNI, "strict-sni", cfg.StrictSNI, "Use strict-sni bind processing (do not use default cert). Not supported for F5.")
 	cmd.Flags().BoolVar(&cfg.Local, "local", cfg.Local, "If true, do not contact the apiserver")
+	cmd.Flags().StringVar(&cfg.MinimumTLSVersion, "min-tls-version", cfg.MinimumTLSVersion, "Specifies a minimum version of the TLS protocol to support. E.g.'1.1', '1.2'")
 
 	cfg.Action.BindForOutput(cmd.Flags())
 	cmd.Flags().String("output-version", "", "The preferred API versions of the output objects")
@@ -666,6 +672,7 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 		"ROUTER_EXTERNAL_HOST_INTERNAL_ADDRESS": cfg.ExternalHostInternalIP,
 		"ROUTER_EXTERNAL_HOST_VXLAN_GW_CIDR":    cfg.ExternalHostVxLANGateway,
 		"ROUTER_CIPHERS":                        cfg.Ciphers,
+		"ROUTER_MINIMUM_TLS_VERSION":            cfg.MinimumTLSVersion,
 		"STATS_PORT":                            strconv.Itoa(cfg.StatsPort),
 		"STATS_USERNAME":                        cfg.StatsUsername,
 		"STATS_PASSWORD":                        cfg.StatsPassword,

--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -61,6 +61,7 @@ type TemplatePluginConfig struct {
 	MaxConnections           string
 	Ciphers                  string
 	StrictSNI                bool
+	MinimumTLSVersion        string
 }
 
 // routerInterface controls the interaction of the plugin with the underlying router implementation

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -46,6 +46,8 @@ os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false -
 os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --ciphers=modern -o yaml' 'modern'
 # strict-sni
 os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --strict-sni -o yaml' 'ROUTER_STRICT_SNI'
+# min-tls-version
+os::cmd::expect_success_and_text 'oc adm router --dry-run --host-network=false --host-ports=false --min-tls-version=1.2 -o yaml' '1.2'
 
 # mount tls crt as secret
 os::cmd::expect_success_and_not_text 'oc adm router --dry-run --host-network=false --host-ports=false -o yaml' 'value: /etc/pki/tls/private/tls.crt'


### PR DESCRIPTION
As a cluster admin, I would like to the ability to deny TLS protocols below a specific version.

This change provides a new option to `oc adm router` which is `--min-tls-version`. Valid options are `1.2` and `1.1`, anything else is ignored. This sets an environment variable `ROUTER_MINIMUM_TLS_VERSION` in the DeploymentConfig

Fixes https://github.com/openshift/origin/issues/17013
