### PR TITLE
Drop auto-egress-IP rules when egress IP is removed from NetNamespace

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -198,6 +198,8 @@ func (eip *egressIPWatcher) handleAddOrUpdateNetNamespace(obj, _ interface{}, ev
 			glog.Warningf("Ignoring extra EgressIPs (%v) in NetNamespace %q", netns.EgressIPs[1:], netns.Name)
 		}
 		eip.updateNamespaceEgress(netns.NetID, netns.EgressIPs[0])
+	} else {
+		eip.deleteNamespaceEgress(netns.NetID)
 	}
 }
 


### PR DESCRIPTION
(Previously we were only doing it when the NetNamespace was deleted.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540846

(does not conflict with #18121 so it doesn't matter which merges first)