### PR TITLE
Log test duration with json format for cluster-loader

### DIFF
--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -179,9 +179,8 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 		}
 
 		// Calculate and log test duration
-		testDuration := time.Since(testStartTime)
-		e2e.Logf("Cluster loading duration: %s", testDuration)
-		err := writeJSONToDisk(TestResult{testDuration}, testResultFile)
+		metrics := []Metrics{NewTestDuration("cluster-loader-test", testStartTime, time.Since(testStartTime))}
+		err := LogMetrics(metrics)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// If config context set to cleanup on completion

--- a/test/extended/cluster/context.go
+++ b/test/extended/cluster/context.go
@@ -89,11 +89,6 @@ type ServiceInfo struct {
 	Port int32
 }
 
-// TestResult struct contains result data to be saved at end of run
-type TestResult struct {
-	Time time.Duration `json:"time"`
-}
-
 // ParseConfig will complete flag parsing as well as viper tasks
 func ParseConfig(config string, isFixture bool) error {
 	// This must be done after common flags are registered, since Viper is a flag option.

--- a/test/extended/cluster/metrics.go
+++ b/test/extended/cluster/metrics.go
@@ -1,0 +1,55 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const (
+	marker_name string = "cluster_loader_marker"
+)
+
+type Metrics interface {
+	printLog() error
+}
+
+type BaseMetrics struct {
+	// To let the 3rd party know that this log entry is important
+	// TODO set this up by config file
+	Marker string `json:"marker"`
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+}
+
+type TestDuration struct {
+	BaseMetrics
+	StartTime    time.Time `json:"startTime"`
+	TestDuration string    `json:"testDuration"`
+}
+
+func (td TestDuration) printLog() error {
+	b, err := json.Marshal(td)
+	fmt.Println(string(b))
+	return err
+}
+
+func LogMetrics(metrics []Metrics) error {
+	for _, m := range metrics {
+		err := m.printLog()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewTestDuration(name string, startTime time.Time, testDuration time.Duration) TestDuration {
+	return TestDuration{
+		BaseMetrics: BaseMetrics{
+			Marker: marker_name,
+			Name:   name,
+			Type:   fmt.Sprintf("%T", (*TestDuration)(nil))[1:]},
+		StartTime:    startTime,
+		TestDuration: fmt.Sprintf("%s", testDuration.String())}
+}

--- a/test/extended/cluster/utils.go
+++ b/test/extended/cluster/utils.go
@@ -508,12 +508,6 @@ func getNsCmdFlag(name string) string {
 	return fmt.Sprintf("--namespace=%v", name)
 }
 
-func writeJSONToDisk(result TestResult, path string) error {
-	resultJSON, _ := json.Marshal(result)
-	err := ioutil.WriteFile(path, resultJSON, 0644)
-	return err
-}
-
 func SetNamespaceLabels(c kclientset.Interface, name string, labels map[string]string) (*kapiv1.Namespace, error) {
 	if len(labels) == 0 {
 		return nil, nil


### PR DESCRIPTION
An example of the log entry:
{"marker":"cluster_loader_marker","name":"cluster-loader-test","type":"TestDuration","startTime":"2018-02-26T22:44:56.46700834Z","testDuration":"639.046555ms"}

The 3rd party, eg, logstash/fluentd can parse the json output by
filtering out the entry by marker. For now, it is hard coded
as "cluster_loader_marker".