### PR TITLE
Revert "Allow insecure path Allow routes to override Redirect routes …

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -11,7 +11,7 @@ RUN INSTALL_PKGS="haproxy18" && \
     yum clean all && \
     mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
     mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
-    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_route_http_insecure,cert_config,os_wildcard_domain}.map,haproxy.config} && \
+    touch /var/lib/haproxy/conf/{{os_http_be,os_edge_http_be,os_tcp_be,os_sni_passthrough,os_reencrypt,os_route_http_expose,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
     chown -R :0 /var/lib/haproxy && \
     chmod -R g+w /var/lib/haproxy

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -161,12 +161,12 @@ frontend public
   http-request set-header Host %[req.hdr(Host),lower]
 
   # check if we need to redirect/force using https.
-  acl secure_redirect base,map_reg(/var/lib/haproxy/conf/os_route_http_insecure.map) redirect
+  acl secure_redirect base,map_reg(/var/lib/haproxy/conf/os_route_http_redirect.map) -m found
   redirect scheme https if secure_redirect
 
   # Check if it is an edge or reencrypt route exposed insecurely.
-  acl secure_redirect_or_allow base,map_reg(/var/lib/haproxy/conf/os_route_http_insecure.map) -m found
-  use_backend %[base,map_reg(/var/lib/haproxy/conf/os_route_http_insecure.map)] if secure_redirect_or_allow !secure_redirect
+  acl route_http_expose base,map_reg(/var/lib/haproxy/conf/os_route_http_expose.map) -m found
+  use_backend %[base,map_reg(/var/lib/haproxy/conf/os_route_http_expose.map)] if route_http_expose
 
   # map to http backend
   # Search from most specific to general path (host case).
@@ -519,24 +519,34 @@ backend be_tcp:{{$cfgIdx}}
 {{ end -}}{{/* end edge http host map template */}}
 
 {{/*
-    os_route_http_insecure.map: edge and reencrypt routes that redirect or allow insecure traffic
+    os_route_http_expose.map: contains a mapping of www.example.com -> <service name>.
+    Map is used to also expose edge terminated and reencrypt routes via an insecure scheme
+    (http) if acls match for routes with insecure option set to expose.
 */}}
-{{ define "/var/lib/haproxy/conf/os_route_http_insecure.map" -}}
+{{ define "/var/lib/haproxy/conf/os_route_http_expose.map" -}}
 {{     range $idx, $cfg := .State -}}
-{{       if ne $cfg.Host "" -}}
-{{         if and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (eq $cfg.InsecureEdgeTerminationPolicy "Allow") -}}
-{{           if (eq $cfg.TLSTermination "edge") -}}
+{{       if and (ne $cfg.Host "") (and (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") (eq $cfg.InsecureEdgeTerminationPolicy "Allow")) -}}
+{{         if (eq $cfg.TLSTermination "edge") -}}
 {{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} be_edge_http:{{$idx}}
-{{           else -}}
+{{         else -}}
 {{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} be_secure:{{$idx}}
-{{           end -}}
-{{         end -}}
-{{         if eq $cfg.InsecureEdgeTerminationPolicy "Redirect" -}}
-{{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} redirect
 {{         end -}}
 {{       end -}}
 {{     end -}}
-{{ end -}}{{/* end edge and reencrypt routes that redirect or allow insecure traffic map template */}}
+{{ end -}}{{/* end edge and reencrypt expose http host map template */}}
+
+{{/*
+    os_route_http_redirect.map: contains a mapping of www.example.com -> <service name>.
+    Map is used to redirect insecure traffic to use a secure scheme (https)
+    if acls match for routes that have the insecure option set to redirect.
+*/}}
+{{ define "/var/lib/haproxy/conf/os_route_http_redirect.map" -}}
+{{     range $idx, $cfg := .State -}}
+{{       if and (ne $cfg.Host "") (eq $cfg.InsecureEdgeTerminationPolicy "Redirect") -}}
+{{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} {{$idx}}
+{{       end -}}
+{{     end -}}
+{{ end -}}{{/* end redirect http host map template */}}
 
 
 {{/*


### PR DESCRIPTION
…without breaking the reverse"

This reverts commit 49993fae10e7be5393f97a50600491a7d0ae4275.


This is not a complete fix for the issue, a real fix will follow later. This behavior has not changed since the first Openshift release, it is recommended to use the same termination type for all routes to the same host. 