### PR TITLE
fix the front proxy CA name

### DIFF
--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -183,7 +183,10 @@ func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 	if err != nil {
 		return err
 	}
-	getFrontProxySignerCertOptions, err := o.createNewSigner(FrontProxyCAFilePrefix)
+
+	frontProxyOptions := o
+	frontProxyOptions.SignerName = DefaultFrontProxySignerName()
+	getFrontProxySignerCertOptions, err := frontProxyOptions.createNewSigner(FrontProxyCAFilePrefix)
 	if err != nil {
 		return err
 	}
@@ -197,7 +200,7 @@ func (o CreateMasterCertsOptions) CreateMasterCerts() error {
 		func() error { return o.createProxyClientCerts(getSignerCertOptions) },
 		func() error { return o.createServiceAccountKeys() },
 		func() error { return o.createServiceSigningCA(getSignerCertOptions) },
-		func() error { return o.createAggregatorClientCerts(getFrontProxySignerCertOptions) },
+		func() error { return frontProxyOptions.createAggregatorClientCerts(getFrontProxySignerCertOptions) },
 	)
 	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -52,6 +52,10 @@ func DefaultKubeletClientCerts(certDir string) []ClientCertInfo {
 	}
 }
 
+func DefaultFrontProxySignerName() string {
+	return fmt.Sprintf("%s@%d", "aggregator-proxy-ca", time.Now().Unix())
+}
+
 func DefaultMasterKubeletClientCertInfo(certDir string) ClientCertInfo {
 	return ClientCertInfo{
 		CertLocation: configapi.CertInfo{


### PR DESCRIPTION
frontproxy-ca.crt was being generated with the same name as the OpenShift signer CA.
@openshift/sig-security 