### PR TITLE
relax aggressive timeouts in declarative pipeline example

### DIFF
--- a/examples/jenkins/pipeline/nodejs-sample-pipeline.yaml
+++ b/examples/jenkins/pipeline/nodejs-sample-pipeline.yaml
@@ -71,11 +71,8 @@ spec:
                             openshift.withCluster() {
                                 openshift.withProject() {
                                     def builds = openshift.selector("bc", templateName).related('builds')
-                                    // wait up to 5 minutes for the build to complete
-                                    timeout(5) {
-                                        builds.untilEach(1) {
-                                            return (it.object().status.phase == "Complete")
-                                        }
+                                    builds.untilEach(1) {
+                                        return (it.object().status.phase == "Complete")
                                     }
                                 }
                             }
@@ -88,11 +85,8 @@ spec:
                             openshift.withCluster() {
                                 openshift.withProject() {
                                     def rm = openshift.selector("dc", templateName).rollout()
-                                    // wait up to 5 minutes for the deployment to complete
-                                    timeout(5) {
-                                        openshift.selector("dc", templateName).related('pods').untilEach(1) {
-                                            return (it.object().status.phase == "Running")
-                                        }
+                                    openshift.selector("dc", templateName).related('pods').untilEach(1) {
+                                        return (it.object().status.phase == "Running")
                                     }
                                 }
                             }

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -6770,11 +6770,8 @@ spec:
                             openshift.withCluster() {
                                 openshift.withProject() {
                                     def builds = openshift.selector("bc", templateName).related('builds')
-                                    // wait up to 5 minutes for the build to complete
-                                    timeout(5) {
-                                        builds.untilEach(1) {
-                                            return (it.object().status.phase == "Complete")
-                                        }
+                                    builds.untilEach(1) {
+                                        return (it.object().status.phase == "Complete")
                                     }
                                 }
                             }
@@ -6787,11 +6784,8 @@ spec:
                             openshift.withCluster() {
                                 openshift.withProject() {
                                     def rm = openshift.selector("dc", templateName).rollout()
-                                    // wait up to 5 minutes for the deployment to complete
-                                    timeout(5) {
-                                        openshift.selector("dc", templateName).related('pods').untilEach(1) {
-                                            return (it.object().status.phase == "Running")
-                                        }
+                                    openshift.selector("dc", templateName).related('pods').untilEach(1) {
+                                        return (it.object().status.phase == "Running")
                                     }
                                 }
                             }

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -28242,11 +28242,8 @@ spec:
                             openshift.withCluster() {
                                 openshift.withProject() {
                                     def builds = openshift.selector("bc", templateName).related('builds')
-                                    // wait up to 5 minutes for the build to complete
-                                    timeout(5) {
-                                        builds.untilEach(1) {
-                                            return (it.object().status.phase == "Complete")
-                                        }
+                                    builds.untilEach(1) {
+                                        return (it.object().status.phase == "Complete")
                                     }
                                 }
                             }
@@ -28259,11 +28256,8 @@ spec:
                             openshift.withCluster() {
                                 openshift.withProject() {
                                     def rm = openshift.selector("dc", templateName).rollout()
-                                    // wait up to 5 minutes for the deployment to complete
-                                    timeout(5) {
-                                        openshift.selector("dc", templateName).related('pods').untilEach(1) {
-                                            return (it.object().status.phase == "Running")
-                                        }
+                                    openshift.selector("dc", templateName).related('pods').untilEach(1) {
+                                        return (it.object().status.phase == "Running")
                                     }
                                 }
                             }


### PR DESCRIPTION
@openshift/sig-developer-experience fyi / ptal

started seeing intermittent flake/timeouts in our declarative pipeline test run

see https://github.com/openshift/jenkins-sync-plugin/pull/208#issuecomment-368146115 for additional details