### PR TITLE
add hypershift command

### DIFF
--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apiserver/pkg/util/logs"
+
+	"github.com/openshift/origin/pkg/cmd/server/start"
+	"github.com/openshift/origin/pkg/cmd/util/serviceability"
+)
+
+func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"))()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	command := NewHyperShiftCommand()
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func NewHyperShiftCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hypershift",
+		Short: "Combined server command for OpenShift",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	startEtcd, _ := start.NewCommandStartEtcdServer(start.RecommendedStartEtcdServerName, "hypershift", os.Stdout, os.Stderr)
+	startEtcd.Deprecated = "will be removed in 3.10"
+	startEtcd.Hidden = true
+	cmd.AddCommand(startEtcd)
+
+	return cmd
+}

--- a/hack/build-local-images.py
+++ b/hack/build-local-images.py
@@ -59,6 +59,7 @@ image_config = {
         "binaries": {
             "openshift": "/usr/bin/openshift",
             "oc": "/usr/bin/oc",
+            "hypershift": "/usr/bin/hypershift",
             "hyperkube": "/usr/bin/hyperkube"
         },
         "files": {}

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -42,6 +42,7 @@ readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX=(
 readonly OS_IMAGE_COMPILE_BINARIES=("${OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX[@]##*/}" "${OS_IMAGE_COMPILE_TARGETS_LINUX[@]##*/}")
 
 readonly OS_CROSS_COMPILE_TARGETS=(
+  cmd/hypershift
   cmd/openshift
   cmd/oc
   cmd/oadm

--- a/origin.spec
+++ b/origin.spec
@@ -276,7 +276,7 @@ PLATFORM="$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 install -d %{buildroot}%{_bindir}
 
 # Install linux components
-for bin in oc oadm openshift template-service-broker
+for bin in oc oadm openshift hypershift template-service-broker
 do
   echo "+++ INSTALLING ${bin}"
   install -p -m 755 _output/local/bin/${PLATFORM}/${bin} %{buildroot}%{_bindir}/${bin}
@@ -398,6 +398,7 @@ install -p -m 755 contrib/migration/* %{buildroot}%{_datadir}/%{name}/migration/
 %license LICENSE
 %{_bindir}/openshift
 %{_bindir}/hyperkube
+%{_bindir}/hypershift
 %{_bindir}/openshift-deploy
 %{_bindir}/openshift-f5-router
 %{_bindir}/openshift-recycle


### PR DESCRIPTION
This starts our hypershift command with the easiest command we have to move: etcd.  It is hidden and deprecated because we know we want to remove it, but it provides a simple pattern for adding the rest and gets the container ready.

I plan to eventually add:
 1. openshift-apiserver - the server with just the openshift resources
 2. openshift-controller-manager - just the openshfit controllers
 3. openshift-kube-apiserver - the openshift version of the kube-apiserver.  This will be hidden and deprecated.


Things I do not plan to add:
 1. oc - this is a client command it should not live in the same repo with the rest of us
 2. openshift-sdn - this is a target for a move to a different repo and it chronically causes rebase problems.
 3. openshift-builders - this has a partially separate vendor dir and is a target for a move to a different repo

Before I add the others, I've realized I have to expand our config options in some ways.

@smarterclayton @mfojtik @soltysh 