### PR TITLE
Add --compress option to oc rsync

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -17731,6 +17731,8 @@ _oc_rsync()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
     flags+=("--container=")
     two_word_flags+=("-c")
     local_nonpersistent_flags+=("--container=")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -17873,6 +17873,8 @@ _oc_rsync()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
     flags+=("--container=")
     two_word_flags+=("-c")
     local_nonpersistent_flags+=("--container=")

--- a/pkg/oc/cli/cmd/rsync/copyrsync.go
+++ b/pkg/oc/cli/cmd/rsync/copyrsync.go
@@ -30,7 +30,7 @@ type rsyncStrategy struct {
 }
 
 // rshExcludeFlags are flags that are passed to oc rsync, and should not be passed on to the underlying command being invoked via oc rsh.
-var rshExcludeFlags = sets.NewString("delete", "strategy", "quiet", "include", "exclude", "progress", "no-perms", "watch")
+var rshExcludeFlags = sets.NewString("delete", "strategy", "quiet", "include", "exclude", "progress", "no-perms", "watch", "compress")
 
 func newRsyncStrategy(f *clientcmd.Factory, c *cobra.Command, o *RsyncOptions) (copyStrategy, error) {
 	// Determine the rsh command to pass to the local rsync command

--- a/pkg/oc/cli/cmd/rsync/rsync.go
+++ b/pkg/oc/cli/cmd/rsync/rsync.go
@@ -79,6 +79,7 @@ type RsyncOptions struct {
 	Quiet             bool
 	Delete            bool
 	Watch             bool
+	Compress          bool
 	SuggestedCmdUsage string
 
 	RsyncInclude  []string
@@ -122,6 +123,8 @@ func NewCmdRsync(name, parent string, f *clientcmd.Factory, out, errOut io.Write
 	cmd.Flags().BoolVar(&o.RsyncProgress, "progress", false, "If true, show progress during transfer")
 	cmd.Flags().BoolVar(&o.RsyncNoPerms, "no-perms", false, "If true, do not transfer permissions")
 	cmd.Flags().BoolVarP(&o.Watch, "watch", "w", false, "Watch directory for changes and resync automatically")
+	cmd.Flags().BoolVar(&o.Compress, "compress", false, "compress file data during the transfer")
+
 	return cmd
 }
 

--- a/pkg/oc/cli/cmd/rsync/util.go
+++ b/pkg/oc/cli/cmd/rsync/util.go
@@ -65,6 +65,9 @@ func rsyncFlagsFromOptions(o *RsyncOptions) []string {
 	if o.Delete {
 		flags = append(flags, "--delete")
 	}
+	if o.Compress {
+		flags = append(flags, "-z")
+	}
 	if len(o.RsyncInclude) > 0 {
 		for _, include := range o.RsyncInclude {
 			flags = append(flags, fmt.Sprintf("--include=%s", include))
@@ -97,6 +100,9 @@ func rsyncSpecificFlags(o *RsyncOptions) []string {
 	}
 	if o.RsyncNoPerms {
 		flags = append(flags, "--no-perms")
+	}
+	if o.Compress {
+		flags = append(flags, "-z")
 	}
 	return flags
 }


### PR DESCRIPTION
This adds option --compress to oc rsync. Fixes #16227

I did some test to verify this is working, some results:

$ Without compression
sent 262 bytes  received 50,558 bytes  7,818.46 bytes/sec
total size is 49,661  speedup is 0.98

$ with compression
sent 262 bytes  received 14,695 bytes  2,301.08 bytes/sec
total size is 49,661  speedup is 3.32