### PR TITLE
better failure debug for fetch url tests

### DIFF
--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -111,6 +111,7 @@ func NewSampleRepoTest(c SampleRepoConfig) func() {
 						if strings.Contains(response, c.expectedString) {
 							return true, nil
 						}
+						e2e.Logf("url check got %s, expected it to contain %s", response, c.expectedString)
 						return false, nil
 					})
 					o.Expect(response).Should(o.ContainSubstring(c.expectedString))

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1283,6 +1283,12 @@ func FetchURL(url string, retryTimeout time.Duration) (response string, err erro
 		if err != nil || r.StatusCode != 200 {
 			// lie to the poller that we didn't get an error even though we did
 			// because otherwise it's going to give up.
+			if err != nil {
+				e2e.Logf("error fetching url: %v", err)
+			}
+			if r != nil {
+				e2e.Logf("non-200 status code fetching url: %d", r.StatusCode)
+			}
 			return false, nil
 		}
 		defer r.Body.Close()


### PR DESCRIPTION
trying to debug failures where the nodejs app pagecount reports as:
```
  <span class="code" id="count-value">61</span>
```

when we should have only hit the app once (we must be hitting it multiple times but not realizing we've successfully hit the app/not gotten the appropriate response)
