### PR TITLE
Restart console container when config changes

### DIFF
--- a/install/origin-web-console/console-template.yaml
+++ b/install/origin-web-console/console-template.yaml
@@ -67,10 +67,17 @@ objects:
               port: 8443
               scheme: HTTPS
           livenessProbe:
-            httpGet:
-              path: /
-              port: 8443
-              scheme: HTTPS
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - |-
+                  if [[ ! -f /tmp/webconsole-config.hash ]]; then \
+                    md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
+                  elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    exit 1; \
+                  fi && curl -k -f https://0.0.0.0:8443/console/
           resources:
             requests:
               cpu: 100m

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -15057,10 +15057,17 @@ objects:
               port: 8443
               scheme: HTTPS
           livenessProbe:
-            httpGet:
-              path: /
-              port: 8443
-              scheme: HTTPS
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - |-
+                  if [[ ! -f /tmp/webconsole-config.hash ]]; then \
+                    md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
+                  elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    exit 1; \
+                  fi && curl -k -f https://0.0.0.0:8443/console/
           resources:
             requests:
               cpu: 100m

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -28992,10 +28992,17 @@ objects:
               port: 8443
               scheme: HTTPS
           livenessProbe:
-            httpGet:
-              path: /
-              port: 8443
-              scheme: HTTPS
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - |-
+                  if [[ ! -f /tmp/webconsole-config.hash ]]; then \
+                    md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
+                  elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    exit 1; \
+                  fi && curl -k -f https://0.0.0.0:8443/console/
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Opening this to get feedback. We have a problem where there is no good way to rollout the console after editing the console config in its config map. Right now we have to tell users to delete the console pods, which is error prone and not friendly. The console only reads config at startup and doesn't watch for changes.

This adds a liveness probe that detects if the config has changed on the filesystem using an md5 hash. If the config changes, the liveness probe fails, and the container restarts. It'a similar to what @aweiteka has done for prometheus config changes. It's a bit of a hack, but it works.

@sdodson This would simplify the install because we'd no longer need to force a console rollout on config changes from the metrics and logging playbooks.

Any objections to this approach?

/assign @jwforres 
/cc @smarterclayton @derekwaynecarr @deads2k
/hold

Holding for feedback :)

@jupierce fyi