### PR TITLE
Allow to reject login if the user id does not match the id in Keystone

### DIFF
--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -1036,6 +1036,8 @@ type KeystonePasswordIdentityProvider struct {
 	RemoteConnectionInfo RemoteConnectionInfo
 	// Domain Name is required for keystone v3
 	DomainName string
+	// UseKeystoneIdentity flag indicates that user should be authenticated by keystone ID, not by username
+	UseKeystoneIdentity bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cmd/server/apis/config/v1/swagger_doc.go
+++ b/pkg/cmd/server/apis/config/v1/swagger_doc.go
@@ -346,8 +346,9 @@ func (JenkinsPipelineConfig) SwaggerDoc() map[string]string {
 }
 
 var map_KeystonePasswordIdentityProvider = map[string]string{
-	"":           "KeystonePasswordIdentityProvider provides identities for users authenticating using keystone password credentials",
-	"domainName": "Domain Name is required for keystone v3",
+	"":                    "KeystonePasswordIdentityProvider provides identities for users authenticating using keystone password credentials",
+	"domainName":          "Domain Name is required for keystone v3",
+	"useKeystoneIdentity": "UseKeystoneIdentity flag indicates that user should be authenticated by keystone ID, not by username",
 }
 
 func (KeystonePasswordIdentityProvider) SwaggerDoc() map[string]string {

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -244,6 +244,7 @@ oauthConfig:
       keyFile: ""
       kind: KeystonePasswordIdentityProvider
       url: ""
+      useKeystoneIdentity: false
   - challenge: false
     login: false
     mappingMethod: claim

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -946,6 +946,8 @@ type KeystonePasswordIdentityProvider struct {
 	RemoteConnectionInfo `json:",inline"`
 	// Domain Name is required for keystone v3
 	DomainName string `json:"domainName"`
+	// UseKeystoneIdentity flag indicates that user should be authenticated by keystone ID, not by username
+	UseKeystoneIdentity bool `json:"useKeystoneIdentity"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword_test.go
+++ b/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword_test.go
@@ -12,11 +12,29 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-type TestUserIdentityMapper struct{}
-
-func (m *TestUserIdentityMapper) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
-	return &user.DefaultInfo{Name: identityInfo.GetProviderUserName()}, nil
+// This type emulates a mapper with "claim" provisioning strategy
+type TestUserIdentityMapperClaim struct {
+	idnts map[string]string
 }
+
+func (m *TestUserIdentityMapperClaim) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
+	userName := identityInfo.GetProviderUserName()
+	if login, ok := identityInfo.GetExtra()[api.IdentityPreferredUsernameKey]; ok && len(login) > 0 {
+		userName = login
+	}
+	claimedIdentityName := identityInfo.GetProviderName() + ":" + identityInfo.GetProviderUserName()
+
+	if identityName, ok := m.idnts[userName]; ok && identityName != claimedIdentityName {
+		// A user with that user name is already mapped to another identity
+		return nil, fmt.Errorf("Ooops")
+	}
+	// Map the user with new identity
+	m.idnts[userName] = claimedIdentityName
+
+	return &user.DefaultInfo{Name: userName}, nil
+}
+
+var keystoneID string
 
 func TestKeystoneLogin(t *testing.T) {
 	th.SetupHTTP()
@@ -47,20 +65,78 @@ func TestKeystoneLogin(t *testing.T) {
 		password := x.Auth.Identity.Password.User.Password
 		if domainName == "default" && userName == "testuser" && password == "testpw" {
 			w.WriteHeader(http.StatusCreated)
-			fmt.Fprintf(w, `{ "token": { "expires_at": "2020-02-02T18:30:59.000000Z" } }`)
+			resp := `{"token": {
+							"methods": [
+								"password"
+							],
+							"expires_at": "2015-11-09T01:42:57.527363Z",
+							"user": {
+								"domain": {
+									"id": "default",
+									"name": "Default"
+								},
+								"id": "` + keystoneID + `",
+								"name": "admin",
+								"password_expires_at": null
+							},
+							"audit_ids": [
+								"lC2Wj1jbQe-dLjLyOx4qPQ"
+							],
+							"issued_at": "2015-11-09T00:42:57.527404Z"
+						}
+					}`
+			fmt.Fprintf(w, resp)
 		} else {
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	})
+	// -----Test Claim strategy with enabled Keystone identity-----
+	mapperClaim := TestUserIdentityMapperClaim{map[string]string{}}
+	keystoneID = "initial_keystone_id"
+	keystoneAuth := New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &mapperClaim, true)
 
-	keystoneAuth := New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &TestUserIdentityMapper{})
+	// 1. User authenticates for the first time, new identity is created
 	_, ok, err := keystoneAuth.AuthenticatePassword("testuser", "testpw")
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, ok, true)
+	th.CheckEquals(t, true, ok)
+	th.CheckEquals(t, "keystone_auth:initial_keystone_id", mapperClaim.idnts["testuser"])
+
+	// 2. Authentication with wrong or empty password fails
 	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "badpw")
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, ok, false)
+	th.CheckEquals(t, false, ok)
 	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "")
 	th.AssertNoErr(t, err)
-	th.CheckEquals(t, ok, false)
+	th.CheckEquals(t, false, ok)
+
+	// 3. Id of "testuser" has changed, authentication will fail
+	keystoneID = "new_keystone_id"
+	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	th.CheckEquals(t, false, ok)
+	th.CheckEquals(t, "Ooops", err.Error())
+
+	// -----Test Claim strategy with disabled Keystone identity-----
+	mapperClaim = TestUserIdentityMapperClaim{map[string]string{}}
+	keystoneID = "initial_keystone_id"
+	keystoneAuth = New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &mapperClaim, false)
+
+	// 1. User authenticates for the first time, new identity is created
+	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, true, ok)
+	th.CheckEquals(t, "keystone_auth:testuser", mapperClaim.idnts["testuser"])
+
+	// 2. Authentication with wrong or empty password fails
+	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "badpw")
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, false, ok)
+	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "")
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, false, ok)
+
+	// 3. Id of "testuser" has changed, authentication will work as before
+	keystoneID = "new_keystone_id"
+	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	th.CheckEquals(t, true, ok)
+	th.AssertNoErr(t, err)
 }

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -602,7 +602,7 @@ func (c *OAuthServerConfig) getPasswordAuthenticator(identityProvider configapi.
 			return nil, fmt.Errorf("Error building KeystonePasswordIdentityProvider client: %v", err)
 		}
 
-		return keystonepassword.New(identityProvider.Name, connectionInfo.URL, transport, provider.DomainName, identityMapper), nil
+		return keystonepassword.New(identityProvider.Name, connectionInfo.URL, transport, provider.DomainName, identityMapper, provider.UseKeystoneIdentity), nil
 
 	default:
 		return nil, fmt.Errorf("No password auth found that matches %v.  The OAuth server cannot start!", identityProvider)


### PR DESCRIPTION
This code prevents situations when, after removing a user
account in Keystone, a new user with the same name can
see all the resources available to the previous user.

This is achieved by storing the user ID instead of his name
in the identity, i.e. "<provider_name>:<keystone_user_id>".
If the identifier of the new user does not match what is
stored in the identity, then the user's request to login
to the system is rejected, even if he entered the correct
password.

For backward compatibility reasons new boolean config option
"useKeystoneIdentity" was added for the provider. If it is
set to false, the old behavior will be used, i.e. authentication
by username.
Default value is false.