### PR TITLE
UPSTREAM: 60978: Fix use of "-w" flag to iptables-restore

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/util/iptables/iptables.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/iptables/iptables.go
@@ -124,7 +124,7 @@ const MinCheckVersion = "1.4.11"
 const WaitMinVersion = "1.4.20"
 const WaitSecondsMinVersion = "1.4.22"
 const WaitString = "-w"
-const WaitSecondsString = "-w5"
+const WaitSecondsValue = "5"
 
 const LockfilePath16x = "/run/xtables.lock"
 
@@ -558,7 +558,7 @@ func getIPTablesWaitFlag(vstring string) []string {
 	if version.LessThan(minVersion) {
 		return []string{WaitString}
 	} else {
-		return []string{WaitSecondsString}
+		return []string{WaitString, WaitSecondsValue}
 	}
 }
 
@@ -594,7 +594,7 @@ func getIPTablesRestoreWaitFlag(exec utilexec.Interface, protocol Protocol) []st
 		return nil
 	}
 
-	return []string{WaitSecondsString}
+	return []string{WaitString, WaitSecondsValue}
 }
 
 // getIPTablesRestoreVersionString runs "iptables-restore --version" to get the version string


### PR DESCRIPTION
iptables-restore's option-parsing code is weird and broken, and it requires you to say "-w 5" rather than "-w5". Up until now we've never been running OpenShift against a version of iptables new enough to have that flag, so we didn't notice, but 1.6.2 is now in updates-testing in Fedora 27, and when it hits updates, it will totally break kube-proxy in docker-in-docker. (For master/3.9; older releases still use F25 so won't ever see iptables 1.6.2.)
