### PR TITLE
 add better logging for oc cluster up component install

### DIFF
--- a/pkg/oc/bootstrap/clusterup/componentinstall/interface.go
+++ b/pkg/oc/bootstrap/clusterup/componentinstall/interface.go
@@ -13,10 +13,10 @@ import (
 
 type Component interface {
 	Name() string
-	Install(dockerClient dockerhelper.Interface) error
+	Install(dockerClient dockerhelper.Interface, logdir string) error
 }
 
-func InstallComponents(components []Component, dockerClient dockerhelper.Interface) error {
+func InstallComponents(components []Component, dockerClient dockerhelper.Interface, logdir string) error {
 	componentNames := []string{}
 	errorCh := make(chan error, len(components))
 	waitGroupOne := sync.WaitGroup{}
@@ -29,7 +29,7 @@ func InstallComponents(components []Component, dockerClient dockerhelper.Interfa
 		go func() {
 			defer waitGroupOne.Done()
 
-			err := component.Install(dockerClient)
+			err := component.Install(dockerClient, logdir)
 			if err != nil {
 				glog.Errorf("Failed to install %q: %v", component.Name(), err)
 				errorCh <- err

--- a/pkg/oc/bootstrap/clusterup/componentinstall/log.go
+++ b/pkg/oc/bootstrap/clusterup/componentinstall/log.go
@@ -1,0 +1,46 @@
+package componentinstall
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func LogContainer(logdir, name, stdout, stderr string) error {
+	if err := os.MkdirAll(logdir, 0755); err != nil {
+		return err
+	}
+
+	spinNumber := 1
+	stdoutFile := ""
+	stderrFile := ""
+	for i := 0; i < 1000; i++ {
+		stdoutFile = fmt.Sprintf("%s-%03d.stdout", strings.Replace(name, "/", "-", -1), spinNumber)
+		stderrFile = fmt.Sprintf("%s-%03d.stderr", strings.Replace(name, "/", "-", -1), spinNumber)
+
+		if _, err := os.Stat(path.Join(logdir, stdoutFile)); !os.IsNotExist(err) {
+			continue
+		}
+		if _, err := os.Stat(path.Join(logdir, stderrFile)); !os.IsNotExist(err) {
+			continue
+		}
+	}
+
+	stdoutErr := ioutil.WriteFile(path.Join(logdir, stdoutFile), []byte(stdout), 0644)
+	stderrErr := ioutil.WriteFile(path.Join(logdir, stderrFile), []byte(stderr), 0644)
+
+	switch {
+	case stdoutErr == nil && stderrErr == nil:
+		return nil
+	case stdoutErr != nil && stderrErr == nil:
+		return stdoutErr
+	case stdoutErr == nil && stderrErr != nil:
+		return stderrErr
+	default:
+		return utilerrors.NewAggregate([]error{stdoutErr, stderrErr})
+	}
+}

--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/config.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/config.go
@@ -4,7 +4,10 @@ import (
 	"os"
 	"path"
 
+	"github.com/docker/docker/api/types"
 	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/componentinstall"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
 	"github.com/openshift/origin/pkg/oc/errors"
@@ -29,21 +32,34 @@ func NewKubeAPIServerStartConfig() *KubeAPIServerStartConfig {
 // and returns a directory in the local file system where
 // the OpenShift configuration has been copied
 func (opt KubeAPIServerStartConfig) MakeMasterConfig(dockerClient dockerhelper.Interface, basedir string) (string, error) {
+	componentName := "create-master-config"
 	imageRunHelper := run.NewRunHelper(dockerhelper.NewHelper(dockerClient)).New()
+	glog.Infof("Running %q", componentName)
 
-	glog.Infof("Creating initial OpenShift master configuration")
 	createConfigCmd := []string{
 		"start", "master",
 	}
 	createConfigCmd = append(createConfigCmd, opt.Args...)
 
-	containerId, _, err := imageRunHelper.Image(opt.MasterImage).
+	containerId, stdout, stderr, rc, err := imageRunHelper.Image(opt.MasterImage).
 		Privileged().
 		HostNetwork().
 		HostPid().
-		Command(createConfigCmd...).Run()
+		Command(createConfigCmd...).Output()
+	defer func() {
+		if err = dockerClient.ContainerRemove(containerId, types.ContainerRemoveOptions{}); err != nil {
+			glog.Errorf("error removing %q: %v", containerId, err)
+		}
+	}()
+
+	if err := componentinstall.LogContainer(path.Join(basedir, "logs"), componentName, stdout, stderr); err != nil {
+		glog.Errorf("error logging %q: %v", componentName, err)
+	}
 	if err != nil {
-		return "", errors.NewError("could not create OpenShift configuration: %v", err).WithCause(err)
+		return "", errors.NewError("could not run %q: %v", componentName, err).WithCause(err)
+	}
+	if rc != 0 {
+		return "", errors.NewError("could not run %q: rc==%v", componentName, rc)
 	}
 
 	// TODO eliminate the linkage that other tasks have on this particular structure

--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_apiserver.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_apiserver.go
@@ -1,7 +1,6 @@
 package kubeapiserver
 
 import (
-	"io"
 	"io/ioutil"
 	"path"
 
@@ -14,7 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/tmpformac"
 )
 
-func MakeOpenShiftAPIServerConfig(existingMasterConfig string, out io.Writer, basedir string) (string, error) {
+func MakeOpenShiftAPIServerConfig(existingMasterConfig string, basedir string) (string, error) {
 	openshiftAPIServerDir := path.Join(basedir, OpenShiftAPIServerDirName)
 	glog.V(1).Infof("Copying kube-apiserver config to local directory %s", openshiftAPIServerDir)
 	if err := tmpformac.CopyDirectory(existingMasterConfig, openshiftAPIServerDir); err != nil {

--- a/pkg/oc/bootstrap/clusterup/kubelet/dns.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/dns.go
@@ -1,7 +1,6 @@
 package kubelet
 
 import (
-	"io"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -15,7 +14,7 @@ import (
 // Start starts the OpenShift master as a Docker container
 // and returns a directory in the local file system where
 // the OpenShift configuration has been copied
-func MutateKubeDNSConfig(nodeConfigDir string, out io.Writer) (string, error) {
+func MutateKubeDNSConfig(nodeConfigDir string) (string, error) {
 	// update DNS resolution to point at the master (for now).  Do this by grabbing the local and prepending to it.
 	// this is probably broken somewhere for some reason and a bad idea of other reasons, but it gets us moving
 	if existingResolveConf, err := ioutil.ReadFile("/etc/resolv.conf"); err == nil {

--- a/pkg/oc/bootstrap/clusterup/kubelet/run_kubelet.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/run_kubelet.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
 	"github.com/openshift/origin/pkg/oc/errors"
 )
@@ -39,7 +41,11 @@ func NewKubeletRunConfig() *KubeletRunConfig {
 // Start starts the OpenShift master as a Docker container
 // and returns a directory in the local file system where
 // the OpenShift configuration has been copied
-func (opt KubeletRunConfig) RunKubelet(imageRunHelper *run.Runner) (string, error) {
+func (opt KubeletRunConfig) StartKubelet(dockerClient dockerhelper.Interface, logdir string) (string, error) {
+	componentName := "start-kubelet"
+	imageRunHelper := run.NewRunHelper(dockerhelper.NewHelper(dockerClient)).New()
+	glog.Infof("Running %q", componentName)
+
 	env := []string{}
 	if len(opt.HTTPProxy) > 0 {
 		env = append(env, fmt.Sprintf("HTTP_PROXY=%s", opt.HTTPProxy))
@@ -52,7 +58,6 @@ func (opt KubeletRunConfig) RunKubelet(imageRunHelper *run.Runner) (string, erro
 	}
 	env = append(env, opt.Environment...)
 
-	glog.Info("Running kubelet")
 	createConfigCmd := []string{
 		"kubelet",
 	}

--- a/pkg/oc/bootstrap/docker/openshift/templateservicebroker.go
+++ b/pkg/oc/bootstrap/docker/openshift/templateservicebroker.go
@@ -23,7 +23,7 @@ const (
 )
 
 // InstallTemplateServiceBroker checks whether the template service broker is installed and installs it if not already installed
-func (h *Helper) InstallTemplateServiceBroker(clusterAdminKubeConfig []byte, f *clientcmd.Factory, imageFormat string, serverLogLevel int) error {
+func (h *Helper) InstallTemplateServiceBroker(clusterAdminKubeConfig []byte, f *clientcmd.Factory, imageFormat string, serverLogLevel int, logdir string) error {
 	// create the actual resources required
 	imageTemplate := variable.NewDefaultImageTemplate()
 	imageTemplate.Format = imageFormat
@@ -66,11 +66,11 @@ func (h *Helper) InstallTemplateServiceBroker(clusterAdminKubeConfig []byte, f *
 	return component.MakeReady(
 		h.image,
 		clusterAdminKubeConfig,
-		params).Install(h.dockerHelper.Client())
+		params).Install(h.dockerHelper.Client(), logdir)
 }
 
 // RegisterTemplateServiceBroker registers the TSB with the SC by creating the broker resource
-func (h *Helper) RegisterTemplateServiceBroker(clusterAdminKubeConfig []byte, configDir string) error {
+func (h *Helper) RegisterTemplateServiceBroker(clusterAdminKubeConfig []byte, configDir string, logdir string) error {
 	// Register the template broker with the service catalog
 	glog.V(2).Infof("registering the template broker with the service catalog")
 
@@ -92,5 +92,5 @@ func (h *Helper) RegisterTemplateServiceBroker(clusterAdminKubeConfig []byte, co
 	return component.MakeReady(
 		h.image,
 		clusterAdminKubeConfig,
-		params).Install(h.dockerHelper.Client())
+		params).Install(h.dockerHelper.Client(), logdir)
 }

--- a/pkg/oc/bootstrap/docker/run/errors.go
+++ b/pkg/oc/bootstrap/docker/run/errors.go
@@ -29,11 +29,12 @@ func (e *runError) Details() string {
 	fmt.Fprintf(out, "Image: %s\n", e.config.Image)
 	fmt.Fprintf(out, "Entrypoint: %v\n", e.config.Entrypoint)
 	fmt.Fprintf(out, "Command: %v\n", e.config.Cmd)
-	if len(e.stdOut) > 0 {
-		errors.PrintLog(out, "Output", e.stdOut)
-	}
-	if len(e.stdErr) > 0 {
-		errors.PrintLog(out, "Error Output", e.stdErr)
-	}
+	// TODO maybe we will re-introduce this, but we're starting to record the container logs in a tempdir, so I doubt it
+	//if len(e.stdOut) > 0 {
+	//	errors.PrintLog(out, "Output", e.stdOut)
+	//}
+	//if len(e.stdErr) > 0 {
+	//	errors.PrintLog(out, "Error Output", e.stdErr)
+	//}
 	return out.String()
 }

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -43,7 +43,6 @@ import (
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/host"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/localcmd"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/openshift"
-	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	osclientcmd "github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 )
@@ -983,7 +982,7 @@ func (c *ClientStartConfig) InstallRegistry(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return c.OpenShiftHelper().InstallRegistry(run.NewRunHelper(c.DockerHelper()).New(), c.openshiftImage(), kubeClient, f, c.LocalConfigDir, c.imageFormat(), c.HostPersistentVolumesDir, out, os.Stderr)
+	return c.OpenShiftHelper().InstallRegistry(c.GetDockerClient(), c.openshiftImage(), kubeClient, f, c.LocalConfigDir, path.Join(c.BaseTempDir, "logs"), c.imageFormat(), c.HostPersistentVolumesDir, out, os.Stderr)
 }
 
 // InstallRouter installs a default router on the server
@@ -996,7 +995,7 @@ func (c *ClientStartConfig) InstallRouter(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return c.OpenShiftHelper().InstallRouter(run.NewRunHelper(c.DockerHelper()).New(), c.openshiftImage(), kubeClient, f, c.LocalConfigDir, c.imageFormat(), c.ServerIP, c.PortForwarding, out, os.Stderr)
+	return c.OpenShiftHelper().InstallRouter(c.GetDockerClient(), c.openshiftImage(), kubeClient, f, c.LocalConfigDir, path.Join(c.BaseTempDir, "logs"), c.imageFormat(), c.ServerIP, c.PortForwarding, out, os.Stderr)
 }
 
 // InstallWebConsole installs the OpenShift web console on the server
@@ -1041,7 +1040,7 @@ func (c *ClientStartConfig) ImportInitialObjects(out io.Writer) error {
 	componentsToInstall = append(componentsToInstall,
 		c.makeObjectImportInstallationComponentsOrDie(out, openshift.OpenshiftInfraNamespace, internalCurrentTemplateLocations)...)
 
-	return componentinstall.InstallComponents(componentsToInstall, c.GetDockerClient())
+	return componentinstall.InstallComponents(componentsToInstall, c.GetDockerClient(), path.Join(c.BaseTempDir, "logs"))
 }
 
 // InstallLogging will start the installation of logging components
@@ -1119,7 +1118,7 @@ func (c *ClientStartConfig) InstallTemplateServiceBroker(out io.Writer) error {
 		return err
 	}
 
-	return c.OpenShiftHelper().InstallTemplateServiceBroker(clusterAdminKubeConfig, f, imageTemplate, c.ServerLogLevel)
+	return c.OpenShiftHelper().InstallTemplateServiceBroker(clusterAdminKubeConfig, f, imageTemplate, c.ServerLogLevel, path.Join(c.BaseTempDir, "logs"))
 }
 
 // RegisterTemplateServiceBroker will register the tsb with the service catalog
@@ -1128,7 +1127,7 @@ func (c *ClientStartConfig) RegisterTemplateServiceBroker(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return c.OpenShiftHelper().RegisterTemplateServiceBroker(clusterAdminKubeConfig, c.LocalConfigDir)
+	return c.OpenShiftHelper().RegisterTemplateServiceBroker(clusterAdminKubeConfig, c.LocalConfigDir, path.Join(c.BaseTempDir, "logs"))
 }
 
 // Login logs into the new server and sets up a default user and project


### PR DESCRIPTION
last commit is unique.

This creates a "logs" directory alongside our config directories and tracks the install containers stdout and stderr output.

@stevekuznetsov Where do I need to copy directories to in order to have my logs picked up on failures?

/assign @soltysh 