### PR TITLE
Fix invalid SuggestFor for oc image

### DIFF
--- a/pkg/oc/cli/cmd/importimage.go
+++ b/pkg/oc/cli/cmd/importimage.go
@@ -49,11 +49,10 @@ var (
 func NewCmdImportImage(fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
 	opts := &ImportImageOptions{}
 	cmd := &cobra.Command{
-		Use:        "import-image IMAGESTREAM[:TAG]",
-		Short:      "Imports images from a Docker registry",
-		Long:       importImageLong,
-		Example:    fmt.Sprintf(importImageExample, fullName),
-		SuggestFor: []string{"image"},
+		Use:     "import-image IMAGESTREAM[:TAG]",
+		Short:   "Imports images from a Docker registry",
+		Long:    importImageLong,
+		Example: fmt.Sprintf(importImageExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(opts.Complete(f, cmd, args, fullName, out, errout))
 			kcmdutil.CheckErr(opts.Validate(cmd))

--- a/pkg/oc/cli/cmd/wrappers.go
+++ b/pkg/oc/cli/cmd/wrappers.go
@@ -480,7 +480,6 @@ func NewCmdRun(fullName string, f *clientcmd.Factory, in io.Reader, out, errout 
 	cmd := kcmd.NewCmdRunWithOptions(f, opts, in, out, errout)
 	cmd.Long = runLong
 	cmd.Example = fmt.Sprintf(runExample, fullName)
-	cmd.SuggestFor = []string{"image"}
 	cmd.Flags().Set("generator", "")
 	cmd.Flag("generator").Usage = "The name of the API generator to use.  Default is 'deploymentconfig/v1' if --restart=Always, otherwise the default is 'run-pod/v1'."
 	cmd.Flag("generator").DefValue = ""


### PR DESCRIPTION
This patch has tiny changes as:

- Replace `oc image` with `oc start` for the suggestion for `oc run`
- Remove `oc image` from the suggetion for `oc import-image`

`oc import` is already existing command, so current `SuggestFor:
[]string{"image"}` is not working.
