### PR TITLE
Attempt to fix projected and downward API flakes.

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/downwardapi_volume.go
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("[sig-storage] Downward API volume", func() {
 	// How long to wait for a log pod to be displayed
-	const podLogTimeout = 3 * time.Minute
+	const podLogTimeout = 5 * time.Minute
 	f := framework.NewDefaultFramework("downward-api")
 	var podClient *framework.PodClient
 	BeforeEach(func() {

--- a/vendor/k8s.io/kubernetes/test/e2e/common/projected.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/projected.go
@@ -853,7 +853,7 @@ var _ = Describe("[sig-storage] Projected", func() {
 
 	// Part 3/3 - DownwardAPI
 	// How long to wait for a log pod to be displayed
-	const podLogTimeout = 2 * time.Minute
+	const podLogTimeout = 5 * time.Minute
 	var podClient *framework.PodClient
 	BeforeEach(func() {
 		podClient = f.PodClient()


### PR DESCRIPTION
Based on https://github.com/kubernetes/kubernetes/commit/dd99d8206a4dcbc75b1ac073695ce2eef04b6c09

Testing if this helps with `[sig-storage] Downward API volume should update annotations on modification [Conformance] [Suite:openshift/conformance/parallel]...` which is frequent flake.

/sig storage

@deads2k will run this for few days to see if we hit those 3 flakes again.