### PR TITLE
Minor fixup to auto egress IP deletion fix

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -213,8 +213,8 @@ func (eip *egressIPWatcher) deleteEgressIP(egressIP string) {
 		if err := eip.releaseEgressIP(egressIP, mark); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error releasing Egress IP %q: %v", egressIP, err))
 		}
-		node.assignedIPs.Delete(egressIP)
 	}
+	node.assignedIPs.Delete(egressIP)
 
 	if ns.assignedIP == egressIP {
 		ns.assignedIP = ""


### PR DESCRIPTION
Fix to #18720. That added a missing `node.assignedIPs.Delete(egressIP)` to `deleteEgressIP`, but it added it in the wrong place, inside the `if node.nodeIP == eip.localIP` check, so only the node hosting the egress IP would clean things up properly and the other nodes would still stay broken. The test added in #18720 didn't pick this up because it only tested add-remove-add in the egress-on-local-node case, not the remote case.

(This is fixed in master as part of the larger changes in #18808, but that's not going to be backported immediately, whereas this could be.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547899