### PR TITLE
UPSTREAM: 59405: increase retry_time for downward api volume test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go
@@ -373,7 +373,7 @@ func downwardAPIVolumePodForUpdateTest(name string, labels, annotations map[stri
 		{
 			Name:    "client-container",
 			Image:   mountImage,
-			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=1200", "--file_content_in_loop=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/18136
Fixes: https://github.com/openshift/origin/issues/17882

Upstream: https://github.com/kubernetes/kubernetes/pull/59405