### PR TITLE
Make it clear deprecation apply also for later servers

### DIFF
--- a/pkg/oc/admin/migrate/authorization/authorization.go
+++ b/pkg/oc/admin/migrate/authorization/authorization.go
@@ -74,7 +74,7 @@ func NewCmdMigrateAuthorization(name, fullName string, f *clientcmd.Factory, in 
 			kcmdutil.CheckErr(options.Validate())
 			kcmdutil.CheckErr(options.Run())
 		},
-		Deprecated: fmt.Sprintf("will not work against 3.7 servers"),
+		Deprecated: fmt.Sprintf("will not work against 3.7 or later servers"),
 	}
 	return cmd
 }

--- a/pkg/oc/cli/cmd/create/policy_binding.go
+++ b/pkg/oc/cli/cmd/create/policy_binding.go
@@ -54,7 +54,7 @@ func NewCmdCreatePolicyBinding(name, fullName string, f *clientcmd.Factory, out 
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
-		Deprecated: fmt.Sprintf("will not work against 3.7 servers. Use (Cluster)RoleBindings instead."),
+		Deprecated: fmt.Sprintf("will not work against 3.7 or later servers. Use (Cluster)RoleBindings instead."),
 	}
 	cmdutil.AddOutputFlagsForMutation(cmd)
 	return cmd


### PR DESCRIPTION
Deprecated commands that do not work against 3.7 server will obviously fail
against later servers. Make it crystal clear.