### PR TITLE
exclude some namespaces in run levels based on name

### DIFF
--- a/pkg/admission/namespaceconditions/decorator.go
+++ b/pkg/admission/namespaceconditions/decorator.go
@@ -7,6 +7,15 @@ import (
 	corev1lister "k8s.io/client-go/listers/core/v1"
 )
 
+// this is a list of namespaces with special meaning.  The kube ones are here in particular because
+// we don't control their creation or labeling on their creation
+var runLevelZeroNamespaces = sets.NewString("default", "kube-system", "kube-public")
+var runLevelOneNamespaces = sets.NewString("openshift-node", "openshift-infra", "openshift")
+
+func init() {
+	runLevelOneNamespaces.Insert(runLevelZeroNamespaces.List()...)
+}
+
 // NamespaceLabelConditions provides a decorator that can delegate and conditionally add label conditions
 type NamespaceLabelConditions struct {
 	// TODO decorators are refactored in 1.10, so this is unnecessary and we'll get a nice chain
@@ -24,19 +33,29 @@ func (d *NamespaceLabelConditions) WithNamespaceLabelConditions(admissionPlugin 
 
 	switch {
 	case d.SkipLevelOneNames.Has(name):
-		return &pluginHandlerWithNamespaceLabelConditions{
-			admissionPlugin:   delegateDecoratedAdmissionPlugin,
-			namespaceClient:   d.NamespaceClient,
-			namespaceLister:   d.NamespaceLister,
-			namespaceSelector: skipRunLevelOneSelector,
+		// return a decorated admission plugin that skips runlevel 0 and 1 namespaces based on name (for known values) and
+		// label.
+		return &pluginHandlerWithNamespaceNameConditions{
+			admissionPlugin: &pluginHandlerWithNamespaceLabelConditions{
+				admissionPlugin:   delegateDecoratedAdmissionPlugin,
+				namespaceClient:   d.NamespaceClient,
+				namespaceLister:   d.NamespaceLister,
+				namespaceSelector: skipRunLevelOneSelector,
+			},
+			namespacesToExclude: runLevelOneNamespaces,
 		}
 
 	case d.SkipLevelZeroNames.Has(name):
-		return &pluginHandlerWithNamespaceLabelConditions{
-			admissionPlugin:   delegateDecoratedAdmissionPlugin,
-			namespaceClient:   d.NamespaceClient,
-			namespaceLister:   d.NamespaceLister,
-			namespaceSelector: skipRunLevelZeroSelector,
+		// return a decorated admission plugin that skips runlevel 0 namespaces based on name (for known values) and
+		// label.
+		return &pluginHandlerWithNamespaceNameConditions{
+			admissionPlugin: &pluginHandlerWithNamespaceLabelConditions{
+				admissionPlugin:   delegateDecoratedAdmissionPlugin,
+				namespaceClient:   d.NamespaceClient,
+				namespaceLister:   d.NamespaceLister,
+				namespaceSelector: skipRunLevelZeroSelector,
+			},
+			namespacesToExclude: runLevelZeroNamespaces,
 		}
 
 	default:

--- a/pkg/admission/namespaceconditions/namecondition.go
+++ b/pkg/admission/namespaceconditions/namecondition.go
@@ -1,0 +1,55 @@
+package namespaceconditions
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// pluginHandlerWithNamespaceNameConditions skips running admission plugins if they deal in the namespaceToExclude list
+type pluginHandlerWithNamespaceNameConditions struct {
+	admissionPlugin     admission.Interface
+	namespacesToExclude sets.String
+}
+
+func (p pluginHandlerWithNamespaceNameConditions) Handles(operation admission.Operation) bool {
+	return p.admissionPlugin.Handles(operation)
+}
+
+// Admit performs a mutating admission control check and emit metrics.
+func (p pluginHandlerWithNamespaceNameConditions) Admit(a admission.Attributes) error {
+	if !p.shouldRunAdmission(a) {
+		return nil
+	}
+
+	mutatingHandler, ok := p.admissionPlugin.(admission.MutationInterface)
+	if !ok {
+		return nil
+	}
+	return mutatingHandler.Admit(a)
+}
+
+// Validate performs a non-mutating admission control check and emits metrics.
+func (p pluginHandlerWithNamespaceNameConditions) Validate(a admission.Attributes) error {
+	if !p.shouldRunAdmission(a) {
+		return nil
+	}
+
+	validatingHandler, ok := p.admissionPlugin.(admission.ValidationInterface)
+	if !ok {
+		return nil
+	}
+	return validatingHandler.Validate(a)
+}
+
+func (p pluginHandlerWithNamespaceNameConditions) shouldRunAdmission(attr admission.Attributes) bool {
+	namespaceName := attr.GetNamespace()
+	if p.namespacesToExclude.Has(namespaceName) {
+		return false
+	}
+	if (attr.GetResource().GroupResource() == schema.GroupResource{Resource: "namespaces"}) && p.namespacesToExclude.Has(attr.GetName()) {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
We don't control the creation of all namespaces.  Some namespaces are created by post-starthooks of one kind or another, upstream and downstream. This special cases them.  We can later create a controller or some such to reconcile these.

/assign @mfojtik 
/assign @sttts 