### PR TITLE
UPSTREAM: <carry>: ensure hijackedConn implements CloseWrite function

### DIFF
--- a/vendor/github.com/docker/docker/client/hijack.go
+++ b/vendor/github.com/docker/docker/client/hijack.go
@@ -206,3 +206,10 @@ type hijackedConn struct {
 func (c *hijackedConn) Read(b []byte) (int, error) {
 	return c.r.Read(b)
 }
+
+func (c *hijackedConn) CloseWrite() error {
+	if conn, ok := c.Conn.(types.CloseWriter); ok {
+		return conn.CloseWrite()
+	}
+	return nil
+}


### PR DESCRIPTION
https://github.com/moby/moby/issues/36516
https://github.com/moby/moby/pull/36517

fixes https://github.com/openshift/origin/issues/18862
