### PR TITLE
Pick 18150: track deployment scaleRefs for hpas

### DIFF
--- a/pkg/api/kubegraph/edges.go
+++ b/pkg/api/kubegraph/edges.go
@@ -11,10 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kapi "k8s.io/kubernetes/pkg/api"
+	kapisext "k8s.io/kubernetes/pkg/apis/extensions"
 
 	osgraph "github.com/openshift/origin/pkg/api/graph"
 	kubegraph "github.com/openshift/origin/pkg/api/kubegraph/nodes"
 	deployapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	appsgraph "github.com/openshift/origin/pkg/apps/graph/nodes"
 	deploygraph "github.com/openshift/origin/pkg/apps/graph/nodes"
 )
 
@@ -241,6 +243,8 @@ func AddHPAScaleRefEdges(g osgraph.Graph) {
 			syntheticNode = kubegraph.FindOrCreateSyntheticReplicationControllerNode(g, &kapi.ReplicationController{ObjectMeta: syntheticMeta})
 		case deployapi.IsResourceOrLegacy("deploymentconfigs", r):
 			syntheticNode = deploygraph.FindOrCreateSyntheticDeploymentConfigNode(g, &deployapi.DeploymentConfig{ObjectMeta: syntheticMeta})
+		case r == kapisext.Resource("deployments"):
+			syntheticNode = appsgraph.FindOrCreateSyntheticDeploymentNode(g, &kapisext.Deployment{ObjectMeta: syntheticMeta})
 		default:
 			continue
 		}


### PR DESCRIPTION
Picks https://github.com/openshift/origin/pull/18150
Backport part of fix for https://bugzilla.redhat.com/show_bug.cgi?id=1539876

Manual pick [due to merge conflicts](https://github.com/openshift/origin/pull/18150#issuecomment-361433006) with cherry-picking from original PR onto 3.8 / 3.7

cc @soltysh 