### PR TITLE
Fix cleanup of auto egress IPs when deleting a NetNamespace

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -298,8 +298,9 @@ func (eip *egressIPWatcher) deleteNamespaceEgress(vnid uint32) {
 
 	if ns.assignedIP != "" {
 		ns.requestedIP = ""
-		eip.deleteEgressIP(ns.assignedIP)
-		delete(eip.namespacesByEgressIP, ns.assignedIP)
+		egressIP := ns.assignedIP
+		eip.deleteEgressIP(egressIP)
+		delete(eip.namespacesByEgressIP, egressIP)
 	}
 	delete(eip.namespacesByVNID, vnid)
 }


### PR DESCRIPTION
When deleting a NetNamespace, we weren't cleaning up all of the state correctly because we tried to make use of a struct field after its value had been cleared, meaning that complicated sequences of egress IP operations could result in junk rules getting added to OVS.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543786