### PR TITLE
use the correct loopback connection

### DIFF
--- a/pkg/apps/apiserver/apiserver.go
+++ b/pkg/apps/apiserver/apiserver.go
@@ -26,7 +26,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	KubeletClientConfig       *kubeletclient.KubeletClientConfig
 
 	// TODO these should all become local eventually
@@ -113,15 +113,15 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 		return nil, err
 	}
 	// This client is using the core api server client config, since the apps server doesn't host images
-	openshiftInternalImageClient, err := imageclientinternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	openshiftInternalImageClient, err := imageclientinternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeExternalClient, err := kclientsetexternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	kubeExternalClient, err := kclientsetexternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authorization/apiserver/apiserver.go
+++ b/pkg/authorization/apiserver/apiserver.go
@@ -31,7 +31,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 	RuleResolver              rbacregistryvalidation.AuthorizationRuleResolver
 	SubjectLocator            rbac.SubjectLocator
@@ -110,7 +110,7 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	rbacClient, err := rbacclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	rbacClient, err := rbacclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/apiserver/apiserver.go
+++ b/pkg/build/apiserver/apiserver.go
@@ -32,7 +32,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	KubeletClientConfig       *kubeletclient.KubeletClientConfig
 
 	// TODO these should all become local eventually
@@ -111,11 +111,11 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeExternalClient, err := kclientsetexternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	kubeExternalClient, err := kclientsetexternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	imageClient, err := imageclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	imageClient, err := imageclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -48,6 +48,7 @@ func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Confi
 	ret := &OpenshiftAPIConfig{
 		GenericConfig: &apiserver.RecommendedConfig{Config: genericConfig},
 		ExtraConfig: OpenshiftAPIExtraConfig{
+			KubeAPIServerClientConfig:          &c.PrivilegedLoopbackClientConfig,
 			KubeClientInternal:                 c.PrivilegedLoopbackKubernetesClientsetInternal,
 			KubeletClientConfig:                c.KubeletClientConfig,
 			KubeInternalInformers:              c.InternalKubeInformers,

--- a/pkg/image/apiserver/apiserver.go
+++ b/pkg/image/apiserver/apiserver.go
@@ -39,7 +39,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig          *restclient.Config
+	KubeAPIServerClientConfig          *restclient.Config
 	LimitVerifier                      imageadmission.LimitVerifier
 	RegistryHostnameRetriever          imageapi.RegistryHostnameRetriever
 	AllowedRegistriesForImport         *configapi.AllowedRegistries
@@ -133,11 +133,11 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 		return nil, fmt.Errorf("unable to configure a default transport for importing: %v", err)
 	}
 
-	coreClient, err := coreclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	coreClient, err := coreclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	authorizationClient, err := authorizationclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	authorizationClient, err := authorizationclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/apiserver/apiserver.go
+++ b/pkg/oauth/apiserver/apiserver.go
@@ -25,7 +25,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	ServiceAccountMethod      configapi.GrantHandlerType
 
 	// TODO these should all become local eventually
@@ -117,11 +117,11 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	routeClient, err := routeclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	routeClient, err := routeclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	coreV1Client, err := corev1.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	coreV1Client, err := corev1.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/apiserver/apiserver.go
+++ b/pkg/project/apiserver/apiserver.go
@@ -27,7 +27,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 	ProjectAuthorizationCache *projectauth.AuthorizationCache
 	ProjectCache              *projectcache.ProjectCache
@@ -109,19 +109,19 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	projectClient, err := projectclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	projectClient, err := projectclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	templateClient, err := templateclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	templateClient, err := templateclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	authorizationClient, err := authorizationclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	authorizationClient, err := authorizationclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 		projectClient.Project(),
 		templateClient,
 		authorizationClient.SubjectAccessReviews(),
-		c.GenericConfig.LoopbackClientConfig,
+		c.ExtraConfig.KubeAPIServerClientConfig,
 		c.ExtraConfig.KubeInternalInformers.Rbac().InternalVersion().RoleBindings().Lister(),
 	)
 

--- a/pkg/route/apiserver/apiserver.go
+++ b/pkg/route/apiserver/apiserver.go
@@ -19,7 +19,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	RouteAllocator            *routeallocationcontroller.RouteAllocationController
 
 	// TODO these should all become local eventually
@@ -96,7 +96,7 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	authorizationClient, err := authorizationclient.NewForConfig(c.GenericConfig.LoopbackClientConfig)
+	authorizationClient, err := authorizationclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/apiserver/apiserver.go
+++ b/pkg/security/apiserver/apiserver.go
@@ -23,7 +23,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 	// SCCStorage is actually created with a kubernetes restmapper options to have the correct prefix,
 	// so we have to have it special cased here to point to the right spot.
 	SCCStorage            *sccstorage.REST
@@ -104,7 +104,7 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/template/apiserver/apiserver.go
+++ b/pkg/template/apiserver/apiserver.go
@@ -20,7 +20,7 @@ import (
 )
 
 type ExtraConfig struct {
-	CoreAPIServerClientConfig *restclient.Config
+	KubeAPIServerClientConfig *restclient.Config
 
 	// TODO these should all become local eventually
 	Scheme   *runtime.Scheme
@@ -97,7 +97,7 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	authorizationClient, err := authorizationclient.NewForConfig(c.ExtraConfig.CoreAPIServerClientConfig)
+	authorizationClient, err := authorizationclient.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Sometimes you need a loopback (your particular apiserver), sometimes you need a connection to the kube-apiserver (resource outside your group).  This provides the distinction.

/assign @mfojtik 
/assign @sttts 

@openshift/sig-master 