### PR TITLE
Make haproxy pass open sockets when reloading

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -40,7 +40,7 @@ global
 {{- end}}
   ca-base /etc/ssl
   crt-base /etc/ssl
-  stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin
+  stats socket /var/lib/haproxy/run/haproxy.sock mode 600 level admin expose-fd listeners
   stats timeout 2m
 
   # Increase the default request size to be comparable to modern cloud load balancers (ALB: 64kb), affects

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -105,7 +105,7 @@ if [ -n "$old_pids" ]; then
     fi
   fi
 
-  /usr/sbin/haproxy -f $config_file -p $pid_file -sf $old_pids
+  /usr/sbin/haproxy -f $config_file -p $pid_file -x /var/lib/haproxy/run/haproxy.sock -sf $old_pids
   reload_status=$?
 
   if [[ "$installed_iptables" == 1 ]]; then


### PR DESCRIPTION
This changes the way we do a reload to take advantage of haproxy 1.8's seamless reload feature (described in https://www.haproxy.com/blog/truly-seamless-reloads-with-haproxy-no-more-hacks/)

Fixes bug 1464657 (https://bugzilla.redhat.com/show_bug.cgi?id=1464657)