### PR TITLE
apps: stop dc cancellation flake

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -125,7 +125,9 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 					e2e.Logf("%02d: cancelling deployment", i)
 					if out, err := oc.Run("rollout").Args("cancel", "dc/deployment-simple").Output(); err != nil {
 						// TODO: we should fix this
-						if !strings.Contains(out, "the object has been modified") && !strings.Contains(out, "there have been no replication controllers") {
+						if !strings.Contains(out, "the object has been modified") &&
+							!strings.Contains(out, "there have been no replication controllers") &&
+							!strings.Contains(out, "there is a meaningful conflict") {
 							o.Expect(err).NotTo(o.HaveOccurred())
 						}
 						e2e.Logf("rollout cancel deployment failed due to known safe error: %v", err)


### PR DESCRIPTION
This stops the flake as the conflict message has changed (?). It does not fix the root cause, which should be investigated and fixed (/cc @tnozicka)

Fixes: https://github.com/openshift/origin/issues/18743

