### PR TITLE
UPSTREAM: 59386: Scheduler - not able to read from config file if configmap not found

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/server.go
@@ -214,7 +214,7 @@ func (o *Options) applyDeprecatedHealthzPortToConfig() {
 // 3. --algorithm-provider to use a named algorithm provider.
 func (o *Options) applyDeprecatedAlgorithmSourceOptionsToConfig() {
 	switch {
-	case o.useLegacyPolicyConfig:
+	case o.useLegacyPolicyConfig || (len(o.policyConfigFile) > 0 && o.policyConfigMapName == ""):
 		o.config.AlgorithmSource = componentconfig.SchedulerAlgorithmSource{
 			Policy: &componentconfig.SchedulerPolicySource{
 				File: &componentconfig.SchedulerPolicyFileSource{


### PR DESCRIPTION
Scheduler is not able to read from config file if configmap is not found. 

Upstream PR: https://github.com/kubernetes/kubernetes/pull/59386

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1540785

/cc @aveshagarwal  @sjenning 