### PR TITLE
pkg/cmd/server/config has moved to pkg/cmd/server/apis/config

### DIFF
--- a/tools/testdebug/cmd/load_etcd.go
+++ b/tools/testdebug/cmd/load_etcd.go
@@ -21,8 +21,8 @@ import (
 
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	"github.com/openshift/origin/pkg/cmd/flagtypes"
+	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	configapi "github.com/openshift/origin/pkg/cmd/server/config"
 	"github.com/openshift/origin/pkg/cmd/server/etcd/etcdserver"
 	kubernetes "github.com/openshift/origin/pkg/cmd/server/kubernetes/master"
 	"github.com/openshift/origin/pkg/cmd/server/origin"


### PR DESCRIPTION
Not sure which unit test was testing this. But it breaks the glide dependency management.

Fixes https://github.com/openshift/origin/issues/18458

Signed-off-by: Rajat Chopra <rchopra@redhat.com>

