### PR TITLE
Allow a new OS_PUSH_BASE_REPO flag to push-release

### DIFF
--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -315,25 +315,25 @@ readonly -f os::build::clean_windows_versioninfo
 
 # OS_ALL_IMAGES is the list of images built by os::build::images.
 readonly OS_ALL_IMAGES=(
-  openshift/origin
-  openshift/origin-base
-  openshift/origin-pod
-  openshift/origin-deployer
-  openshift/origin-docker-builder
-  openshift/origin-keepalived-ipfailover
-  openshift/origin-sti-builder
-  openshift/origin-haproxy-router
-  openshift/origin-f5-router
-  openshift/origin-egress-router
-  openshift/origin-egress-http-proxy
-  openshift/origin-egress-dns-proxy
-  openshift/origin-recycler
-  openshift/origin-cluster-capacity
-  openshift/origin-service-catalog
-  openshift/origin-template-service-broker
-  openshift/hello-openshift
-  openshift/openvswitch
-  openshift/node
+  origin
+  origin-base
+  origin-pod
+  origin-deployer
+  origin-docker-builder
+  origin-keepalived-ipfailover
+  origin-sti-builder
+  origin-haproxy-router
+  origin-f5-router
+  origin-egress-router
+  origin-egress-http-proxy
+  origin-egress-dns-proxy
+  origin-recycler
+  origin-cluster-capacity
+  origin-service-catalog
+  origin-template-service-broker
+  hello-openshift
+  openvswitch
+  node
 )
 
 # os::build::images builds all images in this repo.

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -41,6 +41,8 @@ fi
 
 images=( "${OS_ALL_IMAGES[@]}" )
 
+OS_PUSH_BASE_REPO="${OS_PUSH_BASE_REPO:-openshift/}"
+
 PUSH_OPTS=""
 if docker push --help | grep -q force; then
   PUSH_OPTS="--force"
@@ -50,10 +52,10 @@ fi
 if [[ "${tag}" != ":latest" ]]; then
   if [[ -z "${OS_PUSH_LOCAL-}" ]]; then
     for image in "${images[@]}"; do
-      docker pull "${OS_PUSH_BASE_REGISTRY-}${image}:${source_tag}"
+      docker pull "${OS_PUSH_BASE_REGISTRY-}openshift/${image}:${source_tag}"
     done
   else
-    os::log::warning "Pushing local :${source_tag} images to ${OS_PUSH_BASE_REGISTRY-}*${tag}"
+    os::log::warning "Pushing local :${source_tag} images to ${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}*${tag}"
     if [[ -z "${OS_PUSH_ALWAYS:-}" ]]; then
       echo "  CTRL+C to cancel, or any other key to continue"
       read
@@ -65,15 +67,15 @@ IFS=',' read -r -a tags <<< "$tag"
 if [[ "${OS_PUSH_BASE_REGISTRY-}" != "" || "${tag}" != "" ]]; then
   for image in "${images[@]}"; do
     for tag in "${tags[@]}"; do
-      docker tag "${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
+      docker tag "openshift/${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}${image}${tag}"
     done
   done
 fi
 
 for image in "${images[@]}"; do
   for tag in "${tags[@]}"; do
-    os::log::info "Pushing ${OS_PUSH_BASE_REGISTRY-}${image}${tag}..."
-    docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${image}${tag}"
+    os::log::info "Pushing ${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}${image}${tag}..."
+    docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}${image}${tag}"
   done
 done
 


### PR DESCRIPTION
Will allow us to rename images from openshift/* locally to a different
name when we push, for example to a per PR image repository.

@stevekuznetsov