### PR TITLE
Warn when AuditFilePath is relative

### DIFF
--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -215,6 +215,8 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 				}
 			}
 
+			obj.AuditConfig.InternalAuditFilePath = ""
+
 			// this field isn't serialized
 			obj.DisableOpenAPI = false
 		},
@@ -405,6 +407,9 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 			if len(obj.ServiceAccountMethod) == 0 {
 				obj.ServiceAccountMethod = "prompt"
 			}
+		},
+		func(obj *configapi.AuditConfig, c fuzz.Continue) {
+			obj.InternalAuditFilePath = ""
 		},
 	)
 

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -496,6 +496,9 @@ type AuditConfig struct {
 	Enabled bool
 	// All requests coming to the apiserver will be logged to this file.
 	AuditFilePath string
+	// This field is used to hold actual value of the AuditFilePath as entered
+	// by the user for validation.
+	InternalAuditFilePath string
 	// Maximum number of days to retain old log files based on the timestamp encoded in their filename.
 	MaximumFileRetentionDays int
 	// Maximum number of old log files to retain.

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -417,6 +417,21 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 			}
 			return nil
 		},
+		func(in *AuditConfig, out *internal.AuditConfig, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
+			if len(in.AuditFilePath) > 0 {
+				out.InternalAuditFilePath = in.AuditFilePath
+			}
+			return nil
+		},
+		func(in *internal.AuditConfig, out *AuditConfig, s conversion.Scope) error {
+			if err := s.DefaultConvert(in, out, conversion.IgnoreMissingFields); err != nil {
+				return err
+			}
+			return nil
+		},
 
 		metav1.Convert_resource_Quantity_To_resource_Quantity,
 		metav1.Convert_bool_To_Pointer_bool,

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -212,9 +213,13 @@ func ValidateAuditConfig(config configapi.AuditConfig, fldPath *field.Path) Vali
 		return validationResults
 	}
 
+	// TODO (soltysh): both of these should be turned into errors in 3.11
 	if len(config.AuditFilePath) == 0 {
 		// for backwards compatibility reasons we can't error this out
-		validationResults.AddWarnings(field.Required(fldPath.Child("auditFilePath"), "audit can not be logged to a separate file"))
+		validationResults.AddWarnings(field.Required(fldPath.Child("auditFilePath"), "audit needs to be logged to a separate file"))
+	} else if !filepath.IsAbs(config.InternalAuditFilePath) {
+		// for backwards compatibility reasons we can't error this out
+		validationResults.AddWarnings(field.Invalid(fldPath.Child("auditFilePath"), config.InternalAuditFilePath, "must be absolute path"))
 	}
 	if config.MaximumFileRetentionDays < 0 {
 		validationResults.AddErrors(field.Invalid(fldPath.Child("maximumFileRetentionDays"), config.MaximumFileRetentionDays, "must be greater than or equal to 0"))


### PR DESCRIPTION
Fixes #18753. I'll open an issue for 3.11 to turn change this entirely into a requirement. 

David, you ain't gonna like it, so be warned :wink: but I couldn't figure out a better approach than the one in this PR, b/c we modify all the paths to be absolute before we reach validation. Lemme know what you think. 

/assign @deads2k 