### PR TITLE
UPSTREAM: 59506: fix watch on multiple reqs

### DIFF
--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -37,5 +37,11 @@ os::cmd::expect_success_and_not_text 'oc get users test-user-1' "customlabel=tru
 # test structured and unstructured resources print generically without panic
 os::cmd::expect_success_and_text 'oc get projectrequests -o yaml' 'status: Success'
 os::cmd::expect_success_and_text 'oc get projectrequests,svc,pod -o yaml' 'kind: List'
+# test --wacth does not result in an error when a resource list is served in multiple chunks
+os::cmd::expect_success 'oc create cm cmone'
+os::cmd::expect_success 'oc create cm cmtwo'
+os::cmd::expect_success 'oc create cm cmthree'
+os::cmd::expect_success_and_not_text 'oc get configmap --chunk-size=1 --watch --request-timeout=1s' 'watch is only supported on individual resources'
+os::cmd::expect_success_and_not_text 'oc get configmap --chunk-size=1 --watch-only --request-timeout=1s' 'watch is only supported on individual resources'
 echo "oc get: ok"
 os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/resource/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/resource/get.go
@@ -467,8 +467,25 @@ func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []s
 	if err != nil {
 		return err
 	}
-	if len(infos) != 1 {
-		return i18n.Errorf("watch is only supported on individual resources and resource collections - %d resources were found", len(infos))
+	if len(infos) > 1 {
+		gvk := infos[0].Mapping.GroupVersionKind
+		uniqueGVKs := 1
+
+		// If requesting a resource count greater than a request's --chunk-size,
+		// we will end up making multiple requests to the server, with each
+		// request producing its own "Info" object. Although overall we are
+		// dealing with a single resource type, we will end up with multiple
+		// infos returned by the builder. To handle this case, only fail if we
+		// have at least one info with a different GVK than the others.
+		for _, info := range infos {
+			if info.Mapping.GroupVersionKind != gvk {
+				uniqueGVKs++
+			}
+		}
+
+		if uniqueGVKs > 1 {
+			return i18n.Errorf("watch is only supported on individual resources and resource collections - %d resources were found", uniqueGVKs)
+		}
 	}
 
 	filterOpts := cmdutil.ExtractCmdPrintOptions(cmd, options.AllNamespaces)
@@ -577,7 +594,6 @@ func (options *GetOptions) printGeneric(printer printers.ResourcePrinter, r *res
 
 	var obj runtime.Object
 	if !singleItemImplied || len(infos) > 1 {
-		// we have more than one item, so coerce all items into a list
 		// we have more than one item, so coerce all items into a list.
 		// we don't want an *unstructured.Unstructured list yet, as we
 		// may be dealing with non-unstructured objects. Compose all items


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1537789

`oc get <resource> --watch` only supports watching a single resource kind at a time.
This check fails if more than one resource `Info` is returned.

When dealing with large quantities of a single resource kind, or an amount that exceeds the value of `--chunk-size`, more than one request is made to the server causing a resource `Info` to be created for each of the requests, ultimately causing the above check to fail even though we are dealing with the same type of resource.

This patch modifies that check to take into account the GVKs of all infos returned, and only fail if at least one differs.

cc @deads2k @jeremyeder 