### PR TITLE
Bug 1452162 - oc new-app eval ENV/ARG and ranges in dockerfile EXPOSE

### DIFF
--- a/pkg/oc/generate/cmd/newapp_test.go
+++ b/pkg/oc/generate/cmd/newapp_test.go
@@ -695,7 +695,7 @@ func TestDisallowedNonNumericExposedPorts(t *testing.T) {
 		config.Strategy = test.strategy
 		config.AllowNonNumericExposedPorts = test.allowNonNumericPorts
 
-		repo, err := app.NewSourceRepositoryForDockerfile("FROM centos\nARG PORT=80\nEXPOSE 8080 $PORT")
+		repo, err := app.NewSourceRepositoryForDockerfile("FROM centos\nEXPOSE 8080 NON_NUMERIC_PORT")
 		if err != nil {
 			t.Fatalf("Unexpected error during setup: %v", err)
 		}
@@ -725,6 +725,26 @@ func TestExposedPortsAreValid(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			dockerfile:    "FROM centos\nARG PORT=8080\nEXPOSE $PORT",
+			expectedError: "",
+		},
+		{
+			dockerfile:    "FROM centos\nENV PORT 8080\nEXPOSE $PORT",
+			expectedError: "",
+		},
+		{
+			dockerfile:    "FROM centos\nENV PORT=8080\nEXPOSE $PORT",
+			expectedError: "",
+		},
+		{
+			dockerfile:    "FROM centos\nENV PORT2=8080\nENV PORT1=$PORT2\nENV PORT=$PORT1\nEXPOSE $PORT",
+			expectedError: "",
+		},
+		{
+			dockerfile:    "FROM centos\nENV PORT2=8080 PORT1=$PORT2 PORT=$PORT1\nEXPOSE $PORT",
+			expectedError: "",
+		},
+		{
 			dockerfile:    "FROM centos\nEXPOSE 808080",
 			expectedError: "port number must be in range 0 - 65535",
 		},
@@ -741,7 +761,7 @@ func TestExposedPortsAreValid(t *testing.T) {
 			expectedError: "port number must be in range 0 - 65535",
 		},
 		{
-			dockerfile:    "FROM centos\nARG PORT=8080\nEXPOSE $PORT",
+			dockerfile:    "FROM centos\nEXPOSE PORT",
 			expectedError: "port number must be in range 0 - 65535",
 		},
 		{

--- a/pkg/util/docker/dockerfile/dockerfile.go
+++ b/pkg/util/docker/dockerfile/dockerfile.go
@@ -2,11 +2,17 @@ package dockerfile
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/builder/dockerfile/command"
 	"github.com/docker/docker/builder/dockerfile/parser"
+	"github.com/fsouza/go-dockerclient"
 )
+
+var portRangeRegexp = regexp.MustCompile(`^(\d+)-(\d+)$`)
+var argSplitRegexp = regexp.MustCompile(`^([a-zA-Z_]+[a-zA-Z0-9_]*)=(.*)$`)
 
 // FindAll returns the indices of all children of node such that
 // node.Children[i].Value == cmd. Valid values for cmd are defined in the
@@ -68,22 +74,66 @@ func baseImages(node *parser.Node) []string {
 	return images
 }
 
+func evalRange(port string) string {
+	m, match := match(portRangeRegexp, port)
+	if !match {
+		return port
+	}
+	_, err := strconv.ParseUint(m[1], 10, 16)
+	if err != nil {
+		return port
+	}
+	return m[1]
+}
+
+func evalPorts(exposedPorts []string, node *parser.Node, from, to int) []string {
+	shlex := NewShellLex('\\')
+	shlex.ProcessWord("w", []string{})
+	envs := evalVars(node, from, to, exposedPorts, shlex)
+	ports := make([]string, 0, len(exposedPorts))
+	for _, p := range exposedPorts {
+		dp := docker.Port(p)
+		port := dp.Port()
+		port, err := shlex.ProcessWord(port, envs)
+		if err != nil {
+			//keep the exposed port as was
+			port = dp.Port()
+		}
+		port = evalRange(port)
+		if strings.Contains(p, `/`) {
+			p = port + `/` + dp.Proto()
+		} else {
+			p = port
+		}
+		ports = append(ports, p)
+	}
+	return ports
+}
+
 // LastExposedPorts takes a Dockerfile root node and returns a list of ports
 // exposed in the last image built by the Dockerfile, i.e., only the EXPOSE
 // instructions after the last FROM instruction are considered.
+//
+// It also evaluates the following scenarios
+// 1) env variable - evaluate from ENV and ARG with default value
+// 2) port range - adding the lowest port from range
 func LastExposedPorts(node *parser.Node) []string {
-	exposedPorts := exposedPorts(node)
-	if len(exposedPorts) == 0 {
+	exposedPorts, exposeIndices := exposedPorts(node)
+	if len(exposedPorts) == 0 || len(exposeIndices) == 0 {
 		return nil
 	}
-	return exposedPorts[len(exposedPorts)-1]
+	lastExposed := exposedPorts[len(exposedPorts)-1]
+	froms := FindAll(node, command.From)
+	from := froms[len(froms)-1]
+	to := exposeIndices[len(exposeIndices)-1]
+	return evalPorts(lastExposed, node, from, to)
 }
 
 // exposedPorts takes a Dockerfile root node and returns a list of all ports
 // exposed in the Dockerfile, grouped by images that this Dockerfile produces.
 // The number of port lists returned is the number of images produced by this
 // Dockerfile, which is the same as the number of FROM instructions.
-func exposedPorts(node *parser.Node) [][]string {
+func exposedPorts(node *parser.Node) ([][]string, []int) {
 	var allPorts [][]string
 	var ports []string
 	froms := FindAll(node, command.From)
@@ -95,7 +145,7 @@ func exposedPorts(node *parser.Node) [][]string {
 		allPorts = append([][]string{ports}, allPorts...)
 		ports = nil
 	}
-	return allPorts
+	return allPorts, exposes
 }
 
 // nextValues returns a slice of values from the next nodes following node. This
@@ -110,4 +160,52 @@ func nextValues(node *parser.Node) []string {
 		values = append(values, next.Value)
 	}
 	return values
+}
+
+func match(r *regexp.Regexp, str string) ([]string, bool) {
+	m := r.FindStringSubmatch(str)
+	return m, len(m) == r.NumSubexp()+1
+}
+
+func containsVars(ports []string) bool {
+	for _, p := range ports {
+		if strings.Contains(p, `$`) {
+			return true
+		}
+	}
+	return false
+}
+
+// evalVars is a best effort evaluation of ENV and ARG labels in a dockerfile
+// in order to provide support for variables in EXPOSE label
+// It returns list of evaluated variables as used by ShellLex - ["var=val", ...]
+func evalVars(n *parser.Node, from, to int, ports []string, shlex *ShellLex) []string {
+	envs := make([]string, 0)
+	if !containsVars(ports) {
+		return envs
+	}
+	for i := from; i < to; i++ {
+		switch n.Children[i].Value {
+		case command.Arg:
+			args := nextValues(n.Children[i])
+			if len(args) == 1 {
+				//silently skip ARG without default value
+				if _, match := match(argSplitRegexp, args[0]); match {
+					processed, err := shlex.ProcessWord(args[0], envs)
+					if err == nil {
+						envs = append(envs, processed)
+					}
+				}
+			}
+		case command.Env:
+			args := nextValues(n.Children[i])
+			for j := 0; j < len(args)-1; j += 2 {
+				processed, err := shlex.ProcessWord(args[j+1], envs)
+				if err == nil {
+					envs = append(envs, args[j]+"="+processed)
+				}
+			}
+		}
+	}
+	return envs
 }

--- a/pkg/util/docker/dockerfile/shell_parser.go
+++ b/pkg/util/docker/dockerfile/shell_parser.go
@@ -1,0 +1,372 @@
+package dockerfile
+
+//TODO: when our dependencies allow it, remove this file and put an import in
+// 'dockerfile.go' in this package instead
+//
+// This file is copied form vendor 'github.com/docker/docker', trying to import
+// entire package 'github.com/docker/docker/builder/dockerfile' was causing
+// glide to fail with conflicting versions of other dependencies
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/scanner"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+// ShellLex performs shell word splitting and variable expansion.
+//
+// ShellLex takes a string and an array of env variables and
+// process all quotes (" and ') as well as $xxx and ${xxx} env variable
+// tokens.  Tries to mimic bash shell process.
+// It doesn't support all flavors of ${xx:...} formats but new ones can
+// be added by adding code to the "special ${} format processing" section
+type ShellLex struct {
+	escapeToken rune
+}
+
+// NewShellLex creates a new ShellLex which uses escapeToken to escape quotes.
+func NewShellLex(escapeToken rune) *ShellLex {
+	return &ShellLex{escapeToken: escapeToken}
+}
+
+// ProcessWord will use the 'env' list of environment variables,
+// and replace any env var references in 'word'.
+func (s *ShellLex) ProcessWord(word string, env []string) (string, error) {
+	word, _, err := s.process(word, env)
+	return word, err
+}
+
+// ProcessWords will use the 'env' list of environment variables,
+// and replace any env var references in 'word' then it will also
+// return a slice of strings which represents the 'word'
+// split up based on spaces - taking into account quotes.  Note that
+// this splitting is done **after** the env var substitutions are done.
+// Note, each one is trimmed to remove leading and trailing spaces (unless
+// they are quoted", but ProcessWord retains spaces between words.
+func (s *ShellLex) ProcessWords(word string, env []string) ([]string, error) {
+	_, words, err := s.process(word, env)
+	return words, err
+}
+
+func (s *ShellLex) process(word string, env []string) (string, []string, error) {
+	sw := &shellWord{
+		envs:        env,
+		escapeToken: s.escapeToken,
+	}
+	sw.scanner.Init(strings.NewReader(word))
+	return sw.process(word)
+}
+
+type shellWord struct {
+	scanner     scanner.Scanner
+	envs        []string
+	escapeToken rune
+}
+
+func (sw *shellWord) process(source string) (string, []string, error) {
+	word, words, err := sw.processStopOn(scanner.EOF)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to process %q", source)
+	}
+	return word, words, err
+}
+
+type wordsStruct struct {
+	word   string
+	words  []string
+	inWord bool
+}
+
+func (w *wordsStruct) addChar(ch rune) {
+	if unicode.IsSpace(ch) && w.inWord {
+		if len(w.word) != 0 {
+			w.words = append(w.words, w.word)
+			w.word = ""
+			w.inWord = false
+		}
+	} else if !unicode.IsSpace(ch) {
+		w.addRawChar(ch)
+	}
+}
+
+func (w *wordsStruct) addRawChar(ch rune) {
+	w.word += string(ch)
+	w.inWord = true
+}
+
+func (w *wordsStruct) addString(str string) {
+	var scan scanner.Scanner
+	scan.Init(strings.NewReader(str))
+	for scan.Peek() != scanner.EOF {
+		w.addChar(scan.Next())
+	}
+}
+
+func (w *wordsStruct) addRawString(str string) {
+	w.word += str
+	w.inWord = true
+}
+
+func (w *wordsStruct) getWords() []string {
+	if len(w.word) > 0 {
+		w.words = append(w.words, w.word)
+
+		// Just in case we're called again by mistake
+		w.word = ""
+		w.inWord = false
+	}
+	return w.words
+}
+
+// Process the word, starting at 'pos', and stop when we get to the
+// end of the word or the 'stopChar' character
+func (sw *shellWord) processStopOn(stopChar rune) (string, []string, error) {
+	var result bytes.Buffer
+	var words wordsStruct
+
+	var charFuncMapping = map[rune]func() (string, error){
+		'\'': sw.processSingleQuote,
+		'"':  sw.processDoubleQuote,
+		'$':  sw.processDollar,
+	}
+
+	for sw.scanner.Peek() != scanner.EOF {
+		ch := sw.scanner.Peek()
+
+		if stopChar != scanner.EOF && ch == stopChar {
+			sw.scanner.Next()
+			break
+		}
+		if fn, ok := charFuncMapping[ch]; ok {
+			// Call special processing func for certain chars
+			tmp, err := fn()
+			if err != nil {
+				return "", []string{}, err
+			}
+			result.WriteString(tmp)
+
+			if ch == rune('$') {
+				words.addString(tmp)
+			} else {
+				words.addRawString(tmp)
+			}
+		} else {
+			// Not special, just add it to the result
+			ch = sw.scanner.Next()
+
+			if ch == sw.escapeToken {
+				// '\' (default escape token, but ` allowed) escapes, except end of line
+				ch = sw.scanner.Next()
+
+				if ch == scanner.EOF {
+					break
+				}
+
+				words.addRawChar(ch)
+			} else {
+				words.addChar(ch)
+			}
+
+			result.WriteRune(ch)
+		}
+	}
+
+	return result.String(), words.getWords(), nil
+}
+
+func (sw *shellWord) processSingleQuote() (string, error) {
+	// All chars between single quotes are taken as-is
+	// Note, you can't escape '
+	//
+	// From the "sh" man page:
+	// Single Quotes
+	//   Enclosing characters in single quotes preserves the literal meaning of
+	//   all the characters (except single quotes, making it impossible to put
+	//   single-quotes in a single-quoted string).
+
+	var result bytes.Buffer
+
+	sw.scanner.Next()
+
+	for {
+		ch := sw.scanner.Next()
+		switch ch {
+		case scanner.EOF:
+			return "", errors.New("unexpected end of statement while looking for matching single-quote")
+		case '\'':
+			return result.String(), nil
+		}
+		result.WriteRune(ch)
+	}
+}
+
+func (sw *shellWord) processDoubleQuote() (string, error) {
+	// All chars up to the next " are taken as-is, even ', except any $ chars
+	// But you can escape " with a \ (or ` if escape token set accordingly)
+	//
+	// From the "sh" man page:
+	// Double Quotes
+	//  Enclosing characters within double quotes preserves the literal meaning
+	//  of all characters except dollarsign ($), backquote (`), and backslash
+	//  (\).  The backslash inside double quotes is historically weird, and
+	//  serves to quote only the following characters:
+	//    $ ` " \ <newline>.
+	//  Otherwise it remains literal.
+
+	var result bytes.Buffer
+
+	sw.scanner.Next()
+
+	for {
+		switch sw.scanner.Peek() {
+		case scanner.EOF:
+			return "", errors.New("unexpected end of statement while looking for matching double-quote")
+		case '"':
+			sw.scanner.Next()
+			return result.String(), nil
+		case '$':
+			value, err := sw.processDollar()
+			if err != nil {
+				return "", err
+			}
+			result.WriteString(value)
+		default:
+			ch := sw.scanner.Next()
+			if ch == sw.escapeToken {
+				switch sw.scanner.Peek() {
+				case scanner.EOF:
+					// Ignore \ at end of word
+					continue
+				case '"', '$', sw.escapeToken:
+					// These chars can be escaped, all other \'s are left as-is
+					// Note: for now don't do anything special with ` chars.
+					// Not sure what to do with them anyway since we're not going
+					// to execute the text in there (not now anyway).
+					ch = sw.scanner.Next()
+				}
+			}
+			result.WriteRune(ch)
+		}
+	}
+}
+
+func (sw *shellWord) processDollar() (string, error) {
+	sw.scanner.Next()
+
+	// $xxx case
+	if sw.scanner.Peek() != '{' {
+		name := sw.processName()
+		if name == "" {
+			return "$", nil
+		}
+		return sw.getEnv(name), nil
+	}
+
+	sw.scanner.Next()
+	name := sw.processName()
+	ch := sw.scanner.Peek()
+	if ch == '}' {
+		// Normal ${xx} case
+		sw.scanner.Next()
+		return sw.getEnv(name), nil
+	}
+	if ch == ':' {
+		// Special ${xx:...} format processing
+		// Yes it allows for recursive $'s in the ... spot
+
+		sw.scanner.Next() // skip over :
+		modifier := sw.scanner.Next()
+
+		word, _, err := sw.processStopOn('}')
+		if err != nil {
+			return "", err
+		}
+
+		// Grab the current value of the variable in question so we
+		// can use to to determine what to do based on the modifier
+		newValue := sw.getEnv(name)
+
+		switch modifier {
+		case '+':
+			if newValue != "" {
+				newValue = word
+			}
+			return newValue, nil
+
+		case '-':
+			if newValue == "" {
+				newValue = word
+			}
+			return newValue, nil
+
+		default:
+			return "", errors.Errorf("unsupported modifier (%c) in substitution", modifier)
+		}
+	}
+	return "", errors.Errorf("missing ':' in substitution")
+}
+
+func (sw *shellWord) processName() string {
+	// Read in a name (alphanumeric or _)
+	// If it starts with a numeric then just return $#
+	var name bytes.Buffer
+
+	for sw.scanner.Peek() != scanner.EOF {
+		ch := sw.scanner.Peek()
+		if name.Len() == 0 && unicode.IsDigit(ch) {
+			ch = sw.scanner.Next()
+			return string(ch)
+		}
+		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '_' {
+			break
+		}
+		ch = sw.scanner.Next()
+		name.WriteRune(ch)
+	}
+
+	return name.String()
+}
+
+func (sw *shellWord) getEnv(name string) string {
+	for _, env := range sw.envs {
+		i := strings.Index(env, "=")
+		if i < 0 {
+			if equalEnvKeys(name, env) {
+				// Should probably never get here, but just in case treat
+				// it like "var" and "var=" are the same
+				return ""
+			}
+			continue
+		}
+		compareName := env[:i]
+		if !equalEnvKeys(name, compareName) {
+			continue
+		}
+		return env[i+1:]
+	}
+	return ""
+}
+
+// normalizeWorkdir normalizes a user requested working directory in a
+// platform semantically consistent way.
+func normalizeWorkdir(_ string, current string, requested string) (string, error) {
+	if requested == "" {
+		return "", errors.New("cannot normalize nothing")
+	}
+	current = filepath.FromSlash(current)
+	requested = filepath.FromSlash(requested)
+	if !filepath.IsAbs(requested) {
+		return filepath.Join(string(os.PathSeparator), current, requested), nil
+	}
+	return requested, nil
+}
+
+// equalEnvKeys compare two strings and returns true if they are equal
+func equalEnvKeys(from, to string) bool {
+	return from == to
+}


### PR DESCRIPTION
Dockerfile `EXPOSE` label allows ranges and `ENV`/`ARG` variables as described in the following example:
```
ARG PORT=8079
ENV PORT1 8080
ENV PORT_RANGE=8081-8085 PORT2=8086
EXPOSE $PORT $PORT1 $PORT_RANGE "$PORT2" 8087 8088-8090
```

This change allows setting ports for `EXPOSE` using ranges, `ENV`/`ARG` variables for `oc new-app` as described and discussed in:
https://trello.com/c/MxgLLqju/1228-3-support-additional-expose-values-in-new-app-appcreation