### PR TITLE
UPSTREAM: 58994: Race condition between listener and client in remote…

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/BUILD
@@ -53,5 +53,6 @@ go_test(
         "//pkg/kubelet/apis/cri/testing:go_default_library",
         "//pkg/kubelet/remote/fake:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/fake/fake_runtime.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/fake/fake_runtime.go
@@ -60,7 +60,8 @@ func (f *RemoteRuntime) Start(endpoint string) error {
 		return fmt.Errorf("failed to listen on %q: %v", endpoint, err)
 	}
 
-	return f.server.Serve(l)
+	go f.server.Serve(l)
+	return nil
 }
 
 // Stop stops the fake remote runtime.

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_runtime_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	apitest "k8s.io/kubernetes/pkg/kubelet/apis/cri/testing"
 	fakeremote "k8s.io/kubernetes/pkg/kubelet/remote/fake"
@@ -35,17 +36,17 @@ const (
 // Users should call fakeRuntime.Stop() to cleanup the server.
 func createAndStartFakeRemoteRuntime(t *testing.T) (*fakeremote.RemoteRuntime, string) {
 	endpoint, err := fakeremote.GenerateEndpoint()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	fakeRuntime := fakeremote.NewFakeRemoteRuntime()
-	go fakeRuntime.Start(endpoint)
+	fakeRuntime.Start(endpoint)
 
 	return fakeRuntime, endpoint
 }
 
 func createRemoteRuntimeService(endpoint string, t *testing.T) internalapi.RuntimeService {
 	runtimeService, err := NewRemoteRuntimeService(endpoint, defaultConnectionTimeout)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return runtimeService
 }


### PR DESCRIPTION
…_runtime_test

picks https://github.com/kubernetes/kubernetes/pull/58994
fixes  https://github.com/openshift/origin/issues/17757