### PR TITLE
switch kubedns to be copy of node config, not fresh creation

### DIFF
--- a/pkg/oc/bootstrap/clusterup/kubelet/config.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/config.go
@@ -36,18 +36,11 @@ func NewNodeStartConfig() *NodeStartConfig {
 
 }
 
-func (opt NodeStartConfig) MakeKubeDNSConfig(dockerClient dockerhelper.Interface, basedir string) (string, error) {
-	return opt.makeConfig(dockerClient, KubeDNSDirName, basedir)
-}
-
-func (opt NodeStartConfig) MakeNodeConfig(dockerClient dockerhelper.Interface, basedir string) (string, error) {
-	return opt.makeConfig(dockerClient, NodeConfigDirName, basedir)
-}
-
 // Start starts the OpenShift master as a Docker container
 // and returns a directory in the local file system where
 // the OpenShift configuration has been copied
-func (opt NodeStartConfig) makeConfig(dockerClient dockerhelper.Interface, componentName string, basedir string) (string, error) {
+func (opt NodeStartConfig) MakeNodeConfig(dockerClient dockerhelper.Interface, basedir string) (string, error) {
+	componentName := "create-node-config"
 	imageRunHelper := run.NewRunHelper(dockerhelper.NewHelper(dockerClient)).New()
 	glog.Infof("Running %q", componentName)
 
@@ -80,7 +73,7 @@ func (opt NodeStartConfig) makeConfig(dockerClient dockerhelper.Interface, compo
 		return "", errors.NewError("could not run %q: rc==%v", componentName, rc)
 	}
 
-	nodeConfigDir := path.Join(basedir, componentName)
+	nodeConfigDir := path.Join(basedir, NodeConfigDirName)
 	glog.V(1).Infof("Copying OpenShift node config to local directory %s", nodeConfigDir)
 	if err = dockerhelper.DownloadDirFromContainer(dockerClient, containerId, "/var/lib/origin/openshift.local.config", nodeConfigDir); err != nil {
 		if removeErr := os.RemoveAll(nodeConfigDir); removeErr != nil {


### PR DESCRIPTION
Create the kubedns config based on the node config, not separately.  

I need this to be able to start having cluster-up use `openshift.local.clusterup` in the CWD instead of using a tempdir.  I need that to be able to default to "re-use existing environment" like `openshift start` does today.

/assign @mfojtik 