### PR TITLE
Add mount debugging and container inspection logs

### DIFF
--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -110,6 +110,8 @@ function os::build::environment::cleanup() {
   local container=$1
   local volume=$2
   local tmp_volume=$3
+  os::log::debug "Recording container information to ${LOG_DIR}/${container}.json"
+  docker inspect "${container}" > "${LOG_DIR}/${container}.json"
   os::log::debug "Stopping container ${container}"
   docker stop --time=0 "${container}" > /dev/null || true
   if [[ -z "${OS_BUILD_ENV_LEAVE_CONTAINER:-}" ]]; then

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -207,6 +207,9 @@ function os::util::ensure_tmpfs() {
 	os::log::debug "Filesystem information:
 $( df -h -T )"
 
+	os::log::debug "Mount information:
+$( findmnt --all )"
+
 	local fstype
 	fstype="$( df --output=fstype "${target}" | tail -n 1 )"
 	if [[ "${fstype}" != "tmpfs" ]]; then


### PR DESCRIPTION
In order to help debug issues around the use of `hack/env` and
especially those surrounding mounts in the container, we need to expose
more information in debug logging.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>