### PR TITLE
bootstrap: minor cluster up fixes

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -6801,6 +6801,8 @@ _oc_adm_registry()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--cluster-ip=")
+    local_nonpersistent_flags+=("--cluster-ip=")
     flags+=("--create")
     local_nonpersistent_flags+=("--create")
     flags+=("--daemonset")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -6943,6 +6943,8 @@ _oc_adm_registry()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--cluster-ip=")
+    local_nonpersistent_flags+=("--cluster-ip=")
     flags+=("--create")
     local_nonpersistent_flags+=("--create")
     flags+=("--daemonset")

--- a/pkg/oc/admin/registry/registry.go
+++ b/pkg/oc/admin/registry/registry.go
@@ -190,6 +190,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out, errout i
 	cmd.Flags().StringVar(&cfg.ServingKeyPath, "tls-key", cfg.ServingKeyPath, "An optional path to a PEM encoded private key for serving over TLS")
 	cmd.Flags().StringSliceVar(&cfg.SupplementalGroups, "supplemental-groups", cfg.SupplementalGroups, "Specify supplemental groups which is an array of ID's that grants group access to registry shared storage")
 	cmd.Flags().StringVar(&cfg.FSGroup, "fs-group", "", "Specify fsGroup which is an ID that grants group access to registry block storage")
+	cmd.Flags().StringVar(&cfg.ClusterIP, "cluster-ip", "", "Specify the ClusterIP value for the docker-registry service")
 	cmd.Flags().BoolVar(&cfg.DaemonSet, "daemonset", cfg.DaemonSet, "If true, use a daemonset instead of a deployment config.")
 	cmd.Flags().BoolVar(&cfg.EnforceQuota, "enforce-quota", cfg.EnforceQuota, "If true, the registry will refuse to write blobs if they exceed quota limits")
 	cmd.Flags().BoolVar(&cfg.Local, "local", cfg.Local, "If true, do not contact the apiserver")

--- a/pkg/oc/bootstrap/clusterup/kubelet/flags.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/flags.go
@@ -43,10 +43,7 @@ func (opt KubeletStartFlags) MakeKubeletFlags(dockerClient dockerhelper.Interfac
 	}
 
 	_, stdout, stderr, rc, err := imageRunHelper.Image(opt.NodeImage).
-		Privileged().
 		DiscardContainer().
-		HostNetwork().
-		HostPid().
 		Bind(binds...).
 		Env(env...).
 		Entrypoint("openshift").

--- a/pkg/oc/bootstrap/docker/dockerhelper/helper.go
+++ b/pkg/oc/bootstrap/docker/dockerhelper/helper.go
@@ -19,8 +19,6 @@ import (
 	starterrors "github.com/openshift/origin/pkg/oc/bootstrap/docker/errors"
 )
 
-const openShiftInsecureCIDR = "172.30.0.0/16"
-
 // Helper provides utility functions to help with Docker
 type Helper struct {
 	client Interface
@@ -66,7 +64,7 @@ func (h *Helper) CgroupDriver() (string, error) {
 
 // InsecureRegistryIsConfigured checks to see if the Docker daemon has an appropriate insecure registry argument set so that our services can access the registry
 //hasEntries specifies if Docker daemon has entries at all
-func (h *Helper) InsecureRegistryIsConfigured() (configured bool, hasEntries bool, error error) {
+func (h *Helper) InsecureRegistryIsConfigured(insecureRegistryCIDR string) (configured bool, hasEntries bool, error error) {
 	info, err := h.dockerInfo()
 	if err != nil {
 		return false, false, err
@@ -75,7 +73,7 @@ func (h *Helper) InsecureRegistryIsConfigured() (configured bool, hasEntries boo
 	if !registryConfig.HasCustomInsecureRegistryCIDRs() {
 		return false, false, nil
 	}
-	containsRegistryCIDR, err := registryConfig.ContainsInsecureRegistryCIDR(openShiftInsecureCIDR)
+	containsRegistryCIDR, err := registryConfig.ContainsInsecureRegistryCIDR(insecureRegistryCIDR)
 	if err != nil {
 		return false, true, err
 	}

--- a/pkg/oc/bootstrap/docker/dockerhelper/helper.go
+++ b/pkg/oc/bootstrap/docker/dockerhelper/helper.go
@@ -174,7 +174,7 @@ func (h *Helper) CheckAndPull(image string, out io.Writer) error {
 		return starterrors.NewError("error pulling Docker image %s", image).WithCause(err)
 	}
 
-	fmt.Fprintf(out, "Image pull complete\n")
+	fmt.Fprintln(out, "Image pull complete")
 	return nil
 }
 

--- a/pkg/oc/bootstrap/docker/down.go
+++ b/pkg/oc/bootstrap/docker/down.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/openshift"
-	osclientcmd "github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 )
 
 const CmdDownRecommendedName = "down"
@@ -38,7 +37,7 @@ type ClientStopConfig struct {
 }
 
 // NewCmdDown creates a command that stops OpenShift
-func NewCmdDown(name, fullName string, f *osclientcmd.Factory, out io.Writer) *cobra.Command {
+func NewCmdDown(name, fullName string, out io.Writer) *cobra.Command {
 	config := &ClientStopConfig{}
 	cmd := &cobra.Command{
 		Use:     name,

--- a/pkg/oc/bootstrap/docker/errors/docker.go
+++ b/pkg/oc/bootstrap/docker/errors/docker.go
@@ -16,11 +16,6 @@ func ErrNoDockerMachineClient(name string, err error) error {
 	return NewError("cannot obtain a client for Docker machine %q", name).WithCause(err).WithSolution(noDockerMachineClientSolution())
 }
 
-// ErrCannotPingDocker is returned when a ping to Docker with the Docker client fails
-func ErrCannotPingDocker(err error) error {
-	return NewError("cannot communicate with Docker").WithCause(err).WithSolution(noDockerClientSolution())
-}
-
 // ErrKubeConfigNotWriteable is returned when the file pointed to by KUBECONFIG cannot be created or written to
 func ErrKubeConfigNotWriteable(file string, err error) error {
 	return NewError("KUBECONFIG is set to a file that cannot be created or modified: %s", file).WithCause(err).WithSolution(kubeConfigSolution())

--- a/pkg/oc/bootstrap/docker/errors/errors.go
+++ b/pkg/oc/bootstrap/docker/errors/errors.go
@@ -76,5 +76,5 @@ func PrintLog(out io.Writer, title string, content string) {
 	fmt.Fprintf(out, "%s:\n", title)
 	w := prefixwriter.New("  ", out)
 	fmt.Fprintf(w, "%s", strings.TrimSpace(content))
-	fmt.Fprintf(out, "\n")
+	fmt.Fprintln(out)
 }

--- a/pkg/oc/bootstrap/docker/openshift/errors.go
+++ b/pkg/oc/bootstrap/docker/openshift/errors.go
@@ -2,20 +2,7 @@ package openshift
 
 import (
 	"fmt"
-
-	"github.com/openshift/origin/pkg/oc/bootstrap/docker/errors"
 )
-
-// ErrOpenShiftFailedToStart is thrown when the OpenShift server failed to start
-func ErrOpenShiftFailedToStart(container string) errors.Error {
-	return errors.NewError("could not start OpenShift container %q", container)
-}
-
-// ErrTimedOutWaitingForStart is thrown when the OpenShift server can't be pinged after reasonable
-// amount of time.
-func ErrTimedOutWaitingForStart(container string) errors.Error {
-	return errors.NewError("timed out waiting for OpenShift container %q", container)
-}
 
 type errPortsNotAvailable struct {
 	ports []int

--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -28,52 +28,22 @@ import (
 )
 
 const (
-	defaultNodeName         = "localhost"
-	serverConfigPath        = "/var/lib/origin/openshift.local.config"
-	serverMasterConfig      = serverConfigPath + "/master/master-config.yaml"
-	serverNodeConfig        = serverConfigPath + "/node-" + defaultNodeName + "/node-config.yaml"
-	aggregatorKey           = "aggregator-front-proxy.key"
-	aggregatorCert          = "aggregator-front-proxy.crt"
-	aggregatorCACert        = "front-proxy-ca.crt"
-	aggregatorCAKey         = "front-proxy-ca.key"
-	aggregatorCASerial      = "frontend-proxy-ca.serial.txt"
-	aggregatorKeyPath       = serverConfigPath + "/master/" + aggregatorKey
-	aggregatorCertPath      = serverConfigPath + "/master/" + aggregatorCert
-	aggregatorCACertPath    = serverConfigPath + "/master/" + aggregatorCACert
-	aggregatorCAKeyPath     = serverConfigPath + "/master/" + aggregatorCAKey
-	aggregatorCASerialPath  = serverConfigPath + "/master/" + aggregatorCASerial
-	DefaultDNSPort          = 8053
-	cmdDetermineNodeHost    = "for name in %s; do ls /var/lib/origin/openshift.local.config/node-$name &> /dev/null && echo $name && break; done"
-	OpenShiftContainer      = "origin"
-	OpenshiftNamespace      = "openshift"
-	OpenshiftInfraNamespace = "openshift-infra"
+	defaultNodeName      = "localhost"
+	serverConfigPath     = "/var/lib/origin/openshift.local.config"
+	serverMasterConfig   = serverConfigPath + "/master/master-config.yaml"
+	DefaultDNSPort       = 8053
+	DefaultSvcCIDR       = "172.30.0.0/16"
+	cmdDetermineNodeHost = "for name in %s; do ls /var/lib/origin/openshift.local.config/node-$name &> /dev/null && echo $name && break; done"
+	ContainerName        = "origin"
+	Namespace            = "openshift"
+	InfraNamespace       = "openshift-infra"
 )
 
 var (
-	openShiftContainerBinds = []string{
-		"/var/log:/var/log:rw",
-		"/var/run:/var/run:rw",
-		"/sys:/sys:rw",
-		"/sys/fs/cgroup:/sys/fs/cgroup:rw",
-		"/dev:/dev",
-	}
-	BasePorts        = []int{4001, 7001, 8443, 10250, DefaultDNSPort}
-	RouterPorts      = []int{80, 443}
-	AllPorts         = append(RouterPorts, BasePorts...)
-	SocatPidFile     = filepath.Join(homedir.HomeDir(), clientconfig.OpenShiftConfigHomeDir, "socat-8443.pid")
-	defaultCertHosts = []string{
-		"127.0.0.1",
-		"172.30.0.1",
-		"localhost",
-		"kubernetes",
-		"kubernetes.default",
-		"kubernetes.default.svc",
-		"kubernetes.default.svc.cluster.local",
-		"openshift",
-		"openshift.default",
-		"openshift.default.svc",
-		"openshift.default.svc.cluster.local",
-	}
+	BasePorts    = []int{4001, 7001, 8443, 10250, DefaultDNSPort}
+	RouterPorts  = []int{80, 443}
+	AllPorts     = append(RouterPorts, BasePorts...)
+	SocatPidFile = filepath.Join(homedir.HomeDir(), clientconfig.OpenShiftConfigHomeDir, "socat-8443.pid")
 )
 
 // Helper contains methods and utilities to help with OpenShift startup
@@ -297,7 +267,7 @@ func (h *Helper) GetConfigFromLocalDir(configDir string) (*configapi.MasterConfi
 }
 
 func GetConfigFromContainer(client dockerhelper.Interface) (*configapi.MasterConfig, error) {
-	r, err := dockerhelper.StreamFileFromContainer(client, OpenShiftContainer, serverMasterConfig)
+	r, err := dockerhelper.StreamFileFromContainer(client, ContainerName, serverMasterConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oc/bootstrap/docker/openshift/logging.go
+++ b/pkg/oc/bootstrap/docker/openshift/logging.go
@@ -16,10 +16,6 @@ const (
 	loggingNamespace = "logging"
 )
 
-func getLoggingPlaybook(v semver.Version) string {
-	return "playbooks/openshift-logging/config.yml"
-}
-
 // InstallLoggingViaAnsible checks whether logging is installed and installs it if not already installed
 func (h *Helper) InstallLoggingViaAnsible(f *clientcmd.Factory, serverVersion semver.Version, serverIP, publicHostname, loggerHost, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
 	kubeClient, err := f.ClientSet()
@@ -57,7 +53,8 @@ func (h *Helper) InstallLoggingViaAnsible(f *clientcmd.Factory, serverVersion se
 	runner := newAnsibleRunner(h, kubeClient, securityClient, loggingNamespace, imageStreams, "logging")
 
 	//run logging playbook
-	return runner.RunPlaybook(params, getLoggingPlaybook(serverVersion), hostConfigDir, imagePrefix, imageVersion)
+
+	return runner.RunPlaybook(params, "playbooks/openshift-logging/config.yml", hostConfigDir, imagePrefix, imageVersion)
 }
 
 func LoggingHost(routingSuffix, serverIP string) string {

--- a/pkg/oc/bootstrap/docker/openshift/metrics.go
+++ b/pkg/oc/bootstrap/docker/openshift/metrics.go
@@ -16,10 +16,6 @@ const (
 	svcMetrics     = "hawkular-metrics"
 )
 
-func getMetricsPlaybook(v semver.Version) string {
-	return "playbooks/openshift-metrics/config.yml"
-}
-
 // InstallMetricsViaAnsible checks whether metrics is installed and installs it if not already installed
 func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverVersion semver.Version, serverIP, publicHostname, hostName, imagePrefix, imageVersion, hostConfigDir, imageStreams string) error {
 	kubeClient, err := f.ClientSet()
@@ -53,7 +49,7 @@ func (h *Helper) InstallMetricsViaAnsible(f *clientcmd.Factory, serverVersion se
 	runner := newAnsibleRunner(h, kubeClient, securityClient, infraNamespace, imageStreams, "metrics")
 
 	//run playbook
-	return runner.RunPlaybook(params, getMetricsPlaybook(serverVersion), hostConfigDir, imagePrefix, imageVersion)
+	return runner.RunPlaybook(params, "playbooks/openshift-metrics/config.yml", hostConfigDir, imagePrefix, imageVersion)
 }
 
 func MetricsHost(routingSuffix, serverIP string) string {

--- a/pkg/oc/bootstrap/docker/openshift/servicecatalog.go
+++ b/pkg/oc/bootstrap/docker/openshift/servicecatalog.go
@@ -69,7 +69,7 @@ func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, configDir, publicMa
 	glog.V(2).Infof("instantiating service catalog template with parameters %v", params)
 
 	// Stands up the service catalog apiserver, etcd, and controller manager
-	err = instantiateTemplate(templateClient.Template(), f, OpenshiftInfraNamespace, catalogTemplate, catalogNamespace, params, true)
+	err = instantiateTemplate(templateClient.Template(), f, InfraNamespace, catalogTemplate, catalogNamespace, params, true)
 	if err != nil {
 		return errors.NewError("cannot instantiate service catalog template").WithCause(err)
 	}

--- a/pkg/oc/bootstrap/docker/openshift/webconsole.go
+++ b/pkg/oc/bootstrap/docker/openshift/webconsole.go
@@ -87,7 +87,7 @@ func (h *Helper) InstallWebConsole(f *clientcmd.Factory, imageFormat string, ser
 	glog.V(2).Infof("instantiating web console template with parameters %v", params)
 
 	// instantiate the web console template
-	if err = instantiateTemplate(templateClient.Template(), f, OpenshiftInfraNamespace, consoleAPIServerTemplateName, consoleNamespace, params, true); err != nil {
+	if err = instantiateTemplate(templateClient.Template(), f, InfraNamespace, consoleAPIServerTemplateName, consoleNamespace, params, true); err != nil {
 		return errors.NewError("cannot instantiate web console template").WithCause(err)
 	}
 

--- a/pkg/oc/bootstrap/docker/printer.go
+++ b/pkg/oc/bootstrap/docker/printer.go
@@ -32,7 +32,7 @@ func NewTaskPrinter(out io.Writer) *TaskPrinter {
 func (p *TaskPrinter) StartTask(name string) {
 	fmt.Fprintf(p.out, "%s%s ... ", taskNamePrefix, name)
 	if glog.V(1) {
-		fmt.Fprintf(p.out, "\n")
+		fmt.Fprintln(p.out)
 	}
 }
 
@@ -41,7 +41,7 @@ func (p *TaskPrinter) Success() {
 	if (p.taskWriter != nil && p.taskWriter.used) || bool(glog.V(1)) {
 		return
 	}
-	fmt.Fprintf(p.out, "OK\n")
+	fmt.Fprintln(p.out, "OK")
 }
 
 // TaskWriter is a writer that can be used to write task output
@@ -53,7 +53,7 @@ func (p *TaskPrinter) TaskWriter() io.Writer {
 // Failure writes out a failure marker for a task and outputs the error
 // that caused the failure
 func (p *TaskPrinter) Failure(err error) {
-	fmt.Fprintf(p.out, "FAIL\n")
+	fmt.Fprintln(p.out, "FAIL")
 	PrintError(err, prefixwriter.New(taskIndent, p.out))
 }
 
@@ -72,17 +72,17 @@ type hasSolution interface {
 func PrintError(err error, out io.Writer) {
 	fmt.Fprintf(out, "Error: %v\n", err)
 	if d, ok := err.(hasDetails); ok && len(d.Details()) > 0 {
-		fmt.Fprintf(out, "Details:\n")
+		fmt.Fprintln(out, "Details:")
 		w := prefixwriter.New("  ", out)
 		fmt.Fprintf(w, "%s\n", d.Details())
 	}
 	if s, ok := err.(hasSolution); ok && len(s.Solution()) > 0 {
-		fmt.Fprintf(out, "Solution:\n")
+		fmt.Fprintln(out, "Solution:")
 		w := prefixwriter.New("  ", out)
 		fmt.Fprintf(w, "%s\n", s.Solution())
 	}
 	if c, ok := err.(hasCause); ok && c.Cause() != nil {
-		fmt.Fprintf(out, "Caused By:\n")
+		fmt.Fprintln(out, "Caused By:")
 		w := prefixwriter.New("  ", out)
 		PrintError(c.Cause(), w)
 	}
@@ -105,7 +105,7 @@ func (t *taskWriter) Write(p []byte) (n int, err error) {
 // the code to only work in a narrow case while running the command.
 func (p *TaskPrinter) ToError(err error) error {
 	buf := &bytes.Buffer{}
-	fmt.Fprintf(buf, "FAIL\n")
+	fmt.Fprintln(buf, "FAIL")
 	PrintError(err, prefixwriter.New(taskIndent, buf))
 	return taskError{message: buf.String()}
 }

--- a/pkg/oc/bootstrap/docker/run/run.go
+++ b/pkg/oc/bootstrap/docker/run/run.go
@@ -294,19 +294,19 @@ func printConfig(c *container.Config) string {
 	out := &bytes.Buffer{}
 	fmt.Fprintf(out, "  image: %s\n", c.Image)
 	if len(c.Entrypoint) > 0 {
-		fmt.Fprintf(out, "  entry point:\n")
+		fmt.Fprintln(out, "  entry point:")
 		for _, e := range c.Entrypoint {
 			fmt.Fprintf(out, "    %s\n", e)
 		}
 	}
 	if len(c.Cmd) > 0 {
-		fmt.Fprintf(out, "  command:\n")
+		fmt.Fprintln(out, "  command:")
 		for _, c := range c.Cmd {
 			fmt.Fprintf(out, "    %s\n", c)
 		}
 	}
 	if len(c.Env) > 0 {
-		fmt.Fprintf(out, "  environment:\n")
+		fmt.Fprintln(out, "  environment:")
 		for _, e := range c.Env {
 			fmt.Fprintf(out, "    %s\n", e)
 		}
@@ -320,13 +320,13 @@ func printHostConfig(c *container.HostConfig) string {
 	fmt.Fprintf(out, "  user mode: %s\n", c.UsernsMode)
 	fmt.Fprintf(out, "  network mode: %s\n", c.NetworkMode)
 	if len(c.DNS) > 0 {
-		fmt.Fprintf(out, "  DNS:\n")
+		fmt.Fprintln(out, "  DNS:")
 		for _, h := range c.DNS {
 			fmt.Fprintf(out, "    %s\n", h)
 		}
 	}
 	if len(c.Binds) > 0 {
-		fmt.Fprintf(out, "  volume binds:\n")
+		fmt.Fprintln(out, "  volume binds:")
 		for _, b := range c.Binds {
 			fmt.Fprintf(out, "    %s\n", b)
 		}

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -693,7 +693,7 @@ func getDockerClient(out io.Writer, dockerMachine string, canStartDockerMachine 
 // If one is already running, it throws an error.
 // If one exists, it removes it so a new one can be created.
 func checkExistingOpenShiftContainer(dockerHelper *dockerhelper.Helper, out io.Writer) error {
-	container, running, err := dockerHelper.GetContainerState(openshift.OpenShiftContainer)
+	container, running, err := dockerHelper.GetContainerState(openshift.ContainerName)
 	if err != nil {
 		return errors.NewError("unexpected error while checking OpenShift container state").WithCause(err)
 	}
@@ -701,7 +701,7 @@ func checkExistingOpenShiftContainer(dockerHelper *dockerhelper.Helper, out io.W
 		return errors.NewError("OpenShift is already running").WithSolution("To start OpenShift again, stop the current cluster:\n$ %s\n", "oc cluster down")
 	}
 	if container != nil {
-		err = dockerHelper.RemoveContainer(openshift.OpenShiftContainer)
+		err = dockerHelper.RemoveContainer(openshift.ContainerName)
 		if err != nil {
 			return errors.NewError("cannot delete existing OpenShift container").WithCause(err)
 		}
@@ -938,17 +938,17 @@ func (c *ClusterUpConfig) InstallWebConsole(out io.Writer) error {
 func (c *ClusterUpConfig) ImportInitialObjects(out io.Writer) error {
 	componentsToInstall := []componentinstall.Component{}
 	componentsToInstall = append(componentsToInstall,
-		c.makeObjectImportInstallationComponentsOrDie(out, openshift.OpenshiftNamespace, map[string]string{
+		c.makeObjectImportInstallationComponentsOrDie(out, openshift.Namespace, map[string]string{
 			c.ImageStreams: imageStreams[c.ImageStreams],
 		})...)
 	componentsToInstall = append(componentsToInstall,
-		c.makeObjectImportInstallationComponentsOrDie(out, openshift.OpenshiftNamespace, templateLocations)...)
+		c.makeObjectImportInstallationComponentsOrDie(out, openshift.Namespace, templateLocations)...)
 	componentsToInstall = append(componentsToInstall,
 		c.makeObjectImportInstallationComponentsOrDie(out, "kube-system", adminTemplateLocations)...)
 	componentsToInstall = append(componentsToInstall,
-		c.makeObjectImportInstallationComponentsOrDie(out, openshift.OpenshiftInfraNamespace, internalTemplateLocations)...)
+		c.makeObjectImportInstallationComponentsOrDie(out, openshift.InfraNamespace, internalTemplateLocations)...)
 	componentsToInstall = append(componentsToInstall,
-		c.makeObjectImportInstallationComponentsOrDie(out, openshift.OpenshiftInfraNamespace, internalCurrentTemplateLocations)...)
+		c.makeObjectImportInstallationComponentsOrDie(out, openshift.InfraNamespace, internalCurrentTemplateLocations)...)
 
 	return componentinstall.InstallComponents(componentsToInstall, c.GetDockerClient(), path.Join(c.BaseTempDir, "logs"))
 }
@@ -1165,7 +1165,7 @@ func (c *ClusterUpConfig) Clients() (interface{}, kclientset.Interface, error) {
 // OpenShiftHelper returns a helper object to work with OpenShift on the server
 func (c *ClusterUpConfig) OpenShiftHelper() *openshift.Helper {
 	if c.openshiftHelper == nil {
-		c.openshiftHelper = openshift.NewHelper(c.DockerHelper(), c.HostHelper(), c.openshiftImage(), openshift.OpenShiftContainer, c.RoutingSuffix)
+		c.openshiftHelper = openshift.NewHelper(c.DockerHelper(), c.HostHelper(), c.openshiftImage(), openshift.ContainerName, c.RoutingSuffix)
 	}
 	return c.openshiftHelper
 }

--- a/pkg/oc/cli/cmd/cluster/cluster.go
+++ b/pkg/oc/cli/cmd/cluster/cluster.go
@@ -46,7 +46,7 @@ func NewCmdCluster(name, fullName string, f *clientcmd.Factory, in io.Reader, ou
 	}
 
 	cmds.AddCommand(docker.NewCmdUp(docker.CmdUpRecommendedName, fullName+" "+docker.CmdUpRecommendedName, f, out, errout))
-	cmds.AddCommand(docker.NewCmdDown(docker.CmdDownRecommendedName, fullName+" "+docker.CmdDownRecommendedName, f, out))
+	cmds.AddCommand(docker.NewCmdDown(docker.CmdDownRecommendedName, fullName+" "+docker.CmdDownRecommendedName, out))
 	cmds.AddCommand(docker.NewCmdStatus(docker.CmdStatusRecommendedName, fullName+" "+docker.CmdStatusRecommendedName, f, out))
 	return cmds
 }


### PR DESCRIPTION
First two commits are part of https://github.com/openshift/origin/pull/18896

Other 3 are fixing registry installation, removing unused constants, dealing with proxy setting and making some containers running in non-privileged mode as they don't have to be privileged.

/cc @deads2k 
/cc @openshift/sig-master 