### PR TITLE
automatically remove hostsubnets with no nodes on startup

### DIFF
--- a/pkg/network/apis/network/plugin.go
+++ b/pkg/network/apis/network/plugin.go
@@ -9,6 +9,7 @@ const (
 	// HostSubnet annotations. (Note: should be "hostsubnet.network.openshift.io/", but the incorrect name is now part of the API.)
 	AssignHostSubnetAnnotation = "pod.network.openshift.io/assign-subnet"
 	FixedVNIDHostAnnotation    = "pod.network.openshift.io/fixed-vnid-host"
+	NodeUIDAnnotation          = "pod.network.openshift.io/node-uid"
 
 	// NetNamespace annotations
 	MulticastEnabledAnnotation = "netnamespace.network.openshift.io/multicast-enabled"


### PR DESCRIPTION
openshift deletes a nodes hostsubnet automatically but during startup there is a window before the watches start that a node can be deleted and we miss the event for the deletion of the hostsubnet. At the end of startup look through the list of hostsubnets and make sure there is an accompanying node, if no node is found delete it.

Bug [1470612](https://bugzilla.redhat.com/show_bug.cgi?id=1470612)