### PR TITLE
UPSTREAM: <carry>: hack in working autoscale reference for oc autoscale

### DIFF
--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -140,6 +140,7 @@ os::test::junit::declare_suite_start "cmd/deployments/autoscale"
 os::cmd::expect_success 'oc create -f test/integration/testdata/test-deployment-config.yaml'
 os::cmd::expect_success 'oc autoscale dc/test-deployment-config --max 5'
 os::cmd::expect_success_and_text "oc get hpa/test-deployment-config --template='{{.spec.maxReplicas}}'" "5"
+os::cmd::expect_success_and_text "oc get hpa/test-deployment-config -o jsonpath='{.spec.scaleTargetRef.apiVersion}'" "apps.openshift.io/v1"
 os::cmd::expect_success 'oc delete dc/test-deployment-config'
 os::cmd::expect_success 'oc delete hpa/test-deployment-config'
 echo "autoscale: ok"

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/autoscale.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/autoscale.go
@@ -131,6 +131,11 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		params["scaleRef-name"] = name
 		params["scaleRef-apiVersion"] = mapping.GroupVersionKind.GroupVersion().String()
 
+		// hack to make scaling DCs work.
+		if mapping.GroupVersionKind.Kind == "DeploymentConfig" && len(mapping.GroupVersionKind.Group) == 0 {
+			params["scaleRef-apiVersion"] = "apps.openshift.io/v1"
+		}
+
 		if err = kubectl.ValidateParams(names, params); err != nil {
 			return err
 		}


### PR DESCRIPTION
I lost your bugzilla.  This adds a nasty hack to recognize that we need to specify a different group for autoscaling DCs.

/assign @DirectXMan12 
/assign @juanvallejo 