### PR TITLE
Bug 1538006 - Improve error page when console not installed

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -157,7 +157,7 @@ func (c *MasterConfig) newWebConsoleProxy() (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
-	proxyHandler, err := NewServiceProxyHandler("webconsole", "openshift-web-console", aggregatorapiserver.NewClusterIPServiceResolver(c.ClientGoKubeInformers.Core().V1().Services().Lister()), caBundle)
+	proxyHandler, err := NewServiceProxyHandler("webconsole", "openshift-web-console", aggregatorapiserver.NewClusterIPServiceResolver(c.ClientGoKubeInformers.Core().V1().Services().Lister()), caBundle, "OpenShift web console")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a (very) basic error page for when the console is not installed.

Suggestions to make this better? It's hard to get specific in the error description since it's a generic service proxy.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538006

![screen shot 2018-02-20 at 12 06 51 pm](https://user-images.githubusercontent.com/1167259/36438040-a971f8c4-1636-11e8-9b2c-deebf32eadab.png)

/assign @deads2k 
@jwforres @smarterclayton FYI