### PR TITLE
[3.8] UPSTREAM: 58955: pkg: kubelet: do not assume anything about images names

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/images/image_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/images/image_manager.go
@@ -154,11 +154,12 @@ func applyDefaultImageTag(image string) (string, error) {
 	_, isTagged := named.(dockerref.Tagged)
 	_, isDigested := named.(dockerref.Digested)
 	if !isTagged && !isDigested {
-		named, err := dockerref.WithTag(named, parsers.DefaultImageTag)
-		if err != nil {
-			return "", fmt.Errorf("failed to apply default image tag %q: %v", image, err)
-		}
-		image = named.String()
+		// we just concatenate the image name with the default tag here instead
+		// of using dockerref.WithTag(named, ...) because that would cause the
+		// image to be fully qualified as docker.io/$name if it's a short name
+		// (e.g. just busybox). We don't want that to happen to keep the CRI
+		// agnostic wrt image names and default hostnames.
+		image = image + ":" + parsers.DefaultImageTag
 	}
 	return image, nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/images/image_manager_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/images/image_manager_test.go
@@ -125,7 +125,7 @@ func pullerTestEnv(c pullerTestCase, serialized bool) (puller ImageManager, fake
 	fakeRuntime = &ctest.FakeRuntime{}
 	fakeRecorder := &record.FakeRecorder{}
 
-	fakeRuntime.ImageList = []Image{{ID: "docker.io/library/present_image:latest"}}
+	fakeRuntime.ImageList = []Image{{ID: "present_image:latest"}}
 	fakeRuntime.Err = c.pullerErr
 	fakeRuntime.InspectErr = c.inspectErr
 
@@ -188,7 +188,7 @@ func TestApplyDefaultImageTag(t *testing.T) {
 		Input  string
 		Output string
 	}{
-		{Input: "root", Output: "docker.io/library/root:latest"},
+		{Input: "root", Output: "root:latest"},
 		{Input: "root:tag", Output: "root:tag"},
 		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Output: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 	} {


### PR DESCRIPTION
3.8 backport; see master PR https://github.com/openshift/origin/pull/18340 for details.

@liggitt @derekwaynecarr @frobware @mrunalp @runcom