### PR TITLE
UPSTREAM: <carry>: Remove write permissions on daemonsets from Kubernetes bootstrap policy

### DIFF
--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -4857,7 +4857,6 @@ items:
   - apiGroups:
     - apps
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -4872,6 +4871,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - autoscaling
@@ -4903,7 +4910,6 @@ items:
   - apiGroups:
     - extensions
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -4919,6 +4925,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - policy
@@ -5036,7 +5050,6 @@ items:
   - apiGroups:
     - apps
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -5051,6 +5064,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - autoscaling
@@ -5082,7 +5103,6 @@ items:
   - apiGroups:
     - extensions
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -5098,6 +5118,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - policy

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -5319,7 +5319,6 @@ items:
     - apps
     attributeRestrictions: null
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -5334,6 +5333,15 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - apps
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - autoscaling
@@ -5368,7 +5376,6 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -5384,6 +5391,15 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - policy
@@ -5510,7 +5526,6 @@ items:
     - apps
     attributeRestrictions: null
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -5525,6 +5540,15 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - apps
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - autoscaling
@@ -5559,7 +5583,6 @@ items:
     - extensions
     attributeRestrictions: null
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -5575,6 +5598,15 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    attributeRestrictions: null
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - policy

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -227,17 +227,18 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("impersonate").Groups(legacyGroup).Resources("serviceaccounts").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(appsGroup).Resources("statefulsets",
-					"daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback",
 					"replicasets", "replicasets/scale").RuleOrDie(),
+				rbac.NewRule(Read...).Groups(appsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
-				rbac.NewRule(ReadWrite...).Groups(extensionsGroup).Resources("daemonsets",
+				rbac.NewRule(ReadWrite...).Groups(extensionsGroup).Resources(
 					"deployments", "deployments/scale", "deployments/rollback", "ingresses",
 					"replicasets", "replicasets/scale", "replicationcontrollers/scale").RuleOrDie(),
+				rbac.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(policyGroup).Resources("poddisruptionbudgets").RuleOrDie(),
 
@@ -263,17 +264,18 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("impersonate").Groups(legacyGroup).Resources("serviceaccounts").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(appsGroup).Resources("statefulsets",
-					"daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback",
 					"replicasets", "replicasets/scale").RuleOrDie(),
+				rbac.NewRule(Read...).Groups(appsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
 
-				rbac.NewRule(ReadWrite...).Groups(extensionsGroup).Resources("daemonsets",
+				rbac.NewRule(ReadWrite...).Groups(extensionsGroup).Resources(
 					"deployments", "deployments/scale", "deployments/rollback", "ingresses",
 					"replicasets", "replicasets/scale", "replicationcontrollers/scale").RuleOrDie(),
+				rbac.NewRule(Read...).Groups(extensionsGroup).Resources("daemonsets").RuleOrDie(),
 
 				rbac.NewRule(ReadWrite...).Groups(policyGroup).Resources("poddisruptionbudgets").RuleOrDie(),
 			},

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -130,7 +130,6 @@ items:
   - apiGroups:
     - apps
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -145,6 +144,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - autoscaling
@@ -176,7 +183,6 @@ items:
   - apiGroups:
     - extensions
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -192,6 +198,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - policy
@@ -308,7 +322,6 @@ items:
   - apiGroups:
     - apps
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -323,6 +336,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - autoscaling
@@ -354,7 +375,6 @@ items:
   - apiGroups:
     - extensions
     resources:
-    - daemonsets
     - deployments
     - deployments/rollback
     - deployments/scale
@@ -370,6 +390,14 @@ items:
     - list
     - patch
     - update
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    verbs:
+    - get
+    - list
     - watch
   - apiGroups:
     - policy


### PR DESCRIPTION
Due to how daemonsets interact with the project node selector, we need to limit write access to them to the cluster admin.

Bug 1536304
Bug 1501514

Signed-off-by: Monis Khan <mkhan@redhat.com>

/kind bug
/assign @liggitt @deads2k @simo5 @smarterclayton
@openshift/sig-security

/cherrypick release-3.9