### PR TITLE
 Fix reassignment of egress IP after removal

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -213,6 +213,7 @@ func (eip *egressIPWatcher) deleteEgressIP(egressIP string) {
 		if err := eip.releaseEgressIP(egressIP, mark); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error releasing Egress IP %q: %v", egressIP, err))
 		}
+		node.assignedIPs.Delete(egressIP)
 	}
 
 	if ns.assignedIP == egressIP {

--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -55,7 +55,7 @@ func TestEgressIP(t *testing.T) {
 	}
 	err = assertFlowChanges(origFlows, flows) // no changes
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 
 	// Assign NetNamespace.EgressIP first, then HostSubnet.EgressIP, with a remote EgressIP
@@ -75,7 +75,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 
 	ns42 := eip.namespacesByVNID[42]
@@ -99,7 +99,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -120,7 +120,7 @@ func TestEgressIP(t *testing.T) {
 	}
 	err = assertFlowChanges(origFlows, flows)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 
 	if eip.nodesByEgressIP["172.17.0.100"] != node3 || eip.nodesByEgressIP["172.17.0.101"] != node3 {
@@ -143,7 +143,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -169,7 +169,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 
 	ns44 := eip.namespacesByVNID[44]
@@ -193,7 +193,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -214,7 +214,7 @@ func TestEgressIP(t *testing.T) {
 	}
 	err = assertFlowChanges(origFlows, flows)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 
 	if eip.nodesByEgressIP["172.17.0.102"] != node4 || eip.nodesByEgressIP["172.17.0.103"] != node4 {
@@ -237,7 +237,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -263,7 +263,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -288,7 +288,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -318,7 +318,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -347,7 +347,7 @@ func TestEgressIP(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 	origFlows = flows
 
@@ -367,7 +367,7 @@ func TestEgressIP(t *testing.T) {
 	}
 	err = assertFlowChanges(origFlows, flows)
 	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v", err)
+		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
 	}
 }
 


### PR DESCRIPTION
When dropping an egress IP from eth0, we weren't updating our internal state to reflect that we had done that, so if you added it back again it wouldn't do everything it needed to do. (Introduced in #18121 but not discoverable until after #18547 was fixed.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547899
