### PR TITLE
Fix multi-namespace idling

### DIFF
--- a/pkg/oc/cli/cmd/idle.go
+++ b/pkg/oc/cli/cmd/idle.go
@@ -184,11 +184,21 @@ type idleUpdateInfo struct {
 	scaleRefs map[unidlingapi.CrossGroupObjectReference]struct{}
 }
 
+// controllerRef contains the small subset of info
+// that we need to compare controllers (like ObjectReference,
+// or OwnerReference, but with comparable and with just what we need).
+type controllerRef struct {
+	Name      string
+	Namespace string
+	Kind      string
+	Group     string
+}
+
 // calculateIdlableAnnotationsByService calculates the list of objects involved in the idling process from a list of services in a file.
 // Using the list of services, it figures out the associated scalable objects, and returns a map from the endpoints object for the services to
 // the list of scalable resources associated with that endpoints object, as well as a map from CrossGroupObjectReferences to scale to 0 to the
 // name of the associated service.
-func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory) (map[types.NamespacedName]idleUpdateInfo, map[unidlingapi.CrossGroupObjectReference]types.NamespacedName, error) {
+func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory) (map[types.NamespacedName]idleUpdateInfo, map[namespacedCrossGroupObjectReference]types.NamespacedName, error) {
 	// load our set of services
 	client, err := f.ClientSet()
 	if err != nil {
@@ -212,9 +222,9 @@ func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory)
 		return pod, nil
 	}
 
-	controllersLoaded := make(map[metav1.OwnerReference]metav1.Object)
+	controllersLoaded := make(map[namespacedOwnerReference]metav1.Object)
 	helpers := make(map[schema.GroupKind]*resource.Helper)
-	getController := func(namespace string, ref metav1.OwnerReference) (metav1.Object, error) {
+	getController := func(ref namespacedOwnerReference) (metav1.Object, error) {
 		if controller, ok := controllersLoaded[ref]; ok {
 			return controller, nil
 		}
@@ -241,7 +251,7 @@ func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory)
 		}
 
 		var controller runtime.Object
-		controller, err = helper.Get(namespace, ref.Name, false)
+		controller, err = helper.Get(ref.namespace, ref.Name, false)
 		if err != nil {
 			return nil, err
 		}
@@ -256,7 +266,7 @@ func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory)
 		return controllerMeta, nil
 	}
 
-	targetScaleRefs := make(map[unidlingapi.CrossGroupObjectReference]types.NamespacedName)
+	targetScaleRefs := make(map[namespacedCrossGroupObjectReference]types.NamespacedName)
 	endpointsInfo := make(map[types.NamespacedName]idleUpdateInfo)
 
 	err = o.svcBuilder.Do().Visit(func(info *resource.Info, err error) error {
@@ -278,13 +288,16 @@ func (o *IdleOptions) calculateIdlableAnnotationsByService(f *clientcmd.Factory)
 			return fmt.Errorf("unable to calculate scalable resources for service %s/%s: %v", endpoints.Namespace, endpoints.Name, err)
 		}
 
+		nonNamespacedScaleRefs := make(map[unidlingapi.CrossGroupObjectReference]struct{}, len(scaleRefs))
+
 		for ref := range scaleRefs {
+			nonNamespacedScaleRefs[ref.CrossGroupObjectReference] = struct{}{}
 			targetScaleRefs[ref] = endpointsName
 		}
 
 		idleInfo := idleUpdateInfo{
 			obj:       endpoints,
-			scaleRefs: scaleRefs,
+			scaleRefs: nonNamespacedScaleRefs,
 		}
 
 		endpointsInfo[endpointsName] = idleInfo
@@ -308,11 +321,40 @@ func makeCrossGroupObjRef(ref *metav1.OwnerReference) (unidlingapi.CrossGroupObj
 	}, nil
 }
 
+// namespacedOwnerReference is an OwnerReference with Namespace info,
+// so we differentiate different objects across namespaces.
+type namespacedOwnerReference struct {
+	metav1.OwnerReference
+	namespace string
+}
+
+// namespacedCrossGroupObjectReference is a CrossGroupObjectReference
+// with namespace information attached, so that we can track relevant
+// objects in different namespaces with the same name
+type namespacedCrossGroupObjectReference struct {
+	unidlingapi.CrossGroupObjectReference
+	namespace string
+}
+
+// normalizedNSOwnerRef converts an OwnerReference into an namespacedOwnerReference,
+// and ensure that it's comparable to other owner references (clearing pointer fields, etc)
+func normalizedNSOwnerRef(namespace string, ownerRef *metav1.OwnerReference) namespacedOwnerReference {
+	ref := namespacedOwnerReference{
+		namespace:      namespace,
+		OwnerReference: *ownerRef,
+	}
+
+	ref.Controller = nil
+	ref.BlockOwnerDeletion = nil
+
+	return ref
+}
+
 // findScalableResourcesForEndpoints takes an Endpoints object and looks for the associated
 // scalable objects by checking each address in each subset to see if it has a pod
 // reference, and the following that pod reference to find the owning controller,
 // and returning the unique set of controllers found this way.
-func findScalableResourcesForEndpoints(endpoints *kapi.Endpoints, getPod func(kapi.ObjectReference) (*kapi.Pod, error), getController func(string, metav1.OwnerReference) (metav1.Object, error)) (map[unidlingapi.CrossGroupObjectReference]struct{}, error) {
+func findScalableResourcesForEndpoints(endpoints *kapi.Endpoints, getPod func(kapi.ObjectReference) (*kapi.Pod, error), getController func(namespacedOwnerReference) (metav1.Object, error)) (map[namespacedCrossGroupObjectReference]struct{}, error) {
 	// To find all RCs and DCs for an endpoint, we first figure out which pods are pointed to by that endpoint...
 	podRefs := map[kapi.ObjectReference]*kapi.Pod{}
 	for _, subset := range endpoints.Subsets {
@@ -331,19 +373,20 @@ func findScalableResourcesForEndpoints(endpoints *kapi.Endpoints, getPod func(ka
 	}
 
 	// ... then, for each pod, we check the controller, and find the set of unique controllers...
-	immediateControllerRefs := make(map[metav1.OwnerReference]struct{})
+	immediateControllerRefs := make(map[namespacedOwnerReference]struct{})
 	for _, pod := range podRefs {
 		controllerRef := metav1.GetControllerOf(pod)
+		ref := normalizedNSOwnerRef(pod.Namespace, controllerRef)
 		if controllerRef == nil {
 			return nil, fmt.Errorf("unable to find controller for pod %s/%s: no creator reference listed", pod.Namespace, pod.Name)
 		}
-		immediateControllerRefs[*controllerRef] = struct{}{}
+		immediateControllerRefs[ref] = struct{}{}
 	}
 
 	// ... finally, for each controller, we load it, and see if there is a corresponding owner (to cover cases like DCs, Deployments, etc)
-	controllerRefs := make(map[unidlingapi.CrossGroupObjectReference]struct{})
+	controllerRefs := make(map[namespacedCrossGroupObjectReference]struct{})
 	for controllerRef := range immediateControllerRefs {
-		controller, err := getController(endpoints.Namespace, controllerRef)
+		controller, err := getController(controllerRef)
 		if utilerrors.TolerateNotFoundError(err) != nil {
 			return nil, fmt.Errorf("unable to load %s %q: %v", controllerRef.Kind, controllerRef.Name, err)
 		}
@@ -354,7 +397,7 @@ func findScalableResourcesForEndpoints(endpoints *kapi.Endpoints, getPod func(ka
 			var crossGroupObjRef unidlingapi.CrossGroupObjectReference
 			if parentControllerRef == nil {
 				// if this is just a plain RC, use it
-				crossGroupObjRef, err = makeCrossGroupObjRef(&controllerRef)
+				crossGroupObjRef, err = makeCrossGroupObjRef(&controllerRef.OwnerReference)
 			} else {
 				crossGroupObjRef, err = makeCrossGroupObjRef(parentControllerRef)
 			}
@@ -362,7 +405,10 @@ func findScalableResourcesForEndpoints(endpoints *kapi.Endpoints, getPod func(ka
 			if err != nil {
 				return nil, fmt.Errorf("unable to load the creator of %s %q: %v", controllerRef.Kind, controllerRef.Name, err)
 			}
-			controllerRefs[crossGroupObjRef] = struct{}{}
+			controllerRefs[namespacedCrossGroupObjectReference{
+				CrossGroupObjectReference: crossGroupObjRef,
+				namespace:                 controllerRef.namespace,
+			}] = struct{}{}
 		}
 	}
 
@@ -373,7 +419,7 @@ func findScalableResourcesForEndpoints(endpoints *kapi.Endpoints, getPod func(ka
 // and annotations from an existing object.  It merges the scales and references found in the existing annotations
 // with the new data (using the new scale in case of conflict if present and not 0, and the old scale otherwise),
 // and returns a slice of RecordedScaleReferences suitable for using as the new annotation value.
-func pairScalesWithScaleRefs(serviceName types.NamespacedName, annotations map[string]string, rawScaleRefs map[unidlingapi.CrossGroupObjectReference]struct{}, scales map[unidlingapi.CrossGroupObjectReference]int32) ([]unidlingapi.RecordedScaleReference, error) {
+func pairScalesWithScaleRefs(serviceName types.NamespacedName, annotations map[string]string, rawScaleRefs map[unidlingapi.CrossGroupObjectReference]struct{}, scales map[namespacedCrossGroupObjectReference]int32) ([]unidlingapi.RecordedScaleReference, error) {
 	oldTargetsRaw, hasOldTargets := annotations[unidlingapi.UnidleTargetAnnotation]
 
 	scaleRefs := make([]unidlingapi.RecordedScaleReference, 0, len(rawScaleRefs))
@@ -401,8 +447,12 @@ func pairScalesWithScaleRefs(serviceName types.NamespacedName, annotations map[s
 		// figure out which new targets were already present...
 		for _, newScaleRef := range scaleRefs {
 			if oldTargetInd, ok := oldTargetsSet[newScaleRef.CrossGroupObjectReference]; ok {
-				if newScale, ok := scales[newScaleRef.CrossGroupObjectReference]; !ok || newScale == 0 {
-					scales[newScaleRef.CrossGroupObjectReference] = oldTargets[oldTargetInd].Replicas
+				namespacedScaleRef := namespacedCrossGroupObjectReference{
+					CrossGroupObjectReference: newScaleRef.CrossGroupObjectReference,
+					namespace:                 serviceName.Namespace,
+				}
+				if newScale, ok := scales[namespacedScaleRef]; !ok || newScale == 0 {
+					scales[namespacedScaleRef] = oldTargets[oldTargetInd].Replicas
 				}
 				delete(oldTargetsSet, newScaleRef.CrossGroupObjectReference)
 			}
@@ -416,7 +466,11 @@ func pairScalesWithScaleRefs(serviceName types.NamespacedName, annotations map[s
 
 	for i := range scaleRefs {
 		scaleRef := &scaleRefs[i]
-		newScale, ok := scales[scaleRef.CrossGroupObjectReference]
+		namespacedScaleRef := namespacedCrossGroupObjectReference{
+			CrossGroupObjectReference: scaleRef.CrossGroupObjectReference,
+			namespace:                 serviceName.Namespace,
+		}
+		newScale, ok := scales[namespacedScaleRef]
 		if !ok || newScale == 0 {
 			newScale = 1
 			if scaleRef.Replicas != 0 {
@@ -521,18 +575,18 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 		annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", currentReplicas)
 	})
 
-	replicas := make(map[unidlingapi.CrossGroupObjectReference]int32, len(byScalable))
-	toScale := make(map[unidlingapi.CrossGroupObjectReference]scaleInfo)
+	replicas := make(map[namespacedCrossGroupObjectReference]int32, len(byScalable))
+	toScale := make(map[namespacedCrossGroupObjectReference]scaleInfo)
 
 	mapper, typer := f.Object()
 
 	// first, collect the scale info
 	for scaleRef, svcName := range byScalable {
-		obj, scale, err := scaleAnnotater.GetObjectWithScale(svcName.Namespace, scaleRef)
+		obj, scale, err := scaleAnnotater.GetObjectWithScale(svcName.Namespace, scaleRef.CrossGroupObjectReference)
 		if err != nil {
 			fmt.Fprintf(o.errOut, "error: unable to get scale for %s %s/%s, not marking that scalable as idled: %v\n", scaleRef.Kind, svcName.Namespace, scaleRef.Name, err)
 			svcInfo := byService[svcName]
-			delete(svcInfo.scaleRefs, scaleRef)
+			delete(svcInfo.scaleRefs, scaleRef.CrossGroupObjectReference)
 			hadError = true
 			continue
 		}
@@ -619,7 +673,7 @@ func (o *IdleOptions) RunIdle(f *clientcmd.Factory) error {
 		if !o.dryRun {
 			info.scale.Spec.Replicas = 0
 			scaleUpdater := utilunidling.NewScaleUpdater(f.JSONEncoder(), info.namespace, appClient.Apps(), kclient.Core())
-			if err := scaleAnnotater.UpdateObjectScale(scaleUpdater, info.namespace, scaleRef, info.obj, info.scale); err != nil {
+			if err := scaleAnnotater.UpdateObjectScale(scaleUpdater, info.namespace, scaleRef.CrossGroupObjectReference, info.obj, info.scale); err != nil {
 				fmt.Fprintf(o.errOut, "error: unable to scale %s %s/%s to 0, but still listed as target for unidling: %v\n", scaleRef.Kind, info.namespace, scaleRef.Name, err)
 				hadError = true
 				continue


### PR DESCRIPTION
This commit fixes idling across namespaces.  Previously (possibly since
the feature was introduced), certain bits of code did not handle objects
with the same name in different namespaces, treating them as the same
object.  Now, we properly capture this difference.