### PR TITLE
bootstrap: Remove unused ErrSocatNotFound

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/errors.go
+++ b/pkg/oc/bootstrap/docker/openshift/errors.go
@@ -17,12 +17,6 @@ func ErrTimedOutWaitingForStart(container string) errors.Error {
 	return errors.NewError("timed out waiting for OpenShift container %q", container)
 }
 
-func ErrSocatNotFound() errors.Error {
-	return errors.NewError("socat not found locally").
-		WithDetails("socat is required to enable port forwarding\n").
-		WithSolution("Install socat using your package manager first\n")
-}
-
 type errPortsNotAvailable struct {
 	ports []int
 }


### PR DESCRIPTION
For RHELAH 7.5 we're dropping the `kubernetes` RPM which actually
indirectly dragged in `socat`.  There was some discussion about
this on atomic-devel@ a while ago:
https://lists.projectatomic.io/projectatomic-archives/atomic-devel/2015-March/msg00066.html

From some investigation, it looks like the kubelet now carries the code for
this.

And it turns out that this reference to socat was introduced by
2d58450e03af7a2828ccfc6d4d6f49dfac58ab7f for something different (related to
Docker on OS X), but wasn't even used there.

Since I noticed it's unused, let's delete it. This patch reduces the number of
lines of Go code in this git repo by `0.000027%`.