### PR TITLE
Parametrize local-storage template with image name

### DIFF
--- a/examples/storage-examples/local-examples/README.md
+++ b/examples/storage-examples/local-examples/README.md
@@ -127,15 +127,15 @@ provisioner!
 
 The provisioner is installed from OpenShift template that's available at https://raw.githubusercontent.com/jsafrane/origin/local-storage/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml.
 
-1. Prepare a service account that will be able to run pods as root user and use
-   HostPath volumes:
+1. Prepare a service account that will be able to run pods as root user, use
+   HostPath volumes and run with any SELinux context:
    ```bash
    oc create serviceaccount local-storage-admin
-   oc adm policy add-scc-to-user hostmount-anyuid -z local-storage-admin
+   oc adm policy add-scc-to-user privileged -z local-storage-admin
    ```
-   Root privileges are necessary for the provisioner pod so it can delete any
-   content on the local volumes. HostPath is necessary to access
-   `/mnt/local-storage` on the host.
+   Root privileges and any SELinux context are necessary for the provisioner
+   pod so it can delete any content on the local volumes. HostPath is necessary
+   to access `/mnt/local-storage` on the host.
 
 2. Install the template:
    ```bash

--- a/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml
+++ b/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml
@@ -57,19 +57,24 @@ objects:
                 fieldPath: metadata.namespace
           - name: VOLUME_CONFIG_NAME
             value: ${CONFIGMAP}
-          image: quay.io/external_storage/local-volume-provisioner:v1.0.1
+          image: ${PROVISIONER_IMAGE}
           name: provisioner
           securityContext:
             runAsUser: 0
           volumeMounts:
           - mountPath: /mnt/local-storage
             name: local-storage
+          - mountPath: /etc/provisioner/config
+            name: provisioner-config
+            readOnly: true
         serviceAccountName: "${SERVICE_ACCOUNT}"
         volumes:
         - hostPath:
             path: /mnt/local-storage
           name: local-storage
-
+        - configMap:
+            name: ${CONFIGMAP}
+          name: provisioner-config
 
 parameters:
   - name: SERVICE_ACCOUNT
@@ -84,3 +89,7 @@ parameters:
     description: Name of ConfigMap with local provisioner configuration.
     required: true
     value: local-storage-admin
+  - name: PROVISIONER_IMAGE
+    description: Name of image with local provisioner.
+    required: true
+    value: quay.io/external_storage/local-volume-provisioner:v1.0.1

--- a/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml
+++ b/examples/storage-examples/local-examples/local-storage-provisioner-template.yaml
@@ -61,6 +61,9 @@ objects:
           name: provisioner
           securityContext:
             runAsUser: 0
+            seLinuxOptions:
+              # Trump SELinux contexts of all pods that could write files to local volume - the provisioner must be able to clean their files.
+              level: "s0:c0.c1023"
           volumeMounts:
           - mountPath: /mnt/local-storage
             name: local-storage


### PR DESCRIPTION
In addition, mount the config map to provisioner to support newer upstream
provisioners.

This partly fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540848

/assign @rootfs 
(you can approve there)