### PR TITLE
fix #18291. Use correct playbook for openshift version

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/metrics.go
+++ b/pkg/oc/bootstrap/docker/openshift/metrics.go
@@ -8,6 +8,7 @@ import (
 	kbatch "k8s.io/kubernetes/pkg/apis/batch"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
+	"github.com/blang/semver"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/errors"
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 )
@@ -18,11 +19,17 @@ const (
 	metricsDeployerSA      = "metrics-deployer"
 	metricsDeployerSecret  = "metrics-deployer"
 	metricsDeployerJobName = "metrics-deployer-pod"
-	metricsPlaybook        = "playbooks/byo/openshift-cluster/openshift-metrics.yml"
 )
 
+func getMetricsPlaybook(v semver.Version) string {
+	if v.LTE(version37) {
+		return "playbooks/byo/openshift-cluster/openshift-metrics.yml"
+	}
+	return "playbooks/openshift-metrics/config.yml"
+}
+
 // InstallMetricsViaAnsible checks whether metrics is installed and installs it if not already installed
-func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, publicHostname, hostName, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
+func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverVersion semver.Version, serverIP, publicHostname, hostName, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
 	kubeClient, err := f.ClientSet()
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
@@ -54,7 +61,7 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverIP, public
 	runner := newAnsibleRunner(h, kubeClient, securityClient, infraNamespace, imageStreams, "metrics")
 
 	//run playbook
-	return runner.RunPlaybook(params, metricsPlaybook, hostConfigDir, imagePrefix, imageVersion)
+	return runner.RunPlaybook(params, getMetricsPlaybook(serverVersion), hostConfigDir, imagePrefix, imageVersion)
 }
 
 // InstallMetrics checks whether metrics is installed and installs it if not already installed

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -1099,7 +1099,10 @@ func (c *ClientStartConfig) InstallLogging(out io.Writer) error {
 	}
 	serverVersion, _ := c.OpenShiftHelper().ServerVersion()
 	if useAnsible(serverVersion) {
-		return c.OpenShiftHelper().InstallLoggingViaAnsible(f, c.ServerIP, publicMaster,
+		return c.OpenShiftHelper().InstallLoggingViaAnsible(f,
+			serverVersion,
+			c.ServerIP,
+			publicMaster,
 			openshift.LoggingHost(c.RoutingSuffix, c.ServerIP),
 			c.Image,
 			c.ImageVersion,
@@ -1121,7 +1124,10 @@ func (c *ClientStartConfig) InstallMetrics(out io.Writer) error {
 		if len(publicMaster) == 0 {
 			publicMaster = c.ServerIP
 		}
-		return c.OpenShiftHelper().InstallMetricsViaAnsible(f, c.ServerIP, publicMaster,
+		return c.OpenShiftHelper().InstallMetricsViaAnsible(f,
+			serverVersion,
+			c.ServerIP,
+			publicMaster,
 			openshift.MetricsHost(c.RoutingSuffix, c.ServerIP),
 			c.Image,
 			c.ImageVersion,


### PR DESCRIPTION
This PR fixes #18291 by:

* modifying the playbook used depending upon the release. 

There is an issue https://github.com/openshift/openshift-ansible/issues/7006 however with the containerized version of origin-ansible where there is some conflict with the fact gathering