### PR TITLE
sdn: wait until container runtime is actually ready before using it

### DIFF
--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -31,6 +31,14 @@ func (node *OsdnNode) getRuntimeService() (kubeletapi.RuntimeService, error) {
 				// Wait longer
 				return false, nil
 			}
+
+			// Ensure the runtime is actually alive; gRPC may create the client but
+			// it may not be responding to requests yet
+			if _, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{}); err != nil {
+				// Wait longer
+				return false, nil
+			}
+
 			node.runtimeService = runtimeService
 			return true, nil
 		})


### PR DESCRIPTION
It seems that NewRemoteRuntimeService() doesn't actually block until the
remote runtime is actually running.  And since the remote runtime could
be started in parallel to SDN startup (in the case of dockershim at least)
it may not be available by the time we try to use it in to kill stale
pods on startup.

So when getting the runtime service for stale pod cleanup on SDN startup,
don't return until we can actually talk to it, or the timeout is reached.

@openshift/networking @pravisankar 

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1542910

(note that this doesn't actually fix the whole kill-pods-on-restart problem, because we haven't written /etc/cni/net.d/openshift-sdn.conf yet, and only when that's written and the container runtime has found that file, which is on a 30s timer, can the container runtime actually service the StopPodSandbox() request that we're trying to send it)