### PR TITLE
Update custom tito tagger for new version

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -39,6 +39,6 @@ class OriginTagger(VersionTagger):
         inject_os_git_vars(self.spec_file)
         super(OriginTagger, self)._tag_release()
 
-    def _get_tag_for_version(self, version):
+    def _get_tag_for_version(self, version, release=None):
         return "v{}".format(version)
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:


### PR DESCRIPTION
Tito upstream changed the method signature of the version to tag
resolution routine. We need to update our implementation to stay in
sync.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton 
/assign @smarterclayton @dgoodwin 