### PR TITLE
Handle role binding AlreadyExists errors on project creation

### DIFF
--- a/pkg/authorization/controller/defaultrolebindings/defaultrolebindings.go
+++ b/pkg/authorization/controller/defaultrolebindings/defaultrolebindings.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	rbacinformers "k8s.io/client-go/informers/rbac/v1"
@@ -24,7 +23,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
-var defaultRoleBindingNames = getDefaultRoleBindingNames()
+var defaultRoleBindingNames = bootstrappolicy.GetBootstrapServiceAccountProjectRoleBindingNames()
 
 // DefaultRoleBindingController is a controller to combine cluster roles
 type DefaultRoleBindingController struct {
@@ -184,15 +183,4 @@ func (c *DefaultRoleBindingController) processNextWorkItem() bool {
 	c.queue.AddRateLimited(dsKey)
 
 	return true
-}
-
-func getDefaultRoleBindingNames() sets.String {
-	roleBindings := bootstrappolicy.GetBootstrapServiceAccountProjectV1RoleBindings("default")
-	names := []string{}
-
-	for _, roleBinding := range roleBindings {
-		names = append(names, roleBinding.Name)
-	}
-
-	return sets.NewString(names...)
 }

--- a/pkg/cmd/server/bootstrappolicy/project_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/project_policy.go
@@ -2,6 +2,7 @@ package bootstrappolicy
 
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	rbacv1conversions "k8s.io/kubernetes/pkg/apis/rbac/v1"
@@ -55,4 +56,14 @@ func GetBootstrapServiceAccountProjectV1RoleBindings(namespace string) []rbacv1.
 	}
 
 	return ret
+}
+
+func GetBootstrapServiceAccountProjectRoleBindingNames() sets.String {
+	names := sets.NewString()
+
+	for _, roleBinding := range GetBootstrapServiceAccountProjectRoleBindings("default") {
+		names.Insert(roleBinding.Name)
+	}
+
+	return names
 }


### PR DESCRIPTION
This change correctly allows AlreadyExists errors for the default role bindings during project creation (which is race between the API master and the default role binding controller).  However, it does
not generically ignore these errors.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Fixes #18982
Alternative to #18994
/kind bug
/assign @simo5 @deads2k
@openshift/sig-master