### PR TITLE
Store pod IP in OVS external-ids and use that on teardown

### DIFF
--- a/pkg/util/ovs/fake_ovs.go
+++ b/pkg/util/ovs/fake_ovs.go
@@ -72,13 +72,10 @@ func (fake *ovsFake) AddPort(port string, ofportRequest int, properties ...strin
 		if !strings.HasPrefix(property, "external-ids=") {
 			continue
 		}
-		externalIDs = make(map[string]string, 1)
-		for _, id := range strings.Split(property[13:], ",") {
-			parsed := strings.Split(id, "=")
-			if len(parsed) != 2 {
-				return -1, fmt.Errorf("could not parse external-id %q", id)
-			}
-			externalIDs[parsed[0]] = parsed[1]
+		var err error
+		externalIDs, err = ParseExternalIDs(property[13:])
+		if err != nil {
+			return -1, err
 		}
 	}
 
@@ -150,6 +147,8 @@ func (fake *ovsFake) Find(table, column, condition string) ([]string, error) {
 					results = append(results, portName)
 				} else if column == "ofport" {
 					results = append(results, fmt.Sprintf("%d", portInfo.ofport))
+				} else if column == "external-ids" {
+					results = append(results, UnparseExternalIDs(portInfo.externalIDs))
 				}
 			}
 		}

--- a/pkg/util/ovs/parse.go
+++ b/pkg/util/ovs/parse.go
@@ -361,3 +361,32 @@ func fieldMatches(val, match string, ptype ParseType) bool {
 
 	return false
 }
+
+func ParseExternalIDs(externalIDs string) (map[string]string, error) {
+	ids := make(map[string]string, 1)
+	// Output from "find" and "list" will have braces, but input to "set" won't
+	if externalIDs[0] == '{' && externalIDs[len(externalIDs)-1] == '}' {
+		externalIDs = externalIDs[1 : len(externalIDs)-1]
+	}
+	for _, id := range strings.Split(externalIDs, ",") {
+		parsed := strings.Split(strings.TrimSpace(id), "=")
+		if len(parsed) != 2 {
+			return nil, fmt.Errorf("could not parse external-id %q", id)
+		}
+		key := parsed[0]
+		value := parsed[1]
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			value = unquoted
+		}
+		ids[key] = value
+	}
+	return ids, nil
+}
+
+func UnparseExternalIDs(externalIDs map[string]string) string {
+	ids := []string{}
+	for key, value := range externalIDs {
+		ids = append(ids, key+"="+strconv.Quote(value))
+	}
+	return "{" + strings.Join(ids, ",") + "}"
+}


### PR DESCRIPTION
If the pod is torn down after its veth has already been destroyed, then OVS will report "-1" for its ofport, so we can't rely on using that to find the pod IP from the flows.

One way to reproduce this is to "systemctl restart docker" when there's a pod running. The pod teardown attempt will fail because ovscontroller will try to run "ovs-ofctl dump-flows br0 in_port=-1", and then it will leave behind stray flows related to the old IP address (while reporting success to the caller).

This is a new bug in 3.9, and it's probably not related to #12544