### PR TITLE
router: add permissions for dumping router pods in tests

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -75,7 +75,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] openshift rou
 
 	g.AfterEach(func() {
 		if g.CurrentGinkgoTestDescription().Failed {
-			exutil.DumpPodLogsStartingWithInNamespace("router", "default", oc)
+			exutil.DumpPodLogsStartingWithInNamespace("router", "default", oc.AsAdmin())
 		}
 	})
 


### PR DESCRIPTION
Alternative to https://github.com/openshift/origin/pull/18382 ?

@deads2k it is still weird that the SA here gets the access to endpoints and routes (cluster-wide) but not the services (hence the permission error). My previous fix was wrong, because I was waiting for the user to get the cluster perms, but seems like the SA need that perm as well. I guess when the user create router, the SA in Pod that run the router will inherit that permissions, but it seems like it only gets routes and endpoints?

