### PR TITLE
Add option to configure an external OAuth server

### DIFF
--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -150,6 +150,19 @@ func DefaultSupportedScopesMap() map[string]string {
 	return defaultSupportedScopesMap
 }
 
+func DescribeScopes(scopes []string) map[string]string {
+	ret := map[string]string{}
+	for _, s := range scopes {
+		val, ok := defaultSupportedScopesMap[s]
+		if ok {
+			ret[s] = val
+		} else {
+			ret[s] = ""
+		}
+	}
+	return ret
+}
+
 // user:<scope name>
 type userEvaluator struct{}
 

--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -167,6 +167,9 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 	for k := range config.AuthConfig.WebhookTokenAuthenticators {
 		refs = append(refs, &config.AuthConfig.WebhookTokenAuthenticators[k].ConfigFile)
 	}
+	if len(config.AuthConfig.OAuthMetadataFile) > 0 {
+		refs = append(refs, &config.AuthConfig.OAuthMetadataFile)
+	}
 
 	refs = append(refs, &config.AggregatorConfig.ProxyClientInfo.CertFile)
 	refs = append(refs, &config.AggregatorConfig.ProxyClientInfo.KeyFile)

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -381,6 +381,7 @@ type MasterConfig struct {
 	EtcdConfig *EtcdConfig
 	// OAuthConfig, if present start the /oauth endpoint in this process
 	OAuthConfig *OAuthConfig
+
 	// DNSConfig, if present start the DNS server in this process
 	DNSConfig *DNSConfig
 
@@ -430,6 +431,11 @@ type MasterAuthConfig struct {
 	RequestHeader *RequestHeaderAuthenticationOptions
 	// WebhookTokenAuthnConfig, if present configures remote token reviewers
 	WebhookTokenAuthenticators []WebhookTokenAuthenticator
+	// OAuthMetadataFile is a path to a file containing the discovery endpoint for OAuth 2.0 Authorization
+	// Server Metadata for an external OAuth server.
+	// See IETF Draft: // https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+	// This option is mutually exclusive with OAuthConfig
+	OAuthMetadataFile string
 }
 
 // RequestHeaderAuthenticationOptions provides options for setting up a front proxy against the entire

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -27,6 +27,7 @@ auditConfig:
   webHookKubeConfig: ""
   webHookMode: ""
 authConfig:
+  oauthMetadataFile: ""
   requestHeader: null
   webhookTokenAuthenticators: null
 controllerConfig:

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -244,6 +244,7 @@ type MasterConfig struct {
 	EtcdConfig *EtcdConfig `json:"etcdConfig"`
 	// OAuthConfig, if present start the /oauth endpoint in this process
 	OAuthConfig *OAuthConfig `json:"oauthConfig"`
+
 	// DNSConfig, if present start the DNS server in this process
 	DNSConfig *DNSConfig `json:"dnsConfig"`
 
@@ -293,6 +294,11 @@ type MasterAuthConfig struct {
 	RequestHeader *RequestHeaderAuthenticationOptions `json:"requestHeader"`
 	// WebhookTokenAuthnConfig, if present configures remote token reviewers
 	WebhookTokenAuthenticators []WebhookTokenAuthenticator `json:"webhookTokenAuthenticators"`
+	// OAuthMetadataFile is a path to a file containing the discovery endpoint for OAuth 2.0 Authorization
+	// Server Metadata for an external OAuth server.
+	// See IETF Draft: // https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+	// This option is mutually exclusive with OAuthConfig
+	OAuthMetadataFile string `json:"oauthMetadataFile"`
 }
 
 // RequestHeaderAuthenticationOptions provides options for setting up a front proxy against the entire

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -598,23 +598,22 @@ func defaultOpenAPIConfig(config configapi.MasterConfig) *openapicommon.Config {
 			},
 		}
 	}
-	if config.OAuthConfig != nil {
-		baseUrl := config.OAuthConfig.MasterPublicURL
+	if _, oauthMetadata, _ := oauthutil.PrepOauthMetadata(config); oauthMetadata != nil {
 		securityDefinitions["Oauth2Implicit"] = &spec.SecurityScheme{
 			SecuritySchemeProps: spec.SecuritySchemeProps{
 				Type:             "oauth2",
 				Flow:             "implicit",
-				AuthorizationURL: oauthutil.OpenShiftOAuthAuthorizeURL(baseUrl),
-				Scopes:           scope.DefaultSupportedScopesMap(),
+				AuthorizationURL: oauthMetadata.AuthorizationEndpoint,
+				Scopes:           scope.DescribeScopes(oauthMetadata.ScopesSupported),
 			},
 		}
 		securityDefinitions["Oauth2AccessToken"] = &spec.SecurityScheme{
 			SecuritySchemeProps: spec.SecuritySchemeProps{
 				Type:             "oauth2",
 				Flow:             "accessCode",
-				AuthorizationURL: oauthutil.OpenShiftOAuthAuthorizeURL(baseUrl),
-				TokenURL:         oauthutil.OpenShiftOAuthTokenURL(baseUrl),
-				Scopes:           scope.DefaultSupportedScopesMap(),
+				AuthorizationURL: oauthMetadata.AuthorizationEndpoint,
+				TokenURL:         oauthMetadata.TokenEndpoint,
+				Scopes:           scope.DescribeScopes(oauthMetadata.ScopesSupported),
 			},
 		}
 	}

--- a/pkg/oauth/util/discovery_test.go
+++ b/pkg/oauth/util/discovery_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetOauthMetadata(t *testing.T) {
-	actual := GetOauthMetadata("https://localhost:8443")
+	actual := getOauthMetadata("https://localhost:8443")
 	expected := OauthAuthorizationServerMetadata{
 		Issuer:                "https://localhost:8443",
 		AuthorizationEndpoint: "https://localhost:8443/oauth/authorize",

--- a/test/integration/oauth_external_test.go
+++ b/test/integration/oauth_external_test.go
@@ -1,0 +1,216 @@
+package integration
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/RangelReale/osin"
+
+	kauthn "k8s.io/api/authentication/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	kclientcmd "k8s.io/client-go/tools/clientcmd"
+	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	oauthutil "github.com/openshift/origin/pkg/oauth/util"
+	"github.com/openshift/origin/pkg/oc/util/tokencmd"
+	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+// TestWebhookTokenAuthn checks Tokens directly against an external
+// authenticator
+func TestOauthExternal(t *testing.T) {
+	authToken := "BoringToken"
+	authTestUser := "user"
+	authTestUID := "42"
+	authTestGroups := []string{"testgroup"}
+
+	expectedTokenPost := kauthn.TokenReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "authentication.k8s.io/v1beta1",
+			Kind:       "TokenReview",
+		},
+		Spec: kauthn.TokenReviewSpec{Token: authToken},
+	}
+
+	tokenResponse := kauthn.TokenReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "authentication.k8s.io/v1beta1",
+			Kind:       "TokenReview",
+		},
+		Status: kauthn.TokenReviewStatus{
+			Authenticated: true,
+			User: kauthn.UserInfo{
+				Username: authTestUser,
+				UID:      authTestUID,
+				Groups:   authTestGroups,
+				Extra: map[string]kauthn.ExtraValue{
+					authorizationapi.ScopesKey: []string{
+						"user:info",
+					},
+				},
+			},
+		},
+	}
+
+	// Write cert we're going to use to verify auth server requests
+	caFile, err := ioutil.TempFile("", "test.crt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(caFile.Name())
+	if err := ioutil.WriteFile(caFile.Name(), authLocalhostCert, os.FileMode(0600)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var authServerURL string
+
+	// Set up a dummy authenticator server
+	authServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authenticate":
+			if r.Method != "POST" {
+				t.Fatalf("Expected POST to /authenticate, got %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("Error parsing form POSTed to /token: %v", err)
+			}
+			var tokenPost kauthn.TokenReview
+			if err = json.NewDecoder(r.Body).Decode(&tokenPost); err != nil {
+				t.Fatalf("Expected TokenReview structure in POST request: %v", err)
+			}
+			if !reflect.DeepEqual(tokenPost, expectedTokenPost) {
+				t.Fatalf("Expected\n%#v\ngot\n%#v", expectedTokenPost, tokenPost)
+			}
+			if err = json.NewEncoder(w).Encode(tokenResponse); err != nil {
+				t.Fatalf("Failed to encode Token Review response: %v", err)
+			}
+
+		case "/oauth/authorize":
+			w.Header().Set("Location", fmt.Sprintf("%s/oauth/token/implicit?code=%s", authServerURL, authToken))
+			w.WriteHeader(http.StatusFound)
+
+		case "/oauth/token":
+			w.Write([]byte(fmt.Sprintf(`{"access_token":%q, "token_type":"Bearer"}`, authToken)))
+		default:
+			t.Fatalf("Unexpected request: %v", r.URL.Path)
+		}
+	}))
+	cert, err := tls.X509KeyPair(authLocalhostCert, authLocalhostKey)
+	authServer.TLS = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	authServer.StartTLS()
+	defer authServer.Close()
+	authServerURL = authServer.URL
+
+	authConfigFile, err := ioutil.TempFile("", "test.cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(authConfigFile.Name())
+	authConfigObj := kclientcmdapi.Config{
+		Clusters: map[string]*kclientcmdapi.Cluster{
+			"authService": {
+				CertificateAuthority: caFile.Name(),
+				Server:               authServer.URL + "/authenticate",
+			},
+		},
+		AuthInfos: map[string]*kclientcmdapi.AuthInfo{
+			"apiServer": {
+				ClientCertificateData: authLocalhostCert,
+				ClientKeyData:         authLocalhostKey,
+			},
+		},
+		CurrentContext: "webhook",
+		Contexts: map[string]*kclientcmdapi.Context{
+			"webhook": {
+				Cluster:  "authService",
+				AuthInfo: "apiServer",
+			},
+		},
+	}
+	if err := kclientcmd.WriteToFile(authConfigObj, authConfigFile.Name()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	authServerMetadataFile, err := ioutil.TempFile("", "metadata.cfg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer os.Remove(authServerMetadataFile.Name())
+	authServerMetadata := oauthutil.OauthAuthorizationServerMetadata{
+		Issuer:                        authServer.URL,
+		AuthorizationEndpoint:         authServer.URL + "/oauth/authorize",
+		TokenEndpoint:                 authServer.URL + "/oauth/token",
+		ResponseTypesSupported:        osin.AllowedAuthorizeType{osin.CODE, osin.TOKEN},
+		GrantTypesSupported:           osin.AllowedAccessType{osin.AUTHORIZATION_CODE, "implicit"},
+		CodeChallengeMethodsSupported: []string{"plain", "S256"},
+	}
+	authServerMetadataSerialized, _ := json.MarshalIndent(authServerMetadata, "", "  ")
+	authServerMetadataFile.Write(authServerMetadataSerialized)
+	authServerMetadataFile.Sync()
+	authServerMetadataFile.Close()
+
+	// Get master config
+	masterOptions, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
+
+	masterOptions.OAuthConfig = nil
+	masterOptions.AuthConfig.OAuthMetadataFile = authServerMetadataFile.Name()
+	masterOptions.AuthConfig.WebhookTokenAuthenticators = []configapi.WebhookTokenAuthenticator{
+		{
+			ConfigFile: authConfigFile.Name(),
+			CacheTTL:   "10s",
+		},
+	}
+
+	// Start server
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	anonymousConfig := rest.AnonymousClientConfig(clusterAdminClientConfig)
+	//The client needs to connect to both servers, so trust both certs
+	anonymousConfig.TLSClientConfig.CAData = append(anonymousConfig.TLSClientConfig.CAData, authLocalhostCert...)
+
+	accessToken, err := tokencmd.RequestToken(anonymousConfig, bytes.NewBufferString("user\npass"), "", "")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if accessToken != authToken {
+		t.Errorf("Expected accessToken=%q, got %q", authToken, accessToken)
+	}
+
+	clientConfig := rest.AnonymousClientConfig(clusterAdminClientConfig)
+	clientConfig.BearerToken = accessToken
+
+	user, err := userclient.NewForConfigOrDie(clientConfig).Users().Get("~", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if user.Name != "user" {
+		t.Errorf("expected %v, got %v", "user", user.Name)
+	}
+}


### PR DESCRIPTION
This helps replacing our internal Oauth Server with an external one.
REquires a metadata file to be generated by the external OAuth server and be provided for config.