### PR TITLE
[3.9] dockergc: fix example DS to us oc instead of openshift

### DIFF
--- a/examples/dockergc/dockergc-ds.yaml
+++ b/examples/dockergc/dockergc-ds.yaml
@@ -23,6 +23,8 @@ items:
         serviceAccountName: dockergc
         containers:
         - image: openshift/origin:latest
+          command:
+          - "/usr/bin/oc"
           args:
           - "ex"
           - "dockergc"


### PR DESCRIPTION
master PR https://github.com/openshift/origin/pull/18904

@vikaslaad @derekwaynecarr 