### PR TITLE
Handle usage error of scc-review and scc-subject-review properly

### DIFF
--- a/pkg/oc/admin/policy/review.go
+++ b/pkg/oc/admin/policy/review.go
@@ -85,7 +85,7 @@ func NewCmdSccReview(name, fullName string, f *clientcmd.Factory, out io.Writer)
 
 func (o *sccReviewOptions) Complete(f *clientcmd.Factory, args []string, cmd *cobra.Command, out io.Writer) error {
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
-		return kcmdutil.UsageErrorf(cmd, cmd.Use)
+		return kcmdutil.UsageErrorf(cmd, "one or more resources must be specified")
 	}
 	for _, sa := range o.serviceAccountNames {
 		if strings.HasPrefix(sa, serviceaccount.ServiceAccountUsernamePrefix) {

--- a/pkg/oc/admin/policy/subject_review.go
+++ b/pkg/oc/admin/policy/subject_review.go
@@ -81,14 +81,14 @@ func NewCmdSccSubjectReview(name, fullName string, f *clientcmd.Factory, out io.
 
 func (o *sccSubjectReviewOptions) Complete(f *clientcmd.Factory, args []string, cmd *cobra.Command, out io.Writer) error {
 	if len(args) == 0 && len(o.FilenameOptions.Filenames) == 0 {
-		return kcmdutil.UsageErrorf(cmd, cmd.Use)
+		return kcmdutil.UsageErrorf(cmd, "one or more resources must be specified")
 	}
 	if len(o.User) > 0 && len(o.serviceAccount) > 0 {
-		return fmt.Errorf("--user and --serviceaccount are mutually exclusive")
+		return kcmdutil.UsageErrorf(cmd, "--user and --serviceaccount are mutually exclusive")
 	}
 	if len(o.serviceAccount) > 0 { // check whether user supplied a list of SA
 		if len(strings.Split(o.serviceAccount, ",")) > 1 {
-			return fmt.Errorf("only one Service Account is supported")
+			return kcmdutil.UsageErrorf(cmd, "only one Service Account is supported")
 		}
 		if strings.HasPrefix(o.serviceAccount, serviceaccount.ServiceAccountUsernamePrefix) {
 			_, user, err := serviceaccount.SplitUsername(o.serviceAccount)


### PR DESCRIPTION
Current code for `NewCmdSccSubjectReview()` and `NewCmdSccReview()`
does not handle usage error correctly. Here are some issues:

1. Error message of `oc adm policy scc-subject-review` does not make sense.
- Please see `error: scc-subject-review`. It is not helpful.

~~~
# oc adm policy scc-subject-review
error: scc-subject-review
See 'oc adm policy scc-subject-review -h' for help and examples.
~~~

2. Wrong option error does not show the template error
- Please see below. It does not output `See 'oc adm policy scc-subject-review -h' for help and examples.` after the error.

~~~
# oc adm policy scc-subject-review -u bob -z foo pod
error: --user and --serviceaccount are mutually exclusive
~~~

This patch fixes these issues.
