### PR TITLE
Move pod-namespace calls out of process

### DIFF
--- a/pkg/network/node/cniserver/cniserver_test.go
+++ b/pkg/network/node/cniserver/cniserver_test.go
@@ -62,7 +62,7 @@ func TestCNIServer(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	socketPath := filepath.Join(tmpDir, CNIServerSocketName)
 
-	s := NewCNIServer(tmpDir)
+	s := NewCNIServer(tmpDir, &Config{MTU: 1500})
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -102,6 +102,7 @@ func TestCNIServer(t *testing.T) {
 					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
 					"CNI_NETNS":       "/path/to/something",
 					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"OSDN_HOSTVETH":   "vethABC",
 				},
 				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"openshift-sdn\",\"type\": \"openshift-sdn\"}"),
 			},
@@ -143,6 +144,7 @@ func TestCNIServer(t *testing.T) {
 					"CNI_COMMAND":     string(CNI_ADD),
 					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
 					"CNI_NETNS":       "/path/to/something",
+					"OSDN_HOSTVETH":   "vethABC",
 				},
 				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"openshift-sdn\",\"type\": \"openshift-sdn\"}"),
 			},
@@ -157,6 +159,7 @@ func TestCNIServer(t *testing.T) {
 					"CNI_COMMAND":     string(CNI_ADD),
 					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
 					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"OSDN_HOSTVETH":   "vethABC",
 				},
 				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"openshift-sdn\",\"type\": \"openshift-sdn\"}"),
 			},
@@ -171,11 +174,27 @@ func TestCNIServer(t *testing.T) {
 					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
 					"CNI_NETNS":       "/path/to/something",
 					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+					"OSDN_HOSTVETH":   "vethABC",
 				},
 				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"openshift-sdn\",\"type\": \"openshift-sdn\"}"),
 			},
 			result:      nil,
 			errorPrefix: "unexpected or missing CNI_COMMAND",
+		},
+		// Missing OSDN_HOSTVETH
+		{
+			name: "ARGS4",
+			request: &CNIRequest{
+				Env: map[string]string{
+					"CNI_COMMAND":     string(CNI_ADD),
+					"CNI_CONTAINERID": "adsfadsfasfdasdfasf",
+					"CNI_NETNS":       "/path/to/something",
+					"CNI_ARGS":        "K8S_POD_NAMESPACE=awesome-namespace;K8S_POD_NAME=awesome-name",
+				},
+				Config: []byte("{\"cniVersion\": \"0.1.0\",\"name\": \"openshift-sdn\",\"type\": \"openshift-sdn\"}"),
+			},
+			result:      nil,
+			errorPrefix: "missing OSDN_HOSTVETH",
 		},
 	}
 

--- a/pkg/network/node/cniserver/cniserver_test.go
+++ b/pkg/network/node/cniserver/cniserver_test.go
@@ -60,9 +60,9 @@ func TestCNIServer(t *testing.T) {
 		t.Fatalf("failed to create temp directory: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
+	socketPath := filepath.Join(tmpDir, CNIServerSocketName)
 
-	path := filepath.Join(tmpDir, "cni-server.sock")
-	s := NewCNIServer(path)
+	s := NewCNIServer(tmpDir)
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestCNIServer(t *testing.T) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			Dial: func(proto, addr string) (net.Conn, error) {
-				return net.Dial("unix", path)
+				return net.Dial("unix", socketPath)
 			},
 		},
 	}

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -346,7 +346,7 @@ func (node *OsdnNode) Start() error {
 	}
 
 	glog.V(2).Infof("Starting openshift-sdn pod manager")
-	if err := node.podManager.Start(cniserver.CNIServerSocketPath, node.localSubnetCIDR, node.networkInfo.ClusterNetworks); err != nil {
+	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR, node.networkInfo.ClusterNetworks); err != nil {
 		return err
 	}
 

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -404,15 +404,12 @@ func (oc *ovsController) UpdatePod(sandboxID string, vnid uint32) error {
 	return oc.setupPodFlows(ofport, podIP, podMAC, note, vnid)
 }
 
-func (oc *ovsController) TearDownPod(podIP, sandboxID string) error {
-	if podIP == "" {
-		var err error
-		_, podIP, _, _, err = oc.getPodDetailsBySandboxID(sandboxID)
-		if err != nil {
-			// OVS flows related to sandboxID not found
-			// Nothing needs to be done in that case
-			return nil
-		}
+func (oc *ovsController) TearDownPod(sandboxID string) error {
+	_, podIP, _, _, err := oc.getPodDetailsBySandboxID(sandboxID)
+	if err != nil {
+		// OVS flows related to sandboxID not found
+		// Nothing needs to be done in that case
+		return nil
 	}
 
 	if err := oc.cleanupPodFlows(podIP); err != nil {

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -303,7 +303,7 @@ func TestOVSPod(t *testing.T) {
 	}
 
 	// Delete
-	err = oc.TearDownPod("10.128.0.2", sandboxID)
+	err = oc.TearDownPod(sandboxID)
 	if err != nil {
 		t.Fatalf("Unexpected error deleting pod rules: %v", err)
 	}

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -218,9 +218,7 @@ func TestOVSService(t *testing.T) {
 }
 
 const (
-	sandboxID         string = "bcb5d8d287fcf97458c48ad643b101079e3bc265a94e097e7407440716112f69"
-	sandboxNote       string = "bc.b5.d8.d2.87.fc.f9.74.58.c4.8a.d6.43.b1.01.07.9e.3b.c2.65.a9.4e.09.7e.74.07.44.07.16.11.2f.69"
-	sandboxNoteAction string = "note:" + sandboxNote
+	sandboxID string = "bcb5d8d287fcf97458c48ad643b101079e3bc265a94e097e7407440716112f69"
 )
 
 func TestOVSPod(t *testing.T) {
@@ -239,7 +237,7 @@ func TestOVSPod(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66", sandboxNoteAction},
+			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66"},
 		},
 		flowChange{
 			kind:  flowAdded,
@@ -267,7 +265,7 @@ func TestOVSPod(t *testing.T) {
 	// Update
 	err = oc.UpdatePod(sandboxID, 43)
 	if err != nil {
-		t.Fatalf("Unexpected error adding pod rules: %v", err)
+		t.Fatalf("Unexpected error updating pod rules: %v", err)
 	}
 
 	flows, err = ovsif.DumpFlows("")
@@ -277,7 +275,7 @@ func TestOVSPod(t *testing.T) {
 	err = assertFlowChanges(origFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66", sandboxNoteAction},
+			match: []string{"table=20", fmt.Sprintf("in_port=%d", ofport), "arp", "10.128.0.2", "11:22:33:44:55:66"},
 		},
 		flowChange{
 			kind:  flowAdded,
@@ -323,7 +321,6 @@ func TestGetPodDetails(t *testing.T) {
 		sandboxID string
 		ip        string
 		mac       string
-		note      string
 		errStr    string
 	}
 
@@ -332,7 +329,6 @@ func TestGetPodDetails(t *testing.T) {
 			sandboxID: sandboxID,
 			ip:        "10.130.0.2",
 			mac:       "4a:77:32:e4:ab:9d",
-			note:      sandboxNote,
 		},
 	}
 
@@ -343,7 +339,7 @@ func TestGetPodDetails(t *testing.T) {
 			t.Fatalf("Unexpected error adding pod rules: %v", err)
 		}
 
-		ofport, ip, mac, note, err := oc.getPodDetailsBySandboxID(tc.sandboxID)
+		ofport, ip, mac, err := oc.getPodDetailsBySandboxID(tc.sandboxID)
 		if err != nil {
 			if tc.errStr != "" {
 				if !strings.Contains(err.Error(), tc.errStr) {
@@ -363,9 +359,6 @@ func TestGetPodDetails(t *testing.T) {
 		}
 		if mac != tc.mac {
 			t.Fatalf("unexpected mac %q (expected %q)", mac, tc.mac)
-		}
-		if note != tc.note {
-			t.Fatalf("unexpected note %q (expected %q)", note, tc.note)
 		}
 	}
 }

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -539,7 +539,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 		}
 	}
 
-	var hostVethName, contVethMac string
+	var hostVethName string
 	err = ns.WithNetNSPath(req.Netns, func(hostNS ns.NetNS) error {
 		hostVeth, contVeth, err := ip.SetupVeth(podInterfaceName, int(m.mtu), hostNS)
 		if err != nil {
@@ -588,7 +588,6 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 		}
 
 		hostVethName = hostVeth.Name
-		contVethMac = contVeth.HardwareAddr.String()
 		return nil
 	})
 	if err != nil {
@@ -604,7 +603,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 		return nil, nil, err
 	}
 
-	ofport, err := m.ovs.SetUpPod(hostVethName, podIP.String(), contVethMac, req.SandboxID, vnid)
+	ofport, err := m.ovs.SetUpPod(req.SandboxID, hostVethName, podIP, vnid)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -167,7 +167,7 @@ func getIPAMConfig(clusterNetworks []common.ClusterNetwork, localSubnet string) 
 }
 
 // Start the CNI server and start processing requests from it
-func (m *podManager) Start(socketPath string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork) error {
+func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork) error {
 	if m.enableHostports {
 		iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
 		m.hostportSyncer = kubehostport.NewHostportSyncer(iptInterface)
@@ -180,7 +180,7 @@ func (m *podManager) Start(socketPath string, localSubnetCIDR string, clusterNet
 
 	go m.processCNIRequests()
 
-	m.cniServer = cniserver.NewCNIServer(socketPath)
+	m.cniServer = cniserver.NewCNIServer(rundir)
 	return m.cniServer.Start(m.handleCNIRequest)
 }
 

--- a/pkg/network/node/pod_test.go
+++ b/pkg/network/node/pod_test.go
@@ -156,7 +156,7 @@ func TestPodManager(t *testing.T) {
 		t.Fatalf("failed to create temp directory: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
-	socketPath := filepath.Join(tmpDir, "cni-server.sock")
+	socketPath := filepath.Join(tmpDir, cniserver.CNIServerSocketName)
 
 	testcases := map[string]struct {
 		operations []*operation
@@ -318,7 +318,10 @@ func TestPodManager(t *testing.T) {
 		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
 		_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-		podManager.Start(socketPath, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}})
+		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}})
+		if err != nil {
+			t.Fatalf("could not start PodManager: %v", err)
+		}
 
 		// Add pods to our expected pod list before kicking off the
 		// actual pod setup to ensure we don't concurrently access
@@ -408,13 +411,16 @@ func TestDirectPodUpdate(t *testing.T) {
 		t.Fatalf("failed to create temp directory: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
-	socketPath := filepath.Join(tmpDir, "cni-server.sock")
+	socketPath := filepath.Join(tmpDir, cniserver.CNIServerSocketName)
 
 	podTester := newPodTester(t, "update", socketPath)
 	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
 	_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-	podManager.Start(socketPath, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}})
+	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}})
+	if err != nil {
+		t.Fatalf("could not start PodManager: %v", err)
+	}
 
 	op := &operation{
 		command:   cniserver.CNI_UPDATE,

--- a/pkg/network/sdn-cni-plugin/sdn_cni_plugin_test.go
+++ b/pkg/network/sdn-cni-plugin/sdn_cni_plugin_test.go
@@ -63,8 +63,8 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	path := filepath.Join(tmpDir, "cni-server.sock")
-	server := cniserver.NewCNIServer(path)
+	path := filepath.Join(tmpDir, cniserver.CNIServerSocketName)
+	server := cniserver.NewCNIServer(tmpDir)
 	if err := server.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}

--- a/pkg/network/sdn-cni-plugin/sdn_cni_plugin_test.go
+++ b/pkg/network/sdn-cni-plugin/sdn_cni_plugin_test.go
@@ -15,6 +15,7 @@ import (
 	cniskel "github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cni020 "github.com/containernetworking/cni/pkg/types/020"
+	"github.com/containernetworking/plugins/pkg/ns"
 
 	"github.com/openshift/origin/pkg/network/node/cniserver"
 	utiltesting "k8s.io/client-go/util/testing"
@@ -64,12 +65,17 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	path := filepath.Join(tmpDir, cniserver.CNIServerSocketName)
-	server := cniserver.NewCNIServer(tmpDir)
+	server := cniserver.NewCNIServer(tmpDir, &cniserver.Config{MTU: 1500})
 	if err := server.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
 
-	cniPlugin := NewCNIPlugin(path)
+	hostNS, err := ns.GetCurrentNS()
+	if err != nil {
+		panic(fmt.Sprintf("could not get current kernel netns: %v", err))
+	}
+	defer hostNS.Close()
+	cniPlugin := NewCNIPlugin(path, hostNS)
 
 	expectedIP, expectedNet, _ := net.ParseCIDR("10.0.0.2/24")
 	expectedResult = &cni020.Result{
@@ -139,7 +145,7 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 		skelArgsToEnv(tc.reqType, tc.skelArgs)
 		switch tc.reqType {
 		case cniserver.CNI_ADD:
-			result, err = cniPlugin.CmdAdd(tc.skelArgs)
+			result, err = cniPlugin.testCmdAdd(tc.skelArgs)
 		case cniserver.CNI_DEL:
 			err = cniPlugin.CmdDel(tc.skelArgs)
 		default:
@@ -148,6 +154,9 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 		clearEnv()
 
 		if tc.errorPrefix == "" {
+			if err != nil {
+				t.Fatalf("[%s] expected result %v but got error: %v", tc.name, tc.result, err)
+			}
 			if tc.result != nil && !reflect.DeepEqual(result, tc.result) {
 				t.Fatalf("[%s] expected result %v but got %v", tc.name, tc.result, result)
 			}


### PR DESCRIPTION
As discussed in #15991, we need to move all operations in the pod's network namespace out of process, due to a golang issue that allows setns() calls in a locked thread to leak into other threads, causing random lossage as operations intended for the main network namespace end up running in other namespaces instead. (This is fixed in golang 1.10 but we need a fix before then.)

Fixes #15991
Fixes #14385
Fixes #13108
Fixes #18317