### PR TITLE
UPSTREAM: 56432: e2e: test containers projected volume updates should not exit

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/projected.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/projected.go
@@ -1517,7 +1517,7 @@ func projectedDownwardAPIVolumePodForUpdateTest(name string, labels, annotations
 		{
 			Name:    "client-container",
 			Image:   mountImage,
-			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=1200", "--file_content_in_loop=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",


### PR DESCRIPTION
Attempt to fix: https://github.com/openshift/origin/issues/17605