### PR TITLE
Reject login if the user id does not match the id in Keystone

### DIFF
--- a/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword.go
+++ b/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword.go
@@ -4,17 +4,21 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"encoding/json"
+	"strings"
 
 	"github.com/golang/glog"
+	userclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+	authapi "github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack"
+	tokens3 "github.com/rackspace/gophercloud/openstack/identity/v3/tokens"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
-
-	authapi "github.com/openshift/origin/pkg/oauthserver/api"
-)
+	)
 
 // keystonePasswordAuthenticator uses OpenStack keystone to authenticate a user by password
 type keystonePasswordAuthenticator struct {
@@ -23,17 +27,85 @@ type keystonePasswordAuthenticator struct {
 	client         *http.Client
 	domainName     string
 	identityMapper authapi.UserIdentityMapper
+	user           userclient.UserInterface
 }
 
 // New creates a new password authenticator that uses OpenStack keystone to authenticate a user by password
 // A custom transport can be provided (typically to customize TLS options like trusted roots or present a client certificate).
 // If no transport is provided, http.DefaultTransport is used
-func New(providerName string, url string, transport http.RoundTripper, domainName string, identityMapper authapi.UserIdentityMapper) authenticator.Password {
+func New(providerName string, url string, transport http.RoundTripper, domainName string, identityMapper authapi.UserIdentityMapper, user userclient.UserInterface) authenticator.Password {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
 	client := &http.Client{Transport: transport}
-	return &keystonePasswordAuthenticator{providerName, url, client, domainName, identityMapper}
+	return &keystonePasswordAuthenticator{providerName, url, client, domainName, identityMapper, user}
+}
+
+// Authenticate user and return his ID from Keystone
+func GetUserIDv3(client *gophercloud.ProviderClient, options gophercloud.AuthOptions) (string, error) {
+	// Override the generated service endpoint with the one returned by the version endpoint.
+	v3Client := openstack.NewIdentityV3(client)
+
+	// copy the auth options to a local variable that we can change. `options`
+	// needs to stay as-is for reauth purposes
+	v3Options := options
+
+	var scope *tokens3.Scope
+	if options.TenantID != "" {
+		scope = &tokens3.Scope{
+			ProjectID: options.TenantID,
+		}
+		v3Options.TenantID = ""
+		v3Options.TenantName = ""
+	} else {
+		if options.TenantName != "" {
+			scope = &tokens3.Scope{
+				ProjectName: options.TenantName,
+				DomainID:    options.DomainID,
+				DomainName:  options.DomainName,
+			}
+			v3Options.TenantName = ""
+		}
+	}
+
+	result := tokens3.Create(v3Client, v3Options, scope)
+
+	token, err := result.ExtractToken()
+	if err != nil {
+		return "", err
+	}
+
+	catalog, err := result.ExtractServiceCatalog()
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the body to obtain userID from the response
+	out, err := json.Marshal(result.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var bd map[string]interface{}
+
+	err = json.Unmarshal(out, &bd)
+	if err != nil {
+		return "", err
+	}
+
+	client.TokenID = token.ID
+
+	if options.AllowReauth {
+		client.ReauthFunc = func() error {
+			client.TokenID = ""
+			return openstack.AuthenticateV3(client, options)
+		}
+	}
+	client.EndpointLocator = func(opts gophercloud.EndpointOpts) (string, error) {
+		return openstack.V3EndpointURL(catalog, opts)
+	}
+
+	return bd["token"].(map[string]interface{})["user"].(map[string]interface{})["id"].(string), nil
 }
 
 // AuthenticatePassword approves any login attempt which is successfully validated with Keystone
@@ -65,7 +137,8 @@ func (a keystonePasswordAuthenticator) AuthenticatePassword(username, password s
 	}
 
 	client.HTTPClient = *a.client
-	err = openstack.AuthenticateV3(client, opts)
+	userid, err := GetUserIDv3(client, opts)
+
 	if err != nil {
 		if responseErr, ok := err.(*gophercloud.UnexpectedResponseCodeError); ok {
 			if responseErr.Actual == 401 {
@@ -76,7 +149,28 @@ func (a keystonePasswordAuthenticator) AuthenticatePassword(username, password s
 		return nil, false, err
 	}
 
-	identity := authapi.NewDefaultUserIdentityInfo(a.providerName, username)
+	u, err := a.user.Get(username, metav1.GetOptions{})
+
+	if err == nil {
+		for _, idnt := range u.Identities {
+			// identity has a format "my_keystone_provider:my_user_name"
+			x := strings.SplitN(idnt, ":", 2)
+			if x[0] == a.providerName {
+				if x[1] != userid {
+					// If the identifier of the new user does not match what is stored in the identity,
+					// then the user's request to login to the system is rejected
+					glog.Errorf("It is impossible to authenticate user \"%v\", because a user with the same " +
+						"name is known by a different id. To resolve this issue, contact the administrator", username)
+					return nil, false, nil
+				}
+				break
+			}
+		}
+	}
+
+	identity := authapi.NewDefaultUserIdentityInfo(a.providerName, userid)
+	identity.Extra[authapi.IdentityPreferredUsernameKey] = username
+
 	user, err := a.identityMapper.UserFor(identity)
 	if err != nil {
 		glog.V(4).Infof("Error creating or updating mapping for: %#v due to %v", identity, err)

--- a/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword_test.go
+++ b/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword_test.go
@@ -8,8 +8,12 @@ import (
 	"testing"
 
 	"github.com/openshift/origin/pkg/oauthserver/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/openshift/api/user/v1"
 	th "github.com/rackspace/gophercloud/testhelper"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 )
 
 type TestUserIdentityMapper struct{}
@@ -17,6 +21,29 @@ type TestUserIdentityMapper struct{}
 func (m *TestUserIdentityMapper) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
 	return &user.DefaultInfo{Name: identityInfo.GetProviderUserName()}, nil
 }
+
+type TestUser struct {}
+
+var idnts = []string{}
+
+func (c *TestUser) Get(name string, options metav1.GetOptions) (result *v1.User, err error) {
+	u := v1.User{}
+	u.Identities = idnts
+	return &u, nil
+}
+
+// Stubs to make TestUser compatible with UserInterface
+func (c *TestUser) List(opts metav1.ListOptions) (result *v1.UserList, err error) {return &v1.UserList{}, nil}
+func (c *TestUser) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return watch.NewEmptyWatch(), nil
+}
+func (c *TestUser) Create(user *v1.User) (result *v1.User, err error) {return &v1.User{}, nil}
+func (c *TestUser) Update(user *v1.User) (result *v1.User, err error) {return &v1.User{}, nil}
+func (c *TestUser) Delete(name string, options *metav1.DeleteOptions) error {return nil}
+func (c *TestUser) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {return nil}
+func (c *TestUser) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.User, err error) {return &v1.User{}, nil}
+
 
 func TestKeystoneLogin(t *testing.T) {
 	th.SetupHTTP()
@@ -47,16 +74,43 @@ func TestKeystoneLogin(t *testing.T) {
 		password := x.Auth.Identity.Password.User.Password
 		if domainName == "default" && userName == "testuser" && password == "testpw" {
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprintf(w, `{ "token": { "expires_at": "2020-02-02T18:30:59.000000Z" } }`)
+			resp := `{"token": {
+							"methods": [
+								"password"
+							],
+							"expires_at": "2015-11-09T01:42:57.527363Z",
+							"user": {
+								"domain": {
+									"id": "default",
+									"name": "Default"
+								},
+								"id": "ee4dfb6e5540447cb3741905149d9b6e",
+								"name": "admin",
+								"password_expires_at": null
+							},
+							"audit_ids": [
+								"lC2Wj1jbQe-dLjLyOx4qPQ"
+							],
+							"issued_at": "2015-11-09T00:42:57.527404Z"
+						}
+					}`
+			fmt.Fprintf(w, resp)
 		} else {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	})
 
-	keystoneAuth := New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &TestUserIdentityMapper{})
+	keystoneAuth := New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &TestUserIdentityMapper{}, &TestUser{})
+	// correct password with correct identity in the database
+	idnts = []string{"keystone_auth:ee4dfb6e5540447cb3741905149d9b6e"}
 	_, ok, err := keystoneAuth.AuthenticatePassword("testuser", "testpw")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, ok, true)
+	// correct password with invalid identity
+	idnts = []string{"keystone_auth:wrong_keystone_id"}
+	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, ok, false)
 	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "badpw")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, ok, false)

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -602,7 +602,7 @@ func (c *OAuthServerConfig) getPasswordAuthenticator(identityProvider configapi.
 			return nil, fmt.Errorf("Error building KeystonePasswordIdentityProvider client: %v", err)
 		}
 
-		return keystonepassword.New(identityProvider.Name, connectionInfo.URL, transport, provider.DomainName, identityMapper), nil
+		return keystonepassword.New(identityProvider.Name, connectionInfo.URL, transport, provider.DomainName, identityMapper, c.ExtraOAuthConfig.UserClient), nil
 
 	default:
 		return nil, fmt.Errorf("No password auth found that matches %v.  The OAuth server cannot start!", identityProvider)


### PR DESCRIPTION
This code prevents situations when, after removing a user
account in Keystone, a new user with the same name can
see all the resources available to the previous user.

This is achieved by storing the user ID instead of his name
in the identity, i.e. "<provider_name>:<keystone_user_id>".
If the identifier of the new user does not match what is
stored in the identity, then the user's request to login
to the system is rejected, even if he entered the correct
password.