### PR TITLE
Don't call DeleteHostSubnetRules on a replayed Deleted event

### DIFF
--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -103,6 +103,10 @@ func (node *OsdnNode) handleDeleteHostSubnet(obj interface{}) {
 	if hs.HostIP == node.localIP {
 		return
 	}
+	if _, exists := node.hostSubnetMap[string(hs.UID)]; !exists {
+		return
+	}
+
 	delete(node.hostSubnetMap, string(hs.UID))
 	node.DeleteHostSubnetRules(hs)
 


### PR DESCRIPTION
In some as-yet-undiagnosed set of circumstances, HostSubnet Deleted events are being replayed:

    I0210 19:29:59.006531   36434 sdn_controller.go:268] DeleteHostSubnetRules for ip-172-31-52-121.us-west-2.compute.internal (host: "ip-172-31-52-121.us-west-2.compute.internal", ip: "172.31.52.121", subnet: "10.130.10.0/23")
    I0210 19:30:49.860255   36434 sdn_controller.go:261] AddHostSubnetRules for ip-172-31-52-121.us-west-2.compute.internal (host: "ip-172-31-52-121.us-west-2.compute.internal", ip: "172.31.52.121", subnet: "10.130.18.0/23")
    ...
    I0210 19:59:20.717721   36434 sdn_controller.go:268] DeleteHostSubnetRules for ip-172-31-52-121.us-west-2.compute.internal (host: "ip-172-31-52-121.us-west-2.compute.internal", ip: "172.31.52.121", subnet: "10.130.10.0/23")

(Note that when the HostSubnet was recreated, it got a different subnet (`18` vs `10`), but the second Deleted event references the old subnet again.)

Currently, when we receive the second Deleted event, we don't notice that it's a replay, and just call DeleteHostSubnetRules again. That does:

    otx.DeleteFlows("table=10, tun_src=%s", subnet.HostIP)
    otx.DeleteFlows("table=50, arp, nw_dst=%s", subnet.Subnet)
    otx.DeleteFlows("table=90, ip, nw_dst=%s", subnet.Subnet)

Since the HostIP is still the same, the first DeleteFlows call ends up deleting the rule that was added by the earlier AddHostSubnetRules call. (The second and third DeleteFlows calls are no-ops, because they're trying to delete flows to the `10` subnet, but the current OVS flows refer to the `18` subnet.) As a result, we end up with no rule to accept VXLAN traffic from that node, even though all the other rules for that node are still present.

Anyway, the fix is easy: don't run DeleteHostSubnetRules if the event doesn't correspond to a currently-known-about HostSubnet.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544903