### PR TITLE
CRO admission plugin: never mutate below namespace minimums

### DIFF
--- a/pkg/quota/admission/clusterresourceoverride/admission.go
+++ b/pkg/quota/admission/clusterresourceoverride/admission.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -60,10 +59,8 @@ type clusterResourceOverridePlugin struct {
 	ProjectCache *cache.ProjectCache
 	LimitRanger  admission.Interface
 }
-type limitRangerActions struct{}
 
 var _ = oadmission.WantsProjectCache(&clusterResourceOverridePlugin{})
-var _ = limitranger.LimitRangerActions(&limitRangerActions{})
 var _ = kadmission.WantsInternalKubeInformerFactory(&clusterResourceOverridePlugin{})
 var _ = kadmission.WantsInternalKubeClientSet(&clusterResourceOverridePlugin{})
 
@@ -98,20 +95,6 @@ func (d *clusterResourceOverridePlugin) SetInternalKubeInformerFactory(i informe
 
 func (d *clusterResourceOverridePlugin) SetInternalKubeClientSet(c kclientset.Interface) {
 	d.LimitRanger.(kadmission.WantsInternalKubeClientSet).SetInternalKubeClientSet(c)
-}
-
-// these serve to satisfy the interface so that our kept LimitRanger limits nothing and only provides defaults.
-func (d *limitRangerActions) SupportsAttributes(a admission.Attributes) bool {
-	return true
-}
-func (d *limitRangerActions) SupportsLimit(limitRange *kapi.LimitRange) bool {
-	return true
-}
-func (d *limitRangerActions) MutateLimit(limitRange *kapi.LimitRange, resourceName string, obj runtime.Object) error {
-	return nil
-}
-func (d *limitRangerActions) ValidateLimit(limitRange *kapi.LimitRange, resourceName string, obj runtime.Object) error {
-	return nil
 }
 
 func (a *clusterResourceOverridePlugin) SetProjectCache(projectCache *cache.ProjectCache) {


### PR DESCRIPTION
Update the ClusterResourceOverride admission plugin to never mutate
container resource requirements below the floor specified by any
LimitRange from the same namespace.

Reason:

- Web console stripped out cluster resource override config awareness,
  but the user experience is broken right now when users select a
  memory limit that is the floor of the LimitRange value.

- You can see this on free-int by setting a memory limit of 100Mi,
  your deployment will not work because we allowed
  ClusterResourceOverride to go below the LimitRange floor.

The implication of this change is the over-commit ratio is skewed at
the lower end of the resource consumption scale (but honestly, that
makes sense).