### PR TITLE
Adds trace cmd

### DIFF
--- a/tools/depcheck/examples/origin_excludes.json
+++ b/tools/depcheck/examples/origin_excludes.json
@@ -1,0 +1,6 @@
+[
+	"github.com/openshift/origin/images",
+	"github.com/openshift/origin/pkg/build/builder",
+	"github.com/openshift/origin/cmd/cluster-capacity",
+	"github.com/openshift/origin/cmd/service-catalog"
+]

--- a/tools/depcheck/examples/origin_filters.json
+++ b/tools/depcheck/examples/origin_filters.json
@@ -1,0 +1,4 @@
+[
+	"github.com/openshift/origin/pkg/api",
+	"github.com/openshift/origin/pkg/auth"
+]

--- a/tools/depcheck/pkg/cmd/cmd.go
+++ b/tools/depcheck/pkg/cmd/cmd.go
@@ -22,6 +22,7 @@ func NewCmdDepCheck(name string, out, errout io.Writer) *cobra.Command {
 	}
 
 	cmd.AddCommand(NewCmdPinImports(name, out, errout))
+	cmd.AddCommand(NewCmdTraceImports(name, out, errout))
 
 	// add glog flags to our global flag set
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/tools/depcheck/pkg/cmd/trace.go
+++ b/tools/depcheck/pkg/cmd/trace.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gonum/graph"
+	"github.com/gonum/graph/encoding/dot"
+
+	depgraph "github.com/openshift/origin/tools/depcheck/pkg/graph"
+)
+
+var traceImportsExample = `# create a dependency graph
+%[1]s trace --root=github.com/openshift/origin --entry="./cmd/..."
+
+# create a dependency graph using OpenShift-specific settings
+%[1]s trace --root=github.com/openshift/origin --entry="./cmd/..." --openshift
+
+# create a dependency graph and output in "dot" format
+%[1]s trace --root=github.com/openshift/origin --entry=pkg/foo/... --output=dot --openshift
+`
+
+type TraceOptions struct {
+	GraphOptions *depgraph.GraphOptions
+
+	outputGraphName string
+	OutputFormat    string
+
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+type TraceFlags struct {
+	GraphFlags *depgraph.GraphFlags
+
+	OutputFormat string
+}
+
+func NewCmdTraceImports(parent string, out, errout io.Writer) *cobra.Command {
+	traceFlags := &TraceFlags{
+		GraphFlags:   &depgraph.GraphFlags{},
+		OutputFormat: "dot",
+	}
+
+	cmd := &cobra.Command{
+		Use:     "trace --root=github.com/openshift/origin --entry=pkg/foo/...",
+		Short:   "Creates a dependency graph for a given repository",
+		Long:    "Creates a dependency graph for a given repository, for every Go package reachable from a set of --entry points into the codebase",
+		Example: fmt.Sprintf(traceImportsExample, parent),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts, err := traceFlags.ToOptions(out, errout)
+			if err != nil {
+				return err
+			}
+
+			if err := opts.Complete(); err != nil {
+				return err
+			}
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+			if err := opts.Run(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	traceFlags.GraphFlags.AddFlags(cmd)
+	cmd.Flags().StringVarP(&traceFlags.OutputFormat, "output", "o", traceFlags.OutputFormat, "output generated dependency graph in specified format. One of: dot.")
+	return cmd
+}
+
+func (o *TraceOptions) Complete() error {
+	return o.GraphOptions.Complete()
+}
+
+func (o *TraceOptions) Validate() error {
+	if err := o.GraphOptions.Validate(); err != nil {
+		return err
+	}
+
+	if len(o.OutputFormat) > 0 && o.OutputFormat != "dot" {
+		return fmt.Errorf("invalid output format provided: %s", o.OutputFormat)
+	}
+
+	return nil
+}
+
+func (o *TraceFlags) ToOptions(out, errout io.Writer) (*TraceOptions, error) {
+	graphOpts, err := o.GraphFlags.ToOptions(out, errout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TraceOptions{
+		GraphOptions: graphOpts,
+		OutputFormat: o.OutputFormat,
+
+		outputGraphName: o.GraphFlags.RepoImportPath,
+
+		Out:    out,
+		ErrOut: errout,
+	}, nil
+}
+
+// Run creates a dependency graph using user-specified options.
+// Outputs graph contents in the format specified.
+func (o *TraceOptions) Run() error {
+	g, err := o.GraphOptions.BuildGraph()
+	if err != nil {
+		return err
+	}
+
+	return o.outputGraph(g)
+}
+
+func (o *TraceOptions) outputGraph(g graph.Directed) error {
+	if o.OutputFormat != "dot" {
+		return fmt.Errorf("invalid output format provided: %s", o.OutputFormat)
+	}
+
+	data, err := dot.Marshal(g, fmt.Sprintf("%q", o.outputGraphName), "", " ", false)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "%v\n", string(data))
+	return nil
+}

--- a/tools/depcheck/pkg/graph/filter.go
+++ b/tools/depcheck/pkg/graph/filter.go
@@ -31,7 +31,6 @@ func FilterPackages(g *MutableDirectedGraph, packagePrefixes []string) (*Mutable
 		err := collapsedGraph.AddNode(&Node{
 			UniqueName: collapsedNodeName,
 			Id:         n.ID(),
-			LabelName:  labelNameForNode(collapsedNodeName),
 		})
 		if err != nil {
 			return nil, err
@@ -83,7 +82,15 @@ func FilterPackages(g *MutableDirectedGraph, packagePrefixes []string) (*Mutable
 
 func getFilteredNodeName(collapsedPrefixes []string, packageName string) string {
 	for _, prefix := range collapsedPrefixes {
-		if strings.HasPrefix(packageName, prefix) {
+		// ensure that each prefix ends in a slash
+		// otherwise, we will incorrectly squash packages
+		// like "api" and "apimachinery" into eachother.
+		prefixWithSlash := prefix
+		if string(prefix[len(prefix)-1]) != "/" {
+			prefixWithSlash = prefixWithSlash + "/"
+		}
+
+		if strings.HasPrefix(packageName+"/", prefixWithSlash) {
 			return prefix
 		}
 	}

--- a/tools/depcheck/pkg/graph/filter_test.go
+++ b/tools/depcheck/pkg/graph/filter_test.go
@@ -15,13 +15,13 @@ type testFilterNode struct {
 func getVendorNodes() []*testFilterNode {
 	return []*testFilterNode{
 		{
-			name: "github.com/test/repo/vendor/github.com/testvendor/prefix1",
+			name: "github.com/test/repo/vendor/github.com/testvendor/prefix",
 			outboundEdges: []string{
-				"github.com/test/repo/vendor/github.com/testvendor/prefix1/one",
+				"github.com/test/repo/vendor/github.com/testvendor/prefix/one",
 			},
 		},
 		{
-			name: "github.com/test/repo/vendor/github.com/testvendor/prefix1/one",
+			name: "github.com/test/repo/vendor/github.com/testvendor/prefix/one",
 			outboundEdges: []string{
 				"github.com/test/repo/vendor/github.com/testvendor/prefix2/one",
 			},
@@ -58,15 +58,15 @@ func getVendorNodes() []*testFilterNode {
 func getNonVendorNodes() []*testFilterNode {
 	return []*testFilterNode{
 		{
-			name: "github.com/test/repo/pkg/prefix1",
+			name: "github.com/test/repo/pkg/prefix",
 			outboundEdges: []string{
-				"github.com/test/repo/pkg/prefix1/one",
+				"github.com/test/repo/pkg/prefix/one",
 			},
 		},
 		{
-			name: "github.com/test/repo/pkg/prefix1/one",
+			name: "github.com/test/repo/pkg/prefix/one",
 			outboundEdges: []string{
-				"github.com/test/repo/vendor/github.com/testvendor/prefix1",
+				"github.com/test/repo/vendor/github.com/testvendor/prefix",
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestVendorPackagesCollapsedIntoRepo(t *testing.T) {
 	}
 
 	vendorRoots := []string{
-		"github.com/test/repo/vendor/github.com/testvendor/prefix1",
+		"github.com/test/repo/vendor/github.com/testvendor/prefix",
 		"github.com/test/repo/vendor/github.com/testvendor/prefix2",
 		"github.com/test/repo/vendor/github.com/google/glog",
 		"github.com/test/repo/vendor/github.com/docker/docker-test-util",
@@ -190,7 +190,7 @@ func TestVendorPackagesCollapsedIntoRepo(t *testing.T) {
 		"github.com/test/repo/vendor/github.com/docker/docker-test-util": {
 			"github.com/test/repo/vendor/github.com/google/glog",
 		},
-		"github.com/test/repo/vendor/github.com/testvendor/prefix1": {
+		"github.com/test/repo/vendor/github.com/testvendor/prefix": {
 			"github.com/test/repo/vendor/github.com/testvendor/prefix2",
 		},
 	}
@@ -249,7 +249,9 @@ func TestCollapsedGraphPreservesNonVendorNodes(t *testing.T) {
 	}
 
 	vendorRoots := []string{
-		"github.com/test/repo/vendor/github.com/testvendor/prefix1",
+		// having this prefix come first tests that "prefix2" does
+		// not end up getting accidentally squashed into "testvendor/prefix"
+		"github.com/test/repo/vendor/github.com/testvendor/prefix",
 		"github.com/test/repo/vendor/github.com/testvendor/prefix2",
 		"github.com/test/repo/vendor/github.com/google/glog",
 		"github.com/test/repo/vendor/github.com/docker/docker-test-util",
@@ -280,11 +282,11 @@ func TestCollapsedGraphPreservesNonVendorNodes(t *testing.T) {
 	}
 
 	expectedOutgoingEdges := map[string][]string{
-		"github.com/test/repo/pkg/prefix1": {
-			"github.com/test/repo/pkg/prefix1/one",
+		"github.com/test/repo/pkg/prefix": {
+			"github.com/test/repo/pkg/prefix/one",
 		},
-		"github.com/test/repo/pkg/prefix1/one": {
-			"github.com/test/repo/vendor/github.com/testvendor/prefix1",
+		"github.com/test/repo/pkg/prefix/one": {
+			"github.com/test/repo/vendor/github.com/testvendor/prefix",
 		},
 	}
 

--- a/tools/depcheck/pkg/graph/flags.go
+++ b/tools/depcheck/pkg/graph/flags.go
@@ -1,0 +1,302 @@
+package graph
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/golang/glog"
+
+	"github.com/gonum/graph/concrete"
+)
+
+// GraphOptions contains values necessary to create a dependency graph.
+type GraphOptions struct {
+	// Packages is the caculated list of traversed go packages to use to create the graph
+	Packages *PackageList
+
+	// Roots is a list of go-import paths containing the total set of traversed
+	// packages, from the given set of Entrypoints.
+	Roots []string
+	// Excludes are package go-import paths to ignore while traversing a directory structure
+	Excludes []string
+	// Filters are package go-import paths. Any package paths nested under these are truncated.
+	Filters []string
+}
+
+func (o *GraphOptions) Complete() error {
+	return nil
+}
+
+func (o *GraphOptions) Validate() error {
+	if o.Packages == nil || len(o.Packages.Packages) == 0 {
+		return errors.New("a list of Go Packages is required in order to build the graph")
+	}
+
+	return nil
+}
+
+// BuildGraph receives a list of Go packages and constructs a dependency graph from it.\
+// Each package's ImportPath and non-transitive (immediate) imports are
+// filtered and aggregated. A package is filtered based on whether its ImportPath
+// matches an accepted pattern defined in the set of validPackages.
+// Any core library dependencies (fmt, strings, etc.) are not added to the graph.
+// Any packages whose import path is contained within a list of "excludes" are not added to the graph.
+// Returns a directed graph and a map of package import paths to node ids, or an error.
+func (o *GraphOptions) BuildGraph() (*MutableDirectedGraph, error) {
+	g := NewMutableDirectedGraph(o.Roots)
+
+	// contains the subset of packages from the set of given packages (and their immediate dependencies)
+	// that will actually be included in our graph - any packages in the excludes slice, or that do not
+	// do not match the baseRepoRegex pattern will be filtered out from this collection.
+	filteredPackages := []Package{}
+
+	// add nodes to graph
+	for _, pkg := range o.Packages.Packages {
+		if isExcludedPath(pkg.ImportPath, o.Excludes) {
+			continue
+		}
+		if !isValidPackagePath(pkg.ImportPath) {
+			continue
+		}
+
+		n := &Node{
+			Id:         g.NewNodeID(),
+			UniqueName: pkg.ImportPath,
+		}
+		err := g.AddNode(n)
+		if err != nil {
+			return nil, err
+		}
+
+		filteredPackages = append(filteredPackages, pkg)
+	}
+
+	// add edges
+	for _, pkg := range filteredPackages {
+		from, exists := g.NodeByName(pkg.ImportPath)
+		if !exists {
+			return nil, fmt.Errorf("expected node for package %q was not found in graph", pkg.ImportPath)
+		}
+
+		for _, dependency := range append(pkg.Imports, pkg.TestImports...) {
+			if isExcludedPath(dependency, o.Excludes) {
+				continue
+			}
+			if !isValidPackagePath(dependency) {
+				continue
+			}
+
+			to, exists := g.NodeByName(dependency)
+			if !exists {
+				// if a package imports a dependency that we did not visit
+				// while traversing the code tree, ignore it, as it is not
+				// required for the root repository to build.
+				glog.V(1).Infof("Skipping unvisited (missing) dependency %q, which is imported by package %q", dependency, pkg.ImportPath)
+				continue
+			}
+
+			if g.HasEdgeFromTo(from, to) {
+				continue
+			}
+
+			g.SetEdge(concrete.Edge{
+				F: from,
+				T: to,
+			}, 0)
+		}
+	}
+
+	// filter graph if any filters are specified
+	if len(o.Filters) > 0 {
+		var err error
+		g, err = FilterPackages(g, o.Filters)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	g.PruneOrphans()
+	return g, nil
+}
+
+type GraphFlags struct {
+	Filter  string
+	Exclude string
+
+	Openshift bool
+
+	RepoImportPath string
+	Entrypoints    []string
+}
+
+// calculate roots receives a set of entrypoints and traverses through
+// the directory tree, returning a list of all reachable go packages.
+// Excludes the vendor tree.
+// Returns the list of calculated import paths or an error.
+func (o *GraphFlags) calculateRoots() ([]string, error) {
+	packages, err := getPackageMetadata(
+		o.Entrypoints,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	roots := []string{}
+	for _, pkg := range packages.Packages {
+		roots = append(roots, pkg.ImportPath)
+	}
+
+	return roots, nil
+}
+
+func (o *GraphFlags) ToOptions(out, errout io.Writer) (*GraphOptions, error) {
+	opts := &GraphOptions{}
+
+	if len(o.RepoImportPath) == 0 {
+		return nil, errors.New("the go-import path for the repository must be specified via --root")
+	}
+	if len(o.Entrypoints) == 0 {
+		return nil, errors.New("at least one entrypoint path must be provided")
+	}
+	if o.Openshift && (len(o.Exclude) > 0 || len(o.Filter) > 0) {
+		return nil, errors.New("--exclude or --filter are mutually exclusive with --openshift")
+	}
+
+	// sanitize user-provided entrypoints
+	o.Entrypoints = ensureEntrypointPrefix(o.Entrypoints, o.RepoImportPath)
+
+	// calculate go package info from given set of entrypoints
+	packages, err := getPackageMetadata(
+		ensureVendorEntrypoint(o.Entrypoints, o.RepoImportPath),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	opts.Packages = packages
+
+	// calculate non-vendor trees
+	roots, err := o.calculateRoots()
+	if err != nil {
+		return nil, err
+	}
+	opts.Roots = roots
+
+	// set openshift defaults
+	if o.Openshift {
+		opts.Excludes = getOpenShiftExcludes()
+		filters, err := getOpenShiftFilters()
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Filters = filters
+		return opts, nil
+	}
+
+	if len(o.Exclude) > 0 {
+		f, err := ioutil.ReadFile(o.Exclude)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(f, &opts.Excludes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(o.Filter) > 0 {
+		f, err := ioutil.ReadFile(o.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(f, &opts.Filters)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return opts, nil
+}
+
+func (o *GraphFlags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&o.Openshift, "openshift", o.Openshift, "generate and use OpenShift-specific lists of excluded packages and filters.")
+	cmd.Flags().StringVar(&o.RepoImportPath, "root", o.RepoImportPath, "Go import-path of repository to analyze (e.g. github.com/openshift/origin)")
+	cmd.Flags().StringSliceVar(&o.Entrypoints, "entry", o.Entrypoints, "filepaths for packages within the specified --root relative to the repo's import path (e.g. ./cmd/...). Paths ending in an ellipsis (...) are traversed recursively.")
+	cmd.Flags().StringVarP(&o.Exclude, "exclude", "e", "", "optional path to json file containing a list of import-paths of packages within the specified repository to recursively exclude.")
+	cmd.Flags().StringVarP(&o.Filter, "filter", "c", "", "optional path to json file containing a list of import-paths of packages to collapse sub-packages into.")
+}
+
+func isExcludedPath(path string, excludes []string) bool {
+	for _, exclude := range excludes {
+		if strings.HasPrefix(path, exclude) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ensureEntrypointPrefix receives a list of paths and ensures
+// that each path is prefixed by the repo's go-import path:
+//   ["./cmd"] -> ["github.com/openshift/origin/cmd"]
+func ensureEntrypointPrefix(entrypoints []string, prefix string) []string {
+	for idx, entry := range entrypoints {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+
+		entrypoints[idx] = path.Join(prefix, entry)
+	}
+
+	return entrypoints
+}
+
+// ensureVendorEntrypoint receives a list of paths and ensures that
+// at least one of those paths is a go-import path to the repo's vendor directory
+func ensureVendorEntrypoint(entrypoints []string, prefix string) []string {
+	hasVendor := false
+	for _, entry := range entrypoints {
+		if strings.HasSuffix(path.Clean(entry), "/vendor") {
+			hasVendor = true
+			break
+		}
+	}
+	if !hasVendor {
+		vendor := ensureEntrypointPrefix([]string{"vendor"}, prefix)
+		vendor = ensureEntrypointEllipsis(vendor)
+		entrypoints = append(entrypoints, vendor[0])
+	}
+
+	return entrypoints
+}
+
+// ensureEntrypointEllipsis receives a list of paths
+// and ensures that each path ends in an ellipsis (...).
+func ensureEntrypointEllipsis(entypoints []string) []string {
+	parsedRoots := []string{}
+	for _, entry := range entypoints {
+		if strings.HasSuffix(entry, "...") {
+			parsedRoots = append(parsedRoots, entry)
+			continue
+		}
+
+		slash := ""
+		if string(entry[len(entry)-1]) != "/" {
+			slash = "/"
+		}
+		entry = strings.Join([]string{entry, slash, "..."}, "")
+		parsedRoots = append(parsedRoots, entry)
+	}
+
+	return parsedRoots
+}

--- a/tools/depcheck/pkg/graph/graph.go
+++ b/tools/depcheck/pkg/graph/graph.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gonum/graph"
 	"github.com/gonum/graph/concrete"
@@ -11,7 +12,6 @@ import (
 type Node struct {
 	Id         int
 	UniqueName string
-	LabelName  string
 	Color      string
 }
 
@@ -20,7 +20,7 @@ func (n Node) ID() int {
 }
 
 func (n Node) String() string {
-	return n.LabelName
+	return labelNameForNode(n.UniqueName)
 }
 
 // DOTAttributes implements an attribute getter for the DOT encoding
@@ -31,9 +31,19 @@ func (n Node) DOTAttributes() []dot.Attribute {
 	}
 
 	return []dot.Attribute{
-		{Key: "label", Value: fmt.Sprintf("%q", n.LabelName)},
+		{Key: "label", Value: fmt.Sprintf("%q", n)},
 		{Key: "color", Value: color},
 	}
+}
+
+// labelNameForNode trims vendored paths of their full /vendor/ path
+func labelNameForNode(importPath string) string {
+	segs := strings.Split(importPath, "/vendor/")
+	if len(segs) > 1 {
+		return segs[1]
+	}
+
+	return importPath
 }
 
 func NewMutableDirectedGraph(roots []string) *MutableDirectedGraph {

--- a/tools/depcheck/pkg/graph/openshift.go
+++ b/tools/depcheck/pkg/graph/openshift.go
@@ -1,0 +1,136 @@
+package graph
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+)
+
+var (
+	openshiftDefaultExcludes = []string{
+		"github.com/openshift/origin/images",
+		"github.com/openshift/origin/pkg/build/builder",
+
+		"github.com/openshift/origin/cmd/cluster-capacity",
+		"github.com/openshift/origin/cmd/service-catalog",
+	}
+
+	openshiftImportPath = "github.com/openshift/origin"
+)
+
+type openShiftRepoInfo struct {
+	Dir string
+}
+
+// getOpenShiftExcludes returns a list of known
+// OpenShift-specific paths to exclude
+func getOpenShiftExcludes() []string {
+	return openshiftDefaultExcludes
+}
+
+// getOpenShiftFilters returns a list of known
+// OpenShift-specific paths to use as filters
+func getOpenShiftFilters() ([]string, error) {
+	result := bytes.NewBuffer([]byte{})
+
+	// obtain path to Origin repo
+	goList := exec.Command("go", "list", "--json", "-f", "'{{ .Dir }}'", openshiftImportPath)
+	goList.Stdout = result
+	goList.Stderr = os.Stderr
+
+	if err := goList.Run(); err != nil {
+		return nil, err
+	}
+
+	info := &openShiftRepoInfo{}
+	if err := json.Unmarshal(result.Bytes(), &info); err != nil {
+		return nil, err
+	}
+
+	filters, err := listDirsN([]string{"pkg"}, 1, info.Dir, "")
+	if err != nil {
+		return nil, err
+	}
+
+	k8s, err := listDirsN([]string{"vendor/k8s.io"}, 1, info.Dir, "")
+	if err != nil {
+		return nil, err
+	}
+	filters = append(filters, k8s...)
+
+	gopkg, err := listDirsN([]string{"vendor/gopkg.in"}, 1, info.Dir, "")
+	if err != nil {
+		return nil, err
+	}
+	filters = append(filters, gopkg...)
+
+	github, err := listDirsN([]string{"vendor/github.com"}, 2, info.Dir, "")
+	if err != nil {
+		return nil, err
+	}
+	filters = append(filters, github...)
+
+	vendor, err := listDirsN([]string{"vendor"}, 1, info.Dir, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// filter out vendor pkgs we have expanded
+	skip := map[string]bool{
+		"vendor/k8s.io":     true,
+		"vendor/gopkg.in":   true,
+		"vendor/github.com": true,
+	}
+	for _, v := range vendor {
+		if _, shouldSkip := skip[v]; shouldSkip {
+			continue
+		}
+		filters = append(filters, v)
+	}
+
+	originFilters := []string{}
+	for _, f := range filters {
+		originFilters = append(originFilters, path.Join(openshiftImportPath, f))
+	}
+
+	return originFilters, nil
+}
+
+// listDirsN receives a list of directory names and returns
+// up to N levels of nested directories for each one
+func listDirsN(dirs []string, N int, root, prefix string) ([]string, error) {
+	if N <= 0 {
+		return dirs, nil
+	}
+
+	allDirs := []string{}
+	for _, dir := range dirs {
+		files, err := ioutil.ReadDir(path.Join(root, prefix, dir))
+		if err != nil {
+			return nil, err
+		}
+
+		childDirs := []string{}
+		for _, f := range files {
+			if !f.IsDir() {
+				continue
+			}
+
+			childDirs = append(childDirs, f.Name())
+		}
+
+		nested, err := listDirsN(childDirs, N-1, root, path.Join(prefix, dir))
+		if err != nil {
+			return nil, err
+		}
+
+		for _, n := range nested {
+			allDirs = append(allDirs, path.Join(dir, n))
+		}
+	}
+
+	return allDirs, nil
+}

--- a/tools/depcheck/pkg/graph/pkg_test.go
+++ b/tools/depcheck/pkg/graph/pkg_test.go
@@ -1,83 +1,97 @@
 package graph
 
 import (
-	"strings"
 	"testing"
 )
 
-var pkgs = &PackageList{
-	Packages: []Package{
-		{
-			Dir:        "/path/to/github.com/test/repo/root",
-			ImportPath: "github.com/test/repo/root",
-			Imports: []string{
-				"github.com/test/repo/pkg/one",
-			},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/pkg/one",
-			ImportPath: "github.com/test/repo/pkg/one",
-			Imports: []string{
-				"github.com/test/repo/pkg/two",
-				"github.com/test/repo/pkg/three",
-				"github.com/test/repo/pkg/depends_on_fmt",
-			},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/pkg/two",
-			ImportPath: "github.com/test/repo/pkg/two",
-			Imports: []string{
-				"github.com/test/repo/vendor/github.com/testvendor/vendor_one",
-			},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/pkg/three",
-			ImportPath: "github.com/test/repo/pkg/three",
-			Imports: []string{
-				"github.com/test/repo/shared/shared_one",
-			},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/pkg/depends_on_fmt",
-			ImportPath: "github.com/test/repo/pkg/depends_on_fmt",
-			Imports: []string{
-				"fmt",
-				"github.com/test/repo/unique/unique_nonvendored_one",
-			},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/unique/unique_nonvendored_one",
-			ImportPath: "github.com/test/repo/unique/unique_nonvendored_one",
-			Imports:    []string{},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/shared/shared_one",
-			ImportPath: "github.com/test/repo/shared/shared_one",
-			Imports:    []string{},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/vendor/github.com/testvendor/vendor_one",
-			ImportPath: "github.com/test/repo/vendor/github.com/testvendor/vendor_one",
-			Imports: []string{
-				"github.com/test/repo/unique/unique_vendor_one",
-				"github.com/test/repo/shared/shared_one",
-			},
-		},
-		{
-			Dir:        "/path/to/github.com/test/repo/unique/unique_vendor_one",
-			ImportPath: "github.com/test/repo/unique/unique_vendor_one",
-			Imports:    []string{},
-		},
+type TestPackageList struct {
+	*PackageList
+}
 
-		// simulate a package that is not brought in through any of the repo entrypoints
-		// ("github.com/test/repo/root" in this case) but exists in the codebase
-		// because another package that is part of its repo is a transitive dependency
-		// of one of the main repo's entrypoints.
-		{
-			Dir:        "/path/to/github.com/test/repo/unique/unique_vendor_two",
-			ImportPath: "github.com/test/repo/unique/unique_vendor_two",
-			Imports: []string{
-				"github.com/test/repo/no/node/should/exist/for/this/pkg",
+func (p *TestPackageList) ImportPaths() []string {
+	importPaths := []string{}
+	for _, pkg := range p.PackageList.Packages {
+		importPaths = append(importPaths, pkg.ImportPath)
+	}
+
+	return importPaths
+}
+
+var pkgs = &TestPackageList{
+	&PackageList{
+		Packages: []Package{
+			{
+				Dir:        "/path/to/github.com/test/repo/root",
+				ImportPath: "github.com/test/repo/root",
+				Imports: []string{
+					"github.com/test/repo/pkg/one",
+				},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/pkg/one",
+				ImportPath: "github.com/test/repo/pkg/one",
+				Imports: []string{
+					"github.com/test/repo/pkg/two",
+					"github.com/test/repo/pkg/three",
+					"github.com/test/repo/pkg/depends_on_fmt",
+				},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/pkg/two",
+				ImportPath: "github.com/test/repo/pkg/two",
+				Imports: []string{
+					"github.com/test/repo/vendor/github.com/testvendor/vendor_one",
+				},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/pkg/three",
+				ImportPath: "github.com/test/repo/pkg/three",
+				Imports: []string{
+					"github.com/test/repo/shared/shared_one",
+				},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/pkg/depends_on_fmt",
+				ImportPath: "github.com/test/repo/pkg/depends_on_fmt",
+				Imports: []string{
+					"fmt",
+					"github.com/test/repo/unique/unique_nonvendored_one",
+				},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/unique/unique_nonvendored_one",
+				ImportPath: "github.com/test/repo/unique/unique_nonvendored_one",
+				Imports:    []string{},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/shared/shared_one",
+				ImportPath: "github.com/test/repo/shared/shared_one",
+				Imports:    []string{},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/vendor/github.com/testvendor/vendor_one",
+				ImportPath: "github.com/test/repo/vendor/github.com/testvendor/vendor_one",
+				Imports: []string{
+					"github.com/test/repo/unique/unique_vendor_one",
+					"github.com/test/repo/shared/shared_one",
+				},
+			},
+			{
+				Dir:        "/path/to/github.com/test/repo/unique/unique_vendor_one",
+				ImportPath: "github.com/test/repo/unique/unique_vendor_one",
+				Imports:    []string{},
+			},
+
+			// simulate a package that is not brought in through any of the repo entrypoints
+			// ("github.com/test/repo/root" in this case) but exists in the codebase
+			// because another package that is part of its repo is a transitive dependency
+			// of one of the main repo's entrypoints.
+			{
+				Dir:        "/path/to/github.com/test/repo/unique/unique_vendor_two",
+				ImportPath: "github.com/test/repo/unique/unique_vendor_two",
+				Imports: []string{
+					"github.com/test/repo/no/node/should/exist/for/this/pkg",
+				},
 			},
 		},
 	},
@@ -99,7 +113,12 @@ func TestBuildGraphCreatesExpectedNodesAndEdges(t *testing.T) {
 		"fmt": true,
 	}
 
-	g, err := BuildGraph(pkgs, []string{"github.com/test/repo/root"}, []string{})
+	opts := GraphOptions{
+		Packages: pkgs.PackageList,
+		Roots:    pkgs.ImportPaths(),
+	}
+
+	g, err := opts.BuildGraph()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -139,26 +158,19 @@ func TestBuildGraphCreatesExpectedNodesAndEdges(t *testing.T) {
 	}
 }
 
-func TestBuildGraphErrorsOnMissingRoot(t *testing.T) {
-	_, err := BuildGraph(pkgs, []string{"invalid/root/import/path"}, []string{})
-	if err == nil {
-		t.Fatalf("expecting error, but saw none")
-	}
-
-	expected := "no corresponding node found for the root name"
-	actual := err.Error()
-	if !strings.Contains(actual, expected) {
-		t.Fatalf("unexpected error message. Expecting %q but saw %q", expected, actual)
-	}
-}
-
 func TestBuildGraphExcludesNodes(t *testing.T) {
 	excludes := []string{
 		"github.com/test/repo/pkg/three",
 		"github.com/test/repo/pkg/depends_on_fmt",
 	}
 
-	g, err := BuildGraph(pkgs, nil, excludes)
+	opts := GraphOptions{
+		Packages: pkgs.PackageList,
+		Roots:    pkgs.ImportPaths(),
+		Excludes: excludes,
+	}
+
+	g, err := opts.BuildGraph()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -179,33 +191,40 @@ func TestBuildGraphExcludesNodes(t *testing.T) {
 }
 
 func TestPackagesWithInvalidPathsAreOmitted(t *testing.T) {
-	pkgList := &PackageList{
-		Packages: []Package{
-			{
-				Dir:        "/path/to/github.com/test/repo/invalid",
-				ImportPath: "invalid/import/path1",
-				Imports: []string{
-					"fmt",
-					"invalid.import.path2",
-					"invalid.import.path3",
+	pkgList := &TestPackageList{
+		&PackageList{
+			Packages: []Package{
+				{
+					Dir:        "/path/to/github.com/test/repo/invalid",
+					ImportPath: "invalid/import/path1",
+					Imports: []string{
+						"fmt",
+						"invalid.import.path2",
+						"invalid.import.path3",
+					},
 				},
-			},
-			{
-				Dir:        "/path/to/github.com/test/repo/invalid",
-				ImportPath: "invalid.import.path2",
-				Imports: []string{
-					"net",
-					"encoding/json",
+				{
+					Dir:        "/path/to/github.com/test/repo/invalid",
+					ImportPath: "invalid.import.path2",
+					Imports: []string{
+						"net",
+						"encoding/json",
+					},
 				},
-			},
-			{
-				Dir:        "/path/to/github.com/test/repo/invalid",
-				ImportPath: "invalid3",
+				{
+					Dir:        "/path/to/github.com/test/repo/invalid",
+					ImportPath: "invalid3",
+				},
 			},
 		},
 	}
 
-	g, err := BuildGraph(pkgList, nil, []string{})
+	opts := GraphOptions{
+		Packages: pkgList.PackageList,
+		Roots:    pkgList.ImportPaths(),
+	}
+
+	g, err := opts.BuildGraph()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -216,18 +235,25 @@ func TestPackagesWithInvalidPathsAreOmitted(t *testing.T) {
 }
 
 func TestLabelNamesForVendoredNodes(t *testing.T) {
-	pkgList := &PackageList{
-		Packages: []Package{
-			{
-				Dir:        "/path/to/github.com/test/repo/vendor/github.com/testvendor/vendor_one",
-				ImportPath: "github.com/test/repo/vendor/github.com/testvendor/vendor_one",
+	pkgList := &TestPackageList{
+		&PackageList{
+			Packages: []Package{
+				{
+					Dir:        "/path/to/github.com/test/repo/vendor/github.com/testvendor/vendor_one",
+					ImportPath: "github.com/test/repo/vendor/github.com/testvendor/vendor_one",
+				},
 			},
 		},
 	}
 
 	expectedLabelName := "github.com/testvendor/vendor_one"
 
-	g, err := BuildGraph(pkgList, nil, []string{})
+	opts := GraphOptions{
+		Packages: pkgList.PackageList,
+		Roots:    pkgList.ImportPaths(),
+	}
+
+	g, err := opts.BuildGraph()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -241,7 +267,8 @@ func TestLabelNamesForVendoredNodes(t *testing.T) {
 		t.Fatalf("expected node %v to be of type *depgraph.Node", node)
 	}
 
-	if node.LabelName != expectedLabelName {
-		t.Fatalf("expected node label name to be %q but was %q", expectedLabelName, node.LabelName)
+	actualLabelName := labelNameForNode(node.UniqueName)
+	if actualLabelName != expectedLabelName {
+		t.Fatalf("expected node label name to be %q but was %q", expectedLabelName, actualLabelName)
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/openshift/origin/pull/18625

Wire through the `./depcheck trace` command. Optionally receives a file containing a list of import paths to squash.

Some output generated by it:
```bash
./depcheck trace --root=github.com/openshift/origin --entry=cmd --entry=pkg --exclude=./tools/depcheck/examples/origin_excludes.json --filter=./tools/depcheck/examples/origin_filters.json > graph.dot
```

[Contents of graph.dot](https://gist.github.com/juanvallejo/f962f5493031b601c8e461862fb23dd4)
[Contents of graph.png](https://gist.github.com/juanvallejo/c0dac021691d9d14d21eeb3eebff2aa4)

*Note* the above graph is using the smaller set of filters from `examples/origin_filters.json`, displaying ~50 nodes and only using `pkg` and `cmd` as entrypoints.

[Render of the graph, using the same command but with the full list of package filters](https://gist.github.com/juanvallejo/d27f41857d30a8bbf2023f8d5e549517) (about 247 nodes)

cc @deads2k 