### PR TITLE
Return NotFound error when removing some of non-existing resources 

### DIFF
--- a/pkg/authorization/reaper/cluster_role.go
+++ b/pkg/authorization/reaper/cluster_role.go
@@ -9,7 +9,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl"
 
-	authapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"
 )
 
@@ -55,9 +54,6 @@ func (r *ClusterRoleReaper) Stop(namespace, name string, timeout time.Duration, 
 	}
 
 	if err := r.roleClient.ClusterRoles().Delete(name, &metav1.DeleteOptions{}); err != nil {
-		if kerrors.IsNotFound(err) {
-			return kerrors.NewNotFound(authapi.Resource("clusterrole"), name)
-		}
 		return err
 	}
 

--- a/pkg/authorization/reaper/cluster_role.go
+++ b/pkg/authorization/reaper/cluster_role.go
@@ -53,9 +53,8 @@ func (r *ClusterRoleReaper) Stop(namespace, name string, timeout time.Duration, 
 		}
 	}
 
-	if err := r.roleClient.ClusterRoles().Delete(name, &metav1.DeleteOptions{}); err != nil {
+	if _, err := r.roleClient.ClusterRoles().Get(name, metav1.GetOptions{}); err != nil {
 		return err
 	}
-
-	return nil
+	return r.roleClient.ClusterRoles().Delete(name, &metav1.DeleteOptions{})
 }

--- a/pkg/authorization/reaper/cluster_role.go
+++ b/pkg/authorization/reaper/cluster_role.go
@@ -9,6 +9,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl"
 
+	authapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"
 )
 
@@ -53,7 +54,10 @@ func (r *ClusterRoleReaper) Stop(namespace, name string, timeout time.Duration, 
 		}
 	}
 
-	if err := r.roleClient.ClusterRoles().Delete(name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.roleClient.ClusterRoles().Delete(name, &metav1.DeleteOptions{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return kerrors.NewNotFound(authapi.Resource("clusterrole"), name)
+		}
 		return err
 	}
 

--- a/pkg/authorization/reaper/role.go
+++ b/pkg/authorization/reaper/role.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubectl"
 
-	authapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"
 )
 
@@ -41,9 +40,6 @@ func (r *RoleReaper) Stop(namespace, name string, timeout time.Duration, gracePe
 	}
 
 	if err := r.roleClient.Roles(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
-		if kerrors.IsNotFound(err) {
-			return kerrors.NewNotFound(authapi.Resource("role"), name)
-		}
 		return err
 	}
 

--- a/pkg/authorization/reaper/role.go
+++ b/pkg/authorization/reaper/role.go
@@ -39,9 +39,8 @@ func (r *RoleReaper) Stop(namespace, name string, timeout time.Duration, gracePe
 		}
 	}
 
-	if err := r.roleClient.Roles(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
+	if _, err := r.roleClient.Roles(namespace).Get(name, metav1.GetOptions{}); err != nil {
 		return err
 	}
-
-	return nil
+	return r.roleClient.Roles(namespace).Delete(name, &metav1.DeleteOptions{})
 }

--- a/pkg/authorization/reaper/role.go
+++ b/pkg/authorization/reaper/role.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubectl"
 
+	authapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"
 )
 
@@ -39,7 +40,10 @@ func (r *RoleReaper) Stop(namespace, name string, timeout time.Duration, gracePe
 		}
 	}
 
-	if err := r.roleClient.Roles(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.roleClient.Roles(namespace).Delete(name, &metav1.DeleteOptions{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return kerrors.NewNotFound(authapi.Resource("role"), name)
+		}
 		return err
 	}
 

--- a/pkg/user/reaper/group.go
+++ b/pkg/user/reaper/group.go
@@ -11,6 +11,7 @@ import (
 
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	securitytypedclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
+	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
 
@@ -70,7 +71,10 @@ func (r *GroupReaper) Stop(namespace, name string, timeout time.Duration, graceP
 	}
 
 	// Remove the group
-	if err := r.groupClient.User().Groups().Delete(name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.groupClient.User().Groups().Delete(name, &metav1.DeleteOptions{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return kerrors.NewNotFound(userapi.Resource("group"), name)
+		}
 		return err
 	}
 

--- a/pkg/user/reaper/group.go
+++ b/pkg/user/reaper/group.go
@@ -11,7 +11,6 @@ import (
 
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	securitytypedclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
-	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
 
@@ -72,9 +71,6 @@ func (r *GroupReaper) Stop(namespace, name string, timeout time.Duration, graceP
 
 	// Remove the group
 	if err := r.groupClient.User().Groups().Delete(name, &metav1.DeleteOptions{}); err != nil {
-		if kerrors.IsNotFound(err) {
-			return kerrors.NewNotFound(userapi.Resource("group"), name)
-		}
 		return err
 	}
 

--- a/pkg/user/reaper/group.go
+++ b/pkg/user/reaper/group.go
@@ -69,10 +69,9 @@ func (r *GroupReaper) Stop(namespace, name string, timeout time.Duration, graceP
 		}
 	}
 
-	// Remove the group
-	if err := r.groupClient.User().Groups().Delete(name, &metav1.DeleteOptions{}); err != nil {
+	if _, err := r.groupClient.User().Groups().Get(name, metav1.GetOptions{}); err != nil {
 		return err
 	}
-
-	return nil
+	// Remove the group
+	return r.groupClient.User().Groups().Delete(name, &metav1.DeleteOptions{})
 }

--- a/pkg/user/reaper/user.go
+++ b/pkg/user/reaper/user.go
@@ -116,10 +116,9 @@ func (r *UserReaper) Stop(namespace, name string, timeout time.Duration, gracePe
 	// The user does not "own" the identities
 	// If the admin wants to remove the identities, that is a distinct operation
 
-	// Remove the user
-	if err := r.userClient.User().Users().Delete(name, &metav1.DeleteOptions{}); err != nil {
+	if _, err := r.userClient.User().Users().Get(name, metav1.GetOptions{}); err != nil {
 		return err
 	}
-
-	return nil
+	// Remove the user
+	return r.userClient.User().Users().Delete(name, &metav1.DeleteOptions{})
 }

--- a/pkg/user/reaper/user.go
+++ b/pkg/user/reaper/user.go
@@ -12,7 +12,6 @@ import (
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset"
 	securitytypedclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
-	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
 
@@ -119,9 +118,6 @@ func (r *UserReaper) Stop(namespace, name string, timeout time.Duration, gracePe
 
 	// Remove the user
 	if err := r.userClient.User().Users().Delete(name, &metav1.DeleteOptions{}); err != nil {
-		if kerrors.IsNotFound(err) {
-			return kerrors.NewNotFound(userapi.Resource("user"), name)
-		}
 		return err
 	}
 

--- a/pkg/user/reaper/user.go
+++ b/pkg/user/reaper/user.go
@@ -12,6 +12,7 @@ import (
 	authclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset"
 	securitytypedclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
+	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset"
 )
 
@@ -117,7 +118,10 @@ func (r *UserReaper) Stop(namespace, name string, timeout time.Duration, gracePe
 	// If the admin wants to remove the identities, that is a distinct operation
 
 	// Remove the user
-	if err := r.userClient.User().Users().Delete(name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.userClient.User().Users().Delete(name, &metav1.DeleteOptions{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return kerrors.NewNotFound(userapi.Resource("user"), name)
+		}
 		return err
 	}
 


### PR DESCRIPTION
As `Stop()` method for some resources does not return NewNotFound
error, when an user tries to delete not existing resources, console
outputs successful message as:

````
$ oc delete role notexisting
role "notexisting" deleted
````

It causes operational mistakes.

This patch returns NewNotFound. So, it outputs error message in the
console when users tried to remove not existing resources.
