### PR TITLE
rewire the routing suffix for oc cluster up

### DIFF
--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_apiserver.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_apiserver.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/tmpformac"
 )
 
-func MakeOpenShiftAPIServerConfig(existingMasterConfig string, basedir string) (string, error) {
+func MakeOpenShiftAPIServerConfig(existingMasterConfig string, routingSuffix, basedir string) (string, error) {
 	configDir := path.Join(basedir, OpenShiftAPIServerDirName)
 	glog.V(1).Infof("Copying kube-apiserver config to local directory %s", configDir)
 	if err := tmpformac.CopyDirectory(existingMasterConfig, configDir); err != nil {
@@ -32,6 +32,9 @@ func MakeOpenShiftAPIServerConfig(existingMasterConfig string, basedir string) (
 	}
 	masterconfig := configObj.(*configapi.MasterConfig)
 	masterconfig.ServingInfo.BindAddress = "0.0.0.0:8445"
+
+	// hardcode the route suffix to the old default.  If anyone wants to change it, they can modify their config.
+	masterconfig.RoutingConfig.Subdomain = routingSuffix
 
 	configBytes, err := runtime.Encode(configapilatest.Codec, masterconfig)
 	if err != nil {

--- a/pkg/oc/bootstrap/docker/openshift/logging.go
+++ b/pkg/oc/bootstrap/docker/openshift/logging.go
@@ -60,9 +60,6 @@ func (h *Helper) InstallLoggingViaAnsible(f *clientcmd.Factory, serverVersion se
 	return runner.RunPlaybook(params, getLoggingPlaybook(serverVersion), hostConfigDir, imagePrefix, imageVersion)
 }
 
-func LoggingHost(routingSuffix, serverIP string) string {
-	if len(routingSuffix) > 0 {
-		return fmt.Sprintf("kibana-logging.%s", routingSuffix)
-	}
-	return fmt.Sprintf("kibana-logging.%s.nip.io", serverIP)
+func LoggingHost(routingSuffix string) string {
+	return fmt.Sprintf("kibana-logging.%s", routingSuffix)
 }

--- a/pkg/oc/bootstrap/docker/openshift/metrics.go
+++ b/pkg/oc/bootstrap/docker/openshift/metrics.go
@@ -56,9 +56,6 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverVersion se
 	return runner.RunPlaybook(params, getMetricsPlaybook(serverVersion), hostConfigDir, imagePrefix, imageVersion)
 }
 
-func MetricsHost(routingSuffix, serverIP string) string {
-	if len(routingSuffix) > 0 {
-		return fmt.Sprintf("hawkular-metrics-openshift-infra.%s", routingSuffix)
-	}
-	return fmt.Sprintf("hawkular-metrics-openshift-infra.%s.nip.io", serverIP)
+func MetricsHost(routingSuffix string) string {
+	return fmt.Sprintf("hawkular-metrics-openshift-infra.%s", routingSuffix)
 }

--- a/pkg/oc/bootstrap/docker/openshift/servicecatalog.go
+++ b/pkg/oc/bootstrap/docker/openshift/servicecatalog.go
@@ -137,9 +137,6 @@ func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, configDir, publicMa
 	return nil
 }
 
-func CatalogHost(routingSuffix, serverIP string) string {
-	if len(routingSuffix) > 0 {
-		return fmt.Sprintf("apiserver-service-catalog.%s", routingSuffix)
-	}
-	return fmt.Sprintf("apiserver-service-catalog.%s.nip.io", serverIP)
+func CatalogHost(routingSuffix string) string {
+	return fmt.Sprintf("apiserver-service-catalog.%s", routingSuffix)
 }

--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -358,7 +358,7 @@ func (c *ClusterUpConfig) makeKubeDNSConfig(nodeConfig string) (string, error) {
 }
 
 func (c *ClusterUpConfig) makeOpenShiftAPIServerConfig(masterConfigDir string) (string, error) {
-	return kubeapiserver.MakeOpenShiftAPIServerConfig(masterConfigDir, c.BaseTempDir)
+	return kubeapiserver.MakeOpenShiftAPIServerConfig(masterConfigDir, c.RoutingSuffix, c.BaseTempDir)
 }
 
 func (c *ClusterUpConfig) makeOpenShiftControllerConfig(masterConfigDir string) (string, error) {


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/18902

This sets the routing suffix to `<serverIP>.nip.io` and rewires the `--routing-suffix` option.  Without this flag, you'd have to modify config on every ec2 instance you ran on.

This highlights linkages and ordering requirements that need to be snipped and indicates the need to have `oc cluster up` create pods that can recognize when their config changes so they can restart.  For cluster up, one interesting option we have is a pod that is special for our configuration that starts deleting pods.

@openshift/sig-master 
@liggitt @mfojtik @soltysh 