### PR TITLE
host diagnostics: update master unit names

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics/systemd/locate_units.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/systemd/locate_units.go
@@ -30,7 +30,7 @@ func GetSystemdUnits(logger *log.Logger) map[string]types.SystemdUnit {
 	}
 
 	logger.Notice("DS1001", "Performing systemd discovery")
-	for _, name := range []string{"origin-master", "origin-node", "atomic-openshift-master", "atomic-openshift-node", "docker", "openvswitch", "iptables", "etcd", "kubernetes"} {
+	for _, name := range []string{"origin-master-controllers", "origin-master-api", "origin-node", "atomic-openshift-master-controllers", "atomic-openshift-master-api", "atomic-openshift-node", "docker", "openvswitch", "iptables", "etcd", "kubernetes"} {
 		systemdUnits[name] = discoverSystemdUnit(logger, name)
 
 		if systemdUnits[name].Exists {

--- a/pkg/oc/admin/diagnostics/diagnostics/systemd/systemd.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/systemd/systemd.go
@@ -60,7 +60,7 @@ var tlsClientErrorSeen map[string]bool
 // Specify what units we can check and what to look for and say about it
 var unitLogSpecs = []*unitSpec{
 	{
-		Names:      []string{"origin-master", "atomic-openshift-master"},
+		Names:      []string{"origin-master-api", "atomic-openshift-master-api"},
 		StartMatch: regexp.MustCompile("Starting \\w+ Master"),
 		LogMatchers: []logMatcher{
 			badImageTemplate,

--- a/pkg/oc/admin/diagnostics/diagnostics/systemd/unit_status.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/systemd/unit_status.go
@@ -39,12 +39,12 @@ func (d UnitStatus) Check() types.DiagnosticResult {
 	unitRequiresUnit(r, d.SystemdUnits["atomic-openshift-node"], d.SystemdUnits["iptables"], nodeRequiresIPTables)
 	unitRequiresUnit(r, d.SystemdUnits["atomic-openshift-node"], d.SystemdUnits["docker"], `Nodes use Docker to run containers.`)
 	unitRequiresUnit(r, d.SystemdUnits["atomic-openshift-node"], d.SystemdUnits["openvswitch"], fmt.Sprintf(sdUnitSDNreqOVS, "atomic-openshift-node"))
-	unitRequiresUnit(r, d.SystemdUnits["atomic-openshift-master"], d.SystemdUnits["atomic-openshift-node"], `Masters must currently also be nodes for access to cluster SDN networking`)
+	unitRequiresUnit(r, d.SystemdUnits["atomic-openshift-master-api"], d.SystemdUnits["atomic-openshift-node"], `Masters must currently also be nodes for access to cluster SDN networking`)
 
 	unitRequiresUnit(r, d.SystemdUnits["origin-node"], d.SystemdUnits["iptables"], nodeRequiresIPTables)
 	unitRequiresUnit(r, d.SystemdUnits["origin-node"], d.SystemdUnits["docker"], `Nodes use Docker to run containers.`)
 	unitRequiresUnit(r, d.SystemdUnits["origin-node"], d.SystemdUnits["openvswitch"], fmt.Sprintf(sdUnitSDNreqOVS, "origin-node"))
-	unitRequiresUnit(r, d.SystemdUnits["origin-master"], d.SystemdUnits["origin-node"], `Masters must currently also be nodes for access to cluster SDN networking`)
+	unitRequiresUnit(r, d.SystemdUnits["origin-master-api"], d.SystemdUnits["origin-node"], `Masters must currently also be nodes for access to cluster SDN networking`)
 
 	// Anything that is enabled but not running deserves notice
 	for name, unit := range d.SystemdUnits {


### PR DESCRIPTION
Finally bringing diagnostics systemd unit names into parity with the actual names being used.
Tracking bug https://bugzilla.redhat.com/show_bug.cgi?id=1378883