### PR TITLE
expect build success in test

### DIFF
--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -70,6 +70,8 @@ func testBuildDigest(oc *exutil.CLI, buildFixture string, buildLogLevel uint) {
 		logLevelArg := fmt.Sprintf("--build-loglevel=%d", buildLogLevel)
 		g.By("starting a test build")
 		br, err := exutil.StartBuildAndWait(oc, "test", logLevelArg)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		br.AssertSuccess()
 
 		g.By("checking that the image digest has been saved to the build status")
 		o.Expect(br.Build.Status.Output.To).NotTo(o.BeNil())


### PR DESCRIPTION
give a better test failure reason when the build fails as seen in https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/18415/test_pull_request_origin_extended_builds/1042/
