### PR TITLE
UPSTREAM: opencontainers/runc: 1754: Add timeout while waiting for StartTransinetUnit completion signal

### DIFF
--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/sirupsen/logrus"
 )
 
 type Manager struct {
@@ -300,7 +301,11 @@ func (m *Manager) Apply(pid int) error {
 		return err
 	}
 
-	<-statusChan
+	select {
+	case <-statusChan:
+	case <-time.After(time.Second):
+		logrus.Warnf("Timed out while waiting for StartTransientUnit completion signal from dbus. Continuing...")
+	}
 
 	if err := joinCgroups(c, pid); err != nil {
 		return err


### PR DESCRIPTION
https://github.com/opencontainers/runc/pull/1754

xref https://bugzilla.redhat.com/show_bug.cgi?id=1548358

Hold until upstream merge.

@derekwaynecarr @vikaschoudhary16 

