### PR TITLE
change how extended network tests are selected/skipped

### DIFF
--- a/test/extended/cni_vendor_test.sh
+++ b/test/extended/cni_vendor_test.sh
@@ -2,12 +2,14 @@
 
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
-# Set this to false if the plugin does not implement NetworkPolicy
-export NETWORKING_E2E_NETWORKPOLICY="${NETWORKING_E2E_NETWORKPOLICY:-true}"
+# Uncomment this if the plugin does not implement NetworkPolicy:
 
-# Set this to true if the plugin implements isolation in the same manner as
-# redhat/openshift-ovs-multitenant
-export NETWORKING_E2E_ISOLATION="${NETWORKING_E2E_ISOLATION:-false}"
+# export NETWORKING_E2E_NETWORKPOLICY=false
+
+# Uncomment this if the plugin implements isolation in the same manner as
+# redhat/openshift-ovs-multitenant:
+
+# export NETWORKING_E2E_ISOLATION=true
 
 export NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-\[Area:Networking\]}"
 export NETWORKING_E2E_EXTERNAL=1

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -52,7 +52,6 @@ NETWORKING_E2E_MINIMAL="${NETWORKING_E2E_MINIMAL:-}"
 # Tests that are skipped when running networking-minimal.sh because they're slow
 # and unlikely to be broken by changes outside of the SDN code.
 MINIMAL_SKIP_LIST=(
-  "OVS"
   "multicast"
 )
 
@@ -60,10 +59,6 @@ NETWORKING_E2E_EXTERNAL="${NETWORKING_E2E_EXTERNAL:-}"
 
 # Tests that are are openshift-sdn-specific, so shouldn't be run against external plugins
 EXTERNAL_PLUGIN_SKIP_LIST=(
-  # Tests OpenShift-SDN-specific behavior. Would not necessarily apply even to other
-  # OVS-based plugins
-  "OVS"
-
   # Relies on an OpenShift-specific annotation, and is not a "required" feature for
   # network plugins
   "multicast"

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -130,8 +130,6 @@ TEST_FAILURES=0
 function test-osdn-plugin() {
   local name=$1
   local plugin=$2
-  local isolation=$3
-  local networkpolicy=$4
 
   os::log::info "Targeting ${name} plugin: ${plugin}"
 
@@ -146,9 +144,7 @@ function test-osdn-plugin() {
     export TEST_REPORT_FILE_NAME="${name}-junit"
 
     local kubeconfig="$(get-kubeconfig-from-root "${OPENSHIFT_CONFIG_ROOT}")"
-    if ! TEST_REPORT_FILE_NAME=networking_${name}_${isolation} \
-         NETWORKING_E2E_ISOLATION="${isolation}" \
-         NETWORKING_E2E_NETWORKPOLICY="${networkpolicy}" \
+    if ! TEST_REPORT_FILE_NAME=networking_${name} \
          run-extended-tests "${kubeconfig}" "${log_dir}/test.log"; then
       tests_failed=1
       os::log::error "e2e tests failed for plugin: ${plugin}"
@@ -372,13 +368,13 @@ else
   if [[ -z "${NETWORKING_E2E_MINIMAL}" ]]; then
     # Ignore deployment errors for a given plugin to allow other plugins
     # to be tested.
-    test-osdn-plugin "subnet" "redhat/openshift-ovs-subnet" "false" "false" || true
+    test-osdn-plugin "subnet" "redhat/openshift-ovs-subnet" || true
     if kernel-supports-networkpolicy; then
-      test-osdn-plugin "networkpolicy" "redhat/openshift-ovs-networkpolicy" "false" "true" || true
+      test-osdn-plugin "networkpolicy" "redhat/openshift-ovs-networkpolicy" || true
     else
       os::log::warning "Skipping networkpolicy tests due to kernel version"
     fi
   fi
 
-  test-osdn-plugin "multitenant" "redhat/openshift-ovs-multitenant" "true" "false" || true
+  test-osdn-plugin "multitenant" "redhat/openshift-ovs-multitenant" || true
 fi

--- a/test/extended/networking.sh
+++ b/test/extended/networking.sh
@@ -16,36 +16,7 @@ export SHELLOPTS
 #
 # The EmptyDir test is a canary; it will fail if mount propagation is
 # not properly configured on the host.
-NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-etworking|Services should be able to create a functioning NodePort service|Feature:OSNetworkPolicy|EmptyDir volumes should support \(root,0644,tmpfs\)}"
-NETWORKING_E2E_SKIP="${NETWORKING_E2E_SKIP:-}"
-
-DEFAULT_SKIP_LIST=(
-  # Requires lots of setup that this script doesn't so
-  "\[Feature:Federation\]"
-
-  # Skipped until https://github.com/openshift/origin/issues/11042 is resolved
-  "should preserve source pod IP for traffic thru service cluster IP"
-
-  # Panicing, needs investigation
-  "Networking IPerf"
-
-  # Skipped due to origin returning 403 for some of the urls
-  "should provide unchanging, static URL paths for kubernetes api services"
-
-  # DNS inside container fails in CI but works locally
-  "should provide Internet connection for containers"
-
-  # Skip tests that require GCE or AWS. (They'll skip themselves if we run them, but
-  # only after several seconds of setup.)
-  "should be able to up and down services"
-  "should work after restarting kube-proxy"
-  "should work after restarting apiserver"
-  "should be able to change the type and ports of a service"
-
-  # Assumes kube-proxy (aka OpenShift node) is serving /healthz at port 10249, which we currently
-  # have disabled
-  "Networking.*should check kube-proxy urls"
-)
+NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-Networking|Services|Feature:OSNetworkPolicy|EmptyDir volumes should support \(root,0644,tmpfs\)}"
 
 NETWORKING_E2E_MINIMAL="${NETWORKING_E2E_MINIMAL:-}"
 
@@ -210,16 +181,12 @@ function run-extended-tests() {
   local dlv_debug="${DLV_DEBUG:-}"
 
   local focus_regex="${NETWORKING_E2E_FOCUS}"
-  local skip_regex="${NETWORKING_E2E_SKIP}"
+  local skip_regex=""
 
-  if [[ -z "${skip_regex}" ]]; then
-    skip_regex="$(join '|' "${DEFAULT_SKIP_LIST[@]}")"
-    if [[ -n "${NETWORKING_E2E_MINIMAL}" ]]; then
-      skip_regex="${skip_regex}|$(join '|' "${MINIMAL_SKIP_LIST[@]}")"
-    fi
-    if [[ -n "${NETWORKING_E2E_EXTERNAL}" ]]; then
-      skip_regex="${skip_regex}|$(join '|' "${EXTERNAL_PLUGIN_SKIP_LIST[@]}")"
-    fi
+  if [[ -n "${NETWORKING_E2E_MINIMAL}" ]]; then
+    skip_regex="$(join '|' "${MINIMAL_SKIP_LIST[@]}")"
+  elif [[ -n "${NETWORKING_E2E_EXTERNAL}" ]]; then
+    skip_regex="$(join '|' "${EXTERNAL_PLUGIN_SKIP_LIST[@]}")"
   fi
 
   export KUBECONFIG="${kubeconfig}"

--- a/test/extended/networking/isolation.go
+++ b/test/extended/networking/isolation.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("[Area:Networking] network isolation", func() {
-	InSingleTenantContext(func() {
+	InNonIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-isolation1")
 		f2 := e2e.NewDefaultFramework("net-isolation2")
 
@@ -21,7 +21,7 @@ var _ = Describe("[Area:Networking] network isolation", func() {
 		})
 	})
 
-	InMultiTenantContext(func() {
+	InIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-isolation1")
 		f2 := e2e.NewDefaultFramework("net-isolation2")
 

--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("[Area:Networking] multicast", func() {
-	InSingleTenantContext(func() {
+	InNonIsolatingContext(func() {
 		oc := testexutil.NewCLI("multicast", testexutil.KubeConfigPath())
 		f := oc.KubeFramework()
 
@@ -27,7 +27,7 @@ var _ = Describe("[Area:Networking] multicast", func() {
 		})
 	})
 
-	InMultiTenantContext(func() {
+	InIsolatingContext(func() {
 		oc := testexutil.NewCLI("multicast", testexutil.KubeConfigPath())
 		f := oc.KubeFramework()
 

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -20,7 +20,7 @@ var _ = Describe("[Area:Networking] services", func() {
 		})
 	})
 
-	InSingleTenantContext(func() {
+	InNonIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-services1")
 		f2 := e2e.NewDefaultFramework("net-services2")
 
@@ -33,7 +33,7 @@ var _ = Describe("[Area:Networking] services", func() {
 		})
 	})
 
-	InMultiTenantContext(func() {
+	InIsolatingContext(func() {
 		f1 := e2e.NewDefaultFramework("net-services1")
 		f2 := e2e.NewDefaultFramework("net-services2")
 

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -364,7 +364,7 @@ func checkServiceConnectivity(serverFramework, clientFramework *e2e.Framework, n
 	return checkConnectivityToHost(clientFramework, clientNode.Name, "service-wget", ip, 10*time.Second)
 }
 
-func InSingleTenantContext(body func()) {
+func InNonIsolatingContext(body func()) {
 	Context("when using a plugin that does not isolate namespaces by default", func() {
 		BeforeEach(func() {
 			if pluginIsolatesNamespaces() {
@@ -376,7 +376,7 @@ func InSingleTenantContext(body func()) {
 	})
 }
 
-func InMultiTenantContext(body func()) {
+func InIsolatingContext(body func()) {
 	Context("when using a plugin that isolates namespaces by default", func() {
 		BeforeEach(func() {
 			if !pluginIsolatesNamespaces() {

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -3,9 +3,11 @@ package networking
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/network"
 	networkclient "github.com/openshift/origin/pkg/network/generated/internalclientset"
 	testexutil "github.com/openshift/origin/test/extended/util"
 	testutil "github.com/openshift/origin/test/util"
@@ -252,12 +254,42 @@ func checkConnectivityToHost(f *e2e.Framework, nodeName string, podName string, 
 	return savedErr
 }
 
+var cachedNetworkPluginName *string
+
+func networkPluginName() string {
+	if cachedNetworkPluginName == nil {
+		// We don't use testexutil.NewCLI() here because it can't be called from BeforeEach()
+		out, err := exec.Command(
+			"oc", "--config="+testexutil.KubeConfigPath(),
+			"get", "clusternetwork", "default",
+			"--template={{.pluginName}}",
+		).CombinedOutput()
+		pluginName := string(out)
+		if err != nil {
+			e2e.Logf("Could not check network plugin name: %v. Assuming a non-OpenShift plugin", err)
+			pluginName = ""
+		}
+		cachedNetworkPluginName = &pluginName
+	}
+	return *cachedNetworkPluginName
+}
+
 func pluginIsolatesNamespaces() bool {
-	return os.Getenv("NETWORKING_E2E_ISOLATION") == "true"
+	if os.Getenv("NETWORKING_E2E_ISOLATION") == "true" {
+		return true
+	}
+	// Assume that only the OpenShift SDN "multitenant" plugin isolates by default
+	return networkPluginName() == network.MultiTenantPluginName
 }
 
 func pluginImplementsNetworkPolicy() bool {
-	return os.Getenv("NETWORKING_E2E_NETWORKPOLICY") == "true"
+	if os.Getenv("NETWORKING_E2E_NETWORKPOLICY") == "false" {
+		return false
+	}
+	// Assume that all plugins except the OpenShift SDN "subnet" and "multitenant"
+	// plugins implement NetworkPolicy
+	return networkPluginName() != network.SingleTenantPluginName &&
+		networkPluginName() != network.MultiTenantPluginName
 }
 
 func makeNamespaceGlobal(ns *corev1.Namespace) {

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -339,9 +339,6 @@ var (
 		`should create and stop a working application`,
 		//`should always delete fast`, // will be uncommented in etcd3
 
-		// tested by networking.sh and requires the environment that script sets up
-		`\[networking\] OVS`,
-
 		// We don't install KubeDNS
 		`should check if Kubernetes master services is included in cluster-info`,
 


### PR DESCRIPTION
Currently the extended networking test requires you to set `NETWORKING_E2E_ISOLATION=true` when using the multitenant plugin, and `NETWORKING_E2E_NETWORKPOLICY=true` when using the networkpolicy plugin (or a third-party plugin). This changes it to just check the active network plugin at runtime, and select the right tests automatically based on that. Which means

1. When running the tests against an installed cluster with `OPENSHIFT_TEST_KUBECONFIG=... ./test/extended/networking.sh`, you don't have to also set the correct additional environment variables.
2. We can change conformance_gce to install multitenant rather than subnet, and the tests will adapt themselves correctly automatically.

I know at some point someone said we were supposed to decide what tests to do based on labels or whatever, but the checking-at-runtime approach seems to be more inline with, eg, `framework.SkipUnlessNodeCountIsAtLeast()`, `framework.SkipUnlessLocalEphemeralStorageEnabled()`, `framework.SkipUnlessNodeOSDistroIs()`, etc.