### PR TITLE
Add DOCKER_SERVICE to master system-container

### DIFF
--- a/images/origin/system-container/manifest.json
+++ b/images/origin/system-container/manifest.json
@@ -5,7 +5,7 @@
         "ORIGIN_CONFIG_DIR": "/etc/origin",
         "ORIGIN_DATA_DIR": "/var/lib/origin",
         "ETCD_SERVICE": "etcd.service",
-        "NODE_SERVICE": "atomic-openshift-node.service"
+        "NODE_SERVICE": "atomic-openshift-node.service",
+        "DOCKER_SERVICE": "docker.service"
     }
 }
-

--- a/images/origin/system-container/service.template
+++ b/images/origin/system-container/service.template
@@ -15,4 +15,4 @@ WorkingDirectory=$DESTDIR
 RuntimeDirectory=${NAME}
 
 [Install]
-WantedBy=docker.service
+WantedBy=${DOCKER_SERVICE}


### PR DESCRIPTION
This commit adds DOCKER_SERVICE variable to
the origin master service unit templates
for system containers.

Needed-by: https://github.com/openshift/openshift-ansible/pull/7031
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1542324