### PR TITLE
Allow all node scheduling for more tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -244,11 +244,6 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 		allowAllNodeScheduling(c, ns.Name)
 	}
 
-	// some tests assume they can schedule to all nodes
-	if testNameContains("Granular Checks: Pods") {
-		allowAllNodeScheduling(c, ns.Name)
-	}
-
 	return ns, err
 }
 


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/18823

need to take a pass at all tests that are self-scheduling to see if we need to open this list more.