### PR TITLE
Disable HPA scale ref check in `oc status`

### DIFF
--- a/pkg/oc/cli/describe/projectstatus.go
+++ b/pkg/oc/cli/describe/projectstatus.go
@@ -530,7 +530,8 @@ func getMarkerScanners(logsCommandName, securityPolicyCommandFormat, setProbeCom
 			return kubeanalysis.FindMissingSecrets(g, f)
 		},
 		kubeanalysis.FindHPASpecsMissingCPUTargets,
-		kubeanalysis.FindHPASpecsMissingScaleRefs,
+		// TODO(directxman12): re-enable FindHPASpecsMissingScaleRefs once the graph library
+		// knows how to deal with arbitrary scale targets
 		kubeanalysis.FindOverlappingHPAs,
 		buildanalysis.FindUnpushableBuildConfigs,
 		buildanalysis.FindCircularBuilds,


### PR DESCRIPTION
The graph builder doesn't know how to deal with arbitrary scale targets,
so we're disabling the "missing scale target" checks until we can rework
that.

Related to #18927 