### PR TITLE
Change the haproxy reload detection to tolerate routes named localhost

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -49,7 +49,7 @@ function haproxyHealthCheck() {
 
   echo " - Checking ${url} ..."
   while true; do
-    local httpcode=$(curl $timeout_opts -s -o /dev/null -I -w "%{http_code}" ${url})
+    local httpcode=$(curl $timeout_opts -s -o /dev/null -I -H "Host: " -w "%{http_code}" ${url})
 
     if [ "$httpcode" == "503" ]; then
       echo " - Health check ok : $retries retry attempt(s)."


### PR DESCRIPTION
This changes the reload-haproxy script to explicitly pass no hostname in the http headers so that if a route is created named 'localhost' the reload does not match that route.

Fixes bug 1542612 (https://bugzilla.redhat.com/show_bug.cgi?id=1542612)