### PR TITLE
adjust newapp/newbuild error messages (arg classification vs. actual …

### DIFF
--- a/pkg/oc/cli/cmd/newapp.go
+++ b/pkg/oc/cli/cmd/newapp.go
@@ -605,7 +605,29 @@ func CompleteAppConfig(config *newcmd.AppConfig, f *clientcmd.Factory, c *cobra.
 
 	unknown := config.AddArguments(args)
 	if len(unknown) != 0 {
-		return kcmdutil.UsageErrorf(c, "Did not recognize the following arguments: %v", unknown)
+		buf := &bytes.Buffer{}
+		fmt.Fprintf(buf, "Did not recognize the following arguments: %v\n\n", unknown)
+		for _, argName := range unknown {
+			fmt.Fprintf(buf, "%s:\n", argName)
+			for _, classErr := range config.EnvironmentClassificationErrors {
+				if classErr.Value != nil {
+					fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+				} else {
+					fmt.Fprintf(buf, fmt.Sprintf("%s\n", classErr.Key))
+				}
+			}
+			for _, classErr := range config.SourceClassificationErrors {
+				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+			}
+			for _, classErr := range config.TemplateClassificationErrors {
+				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+			}
+			for _, classErr := range config.ComponentClassificationErrors {
+				fmt.Fprintf(buf, fmt.Sprintf("%s:  %v\n", classErr.Key, classErr.Value))
+			}
+			fmt.Fprintln(buf)
+		}
+		return kcmdutil.UsageErrorf(c, heredoc.Docf(buf.String()))
 	}
 
 	if config.AllowMissingImages && config.AsSearch {
@@ -701,7 +723,7 @@ func retryBuildConfig(info *resource.Info, err error) runtime.Object {
 	return nil
 }
 
-func handleError(err error, baseName, commandName, commandPath string, config *newcmd.AppConfig, transformError func(err error, baseName, commandName, commandPath string, groups errorGroups)) error {
+func handleError(err error, baseName, commandName, commandPath string, config *newcmd.AppConfig, transformError func(err error, baseName, commandName, commandPath string, groups errorGroups, config *newcmd.AppConfig)) error {
 	if err == nil {
 		return nil
 	}
@@ -711,23 +733,19 @@ func handleError(err error, baseName, commandName, commandPath string, config *n
 	}
 	groups := errorGroups{}
 	for _, err := range errs {
-		transformError(err, baseName, commandName, commandPath, groups)
+		transformError(err, baseName, commandName, commandPath, groups, config)
 	}
 	buf := &bytes.Buffer{}
-	if len(config.ArgumentClassificationErrors) > 0 {
-		fmt.Fprintf(buf, "Errors occurred while determining argument types:\n")
-		for _, classErr := range config.ArgumentClassificationErrors {
-			fmt.Fprintf(buf, fmt.Sprintf("\n%s:  %v\n", classErr.Key, classErr.Value))
-		}
-		fmt.Fprint(buf, "\n")
-		// this print serves as a header for the printing of the errorGroups, but
-		// only print it if we precede with classification errors, to help distinguish
-		// between the two
-		fmt.Fprintln(buf, "Errors occurred during resource creation:")
-	}
 	for _, group := range groups {
 		fmt.Fprint(buf, kcmdutil.MultipleErrors("error: ", group.errs))
+		if len(group.classification) > 0 {
+			fmt.Fprintln(buf)
+		}
+		fmt.Fprintf(buf, group.classification)
 		if len(group.suggestion) > 0 {
+			if len(group.classification) > 0 {
+				fmt.Fprintln(buf)
+			}
 			fmt.Fprintln(buf)
 		}
 		fmt.Fprint(buf, group.suggestion)
@@ -736,20 +754,22 @@ func handleError(err error, baseName, commandName, commandPath string, config *n
 }
 
 type errorGroup struct {
-	errs       []error
-	suggestion string
+	errs           []error
+	suggestion     string
+	classification string
 }
 type errorGroups map[string]errorGroup
 
-func (g errorGroups) Add(group string, suggestion string, err error, errs ...error) {
+func (g errorGroups) Add(group string, suggestion string, classification string, err error, errs ...error) {
 	all := g[group]
 	all.errs = append(all.errs, errs...)
 	all.errs = append(all.errs, err)
 	all.suggestion = suggestion
+	all.classification = classification
 	g[group] = all
 }
 
-func transformRunError(err error, baseName, commandName, commandPath string, groups errorGroups) {
+func transformRunError(err error, baseName, commandName, commandPath string, groups errorGroups, config *newcmd.AppConfig) {
 	switch t := err.(type) {
 	case newcmd.ErrRequiresExplicitAccess:
 		if t.Input.Token != nil && t.Input.Token.ServiceAccount {
@@ -762,6 +782,7 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 					You can see more information about the image by adding the --dry-run flag.
 					If you trust the provided image, include the flag --grant-install-rights.`,
 				),
+				"",
 				fmt.Errorf("installing %q requires an 'installer' service account with project editor access", t.Match.Value),
 			)
 		} else {
@@ -774,11 +795,19 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 					You can see more information about the image by adding the --dry-run flag.
 					If you trust the provided image, include the flag --grant-install-rights.`,
 				),
+				"",
 				fmt.Errorf("installing %q requires that you grant the image access to run with your credentials", t.Match.Value),
 			)
 		}
 		return
 	case newapp.ErrNoMatch:
+		classification, _ := config.ClassificationWinners[t.Value]
+		if classification.IncludeGitErrors {
+			notGitRepo, ok := config.SourceClassificationErrors[t.Value]
+			if ok {
+				t.Errs = append(t.Errs, notGitRepo.Value)
+			}
+		}
 		groups.Add(
 			"no-matches",
 			heredoc.Docf(`
@@ -794,11 +823,13 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 
 				See '%[1]s -h' for examples.`, commandPath,
 			),
+			heredoc.Docf(classification.String()),
 			t,
 			t.Errs...,
 		)
 		return
 	case newapp.ErrMultipleMatches:
+		classification, _ := config.ClassificationWinners[t.Value]
 		buf := &bytes.Buffer{}
 		for i, match := range t.Matches {
 
@@ -812,6 +843,7 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 
 						%[2]sTo view a full list of matches, use '%[3]s %[4]s -S %[1]s'`, t.Value, buf.String(), baseName, commandName,
 					),
+					classification.String(),
 					t,
 					t.Errs...,
 				)
@@ -830,11 +862,13 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 
 					%[2]s`, t.Value, buf.String(),
 			),
+			classification.String(),
 			t,
 			t.Errs...,
 		)
 		return
 	case newapp.ErrPartialMatch:
+		classification, _ := config.ClassificationWinners[t.Value]
 		buf := &bytes.Buffer{}
 		fmt.Fprintf(buf, "* %s\n", t.Match.Description)
 		fmt.Fprintf(buf, "  Use %[1]s to specify this image or template\n\n", t.Match.Argument)
@@ -846,11 +880,13 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 
 					%[2]s`, t.Value, buf.String(),
 			),
+			classification.String(),
 			t,
 			t.Errs...,
 		)
 		return
 	case newapp.ErrNoTagsFound:
+		classification, _ := config.ClassificationWinners[t.Value]
 		buf := &bytes.Buffer{}
 		fmt.Fprintf(buf, "  Use --allow-missing-imagestream-tags to use this image stream\n\n")
 		groups.Add(
@@ -860,6 +896,7 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 
 					%[2]s`, t.Match.Name, buf.String(),
 			),
+			classification.String(),
 			t,
 			t.Errs...,
 		)
@@ -868,13 +905,14 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 	switch err {
 	case errNoTokenAvailable:
 		// TODO: improve by allowing token generation
-		groups.Add("", "", fmt.Errorf("to install components you must be logged in with an OAuth token (instead of only a certificate)"))
+		groups.Add("", "", "", fmt.Errorf("to install components you must be logged in with an OAuth token (instead of only a certificate)"))
 	case newcmd.ErrNoInputs:
 		// TODO: suggest things to the user
-		groups.Add("", "", usageError(commandPath, newAppNoInput, baseName, commandName))
+		groups.Add("", "", "", usageError(commandPath, newAppNoInput, baseName, commandName))
 	default:
-		groups.Add("", "", err)
+		groups.Add("", "", "", err)
 	}
+	return
 }
 
 func usageError(commandPath, format string, args ...interface{}) error {

--- a/pkg/oc/cli/cmd/newbuild.go
+++ b/pkg/oc/cli/cmd/newbuild.go
@@ -212,9 +212,16 @@ func (o *NewBuildOptions) RunNewBuild() error {
 	return nil
 }
 
-func transformBuildError(err error, baseName, commandName, commandPath string, groups errorGroups) {
+func transformBuildError(err error, baseName, commandName, commandPath string, groups errorGroups, config *newcmd.AppConfig) {
 	switch t := err.(type) {
 	case newapp.ErrNoMatch:
+		classification, _ := config.ClassificationWinners[t.Value]
+		if classification.IncludeGitErrors {
+			notGitRepo, ok := config.SourceClassificationErrors[t.Value]
+			if ok {
+				t.Errs = append(t.Errs, notGitRepo.Value)
+			}
+		}
 		groups.Add(
 			"no-matches",
 			heredoc.Docf(`
@@ -229,6 +236,7 @@ func transformBuildError(err error, baseName, commandName, commandPath string, g
 
 				See '%[1]s -h' for examples.`, commandPath,
 			),
+			classification.String(),
 			t,
 			t.Errs...,
 		)
@@ -236,8 +244,9 @@ func transformBuildError(err error, baseName, commandName, commandPath string, g
 	}
 	switch err {
 	case newcmd.ErrNoInputs:
-		groups.Add("", "", usageError(commandPath, newBuildNoInput, baseName, commandName))
+		groups.Add("", "", "", usageError(commandPath, newBuildNoInput, baseName, commandName))
 		return
 	}
-	transformRunError(err, baseName, commandName, commandPath, groups)
+	transformRunError(err, baseName, commandName, commandPath, groups, config)
+	return
 }

--- a/pkg/oc/cli/cmd/newbuild_test.go
+++ b/pkg/oc/cli/cmd/newbuild_test.go
@@ -108,6 +108,10 @@ type MockSearcher struct {
 	OnSearch func(precise bool, terms ...string) (app.ComponentMatches, []error)
 }
 
+func (m MockSearcher) Type() string {
+	return ""
+}
+
 // Search mocks a search.
 func (m MockSearcher) Search(precise bool, terms ...string) (app.ComponentMatches, []error) {
 	return m.OnSearch(precise, terms...)

--- a/pkg/oc/generate/app/componentresolvers_test.go
+++ b/pkg/oc/generate/app/componentresolvers_test.go
@@ -9,6 +9,10 @@ type mockSearcher struct {
 	numResults int
 }
 
+func (m mockSearcher) Type() string {
+	return ""
+}
+
 func (m mockSearcher) Search(precise bool, terms ...string) (ComponentMatches, []error) {
 	results := ComponentMatches{}
 	for i := 0; i < m.numResults; i++ {

--- a/pkg/oc/generate/app/dockerimagelookup.go
+++ b/pkg/oc/generate/app/dockerimagelookup.go
@@ -41,6 +41,10 @@ type DockerClientSearcher struct {
 	AllowMissingImages bool
 }
 
+func (r DockerClientSearcher) Type() string {
+	return "local docker images"
+}
+
 // Search searches all images in local docker server for images that match terms
 func (r DockerClientSearcher) Search(precise bool, terms ...string) (ComponentMatches, []error) {
 	componentMatches := ComponentMatches{}
@@ -164,6 +168,10 @@ func (r DockerClientSearcher) Search(precise bool, terms ...string) (ComponentMa
 type MissingImageSearcher struct {
 }
 
+func (r MissingImageSearcher) Type() string {
+	return "images not found in docker registry nor locally"
+}
+
 // Search always returns an exact match for the search terms.
 func (r MissingImageSearcher) Search(precise bool, terms ...string) (ComponentMatches, []error) {
 	componentMatches := ComponentMatches{}
@@ -182,6 +190,10 @@ type ImageImportSearcher struct {
 	Client        imageclient.ImageStreamImportInterface
 	AllowInsecure bool
 	Fallback      Searcher
+}
+
+func (s ImageImportSearcher) Type() string {
+	return "images via the image stream import API"
 }
 
 // Search invokes the new ImageStreamImport API to have the server look up Docker images for the user,
@@ -265,6 +277,10 @@ func (s ImageImportSearcher) Search(precise bool, terms ...string) (ComponentMat
 type DockerRegistrySearcher struct {
 	Client        dockerregistry.Client
 	AllowInsecure bool
+}
+
+func (r DockerRegistrySearcher) Type() string {
+	return "images in the docker registry"
 }
 
 // Search searches in the Docker registry for images that match terms

--- a/pkg/oc/generate/app/dockerimagelookup_test.go
+++ b/pkg/oc/generate/app/dockerimagelookup_test.go
@@ -12,6 +12,10 @@ type fakeRegistrySearcher struct {
 	errs    []error
 }
 
+func (f fakeRegistrySearcher) Type() string {
+	return ""
+}
+
 func (f fakeRegistrySearcher) Search(precise bool, terms ...string) (ComponentMatches, []error) {
 	return f.matches, f.errs
 }

--- a/pkg/oc/generate/app/errors.go
+++ b/pkg/oc/generate/app/errors.go
@@ -11,15 +11,16 @@ import (
 // given component.
 type ErrNoMatch struct {
 	Value     string
+	Type      string
 	Qualifier string
 	Errs      []error
 }
 
 func (e ErrNoMatch) Error() string {
 	if len(e.Qualifier) != 0 {
-		return fmt.Sprintf("no match for %q: %s", e.Value, e.Qualifier)
+		return fmt.Sprintf("unable to locate any %s with name %q: %s", e.Type, e.Value, e.Qualifier)
 	}
-	return fmt.Sprintf("no match for %q", e.Value)
+	return fmt.Sprintf("unable to locate any %s with name %q", e.Type, e.Value)
 }
 
 // Suggestion is the usage error message returned when no match is found.

--- a/pkg/oc/generate/app/imagestreamlookup.go
+++ b/pkg/oc/generate/app/imagestreamlookup.go
@@ -20,6 +20,10 @@ type ImageStreamSearcher struct {
 	AllowMissingTags  bool
 }
 
+func (r ImageStreamSearcher) Type() string {
+	return "images in image streams"
+}
+
 // Search will attempt to find imagestreams with names that match the passed in value
 func (r ImageStreamSearcher) Search(precise bool, terms ...string) (ComponentMatches, []error) {
 	componentMatches := ComponentMatches{}
@@ -360,6 +364,10 @@ func (r *ImageStreamByAnnotationSearcher) annotationMatches(stream *imageapi.Ima
 		matches = append(matches, match)
 	}
 	return matches
+}
+
+func (r *ImageStreamByAnnotationSearcher) Type() string {
+	return "image stream images with a 'supports' annotation"
 }
 
 // Search finds image stream images using their 'supports' annotation

--- a/pkg/oc/generate/app/templatelookup.go
+++ b/pkg/oc/generate/app/templatelookup.go
@@ -25,6 +25,10 @@ type TemplateSearcher struct {
 	StopOnExactMatch bool
 }
 
+func (r TemplateSearcher) Type() string {
+	return "templates loaded in accessible projects"
+}
+
 // Search searches for a template and returns matches with the object representation
 func (r TemplateSearcher) Search(precise bool, terms ...string) (ComponentMatches, []error) {
 	matches := ComponentMatches{}
@@ -102,6 +106,10 @@ func IsPossibleTemplateFile(value string) (bool, error) {
 type TemplateFileSearcher struct {
 	Builder   *resource.Builder
 	Namespace string
+}
+
+func (r *TemplateFileSearcher) Type() string {
+	return "template files"
 }
 
 // Search attempts to read template files and transform it into template objects

--- a/pkg/oc/generate/cmd/newapp_test.go
+++ b/pkg/oc/generate/cmd/newapp_test.go
@@ -186,6 +186,11 @@ func TestBuildTemplates(t *testing.T) {
 	for n, c := range tests {
 		appCfg := AppConfig{}
 		appCfg.Out = &bytes.Buffer{}
+		appCfg.EnvironmentClassificationErrors = map[string]ArgumentClassificationError{}
+		appCfg.SourceClassificationErrors = map[string]ArgumentClassificationError{}
+		appCfg.TemplateClassificationErrors = map[string]ArgumentClassificationError{}
+		appCfg.ComponentClassificationErrors = map[string]ArgumentClassificationError{}
+		appCfg.ClassificationWinners = map[string]ArgumentClassificationWinner{}
 
 		// the previous fake was broken and didn't 404 properly.  this test is relying on that
 		templateFake := templatefakeclient.NewSimpleClientset()

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -53,14 +53,25 @@ os::cmd::expect_success 'oc delete is myruby'
 os::cmd::expect_failure_and_text 'oc new-app https://github.com/openshift/nodejs-ex --strategy=docker' 'No Dockerfile was found'
 
 # repo related error message validation
-os::cmd::expect_failure_and_text 'oc new-app mysql-persisten mysql' 'mysql-persisten as a local directory'
-os::cmd::expect_failure_and_text 'oc new-app mysql-persisten mysql' 'mysql as a local directory'
-os::cmd::expect_failure_and_text 'oc new-app --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git' 'as a Git repository URL:  '
-os::cmd::expect_failure_and_text 'oc new-app https://www.google.com/openshift/nodejs-e' 'as a Git repository URL:  '
-os::cmd::expect_failure_and_text 'oc new-app https://examplegit.com/openshift/nodejs-e' 'as a Git repository URL:  '
-os::cmd::expect_failure_and_text 'oc new-build --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git' 'as a Git repository URL:  '
-os::cmd::expect_failure_and_text 'oc new-build https://www.google.com/openshift/nodejs-e' 'as a Git repository URL:  '
-os::cmd::expect_failure_and_text 'oc new-build https://examplegit.com/openshift/nodejs-e' 'as a Git repository URL:  '
+os::cmd::expect_success 'oc create -f examples/db-templates/mysql-persistent-template.json'
+os::cmd::expect_failure_and_text 'oc new-app mysql-persisten mysql' 'only a partial match was found for'
+os::cmd::expect_success 'oc delete template/mysql-persistent'
+os::cmd::expect_failure_and_text 'oc new-app --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git' 'none of the arguments provided could be classified as a source code location'
+os::cmd::expect_failure_and_text 'oc new-app https://www.google.com/openshift/nodejs-e' 'unable to load template file'
+os::cmd::expect_failure_and_text 'oc new-app https://www.google.com/openshift/nodejs-e' 'unable to locate any'
+os::cmd::expect_failure_and_text 'oc new-app https://www.google.com/openshift/nodejs-e' 'was classified as an image, image~source, or loaded template reference.'
+os::cmd::expect_failure_and_text 'oc new-app https://examplegit.com/openshift/nodejs-e' 'unable to load template file'
+os::cmd::expect_failure_and_text 'oc new-app https://examplegit.com/openshift/nodejs-e' 'unable to locate any'
+os::cmd::expect_failure_and_text 'oc new-app https://examplegit.com/openshift/nodejs-e' 'was classified as an image, image~source, or loaded template reference.'
+os::cmd::expect_failure_and_text 'oc new-build --strategy=docker https://192.30.253.113/openshift/ruby-hello-world.git' 'none of the arguments provided could be classified as a source code location'
+os::cmd::expect_failure_and_text 'oc new-build https://www.google.com/openshift/nodejs-e' 'unable to load template file'
+os::cmd::expect_failure_and_text 'oc new-build https://www.google.com/openshift/nodejs-e' 'unable to locate any'
+os::cmd::expect_failure_and_text 'oc new-build https://www.google.com/openshift/nodejs-e' 'was classified as an image, image~source, or loaded template reference.'
+os::cmd::expect_failure_and_text 'oc new-build https://examplegit.com/openshift/nodejs-e' 'unable to load template file'
+os::cmd::expect_failure_and_text 'oc new-build https://examplegit.com/openshift/nodejs-e' 'unable to locate any'
+os::cmd::expect_failure_and_text 'oc new-build https://examplegit.com/openshift/nodejs-e' 'was classified as an image, image~source, or loaded template reference.'
+os::cmd::expect_failure_and_text 'oc new-build --name imagesourcetest python~https://github.com/openshift-katacoda/blog-django-py --source-image xxx --source-image-path=yyy --dry-run' 'unable to locate any '
+os::cmd::expect_failure_and_text 'oc new-app ~java' 'you must specify a image name'
 
 # setting source secret via the --source-secret flag
 os::cmd::expect_success_and_text 'oc new-app https://github.com/openshift/cakephp-ex --source-secret=mysecret -o yaml' 'name: mysecret'
@@ -346,8 +357,8 @@ os::cmd::expect_success_and_text 'oc new-app --dry-run --docker-image=mysql' 'Th
 os::cmd::expect_success_and_text 'oc new-app --dry-run --docker-image=mysql' "WARNING: Image \"mysql\" runs as the 'root' user"
 
 # verify multiple errors are displayed together, a nested error is returned, and that the usage message is displayed
-os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' 'error: no match for "__template_fail"'
-os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' 'error: no match for "__templatefile_fail"'
+os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' 'error: unable to locate any'
+os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' 'with name "__templatefile_fail"'
 os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' 'error: unable to find the specified template file'
 os::cmd::expect_failure_and_text 'oc new-app --dry-run __template_fail __templatefile_fail' "The 'oc new-app' command will match arguments"
 
@@ -448,7 +459,7 @@ os::cmd::expect_success_and_text 'oc new-app -f test/testdata/circular.yaml' 'sh
 os::cmd::expect_success_and_not_text 'oc new-app -f test/testdata/bc-from-imagestreamimage.json --dry-run' 'Unable to follow reference type'
 
 # do not allow use of non-existent image (should fail)
-os::cmd::expect_failure_and_text 'oc new-app  openshift/bogusimage https://github.com/openshift/ruby-hello-world.git -o yaml' "no match for"
+os::cmd::expect_failure_and_text 'oc new-app  openshift/bogusimage https://github.com/openshift/ruby-hello-world.git -o yaml' "unable to locate any"
 # allow use of non-existent image (should succeed)
 os::cmd::expect_success 'oc new-app openshift/bogusimage https://github.com/openshift/ruby-hello-world.git -o yaml --allow-missing-images'
 

--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -119,6 +119,11 @@ func TestNewAppAddArguments(t *testing.T) {
 
 	for n, c := range tests {
 		a := &cmd.AppConfig{}
+		a.EnvironmentClassificationErrors = map[string]cmd.ArgumentClassificationError{}
+		a.SourceClassificationErrors = map[string]cmd.ArgumentClassificationError{}
+		a.TemplateClassificationErrors = map[string]cmd.ArgumentClassificationError{}
+		a.ComponentClassificationErrors = map[string]cmd.ArgumentClassificationError{}
+		a.ClassificationWinners = map[string]cmd.ArgumentClassificationWinner{}
 		unknown := a.AddArguments(c.args)
 		if !reflect.DeepEqual(a.Environment, c.env) {
 			t.Errorf("%s: Different env variables. Expected: %v, Actual: %v", n, c.env, a.Environment)
@@ -154,7 +159,7 @@ func TestNewAppResolve(t *testing.T) {
 						},
 					},
 				})},
-			expectedErr: `no match for "mysql:invalid`,
+			expectedErr: `unable to locate any`,
 		},
 		{
 			name: "Successful mysql builder",
@@ -279,6 +284,10 @@ type ExactMatchDockerSearcher struct {
 	Errs []error
 }
 
+func (r *ExactMatchDockerSearcher) Type() string {
+	return ""
+}
+
 // Search always returns a match for every term passed in
 func (r *ExactMatchDockerSearcher) Search(precise bool, terms ...string) (app.ComponentMatches, []error) {
 	matches := app.ComponentMatches{}
@@ -299,6 +308,10 @@ func (r *ExactMatchDockerSearcher) Search(precise bool, terms ...string) (app.Co
 // creates a Matcher which triggers the logic to enable tag support.
 type ExactMatchDirectTagDockerSearcher struct {
 	Errs []error
+}
+
+func (r *ExactMatchDirectTagDockerSearcher) Type() string {
+	return ""
 }
 
 func (r *ExactMatchDirectTagDockerSearcher) Search(precise bool, terms ...string) (app.ComponentMatches, []error) {


### PR DESCRIPTION
…processing

Fixes https://github.com/openshift/origin/issues/17925

@openshift/sig-developer-experience ptal

Now produces:

```
gmontero ~/go/src/github.com/openshift/origin  (new-app-bld-msgs)$ oc new-build --name imagesourcetest python~https://github.com/openshift-katacoda/blog-django-py --source-image xxx --source-image-path=yyy --dry-run
error: unable to locate resource for "xxx"

The 'oc new-build' command will match arguments to the following types:

  1. Images tagged into image streams in the current project or the 'openshift' project
     - if you don't specify a tag, we'll add ':latest'
  2. Images in the Docker Hub, on remote registries, or on the local Docker engine
  3. Git repository URLs or local paths that point to Git repositories

--allow-missing-images can be used to force the use of an image that was not matched

See 'oc new-build -h' for examples.

```