### PR TITLE
return containerID from completed pod

### DIFF
--- a/pkg/oc/bootstrap/docker/host/host.go
+++ b/pkg/oc/bootstrap/docker/host/host.go
@@ -60,7 +60,7 @@ func NewHostHelper(dockerHelper *dockerhelper.Helper, image, volumesDir, configD
 
 // CanUseNsenterMounter returns true if the Docker host machine can execute findmnt through nsenter
 func (h *HostHelper) CanUseNsenterMounter() (bool, error) {
-	rc, err := h.runner().
+	_, rc, err := h.runner().
 		Image(h.image).
 		DiscardContainer().
 		Privileged().
@@ -74,7 +74,7 @@ func (h *HostHelper) CanUseNsenterMounter() (bool, error) {
 // for OpenShift volumes
 func (h *HostHelper) EnsureVolumeShare() error {
 	cmd := fmt.Sprintf(ensureVolumeShareCmd, h.volumesDir)
-	rc, err := h.runner().
+	_, rc, err := h.runner().
 		Image(h.image).
 		DiscardContainer().
 		HostPid().
@@ -138,7 +138,7 @@ func (h *HostHelper) UploadFileToContainer(src, dst string) error {
 
 // Hostname retrieves the FQDN of the Docker host machine
 func (h *HostHelper) Hostname() (string, error) {
-	hostname, _, _, err := h.runner().
+	_, hostname, _, _, err := h.runner().
 		Image(h.image).
 		HostNetwork().
 		HostPid().
@@ -168,7 +168,7 @@ func (h *HostHelper) EnsureHostDirectories(createVolumeShare bool) error {
 	}
 	if len(dirs) > 0 {
 		cmd := fmt.Sprintf(cmdEnsureHostDirs, strings.Join(dirs, " "))
-		rc, err := h.runner().
+		_, rc, err := h.runner().
 			Image(h.image).
 			DiscardContainer().
 			Privileged().

--- a/pkg/oc/bootstrap/docker/openshift/cnetwork.go
+++ b/pkg/oc/bootstrap/docker/openshift/cnetwork.go
@@ -31,7 +31,7 @@ exit 1
 // TestContainerNetworking launches a container that will check whether the container
 // can communicate with the master API and DNS endpoints.
 func (h *Helper) TestContainerNetworking(ip string) error {
-	_, err := h.runHelper.New().Image(h.image).
+	_, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Env(fmt.Sprintf("MASTER_IP=%s", ip)).
 		DNS("172.30.0.1").

--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -149,7 +149,7 @@ func NewHelper(dockerHelper *dockerhelper.Helper, hostHelper *host.HostHelper, i
 }
 
 func (h *Helper) TestPorts(ports []int) error {
-	portData, _, _, err := h.runHelper.New().Image(h.image).
+	_, portData, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -208,7 +208,7 @@ func (h *Helper) TestForwardedIP(ip string) error {
 }
 
 func (h *Helper) DetermineNodeHost(hostConfigDir string, names ...string) (string, error) {
-	result, _, _, err := h.runHelper.New().Image(h.image).
+	_, result, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -226,7 +226,7 @@ func (h *Helper) ServerIP() (string, error) {
 	if len(h.serverIP) > 0 {
 		return h.serverIP, nil
 	}
-	result, _, _, err := h.runHelper.New().Image(h.image).
+	_, result, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -240,7 +240,7 @@ func (h *Helper) ServerIP() (string, error) {
 
 // OtherIPs tries to find other IPs besides the argument IP for the Docker host
 func (h *Helper) OtherIPs(excludeIP string) ([]string, error) {
-	result, _, _, err := h.runHelper.New().Image(h.image).
+	_, result, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -342,7 +342,7 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 			fmt.Sprintf("--hostname=%s", defaultNodeName),
 			fmt.Sprintf("--public-master=https://%s:8443", publicHost),
 		}
-		_, err := h.runHelper.New().Image(h.image).
+		_, _, err := h.runHelper.New().Image(h.image).
 			Privileged().
 			DiscardContainer().
 			HostNetwork().
@@ -651,7 +651,7 @@ func (h *Helper) ServerPrereleaseVersion() (semver.Version, error) {
 		return *h.prereleaseVersion, nil
 	}
 
-	versionText, _, _, err := h.runHelper.New().Image(h.image).
+	_, versionText, _, _, err := h.runHelper.New().Image(h.image).
 		Command("version").
 		DiscardContainer().
 		Output()
@@ -945,7 +945,7 @@ fi
 
 kubelet --help | grep -- "--cgroup-driver"
 `
-	rc, err := h.runHelper.New().Image(h.image).
+	_, rc, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Entrypoint("/bin/bash").
 		Command("-c", script).


### PR DESCRIPTION
noisy part of https://github.com/openshift/origin/pull/18536

@mfojtik I don't care if it merges here, but figured I'd give you the option or at least split it out so you can see it.  I need the ability to download files from a completed container and to do that I need the containerId which wasn't exposed before.