### PR TITLE
Fix multicast test to run under ovs-networkpolicy plugin

### DIFF
--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -104,9 +104,7 @@ func testMulticast(f *e2e.Framework, oc *testexutil.CLI) error {
 	for i := range pod {
 		pod[i] = fmt.Sprintf("multicast-%d", i)
 		ip[i], err[i] = launchTestMulticastPod(f, nodes.Items[i/2].Name, pod[i])
-		if err[i] != nil {
-			return err[i]
-		}
+		expectNoError(err[i])
 		var zero int64
 		defer f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(pod[i], &metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		matchIP[i] = regexp.MustCompile(ip[i] + ".*multicast.*1/1/0%")

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -431,3 +431,24 @@ func InNetworkPolicyContext(body func()) {
 		body()
 	})
 }
+
+func InPluginContext(plugins []string, body func()) {
+	Context(fmt.Sprintf("when using one of the plugins '%s'", strings.Join(plugins, ", ")),
+		func() {
+			BeforeEach(func() {
+				found := false
+				for _, plugin := range plugins {
+					if networkPluginName() == plugin {
+						found = true
+						break
+					}
+				}
+				if !found {
+					e2e.Skipf("Not using one of the specified plugins")
+				}
+			})
+
+			body()
+		},
+	)
+}


### PR DESCRIPTION
We're currently testing multicast only on the multitenant plugin, but we should be testing it on ovs-networkpolicy too. (In particular, with conformance-gce now running ovs-networkpolicy, we should test that multicast works, rather than only testing that it *doesn't* work when you don't enable it.)