### PR TITLE
Fix govet error - formatting in glog.V(0).Info() call

### DIFF
--- a/pkg/image/apis/image/validation/whitelist/whitelister.go
+++ b/pkg/image/apis/image/validation/whitelist/whitelister.go
@@ -195,11 +195,11 @@ func (rw *registryWhitelister) AdmitDockerImageReference(ref *imageapi.DockerIma
 	}
 
 	if len(rw.whitelist) == 0 {
-		glog.V(5).Info("registry %q not allowed by empty whitelist", hostname)
+		glog.V(5).Infof("registry %q not allowed by empty whitelist", hostname)
 		return fmt.Errorf("registry %q not allowed by empty whitelist", hostname)
 	}
 
-	glog.V(5).Info("registry %q not allowed by whitelist: %s", hostname, strings.Join(whitelist, ", "))
+	glog.V(5).Infof("registry %q not allowed by whitelist: %s", hostname, strings.Join(whitelist, ", "))
 	if len(rw.whitelist) <= showMax {
 		return fmt.Errorf("registry %q not allowed by whitelist: %s", hostname, strings.Join(whitelist, ", "))
 	}


### PR DESCRIPTION
[21:42] $ hack/verify-govet.sh
pkg/image/apis/image/validation/whitelist/whitelister.go:198: possible formatting directive in Info call
pkg/image/apis/image/validation/whitelist/whitelister.go:202: possible formatting directive in Info call
[FATAL] FAILURE: go vet failed!
[ERROR] hack/verify-govet.sh exited with code 1 after 00h 00m 08s