### PR TITLE
Don't try to delete (nonexistent) OVS flows for headless/external services

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -473,7 +473,7 @@ func (node *OsdnNode) watchServices() {
 
 func (node *OsdnNode) handleAddOrUpdateService(obj, oldObj interface{}, eventType watch.EventType) {
 	serv := obj.(*kapi.Service)
-	// Ignore headless services
+	// Ignore headless/external services
 	if !kapihelper.IsServiceIPSet(serv) {
 		return
 	}
@@ -499,6 +499,11 @@ func (node *OsdnNode) handleAddOrUpdateService(obj, oldObj interface{}, eventTyp
 
 func (node *OsdnNode) handleDeleteService(obj interface{}) {
 	serv := obj.(*kapi.Service)
+	// Ignore headless/external services
+	if !kapihelper.IsServiceIPSet(serv) {
+		return
+	}
+
 	glog.V(5).Infof("Watch %s event for Service %q", watch.Deleted, serv.Name)
 	node.DeleteServiceRules(serv)
 }


### PR DESCRIPTION
When moving to shared informers in 3.6, the check to ignore events for headless/external services accidentally got limited to only add events, not delete, so now Online logs lots of errors like:

    I0307 15:51:47.196166   21826 ovs.go:143] Error executing ovs-ofctl: ovs-ofctl: 0/0: invalid IP address
    E0307 15:51:47.196211   21826 sdn_controller.go:284] Error deleting OVS flows for service &{...}: exit status 1

(That's for deleting an ExternalName service; trying to delete a headless service gives `ovs-ofctl: None: invalid IP address`.) In either case, the bug is harmless other than the spurious error message; we're just failing to delete a flow that wasn't there anyway.

