### PR TITLE
UPSTREAM: 58991: restore original object on apply err

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/apply.go
@@ -674,13 +674,13 @@ func (p *patcher) patch(current runtime.Object, modified []byte, source, namespa
 		}
 		patchBytes, patchObject, err = p.patchSimple(current, modified, source, namespace, name, errOut)
 	}
-	if err != nil && p.force {
-		patchBytes, patchObject, err = p.deleteAndCreate(modified, namespace, name)
+	if err != nil && errors.IsConflict(err) && p.force {
+		patchBytes, patchObject, err = p.deleteAndCreate(current, modified, namespace, name)
 	}
 	return patchBytes, patchObject, err
 }
 
-func (p *patcher) deleteAndCreate(modified []byte, namespace, name string) ([]byte, runtime.Object, error) {
+func (p *patcher) deleteAndCreate(original runtime.Object, modified []byte, namespace, name string) ([]byte, runtime.Object, error) {
 	err := p.delete(namespace, name)
 	if err != nil {
 		return modified, nil, err
@@ -699,5 +699,15 @@ func (p *patcher) deleteAndCreate(modified []byte, namespace, name string) ([]by
 		return modified, nil, err
 	}
 	createdObject, err := p.helper.Create(namespace, true, versionedObject)
+	if err != nil {
+		// restore the original object if we fail to create the new one
+		// but still propagate and advertise error to user
+		recreated, recreateErr := p.helper.Create(namespace, true, original)
+		if recreateErr != nil {
+			err = fmt.Errorf("An error ocurred force-replacing the existing object with the newly provided one:\n\n%v.\n\nAdditionally, an error ocurred attempting to restore the original object:\n\n%v\n", err, recreateErr)
+		} else {
+			createdObject = recreated
+		}
+	}
 	return modified, createdObject, err
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1539529

When `oc apply` is used with the `--force` flag, it will attempt to patch an existing object `A` up to 5 times before it deletes the existing object and re-creates it with a new object `B` originally used to patch `A`.

If object `B` has invalid syntax, or a change preventing it from passing validation, the new object will fail to be created and `oc apply` will simply delete the original object without informing the user that their object no longer exists, and a new one was not created.

This patch restores the original object in the event that an error occurs while attempting to outright replace it with a new one.

Hoping to use this thread to at least discuss the nature of `oc apply --force`, and better define its behavior when it encounters a non-conflict error.

cc @ironcladlou 