### PR TITLE
Change the Zookeeper statefulset annotation usage to PodSpec. Preventing from function unno…

### DIFF
--- a/examples/statefulsets/zookeeper/zookeeper.yaml
+++ b/examples/statefulsets/zookeeper/zookeeper.yaml
@@ -29,57 +29,6 @@ spec:
     metadata:
       labels:
         app: zk
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "install",
-                "image": "gcr.io/google_containers/zookeeper-install:0.1",
-                "imagePullPolicy": "Always",
-                "args": ["--version=3.5.0-alpha", "--install-into=/opt", "--work-dir=/work-dir"],
-                "volumeMounts": [
-                    {
-                        "name": "opt",
-                        "mountPath": "/opt/"
-                    },
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    }
-                ]
-            },
-            {
-                "name": "bootstrap",
-                "image": "java:openjdk-8-jre",
-                "command": ["/work-dir/peer-finder"],
-                "args": ["-on-start=\"/work-dir/on-start.sh\"", "-service=zk"],
-                "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-                "volumeMounts": [
-                    {
-                        "name": "opt",
-                        "mountPath": "/opt/"
-                    },
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    },
-                    {
-                        "name": "datadir",
-                        "mountPath": "/tmp/zookeeper"
-                    }
-                ]
-            }
-        ]'
     spec:
       containers:
       - name: zk
@@ -106,6 +55,34 @@ spec:
           mountPath: /tmp/zookeeper
         - name: opt
           mountPath: /opt/
+      initContainers:
+      - name: install
+        image: gcr.io/google_containers/zookeeper-install:0.1
+        imagePullPolicy: Always
+        args: ["--version=3.5.0-alpha", "--install-into=/opt", "--work-dir=/work-dir"]
+        volumeMounts:
+        - name: opt
+          mountPath: /opt/
+        - name: workdir
+          mountPath: /work-dir
+      - name: bootstrap
+        image: java:openjdk-8-jre
+        imagePullPolicy: Always
+        command: ["/work-dir/peer-finder"]
+        args: ["-on-start=\"/work-dir/on-start.sh\"", "-service=zk"]
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: "metadata.namespace"
+        volumeMounts:
+        - name: opt
+          mountPath: /opt/
+        - name: workdir
+          mountPath: /work-dir
+        - name: datadir
+          mountPath: /tmp/zookeeper
       volumes:
       - name: opt
         emptyDir: {}


### PR DESCRIPTION
Change the Zookeeper Statefulset annotation usage to PodSpec. Preventing from function unnormally at Kubernetes 1.8

According to [PetSet annotation](https://github.com/kubernetes/kubernetes/issues/35498) and [K8s Init Container Concept](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)

The` "pod.alpha.kubernetes.io/initialize"` is the annotaiton of Petset, and will be removed.

The Init Container annotation `pod.alpha.kubernetes.io/init-containers` has existed beta in 1.6, and sugggested to use PodSpec insetead. The annotaiton support will be removed at Kubernetes 1.8.

I change the yaml usage.  Changing the  annotation usage to PodSpec, and keep other functions unchangedly.

I have test in my Openshift environment