### PR TITLE
[DO NOT MERGE] clean up for code we know we're deleting

### DIFF
--- a/pkg/bulk/cmd.go
+++ b/pkg/bulk/cmd.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
 	"github.com/openshift/origin/pkg/api/latest"
@@ -153,7 +152,7 @@ func ClientMapperFromConfig(config *rest.Config) resource.ClientMapperFunc {
 			return rest.RESTClientFor(&configCopy)
 		}
 
-		if err := unversioned.SetKubernetesDefaults(&configCopy); err != nil {
+		if err := rest.SetKubernetesDefaults(&configCopy); err != nil {
 			return nil, err
 		}
 		gvk := mapping.GroupVersionKind

--- a/pkg/cmd/server/kubernetes/master/master_test.go
+++ b/pkg/cmd/server/kubernetes/master/master_test.go
@@ -4,24 +4,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
+
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/apiserver/pkg/storage/storagebackend"
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
 func TestNewMasterLeasesHasCorrectTTL(t *testing.T) {
-	server := etcdtesting.NewUnsecuredEtcdTestClientServer(t)
-	etcdStorage := &storagebackend.Config{
-		Type:                     "etcd2",
-		Prefix:                   etcdtest.PathPrefix(),
-		ServerList:               server.Client.Endpoints(),
-		DeserializationCacheSize: etcdtest.DeserializationCacheSize,
-		Codec: testapi.Groups[""].StorageCodec(),
-	}
+	server, etcdStorage := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
+	etcdStorage.Codec = testapi.Groups[""].StorageCodec()
 
 	restOptions := generic.RESTOptions{StorageConfig: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1}
 	storageInterface, _ := restOptions.Decorator(restOptions.StorageConfig, nil, "masterleases", nil, nil, nil, nil)
@@ -32,9 +25,8 @@ func TestNewMasterLeasesHasCorrectTTL(t *testing.T) {
 		t.Fatalf("error updating lease: %v", err)
 	}
 
-	etcdClient := server.Client
-	keys := client.NewKeysAPI(etcdClient)
-	resp, err := keys.Get(context.Background(), etcdtest.PathPrefix()+"/masterleases/1.2.3.4", nil)
+	etcdClient := server.V3Client
+	resp, err := etcdClient.Get(context.Background(), etcdtest.PathPrefix()+"/masterleases/1.2.3.4", nil)
 	if err != nil {
 		t.Fatalf("error getting key: %v", err)
 	}


### PR DESCRIPTION
Some methods are being removed from upstream in 1.10.  This reacts ahead of time.

