### PR TITLE
Remove requirement of having deprecated clusterNetworkCIDR/hostSubnetLength in master.networkConfig

### DIFF
--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -133,9 +133,15 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 				obj.NetworkConfig.DeprecatedClusterNetworkCIDR = obj.NetworkConfig.ClusterNetworks[0].CIDR
 				obj.NetworkConfig.DeprecatedHostSubnetLength = obj.NetworkConfig.ClusterNetworks[0].HostSubnetLength
 			} else {
-				obj.NetworkConfig.ClusterNetworks = nil
 				obj.NetworkConfig.DeprecatedClusterNetworkCIDR = ""
 				obj.NetworkConfig.DeprecatedHostSubnetLength = 0
+				clusterNetwork := []configapi.ClusterNetworkEntry{
+					{
+						CIDR:             obj.NetworkConfig.DeprecatedClusterNetworkCIDR,
+						HostSubnetLength: obj.NetworkConfig.DeprecatedHostSubnetLength,
+					},
+				}
+				obj.NetworkConfig.ClusterNetworks = clusterNetwork
 			}
 
 			// TODO stop duplicating the conversion in the test.

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -392,28 +392,14 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
 				return err
 			}
-			if len(in.DeprecatedClusterNetworkCIDR) > 0 || in.DeprecatedHostSubnetLength > 0 {
-				if len(out.ClusterNetworks) > 0 {
-					out.ClusterNetworks[0].CIDR = in.DeprecatedClusterNetworkCIDR
-					out.ClusterNetworks[0].HostSubnetLength = in.DeprecatedHostSubnetLength
-				} else {
-					out.ClusterNetworks = []internal.ClusterNetworkEntry{
-						{
-							CIDR:             in.DeprecatedClusterNetworkCIDR,
-							HostSubnetLength: in.DeprecatedHostSubnetLength,
-						},
-					}
+
+			if len(out.ClusterNetworks) == 0 {
+				out.ClusterNetworks = []internal.ClusterNetworkEntry{
+					{
+						CIDR:             in.DeprecatedClusterNetworkCIDR,
+						HostSubnetLength: in.DeprecatedHostSubnetLength,
+					},
 				}
-			}
-			return nil
-		},
-		func(in *internal.MasterNetworkConfig, out *MasterNetworkConfig, s conversion.Scope) error {
-			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
-				return err
-			}
-			if len(in.ClusterNetworks) > 0 {
-				out.DeprecatedHostSubnetLength = in.ClusterNetworks[0].HostSubnetLength
-				out.DeprecatedClusterNetworkCIDR = in.ClusterNetworks[0].CIDR
 			}
 			return nil
 		},

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -132,7 +132,9 @@ masterClients:
   openshiftLoopbackKubeConfig: ""
 masterPublicURL: ""
 networkConfig:
-  clusterNetworks: null
+  clusterNetworks:
+  - cidr: ""
+    hostSubnetLength: 0
   externalIPNetworkCIDRs: null
   ingressIPNetworkCIDR: 172.29.0.0/16
   networkPluginName: ""

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -724,11 +724,22 @@ func ValidateIngressIPNetworkCIDR(config *configapi.MasterConfig, fldPath *field
 func ValidateDeprecatedClusterNetworkConfig(config *configapi.MasterConfig, fldPath *field.Path) ValidationResults {
 	validationResults := ValidationResults{}
 
-	if len(config.NetworkConfig.ClusterNetworks) > 0 && config.NetworkConfig.DeprecatedHostSubnetLength != config.NetworkConfig.ClusterNetworks[0].HostSubnetLength {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("hostSubnetLength"), config.NetworkConfig.DeprecatedHostSubnetLength, "cannot set hostSubnetLength and clusterNetworks, please use clusterNetworks"))
+	if len(config.NetworkConfig.ClusterNetworks) > 1 {
+		if config.NetworkConfig.DeprecatedHostSubnetLength != 0 {
+			validationResults.AddErrors(field.Invalid(fldPath.Child("hostSubnetLength"), config.NetworkConfig.DeprecatedHostSubnetLength, "cannot set hostSubnetLength and clusterNetworks, please use clusterNetworks"))
+		}
+		if len(config.NetworkConfig.DeprecatedClusterNetworkCIDR) != 0 {
+			validationResults.AddErrors(field.Invalid(fldPath.Child("clusterNetworkCIDR"), config.NetworkConfig.DeprecatedClusterNetworkCIDR, "cannot set clusterNetworkCIDR and clusterNetworks, please use clusterNetworks"))
+		}
+
+	} else if len(config.NetworkConfig.ClusterNetworks) == 1 {
+		if config.NetworkConfig.DeprecatedHostSubnetLength != config.NetworkConfig.ClusterNetworks[0].HostSubnetLength && config.NetworkConfig.DeprecatedHostSubnetLength != 0 {
+			validationResults.AddErrors(field.Invalid(fldPath.Child("hostSubnetLength"), config.NetworkConfig.DeprecatedHostSubnetLength, "cannot set hostSubnetLength and clusterNetworks, please use clusterNetworks"))
+		}
+		if config.NetworkConfig.DeprecatedClusterNetworkCIDR != config.NetworkConfig.ClusterNetworks[0].CIDR && len(config.NetworkConfig.DeprecatedClusterNetworkCIDR) != 0 {
+			validationResults.AddErrors(field.Invalid(fldPath.Child("clusterNetworkCIDR"), config.NetworkConfig.DeprecatedClusterNetworkCIDR, "cannot set clusterNetworkCIDR and clusterNetworks, please use clusterNetworks"))
+		}
 	}
-	if len(config.NetworkConfig.ClusterNetworks) > 0 && config.NetworkConfig.DeprecatedClusterNetworkCIDR != config.NetworkConfig.ClusterNetworks[0].CIDR {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("clusterNetworkCIDR"), config.NetworkConfig.DeprecatedClusterNetworkCIDR, "cannot set clusterNetworkCIDR and clusterNetworks, please use clusterNetworks"))
-	}
+
 	return validationResults
 }


### PR DESCRIPTION


Currently in order for openshift to start the first entry in clusterNetworks and the old clusterNetworkCIDR/hostSubnetLength have to match. Change it
so the older clusterNetworkCIDR/hostSubnetLength fields are no longer required.

Bug [1534779](https://bugzilla.redhat.com/show_bug.cgi?id=1534779)