### PR TITLE
UPSTREAM: 59301: dockershim: don't check pod IP in StopPodSandbox

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -207,9 +207,6 @@ func TestNetworkPluginInvocation(t *testing.T) {
 
 	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
 	setup := mockPlugin.EXPECT().SetUpPod(ns, name, cID)
-	// StopPodSandbox performs a lookup on status to figure out if the sandbox
-	// is running with hostnetworking, as all its given is the ID.
-	mockPlugin.EXPECT().GetPodNetworkStatus(ns, name, cID)
 	mockPlugin.EXPECT().TearDownPod(ns, name, cID).After(setup)
 
 	_, err := ds.RunPodSandbox(c)


### PR DESCRIPTION
We're about to tear the container down, there's no point.  It also suppresses
an annoying error message due to kubelet stupidity that causes multiple
parallel calls to StopPodSandbox for the same sandbox.

docker_sandbox.go:355] failed to read pod IP from plugin/docker: NetworkPlugin cni failed on the status hook for pod "docker-registry-1-deploy_default": Unexpected command output nsenter: cannot open /proc/22646/ns/net: No such file or directory

1) A first StopPodSandbox() request triggered by SyncLoop(PLEG) for
a ContainerDied event calls into TearDownPod() and thus the network
plugin.  Until this completes, networkReady=true for the
sandbox.

2) A second StopPodSandbox() request triggered by SyncLoop(REMOVE)
calls PodSandboxStatus() and calls into the network plugin to read
the IP address because networkReady=true

3) The first request exits the network plugin, sets networReady=false,
and calls StopContainer() on the sandbox.  This destroys the network
namespace.

4) The second request finally gets around to running nsenter but
the network namespace is already destroyed.  It returns an error
which is logged by getIP().

Fixes: https://github.com/openshift/origin/issues/18414

@danwinship