### PR TITLE
Use ^uint32(0) instead of 0XFFFFFFFF

### DIFF
--- a/pkg/oc/bootstrap/docker/dockerhelper/ipv4range.go
+++ b/pkg/oc/bootstrap/docker/dockerhelper/ipv4range.go
@@ -103,7 +103,7 @@ func fromCIDR(ipnet *net.IPNet) IPV4Range {
 	// The upper bound can be calculated by adding
 	// the inverse of the mask to the lower bound.
 	ones, _ := ipnet.Mask.Size()
-	toAdd := 0XFFFFFFFF >> uint32(ones)
+	toAdd := ^uint32(0) >> uint32(ones)
 	upper := uint32(lower) + uint32(toAdd)
 	return IPV4Range{lower, ipv4(upper)}
 }


### PR DESCRIPTION
Currently `fromCIDR()` uses fixed value `0XFFFFFFFF` to get upper
bound. Due to this, compiling for 32 bit env (e.g windows/386) fails
by overflows. Below is the error:

```
$ make all OS_BUILD_PLATFORMS=windows/386 WHAT=cmd/oc
hack/build-go.sh cmd/oc
++ Building go targets for windows/386: cmd/oc
# github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper
pkg/oc/bootstrap/docker/dockerhelper/ipv4range.go:106:22: constant 4294967295 overflows int
```

This patch replace `0XFFFFFFFF` with `^uint32(0)`, so users can
compile the binary for 32 bit platform.
