### PR TITLE
dockergc: fix example DS to use oc instead of openshift

### DIFF
--- a/examples/dockergc/dockergc-ds.yaml
+++ b/examples/dockergc/dockergc-ds.yaml
@@ -23,6 +23,8 @@ items:
         serviceAccountName: dockergc
         containers:
         - image: openshift/origin:latest
+          command:
+          - "/usr/bin/oc"
           args:
           - "ex"
           - "dockergc"


### PR DESCRIPTION
The `ex` subcommand moved to `oc` from `openshift` in 3.9.  Need to update this example.

@vikaslaad @derekwaynecarr 