### PR TITLE
WIP: Switch adm to deployments

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -625,8 +625,8 @@ function os::start::router() {
 	if [[ -n "${DROP_SYN_DURING_RESTART:-}" ]]; then
 		# Rewrite the DC for the router to add the environment variable into the pod definition
 		os::log::debug "Changing the router DC to drop SYN packets during a reload"
-		oc patch dc router -p '{"spec":{"template":{"spec":{"containers":[{"name":"router","securityContext":{"privileged":true}}],"securityContext":{"runAsUser": 0}}}}}'
-		oc set env dc/router -c router DROP_SYN_DURING_RESTART=true
+		oc patch deploy router -p '{"spec":{"template":{"spec":{"containers":[{"name":"router","securityContext":{"privileged":true}}],"securityContext":{"runAsUser": 0}}}}}'
+		oc set env deploy/router -c router DROP_SYN_DURING_RESTART=true
 	fi
 }
 readonly -f os::start::router

--- a/pkg/oc/bootstrap/docker/status.go
+++ b/pkg/oc/bootstrap/docker/status.go
@@ -101,13 +101,13 @@ func (c *ClientStatusConfig) Status(f *clientcmd.Factory, out io.Writer) error {
 
 	eh := exec.NewExecHelper(dockerClient, openshift.OpenShiftContainer)
 
-	stdout, _, _ := eh.Command("oc", "get", "dc", "docker-registry", "-n", "default", "-o", "template", "--template", "{{.status.availableReplicas}}").Output()
+	stdout, _, _ := eh.Command("oc", "get", "deploy", "docker-registry", "-n", "default", "-o", "template", "--template", "{{.status.availableReplicas}}").Output()
 	if stdout != "1" {
 		fmt.Fprintln(out, "Notice: Docker registry is not yet ready")
 		notReady++
 	}
 
-	stdout, _, _ = eh.Command("oc", "get", "dc", "router", "-n", "default", "-o", "template", "--template", "{{.status.availableReplicas}}").Output()
+	stdout, _, _ = eh.Command("oc", "get", "deploy", "router", "-n", "default", "-o", "template", "--template", "{{.status.availableReplicas}}").Output()
 	if stdout != "1" {
 		fmt.Fprintln(out, "Notice: Router is not yet ready")
 		notReady++

--- a/pkg/oc/cli/cmd/rsh.go
+++ b/pkg/oc/cli/cmd/rsh.go
@@ -48,7 +48,7 @@ var (
 	  %[1]s foo cat /etc/resolv.conf
 
 	  # See the configuration of your internal registry
-	  %[1]s dc/docker-registry cat config.yml
+	  %[1]s deploy/docker-registry cat config.yml
 
 	  # Open a shell session on the container named 'index' inside a pod of your job
 	  # %[1]s -c index job/sheduled`)

--- a/pkg/oc/cli/cmd/set/probe.go
+++ b/pkg/oc/cli/cmd/set/probe.go
@@ -47,10 +47,10 @@ var (
 
 	probeExample = templates.Examples(`
 		# Clear both readiness and liveness probes off all containers
-	  %[1]s probe dc/registry --remove --readiness --liveness
+	  %[1]s probe deploy/docker-registry --remove --readiness --liveness
 
 	  # Set an exec action as a liveness probe to run 'echo ok'
-	  %[1]s probe dc/registry --liveness -- echo ok
+	  %[1]s probe deploy/docker-registry --liveness -- echo ok
 
 	  # Set a readiness probe to try to open a TCP socket on 3306
 	  %[1]s probe rc/mysql --readiness --open-tcp=3306
@@ -59,7 +59,7 @@ var (
 	  %[1]s probe dc/webapp --readiness --get-url=http://:8080/healthz
 
 	  # Set an HTTP readiness probe over HTTPS on 127.0.0.1 for a hostNetwork pod
-	  %[1]s probe dc/router --readiness --get-url=https://127.0.0.1:1936/stats
+	  %[1]s probe deploy/router --readiness --get-url=https://127.0.0.1:1936/stats
 
 	  # Set only the initial-delay-seconds field on all deployments
 	  %[1]s probe dc --all --readiness --initial-delay-seconds=30`)

--- a/pkg/oc/generate/app/pipeline.go
+++ b/pkg/oc/generate/app/pipeline.go
@@ -372,6 +372,11 @@ func AddServices(objects Objects, firstPortOnly bool) Objects {
 			if svc != nil {
 				svcs = append(svcs, svc)
 			}
+		case *extensions.Deployment:
+			svc := addServiceInternal(t.Spec.Template.Spec.Containers, t.ObjectMeta, t.Spec.Selector.MatchLabels, firstPortOnly)
+			if svc != nil {
+				svcs = append(svcs, svc)
+			}
 		case *extensions.DaemonSet:
 			svc := addServiceInternal(t.Spec.Template.Spec.Containers, t.ObjectMeta, t.Spec.Template.Labels, firstPortOnly)
 			if svc != nil {

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -323,7 +323,7 @@ os::cmd::expect_success "oc adm policy add-scc-to-user privileged system:service
 os::cmd::expect_success_and_text "oc adm router -o yaml --service-account=router -n default" 'image:.*\-haproxy\-router:'
 os::cmd::expect_success "oc adm router --images='${USE_IMAGES}' --service-account=router -n default"
 os::cmd::expect_success_and_text 'oc adm router -n default' 'service exists'
-os::cmd::expect_success_and_text 'oc get dc/router -o yaml -n default' 'readinessProbe'
+os::cmd::expect_success_and_text 'oc get deploy/router -o yaml -n default' 'readinessProbe'
 echo "router: ok"
 os::test::junit::declare_suite_end
 
@@ -345,8 +345,8 @@ os::cmd::expect_success_and_text "oc adm registry -o yaml" 'image:.*\-docker\-re
 os::cmd::expect_success "oc adm registry --images='${USE_IMAGES}'"
 os::cmd::expect_success_and_text 'oc adm registry' 'service exists'
 os::cmd::expect_success_and_text 'oc describe svc/docker-registry' 'Session Affinity:\s*ClientIP'
-os::cmd::expect_success_and_text 'oc get dc/docker-registry -o yaml' 'readinessProbe'
-os::cmd::expect_success_and_text 'oc env --list dc/docker-registry' 'REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA=false'
+os::cmd::expect_success_and_text 'oc get deploy/docker-registry -o yaml' 'readinessProbe'
+os::cmd::expect_success_and_text 'oc env --list deploy/docker-registry' 'REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA=false'
 echo "registry: ok"
 os::test::junit::declare_suite_end
 
@@ -355,7 +355,7 @@ workingdir=$(mktemp -d)
 os::cmd::expect_success "oc adm registry -o yaml > ${workingdir}/oadm_registry.yaml"
 os::util::sed "s/5000/6000/g" ${workingdir}/oadm_registry.yaml
 os::cmd::expect_success "oc apply -f ${workingdir}/oadm_registry.yaml"
-os::cmd::expect_success_and_text 'oc get dc/docker-registry -o yaml' '6000'
+os::cmd::expect_success_and_text 'oc get deploy/docker-registry -o yaml' '6000'
 echo "apply: ok"
 os::test::junit::declare_suite_end
 

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -64,11 +64,11 @@ os::cmd::expect_failure_and_text "oc adm router --ports=80,8443:443" 'container 
 os::cmd::expect_success_and_text "oc adm router -o yaml" 'image:.*-haproxy-router:'
 os::cmd::expect_success "oc adm router --images='${USE_IMAGES}'"
 os::cmd::expect_success_and_text 'oc adm router' 'service exists'
-os::cmd::expect_success_and_text 'oc get dc/router -o yaml' 'readinessProbe'
+os::cmd::expect_success_and_text 'oc get deploy/router -o yaml' 'readinessProbe'
 
 # delete the router and deployment config, leaving the clusterrolebinding and service account
 os::cmd::expect_success_and_text "oc delete svc/router" 'service "router" deleted'
-os::cmd::expect_success_and_text "oc delete dc/router" 'deploymentconfig "router" deleted'
+os::cmd::expect_success_and_text "oc delete deploy/router" 'deployment "router" deleted'
 # create a router and check for success with a warning about the existing clusterrolebinding
 os::cmd::expect_success_and_text "oc adm router" 'warning: clusterrolebindings "router-router-role" already exists'
 

--- a/test/extended/cmd.sh
+++ b/test/extended/cmd.sh
@@ -39,7 +39,7 @@ oc login -u system:admin -n default
 oc adm policy add-role-to-group view system:authenticated -n default
 
 os::start::registry
-oc rollout status dc/docker-registry
+oc rollout status deploy/docker-registry
 docker_registry="$( oc get service/docker-registry -n default -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}' )"
 
 os::test::junit::declare_suite_start "extended/cmd"

--- a/test/extended/gssapi.sh
+++ b/test/extended/gssapi.sh
@@ -51,7 +51,7 @@ os::start::server
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
 
 os::start::registry
-os::cmd::expect_success 'oc rollout status dc/docker-registry'
+os::cmd::expect_success 'oc rollout status deploy/docker-registry'
 
 os::cmd::expect_success 'oc login -u system:admin'
 os::cmd::expect_success "oc new-project ${project_name}"

--- a/test/extended/images/hardprune.go
+++ b/test/extended/images/hardprune.go
@@ -425,7 +425,7 @@ func LogRegistryPod(oc *exutil.CLI) error {
 
 	ocLocal := *oc
 	ocLocal.SetOutputDir(exutil.ArtifactDirPath())
-	path, err := ocLocal.Run("logs").Args("dc/docker-registry").OutputToFile("pod-" + pod.Name + ".log")
+	path, err := ocLocal.Run("logs").Args("deploy/docker-registry").OutputToFile("pod-" + pod.Name + ".log")
 	if err == nil {
 		fmt.Fprintf(g.GinkgoWriter, "written registry pod log to %s\n", path)
 	}
@@ -437,7 +437,7 @@ func LogRegistryPod(oc *exutil.CLI) error {
 func ConfigureRegistry(oc *exutil.CLI, desiredState RegistryConfiguration) error {
 	defer func(ns string) { oc.SetNamespace(ns) }(oc.Namespace())
 	oc = oc.SetNamespace(metav1.NamespaceDefault).AsAdmin()
-	env, err := oc.Run("env").Args("dc/docker-registry", "--list").Output()
+	env, err := oc.Run("env").Args("deploy/docker-registry", "--list").Output()
 	if err != nil {
 		return err
 	}
@@ -473,7 +473,7 @@ func ConfigureRegistry(oc *exutil.CLI, desiredState RegistryConfiguration) error
 		fmt.Fprintf(g.GinkgoWriter, "failed to log registry pod: %v\n", err)
 	}
 
-	err = oc.Run("env").Args(append([]string{"dc/docker-registry"}, envOverrides...)...).Execute()
+	err = oc.Run("env").Args(append([]string{"deploy/docker-registry"}, envOverrides...)...).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to update registry's environment with %s: %v", &waitForVersion, err)
 	}
@@ -502,7 +502,7 @@ func makeReadonlyEnvValue(on bool) string {
 func GetRegistryStorageSize(oc *exutil.CLI) (int64, error) {
 	defer func(ns string) { oc.SetNamespace(ns) }(oc.Namespace())
 	out, err := oc.SetNamespace(metav1.NamespaceDefault).AsAdmin().Run("rsh").Args(
-		"dc/docker-registry", "du", "--bytes", "--summarize", "/registry/docker/registry").Output()
+		"deploy/docker-registry", "du", "--bytes", "--summarize", "/registry/docker/registry").Output()
 	if err != nil {
 		return 0, err
 	}
@@ -523,7 +523,7 @@ func GetRegistryStorageSize(oc *exutil.CLI) (int64, error) {
 // schema 2.
 func DoesRegistryAcceptSchema2(oc *exutil.CLI) (bool, error) {
 	defer func(ns string) { oc.SetNamespace(ns) }(oc.Namespace())
-	env, err := oc.SetNamespace(metav1.NamespaceDefault).AsAdmin().Run("env").Args("dc/docker-registry", "--list").Output()
+	env, err := oc.SetNamespace(metav1.NamespaceDefault).AsAdmin().Run("env").Args("deploy/docker-registry", "--list").Output()
 	if err != nil {
 		return defaultAcceptSchema2, err
 	}

--- a/test/extended/images/helper.go
+++ b/test/extended/images/helper.go
@@ -576,7 +576,7 @@ func pathExistsInRegistry(oc *exutil.CLI, pthComponents ...string) (bool, error)
 	cmd := fmt.Sprintf("test -e '%s' && echo exists || echo missing", pth)
 	defer func(ns string) { oc.SetNamespace(ns) }(oc.Namespace())
 	out, err := oc.SetNamespace(metav1.NamespaceDefault).AsAdmin().Run("rsh").Args(
-		"dc/docker-registry", "/bin/sh", "-c", cmd).Output()
+		"deploy/docker-registry", "/bin/sh", "-c", cmd).Output()
 	if err != nil {
 		return false, fmt.Errorf("failed to check for blob existence: %v", err)
 	}
@@ -626,7 +626,7 @@ func RunHardPrune(oc *exutil.CLI, dryRun bool) (*RegistryStorageFiles, error) {
 	}
 
 	defer func(ns string) { oc.SetNamespace(ns) }(oc.Namespace())
-	output, err := oc.AsAdmin().SetNamespace(metav1.NamespaceDefault).Run("env").Args("--list", "dc/docker-registry").Output()
+	output, err := oc.AsAdmin().SetNamespace(metav1.NamespaceDefault).Run("env").Args("--list", "deploy/docker-registry").Output()
 	if err != nil {
 		return nil, err
 	}
@@ -800,7 +800,7 @@ func (c *CleanUpContainer) Run() {
 	// Remove registry database between tests to avoid the influence of one test on another.
 	// TODO: replace this with removals of individual blobs used in the test case.
 	out, err := c.OC.SetNamespace(metav1.NamespaceDefault).AsAdmin().
-		Run("rsh").Args("dc/docker-registry", "find", "/registry", "-mindepth", "1", "-delete").Output()
+		Run("rsh").Args("deploy/docker-registry", "find", "/registry", "-mindepth", "1", "-delete").Output()
 	if err != nil {
 		fmt.Fprintf(g.GinkgoWriter, "clean up registry failed: %v\n", err)
 		fmt.Fprintf(g.GinkgoWriter, "%s\n", out)

--- a/test/extended/ldap_groups.sh
+++ b/test/extended/ldap_groups.sh
@@ -32,7 +32,7 @@ os::start::server
 export KUBECONFIG="${ADMIN_KUBECONFIG}"
 
 os::start::registry
-oc rollout status dc/docker-registry
+oc rollout status deploy/docker-registry
 
 oc login ${MASTER_ADDR} -u ldap -p password --certificate-authority=${MASTER_CONFIG_DIR}/ca.crt
 oc new-project openldap

--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -138,7 +138,7 @@ function os::test::extended::setup () {
 
 	os::start::registry
 	if [[ -z "${SKIP_NODE:-}" ]]; then
-		oc rollout status dc/docker-registry
+		oc rollout status deploy/docker-registry
 	fi
 	DROP_SYN_DURING_RESTART=true CREATE_ROUTER_CERT=true os::start::router
 

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -491,7 +491,7 @@ func (t *BuildResult) dumpRegistryLogs() {
 	// here so we can restore it when done with registry logs
 	savedNamespace := t.Oc.Namespace()
 	oadm := t.Oc.AsAdmin().SetNamespace("default")
-	out, err := oadm.Run("logs").Args("dc/docker-registry", "--since="+since.String()).Output()
+	out, err := oadm.Run("logs").Args("deploy/docker-registry", "--since="+since.String()).Output()
 	if err != nil {
 		e2e.Logf("Error during log retrieval: %+v\n", err)
 	} else {


### PR DESCRIPTION
@deads2k separate pull as requested.

This will switch `oc adm registry` and `oc adm router` to generate Deployment instead of DeploymentConfig.
There is no reason why registry or router should use DeploymentConfigs as there are no hooks or image triggers defined.

A benefit will be faster bootstrap times for `oc cluster up` as we don't have to pull the deployer image anymore. Also might make the deployments of these two more stable in terms there is no deployer pod involved. Additionally these two can be deployed before we have OpenShift API available as Deployments are Kubernetes API (although they will be functionally broken until Image APi and Router API is available to them...)

I'm not sure if we need a "transition" flag and support DC one more release before we switch. I don't think that this switch is going to break things functionally, but if there are any steps in installer or tests that depends on DC to be present they might be broken until they are switched to use Deployments.