### PR TITLE
Bld metrics path to alerts part 2

### DIFF
--- a/pkg/build/metrics/prometheus/metrics_test.go
+++ b/pkg/build/metrics/prometheus/metrics_test.go
@@ -44,18 +44,18 @@ func TestMetrics(t *testing.T) {
 	// went per line vs. a block of expected test in case assumptions on ordering are subverted, as well as defer on
 	// getting newlines right
 	expectedResponse := []string{
-		"# HELP openshift_build_total Counts builds by phase and reason",
+		"# HELP openshift_build_total Counts builds by phase, reason, and strategy",
 		"# TYPE openshift_build_total gauge",
-		"openshift_build_total{phase=\"Cancelled\",reason=\"\"} 1",
-		"openshift_build_total{phase=\"Complete\",reason=\"\"} 1",
-		"openshift_build_total{phase=\"Error\",reason=\"\"} 1",
-		"openshift_build_total{phase=\"Failed\",reason=\"ExceededRetryTimeout\"} 1",
-		"openshift_build_total{phase=\"New\",reason=\"InvalidOutputReference\"} 1",
-		"# HELP openshift_build_active_time_seconds Shows the last transition time in unix epoch for running builds by namespace, name, phase, and reason",
+		"openshift_build_total{phase=\"Cancelled\",reason=\"\",strategy=\"\"} 1",
+		"openshift_build_total{phase=\"Complete\",reason=\"\",strategy=\"\"} 1",
+		"openshift_build_total{phase=\"Error\",reason=\"\",strategy=\"\"} 1",
+		"openshift_build_total{phase=\"Failed\",reason=\"ExceededRetryTimeout\",strategy=\"\"} 1",
+		"openshift_build_total{phase=\"New\",reason=\"InvalidOutputReference\",strategy=\"\"} 1",
+		"# HELP openshift_build_active_time_seconds Shows the last transition time in unix epoch for running builds by namespace, name, phase, reason, and strategy",
 		"# TYPE openshift_build_active_time_seconds gauge",
-		"openshift_build_active_time_seconds{name=\"testname1\",namespace=\"testnamespace\",phase=\"New\",reason=\"\"} 123",
-		"openshift_build_active_time_seconds{name=\"testname2\",namespace=\"testnamespace\",phase=\"Pending\",reason=\"\"} 123",
-		"openshift_build_active_time_seconds{name=\"testname3\",namespace=\"testnamespace\",phase=\"Running\",reason=\"\"} 123",
+		"openshift_build_active_time_seconds{name=\"testname1\",namespace=\"testnamespace\",phase=\"New\",reason=\"\",strategy=\"\"} 123",
+		"openshift_build_active_time_seconds{name=\"testname2\",namespace=\"testnamespace\",phase=\"Pending\",reason=\"\",strategy=\"\"} 123",
+		"openshift_build_active_time_seconds{name=\"testname3\",namespace=\"testnamespace\",phase=\"Running\",reason=\"\",strategy=\"\"} 123",
 	}
 	registry := prometheus.NewRegistry()
 


### PR DESCRIPTION
@openshift/sig-developer-experience fyi / ptal 

Part of the efforts for https://trello.com/c/kl4dzl8F/1483-2-define-candidate-metricsalerts-for-builds

A few things prompted this proposed change:

1) after the SRE videos, learned the existing zabbix query for builds stuck in new state that Ops is using filters out jenkins pipeline, so added strategy label

It is possible we want to get the strategy label into 3.9 ... let's include in the discussion

2) also, based on us-starter-east research, learned there are some user errors that will result in builds getting stuck in New state .... filtering those out ... reasons for all stages were recently merged

3) Through various exchanges with @jim-minter and @bparees , this PR originally attempted to follow some of the new approaches @jim-minter established for templates ... but in reviewing how those would look, including reviving the prior experience with maintaining metrics in the build controller FSM, the change to add a counter of that fashion has been removed.

Also, I never added like @jim-minter currently has a histogram, much less replace the constant time metric ... I'm going to give a simple answer vs. the fully detailed answer of "not sure ... going to wait and see how it goes for @jim-minter "

4) Based on prior interaction when messing with build metrics, I've updated the sample queries in the example/prometheus README ... those samples are in essence my proposals around possible alert queries

For now, I've marked this as WIP with a 3.10 milestone, and have broken the changes out into a few commits