### PR TITLE
UPSTREAM:17757 unit test k8s.io/kubernetes/pkg/kubelet/rkt TestVersion

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/fake/fake_runtime.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/fake/fake_runtime.go
@@ -60,7 +60,8 @@ func (f *RemoteRuntime) Start(endpoint string) error {
 		return fmt.Errorf("failed to listen on %q: %v", endpoint, err)
 	}
 
-	return f.server.Serve(l)
+	go f.server.Serve(l)
+	return nil
 }
 
 // Stop stops the fake remote runtime.

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_runtime_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	apitest "k8s.io/kubernetes/pkg/kubelet/apis/cri/testing"
 	fakeremote "k8s.io/kubernetes/pkg/kubelet/remote/fake"
@@ -35,24 +36,24 @@ const (
 // Users should call fakeRuntime.Stop() to cleanup the server.
 func createAndStartFakeRemoteRuntime(t *testing.T) (*fakeremote.RemoteRuntime, string) {
 	endpoint, err := fakeremote.GenerateEndpoint()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	fakeRuntime := fakeremote.NewFakeRemoteRuntime()
-	go fakeRuntime.Start(endpoint)
+	fakeRuntime.Start(endpoint)
 
 	return fakeRuntime, endpoint
 }
 
 func createRemoteRuntimeService(endpoint string, t *testing.T) internalapi.RuntimeService {
 	runtimeService, err := NewRemoteRuntimeService(endpoint, defaultConnectionTimeout)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return runtimeService
 }
 
 func createRemoteImageService(endpoint string, t *testing.T) internalapi.ImageManagerService {
 	imageService, err := NewRemoteImageService(endpoint, defaultConnectionTimeout)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return imageService
 }
@@ -63,7 +64,7 @@ func TestVersion(t *testing.T) {
 
 	r := createRemoteRuntimeService(endpoint, t)
 	version, err := r.Version(apitest.FakeVersion)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, apitest.FakeVersion, version.Version)
 	assert.Equal(t, apitest.FakeRuntimeName, version.RuntimeName)
 }


### PR DESCRIPTION
Two issues:

Main issue is that fakeRuntime.Start() is returning prior to the listener being set up, and the remote runtime test is assuming that everything is ready. Whether this happens correctly or not depends upon factors such as speed of and load on the system under test among others. Solution: fakeRuntime.Start() must not return until it has successfully created the listener. remote.createAndStartFakeRemoteRuntime() must call fakeremote.Start() normally, and fakeRemote.Start() must call RemoteRuntime.server.Serve() as a goroutine.

Secondary issue (causing a segv rather than a more useful error message) is that various places in remote_runtime_test.go must require.noError() rather than assert.noError().

Tested by introducing a 1 second sleep in util.createListener, test failed every time. Fix #1, problem did not reproduce in about 10 tries. Also ran a long loop, and adding load to the system.  No failures after 16726 iterations.