### PR TITLE
masterPublicURL must be both internally and externally accessible

### DIFF
--- a/pkg/cmd/server/apis/config/v1/swagger_doc.go
+++ b/pkg/cmd/server/apis/config/v1/swagger_doc.go
@@ -612,7 +612,7 @@ var map_OAuthConfig = map[string]string{
 	"":                            "OAuthConfig holds the necessary configuration options for OAuth authentication",
 	"masterCA":                    "MasterCA is the CA for verifying the TLS connection back to the MasterURL.",
 	"masterURL":                   "MasterURL is used for making server-to-server calls to exchange authorization codes for access tokens",
-	"masterPublicURL":             "MasterPublicURL is used for building valid client redirect URLs for external access",
+	"masterPublicURL":             "MasterPublicURL is used for building valid client redirect URLs for internal and external access",
 	"assetPublicURL":              "AssetPublicURL is used for building valid client redirect URLs for external access",
 	"alwaysShowProviderSelection": "AlwaysShowProviderSelection will force the provider selection page to render even when there is only a single provider.",
 	"identityProviders":           "IdentityProviders is an ordered list of ways for a user to identify themselves",

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -719,7 +719,7 @@ type OAuthConfig struct {
 	// MasterURL is used for making server-to-server calls to exchange authorization codes for access tokens
 	MasterURL string `json:"masterURL"`
 
-	// MasterPublicURL is used for building valid client redirect URLs for external access
+	// MasterPublicURL is used for building valid client redirect URLs for internal and external access
 	MasterPublicURL string `json:"masterPublicURL"`
 
 	// AssetPublicURL is used for building valid client redirect URLs for external access


### PR DESCRIPTION
fda7222b1e6893ff97200e67156bc3f304fc9fa5 changed the doc for the internal struct.  This change simply updates the external type to match.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: https://github.com/openshift/origin/pull/10845/files#diff-3788994f990386b63387ece5c3b5dc33R638
xref: https://github.com/openshift/oauth-proxy/issues/55

/assign @liggitt