### PR TITLE
Allow all nodes to run upstream kube tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -239,6 +239,9 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 			return ns, err
 		}
 		addRoleToE2EServiceAccounts(authorizationClient, []kapiv1.Namespace{*ns}, bootstrappolicy.ViewRoleName)
+
+		// in practice too many kube tests ignore scheduling constraints
+		allowAllNodeScheduling(c, ns.Name)
 	}
 
 	// some tests assume they can schedule to all nodes


### PR DESCRIPTION
This is extracted from https://github.com/openshift/origin/pull/18816/ in order
to make hostpath tests pass.