### PR TITLE
add an admission decorator that allows skipping some admission checks…

### DIFF
--- a/pkg/admission/namespaceconditions/decorator.go
+++ b/pkg/admission/namespaceconditions/decorator.go
@@ -1,0 +1,46 @@
+package namespaceconditions
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+)
+
+// NamespaceLabelConditions provides a decorator that can delegate and conditionally add label conditions
+type NamespaceLabelConditions struct {
+	// TODO decorators are refactored in 1.10, so this is unnecessary and we'll get a nice chain
+	Delegate admission.Decorator
+
+	NamespaceClient corev1client.NamespacesGetter
+	NamespaceLister corev1lister.NamespaceLister
+
+	SkipLevelZeroNames sets.String
+	SkipLevelOneNames  sets.String
+}
+
+func (d *NamespaceLabelConditions) WithNamespaceLabelConditions(admissionPlugin admission.Interface, name string) admission.Interface {
+	delegateDecoratedAdmissionPlugin := d.Delegate(admissionPlugin, name)
+
+	switch {
+	case d.SkipLevelOneNames.Has(name):
+		return &pluginHandlerWithNamespaceLabelConditions{
+			admissionPlugin:   delegateDecoratedAdmissionPlugin,
+			namespaceClient:   d.NamespaceClient,
+			namespaceLister:   d.NamespaceLister,
+			namespaceSelector: skipRunLevelOneSelector,
+		}
+
+	case d.SkipLevelZeroNames.Has(name):
+		return &pluginHandlerWithNamespaceLabelConditions{
+			admissionPlugin:   delegateDecoratedAdmissionPlugin,
+			namespaceClient:   d.NamespaceClient,
+			namespaceLister:   d.NamespaceLister,
+			namespaceSelector: skipRunLevelZeroSelector,
+		}
+
+	default:
+		return delegateDecoratedAdmissionPlugin
+	}
+
+}

--- a/pkg/admission/namespaceconditions/labelcondition.go
+++ b/pkg/admission/namespaceconditions/labelcondition.go
@@ -1,0 +1,120 @@
+package namespaceconditions
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+)
+
+const runLevelLabel = "openshift.io/run-level"
+
+var (
+	skipRunLevelZeroSelector labels.Selector
+	skipRunLevelOneSelector  labels.Selector
+)
+
+func init() {
+	var err error
+	skipRunLevelZeroSelector, err = labels.Parse(runLevelLabel + " notin ( 0 )")
+	if err != nil {
+		panic(err)
+	}
+	skipRunLevelOneSelector, err = labels.Parse(runLevelLabel + " notin ( 0,1 )")
+	if err != nil {
+		panic(err)
+	}
+}
+
+// pluginHandlerWithNamespaceLabelConditions wraps an admission plugin in a conditional skip based on namespace labels
+type pluginHandlerWithNamespaceLabelConditions struct {
+	admissionPlugin   admission.Interface
+	namespaceClient   corev1client.NamespacesGetter
+	namespaceLister   corev1lister.NamespaceLister
+	namespaceSelector labels.Selector
+}
+
+func (p pluginHandlerWithNamespaceLabelConditions) Handles(operation admission.Operation) bool {
+	return p.admissionPlugin.Handles(operation)
+}
+
+// Admit performs a mutating admission control check and emit metrics.
+func (p pluginHandlerWithNamespaceLabelConditions) Admit(a admission.Attributes) error {
+	if !p.shouldRunAdmission(a) {
+		return nil
+	}
+
+	mutatingHandler, ok := p.admissionPlugin.(admission.MutationInterface)
+	if !ok {
+		return nil
+	}
+	return mutatingHandler.Admit(a)
+}
+
+// Validate performs a non-mutating admission control check and emits metrics.
+func (p pluginHandlerWithNamespaceLabelConditions) Validate(a admission.Attributes) error {
+	if !p.shouldRunAdmission(a) {
+		return nil
+	}
+
+	validatingHandler, ok := p.admissionPlugin.(admission.ValidationInterface)
+	if !ok {
+		return nil
+	}
+	return validatingHandler.Validate(a)
+}
+
+// MatchNamespaceSelector decideds whether the request matches the
+// namespaceSelctor of the webhook. Only when they match, the webhook is called.
+func (p pluginHandlerWithNamespaceLabelConditions) shouldRunAdmission(attr admission.Attributes) bool {
+	namespaceName := attr.GetNamespace()
+	if len(namespaceName) == 0 && attr.GetResource().Resource != "namespaces" {
+		// cluster scoped resources always run admission
+		return true
+	}
+	namespaceLabels, err := p.getNamespaceLabels(attr)
+	if err != nil {
+		// default to running the hook so we don't leak namespace existence information
+		return true
+	}
+	// TODO: adding an LRU cache to cache the match decision
+	return p.namespaceSelector.Matches(labels.Set(namespaceLabels))
+}
+
+// getNamespaceLabels gets the labels of the namespace related to the attr.
+func (p pluginHandlerWithNamespaceLabelConditions) getNamespaceLabels(attr admission.Attributes) (map[string]string, error) {
+	// If the request itself is creating or updating a namespace, then get the
+	// labels from attr.Object, because namespaceLister doesn't have the latest
+	// namespace yet.
+	//
+	// However, if the request is deleting a namespace, then get the label from
+	// the namespace in the namespaceLister, because a delete request is not
+	// going to change the object, and attr.Object will be a DeleteOptions
+	// rather than a namespace object.
+	if attr.GetResource().Resource == "namespaces" &&
+		len(attr.GetSubresource()) == 0 &&
+		(attr.GetOperation() == admission.Create || attr.GetOperation() == admission.Update) {
+		accessor, err := meta.Accessor(attr.GetObject())
+		if err != nil {
+			return nil, err
+		}
+		return accessor.GetLabels(), nil
+	}
+
+	namespaceName := attr.GetNamespace()
+	namespace, err := p.namespaceLister.Get(namespaceName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if apierrors.IsNotFound(err) {
+		// in case of latency in our caches, make a call direct to storage to verify that it truly exists or not
+		namespace, err = p.namespaceClient.Namespaces().Get(namespaceName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return namespace.Labels, nil
+}

--- a/pkg/admission/namespaceconditions/labelcondition_test.go
+++ b/pkg/admission/namespaceconditions/labelcondition_test.go
@@ -1,0 +1,97 @@
+package namespaceconditions
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+type fakeNamespaceLister struct {
+	namespaces map[string]*corev1.Namespace
+}
+
+func (f fakeNamespaceLister) List(selector labels.Selector) (ret []*corev1.Namespace, err error) {
+	return nil, nil
+}
+func (f fakeNamespaceLister) Get(name string) (*corev1.Namespace, error) {
+	ns, ok := f.namespaces[name]
+	if ok {
+		return ns, nil
+	}
+	return nil, errors.NewNotFound(corev1.Resource("namespaces"), name)
+}
+
+func TestGetNamespaceLabels(t *testing.T) {
+	namespace1Labels := map[string]string{
+		"runlevel": "1",
+	}
+	namespace1 := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "1",
+			Labels: namespace1Labels,
+		},
+	}
+	namespace2Labels := map[string]string{
+		"runlevel": "2",
+	}
+	namespace2 := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "2",
+			Labels: namespace2Labels,
+		},
+	}
+	namespaceLister := fakeNamespaceLister{map[string]*corev1.Namespace{
+		"1": &namespace1,
+	},
+	}
+
+	tests := []struct {
+		name           string
+		attr           admission.Attributes
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "request is for creating namespace, the labels should be from the object itself",
+			attr:           admission.NewAttributesRecord(&namespace2, nil, schema.GroupVersionKind{}, "", namespace2.Name, schema.GroupVersionResource{Resource: "namespaces"}, "", admission.Create, nil),
+			expectedLabels: namespace2Labels,
+		},
+		{
+			name:           "request is for updating namespace, the labels should be from the new object",
+			attr:           admission.NewAttributesRecord(&namespace2, nil, schema.GroupVersionKind{}, namespace2.Name, namespace2.Name, schema.GroupVersionResource{Resource: "namespaces"}, "", admission.Update, nil),
+			expectedLabels: namespace2Labels,
+		},
+		{
+			name:           "request is for deleting namespace, the labels should be from the cache",
+			attr:           admission.NewAttributesRecord(&namespace2, nil, schema.GroupVersionKind{}, namespace1.Name, namespace1.Name, schema.GroupVersionResource{Resource: "namespaces"}, "", admission.Delete, nil),
+			expectedLabels: namespace1Labels,
+		},
+		{
+			name:           "request is for namespace/finalizer",
+			attr:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, namespace1.Name, "mock-name", schema.GroupVersionResource{Resource: "namespaces"}, "finalizers", admission.Create, nil),
+			expectedLabels: namespace1Labels,
+		},
+		{
+			name:           "request is for pod",
+			attr:           admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, namespace1.Name, "mock-name", schema.GroupVersionResource{Resource: "pods"}, "", admission.Create, nil),
+			expectedLabels: namespace1Labels,
+		},
+	}
+	matcher := pluginHandlerWithNamespaceLabelConditions{
+		namespaceLister: namespaceLister,
+	}
+	for _, tt := range tests {
+		actualLabels, err := matcher.getNamespaceLabels(tt.attr)
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(actualLabels, tt.expectedLabels) {
+			t.Errorf("expected labels to be %#v, got %#v", tt.expectedLabels, actualLabels)
+		}
+	}
+}

--- a/pkg/cmd/server/origin/admission/chain_builder.go
+++ b/pkg/cmd/server/origin/admission/chain_builder.go
@@ -10,7 +10,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
-	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	noderestriction "k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
 	expandpvcadmission "k8s.io/kubernetes/plugin/pkg/admission/persistentvolume/resize"
@@ -30,6 +29,22 @@ import (
 )
 
 var (
+	// these are admission plugins that cannot be applied until after the kubeapiserver starts.
+	// TODO if nothing comes to mind in 3.10, kill this
+	SkipRunLevelZeroPlugins = sets.NewString()
+	// these are admission plugins that cannot be applied until after the openshiftapiserver apiserver starts.
+	SkipRunLevelOnePlugins = sets.NewString(
+		"ProjectRequestLimit",
+		"openshift.io/RestrictSubjectBindings",
+		"openshift.io/ClusterResourceQuota",
+		imagepolicy.PluginName,
+		overrideapi.PluginName,
+		"OriginPodNodeEnvironment",
+		"RunOnceDuration",
+		sccadmission.PluginName,
+		"SCCExecRestrictions",
+	)
+
 	// openshiftAdmissionControlPlugins gives the in-order default admission chain for openshift resources.
 	openshiftAdmissionControlPlugins = []string{
 		"ProjectRequestLimit",
@@ -167,6 +182,7 @@ func fixupAdmissionPlugins(plugins []string) []string {
 func NewAdmissionChains(
 	options configapi.MasterConfig,
 	admissionInitializer admission.PluginInitializer,
+	admissionDecorator admission.Decorator,
 ) (admission.Interface, error) {
 	admissionPluginConfigFilename := ""
 	if len(options.KubernetesMasterConfig.APIServerArguments["admission-control-config-file"]) > 0 {
@@ -204,7 +220,7 @@ func NewAdmissionChains(
 	}
 	admissionPluginNames = fixupAdmissionPlugins(admissionPluginNames)
 
-	admissionChain, err := newAdmissionChainFunc(admissionPluginNames, admissionPluginConfigFilename, options, admissionInitializer)
+	admissionChain, err := newAdmissionChainFunc(admissionPluginNames, admissionPluginConfigFilename, options, admissionInitializer, admissionDecorator)
 
 	if err != nil {
 		return nil, err
@@ -216,7 +232,7 @@ func NewAdmissionChains(
 // newAdmissionChainFunc is for unit testing only.  You should NEVER OVERRIDE THIS outside of a unit test.
 var newAdmissionChainFunc = newAdmissionChain
 
-func newAdmissionChain(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, admissionInitializer admission.PluginInitializer) (admission.Interface, error) {
+func newAdmissionChain(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, admissionInitializer admission.PluginInitializer, admissionDecorator admission.Decorator) (admission.Interface, error) {
 	plugins := []admission.Interface{}
 	for _, pluginName := range pluginNames {
 		var (
@@ -266,7 +282,7 @@ func newAdmissionChain(pluginNames []string, admissionConfigFilename string, opt
 			if err != nil {
 				return nil, err
 			}
-			plugin, err = OriginAdmissionPlugins.NewFromPlugins([]string{pluginName}, pluginsConfigProvider, admissionInitializer, admissionmetrics.WithControllerMetrics)
+			plugin, err = OriginAdmissionPlugins.NewFromPlugins([]string{pluginName}, pluginsConfigProvider, admissionInitializer, admissionDecorator)
 			if err != nil {
 				// should have been caught with validation
 				return nil, err

--- a/pkg/cmd/server/origin/admission/config_test.go
+++ b/pkg/cmd/server/origin/admission/config_test.go
@@ -96,14 +96,14 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		options               configapi.MasterConfig
-		admissionChainBuilder func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error)
+		admissionChainBuilder func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error)
 	}{
 		{
 			name: "stock everything",
 			options: configapi.MasterConfig{
 				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error) {
 				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
 					t.Errorf("%s: expected %v, got %v", "stock everything", combinedAdmissionControlPlugins, pluginNames)
 				}
@@ -118,7 +118,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 					PluginOrderOverride: []string{"foo"},
 				},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error) {
 				isKube := reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins)
 
 				expectedOrigin := []string{"foo"}
@@ -140,7 +140,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 					},
 				},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error) {
 				isKube := reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins)
 				isOrigin := reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins)
 				if !isKube && !isOrigin {
@@ -161,7 +161,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 					},
 				},
 			},
-			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer) (admission.Interface, error) {
+			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error) {
 				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
 					t.Errorf("%s: expected %v, got %v", "specified, non-conflicting plugin configs 01", combinedAdmissionControlPlugins, pluginNames)
 				}
@@ -172,7 +172,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 
 	for _, tc := range testCases {
 		newAdmissionChainFunc = tc.admissionChainBuilder
-		_, _ = NewAdmissionChains(tc.options, nil)
+		_, _ = NewAdmissionChains(tc.options, nil, nil)
 	}
 }
 


### PR DESCRIPTION
… based on namespace labels

Needed to split apiservers.  This provides a decorator that optionally wraps an admission plugin in a "skip if namespace is labelled a certain way" function.  `openshift.io/run-level=1` is the intent.

/assign @sttts 
/assign @mfojtik 

@openshift/sig-master 