### PR TITLE
JenkinsPipelineStrategy builds should not be pruned on BuildConfig save

### DIFF
--- a/pkg/build/controller/common/util.go
+++ b/pkg/build/controller/common/util.go
@@ -43,6 +43,11 @@ func HandleBuildPruning(buildConfigName string, namespace string, buildLister bu
 		return err
 	}
 
+	if buildConfig.Spec.Strategy.JenkinsPipelineStrategy != nil {
+		glog.V(4).Infof("Build pruning for %s/%s is handled by Jenkins, skipping.", buildConfig.Namespace, buildConfig.Name)
+		return nil
+	}
+
 	var buildsToDelete []*buildapi.Build
 	var errList []error
 


### PR DESCRIPTION
JenkinsPipelineStrategy builds should only be pruned by Jenkins
and not the default build pruning logic including saving the
BuildConfig.