### PR TITLE
UPSTREAM: 60457: tests: e2e: empty msg from channel other than stdout should be non-fatal

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/pods.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/pods.go
@@ -523,7 +523,13 @@ var _ = framework.KubeDescribe("Pods", func() {
 					continue
 				}
 				if msg[0] != 1 {
-					framework.Failf("Got message from server that didn't start with channel 1 (STDOUT): %v", msg)
+					if len(msg) == 1 {
+						// skip an empty message on stream other than stdout
+						continue
+					} else {
+						framework.Failf("Got message from server that didn't start with channel 1 (STDOUT): %v", msg)
+					}
+
 				}
 				buf.Write(msg[1:])
 			}


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/60457

fixes https://github.com/openshift/origin/issues/18726

@smarterclayton @liggitt @derekwaynecarr 