### PR TITLE
Migrate: handle NotFound via resource matching and during conflicts

### DIFF
--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -519,6 +519,11 @@ func DefaultRetriable(info *resource.Info, err error) error {
 		return ErrNotRetriable{err}
 	case errors.IsConflict(err):
 		if refreshErr := info.Get(); refreshErr != nil {
+			// tolerate the deletion of resources during migration
+			// report unchanged since we did not actually migrate this object
+			if isNotFoundForInfo(info, refreshErr) {
+				return ErrUnchanged
+			}
 			return ErrNotRetriable{err}
 		}
 		return ErrRetriable{err}
@@ -542,11 +547,14 @@ func isNotFoundForInfo(info *resource.Info, err error) bool {
 	if details == nil {
 		return false
 	}
-	// get schema.GroupKind from the mapping since the actual object may not have type meta filled out
+	// get schema.GroupKind and Resource from the mapping since the actual object may not have type meta filled out
 	gk := info.Mapping.GroupVersionKind.GroupKind()
+	mappingResource := info.Mapping.Resource
 	// based on case-insensitive string comparisons, the error matches info iff
-	// the name and kind match
-	// the group match, but only if both the error and info specify a group
-	return strings.EqualFold(details.Name, info.Name) && strings.EqualFold(details.Kind, gk.Kind) &&
+	// the names match
+	// the error's kind matches the mapping's kind or the mapping's resource
+	// the groups match, but only if both the error and info specify a group
+	return strings.EqualFold(details.Name, info.Name) &&
+		(strings.EqualFold(details.Kind, gk.Kind) || strings.EqualFold(details.Kind, mappingResource)) &&
 		(len(details.Group) == 0 || len(gk.Group) == 0 || strings.EqualFold(details.Group, gk.Group))
 }

--- a/pkg/oc/admin/migrate/migrator_test.go
+++ b/pkg/oc/admin/migrate/migrator_test.go
@@ -334,6 +334,72 @@ func TestIsNotFoundForInfo(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "case-insensitive match due to different kinds but same resource",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						Resource: "KIND2",
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind1",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "GROUP1",
+					Resource: "kind2", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive match due to different resource but same kinds",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						Resource: "kind1",
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "KIND2",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "GROUP1",
+					Resource: "kind2", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive not match due to different resource and different kinds",
+			args: args{
+				info: &resource.Info{
+					Mapping: &meta.RESTMapping{
+						Resource: "kind1",
+						GroupVersionKind: schema.GroupVersionKind{
+							Group: "group1",
+							Kind:  "kind3",
+						},
+					},
+					Name: "NOTname",
+				},
+				err: errors.NewNotFound(schema.GroupResource{
+					Group:    "GROUP1",
+					Resource: "kind2", // this is the kind
+				},
+					"notNAME",
+				),
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This change fixes two issues with the migrate command:

1. It updates `isNotFoundForInfo` to compare the error's kind to the info's resource as well as its kind.  The server error's use the resource value in places where the kind should be used.  We simply accept both now.
2. It updates `DefaultRetriable` to not fail on conflict errors if they were caused by the deletion of the given resource.

The following shell based tests were used to stress the edge cases that this change fixes.  The migrate command will readily fail in these tests without the fixes from this change.

In one shell we continuously create service accounts with random names as fast as possible.  The resource type is not relevant.

```bash
N=8
while true; do
    ((i=i%N)); ((i++==0)) && wait
    oc create serviceaccount $((1 + RANDOM % 10000000)) &
done
```

In a second shell we try to continuously delete all service accounts:

```bash
while true; do
    oc delete sa --all
done
```

In a third shell we try to continuously migrate service accounts:

```bash
while true; do
    oc adm migrate storage --include='serviceaccount' --confirm
done
```

[Bug 1537751](https://bugzilla.redhat.com/show_bug.cgi?id=1537751)

Signed-off-by: Monis Khan <mkhan@redhat.com>