### PR TITLE
examples/prometheus: fix some prometheus service discovery scraping

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -314,6 +314,7 @@ objects:
           - -tls-key=/etc/tls/private/tls.key
           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
           volumeMounts:
           - mountPath: /etc/tls/private
             name: alerts-tls-secret
@@ -328,9 +329,6 @@ objects:
           volumeMounts:
           - mountPath: /alert-buffer
             name: alerts-data
-          ports:
-          - containerPort: 9099
-            name: alert-buf
 
         - name: alertmanager-proxy
           image: ${IMAGE_PROXY}
@@ -365,9 +363,6 @@ objects:
           - --config.file=/etc/alertmanager/alertmanager.yml
           image: ${IMAGE_ALERTMANAGER}
           imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 9093
-            name: web
           volumeMounts:
           - mountPath: /etc/alertmanager
             name: alertmanager-config
@@ -399,10 +394,10 @@ objects:
             name: alertmanager
         - name: alertmanager-tls-secret
           secret:
-            secretName: alertmanager-tls  
+            secretName: alertmanager-tls
         - name: alertmanager-proxy-secret
           secret:
-            secretName: alertmanager-proxy         
+            secretName: alertmanager-proxy
 
         - name: alerts-proxy-secrets
           secret:
@@ -432,7 +427,7 @@ objects:
             miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
-    
+
     recording.rules: |
       groups:
       - name: aggregate_container_resources

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14269,6 +14269,7 @@ objects:
           - -tls-key=/etc/tls/private/tls.key
           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
           volumeMounts:
           - mountPath: /etc/tls/private
             name: alerts-tls-secret
@@ -14283,9 +14284,6 @@ objects:
           volumeMounts:
           - mountPath: /alert-buffer
             name: alerts-data
-          ports:
-          - containerPort: 9099
-            name: alert-buf
 
         - name: alertmanager-proxy
           image: ${IMAGE_PROXY}
@@ -14320,9 +14318,6 @@ objects:
           - --config.file=/etc/alertmanager/alertmanager.yml
           image: ${IMAGE_ALERTMANAGER}
           imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 9093
-            name: web
           volumeMounts:
           - mountPath: /etc/alertmanager
             name: alertmanager-config
@@ -14354,10 +14349,10 @@ objects:
             name: alertmanager
         - name: alertmanager-tls-secret
           secret:
-            secretName: alertmanager-tls  
+            secretName: alertmanager-tls
         - name: alertmanager-proxy-secret
           secret:
-            secretName: alertmanager-proxy         
+            secretName: alertmanager-proxy
 
         - name: alerts-proxy-secrets
           secret:
@@ -14387,7 +14382,7 @@ objects:
             miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
-    
+
     recording.rules: |
       groups:
       - name: aggregate_container_resources

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -25825,6 +25825,7 @@ objects:
           - -tls-key=/etc/tls/private/tls.key
           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
+          - -skip-auth-regex=^/metrics
           volumeMounts:
           - mountPath: /etc/tls/private
             name: alerts-tls-secret
@@ -25839,9 +25840,6 @@ objects:
           volumeMounts:
           - mountPath: /alert-buffer
             name: alerts-data
-          ports:
-          - containerPort: 9099
-            name: alert-buf
 
         - name: alertmanager-proxy
           image: ${IMAGE_PROXY}
@@ -25876,9 +25874,6 @@ objects:
           - --config.file=/etc/alertmanager/alertmanager.yml
           image: ${IMAGE_ALERTMANAGER}
           imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 9093
-            name: web
           volumeMounts:
           - mountPath: /etc/alertmanager
             name: alertmanager-config
@@ -25910,10 +25905,10 @@ objects:
             name: alertmanager
         - name: alertmanager-tls-secret
           secret:
-            secretName: alertmanager-tls  
+            secretName: alertmanager-tls
         - name: alertmanager-proxy-secret
           secret:
-            secretName: alertmanager-proxy         
+            secretName: alertmanager-proxy
 
         - name: alerts-proxy-secrets
           secret:
@@ -25943,7 +25938,7 @@ objects:
             miqTarget: "ContainerNode"
             severity: "HIGH"
             message: "{{$labels.instance}} is down"
-    
+
     recording.rules: |
       groups:
       - name: aggregate_container_resources


### PR DESCRIPTION
- remove containerPort config from alertmanager and alertbuffer so that the prometheus
  kube discovery doesn't try to scrape them
- allow unauthenticated access to /metrics path so and alert buffer can be scraped
- minor whitespace fix