### PR TITLE
spec: Use Requires: git-core if distribution is new enough

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -150,7 +150,12 @@ Provides:       tuned-profiles-%{name}-node
 %package clients
 Summary:        %{product_name} Client binaries for Linux
 Obsoletes:      openshift-clients < %{package_refector_version}
+# https://bugzilla.redhat.com/show_bug.cgi?id=1161251
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Requires:       git-core
+%else
 Requires:       git
+%endif
 Requires:       bash-completion
 
 %description clients


### PR DESCRIPTION
I am planning to propose we include `origin-clients` in Fedora Atomic
Workstation by default.

It was pointed out that that pulls in `git` which pulls in Perl.  A
while ago we added a `git-core` which is really all we need:
https://bugzilla.redhat.com/show_bug.cgi?id=1161251