### PR TITLE
Replace icon-cogs with fa-cogs in templates

### DIFF
--- a/examples/grafana/grafana.yaml
+++ b/examples/grafana/grafana.yaml
@@ -7,7 +7,7 @@ metadata:
     "openshift.io/display-name": Grafana
     description: |
       Grafana server with patched Prometheus datasource.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "metrics,monitoring,grafana,prometheus"
 parameters:
 - description: The location of the grafana image

--- a/examples/heapster/heapster-standalone.yaml
+++ b/examples/heapster/heapster-standalone.yaml
@@ -6,7 +6,7 @@ metadata:
     "openshift.io/display-name": Heapster Metrics (Standalone)
     description: |
       A simple metrics solution for an OpenShift cluster. Expects to be installed in the 'kube-system' namespace.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "metrics,monitoring,heapster"
   labels:
     metrics-infra: heapster

--- a/examples/prometheus/prometheus-standalone.yaml
+++ b/examples/prometheus/prometheus-standalone.yaml
@@ -6,7 +6,7 @@ metadata:
     "openshift.io/display-name": Prometheus
     description: |
       A Prometheus deployment that can be customized to monitor components and dispatch alerts. It is secure by default and can be used to monitor arbitrary clients.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "monitoring,prometheus,alertmanager,time-series"
 parameters:
 - description: The location of the proxy image

--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -6,7 +6,7 @@ metadata:
     "openshift.io/display-name": Prometheus
     description: |
       A monitoring solution for an OpenShift cluster - collect and gather metrics and alerts from nodes, services, and the infrastructure. This is a tech preview feature.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "monitoring,prometheus, alertmanager,time-series"
 parameters:
 - description: The namespace to instantiate prometheus under. Defaults to 'kube-system'.

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -13708,7 +13708,7 @@ metadata:
     "openshift.io/display-name": Heapster Metrics (Standalone)
     description: |
       A simple metrics solution for an OpenShift cluster. Expects to be installed in the 'kube-system' namespace.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "metrics,monitoring,heapster"
   labels:
     metrics-infra: heapster
@@ -13839,7 +13839,7 @@ metadata:
     "openshift.io/display-name": Prometheus
     description: |
       A monitoring solution for an OpenShift cluster - collect and gather metrics and alerts from nodes, services, and the infrastructure. This is a tech preview feature.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "monitoring,prometheus, alertmanager,time-series"
 parameters:
 - description: The namespace to instantiate prometheus under. Defaults to 'kube-system'.

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -25380,7 +25380,7 @@ metadata:
     "openshift.io/display-name": Prometheus
     description: |
       A monitoring solution for an OpenShift cluster - collect and gather metrics and alerts from nodes, services, and the infrastructure. This is a tech preview feature.
-    iconClass: icon-cogs
+    iconClass: fa fa-cogs
     tags: "monitoring,prometheus, alertmanager,time-series"
 parameters:
 - description: The namespace to instantiate prometheus under. Defaults to 'kube-system'.


### PR DESCRIPTION
`icon-cogs` has been removed. Update example templates to use `fa-cogs`,
which is the replacement.

Fixes https://github.com/openshift/origin-web-console/issues/2767

/assign @rhamilto 
