### PR TITLE
Bug 1475680 - Fix DiagnosticPod default image path

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics/cluster/network/in_pod/util/util.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/cluster/network/in_pod/util/util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/origin/pkg/network"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	networktypedclient "github.com/openshift/origin/pkg/network/generated/internalclientset/typed/network/internalversion"
+	"github.com/openshift/origin/pkg/oc/admin/diagnostics/diagnostics/util"
 	osclientcmd "github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	"github.com/openshift/origin/pkg/util/netutils"
 )
@@ -37,29 +38,17 @@ const (
 	NetworkDiagDefaultTestPodPort     = 8080
 )
 
-func trimRegistryPath(image string) string {
-	// Image format could be: [<dns-name>/]openshift/origin-deployer[:<tag>]
-	// Return image without registry dns: openshift/origin-deployer[:<tag>]
-	tokens := strings.Split(image, "/")
-	sz := len(tokens)
-	trimmedImage := image
-	if sz >= 2 {
-		trimmedImage = fmt.Sprintf("%s/%s", tokens[sz-2], tokens[sz-1])
-	}
-	return trimmedImage
-}
-
 func GetNetworkDiagDefaultPodImage() string {
 	imageTemplate := variable.NewDefaultImageTemplate()
 	imageTemplate.Format = variable.DefaultImagePrefix + ":${version}"
 	image := imageTemplate.ExpandOrDie("")
-	return trimRegistryPath(image)
+	return util.TrimRegistryPath(image)
 }
 
 func GetNetworkDiagDefaultTestPodImage() string {
 	imageTemplate := variable.NewDefaultImageTemplate()
 	image := imageTemplate.ExpandOrDie("deployer")
-	return trimRegistryPath(image)
+	return util.TrimRegistryPath(image)
 }
 
 func GetOpenShiftNetworkPlugin(clusterNetworkClient networktypedclient.ClusterNetworksGetter) (string, bool, error) {

--- a/pkg/oc/admin/diagnostics/diagnostics/util/util.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/kubernetes/pkg/apis/authorization"
 	authorizationtypedclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 )
@@ -28,4 +31,16 @@ func UserCan(sarClient authorizationtypedclient.SelfSubjectAccessReviewsGetter, 
 	}
 
 	return false, nil
+}
+
+func TrimRegistryPath(image string) string {
+	// Image format could be: [<dns-name>/]openshift/origin-deployer[:<tag>]
+	// Return image without registry dns: openshift/origin-deployer[:<tag>]
+	tokens := strings.Split(image, "/")
+	sz := len(tokens)
+	trimmedImage := image
+	if sz >= 2 {
+		trimmedImage = fmt.Sprintf("%s/%s", tokens[sz-2], tokens[sz-1])
+	}
+	return trimmedImage
 }

--- a/pkg/oc/admin/diagnostics/diagnostics/util/util_test.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/util/util_test.go
@@ -44,7 +44,7 @@ func TestTrimRegistryPath(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		trimmedImage := trimRegistryPath(tc.image)
+		trimmedImage := TrimRegistryPath(tc.image)
 		if trimmedImage != tc.expectedImage {
 			t.Fatalf("[%s] failed: expected %s but got %s", name, tc.expectedImage, trimmedImage)
 		}


### PR DESCRIPTION
- DiagnosticPod diagnostics is run as a admin CLI command so there is no config for
variable.DefaultImagePrefix and it defaults to 'registry.access.redhat.com' in case
of ansible deployment which may not be true for AWS or some other openshift environments.

- This change will remove the registry path from the default image so that it
defaults to registry configured on the openshift node.
Example:
  Earlier image path: registry.access.redhat.com/openshift3/ose-deployer
  New image path: openshift3/ose-deployer
  On AWS node, this will resolve to registry.reg-aws.openshift.com:443/openshift3/ose-deployer

- '--latest-images' flag is unnecessary as the same result can be
achieved by specifying ':latest' tag to '--images' flag.
Example: --images=openshift3/ose-deployer:latest

- This change hides '--latest-images' flag to retain backward
compatibility and we could remove this flag in future release.