### PR TITLE
Use utilruntime.HandleError instead of glog.Error in openshift SDN

### DIFF
--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/golang/glog"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -53,7 +52,7 @@ func ParseNetworkInfo(clusterNetwork []networkapi.ClusterNetworkEntry, serviceNe
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse ClusterNetwork CIDR %s: %v", entry.CIDR, err)
 			}
-			glog.Errorf("Configured clusterNetworks value %q is invalid; treating it as %q", entry.CIDR, cidr.String())
+			utilruntime.HandleError(fmt.Errorf("Configured clusterNetworks value %q is invalid; treating it as %q", entry.CIDR, cidr.String()))
 		}
 		cns = append(cns, ClusterNetwork{ClusterCIDR: cidr, HostSubnetLength: entry.HostSubnetLength})
 	}
@@ -64,7 +63,7 @@ func ParseNetworkInfo(clusterNetwork []networkapi.ClusterNetworkEntry, serviceNe
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse ServiceNetwork CIDR %s: %v", serviceNetwork, err)
 		}
-		glog.Errorf("Configured serviceNetworkCIDR value %q is invalid; treating it as %q", serviceNetwork, sn.String())
+		utilruntime.HandleError(fmt.Errorf("Configured serviceNetworkCIDR value %q is invalid; treating it as %q", serviceNetwork, sn.String()))
 	}
 
 	return &NetworkInfo{

--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -8,9 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
-
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -131,7 +130,7 @@ func (d *DNS) updateOne(dns string) (error, bool) {
 
 		ttl, err := time.ParseDuration(fmt.Sprintf("%ss", fields[1]))
 		if err != nil {
-			glog.Errorf("Invalid TTL value for domain: %q, err: %v, defaulting ttl=%s", dns, err, defaultTTL.String())
+			utilruntime.HandleError(fmt.Errorf("Invalid TTL value for domain: %q, err: %v, defaulting ttl=%s", dns, err, defaultTTL.String()))
 			ttl = defaultTTL
 		}
 		if (minTTL.Seconds() == 0) || (minTTL.Seconds() > ttl.Seconds()) {

--- a/pkg/network/common/egress_dns.go
+++ b/pkg/network/common/egress_dns.go
@@ -5,11 +5,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
-
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 
 	ktypes "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kexec "k8s.io/utils/exec"
 )
 
@@ -47,7 +46,7 @@ func (e *EgressDNS) Add(policy networkapi.EgressNetworkPolicy) {
 	for _, rule := range policy.Spec.Egress {
 		if len(rule.To.DNSName) > 0 {
 			if err := dnsInfo.Add(rule.To.DNSName); err != nil {
-				glog.Error(err)
+				utilruntime.HandleError(err)
 			}
 		}
 	}
@@ -96,7 +95,7 @@ func (e *EgressDNS) Sync() {
 			} else {
 				err, changed := e.Update(policyUID)
 				if err != nil {
-					glog.Error(err)
+					utilruntime.HandleError(err)
 				}
 
 				if changed {

--- a/pkg/network/common/informers.go
+++ b/pkg/network/common/informers.go
@@ -1,11 +1,11 @@
 package common
 
 import (
+	"fmt"
 	"reflect"
 
-	"github.com/golang/glog"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	kcache "k8s.io/client-go/tools/cache"
 )
@@ -28,13 +28,13 @@ func InformerFuncs(objType runtime.Object, addOrUpdateFunc InformerAddOrUpdateFu
 			if reflect.TypeOf(objType) != reflect.TypeOf(obj) {
 				tombstone, ok := obj.(kcache.DeletedFinalStateUnknown)
 				if !ok {
-					glog.Errorf("Couldn't get object from tombstone: %+v", obj)
+					utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone: %+v", obj))
 					return
 				}
 
 				obj = tombstone.Obj
 				if reflect.TypeOf(objType) != reflect.TypeOf(obj) {
-					glog.Errorf("Tombstone contained object, expected resource type: %v but got: %v", reflect.TypeOf(objType), reflect.TypeOf(obj))
+					utilruntime.HandleError(fmt.Errorf("Tombstone contained object, expected resource type: %v but got: %v", reflect.TypeOf(objType), reflect.TypeOf(obj)))
 					return
 				}
 			}

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -9,6 +9,7 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -109,7 +110,7 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 			glog.Infof("Created ClusterNetwork %s", common.ClusterNetworkToString(configCN))
 
 			if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
-				glog.Errorf("Cluster contains objects incompatible with new ClusterNetwork: %v", err)
+				utilruntime.HandleError(fmt.Errorf("Cluster contains objects incompatible with new ClusterNetwork: %v", err))
 			}
 		} else {
 			configChanged, err := clusterNetworkChanged(configCN, existingCN)
@@ -120,7 +121,7 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 				configCN.TypeMeta = existingCN.TypeMeta
 				configCN.ObjectMeta = existingCN.ObjectMeta
 				if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
-					glog.Errorf("Attempting to modify cluster to exclude existing objects: %v", err)
+					utilruntime.HandleError(fmt.Errorf("Attempting to modify cluster to exclude existing objects: %v", err))
 					return false, err
 				}
 				if _, err = master.networkClient.Network().ClusterNetworks().Update(configCN); err != nil {

--- a/pkg/network/master/vnids.go
+++ b/pkg/network/master/vnids.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/glog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
@@ -292,7 +293,7 @@ func (master *OsdnMaster) handleAddOrUpdateNamespace(obj, _ interface{}, eventTy
 	ns := obj.(*kapi.Namespace)
 	glog.V(5).Infof("Watch %s event for Namespace %q", eventType, ns.Name)
 	if err := master.vnids.assignVNID(master.networkClient, ns.Name); err != nil {
-		glog.Errorf("Error assigning netid: %v", err)
+		utilruntime.HandleError(fmt.Errorf("Error assigning netid: %v", err))
 	}
 }
 
@@ -300,7 +301,7 @@ func (master *OsdnMaster) handleDeleteNamespace(obj interface{}) {
 	ns := obj.(*kapi.Namespace)
 	glog.V(5).Infof("Watch %s event for Namespace %q", watch.Deleted, ns.Name)
 	if err := master.vnids.revokeVNID(master.networkClient, ns.Name); err != nil {
-		glog.Errorf("Error revoking netid: %v", err)
+		utilruntime.HandleError(fmt.Errorf("Error revoking netid: %v", err))
 	}
 }
 
@@ -315,6 +316,6 @@ func (master *OsdnMaster) handleAddOrUpdateNetNamespace(obj, _ interface{}, even
 
 	err := master.vnids.updateVNID(master.networkClient, netns)
 	if err != nil {
-		glog.Errorf("Error updating netid: %v", err)
+		utilruntime.HandleError(fmt.Errorf("Error updating netid: %v", err))
 	}
 }

--- a/pkg/network/node/egress_network_policy.go
+++ b/pkg/network/node/egress_network_policy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/origin/pkg/network/common"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -66,7 +67,7 @@ func (plugin *OsdnNode) handleDeleteEgressNetworkPolicy(obj interface{}) {
 func (plugin *OsdnNode) handleEgressNetworkPolicy(policy *networkapi.EgressNetworkPolicy, eventType watch.EventType) {
 	vnid, err := plugin.policy.GetVNID(policy.Namespace)
 	if err != nil {
-		glog.Errorf("Could not find netid for namespace %q: %v", policy.Namespace, err)
+		utilruntime.HandleError(fmt.Errorf("Could not find netid for namespace %q: %v", policy.Namespace, err))
 		return
 	}
 

--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	"k8s.io/kubernetes/pkg/util/iptables"
@@ -41,7 +42,7 @@ func (n *NodeIPTables) Setup() error {
 	// If firewalld is running, reload will call this method
 	n.ipt.AddReloadFunc(func() {
 		if err := n.syncIPTableRules(); err != nil {
-			glog.Errorf("Reloading openshift iptables failed: %v", err)
+			utilruntime.HandleError(fmt.Errorf("Reloading openshift iptables failed: %v", err))
 		}
 	})
 
@@ -59,7 +60,7 @@ func (n *NodeIPTables) syncLoop() {
 		glog.V(6).Infof("Periodic openshift iptables sync")
 		err := n.syncIPTableRules()
 		if err != nil {
-			glog.Errorf("Syncing openshift iptables failed: %v", err)
+			utilruntime.HandleError(fmt.Errorf("Syncing openshift iptables failed: %v", err))
 		}
 	}
 }

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeutilnet "k8s.io/apimachinery/pkg/util/net"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/record"
@@ -225,7 +226,7 @@ func (c *OsdnNodeConfig) setNodeIP() error {
 		if err == ErrorNetworkInterfaceNotFound {
 			err = fmt.Errorf("node IP %q is not a local/private address (hostname %q)", c.SelfIP, c.Hostname)
 		}
-		glog.Errorf("Unable to find network interface for node IP; some features will not work! (%v)", err)
+		utilruntime.HandleError(fmt.Errorf("Unable to find network interface for node IP; some features will not work! (%v)", err))
 	}
 
 	return nil
@@ -304,7 +305,7 @@ func (node *OsdnNode) Start() error {
 	}
 	if err := node.networkInfo.CheckHostNetworks(hostIPNets); err != nil {
 		// checkHostNetworks() errors *should* be fatal, but we didn't used to check this, and we can't break (mostly-)working nodes on upgrade.
-		glog.Errorf("Local networks conflict with SDN; this will eventually cause problems: %v", err)
+		utilruntime.HandleError(fmt.Errorf("Local networks conflict with SDN; this will eventually cause problems: %v", err))
 	}
 
 	node.localSubnetCIDR, err = node.getLocalSubnet()
@@ -484,7 +485,7 @@ func (node *OsdnNode) handleAddOrUpdateService(obj, oldObj interface{}, eventTyp
 
 	netid, err := node.policy.GetVNID(serv.Namespace)
 	if err != nil {
-		glog.Errorf("Skipped adding service rules for serviceEvent: %v, Error: %v", eventType, err)
+		utilruntime.HandleError(fmt.Errorf("Skipped adding service rules for serviceEvent: %v, Error: %v", eventType, err))
 		return
 	}
 

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/network/common"
 	"github.com/openshift/origin/pkg/util/ovs"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -559,7 +560,7 @@ func (oc *ovsController) AddServiceRules(service *kapi.Service, netID uint32) er
 	for _, port := range service.Spec.Ports {
 		baseRule, err := generateBaseAddServiceRule(service.Spec.ClusterIP, port.Protocol, int(port.Port))
 		if err != nil {
-			glog.Errorf("Error creating OVS flow for service %v, netid %d: %v", service, netID, err)
+			utilruntime.HandleError(fmt.Errorf("Error creating OVS flow for service %v, netid %d: %v", service, netID, err))
 		}
 		otx.AddFlow(baseRule + action)
 	}
@@ -639,7 +640,7 @@ func (oc *ovsController) UpdateVXLANMulticastFlows(remoteIPs []string) error {
 func (oc *ovsController) FindUnusedVNIDs() []int {
 	flows, err := oc.ovs.DumpFlows("")
 	if err != nil {
-		glog.Errorf("FindUnusedVNIDs: could not DumpFlows: %v", err)
+		utilruntime.HandleError(fmt.Errorf("FindUnusedVNIDs: could not DumpFlows: %v", err))
 		return nil
 	}
 

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapiv1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -266,7 +267,7 @@ func (m *podManager) updateLocalMulticastRulesWithLock(vnid uint32) {
 	}
 
 	if err := m.ovs.UpdateLocalMulticastFlows(vnid, enabled, ofports); err != nil {
-		glog.Errorf("Error updating OVS multicast flows for VNID %d: %v", vnid, err)
+		utilruntime.HandleError(fmt.Errorf("Error updating OVS multicast flows for VNID %d: %v", vnid, err))
 
 	}
 }

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/origin/pkg/network/common"
 	"github.com/openshift/origin/pkg/util/netutils"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/util/sysctl"
@@ -97,7 +98,7 @@ func deleteLocalSubnetRoute(device, localSubnetCIDR string) {
 	})
 
 	if err != nil {
-		glog.Errorf("error removing %s route from dev %s: %v; if the route appears later it will not be deleted.", localSubnetCIDR, device, err)
+		utilruntime.HandleError(fmt.Errorf("Error removing %s route from dev %s: %v; if the route appears later it will not be deleted.", localSubnetCIDR, device, err))
 	}
 }
 
@@ -203,34 +204,34 @@ func (plugin *OsdnNode) updateEgressNetworkPolicyRules(vnid uint32) {
 	policies := plugin.egressPolicies[vnid]
 	namespaces := plugin.policy.GetNamespaces(vnid)
 	if err := plugin.oc.UpdateEgressNetworkPolicyRules(policies, vnid, namespaces, plugin.egressDNS); err != nil {
-		glog.Errorf("Error updating OVS flows for EgressNetworkPolicy: %v", err)
+		utilruntime.HandleError(fmt.Errorf("Error updating OVS flows for EgressNetworkPolicy: %v", err))
 	}
 }
 
 func (plugin *OsdnNode) AddHostSubnetRules(subnet *networkapi.HostSubnet) {
 	glog.Infof("AddHostSubnetRules for %s", common.HostSubnetToString(subnet))
 	if err := plugin.oc.AddHostSubnetRules(subnet); err != nil {
-		glog.Errorf("Error adding OVS flows for subnet %q: %v", subnet.Subnet, err)
+		utilruntime.HandleError(fmt.Errorf("Error adding OVS flows for subnet %q: %v", subnet.Subnet, err))
 	}
 }
 
 func (plugin *OsdnNode) DeleteHostSubnetRules(subnet *networkapi.HostSubnet) {
 	glog.Infof("DeleteHostSubnetRules for %s", common.HostSubnetToString(subnet))
 	if err := plugin.oc.DeleteHostSubnetRules(subnet); err != nil {
-		glog.Errorf("Error deleting OVS flows for subnet %q: %v", subnet.Subnet, err)
+		utilruntime.HandleError(fmt.Errorf("Error deleting OVS flows for subnet %q: %v", subnet.Subnet, err))
 	}
 }
 
 func (plugin *OsdnNode) AddServiceRules(service *kapi.Service, netID uint32) {
 	glog.V(5).Infof("AddServiceRules for %v", service)
 	if err := plugin.oc.AddServiceRules(service, netID); err != nil {
-		glog.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err)
+		utilruntime.HandleError(fmt.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err))
 	}
 }
 
 func (plugin *OsdnNode) DeleteServiceRules(service *kapi.Service) {
 	glog.V(5).Infof("DeleteServiceRules for %v", service)
 	if err := plugin.oc.DeleteServiceRules(service); err != nil {
-		glog.Errorf("Error deleting OVS flows for service %v: %v", service, err)
+		utilruntime.HandleError(fmt.Errorf("Error deleting OVS flows for service %v: %v", service, err))
 	}
 }

--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -10,6 +10,7 @@ import (
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -116,6 +117,6 @@ func (node *OsdnNode) updateVXLANMulticastRules() {
 		}
 	}
 	if err := node.oc.UpdateVXLANMulticastFlows(remoteIPs); err != nil {
-		glog.Errorf("Error updating OVS VXLAN multicast flows: %v", err)
+		utilruntime.HandleError(fmt.Errorf("Error updating OVS VXLAN multicast flows: %v", err))
 	}
 }


### PR DESCRIPTION
- This ensures that we get rate limiting, non user errors are reported to sentry and also that hotloop requests get processed.
