### PR TITLE
Replace loop index with generation number of istag

### DIFF
--- a/pkg/oc/admin/prune/imageprune/prune.go
+++ b/pkg/oc/admin/prune/imageprune/prune.go
@@ -936,14 +936,14 @@ func pruneISTagHistory(
 	history := imageStream.Status.Tags[tag]
 	newHistory := imageapi.TagEventList{}
 
-	for i, tagEvent := range history.Items {
-		glog.V(4).Infof("Checking tag event %d with image %q", i, tagEvent.Image)
+	for _, tagEvent := range history.Items {
+		glog.V(4).Infof("Checking image stream tag %s:%s generation %d with image %q", streamName, tag, tagEvent.Generation, tagEvent.Image)
 
 		if ok, reason := tagEventIsPrunable(tagEvent, g, prunableImageNodes, keepYoungerThan); ok {
-			glog.V(4).Infof("Image stream tag %s:%s revision %d - removing because %s", streamName, tag, i, reason)
+			glog.V(4).Infof("Image stream tag %s:%s generation %d - removing because %s", streamName, tag, tagEvent.Generation, reason)
 			tagUpdated = true
 		} else {
-			glog.V(4).Infof("Image stream tag %s:%s revision %d - keeping because %s", streamName, tag, i, reason)
+			glog.V(4).Infof("Image stream tag %s:%s generation %d - keeping because %s", streamName, tag, tagEvent.Generation, reason)
 			newHistory.Items = append(newHistory.Items, tagEvent)
 		}
 	}


### PR DESCRIPTION
Currently oc adm prune images --loglevel=4 outputs following messages:

```
I0213 10:44:11.087605   90830 prune.go:942] Checking tag event 2 with image "sha256:bb27dbe072dd33a0f188d777f42e42cea4e548bd805e87e730b7a70506f6311c"
I0213 10:44:11.087619   90830 prune.go:945] Image stream tag openshift/perl:5.24 revision 2 - removing because image "sha256:bb27dbe072dd33a0f188d777f42e42cea4e548bd805e87e730b7a70506f6311c" matches deleted image
```

However, `event 2` and `revision 2` are the index in the loop of code
actaully, so it does not make sense. This patch changes the number to
generation number which users can see with `oc get is -o yaml`.