### PR TITLE
UPSTREAM: <carry>: filter daemonset nodes by namespace node selectors

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/apps.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/apps.go
@@ -32,7 +32,10 @@ func startDaemonSetController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}] {
 		return false, nil
 	}
-	dsc, err := daemon.NewDaemonSetsController(
+	dsc, err := daemon.NewNodeSelectorAwareDaemonSetsController(
+		ctx.OpenShiftContext.OpenShiftDefaultProjectNodeSelector,
+		ctx.OpenShiftContext.KubeDefaultProjectNodeSelector,
+		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.InformerFactory.Apps().V1().DaemonSets(),
 		ctx.InformerFactory.Apps().V1().ControllerRevisions(),
 		ctx.InformerFactory.Core().V1().Pods(),

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/config/config.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/config/config.go
@@ -26,7 +26,7 @@ import (
 type ExtraConfig struct {
 	NodeStatusUpdateFrequency time.Duration
 
-	OpenShiftConfig string
+	OpenShiftContext OpenShiftContext
 }
 
 // Config is the main context object for the controller manager.

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/config/patch.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/config/patch.go
@@ -1,0 +1,9 @@
+package config
+
+// OpenShiftContext is additional context that we need to launch the kube-controller-manager for openshift.
+// Basically, this holds our additional config information.
+type OpenShiftContext struct {
+	OpenShiftConfig                     string
+	OpenShiftDefaultProjectNodeSelector string
+	KubeDefaultProjectNodeSelector      string
+}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -167,7 +167,7 @@ func Run(c *config.CompletedConfig) error {
 		}
 		saTokenControllerInitFunc := serviceAccountTokenControllerStarter{rootClientBuilder: rootClientBuilder}.startServiceAccountTokenController
 
-		if err := createPVRecyclerSA(c.Extra.OpenShiftConfig, rootClientBuilder); err != nil {
+		if err := createPVRecyclerSA(c.Extra.OpenShiftContext.OpenShiftConfig, rootClientBuilder); err != nil {
 			glog.Fatalf("error creating recycler serviceaccount: %v", err)
 		}
 
@@ -221,6 +221,8 @@ func Run(c *config.CompletedConfig) error {
 }
 
 type ControllerContext struct {
+	OpenShiftContext config.OpenShiftContext
+
 	// ClientBuilder will provide a client for this controller to use
 	ClientBuilder controller.ControllerClientBuilder
 
@@ -413,6 +415,7 @@ func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clien
 	}
 
 	ctx := ControllerContext{
+		OpenShiftContext:   s.Extra.OpenShiftContext,
 		ClientBuilder:      clientBuilder,
 		InformerFactory:    sharedInformers,
 		ComponentConfig:    s.Generic.ComponentConfig,

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
@@ -42,7 +42,7 @@ import (
 type KubeControllerManagerOptions struct {
 	Generic cmoptions.GenericControllerManagerOptions
 
-	OpenShiftConfig string
+	OpenShiftContext kubecontrollerconfig.OpenShiftContext
 }
 
 // NewKubeControllerManagerOptions creates a new KubeControllerManagerOptions with a default config.
@@ -71,7 +71,7 @@ func NewKubeControllerManagerOptions() *KubeControllerManagerOptions {
 func (s *KubeControllerManagerOptions) AddFlags(fs *pflag.FlagSet, allControllers []string, disabledByDefaultControllers []string) {
 	s.Generic.AddFlags(fs)
 
-	fs.StringVar(&s.OpenShiftConfig, "openshift-config", s.OpenShiftConfig, "indicates that this process should be compatible with openshift start master")
+	fs.StringVar(&s.OpenShiftContext.OpenShiftConfig, "openshift-config", s.OpenShiftContext.OpenShiftConfig, "indicates that this process should be compatible with openshift start master")
 	fs.MarkHidden("openshift-config")
 
 	fs.StringSliceVar(&s.Generic.ComponentConfig.Controllers, "controllers", s.Generic.ComponentConfig.Controllers, fmt.Sprintf(""+
@@ -155,7 +155,7 @@ func (s *KubeControllerManagerOptions) AddFlags(fs *pflag.FlagSet, allController
 func (s *KubeControllerManagerOptions) ApplyTo(c *kubecontrollerconfig.Config) error {
 	err := s.Generic.ApplyTo(&c.Generic, "controller-manager")
 
-	c.Extra.OpenShiftConfig = s.OpenShiftConfig
+	c.Extra.OpenShiftContext = s.OpenShiftContext
 
 	return err
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
@@ -11,12 +11,12 @@ import (
 var InformerFactoryOverride informers.SharedInformerFactory
 
 func ShimForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions, controllerManager *config.Config) (func(), error) {
-	if len(controllerManager.Extra.OpenShiftConfig) == 0 {
+	if len(controllerManager.Extra.OpenShiftContext.OpenShiftConfig) == 0 {
 		return func() {}, nil
 	}
 
 	// TODO this gets removed when no longer take flags and no longer build a recycler template
-	openshiftConfig, err := getOpenShiftConfig(controllerManager.Extra.OpenShiftConfig)
+	openshiftConfig, err := getOpenShiftConfig(controllerManager.Extra.OpenShiftContext.OpenShiftConfig)
 	if err != nil {
 		return func() {}, err
 	}
@@ -33,7 +33,7 @@ func ShimForOpenShift(controllerManagerOptions *options.KubeControllerManagerOpt
 	}
 
 	// TODO this should be replaced by using a flex volume to inject service serving cert CAs into pods instead of adding it to the sa token
-	if err := applyOpenShiftServiceServingCertCAFunc(path.Dir(controllerManager.Extra.OpenShiftConfig), openshiftConfig); err != nil {
+	if err := applyOpenShiftServiceServingCertCAFunc(path.Dir(controllerManager.Extra.OpenShiftContext.OpenShiftConfig), openshiftConfig); err != nil {
 		return func() {}, err
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/controller/daemon/patch_nodeselector.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/daemon/patch_nodeselector.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func NewNodeSelectorAwareDaemonSetsController(openshiftDefaultNodeSelectorString, kubeDefaultNodeSelectorString string, namepaceInformer coreinformers.NamespaceInformer, daemonSetInformer appsinformers.DaemonSetInformer, historyInformer appsinformers.ControllerRevisionInformer, podInformer coreinformers.PodInformer, nodeInformer coreinformers.NodeInformer, kubeClient clientset.Interface) (*DaemonSetsController, error) {
+	controller, err := NewDaemonSetsController(daemonSetInformer, historyInformer, podInformer, nodeInformer, kubeClient)
+	if err != nil {
+		return controller, err
+	}
+	controller.namespaceLister = namepaceInformer.Lister()
+	controller.namespaceStoreSynced = namepaceInformer.Informer().HasSynced
+	controller.openshiftDefaultNodeSelectorString = openshiftDefaultNodeSelectorString
+	if len(controller.openshiftDefaultNodeSelectorString) > 0 {
+		controller.openshiftDefaultNodeSelector, err = labels.Parse(controller.openshiftDefaultNodeSelectorString)
+		if err != nil {
+			return nil, err
+		}
+	}
+	controller.kubeDefaultNodeSelectorString = kubeDefaultNodeSelectorString
+	if len(controller.kubeDefaultNodeSelectorString) > 0 {
+		controller.kubeDefaultNodeSelector, err = labels.Parse(controller.kubeDefaultNodeSelectorString)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return controller, nil
+}
+
+func (dsc *DaemonSetsController) namespaceNodeSelectorMatches(node *v1.Node, ds *appsv1.DaemonSet) (bool, error) {
+	if dsc.namespaceLister == nil {
+		return true, nil
+	}
+
+	// this is racy (different listers) and we get to choose which way to fail.  This should requeue.
+	ns, err := dsc.namespaceLister.Get(ds.Namespace)
+	if apierrors.IsNotFound(err) {
+		return false, err
+	}
+	// if we had any error, default to the safe option of creating a pod for the node.
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true, nil
+	}
+
+	return dsc.nodeSelectorMatches(node, ns), nil
+}
+
+func (dsc *DaemonSetsController) nodeSelectorMatches(node *v1.Node, ns *v1.Namespace) bool {
+	originNodeSelector, ok := ns.Annotations["openshift.io/node-selector"]
+	switch {
+	case ok:
+		selector, err := labels.Parse(originNodeSelector)
+		if err == nil {
+			if !selector.Matches(labels.Set(node.Labels)) {
+				return false
+			}
+		}
+	case !ok && len(dsc.openshiftDefaultNodeSelectorString) > 0:
+		if !dsc.openshiftDefaultNodeSelector.Matches(labels.Set(node.Labels)) {
+			return false
+		}
+	}
+
+	kubeNodeSelector, ok := ns.Annotations["scheduler.alpha.kubernetes.io/node-selector"]
+	switch {
+	case ok:
+		selector, err := labels.Parse(kubeNodeSelector)
+		if err == nil {
+			if !selector.Matches(labels.Set(node.Labels)) {
+				return false
+			}
+		}
+	case !ok && len(dsc.kubeDefaultNodeSelectorString) > 0:
+		if !dsc.kubeDefaultNodeSelector.Matches(labels.Set(node.Labels)) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/k8s.io/kubernetes/pkg/controller/daemon/patch_nodeselector_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/daemon/patch_nodeselector_test.go
@@ -1,0 +1,184 @@
+package daemon
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestNamespaceNodeSelectorMatches(t *testing.T) {
+	nodes := []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "first",
+				Labels: map[string]string{
+					"alpha": "bravo",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "second",
+				Labels: map[string]string{
+					"charlie": "delta",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "third",
+				Labels: map[string]string{
+					"echo": "foxtrot",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "fourth",
+				Labels: map[string]string{},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fifth",
+				Labels: map[string]string{
+					"charlie": "delta",
+					"echo":    "foxtrot",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "sixth",
+				Labels: map[string]string{
+					"alpha":   "bravo",
+					"charlie": "delta",
+					"echo":    "foxtrot",
+				},
+			},
+		},
+	}
+
+	pureDefault := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+	all := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"openshift.io/node-selector": "",
+			},
+		},
+	}
+	projectSpecified := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"openshift.io/node-selector": "echo=foxtrot",
+			},
+		},
+	}
+	schedulerSpecified := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"scheduler.alpha.kubernetes.io/node-selector": "charlie=delta",
+			},
+		},
+	}
+	bothSpecified := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"openshift.io/node-selector":                  "echo=foxtrot",
+				"scheduler.alpha.kubernetes.io/node-selector": "charlie=delta",
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		defaultSelector string
+		namespace       *v1.Namespace
+		expected        map[string]bool
+	}{
+		{
+			name:            "pure-default",
+			defaultSelector: "alpha=bravo",
+			namespace:       pureDefault,
+			expected: map[string]bool{
+				"first": true,
+				"sixth": true,
+			},
+		},
+		{
+			name:            "all",
+			defaultSelector: "alpha=bravo",
+			namespace:       all,
+			expected: map[string]bool{
+				"first":  true,
+				"second": true,
+				"third":  true,
+				"fourth": true,
+				"fifth":  true,
+				"sixth":  true,
+			},
+		},
+		{
+			name:      "pure-default-without-default",
+			namespace: pureDefault,
+			expected: map[string]bool{
+				"first":  true,
+				"second": true,
+				"third":  true,
+				"fourth": true,
+				"fifth":  true,
+				"sixth":  true,
+			},
+		},
+		{
+			name:      "projectSpecified",
+			namespace: projectSpecified,
+			expected: map[string]bool{
+				"third": true,
+				"fifth": true,
+				"sixth": true,
+			},
+		},
+		{
+			name:      "schedulerSpecified",
+			namespace: schedulerSpecified,
+			expected: map[string]bool{
+				"second": true,
+				"fifth":  true,
+				"sixth":  true,
+			},
+		},
+		{
+			name:      "bothSpecified",
+			namespace: bothSpecified,
+			expected: map[string]bool{
+				"fifth": true,
+				"sixth": true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &DaemonSetsController{}
+			c.openshiftDefaultNodeSelectorString = test.defaultSelector
+			if len(c.openshiftDefaultNodeSelectorString) > 0 {
+				var err error
+				c.openshiftDefaultNodeSelector, err = labels.Parse(c.openshiftDefaultNodeSelectorString)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			for _, node := range nodes {
+				if e, a := test.expected[node.Name], c.nodeSelectorMatches(node, test.namespace); e != a {
+					t.Errorf("%q expected %v, got %v", node.Name, e, a)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Something to talk about.  This places a shim in the upstream controller to check nodes against node selectors to avoid creating extra pods. We can talk about the expense of making the check compared to alternatives, but something concrete to show relative complexity may be useful.

Changing the default policy for all openshift installations seems like a comparatively big deal.  The cost of this patch is only borne by those who enable the node limiting features.

@simo5 @mfojtik @tnozicka @liggitt 

