### PR TITLE
Fix doc text on `migrate legacy-hpa`

### DIFF
--- a/pkg/oc/admin/migrate/legacyhpa/hpa.go
+++ b/pkg/oc/admin/migrate/legacyhpa/hpa.go
@@ -49,13 +49,7 @@ var (
 	  %[1]s
 
 	  # To actually perform the update, the confirm flag must be appended
-	  %[1]s --confirm
-
-	  # Migrate a specific group-version-kind to the latest preferred version
-	  %[1]s --initial=extensions/v1beta1.ReplicaSet --confirm
-
-	  # Migrate a specific group-version-kind to a specific group-version-kind
-	  %[1]s --initial=v1.DeploymentConfig --final=apps.openshift.io/v1.DeploymentConfig --confirm`)
+	  %[1]s --confirm`)
 )
 
 func prettyPrintMigrations(versionKinds map[metav1.TypeMeta]metav1.TypeMeta) string {


### PR DESCRIPTION
The doc text on `oc adm migrate legacy-hpa` referenced some non-existent
flags.  This fixes it to no longer reference those flags.