### PR TITLE
One tiny suggest to separate oc debug info and yaml output

### DIFF
--- a/pkg/oc/cli/cmd/debug.go
+++ b/pkg/oc/cli/cmd/debug.go
@@ -272,6 +272,7 @@ func (o *DebugOptions) Complete(cmd *cobra.Command, f *clientcmd.Factory, args [
 		if len(fullCmdName) > 0 && kcmdutil.IsSiblingCommandExists(cmd, "describe") {
 			fmt.Fprintf(o.Attach.Err, "Defaulting container name to %s.\n", pod.Spec.Containers[0].Name)
 			fmt.Fprintf(o.Attach.Err, "Use '%s describe pod/%s -n %s' to see all of the containers in this pod.\n", fullCmdName, pod.Name, pod.Namespace)
+			fmt.Fprintf(o.Attach.Err, "\n")
 		}
 
 		glog.V(4).Infof("Defaulting container name to %s", pod.Spec.Containers[0].Name)


### PR DESCRIPTION
Now that there are extra info together with yaml output, suggest to separate them.
Currently they are output together, not so easy for user to pick up yaml text or even for automation test checking yaml.

`$ Shell Commands: oc debug  --config=/home/jenkins/workspace/Runner-v3/workdir/cucushift-oc39-standard-slave-pdxxt-0/ose_hasha1.kubeconfig dc/hello --keep-annotations -o yaml`
```
Defaulting container name to hello.
Use 'oc describe pod/hello-debug -n urrqq' to see all of the containers in this pod.
apiVersion: v1
kind: Pod
metadata:
  annotations:
    debug.openshift.io/source-container: hello
    debug.openshift.io/source-resource: deploymentconfigs/hello
    openshift.io/deployment-config.latest-version: "1"
    openshift.io/deployment-config.name: hello
    openshift.io/deployment.name: hello-1
  creationTimestamp: null
  name: hello-debug
  namespace: urrqq
spec:
  containers:
  - command:
    - /bin/sh
    image: openshift/hello-openshift:latest
    imagePullPolicy: Always
    name: hello
    resources: {}
    securityContext: {}
    stdin: true
    stdinOnce: true
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
  dnsPolicy: ClusterFirst
  restartPolicy: Never
  schedulerName: default-scheduler
  securityContext: {}
  terminationGracePeriodSeconds: 30
status: {}
```