### PR TITLE
Re-fix NetworkPolicy bootstrap policies

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -305,7 +305,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 
 				rbac.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
 
-				rbac.NewRule(readWrite...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
+				rbac.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
 				// backwards compatibility
 				rbac.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
@@ -347,7 +347,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 
 				rbac.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
 
-				rbac.NewRule(readWrite...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
+				rbac.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
 				// backwards compatibility
 				rbac.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -867,6 +867,7 @@ items:
     - update
     - watch
   - apiGroups:
+    - extensions
     - networking.k8s.io
     resources:
     - networkpolicies
@@ -1108,6 +1109,7 @@ items:
     - update
     - watch
   - apiGroups:
+    - extensions
     - networking.k8s.io
     resources:
     - networkpolicies

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -947,6 +947,7 @@ items:
     - update
     - watch
   - apiGroups:
+    - extensions
     - networking.k8s.io
     attributeRestrictions: null
     resources:
@@ -1210,6 +1211,7 @@ items:
     - update
     - watch
   - apiGroups:
+    - extensions
     - networking.k8s.io
     attributeRestrictions: null
     resources:


### PR DESCRIPTION
#17976 "use cluster role aggregation for admin, edit, and view" removed permission for "admin" and "edit" on extensions.NetworkPolicy (but not networking.NetworkPolicy). It appears to have been a mistake?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538048
