### PR TITLE
route: wait for the router SA to have cluster scope access to services

### DIFF
--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -11,12 +11,14 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+	"github.com/openshift/origin/pkg/api"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	testutil "github.com/openshift/origin/test/util"
 )
 
 var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] weighted openshift router", func() {
@@ -32,6 +34,9 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] weighted open
 			imagePrefix = "openshift/origin"
 		}
 		err := oc.AsAdmin().Run("adm").Args("policy", "add-cluster-role-to-user", "system:router", oc.Username()).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// Wait for the policy to be propagated
+		testutil.WaitForClusterPolicyUpdate(oc.InternalKubeClient().Authorization(), "get", api.Resource("service"), true)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("new-app").Args("-f", configPath, "-p", "IMAGE="+imagePrefix+"-haproxy-router").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
As seen in [logs](https://openshift-gce-devel.appspot.com//build/origin-ci-test/pr-logs/pull/18342/test_pull_request_origin_extended_conformance_install/6624/?log#log) : 

`
I0201 05:17:07.264583       1 reflector.go:240] Listing and watching *core.Service from github.com/openshift/origin/pkg/router/template/service_lookup.go:32
E0201 05:17:07.267503       1 reflector.go:205] github.com/openshift/origin/pkg/router/template/service_lookup.go:32: Failed to list *core.Service: services is forbidden: User "system:serviceaccount:extended-test-weighted-router-bbx6p-mg255:default" cannot list services at the cluster scope: User "system:serviceaccount:extended-test-weighted-router-bbx6p-mg255:default" cannot list all services in the cluster
`

This might delay the route creation which if my theory is right might case our number one [flake](https://github.com/openshift/origin/issues/17731) (http://snowstorm-dev.app.mfojtik.io)