### PR TITLE
Fix node system container service template

### DIFF
--- a/images/node/system-container/service.template
+++ b/images/node/system-container/service.template
@@ -21,4 +21,4 @@ WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
 
 [Install]
-WantedBy=docker.service
+WantedBy=${DOCKER_SERVICE}


### PR DESCRIPTION
node image may not always be deployed with docker.

This commit templates the 'WantedBy' to ensure
node can start with target.wants of each
respective runtime.