### PR TITLE
Perform real backoff when contending for writes from the router

### DIFF
--- a/pkg/cmd/infra/router/router.go
+++ b/pkg/cmd/infra/router/router.go
@@ -137,8 +137,6 @@ func (o *RouterSelection) AdmissionCheck(route *routeapi.Route) error {
 		glog.V(4).Infof("host %s rejected - not in the list of allowed domains", route.Spec.Host)
 		return fmt.Errorf("host not in the allowed list of domains")
 	}
-
-	glog.V(4).Infof("host %s admitted", route.Spec.Host)
 	return nil
 }
 

--- a/pkg/router/controller/router_controller.go
+++ b/pkg/router/controller/router_controller.go
@@ -277,8 +277,10 @@ func (c *RouterController) Commit() {
 func (c *RouterController) processRoute(eventType watch.EventType, route *routeapi.Route) {
 	glog.V(4).Infof("Processing Route: %s/%s -> %s", route.Namespace, route.Name, route.Spec.To.Name)
 	glog.V(4).Infof("           Alias: %s", route.Spec.Host)
-	glog.V(4).Infof("           Path: %s", route.Spec.Path)
-	glog.V(4).Infof("           Event: %s", eventType)
+	if len(route.Spec.Path) > 0 {
+		glog.V(4).Infof("           Path: %s", route.Spec.Path)
+	}
+	glog.V(4).Infof("           Event: %s rv=%s", eventType, route.ResourceVersion)
 
 	c.RecordNamespaceRoutes(eventType, route)
 	if err := c.Plugin.HandleRoute(eventType, route); err != nil {

--- a/pkg/util/writerlease/writerlease.go
+++ b/pkg/util/writerlease/writerlease.go
@@ -1,0 +1,301 @@
+package writerlease
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Lease performs the equivalent of leader election by competing to perform work (such as
+// updating a contended resource). Every successful work unit is considered a lease renewal,
+// while work that is observed from others or that fails is treated as renewing another processes
+// lease. When a lease expires (no work is detected within the lease term) the writer competes
+// to perform work. When competing for the lease, exponential backoff is used.
+type Lease interface {
+	// Wait waits for the first work function to complete and then returns whether the current
+	// process is the leader. This function will block forever if no work has been requested or if the
+	// work retries forever.
+	Wait() bool
+	// WaitUntil waits at most the provided duration for the frist work function to complete.
+	// If the duration expires without work completing it will return false for expired, otherwise
+	// it will return whether the lease is held by this process.
+	WaitUntil(t time.Duration) (leader bool, ok bool)
+	// Try runs the provided function when the lease is held is the leader. It retries work until
+	// the work func indicates retry is not necessary.
+	Try(key string, fn WorkFunc)
+	// Extend indicates that the caller has observed another writer performing work against
+	// the specified key. This will clear the work remaining for the lease and extend the lease
+	// interval.
+	Extend(key string)
+	// Remove clears any pending work for the provided key.
+	Remove(key string)
+}
+
+// WorkFunc is a retriable unit of work. It should return an error if the work couldn't be
+// completed successfully, or true if we can assume our lease has been extended. If the
+// lease could not be extended, we drop this unit of work.
+type WorkFunc func() (extendLease, retry bool)
+
+// LimitRetries allows a work function to be retried up to retries times.
+func LimitRetries(retries int, fn WorkFunc) WorkFunc {
+	i := 0
+	return func() (bool, bool) {
+		extend, retry := fn()
+		if retry {
+			retry = i < retries
+			i++
+		}
+		return extend, retry
+	}
+}
+
+// State is the state of the lease.
+type State int
+
+const (
+	// Election is before a work unit has been completed.
+	Election State = iota
+	Leader
+	Follower
+)
+
+var nowFn = time.Now
+
+type WriterLease struct {
+	name          string
+	backoff       wait.Backoff
+	maxBackoff    time.Duration
+	retryInterval time.Duration
+	once          chan struct{}
+
+	lock    sync.Mutex
+	queued  map[string]WorkFunc
+	queue   workqueue.DelayingInterface
+	state   State
+	expires time.Time
+	tick    int
+}
+
+// New creates a new Lease. Specify the duration to hold leases for and the retry
+// interval on requests that fail.
+func New(leaseDuration, retryInterval time.Duration) *WriterLease {
+	backoff := wait.Backoff{
+		Duration: 20 * time.Millisecond,
+		Factor:   4,
+		Steps:    5,
+		Jitter:   0.5,
+	}
+	return &WriterLease{
+		backoff:       backoff,
+		maxBackoff:    leaseDuration,
+		retryInterval: retryInterval,
+
+		queued: make(map[string]WorkFunc),
+		queue:  workqueue.NewDelayingQueue(),
+		once:   make(chan struct{}),
+	}
+}
+
+// NewWithBackoff creates a new Lease. Specify the duration to hold leases for and the retry
+// interval on requests that fail.
+func NewWithBackoff(name string, leaseDuration, retryInterval time.Duration, backoff wait.Backoff) *WriterLease {
+	return &WriterLease{
+		name:          name,
+		backoff:       backoff,
+		maxBackoff:    leaseDuration,
+		retryInterval: retryInterval,
+
+		queued: make(map[string]WorkFunc),
+		queue:  workqueue.NewNamedDelayingQueue(name),
+		once:   make(chan struct{}),
+	}
+}
+
+func (l *WriterLease) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer l.queue.ShutDown()
+
+	go func() {
+		defer utilruntime.HandleCrash()
+		l.work()
+		glog.V(4).Infof("[%s] Worker stopped", l.name)
+	}()
+
+	<-stopCh
+}
+
+func (l *WriterLease) Expire() {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.expires = time.Time{}
+}
+
+func (l *WriterLease) Wait() bool {
+	<-l.once
+	state, _, _ := l.leaseState()
+	return state == Leader
+}
+
+func (l *WriterLease) WaitUntil(t time.Duration) (bool, bool) {
+	select {
+	case <-l.once:
+	case <-time.After(t):
+		return false, false
+	}
+	state, _, _ := l.leaseState()
+	return state == Leader, true
+}
+
+func (l *WriterLease) Try(key string, fn WorkFunc) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.queued[key] = fn
+	if l.state == Follower {
+		delay := l.expires.Sub(nowFn())
+		// no matter what, always wait at least some amount of time as a follower to give the nominal
+		// leader a chance to win
+		if delay < l.backoff.Duration*2 {
+			delay = l.backoff.Duration * 2
+		}
+		l.queue.AddAfter(key, delay)
+	} else {
+		l.queue.Add(key)
+	}
+}
+
+func (l *WriterLease) Extend(key string) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if _, ok := l.queued[key]; ok {
+		delete(l.queued, key)
+		switch l.state {
+		case Follower:
+			l.tick++
+			backoff := l.nextBackoff()
+			glog.V(4).Infof("[%s] Clearing work for %s and extending lease by %s", l.name, key, backoff)
+			l.expires = nowFn().Add(backoff)
+		}
+	}
+}
+
+func (l *WriterLease) Len() int {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return len(l.queued)
+}
+
+func (l *WriterLease) Remove(key string) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	delete(l.queued, key)
+}
+
+func (l *WriterLease) get(key string) WorkFunc {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return l.queued[key]
+}
+
+func (l *WriterLease) leaseState() (State, time.Time, int) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return l.state, l.expires, l.tick
+}
+
+func (l *WriterLease) work() {
+	for {
+		item, shutdown := l.queue.Get()
+		if shutdown {
+			return
+		}
+		key := item.(string)
+
+		fn := l.get(key)
+		if fn == nil {
+			glog.V(4).Infof("[%s] Work item %s was cleared, done", l.name, key)
+			l.queue.Done(key)
+			continue
+		}
+
+		leaseState, leaseExpires, _ := l.leaseState()
+		if leaseState == Follower {
+			// if we are following, continue to defer work until the lease expires
+			if remaining := leaseExpires.Sub(nowFn()); remaining > 0 {
+				glog.V(4).Infof("[%s] Follower, %s remaining in lease", l.name, remaining)
+				l.queue.AddAfter(key, remaining)
+				l.queue.Done(key)
+				continue
+			}
+			glog.V(4).Infof("[%s] Lease expired, running %s", l.name, key)
+		} else {
+			glog.V(4).Infof("[%s] Lease owner or electing, running %s", l.name, key)
+		}
+
+		isLeader, retry := fn()
+		if retry {
+			// come back in a bit
+			glog.V(4).Infof("[%s] Retrying %s", l.name, key)
+			l.queue.AddAfter(key, l.retryInterval)
+			l.queue.Done(key)
+			continue
+		}
+
+		l.finishKey(key, isLeader)
+	}
+}
+
+func (l *WriterLease) finishKey(key string, isLeader bool) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	resolvedElection := l.state == Election
+	if isLeader {
+		switch l.state {
+		case Election, Follower:
+			l.tick = 0
+			l.state = Leader
+		}
+		l.expires = nowFn().Add(l.maxBackoff)
+	} else {
+		switch l.state {
+		case Election, Leader:
+			l.tick = 0
+			l.state = Follower
+		case Follower:
+			l.tick++
+		}
+		l.expires = nowFn().Add(l.nextBackoff())
+	}
+	delete(l.queued, key)
+	// close the channel before we remove the key from the queue to prevent races in Wait
+	if resolvedElection {
+		close(l.once)
+	}
+	l.queue.Done(key)
+	glog.V(4).Infof("[%s] Completed work for %s in state=%d tick=%d expires=%s", l.name, key, l.state, l.tick, l.expires)
+}
+
+func (l *WriterLease) nextBackoff() time.Duration {
+	step := l.tick
+	b := l.backoff
+	if step > b.Steps {
+		return l.maxBackoff
+	}
+	duration := b.Duration
+	for i := 0; i < step; i++ {
+		adjusted := duration
+		if b.Jitter > 0.0 {
+			adjusted = wait.Jitter(duration, b.Jitter)
+		}
+		duration = time.Duration(float64(adjusted) * b.Factor)
+		if duration > l.maxBackoff {
+			return l.maxBackoff
+		}
+	}
+	return duration
+}

--- a/pkg/util/writerlease/writerlease_test.go
+++ b/pkg/util/writerlease/writerlease_test.go
@@ -1,0 +1,120 @@
+package writerlease
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWaitForLeader(t *testing.T) {
+	l := New(0, 0)
+	defer func() {
+		if len(l.queued) > 0 {
+			t.Fatalf("queue was not empty on shutdown: %#v", l.queued)
+		}
+	}()
+	ch := make(chan struct{})
+	defer close(ch)
+	go l.Run(ch)
+	calls := make(chan struct{}, 1)
+
+	l.Try("test", func() (bool, bool) {
+		calls <- struct{}{}
+		return true, false
+	})
+	if !l.Wait() {
+		t.Errorf("should have elected leader: %#v", l)
+	}
+	if len(calls) != 1 {
+		t.Errorf("incorrect number of calls: %d", len(calls))
+	}
+}
+
+func TestBecomeLeaderAfterRetry(t *testing.T) {
+	l := New(0, 0)
+	defer func() {
+		if len(l.queued) > 0 {
+			t.Fatalf("queue was not empty on shutdown: %#v", l.queued)
+		}
+	}()
+	ch := make(chan struct{})
+	defer close(ch)
+	go l.Run(ch)
+	calls := make(chan struct{}, 10)
+	i := 0
+	l.Try("test", func() (bool, bool) {
+		calls <- struct{}{}
+		i++
+		return true, i < 5
+	})
+	if !l.Wait() {
+		t.Errorf("should have elected leader: %#v", l)
+	}
+	if len(calls) != 5 {
+		t.Errorf("incorrect number of calls: %d", len(calls))
+	}
+}
+
+func TestBecomeFollowerAfterRetry(t *testing.T) {
+	l := New(0, 0)
+	l.backoff.Steps = 0
+	l.backoff.Duration = 0
+	defer func() {
+		if len(l.queued) > 0 {
+			t.Fatalf("queue was not empty on shutdown: %#v", l.queued)
+		}
+	}()
+	ch := make(chan struct{})
+	defer close(ch)
+	go l.Run(ch)
+	calls := make(chan struct{}, 10)
+	i := 0
+	l.Try("test", func() (bool, bool) {
+		calls <- struct{}{}
+		i++
+		return false, i < 5
+	})
+	if l.Wait() {
+		t.Errorf("should have become follower: %#v", l)
+	}
+	if len(calls) != 5 {
+		t.Errorf("incorrect number of calls: %d", len(calls))
+	}
+}
+
+func TestExtend(t *testing.T) {
+	nowFn = func() time.Time { return time.Unix(0, 0) }
+	defer func() { nowFn = time.Now }()
+
+	l := New(10*time.Millisecond, 0)
+	l.backoff.Steps = 0
+	l.backoff.Duration = 2 * time.Millisecond
+	defer func() {
+		if len(l.queued) > 0 {
+			t.Fatalf("queue was not empty on shutdown: %#v", l.queued)
+		}
+	}()
+	ch := make(chan struct{})
+	defer close(ch)
+	calls := make(chan struct{})
+	go l.Run(ch)
+
+	l.Try("test", func() (bool, bool) {
+		calls <- struct{}{}
+		return false, false
+	})
+	l.Try("test2", func() (bool, bool) {
+		calls <- struct{}{}
+		return false, false
+	})
+	<-calls
+	l.Extend("test2")
+
+	l.Wait()
+	for l.queue.Len() > 0 {
+		time.Sleep(time.Millisecond)
+	}
+	state, expires, _ := l.leaseState()
+	if state != Follower || expires != time.Unix(0, int64(10*time.Millisecond)) {
+		t.Errorf("unexpected lease state: %v %#v", expires.UnixNano(), l)
+	}
+}

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -1,0 +1,368 @@
+package images
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	routev1 "github.com/openshift/api/route/v1"
+	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
+	defer g.GinkgoRecover()
+	var (
+		routerImage string
+		ns          string
+		oc          *exutil.CLI
+	)
+
+	// this hook must be registered before the framework namespace teardown
+	// hook
+	g.AfterEach(func() {
+		if g.CurrentGinkgoTestDescription().Failed {
+			client := routeclientset.NewForConfigOrDie(oc.AdminConfig()).Route().Routes(ns)
+			if routes, _ := client.List(metav1.ListOptions{}); routes != nil {
+				outputIngress(routes.Items...)
+			}
+			exutil.DumpPodLogsStartingWith("router-", oc)
+		}
+	})
+
+	oc = exutil.NewCLI("router-stress", exutil.KubeConfigPath())
+
+	g.BeforeEach(func() {
+		ns = oc.Namespace()
+
+		dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
+		if kapierrs.IsNotFound(err) {
+			g.Skip("no router installed on the cluster")
+			imagePrefix := os.Getenv("OS_IMAGE_PREFIX")
+			if len(imagePrefix) == 0 {
+				imagePrefix = "openshift/origin"
+			}
+			routerImage = imagePrefix + "-haproxy-router:latest"
+			return
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		routerImage = dc.Spec.Template.Spec.Containers[0].Image
+
+		_, err = oc.AdminKubeClient().Rbac().RoleBindings(ns).Create(&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "router",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind: "ServiceAccount",
+					Name: "default",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind: "ClusterRole",
+				Name: "system:router",
+			},
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.Describe("The HAProxy router", func() {
+		g.It("converges when multiple routers are writing status", func() {
+			g.By("deploying a scaled out namespace scoped router")
+			rs, err := oc.KubeClient().Extensions().ReplicaSets(ns).Create(
+				scaledRouter(
+					routerImage,
+					[]string{
+						"--loglevel=4",
+						fmt.Sprintf("--namespace=%s", ns),
+						"--resync-interval=2m",
+						"--name=namespaced",
+					},
+				),
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = e2e.WaitForReadyReplicaSet(oc.KubeClient(), ns, rs.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating multiple routes")
+			client := routeclientset.NewForConfigOrDie(oc.AdminConfig()).Route().Routes(ns)
+			var rv string
+			for i := 0; i < 10; i++ {
+				_, err := client.Create(&routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("%d", i),
+					},
+					Spec: routev1.RouteSpec{
+						To: routev1.RouteTargetReference{Name: "test"},
+						Port: &routev1.RoutePort{
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				})
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			g.By("waiting for all routes to have a status")
+			err = wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
+				routes, err := client.List(metav1.ListOptions{})
+				if err != nil {
+					return false, err
+				}
+				o.Expect(routes.Items).To(o.HaveLen(10))
+				for _, route := range routes.Items {
+					ingress := findIngress(&route, "namespaced")
+					if ingress == nil {
+						return false, nil
+					}
+					o.Expect(ingress.Host).NotTo(o.BeEmpty())
+					o.Expect(ingress.Conditions).NotTo(o.BeEmpty())
+					o.Expect(ingress.Conditions[0].LastTransitionTime).NotTo(o.BeNil())
+					o.Expect(ingress.Conditions[0].Type).To(o.Equal(routev1.RouteAdmitted))
+					o.Expect(ingress.Conditions[0].Status).To(o.Equal(corev1.ConditionTrue))
+				}
+				outputIngress(routes.Items...)
+				rv = routes.ResourceVersion
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying that we don't continue to write")
+			writes := 0
+			w, err := client.Watch(metav1.ListOptions{Watch: true, ResourceVersion: rv})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer w.Stop()
+			timer := time.NewTimer(10 * time.Second)
+			ch := w.ResultChan()
+		Wait:
+			for i := 0; ; i++ {
+				select {
+				case _, ok := <-ch:
+					writes++
+					o.Expect(ok).To(o.BeTrue())
+				case <-timer.C:
+					break Wait
+				}
+			}
+			o.Expect(writes).To(o.BeNumerically("<", 10))
+
+			verifyCommandEquivalent(oc.KubeClient(), rs, "md5sum /var/lib/haproxy/conf/*")
+		})
+
+		g.It("converges when multiple routers are writing conflicting status", func() {
+			g.By("deploying a scaled out namespace scoped router")
+
+			rs, err := oc.KubeClient().Extensions().ReplicaSets(ns).Create(
+				scaledRouter(
+					routerImage,
+					[]string{
+						"--loglevel=4",
+						fmt.Sprintf("--namespace=%s", ns),
+						"--resync-interval=2m",
+						"--name=conflicting",
+						"--override-hostname",
+						// causes each pod to have a different value
+						"--hostname-template=${name}-${namespace}.$(NAME).local",
+					},
+				),
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = e2e.WaitForReadyReplicaSet(oc.KubeClient(), ns, rs.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("creating multiple routes")
+			client := routeclientset.NewForConfigOrDie(oc.AdminConfig()).Route().Routes(ns)
+			var rv string
+			for i := 0; i < 10; i++ {
+				_, err := client.Create(&routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("%d", i),
+					},
+					Spec: routev1.RouteSpec{
+						To: routev1.RouteTargetReference{Name: "test"},
+						Port: &routev1.RoutePort{
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				})
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			g.By("waiting for sufficient routes to have a status")
+			err = wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
+				routes, err := client.List(metav1.ListOptions{})
+				if err != nil {
+					return false, err
+				}
+				o.Expect(routes.Items).To(o.HaveLen(10))
+				conflicting := 0
+				for _, route := range routes.Items {
+					ingress := findIngress(&route, "conflicting")
+					if ingress == nil {
+						continue
+					}
+					conflicting++
+					o.Expect(ingress.Host).NotTo(o.BeEmpty())
+					o.Expect(ingress.Conditions).NotTo(o.BeEmpty())
+					o.Expect(ingress.Conditions[0].LastTransitionTime).NotTo(o.BeNil())
+					o.Expect(ingress.Conditions[0].Type).To(o.Equal(routev1.RouteAdmitted))
+					o.Expect(ingress.Conditions[0].Status).To(o.Equal(corev1.ConditionTrue))
+				}
+				if conflicting < 3 {
+					return false, nil
+				}
+				outputIngress(routes.Items...)
+				rv = routes.ResourceVersion
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying that we stop writing conflicts rapidly")
+			writes := 0
+			w, err := client.Watch(metav1.ListOptions{Watch: true, ResourceVersion: rv})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			func() {
+				defer w.Stop()
+				timer := time.NewTimer(10 * time.Second)
+				ch := w.ResultChan()
+			Wait:
+				for i := 0; ; i++ {
+					select {
+					case _, ok := <-ch:
+						writes++
+						o.Expect(ok).To(o.BeTrue())
+					case <-timer.C:
+						break Wait
+					}
+				}
+				o.Expect(writes).To(o.BeNumerically("<", 10))
+			}()
+
+			// the os_http_be.map file will vary, so only check the haproxy config
+			verifyCommandEquivalent(oc.KubeClient(), rs, "md5sum /var/lib/haproxy/conf/haproxy.config")
+
+			g.By("clearing a single route's status")
+			route, err := client.Patch("9", types.MergePatchType, []byte(`{"status":{"ingress":[]}}`), "status")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying that only get a few updates")
+			writes = 0
+			w, err = client.Watch(metav1.ListOptions{Watch: true, ResourceVersion: route.ResourceVersion})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			func() {
+				defer w.Stop()
+				timer := time.NewTimer(10 * time.Second)
+				ch := w.ResultChan()
+			Wait:
+				for i := 0; ; i++ {
+					select {
+					case _, ok := <-ch:
+						writes++
+						o.Expect(ok).To(o.BeTrue())
+						o.Expect(i).To(o.BeNumerically("<", 3))
+					case <-timer.C:
+						break Wait
+					}
+				}
+				e2e.Logf("Recorded %d writes total", writes)
+			}()
+		})
+	})
+})
+
+func findIngress(route *routev1.Route, name string) *routev1.RouteIngress {
+	for i, ingress := range route.Status.Ingress {
+		if ingress.RouterName == name {
+			return &route.Status.Ingress[i]
+		}
+	}
+	return nil
+}
+
+func scaledRouter(image string, args []string) *extensionsv1beta1.ReplicaSet {
+	one := int64(1)
+	scale := int32(3)
+	return &extensionsv1beta1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router",
+		},
+		Spec: extensionsv1beta1.ReplicaSetSpec{
+			Replicas: &scale,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "router"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "router"},
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &one,
+					Containers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{Name: "NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+							},
+							Name:  "router",
+							Image: image,
+							Args:  args,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func outputIngress(routes ...routev1.Route) {
+	b := &bytes.Buffer{}
+	w := tabwriter.NewWriter(b, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "NAME\tROUTER\tHOST\tLAST TRANSITION\n")
+	for _, route := range routes {
+		for _, ingress := range route.Status.Ingress {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", route.Name, ingress.RouterName, ingress.Host, ingress.Conditions[0].LastTransitionTime)
+		}
+	}
+	w.Flush()
+	e2e.Logf("Routes:\n%s", b.String())
+}
+
+func verifyCommandEquivalent(c clientset.Interface, rs *extensionsv1beta1.ReplicaSet, cmd string) {
+	selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	podList, err := c.CoreV1().Pods(rs.Namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	var values map[string]string
+	err = wait.PollImmediate(5*time.Second, time.Minute, func() (bool, error) {
+		values = make(map[string]string)
+		uniques := make(map[string]struct{})
+		for _, pod := range podList.Items {
+			stdout, err := e2e.RunHostCmdWithRetries(pod.Namespace, pod.Name, cmd, e2e.StatefulSetPoll, e2e.StatefulPodTimeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			values[pod.Name] = stdout
+			uniques[stdout] = struct{}{}
+		}
+		return len(uniques) == 1, nil
+	})
+	for name, stdout := range values {
+		stdout = strings.TrimSuffix(stdout, "\n")
+		e2e.Logf(name + ": " + strings.Join(strings.Split(stdout, "\n"), fmt.Sprintf("\n%s: ", name)))
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+}

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 	kclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	kinternalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -384,6 +385,14 @@ func (c *CLI) InternalAdminKubeClient() kinternalclientset.Interface {
 		FatalErr(err)
 	}
 	return kubeClient
+}
+
+func (c *CLI) AdminConfig() *restclient.Config {
+	_, clientConfig, err := configapi.GetExternalKubeClient(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
+	return clientConfig
 }
 
 // Namespace returns the name of the namespace used in the current test case.

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -256,7 +256,7 @@ func DumpPodLogs(pods []kapiv1.Pod, oc *CLI) {
 		}
 
 		dumpContainer := func(container *kapiv1.Container) {
-			depOutput, err := oc.AsAdmin().Run("logs").Args("pod/"+pod.Name, "-c", container.Name).Output()
+			depOutput, err := oc.AsAdmin().Run("logs").WithoutNamespace().Args("pod/"+pod.Name, "-c", container.Name, "-n", pod.Namespace).Output()
 			if err == nil {
 				e2e.Logf("Log for pod %q/%q\n---->\n%s\n<----end of log for %[1]q/%[2]q\n", pod.Name, container.Name, depOutput)
 			} else {

--- a/test/extended/util/url/url.go
+++ b/test/extended/util/url/url.go
@@ -1,0 +1,284 @@
+package url
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	o "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kclientset "k8s.io/client-go/kubernetes"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type Tester struct {
+	client    kclientset.Interface
+	namespace string
+	podName   string
+}
+
+func NewTester(client kclientset.Interface, ns string) *Tester {
+	return &Tester{client: client, namespace: ns}
+}
+
+func (ut *Tester) Close() {
+	if err := ut.client.Core().Pods(ut.namespace).Delete(ut.podName, metav1.NewDeleteOptions(1)); err != nil {
+		e2e.Logf("Failed to delete exec pod %s: %v", ut.podName, err)
+	}
+	ut.podName = ""
+}
+
+func (ut *Tester) Responses(tests ...*Test) []*Response {
+	script := testsToScript(tests)
+	if len(ut.podName) == 0 {
+		name, err := createExecPod(ut.client, ut.namespace, "execpod")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ut.podName = name
+	}
+	output, err := e2e.RunHostCmd(ut.namespace, ut.podName, script)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	responses, err := parseResponses(output)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if len(responses) != len(tests) {
+		o.Expect(fmt.Errorf("number of tests did not match number of responses: %d and %d", len(responses), len(tests))).NotTo(o.HaveOccurred())
+	}
+	return responses
+}
+
+func (ut *Tester) Within(t time.Duration, tests ...*Test) {
+	var errs []error
+	failing := tests
+	err := wait.PollImmediate(time.Second, t, func() (bool, error) {
+		errs = errs[:0]
+		responses := ut.Responses(failing...)
+		var next []*Test
+		for i, res := range responses {
+			if err := failing[i].Test(i, res); err != nil {
+				next = append(next, failing[i])
+				errs = append(errs, err)
+			}
+		}
+		e2e.Logf("%d/%d failed out of %d", len(errs), len(failing), len(tests))
+		// perform one more loop if we haven't seen all tests pass at the same time
+		if len(next) == 0 && len(failing) != len(tests) {
+			failing = tests
+			return false, nil
+		}
+		failing = next
+		return len(errs) == 0, nil
+	})
+	if len(errs) > 0 {
+		o.Expect(fmt.Errorf("%d/%d tests failed after %s: %v", len(errs), len(tests), t, errs))
+	}
+	o.Expect(err).ToNot(o.HaveOccurred())
+}
+
+// createExecPod creates a simple centos:7 pod in a sleep loop used as a
+// vessel for kubectl exec commands.
+// Returns the name of the created pod.
+func createExecPod(clientset kclientset.Interface, ns, name string) (string, error) {
+	e2e.Logf("Creating new exec pod")
+	immediate := int64(0)
+	execPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Command:         []string{"/bin/bash", "-c", "exec sleep 10000"},
+					Name:            "hostexec",
+					Image:           "centos:7",
+					ImagePullPolicy: v1.PullIfNotPresent,
+				},
+			},
+			HostNetwork:                   true,
+			TerminationGracePeriodSeconds: &immediate,
+		},
+	}
+	client := clientset.CoreV1()
+	created, err := client.Pods(ns).Create(execPod)
+	if err != nil {
+		return "", err
+	}
+	err = wait.PollImmediate(e2e.Poll, 5*time.Minute, func() (bool, error) {
+		retrievedPod, err := client.Pods(execPod.Namespace).Get(created.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return retrievedPod.Status.Phase == v1.PodRunning, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return created.Name, nil
+}
+
+func testsToScript(tests []*Test) string {
+	testScripts := []string{
+		"set -euo pipefail",
+		`function json_escape() {`,
+		`  python -c 'import json,sys; print json.dumps(sys.stdin.read())'`,
+		`}`,
+	}
+	for i, test := range tests {
+		testScripts = append(testScripts, test.ToShell(i))
+	}
+	script := strings.Join(testScripts, "\n")
+	return script
+}
+
+func parseResponses(out string) ([]*Response, error) {
+	var responses []*Response
+	d := json.NewDecoder(bytes.NewReader([]byte(out)))
+	for i := 0; ; i++ {
+		r := &Response{}
+		if err := d.Decode(r); err != nil {
+			if err == io.EOF {
+				return responses, nil
+			}
+			return nil, fmt.Errorf("response %d could not be decoded: %v", i, err)
+		}
+
+		if i != r.Test {
+			return nil, fmt.Errorf("response %d does not match test body %d", i, r.Test)
+		}
+
+		// parse the HTTP response
+		res, err := http.ReadResponse(bufio.NewReader(bytes.NewBufferString(r.Headers)), nil)
+		if err != nil {
+			return nil, fmt.Errorf("response %d was unparseable: %v\n%s", i, err, r.Headers)
+		}
+		if res.StatusCode != r.CURL.Code {
+			return nil, fmt.Errorf("response %d returned a different status code than was encoded in the headers:\n%s", i, r.Headers)
+		}
+		res.Body = ioutil.NopCloser(bytes.NewBuffer(r.Body))
+		r.Response = res
+
+		responses = append(responses, r)
+	}
+}
+
+type Response struct {
+	Test       int    `json:"test"`
+	ReturnCode int    `json:"rc"`
+	Error      string `json:"error"`
+
+	CURL    CURL   `json:"curl"`
+	Body    []byte `json:"body"`
+	Headers string `json:"headers"`
+
+	Response *http.Response
+}
+
+type CURL struct {
+	Code int `json:"code"`
+}
+
+type Test struct {
+	Name       string
+	Req        *http.Request
+	SkipVerify bool
+
+	Wants []func(*http.Response) error
+}
+
+func Expect(method, url string) *Test {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		panic(err)
+	}
+	return &Test{
+		Req: req,
+	}
+}
+
+func (ut *Test) Through(addr string) *Test {
+	ut.Req.Header.Set("Host", ut.Req.URL.Host)
+	ut.Req.URL.Host = addr
+	return ut
+}
+
+func (ut *Test) HasStatusCode(codes ...int) *Test {
+	ut.Wants = append(ut.Wants, func(res *http.Response) error {
+		for _, code := range codes {
+			if res.StatusCode == code {
+				return nil
+			}
+		}
+		return fmt.Errorf("status code %d not in %v", res.StatusCode, codes)
+	})
+	return ut
+}
+
+func (ut *Test) RedirectsTo(url string, codes ...int) *Test {
+	if len(codes) == 0 {
+		codes = []int{http.StatusFound, http.StatusPermanentRedirect, http.StatusTemporaryRedirect}
+	}
+	ut.HasStatusCode(codes...)
+	ut.Wants = append(ut.Wants, func(res *http.Response) error {
+		location := res.Header.Get("Location")
+		if location != url {
+			return fmt.Errorf("Location header was %q, not %q", location, url)
+		}
+		return nil
+	})
+	return ut
+}
+
+func (ut *Test) SkipTLSVerification() *Test {
+	ut.SkipVerify = true
+	return ut
+}
+
+func (ut *Test) Test(i int, res *Response) error {
+	if len(res.Error) > 0 || res.ReturnCode != 0 {
+		return fmt.Errorf("test %d was not successful: %d %s", i, res.ReturnCode, res.Error)
+	}
+	for _, fn := range ut.Wants {
+		if err := fn(res.Response); err != nil {
+			return fmt.Errorf("test %d was not successful: %v", i, err)
+		}
+	}
+	if len(ut.Wants) == 0 {
+		if res.Response.StatusCode < 200 || res.Response.StatusCode >= 300 {
+			return fmt.Errorf("test %d did not return a 2xx status code: %d", i, res.Response.StatusCode)
+		}
+	}
+	return nil
+}
+
+func (ut *Test) ToShell(i int) string {
+	var lines []string
+	if len(ut.Name) > 0 {
+		lines = append(lines, fmt.Sprintf("# Test: %s (%d)", ut.Name, i))
+	} else {
+		lines = append(lines, fmt.Sprintf("# Test: %d", i))
+	}
+	var headers []string
+	for k, values := range ut.Req.Header {
+		for _, v := range values {
+			headers = append(headers, fmt.Sprintf("-H %q", k+":"+v))
+		}
+	}
+	lines = append(lines, `rc=0`)
+	cmd := fmt.Sprintf(`curl -X %s %s -s -S -o /tmp/body -D /tmp/headers %q`, ut.Req.Method, strings.Join(headers, " "), ut.Req.URL)
+	cmd += ` -w '{"code":%{http_code}}'`
+	if ut.SkipVerify {
+		cmd += ` -k`
+	}
+	cmd += " 2>/tmp/error 1>/tmp/output || rc=$?"
+	lines = append(lines, cmd)
+	lines = append(lines, fmt.Sprintf(`echo "{\"test\":%d,\"rc\":$(echo $rc),\"curl\":$(cat /tmp/output),\"error\":$(cat /tmp/error | json_escape),\"body\":\"$(cat /tmp/body | base64 -w 0 -)\",\"headers\":$(cat /tmp/headers | json_escape)}"`, i))
+	return strings.Join(lines, "\n")
+}

--- a/test/extended/util/url/url_test.go
+++ b/test/extended/util/url/url_test.go
@@ -1,0 +1,13 @@
+package url
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTestsToScript(t *testing.T) {
+	tests := []*URLTest{
+		MustURLTest("GET", "https://www.google.com"),
+	}
+	fmt.Println(testsToScript(tests))
+}

--- a/test/integration/router_without_haproxy_test.go
+++ b/test/integration/router_without_haproxy_test.go
@@ -391,8 +391,10 @@ func initializeRouterPlugins(routeclient routeinternalclientset.Interface, proje
 		return rateLimitingFunc()
 	})
 
+	tracker := controller.NewSimpleContentionTracker(time.Minute)
+	go tracker.Run(wait.NeverStop)
 	templatePlugin := &templateplugin.TemplatePlugin{Router: r}
-	statusPlugin := controller.NewStatusAdmitter(templatePlugin, routeclient.Route(), name, "")
+	statusPlugin := controller.NewStatusAdmitter(templatePlugin, routeclient.Route(), name, "", tracker)
 	validationPlugin := controller.NewExtendedValidator(statusPlugin, controller.RejectionRecorder(statusPlugin))
 	uniquePlugin := controller.NewUniqueHost(validationPlugin, controller.HostForRoute, false, controller.RejectionRecorder(statusPlugin))
 


### PR DESCRIPTION
The current route backoff mechanism works by tracking the last touch
time from other routes, but this is prone to failure and will not scale
to very large sets of routers competing for updating status.

Instead, treat the ability to write status as a lease renewal, and have
failure to write status as a cue to backoff. Each new write further
increases the lease confidence up to an interval. Treat observed writes
from other processes as a signal that the lease holder is maintaining
their lease.

This should allow route status updates to be scale free

Needs an e2e test still

@openshift/sig-networking @ramr