### PR TITLE
UPSTREAM: 59669: add request-timeout port-forward

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/portforward.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/portforward.go
@@ -23,11 +23,13 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -46,8 +48,11 @@ type PortForwardOptions struct {
 	PodClient     coreclient.PodsGetter
 	Ports         []string
 	PortForwarder portForwarder
+	Timeout       time.Duration
 	StopChannel   chan struct{}
 	ReadyChannel  chan struct{}
+
+	errOut io.Writer
 }
 
 var (
@@ -68,6 +73,8 @@ func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Comma
 			cmdOut: cmdOut,
 			cmdErr: cmdErr,
 		},
+
+		errOut: cmdErr,
 	}
 	cmd := &cobra.Command{
 		Use:     "port-forward POD [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
@@ -148,6 +155,13 @@ func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, arg
 		return err
 	}
 
+	unparsedTimeout := cmdutil.GetFlagString(cmd, "request-timeout")
+	timeout, err := clientcmd.ParseTimeout(unparsedTimeout)
+	if err != nil {
+		return err
+	}
+	o.Timeout = timeout
+
 	o.StopChannel = make(chan struct{}, 1)
 	o.ReadyChannel = make(chan struct{})
 	return nil
@@ -190,6 +204,16 @@ func (o PortForwardOptions) RunPortForward() error {
 			close(o.StopChannel)
 		}
 	}()
+
+	if o.Timeout > 0 {
+		go func() {
+			select {
+			case <-time.After(o.Timeout):
+				fmt.Fprintf(o.errOut, "info: timed out request after %v\n", o.Timeout)
+				o.StopChannel <- struct{}{}
+			}
+		}()
+	}
 
 	req := o.RESTClient.Post().
 		Resource("pods").


### PR DESCRIPTION
UPSTREAM: https://github.com/kubernetes/kubernetes/pull/59669
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543797

Leverages the existing `--request-timeout` flag to add timeout support to `port-forward`.
```
$ oc port-forward mypod 8080:8080 --request-timeout=1s
Forwarding from 127.0.0.1:8080 -> 8080
info: timed out request after 1s
```

cc @deads2k 