### PR TITLE
Update grafana.yaml

### DIFF
--- a/examples/grafana/grafana.yaml
+++ b/examples/grafana/grafana.yaml
@@ -120,6 +120,8 @@ objects:
           - '-openshift-sar={"namespace": "${NAMESPACE}", "verb": "list", "resource": "services"}'
           - -tls-cert=/etc/tls/private/tls.crt
           - -tls-key=/etc/tls/private/tls.key
+          - -openshift-ca=/etc/pki/tls/cert.pem
+          - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
           - -skip-auth-regex=^/metrics,/api/datasources,/api/dashboards


### PR DESCRIPTION
Added openshift-ca to work around situations where openshift have signed its own master ca but where it goes trough a loadbalancer with a public signed cert. same settings as were added in prom-proxy and alerts-proxy to avoid these errors.