### PR TITLE
Test case reuses a hostname from another test

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -130,7 +130,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router] openshift rou
 					}
 					// send a burst of traffic to the router
 					g.By("sending traffic to a weighted route")
-					err = expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), "weighted.example.com", http.StatusOK, times)
+					err = expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), "weighted.metrics.example.com", http.StatusOK, times)
 					o.Expect(err).NotTo(o.HaveOccurred())
 				}
 				g.By("retrying metrics until all backend servers appear")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -9420,7 +9420,7 @@ items:
       test: router
       select: weighted
   spec:
-    host: weighted.example.com
+    host: weighted.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service
@@ -9441,7 +9441,7 @@ items:
       test: router
       select: weighted
   spec:
-    host: zeroweight.example.com
+    host: zeroweight.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service

--- a/test/extended/testdata/router-metrics.yaml
+++ b/test/extended/testdata/router-metrics.yaml
@@ -10,7 +10,7 @@ items:
       test: router
       select: weighted
   spec:
-    host: weighted.example.com
+    host: weighted.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service
@@ -31,7 +31,7 @@ items:
       test: router
       select: weighted
   spec:
-    host: zeroweight.example.com
+    host: zeroweight.metrics.example.com
     to:
       name: weightedendpoints1
       kind: Service


### PR DESCRIPTION
The test is flaking because another test runs at the exact same time and
the shared router doesn't let the test have the same hostname and so doesn't admit the route. Change
the hostname to be unique to this test.

Flaked in after the networking fix, logs from router made it clear why it wasn't allowed.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/7007/test_pull_request_openshift_ansible_extended_conformance_gce/379/?log#conformanceareanetworkingfeaturerouter-openshift-router-metrics-the-haproxy-router-should-expose-prometheus-metrics-for-a-route-suiteopenshiftconformanceparallel