### PR TITLE
SDN options and CNI directory cleanup

### DIFF
--- a/pkg/cmd/server/kubernetes/network/sdn_linux.go
+++ b/pkg/cmd/server/kubernetes/network/sdn_linux.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	kinternalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
+	kcni "k8s.io/kubernetes/pkg/kubelet/network/cni"
 	"k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
@@ -35,6 +36,11 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 		}
 	}
 
+	cniConfDir := kcni.DefaultNetDir
+	if val, ok := options.KubeletArguments["cni-conf-dir"]; ok && len(val) == 1 {
+		cniConfDir = val[0]
+	}
+
 	// dockershim + kube CNI driver delegates hostport handling to plugins,
 	// while CRI-O handles hostports itself. Thus we need to disable the
 	// SDN's hostport handling when run under CRI-O.
@@ -49,6 +55,7 @@ func NewSDNInterfaces(options configapi.NodeConfig, networkClient networkclient.
 		Hostname:           options.NodeName,
 		SelfIP:             options.NodeIP,
 		RuntimeEndpoint:    runtimeEndpoint,
+		CNIConfDir:         cniConfDir,
 		MTU:                options.NetworkConfig.MTU,
 		NetworkClient:      networkClient,
 		KClient:            kubeClient,

--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -13,7 +13,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kclientsetexternal "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
 	kubeletcni "k8s.io/kubernetes/pkg/kubelet/network/cni"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 
@@ -88,9 +87,6 @@ func ComputeKubeletFlagsAsMap(startingArgs map[string][]string, options configap
 	if network.IsOpenShiftNetworkPlugin(options.NetworkConfig.NetworkPluginName) {
 		// SDN plugin pod setup/teardown is implemented as a CNI plugin
 		setIfUnset(args, "network-plugin", kubeletcni.CNIPluginName)
-		setIfUnset(args, "cni-conf-dir", kubeletcni.DefaultNetDir)
-		setIfUnset(args, "cni-bin-dir", kubeletcni.DefaultCNIDir)
-		setIfUnset(args, "hairpin-mode", kubeletconfig.HairpinNone)
 	} else {
 		setIfUnset(args, "network-plugin", options.NetworkConfig.NetworkPluginName)
 	}

--- a/pkg/network/node/metrics.go
+++ b/pkg/network/node/metrics.go
@@ -167,7 +167,7 @@ func updateARPMetrics() {
 
 func updatePodIPMetrics() {
 	numAddrs := 0
-	items, err := ioutil.ReadDir("/var/lib/cni/networks/openshift-sdn/")
+	items, err := ioutil.ReadDir(hostLocalDataDir + "/networks/openshift-sdn/")
 	if err != nil && os.IsNotExist(err) {
 		// Don't log an error if the directory doesn't exist (eg, no pods started yet)
 		return


### PR DESCRIPTION
Remove un-needed kubelet flags and rationalize paths that kubelet and the SDN use.

@knobunc @openshift/networking @danwinship 