### PR TITLE
output grouped resources `oc export`

### DIFF
--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -15,7 +14,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
-	kprinters "k8s.io/kubernetes/pkg/printers"
 
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
@@ -50,20 +48,56 @@ var (
 	  %[1]s export service -o json`)
 )
 
+type ExportOptions struct {
+	asTemplate string
+	selector   string
+	output     string
+	template   string
+
+	allNamespaces bool
+	exact         bool
+	raw           bool
+	forceList     bool
+
+	filenames []string
+
+	infos []*resource.Info
+
+	encoder runtime.Encoder
+	decoder runtime.Decoder
+
+	printObj func(runtime.Object) error
+
+	outputVersion schema.GroupVersion
+	exporter      *DefaultExporter
+
+	in  io.Reader
+	out io.Writer
+}
+
 func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
-	exporter := &DefaultExporter{}
-	var filenames []string
+	opts := &ExportOptions{
+		exporter: &DefaultExporter{},
+
+		in:  in,
+		out: out,
+	}
+
 	cmd := &cobra.Command{
 		Use:     "export RESOURCE/NAME ... [options]",
 		Short:   "Export resources so they can be used elsewhere",
 		Long:    exportLong,
 		Example: fmt.Sprintf(exportExample, fullName),
-		Run: func(cmd *cobra.Command, args []string) {
-			err := RunExport(f, exporter, in, out, cmd, args, filenames)
-			if err == kcmdutil.ErrExit {
-				os.Exit(1)
+		Run: func(c *cobra.Command, args []string) {
+			if err := opts.Complete(f, args, c); err != nil {
+				kcmdutil.CheckErr(err)
 			}
-			kcmdutil.CheckErr(err)
+			if err := opts.Validate(c); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+			if err := opts.RunExport(); err != nil {
+				kcmdutil.CheckErr(err)
+			}
 		},
 	}
 	cmd.Flags().String("as-template", "", "Output a Template object with specified name instead of a List or single object.")
@@ -71,7 +105,7 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 	cmd.Flags().Bool("raw", false, "If true, do not alter the resources in any way after they are loaded.")
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on")
 	cmd.Flags().Bool("all-namespaces", false, "If true, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	cmd.Flags().StringSliceVarP(&filenames, "filename", "f", filenames, "Filename, directory, or URL to file for the resource to export.")
+	cmd.Flags().StringSliceVarP(&opts.filenames, "filename", "f", opts.filenames, "Filename, directory, or URL to file for the resource to export.")
 	cmd.MarkFlagFilename("filename")
 	cmd.Flags().Bool("all", true, "DEPRECATED: all is ignored, specifying a resource without a name selects all the instances of that resource")
 	cmd.Flags().MarkDeprecated("all", "all is ignored because specifying a resource without a name selects all the instances of that resource")
@@ -79,30 +113,46 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 	return cmd
 }
 
-func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Writer, cmd *cobra.Command, args []string, filenames []string) error {
-	selector := kcmdutil.GetFlagString(cmd, "selector")
-	allNamespaces := kcmdutil.GetFlagBool(cmd, "all-namespaces")
-	exact := kcmdutil.GetFlagBool(cmd, "exact")
-	asTemplate := kcmdutil.GetFlagString(cmd, "as-template")
-	raw := kcmdutil.GetFlagBool(cmd, "raw")
-	if exact && raw {
-		return kcmdutil.UsageErrorf(cmd, "--exact and --raw may not both be specified")
-	}
+func (o *ExportOptions) Complete(f kcmdutil.Factory, args []string, cmd *cobra.Command) error {
+	o.selector = kcmdutil.GetFlagString(cmd, "selector")
+	o.allNamespaces = kcmdutil.GetFlagBool(cmd, "all-namespaces")
+	o.exact = kcmdutil.GetFlagBool(cmd, "exact")
+	o.asTemplate = kcmdutil.GetFlagString(cmd, "as-template")
+	o.raw = kcmdutil.GetFlagBool(cmd, "raw")
 
-	clientConfig, err := f.ClientConfig()
-	if err != nil {
-		return err
-	}
-
-	var outputVersion schema.GroupVersion
-	outputVersionString := kcmdutil.GetFlagString(cmd, "output-version")
-	if len(outputVersionString) == 0 {
-		outputVersion = *clientConfig.GroupVersion
-	} else {
-		outputVersion, err = schema.ParseGroupVersion(outputVersionString)
+	outputVersion := kcmdutil.GetFlagString(cmd, "output-version")
+	if len(outputVersion) > 0 {
+		version, err := schema.ParseGroupVersion(outputVersion)
 		if err != nil {
 			return err
 		}
+
+		o.outputVersion = version
+	}
+
+	o.output = kcmdutil.GetFlagString(cmd, "output")
+	o.template = kcmdutil.GetFlagString(cmd, "template")
+
+	// default --output to "yaml"
+	if len(o.output) == 0 && len(o.template) > 0 {
+		o.output = "template"
+	}
+	if len(o.output) == 0 {
+		o.output = "yaml"
+	}
+
+	o.printObj = func(obj runtime.Object) error {
+		printOpts := kcmdutil.ExtractCmdPrintOptions(cmd, false)
+		printOpts.OutputFormatType = o.output
+		printOpts.OutputFormatArgument = o.template
+		printOpts.AllowMissingKeys = kcmdutil.GetFlagBool(cmd, "allow-missing-template-keys")
+
+		p, err := f.PrinterForOptions(printOpts)
+		if err != nil {
+			return err
+		}
+
+		return p.PrintObj(obj, o.out)
 	}
 
 	cmdNamespace, explicit, err := f.DefaultNamespace()
@@ -110,11 +160,14 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		return err
 	}
 
+	o.encoder = f.JSONEncoder()
+	o.decoder = f.Decoder(true)
+
 	b := f.NewBuilder().
 		Unstructured().
-		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
-		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: filenames}).
-		LabelSelectorParam(selector).
+		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(o.allNamespaces).
+		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: o.filenames}).
+		LabelSelectorParam(o.selector).
 		ResourceTypeOrNameArgs(true, args...).
 		Flatten()
 
@@ -124,23 +177,41 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		return err
 	}
 
+	o.forceList = !one
+
 	if len(infos) == 0 {
 		return fmt.Errorf("no resources found - nothing to export")
 	}
 
-	if !raw {
+	o.infos = infos
+	return nil
+}
+
+func (o *ExportOptions) Validate(cmd *cobra.Command) error {
+	if o.exact && o.raw {
+		return kcmdutil.UsageErrorf(cmd, "--exact and --raw may not both be specified")
+	}
+
+	return nil
+}
+
+func (o *ExportOptions) RunExport() error {
+	if !o.raw {
 		newInfos := []*resource.Info{}
 		errs := []error{}
-		for _, info := range infos {
+		for _, info := range o.infos {
 			converted := false
 
+			// capture original gvk in order to reconvert object later
+			originalGVK := info.Object.GetObjectKind().GroupVersionKind()
+
 			// convert unstructured object to runtime.Object
-			data, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(), info.Object)
+			data, err := runtime.Encode(o.encoder, info.Object)
 			if err != nil {
 				errs = append(errs, err)
 				continue
 			}
-			decoded, err := runtime.Decode(f.Decoder(true), data)
+			decoded, err := runtime.Decode(o.decoder, data)
 			if err == nil {
 				// ignore error, if any, in order to allow resources
 				// not known by the client to still be exported
@@ -148,7 +219,7 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 				converted = true
 			}
 
-			if err := exporter.Export(info.Object, exact); err != nil {
+			if err := o.exporter.Export(info.Object, o.exact); err != nil {
 				if err == ErrExportOmit {
 					continue
 				}
@@ -159,15 +230,30 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 			// re-convert that object once again into its external version.
 			// If object cannot be converted to an external version, ignore error and proceed with
 			// internal version.
-			if converted {
-				if data, err = runtime.Encode(legacyscheme.Codecs.LegacyCodec(outputVersion), info.Object); err == nil {
-					external, err := runtime.Decode(f.Decoder(false), data)
-					if err != nil {
-						errs = append(errs, fmt.Errorf("error: failed to convert resource to external version: %v", err))
-						continue
-					}
-					info.Object = external
+
+			// re-convert objects back to original groupVersion and decode back to unstructured
+			// only if an --output-version has not been provided.
+			if converted && o.outputVersion.Empty() {
+				convertedObj, err := info.Mapping.ConvertToVersion(info.Object, originalGVK.GroupVersion())
+				if err != nil {
+					errs = append(errs, fmt.Errorf("error: failed to convert resource to external version: %v", err))
+					continue
 				}
+
+				// convert back to unstructured
+				unstructBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, convertedObj)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("error: failed to encode the object: %v", err))
+					continue
+				}
+
+				unstruct, err := runtime.Decode(unstructured.UnstructuredJSONScheme, unstructBytes)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("error: failed to convert resource to *unstructured.Unstructured: %v", err))
+					continue
+				}
+
+				info.Object = unstruct
 			}
 
 			newInfos = append(newInfos, info)
@@ -175,52 +261,60 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		if len(errs) > 0 {
 			return utilerrors.NewAggregate(errs)
 		}
-		infos = newInfos
+		o.infos = newInfos
 	}
 
+	if o.outputVersion.Empty() {
+		result := o.infos[0].Object
+
+		template := &templateapi.Template{}
+		list := &unstructured.UnstructuredList{
+			Object: map[string]interface{}{
+				"kind":       "List",
+				"apiVersion": "v1",
+				"metadata":   map[string]interface{}{},
+			},
+		}
+
+		for _, info := range o.infos {
+			// we are fetching unstructured objects from the resource builder to begin with,
+			// so no need to worry about casting here
+			list.Items = append(list.Items, *info.Object.(*unstructured.Unstructured))
+			template.Objects = append(template.Objects, info.Object)
+		}
+
+		if len(o.asTemplate) > 0 {
+			template.Name = o.asTemplate
+			result = template
+		} else if len(o.infos) > 1 {
+			result = list
+		}
+
+		return o.printObj(result)
+	}
+
+	// handle --output-version provided
 	var result runtime.Object
-	if len(asTemplate) > 0 {
-		objects, err := clientcmd.AsVersionedObjects(infos, outputVersion, legacyscheme.Codecs.LegacyCodec(outputVersion))
+	if len(o.asTemplate) > 0 {
+		objects, err := clientcmd.AsVersionedObjects(o.infos, o.outputVersion, legacyscheme.Codecs.LegacyCodec(o.outputVersion))
 		if err != nil {
 			return err
 		}
 		template := &templateapi.Template{
 			Objects: objects,
 		}
-		template.Name = asTemplate
-		result, err = legacyscheme.Scheme.ConvertToVersion(template, outputVersion)
+		template.Name = o.asTemplate
+		result, err = legacyscheme.Scheme.ConvertToVersion(template, o.outputVersion)
 		if err != nil {
 			return err
 		}
 	} else {
-		object, err := clientcmd.AsVersionedObject(infos, !one, outputVersion, legacyscheme.Codecs.LegacyCodec(outputVersion))
+		object, err := clientcmd.AsVersionedObject(o.infos, o.forceList, o.outputVersion, legacyscheme.Codecs.LegacyCodec(o.outputVersion))
 		if err != nil {
 			return err
 		}
 		result = object
 	}
 
-	// use YAML as the default format
-	outputFormat := kcmdutil.GetFlagString(cmd, "output")
-	templateFile := kcmdutil.GetFlagString(cmd, "template")
-	if len(outputFormat) == 0 && len(templateFile) != 0 {
-		outputFormat = "template"
-	}
-	if len(outputFormat) == 0 {
-		outputFormat = "yaml"
-	}
-	decoders := []runtime.Decoder{f.Decoder(true), unstructured.UnstructuredJSONScheme}
-	printOpts := kcmdutil.ExtractCmdPrintOptions(cmd, false)
-	printOpts.OutputFormatType = outputFormat
-	printOpts.OutputFormatArgument = templateFile
-	printOpts.AllowMissingKeys = kcmdutil.GetFlagBool(cmd, "allow-missing-template-keys")
-
-	mapper, typer := f.Object()
-	p, err := kprinters.GetStandardPrinter(
-		mapper, typer, legacyscheme.Codecs.LegacyCodec(outputVersion), decoders, *printOpts)
-
-	if err != nil {
-		return err
-	}
-	return p.PrintObj(result, out)
+	return o.printObj(result)
 }


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/17708

Updates the export command to output grouped resources.
Support for --output-version is kept.

Updates the export command to follow complete, validate, run pattern.

cc @soltysh @mfojtik 