### PR TITLE
remove-role-from-user outputs error when target was not found

### DIFF
--- a/pkg/oc/admin/policy/remove_from_project.go
+++ b/pkg/oc/admin/policy/remove_from_project.go
@@ -162,7 +162,7 @@ func (o *RemoveFromProjectOptions) Run() error {
 		oldUsers, oldGroups, oldSAs, oldOthers := authorizationapi.SubjectsStrings(currBinding.Namespace, originalSubjects)
 		oldUsersSet, oldGroupsSet, oldSAsSet, oldOtherSet := sets.NewString(oldUsers...), sets.NewString(oldGroups...), sets.NewString(oldSAs...), sets.NewString(oldOthers...)
 
-		currBinding.Subjects = removeSubjects(currBinding.Subjects, subjectsToRemove)
+		currBinding.Subjects, _ = removeSubjects(currBinding.Subjects, subjectsToRemove)
 		newUsers, newGroups, newSAs, newOthers := authorizationapi.SubjectsStrings(currBinding.Namespace, currBinding.Subjects)
 		newUsersSet, newGroupsSet, newSAsSet, newOtherSet := sets.NewString(newUsers...), sets.NewString(newGroups...), sets.NewString(newSAs...), sets.NewString(newOthers...)
 

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -153,6 +153,8 @@ os::cmd::expect_success "oc adm policy remove-role-from-user admin system:servic
 os::cmd::expect_success_and_not_text 'oc get rolebinding/admin -o jsonpath={.subjects}' 'fake-sa'
 os::cmd::expect_success 'oc adm policy remove-role-from-group cluster-admin system:unauthenticated'
 os::cmd::expect_success 'oc adm policy remove-role-from-user cluster-admin system:no-user'
+os::cmd::expect_failure_and_text 'oc adm policy remove-role-from-user admin ghost' 'error: unable to find target \[ghost\]'
+os::cmd::expect_failure_and_text 'oc adm policy remove-role-from-user admin -z ghost' 'error: unable to find target \[ghost\]'
 os::cmd::expect_success 'oc adm policy remove-group system:unauthenticated'
 os::cmd::expect_success 'oc adm policy remove-user system:no-user'
 os::cmd::expect_success 'oc adm policy add-cluster-role-to-group cluster-admin system:unauthenticated'

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -89,6 +89,7 @@ os::cmd::expect_success_and_text     'oc adm policy who-can create builds/jenkin
 os::cmd::expect_success_and_text 'oc adm policy remove-cluster-role-from-group system:build-strategy-docker system:authenticated' 'cluster role "system:build-strategy-docker" removed: "system:authenticated"'
 os::cmd::expect_success_and_text 'oc adm policy remove-cluster-role-from-group system:build-strategy-source system:authenticated' 'cluster role "system:build-strategy-source" removed: "system:authenticated"'
 os::cmd::expect_success_and_text 'oc adm policy remove-cluster-role-from-group system:build-strategy-jenkinspipeline system:authenticated' 'cluster role "system:build-strategy-jenkinspipeline" removed: "system:authenticated"'
+
 # ensure build strategy permissions no longer exist
 os::cmd::try_until_failure           'oc adm policy who-can create builds/source | grep system:authenticated'
 os::cmd::expect_success_and_not_text 'oc adm policy who-can create builds/docker' 'system:authenticated'
@@ -125,6 +126,13 @@ os::cmd::expect_success_and_text 'oc adm policy add-cluster-role-to-group cluste
 os::cmd::expect_success_and_text 'oc adm policy add-cluster-role-to-user cluster-reader namespaced-user --dry-run' 'cluster role "cluster\-reader" added: "namespaced\-user" \(dry run\)'
 
 os::cmd::expect_success 'oc adm policy add-role-to-group view testgroup'
+os::cmd::expect_success 'oc adm policy add-cluster-role-to-group cluster-reader testgroup'
+os::cmd::expect_success 'oc adm policy add-cluster-role-to-user cluster-reader namespaced-user'
+
+# ensure that removing missing target causes error.
+os::cmd::expect_failure_and_text 'oc adm policy remove-cluster-role-from-user admin ghost' 'error: unable to find target \[ghost\]'
+os::cmd::expect_failure_and_text 'oc adm policy remove-cluster-role-from-user admin -z ghost' 'error: unable to find target \[ghost\]'
+
 os::cmd::expect_success_and_text 'oc adm policy remove-role-from-group view testgroup -o yaml' 'subjects: \[\]'
 os::cmd::expect_success_and_text 'oc adm policy remove-cluster-role-from-group cluster-reader testgroup -o yaml' 'name: cluster\-readers'
 os::cmd::expect_success_and_text 'oc adm policy remove-cluster-role-from-user cluster-reader namespaced-user -o yaml' 'name: cluster\-reader'


### PR DESCRIPTION
When `oc adm policy remove-role-from-user` tries to remove non
existing user/sa, the command does not output any error, so users
cannot notice their misoperations like typo.

```
$ oc adm policy remove-role-from-user view non-existing-user
role "view" removed: "non-existing-user"
```

This patch changes to output when `oc adm policy
remove-role-from-user` tried to remove non existing user/sa.

```
$ ./oc adm policy remove-role-from-user view non-existing-user
error: unable to find target [non-existing-user]
```