### PR TITLE
Correctly handle newlines in serial files

### DIFF
--- a/test/cmd/certs.sh
+++ b/test/cmd/certs.sh
@@ -18,11 +18,28 @@ os::cmd::expect_success_and_not_text \
                                 --overwrite=true" \
     'WARNING: .* is greater than 5 years'
 
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '00'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
+
 expected_year="$(TZ=GMT date -d "+$((365*5)) days" +'%Y')"
 
 os::cmd::expect_success_and_text \
     "openssl x509 -in '${CERT_DIR}/ca.crt' -enddate -noout | awk '{print \$4}'" \
     "${expected_year}"
+
+# Make a cert with the CA to see the counter increment
+# We can then check to see if it gets reset due to overwrite
+os::cmd::expect_success \
+    "oc adm create-api-client-config \
+            --client-dir='${CERT_DIR}' \
+            --user=some-user \
+            --certificate-authority='${CERT_DIR}/ca.crt' \
+            --signer-cert='${CERT_DIR}/ca.crt' \
+            --signer-key='${CERT_DIR}/ca.key' \
+            --signer-serial='${CERT_DIR}/ca.serial.txt'"
+
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '01'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
 
 # oc adm ca create-signer-cert should generate certificate with specified number of days and show warning
 os::cmd::expect_success_and_text \
@@ -32,6 +49,9 @@ os::cmd::expect_success_and_text \
                                 --overwrite=true \
                                 --expire-days=$((365*6))" \
     'WARNING: .* is greater than 5 years'
+
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '00'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
 
 expected_year="$(TZ=GMT date -d "+$((365*6)) days" +'%Y')"
 
@@ -57,6 +77,9 @@ os::cmd::expect_success_and_not_text \
             --signer-key='${CERT_DIR}/ca.key' \
             --signer-serial='${CERT_DIR}/ca.serial.txt'" \
     'WARNING: .* is greater than 2 years'
+
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '02'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
 
 expected_year="$(TZ=GMT date -d "+$((365*2)) days" +'%Y')"
 for CERT_FILE in master-client.crt server.crt; do
@@ -84,6 +107,9 @@ os::cmd::expect_success_and_text \
             --expire-days=$((365*3))" \
     'WARNING: .* is greater than 2 years'
 
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '04'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
+
 expected_year="$(TZ=GMT date -d "+$((365*3)) days" +'%Y')"
 
 for CERT_FILE in master-client.crt server.crt; do
@@ -106,6 +132,10 @@ os::cmd::expect_success_and_not_text \
             --signer-serial='${CERT_DIR}/ca.serial.txt'" \
     'WARNING: .* is greater than 2 years'
 
+
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '05'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
+
 expected_year="$(TZ=GMT date -d "+$((365*2)) days" +'%Y')"
 os::cmd::expect_success_and_text \
     "openssl x509 -in '${CERT_DIR}/test-user.crt' -enddate -noout | awk '{print \$4}'" \
@@ -125,6 +155,9 @@ os::cmd::expect_success_and_text \
             --expire-days=$((365*3))" \
     'WARNING: .* is greater than 2 years'
 
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '06'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
+
 expected_year="$(TZ=GMT date -d "+$((365*3)) days" +'%Y')"
 os::cmd::expect_success_and_text \
     "openssl x509 -in '${CERT_DIR}/test-user.crt' -enddate -noout | awk '{print \$4}'" \
@@ -143,6 +176,9 @@ os::cmd::expect_success_and_not_text \
                                 --key='${CERT_DIR}/example.org.key'" \
     'WARNING: .* is greater than 2 years'
 
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '07'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
+
 expected_year="$(TZ=GMT date -d "+$((365*2)) days" +'%Y')"
 
 os::cmd::expect_success_and_text \
@@ -160,6 +196,9 @@ os::cmd::expect_success_and_text \
                                 --key='${CERT_DIR}/example.org.key' \
                                 --expire-days=$((365*3))" \
     'WARNING: .* is greater than 2 years'
+
+os::cmd::expect_success_and_text "cat '${CERT_DIR}/ca.serial.txt'" '08'
+os::cmd::expect_success_and_text "tail -c 1 '${CERT_DIR}/ca.serial.txt' | wc -l" '1'  # check for newline at end
 
 expected_year="$(TZ=GMT date -d "+$((365*3)) days" +'%Y')"
 


### PR DESCRIPTION
Correctly handle newlines in SerialFileGenerator

This change makes it so that `SerialFileGenerator` correctly reads and writes serial files that end in a newline.  This allows it to interoperate with other tools that may interact with the serial file such as openssl.  Tests were added to assert that the incrementing logic works and that the serial file always ends with a newline.

[Bug 1512825](https://bugzilla.redhat.com/show_bug.cgi?id=1512825)

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/kind bug
/assign @simo5 @deads2k
@openshift/sig-security