### PR TITLE
Correctly flush stale ovs rules on Node startup

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -62,7 +62,11 @@ func (oc *ovsController) AlreadySetUp() bool {
 }
 
 func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway string) error {
-	err := oc.ovs.AddBridge("fail-mode=secure", "protocols=OpenFlow13")
+	err := oc.ovs.DeleteBridge(true)
+	if err != nil {
+		return err
+	}
+	err = oc.ovs.AddBridge("fail-mode=secure", "protocols=OpenFlow13")
 	if err != nil {
 		return err
 	}

--- a/pkg/util/ovs/fake_ovs.go
+++ b/pkg/util/ovs/fake_ovs.go
@@ -37,7 +37,7 @@ func (fake *ovsFake) AddBridge(properties ...string) error {
 	return nil
 }
 
-func (fake *ovsFake) DeleteBridge() error {
+func (fake *ovsFake) DeleteBridge(ifExists bool) error {
 	fake.ports = nil
 	fake.flows = nil
 	return nil


### PR DESCRIPTION
currently in openshift when creating a new ovs bridge it does so using

ovs-vsctl --if-exists del-br br0 -- add-br br0 -- set Bridge br0 fail-mode=secure protocols=OpenFlow13

which while it does delete the bridge does not clear the flows attached to it. Spliting bridge creation into two steps, deleting the old bridge and creating the new one correctly deletes any stale ovs flows.

Bug [1539187](https://bugzilla.redhat.com/show_bug.cgi?id=1539187)