### PR TITLE
Fixing issue 18426: Jenkins 2 image tag

### DIFF
--- a/examples/image-streams/image-streams-rhel7.json
+++ b/examples/image-streams/image-streams-rhel7.json
@@ -1022,7 +1022,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.9"
+              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.7"
             }
           }
         ]


### PR DESCRIPTION
Importing origin/examples/image-streams/image-streams-rhel7.json results in a broken image. This is because tag 3.9 doesn't exist for registry.access.redhat.com/openshift3/jenkins-2-rhel7. The latest version is 3.7