### PR TITLE
Prometheus config reload livenessprobe

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -224,6 +224,20 @@ objects:
           - --web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |-
+                set -euo pipefail;
+                touch /tmp/prometheusconfig.hash;
+                if [[ $(find /etc/prometheus -type f | sort | xargs md5sum | md5sum) != $(cat /tmp/prometheusconfig.hash) ]]; then
+                  find /etc/prometheus -type f | sort | xargs md5sum | md5sum > /tmp/prometheusconfig.hash;
+                  kill -HUP 1;
+                fi
+            initialDelaySeconds: 60
+            periodSeconds: 60
           volumeMounts:
           - mountPath: /etc/prometheus
             name: prometheus-config
@@ -335,10 +349,10 @@ objects:
             name: alertmanager
         - name: alertmanager-tls-secret
           secret:
-            secretName: alertmanager-tls  
+            secretName: alertmanager-tls
         - name: alertmanager-proxy-secret
           secret:
-            secretName: alertmanager-proxy         
+            secretName: alertmanager-proxy
 
         - name: alerts-proxy-secrets
           secret:
@@ -368,7 +382,7 @@ objects:
             miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
-    
+
     recording.rules: |
       groups:
       - name: aggregate_container_resources

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14057,6 +14057,20 @@ objects:
           - --web.listen-address=localhost:9090
           image: ${IMAGE_PROMETHEUS}
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |-
+                set -euo pipefail;
+                touch /tmp/prometheusconfig.hash;
+                if [[ $(find /etc/prometheus -type f | sort | xargs md5sum | md5sum) != $(cat /tmp/prometheusconfig.hash) ]]; then
+                  find /etc/prometheus -type f | sort | xargs md5sum | md5sum > /tmp/prometheusconfig.hash;
+                  kill -HUP 1;
+                fi
+            initialDelaySeconds: 60
+            periodSeconds: 60
           volumeMounts:
           - mountPath: /etc/prometheus
             name: prometheus-config
@@ -14168,10 +14182,10 @@ objects:
             name: alertmanager
         - name: alertmanager-tls-secret
           secret:
-            secretName: alertmanager-tls  
+            secretName: alertmanager-tls
         - name: alertmanager-proxy-secret
           secret:
-            secretName: alertmanager-proxy         
+            secretName: alertmanager-proxy
 
         - name: alerts-proxy-secrets
           secret:
@@ -14201,7 +14215,7 @@ objects:
             miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
-    
+
     recording.rules: |
       groups:
       - name: aggregate_container_resources


### PR DESCRIPTION
Use case: config updated via configmap. When the change lands in the container (~60 seconds delay) the config directory hash changes and the process is killed. This does not kill the pod but results in a silent reload of config with a corresponding metric timestamp, `prometheus_config_last_reload_success_timestamp_seconds`.

Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>