### PR TITLE
use the major.minor version as default for cluster up

### DIFF
--- a/pkg/cmd/util/variable/variable.go
+++ b/pkg/cmd/util/variable/variable.go
@@ -58,13 +58,13 @@ func Identity(key string) (string, bool) {
 func Versions(key string) (string, bool) {
 	switch key {
 	case "shortcommit":
-		s := OverrideVersion.GitCommit
+		s := overrideVersion.GitCommit
 		if len(s) > 7 {
 			s = s[:7]
 		}
 		return s, true
 	case "version":
-		s := OverrideVersion.LastSemanticVersion()
+		s := overrideVersion.LastSemanticVersion()
 		return s, true
 	default:
 		return "", false
@@ -76,14 +76,5 @@ func Env(key string) (string, bool) {
 	return os.Getenv(key), true
 }
 
-// EnvPresent is a KeyFunc which returns an environment variable if it is present.
-func EnvPresent(key string) (string, bool) {
-	s := os.Getenv(key)
-	if len(s) == 0 {
-		return "", false
-	}
-	return s, true
-}
-
-// OverrideVersion is the latest version, exposed for testing.
-var OverrideVersion = version.Get()
+// overrideVersion is the latest version, exposed for testing.
+var overrideVersion = version.Get()

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -45,6 +45,7 @@ import (
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/openshift"
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	osclientcmd "github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
+	"github.com/openshift/origin/pkg/version"
 )
 
 const (
@@ -322,7 +323,8 @@ func (c *CommonStartConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command,
 
 	// do some defaulting
 	if len(c.ImageVersion) == 0 {
-		c.ImageVersion = defaultImageVersion()
+		c.ImageVersion = strings.TrimRight("v"+version.Get().Major+"."+version.Get().Minor, "+")
+
 	}
 	if len(c.BaseTempDir) == 0 {
 		var err error
@@ -619,10 +621,6 @@ func (c *ClientStartConfig) Start(out io.Writer) error {
 func defaultPortForwarding() bool {
 	// Defaults to true if running on Mac, with no DOCKER_HOST defined
 	return runtime.GOOS == "darwin" && len(os.Getenv("DOCKER_HOST")) == 0
-}
-
-func defaultImageVersion() string {
-	return variable.OverrideVersion.LastSemanticVersion()
 }
 
 // checkOpenShiftClient ensures that the client can be configured


### PR DESCRIPTION
Uses a tag like `v3.10` instead of something qualifying all the way down to last tagged level.

@smarterclayton as discussed
@openshift/sig-master 
/assign @soltysh 