### PR TITLE
Deployment updates in status graph

### DIFF
--- a/pkg/oc/cli/describe/projectstatus.go
+++ b/pkg/oc/cli/describe/projectstatus.go
@@ -298,12 +298,20 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 		}
 
 		for _, standaloneDC := range standaloneDCs {
+			if !standaloneDC.DeploymentConfig.Found() {
+				continue
+			}
+
 			fmt.Fprintln(out)
 			printLines(out, indent, 0, describeDeploymentConfigInServiceGroup(f, standaloneDC, func(rc *kubegraph.ReplicationControllerNode) int32 {
 				return graphview.MaxRecentContainerRestartsForRC(g, rc)
 			})...)
 		}
 		for _, standaloneDeployment := range standaloneDeployments {
+			if !standaloneDeployment.Deployment.Found() {
+				continue
+			}
+
 			fmt.Fprintln(out)
 			printLines(out, indent, 0, describeDeploymentInServiceGroup(f, standaloneDeployment, func(rs *kubegraph.ReplicaSetNode) int32 {
 				return graphview.MaxRecentContainerRestartsForRS(g, rs)
@@ -318,11 +326,19 @@ func (d *ProjectStatusDescriber) Describe(namespace, name string) (string, error
 		}
 
 		for _, standaloneRC := range standaloneRCs {
+			if !standaloneRC.RC.Found() {
+				continue
+			}
+
 			fmt.Fprintln(out)
 			printLines(out, indent, 0, describeRCInServiceGroup(f, standaloneRC.RC)...)
 		}
 
 		for _, standaloneRS := range standaloneRSs {
+			if !standaloneRS.RS.Found() {
+				continue
+			}
+
 			fmt.Fprintln(out)
 			printLines(out, indent, 0, describeRSInServiceGroup(f, standaloneRS.RS)...)
 		}

--- a/pkg/oc/graph/kubegraph/nodes/nodes.go
+++ b/pkg/oc/graph/kubegraph/nodes/nodes.go
@@ -229,7 +229,7 @@ func EnsureStatefulSetNode(g osgraph.MutableUniqueGraph, statefulSet *kapps.Stat
 	node := osgraph.EnsureUnique(g,
 		nodeName,
 		func(node osgraph.Node) graph.Node {
-			return &StatefulSetNode{node, statefulSet}
+			return &StatefulSetNode{node, statefulSet, false}
 		},
 	).(*StatefulSetNode)
 

--- a/pkg/oc/graph/kubegraph/nodes/types.go
+++ b/pkg/oc/graph/kubegraph/nodes/types.go
@@ -379,6 +379,10 @@ type DeploymentNode struct {
 	IsFound bool
 }
 
+func (n DeploymentNode) Found() bool {
+	return n.IsFound
+}
+
 func (n DeploymentNode) Object() interface{} {
 	return n.Deployment
 }
@@ -430,6 +434,12 @@ func StatefulSetNodeName(o *kapps.StatefulSet) osgraph.UniqueName {
 type StatefulSetNode struct {
 	osgraph.Node
 	StatefulSet *kapps.StatefulSet
+
+	IsFound bool
+}
+
+func (n StatefulSetNode) Found() bool {
+	return n.IsFound
 }
 
 func (n StatefulSetNode) Object() interface{} {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544183

- Implements the `ExistenceChecker` interface for Deployments and ReplicaSets
which allows the HPA error marker to be set if it is trying to scale a deleted Deployment (or rs).

- Skips standalone resources that are not found

cc @soltysh @mfojtik @deads2k 