### PR TITLE
sdn: fix CNI IPAM data dir

### DIFF
--- a/pkg/network/node/metrics.go
+++ b/pkg/network/node/metrics.go
@@ -167,7 +167,7 @@ func updateARPMetrics() {
 
 func updatePodIPMetrics() {
 	numAddrs := 0
-	items, err := ioutil.ReadDir(hostLocalDataDir + "/networks/openshift-sdn/")
+	items, err := ioutil.ReadDir(hostLocalDataDir + "/openshift-sdn/")
 	if err != nil && os.IsNotExist(err) {
 		// Don't log an error if the directory doesn't exist (eg, no pods started yet)
 		return

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	openshiftCNIFile = "80-openshift-network.conf"
-	hostLocalDataDir = "/var/lib/cni"
+	hostLocalDataDir = "/var/lib/cni/networks"
 )
 
 type osdnPolicy interface {


### PR DESCRIPTION
Data directory passed to the CNI host-local delegate plugin
should be /var/lib/cni/networks, but the original patch missed
one place to append "/networks" (the one that mattered).

Fix-up for https://github.com/openshift/origin/pull/18404

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1549491

@openshift/networking