### PR TITLE
oc cluster up: fix --logging

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/admin.go
+++ b/pkg/oc/bootstrap/docker/openshift/admin.go
@@ -208,6 +208,22 @@ func AddClusterRole(authorizationClient authorizationtypedclient.ClusterRoleBind
 	return addClusterReaderRole.AddRole()
 }
 
+func AddClusterRoleToServiceAccount(authorizationClient authorizationtypedclient.ClusterRoleBindingsGetter, role, sa, namespace string) error {
+	clusterRoleBindingAccessor := policy.NewClusterRoleBindingAccessor(authorizationClient)
+	addClusterReaderRole := policy.RoleModificationOptions{
+		RoleName:            role,
+		RoleBindingAccessor: clusterRoleBindingAccessor,
+		Subjects: []kapi.ObjectReference{
+			{
+				Namespace: namespace,
+				Name:      sa,
+				Kind:      "ServiceAccount",
+			},
+		},
+	}
+	return addClusterReaderRole.AddRole()
+}
+
 func AddRoleToServiceAccount(authorizationClient authorizationtypedclient.RoleBindingsGetter, role, sa, namespace string) error {
 	roleBindingAccessor := policy.NewLocalRoleBindingAccessor(namespace, authorizationClient)
 	addRole := policy.RoleModificationOptions{

--- a/pkg/oc/bootstrap/docker/openshift/metrics.go
+++ b/pkg/oc/bootstrap/docker/openshift/metrics.go
@@ -38,6 +38,10 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverVersion se
 	if err != nil {
 		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
 	}
+	authorizationClient, err := f.OpenshiftInternalAuthorizationClient()
+	if err != nil {
+		return errors.NewError("cannot obtain API clients").WithCause(err).WithDetails(h.OriginLog())
+	}
 
 	_, err = kubeClient.Core().Services(infraNamespace).Get(svcMetrics, metav1.GetOptions{})
 	if err == nil {
@@ -58,7 +62,7 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverVersion se
 	params.HawkularHostName = hostName
 	params.MetricsResolution = "10s"
 
-	runner := newAnsibleRunner(h, kubeClient, securityClient, infraNamespace, imageStreams, "metrics")
+	runner := newAnsibleRunner(h, kubeClient, securityClient, authorizationClient, infraNamespace, imageStreams, "metrics")
 
 	//run playbook
 	return runner.RunPlaybook(params, getMetricsPlaybook(serverVersion), hostConfigDir, imagePrefix, imageVersion)


### PR DESCRIPTION
Command `oc cluster up --logging` creates `openshift-ansible` container inside the `logging` namespace. Running the playbook inside a container creates a few issues that are not present when running ansible on host.

1) `system:serviceaccount:logging:openshift-ansible` SA gets cluster-admin:
Logging playbook uses `oc adm ...` frequently and that requires higher privileges. Given the `openshift-ansible` pod already mounts entire `/etc/origin/master` from host and is de facto cluster-admin, adding the cluster-admin role to the SA doesn't change what the pod can do, only helps with the syntax of `oc commands`.
Instead of:
`oc [COMMAND] --as=system:admin --config=/etc/origin/master/admin.kubeconfig`
can use the common:
`oc [COMMAND]`

2) Adding `__openshift_oc_cluster_up` for logging playbook usage:
`openshift_logging` role used to populate `assetConfig.loggingPublicURL` in the origin master-config file. In order for origin-master to respect this change, it needed to `systemctl restart origin-master-api` but given the playbook runs inside a container, we don't have `systemctl` available there.

3) oauth-proxy in dockerhub doesn't follow image naming conventions for origin
It doesn't follow the same release pattern upstream as every other openshift image:
https://hub.docker.com/r/openshift/oauth-proxy/tags/
In other registries, it does follow the release pattern:
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/openshift3/oauth-proxy

**DEPENDS ON** a PR to openshift-ansible https://github.com/openshift/openshift-ansible/pull/7165

**FIXES** an issue in openshift-ansible https://github.com/openshift/openshift-ansible/issues/7006

@ewolinetz , @jcantrill: please could you comment or suggest a better approach?