### PR TITLE
snip oauthserver links to oauthapi and kubernetes

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -355,7 +355,6 @@
       "vendor/github.com/gorilla/context",
       "vendor/github.com/rackspace/gophercloud",
       "vendor/gopkg.in/ldap.v2",
-      "vendor/k8s.io/kubernetes",
       "vendor/github.com/prometheus/client_golang/prometheus",
       "vendor/github.com/openshift/api",
       "vendor/github.com/openshift/client-go",
@@ -365,8 +364,6 @@
     ],
     "allowedImportPackages": [
       "vendor/github.com/golang/glog",
-      "vendor/k8s.io/kubernetes/pkg/api/legacyscheme",
-      "github.com/openshift/origin/pkg/authorization/apis/authorization",
       "github.com/openshift/origin/pkg/cmd/server/api",
       "github.com/openshift/origin/pkg/util/http/links",
       "github.com/openshift/origin/pkg/authorization/authorizer/scope",

--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -361,8 +361,7 @@
       "vendor/github.com/openshift/client-go",
 
       "github.com/openshift/origin/pkg/oauthserver",
-      "github.com/openshift/origin/pkg/route/generated",
-      "github.com/openshift/origin/pkg/oauth/generated"
+      "github.com/openshift/origin/pkg/route/generated"
     ],
     "allowedImportPackages": [
       "vendor/github.com/golang/glog",
@@ -373,7 +372,6 @@
       "github.com/openshift/origin/pkg/authorization/authorizer/scope",
       "github.com/openshift/origin/pkg/oauth/apis/oauth/validation",
       "github.com/openshift/origin/pkg/oauth/scope",
-      "github.com/openshift/origin/pkg/oauth/apis/oauth",
       "github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization",
       "github.com/openshift/origin/pkg/cmd/server/api",
       "github.com/openshift/origin/pkg/cmd/server/api/latest",

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -14,9 +14,9 @@ import (
 	rbaclisters "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion"
 	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
+	oauthapi "github.com/openshift/api/oauth/v1"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 )
@@ -486,7 +486,7 @@ func validateScopeRestrictions(client *oauthapi.OAuthClient, scope string) error
 
 	for _, restriction := range client.ScopeRestrictions {
 		if len(restriction.ExactValues) > 0 {
-			if err := ValidateLiteralScopeRestrictions(scope, restriction.ExactValues); err != nil {
+			if err := validateLiteralScopeRestrictions(scope, restriction.ExactValues); err != nil {
 				errs = append(errs, err)
 				continue
 			}
@@ -497,7 +497,7 @@ func validateScopeRestrictions(client *oauthapi.OAuthClient, scope string) error
 			if !clusterRoleEvaluatorInstance.Handles(scope) {
 				continue
 			}
-			if err := ValidateClusterRoleScopeRestrictions(scope, *restriction.ClusterRole); err != nil {
+			if err := validateClusterRoleScopeRestrictions(scope, *restriction.ClusterRole); err != nil {
 				errs = append(errs, err)
 				continue
 			}
@@ -513,7 +513,7 @@ func validateScopeRestrictions(client *oauthapi.OAuthClient, scope string) error
 	return kutilerrors.NewAggregate(errs)
 }
 
-func ValidateLiteralScopeRestrictions(scope string, literals []string) error {
+func validateLiteralScopeRestrictions(scope string, literals []string) error {
 	for _, literal := range literals {
 		if literal == scope {
 			return nil
@@ -523,7 +523,7 @@ func ValidateLiteralScopeRestrictions(scope string, literals []string) error {
 	return fmt.Errorf("%v not found in %v", scope, literals)
 }
 
-func ValidateClusterRoleScopeRestrictions(scope string, restriction oauthapi.ClusterRoleScopeRestriction) error {
+func validateClusterRoleScopeRestrictions(scope string, restriction oauthapi.ClusterRoleScopeRestriction) error {
 	role, namespace, escalating, err := clusterRoleEvaluatorInstance.parseScope(scope)
 	if err != nil {
 		return err

--- a/pkg/authorization/authorizer/scope/validate_test.go
+++ b/pkg/authorization/authorizer/scope/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapi "github.com/openshift/api/oauth/v1"
 )
 
 func TestValidateScopeRestrictions(t *testing.T) {

--- a/pkg/authorization/registry/clusterrole/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy.go
@@ -11,7 +11,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
-	authclient "github.com/openshift/origin/pkg/oauthserver/client"
+	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 

--- a/pkg/authorization/registry/clusterrolebinding/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy.go
@@ -11,7 +11,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
-	authclient "github.com/openshift/origin/pkg/oauthserver/client"
+	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 

--- a/pkg/authorization/registry/role/proxy.go
+++ b/pkg/authorization/registry/role/proxy.go
@@ -12,7 +12,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
-	authclient "github.com/openshift/origin/pkg/oauthserver/client"
+	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 

--- a/pkg/authorization/registry/rolebinding/proxy.go
+++ b/pkg/authorization/registry/rolebinding/proxy.go
@@ -12,7 +12,7 @@ import (
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
-	authclient "github.com/openshift/origin/pkg/oauthserver/client"
+	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 

--- a/pkg/build/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/admission/jenkinsbootstrapper/admission.go
@@ -20,9 +20,9 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	jenkinscontroller "github.com/openshift/origin/pkg/build/controller/jenkins"
 	"github.com/openshift/origin/pkg/bulk"
+	authenticationclient "github.com/openshift/origin/pkg/client/impersonatingclient"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	authenticationclient "github.com/openshift/origin/pkg/oauthserver/client"
 	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 )
 

--- a/pkg/build/admission/secretinjector/admission.go
+++ b/pkg/build/admission/secretinjector/admission.go
@@ -13,8 +13,8 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
-	authclient "github.com/openshift/origin/pkg/oauthserver/client"
 	"github.com/openshift/origin/pkg/util/urlpattern"
 )
 

--- a/pkg/client/impersonatingclient/impersonate_rbac.go
+++ b/pkg/client/impersonatingclient/impersonate_rbac.go
@@ -1,4 +1,4 @@
-package client
+package impersonatingclient
 
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/cmd/server/origin/handlers.go
+++ b/pkg/cmd/server/origin/handlers.go
@@ -23,8 +23,8 @@ import (
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/client/impersonatingclient"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	authenticationapi "github.com/openshift/origin/pkg/oauthserver/api"
 )
 
 // cacheExcludedPaths is small and simple until the handlers include the cache headers they need
@@ -158,7 +158,7 @@ func (c *MasterConfig) versionSkewFilter(handler http.Handler, contextMapper api
 // translateLegacyScopeImpersonation is a filter that will translates user scope impersonation for openshift into the equivalent kube headers.
 func translateLegacyScopeImpersonation(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		for _, scope := range req.Header[authenticationapi.ImpersonateUserScopeHeader] {
+		for _, scope := range req.Header[impersonatingclient.ImpersonateUserScopeHeader] {
 			req.Header[authenticationv1.ImpersonateUserExtraHeaderPrefix+authorizationapi.ScopesKey] =
 				append(req.Header[authenticationv1.ImpersonateUserExtraHeaderPrefix+authorizationapi.ScopesKey], scope)
 		}

--- a/pkg/cmd/server/origin/oauth_apiserver_adapter.go
+++ b/pkg/cmd/server/origin/oauth_apiserver_adapter.go
@@ -63,7 +63,7 @@ func NewOAuthServerConfigFromMasterConfig(masterConfig *MasterConfig, listener n
 	}
 	// TODO pass a privileged client config through during construction.  It is NOT a loopback client.
 	oauthServerConfig.ExtraOAuthConfig.RouteClient = routeClient
-	oauthServerConfig.ExtraOAuthConfig.KubeClient = masterConfig.PrivilegedLoopbackKubernetesClientsetInternal
+	oauthServerConfig.ExtraOAuthConfig.KubeClient = masterConfig.PrivilegedLoopbackKubernetesClientsetExternal
 
 	// Build the list of valid redirect_uri prefixes for a login using the openshift-web-console client to redirect to
 	if !options.DisabledFeatures.Has(configapi.FeatureWebConsole) {

--- a/pkg/oauth/apiserver/apiserver.go
+++ b/pkg/oauth/apiserver/apiserver.go
@@ -10,7 +10,6 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
-	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
@@ -118,10 +117,6 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	coreClient, err := coreclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
-	if err != nil {
-		return nil, err
-	}
 	routeClient, err := routeclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
 	if err != nil {
 		return nil, err
@@ -132,8 +127,8 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	}
 
 	combinedOAuthClientGetter := saoauth.NewServiceAccountOAuthClientGetter(
-		coreClient,
-		coreClient,
+		coreV1Client,
+		coreV1Client,
 		coreV1Client.Events(""),
 		routeClient.Route(),
 		oauthClient.OAuthClients(),

--- a/pkg/oauth/apiserver/apiserver.go
+++ b/pkg/oauth/apiserver/apiserver.go
@@ -13,9 +13,8 @@ import (
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	accesstokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken/etcd"
 	authorizetokenetcd "github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken/etcd"
 	clientetcd "github.com/openshift/origin/pkg/oauth/registry/oauthclient/etcd"
@@ -109,10 +108,10 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	}
 
 	// If OAuth is disabled, set the strategy to Deny
-	saAccountGrantMethod := oauthapi.GrantHandlerDeny
+	saAccountGrantMethod := oauthapiv1.GrantHandlerDeny
 	if len(c.ExtraConfig.ServiceAccountMethod) > 0 {
 		// Otherwise, take the value provided in master-config.yaml
-		saAccountGrantMethod = oauthapi.GrantHandlerType(c.ExtraConfig.ServiceAccountMethod)
+		saAccountGrantMethod = oauthapiv1.GrantHandlerType(c.ExtraConfig.ServiceAccountMethod)
 	}
 
 	oauthClient, err := oauthclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)

--- a/pkg/oauth/registry/oauthclient/registry.go
+++ b/pkg/oauth/registry/oauthclient/registry.go
@@ -3,7 +3,7 @@ package oauthclient
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapi "github.com/openshift/api/oauth/v1"
 )
 
 // Getter exposes a way to get a specific client.  This is useful for other registries to get scope limitations

--- a/pkg/oauth/registry/oauthclientauthorization/strategy_test.go
+++ b/pkg/oauth/registry/oauthclientauthorization/strategy_test.go
@@ -5,8 +5,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	oauth "github.com/openshift/api/oauth/v1"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	"github.com/openshift/origin/pkg/oauth/apis/oauth"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 )
 

--- a/pkg/oauthserver/api/types.go
+++ b/pkg/oauthserver/api/types.go
@@ -13,10 +13,6 @@ const (
 	// This is useful when the immutable providerUserName is different than the login used to authenticate
 	// If present, this extra value is used as the preferred username
 	IdentityPreferredUsernameKey = "preferred_username"
-
-	ImpersonateUserHeader      = "Impersonate-User"
-	ImpersonateGroupHeader     = "Impersonate-Group"
-	ImpersonateUserScopeHeader = "Impersonate-User-Scope"
 )
 
 // UserIdentityInfo contains information about an identity.  Identities are distinct from users.  An authentication server of

--- a/pkg/oauthserver/oauth/handlers/default_auth_handler.go
+++ b/pkg/oauthserver/oauth/handlers/default_auth_handler.go
@@ -9,7 +9,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapi "github.com/openshift/api/oauth/v1"
 	authapi "github.com/openshift/origin/pkg/oauthserver/api"
 )
 

--- a/pkg/oauthserver/oauth/handlers/default_auth_handler_test.go
+++ b/pkg/oauthserver/oauth/handlers/default_auth_handler_test.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/apiserver/pkg/endpoints/request"
 
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthapi "github.com/openshift/api/oauth/v1"
 )
 
 type testClient struct {

--- a/pkg/oauthserver/oauth/handlers/grant.go
+++ b/pkg/oauthserver/oauth/handlers/grant.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
 
+	oauthapi "github.com/openshift/api/oauth/v1"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/apis/oauth/validation"
 	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/api"

--- a/pkg/oauthserver/oauth/registry/grantchecker.go
+++ b/pkg/oauthserver/oauth/registry/grantchecker.go
@@ -8,8 +8,8 @@ import (
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
+	oauth "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization"
 	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/api"

--- a/pkg/oauthserver/oauth/registry/registry_test.go
+++ b/pkg/oauthserver/oauth/registry/registry_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
 
-	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthfake "github.com/openshift/origin/pkg/oauth/generated/internalclientset/fake"
+	oapi "github.com/openshift/api/oauth/v1"
+	oauthfake "github.com/openshift/client-go/oauth/clientset/versioned/fake"
 	"github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/oauth/handlers"
 	"github.com/openshift/origin/pkg/oauthserver/osinserver"

--- a/pkg/oauthserver/oauth/registry/userconversion.go
+++ b/pkg/oauthserver/oauth/registry/userconversion.go
@@ -5,7 +5,7 @@ import (
 
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 
-	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oapi "github.com/openshift/api/oauth/v1"
 )
 
 type UserConversion struct{}

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/util/retry"
 
+	oauthapi "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	clientregistry "github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	oauthutil "github.com/openshift/origin/pkg/oauth/util"
 	"github.com/openshift/origin/pkg/oauthserver/authenticator/challenger/passwordchallenger"

--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
+	oauthapi "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	userclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/api/latest"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	oauthutil "github.com/openshift/origin/pkg/oauth/util"
 	"github.com/openshift/origin/pkg/oauthserver/server/session"
 	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset"

--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -9,16 +9,17 @@ import (
 	"github.com/pborman/uuid"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	kclientset "k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	oauthapi "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
@@ -30,8 +31,13 @@ import (
 	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset"
 )
 
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
 func NewOAuthServerConfig(oauthConfig configapi.OAuthConfig, userClientConfig *rest.Config) (*OAuthServerConfig, error) {
-	genericConfig := genericapiserver.NewRecommendedConfig(legacyscheme.Codecs)
+	genericConfig := genericapiserver.NewRecommendedConfig(codecs)
 
 	var sessionAuth *session.Authenticator
 	var sessionHandlerWrapper handlerWrapper

--- a/pkg/oauthserver/osinserver/registrystorage/storage.go
+++ b/pkg/oauthserver/osinserver/registrystorage/storage.go
@@ -9,9 +9,9 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	oauthapi "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	oauthclientregistry "github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/oauth/handlers"

--- a/pkg/oauthserver/server/grant/grant.go
+++ b/pkg/oauthserver/server/grant/grant.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 
+	oapi "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	oauthclientregistry "github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization"
 	"github.com/openshift/origin/pkg/oauth/scope"

--- a/pkg/oauthserver/server/grant/grant_test.go
+++ b/pkg/oauthserver/server/grant/grant_test.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	clienttesting "k8s.io/client-go/testing"
 
-	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthfake "github.com/openshift/origin/pkg/oauth/generated/internalclientset/fake"
+	oapi "github.com/openshift/api/oauth/v1"
+	oauthfake "github.com/openshift/client-go/oauth/clientset/versioned/fake"
 	oauthclientregistry "github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
 )

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry.go
@@ -21,8 +21,8 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 
+	oauthapi "github.com/openshift/api/oauth/v1"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset/typed/route/internalversion"

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
@@ -5,17 +5,18 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
 	_ "github.com/openshift/origin/pkg/oauth/apis/oauth/install"
@@ -26,9 +27,9 @@ import (
 var (
 	encoder                 = legacyscheme.Codecs.LegacyCodec(oauthapiv1.SchemeGroupVersion)
 	decoder                 = legacyscheme.Codecs.UniversalDecoder()
-	serviceAccountsResource = schema.GroupVersionResource{Group: "", Version: "", Resource: "serviceaccounts"}
-	secretsResource         = schema.GroupVersionResource{Group: "", Version: "", Resource: "secrets"}
-	secretKind              = schema.GroupVersionKind{Group: "", Version: "", Kind: "Secret"}
+	serviceAccountsResource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
+	secretsResource         = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	secretKind              = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 	routesResource          = schema.GroupVersionResource{Group: "route.openshift.io", Version: "", Resource: "routes"}
 	routeClientKind         = schema.GroupVersionKind{Group: "route.openshift.io", Version: "", Kind: "Route"}
 )
@@ -69,7 +70,7 @@ func TestGetClient(t *testing.T) {
 			name:       "sa no redirects",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   "ns-01",
 						Name:        "default",
@@ -88,7 +89,7 @@ func TestGetClient(t *testing.T) {
 			name:       "sa invalid redirect scheme",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   "ns-01",
 						Name:        "default",
@@ -105,7 +106,7 @@ func TestGetClient(t *testing.T) {
 			name:       "sa no tokens",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   "ns-01",
 						Name:        "default",
@@ -125,7 +126,7 @@ func TestGetClient(t *testing.T) {
 			name:       "good SA",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:   "ns-01",
 						Name:        "default",
@@ -133,17 +134,17 @@ func TestGetClient(t *testing.T) {
 						Annotations: map[string]string{OAuthRedirectModelAnnotationURIPrefix + "one": "http://anywhere"},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(),
 			expectedClient: &oauthapiv1.OAuthClient{
@@ -163,7 +164,7 @@ func TestGetClient(t *testing.T) {
 			name:       "good SA with valid, simple route redirects",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
@@ -174,17 +175,17 @@ func TestGetClient(t *testing.T) {
 						},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(
 				&routeapi.Route{
@@ -223,7 +224,7 @@ func TestGetClient(t *testing.T) {
 			name:       "good SA with invalid route redirects",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
@@ -235,17 +236,17 @@ func TestGetClient(t *testing.T) {
 						},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(
 				&routeapi.Route{
@@ -284,7 +285,7 @@ func TestGetClient(t *testing.T) {
 			name:       "good SA with a route that doesn't have a host",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
@@ -295,17 +296,17 @@ func TestGetClient(t *testing.T) {
 						},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(
 				&routeapi.Route{
@@ -344,7 +345,7 @@ func TestGetClient(t *testing.T) {
 			name:       "good SA with routes that don't have hosts, some of which are empty or duplicates",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
@@ -357,17 +358,17 @@ func TestGetClient(t *testing.T) {
 						},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(
 				&routeapi.Route{
@@ -430,7 +431,7 @@ func TestGetClient(t *testing.T) {
 			name:       "host overrides route data",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
@@ -443,17 +444,17 @@ func TestGetClient(t *testing.T) {
 						},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(
 				&routeapi.Route{
@@ -509,7 +510,7 @@ func TestGetClient(t *testing.T) {
 			name:       "good SA with valid, route redirects using the same route twice",
 			clientName: "system:serviceaccount:ns-01:default",
 			kubeClient: fake.NewSimpleClientset(
-				&kapi.ServiceAccount{
+				&corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
@@ -522,17 +523,17 @@ func TestGetClient(t *testing.T) {
 						},
 					},
 				},
-				&kapi.Secret{
+				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "ns-01",
 						Name:      "default",
 						Annotations: map[string]string{
-							kapi.ServiceAccountNameKey: "default",
-							kapi.ServiceAccountUIDKey:  "any",
+							corev1.ServiceAccountNameKey: "default",
+							corev1.ServiceAccountUIDKey:  "any",
 						},
 					},
-					Type: kapi.SecretTypeServiceAccountToken,
-					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
+					Type: corev1.SecretTypeServiceAccountToken,
+					Data: map[string][]byte{corev1.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(
 				&routeapi.Route{

--- a/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
+++ b/pkg/serviceaccounts/oauthclient/oauthclientregistry_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	_ "github.com/openshift/origin/pkg/oauth/apis/oauth/install"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	routefake "github.com/openshift/origin/pkg/route/generated/internalclientset/fake"
@@ -44,7 +43,7 @@ func TestGetClient(t *testing.T) {
 		expectedDelegation  bool
 		expectedErr         string
 		expectedEventMsg    string
-		expectedClient      *oauthapi.OAuthClient
+		expectedClient      *oauthapiv1.OAuthClient
 		expectedKubeActions []clientgotesting.Action
 		expectedOSActions   []clientgotesting.Action
 	}{
@@ -147,12 +146,12 @@ func TestGetClient(t *testing.T) {
 					Data: map[string][]byte{kapi.ServiceAccountTokenKey: []byte("foo")},
 				}),
 			routeClient: routefake.NewSimpleClientset(),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"http://anywhere"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -205,12 +204,12 @@ func TestGetClient(t *testing.T) {
 					},
 				},
 			),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"http://anywhere", "https://example1.com/defaultpath"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -268,12 +267,12 @@ func TestGetClient(t *testing.T) {
 					},
 				},
 			),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"http://anywhere"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -326,12 +325,12 @@ func TestGetClient(t *testing.T) {
 					},
 				},
 			),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"http://anywhere"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -412,12 +411,12 @@ func TestGetClient(t *testing.T) {
 					},
 				},
 			),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"http://anywhere", "https://a.com/defaultpath", "https://a.com/path2", "https://b.com/defaultpath", "https://b.com/path2"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -491,12 +490,12 @@ func TestGetClient(t *testing.T) {
 					},
 				},
 			),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"https://google.com/otherpath", "https://redhat.com/defaultpath"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -552,12 +551,12 @@ func TestGetClient(t *testing.T) {
 					},
 				},
 			),
-			expectedClient: &oauthapi.OAuthClient{
+			expectedClient: &oauthapiv1.OAuthClient{
 				ObjectMeta:        metav1.ObjectMeta{Name: "system:serviceaccount:ns-01:default"},
 				ScopeRestrictions: getScopeRestrictionsFor("ns-01", "default"),
 				AdditionalSecrets: []string{"foo"},
 				RedirectURIs:      []string{"https://woot.com/awesomepath", "https://woot.com:8000"},
-				GrantMethod:       oauthapi.GrantHandlerPrompt,
+				GrantMethod:       oauthapiv1.GrantHandlerPrompt,
 			},
 			expectedKubeActions: []clientgotesting.Action{
 				clientgotesting.NewGetAction(serviceAccountsResource, "ns-01", "default"),
@@ -578,7 +577,7 @@ func TestGetClient(t *testing.T) {
 			eventRecorder: fakerecorder,
 			routeClient:   tc.routeClient.Route(),
 			delegate:      delegate,
-			grantMethod:   oauthapi.GrantHandlerPrompt,
+			grantMethod:   oauthapiv1.GrantHandlerPrompt,
 			decoder:       legacyscheme.Codecs.UniversalDecoder(),
 		}
 		client, err := getter.Get(tc.clientName, metav1.GetOptions{})
@@ -628,7 +627,7 @@ type fakeDelegate struct {
 	called bool
 }
 
-func (d *fakeDelegate) Get(name string, options metav1.GetOptions) (*oauthapi.OAuthClient, error) {
+func (d *fakeDelegate) Get(name string, options metav1.GetOptions) (*oauthapiv1.OAuthClient, error) {
 	d.called = true
 	return nil, nil
 }

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -11,10 +11,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
+	oauthapi "github.com/openshift/api/oauth/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	"github.com/openshift/origin/pkg/oauthserver/osinserver"
-	registrystorage "github.com/openshift/origin/pkg/oauthserver/osinserver/registrystorage"
+	"github.com/openshift/origin/pkg/oauthserver/osinserver/registrystorage"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
+	"github.com/openshift/origin/pkg/client/impersonatingclient"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
-	authenticationapi "github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/oauthserver"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
@@ -105,8 +105,8 @@ func TestScopedImpersonation(t *testing.T) {
 	}
 
 	err = clusterAdminBuildClient.Build().RESTClient().Get().
-		SetHeader(authenticationapi.ImpersonateUserHeader, "harold").
-		SetHeader(authenticationapi.ImpersonateUserScopeHeader, "user:info").
+		SetHeader(impersonatingclient.ImpersonateUserHeader, "harold").
+		SetHeader(impersonatingclient.ImpersonateUserScopeHeader, "user:info").
 		Namespace(projectName).Resource("builds").Name("name").Do().Into(&buildapi.Build{})
 	if !kapierrors.IsForbidden(err) {
 		t.Fatalf("unexpected error: %v", err)
@@ -114,8 +114,8 @@ func TestScopedImpersonation(t *testing.T) {
 
 	user := &userapi.User{}
 	err = userclient.NewForConfigOrDie(clusterAdminClientConfig).RESTClient().Get().
-		SetHeader(authenticationapi.ImpersonateUserHeader, "harold").
-		SetHeader(authenticationapi.ImpersonateUserScopeHeader, "user:info").
+		SetHeader(impersonatingclient.ImpersonateUserHeader, "harold").
+		SetHeader(impersonatingclient.ImpersonateUserScopeHeader, "user:info").
 		Resource("users").Name("~").Do().Into(user)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This continues work to snip links to internal oauth types and to k8s.io/kubernetes