### PR TITLE
Add source secret validation to new build

### DIFF
--- a/pkg/oc/generate/cmd/newapp.go
+++ b/pkg/oc/generate/cmd/newapp.go
@@ -898,6 +898,9 @@ func (c *AppConfig) Run() (*AppResult, error) {
 		}
 	}
 	if len(c.SourceSecret) > 0 {
+		if len(validation.ValidateSecretName(c.SourceSecret, false)) != 0 {
+			return nil, fmt.Errorf("source secret name %q is invalid", c.SourceSecret)
+		}
 		for _, obj := range objects {
 			if bc, ok := obj.(*buildapi.BuildConfig); ok {
 				glog.V(4).Infof("Setting source secret for build config to: %v", c.SourceSecret)

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -65,6 +65,7 @@ os::cmd::expect_failure_and_text 'oc new-build https://examplegit.com/openshift/
 # setting source secret via the --source-secret flag
 os::cmd::expect_success_and_text 'oc new-app https://github.com/openshift/cakephp-ex --source-secret=mysecret -o yaml' 'name: mysecret'
 os::cmd::expect_success_and_text 'oc new-build https://github.com/openshift/cakephp-ex --source-secret=mynewsecret -o yaml' 'name: mynewsecret'
+os::cmd::expect_failure_and_text 'oc new-app https://github.com/openshift/cakephp-ex --source-secret=InvalidSecretName -o yaml' 'error: source secret name "InvalidSecretName" is invalid'
 os::cmd::expect_success_and_text 'oc new-app -f examples/quickstarts/cakephp-mysql.json --source-secret=mysecret -o yaml' 'name: mysecret'
 os::cmd::expect_success 'oc new-app https://github.com/openshift/cakephp-ex --source-secret=mysecret'
 os::cmd::expect_success 'oc delete all --selector="label=cakephp-ex"'


### PR DESCRIPTION
This patch makes a tiny change by adding source secret name validation
to new build.

Currently even though build-secret has the validation, source secret
does not.