### PR TITLE
Handle correct source kind properly when determineSourceKind failed to get REST mapper

### DIFF
--- a/pkg/oc/cli/cmd/tag.go
+++ b/pkg/oc/cli/cmd/tag.go
@@ -184,9 +184,6 @@ func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 			if err != nil {
 				return fmt.Errorf("failed to determine source kind: %v", err)
 			}
-			if len(sourceKind) == 0 {
-				return fmt.Errorf("failed to determine source kind. client might not be compatible with server side")
-			}
 		}
 		if len(sourceKind) > 0 {
 			validSources := sets.NewString("imagestreamtag", "istag", "imagestreamimage", "isimage", "docker", "dockerimage")

--- a/pkg/oc/cli/cmd/tag.go
+++ b/pkg/oc/cli/cmd/tag.go
@@ -145,9 +145,9 @@ func determineSourceKind(f *clientcmd.Factory, input string) string {
 		return "DockerImage"
 	}
 
-	glog.Warningf("%v", err)
+	glog.V(1).Infof("error while determining source kind: %v", err)
 
-	switch input {
+	switch strings.ToLower(input) {
 	case "istag":
 		return "ImageStreamTag"
 	case "isimage":
@@ -197,8 +197,6 @@ func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(cmd, "invalid source %q; valid values are %v", o.sourceKind, strings.Join(validSources.List(), ", ")))
 			}
 		}
-
-		glog.V(3).Infof("Using %q as a source kind", sourceKind)
 
 		ref, err := imageapi.ParseDockerImageReference(source)
 		if err != nil {

--- a/pkg/oc/cli/cmd/tag.go
+++ b/pkg/oc/cli/cmd/tag.go
@@ -141,7 +141,10 @@ func determineSourceKind(f *clientcmd.Factory, input string) (string, error) {
 
 	mapper, _ := f.Object()
 	gvks, err := mapper.KindsFor(schema.GroupVersionResource{Group: imageapi.GroupName, Resource: input})
-	return gvks[0].Kind, err
+	if err == nil && len(gvks) > 0 {
+		return gvks[0].Kind, nil
+	}
+	return "", err
 }
 
 // Complete completes all the required options for the tag command.
@@ -180,6 +183,9 @@ func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 			sourceKind, err = determineSourceKind(f, sourceKind)
 			if err != nil {
 				return fmt.Errorf("failed to determine source kind: %v", err)
+			}
+			if len(sourceKind) == 0 {
+				return fmt.Errorf("failed to determine source kind. client might not be compatible with server side")
 			}
 		}
 		if len(sourceKind) > 0 {

--- a/pkg/oc/cli/cmd/tag.go
+++ b/pkg/oc/cli/cmd/tag.go
@@ -145,6 +145,15 @@ func determineSourceKind(f *clientcmd.Factory, input string) string {
 		return "DockerImage"
 	}
 
+	glog.Warningf("%v", err)
+
+	switch input {
+	case "istag":
+		return "ImageStreamTag"
+	case "isimage":
+		return "ImageStreamImage"
+	}
+
 	return input
 }
 
@@ -188,6 +197,8 @@ func (o *TagOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, args []s
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(cmd, "invalid source %q; valid values are %v", o.sourceKind, strings.Join(validSources.List(), ", ")))
 			}
 		}
+
+		glog.V(3).Infof("Using %q as a source kind", sourceKind)
 
 		ref, err := imageapi.ParseDockerImageReference(source)
 		if err != nil {

--- a/pkg/oc/cli/cmd/tag.go
+++ b/pkg/oc/cli/cmd/tag.go
@@ -148,9 +148,9 @@ func determineSourceKind(f *clientcmd.Factory, input string) string {
 	glog.V(1).Infof("error while determining source kind: %v", err)
 
 	switch strings.ToLower(input) {
-	case "istag":
+	case "istag", "imagestreamtag":
 		return "ImageStreamTag"
-	case "isimage":
+	case "isimage", "imagestreamimage":
 		return "ImageStreamImage"
 	}
 


### PR DESCRIPTION
When `determineSourceKind()` failed to get REST mapper _but_
sourceKind set `istag` or `isimage`, program continues and behaves
wrongly.

For example, running unexpected procedure and wrong error happens as:

~~~
$ _output/local/bin/linux/amd64/oc tag iknow:wrong foo:bar --source=isimage --loglevel=3
I0130 00:33:41.295657    3139 tag.go:179] Using "iknow:wrong" as a source tag
I0130 00:33:47.166424    3139 tag.go:260] Source tag isimage image.DockerImageReference{Registry:"", Namespace:"", Name:"iknow", Tag:"wrong", ID:""}
I0130 00:33:47.166450    3139 tag.go:271] Using "demo1/foo:bar" as a destination tag
F0130 00:33:47.338908    3139 helpers.go:119] The ImageStreamTag "foo:bar" is invalid: tag.from.kind: Required value: valid values are 'DockerImage', 'ImageStreamImage', 'ImageStreamTag'
~~~

This patch changes to convert `istag` and `isimage` when
determineSourceKind() failed to get REST mapper, then continue the
program correctly.

(After applied this patch)

~~~
$ _output/local/bin/linux/amd64/oc tag iknow:wrong foo:bar --source=isimage --loglevel=3
I0130 00:32:25.296587    2413 tag.go:188] Using "iknow:wrong" as a source tag
W0130 00:32:31.662123    2413 tag.go:148] no matches for {image.openshift.io  isimage}
I0130 00:32:31.662156    2413 tag.go:201] Using "ImageStreamImage" as a source kind
F0130 00:32:31.662197    2413 helpers.go:119] error: --source=ImageStreamImage requires a valid <name>@<id> in SOURCE
~~~