### PR TITLE
Fixes index out of range error on oc new-app --template foo

### DIFF
--- a/pkg/oc/cli/cmd/newapp.go
+++ b/pkg/oc/cli/cmd/newapp.go
@@ -823,7 +823,7 @@ func transformRunError(err error, baseName, commandName, commandPath string, gro
 
 				See '%[1]s -h' for examples.`, commandPath,
 			),
-			heredoc.Docf(classification.String()),
+			classification.String(),
 			t,
 			t.Errs...,
 		)

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -351,6 +351,8 @@ os::cmd::expect_failure_and_text 'oc new-app --search winter-is-coming' 'no matc
 os::cmd::expect_failure_and_text 'oc new-app -S mysql --env=FOO=BAR' "can't be used"
 os::cmd::expect_failure_and_text 'oc new-app --search mysql --code=https://github.com/openshift/ruby-hello-world' "can't be used"
 os::cmd::expect_failure_and_text 'oc new-app --search mysql --param=FOO=BAR' "can't be used"
+# check specifying a non-existent template does not cause an index out of range error
+os::cmd::expect_failure_and_not_text 'oc new-app --template foo' 'index out of range'
 
 # set context-dir
 os::cmd::expect_success_and_text 'oc new-app https://github.com/openshift/sti-ruby.git --context-dir="2.3/test/puma-test-app" -o yaml' 'contextDir: 2.3/test/puma-test-app'


### PR DESCRIPTION
I think someone just got a little overzealous with the `heredoc.Docf()` where it was not specifically needed.
Fixes #18562

Previous Output:
```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/openshift/origin/vendor/github.com/MakeNowJust/heredoc.Doc(0x0, 0x0, 0xc4216f8f38, 0x1)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/MakeNowJust/heredoc/heredoc.go:36 +0x15c
github.com/openshift/origin/pkg/oc/cli/cmd.transformRunError(0x7a6d100, 0xc4201f6500, 0x4c8029e, 0x2, 0x4c87799, 0x7, 0xc4205f5446, 0xa, 0xc420b69a70, 0xc42117bc00)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/cmd/newapp.go:832 +0x1a01
github.com/openshift/origin/pkg/oc/cli/cmd.handleError(0x7fb72a88f900, 0xc42083b4c0, 0x4c8029e, 0x2, 0x4c87799, 0x7, 0xc4205f5446, 0xa, 0xc42117bc00, 0x4f3b9b0, ...)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/cmd/newapp.go:739 +0x1b6
github.com/openshift/origin/pkg/oc/cli/cmd.(*NewAppOptions).RunNewApp(0xc420dfe410, 0x0, 0x2)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/cmd/newapp.go:306 +0x474
github.com/openshift/origin/pkg/oc/cli/cmd.NewCmdNewApplication.func1(0xc420340d80, 0xc4204acae0, 0x0, 0x2)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/cmd/newapp.go:224 +0x10a
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc420340d80, 0xc4204ac920, 0x2, 0x2, 0xc420340d80, 0xc4204ac920)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:603 +0x234
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4204a0480, 0x2036221, 0xc4204a0480, 0xc42033cf90)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:689 +0x2fe
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4204a0480, 0x2, 0xc4204a0480)
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:648 +0x2b
main.main()
	/home/cdaley/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/oc/oc.go:41 +0x293
```
**Corrected Output:**
```
error: unable to locate any templates loaded in accessible projects with name "foo"

The 'oc new-app' command will match arguments to the following types:

  1. Images tagged into image streams in the current project or the 'openshift' project
     - if you don't specify a tag, we'll add ':latest'
  2. Images in the Docker Hub, on remote registries, or on the local Docker engine
  3. Templates in the current project or the 'openshift' project
  4. Git repository URLs or local paths that point to Git repositories

--allow-missing-images can be used to point to an image that does not exist yet.

See 'oc new-app -h' for examples.

```
