### PR TITLE
Multiple auto-egress-IP fixes

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -278,8 +278,9 @@ func (eip *egressIPWatcher) updateNamespaceEgress(vnid uint32, egressIP string) 
 	}
 
 	if ns.assignedIP != "" {
-		eip.deleteEgressIP(egressIP)
-		delete(eip.namespacesByEgressIP, egressIP)
+		oldEgressIP := ns.assignedIP
+		eip.deleteEgressIP(oldEgressIP)
+		delete(eip.namespacesByEgressIP, oldEgressIP)
 		ns.assignedIP = ""
 		ns.nodeIP = ""
 	}

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -194,7 +194,7 @@ func (eip *egressIPWatcher) maybeAddEgressIP(egressIP string) {
 		ns.assignedIP = egressIP
 		ns.nodeIP = nodeIP
 
-		err := eip.oc.UpdateNamespaceEgressRules(ns.vnid, ns.nodeIP, mark)
+		err := eip.oc.SetNamespaceEgressViaEgressIP(ns.vnid, ns.nodeIP, mark)
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules: %v", err))
 		}
@@ -224,10 +224,10 @@ func (eip *egressIPWatcher) deleteEgressIP(egressIP string) {
 	var err error
 	if ns.requestedIP == "" {
 		// Namespace no longer wants EgressIP
-		err = eip.oc.UpdateNamespaceEgressRules(ns.vnid, "", "")
+		err = eip.oc.SetNamespaceEgressNormal(ns.vnid)
 	} else {
 		// Namespace still wants EgressIP but no node provides it
-		err = eip.oc.UpdateNamespaceEgressRules(ns.vnid, "", mark)
+		err = eip.oc.SetNamespaceEgressDropped(ns.vnid)
 	}
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules: %v", err))


### PR DESCRIPTION
OK, 3 "setup" commits followed by 2 commits with fixes:
- the first and second commits only change `egressip_test.go`, so clearly don't break the actual functioning of auto-egress-IP
- the third commit ("Have multiple egress IP ovscontroller methods rather than one confusing one") is small and fairly self-explanatory.
- the fourth commit ("Fix egressip handling when a NetNamespace is updated") involves a small fix to `egressip.go` and then a larger update to `egressip_test.go` to show that the fix works. Specifically: if the `EgressIPs` field on a NetNamespace was changed while that egress IP was active, then we did not clean up all of the state associated with the old egress IP, because we were accidentally cleaning up the state associated with the *new* egress IP instead.
- the last commit ("Rearrange egressip internals, add duplication tests") is very large and complicated and needs the most review, but in particular note that all of the existing tests still pass with the new code, and it adds two more tests (which don't pass with the old code). This fixes the problem that we were previously mostly doing the right thing when the user screwed up and added a duplicate EgressIP, but we weren't doing the right thing when they *removed* the duplicates, because we weren't keeping enough information about the global merged node/namespace EgressIP state. I think the end result is actually simpler than the old code.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1551028
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547899
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543786
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1520363

@openshift/sig-networking PTAL