### PR TITLE
Allow subnet allocator to mark assigned subnet dynamically

### DIFF
--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -33,7 +33,7 @@ type OsdnMaster struct {
 	kClient             kclientset.Interface
 	networkClient       networkclient.Interface
 	networkInfo         *common.NetworkInfo
-	subnetAllocatorList []*netutils.SubnetAllocator
+	subnetAllocatorList []*SubnetAllocator
 	vnids               *masterVNIDMap
 
 	kubeInformers    kinternalinformers.SharedInformerFactory

--- a/pkg/network/master/subnet_allocator.go
+++ b/pkg/network/master/subnet_allocator.go
@@ -1,6 +1,7 @@
-package netutils
+package master
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"sync"
@@ -132,4 +133,14 @@ func (sna *SubnetAllocator) ReleaseNetwork(ipnet *net.IPNet) error {
 	sna.allocMap[ipnetStr] = false
 
 	return nil
+}
+
+func IPToUint32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip.To4())
+}
+
+func Uint32ToIP(u uint32) net.IP {
+	ip := make([]byte, 4)
+	binary.BigEndian.PutUint32(ip, u)
+	return net.IPv4(ip[0], ip[1], ip[2], ip[3])
 }

--- a/pkg/network/master/subnet_allocator_test.go
+++ b/pkg/network/master/subnet_allocator_test.go
@@ -1,4 +1,4 @@
-package netutils
+package master
 
 import (
 	"fmt"
@@ -246,5 +246,21 @@ func TestAllocateReleaseSubnet(t *testing.T) {
 	sn, err = sna.GetNetwork()
 	if err == nil {
 		t.Fatalf("Unexpectedly succeeded in getting network (sn=%s)", sn.String())
+	}
+}
+
+func TestConversion(t *testing.T) {
+	ip := net.ParseIP("10.1.2.3")
+	if ip == nil {
+		t.Fatal("Failed to parse IP")
+	}
+
+	u := IPToUint32(ip)
+	t.Log(u)
+	ip2 := Uint32ToIP(u)
+	t.Log(ip2)
+
+	if !ip2.Equal(ip) {
+		t.Fatal("Conversion back and forth failed")
 	}
 }

--- a/pkg/network/master/subnets.go
+++ b/pkg/network/master/subnets.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/origin/pkg/network"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/common"
-	"github.com/openshift/origin/pkg/util/netutils"
 )
 
 func (master *OsdnMaster) SubnetStartMaster(clusterNetworks []common.ClusterNetwork) error {
@@ -44,9 +43,9 @@ func (master *OsdnMaster) SubnetStartMaster(clusterNetworks []common.ClusterNetw
 			}
 		}
 	}
-	var subnetAllocatorList []*netutils.SubnetAllocator
+	var subnetAllocatorList []*SubnetAllocator
 	for _, cn := range clusterNetworks {
-		subnetAllocator, err := netutils.NewSubnetAllocator(cn.ClusterCIDR.String(), cn.HostSubnetLength, subrange[cn])
+		subnetAllocator, err := NewSubnetAllocator(cn.ClusterCIDR.String(), cn.HostSubnetLength, subrange[cn])
 		if err != nil {
 			return err
 		}
@@ -144,7 +143,7 @@ func (master *OsdnMaster) addNode(nodeName string, nodeUID string, nodeIP string
 	}
 	for _, possibleSubnet := range master.subnetAllocatorList {
 		sn, err := possibleSubnet.GetNetwork()
-		if err == netutils.ErrSubnetAllocatorFull {
+		if err == ErrSubnetAllocatorFull {
 			// Current subnet exhausted, check the next one
 			continue
 		} else if err != nil {

--- a/pkg/util/netutils/common.go
+++ b/pkg/util/netutils/common.go
@@ -1,7 +1,6 @@
 package netutils
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net"
 
@@ -12,16 +11,6 @@ import (
 
 var localHosts []string = []string{"127.0.0.1", "::1", "localhost"}
 var localSubnets []string = []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "fc00::/7", "fe80::/10"}
-
-func IPToUint32(ip net.IP) uint32 {
-	return binary.BigEndian.Uint32(ip.To4())
-}
-
-func Uint32ToIP(u uint32) net.IP {
-	ip := make([]byte, 4)
-	binary.BigEndian.PutUint32(ip, u)
-	return net.IPv4(ip[0], ip[1], ip[2], ip[3])
-}
 
 // Generate the default gateway IP Address for a subnet
 func GenerateDefaultGateway(sna *net.IPNet) net.IP {

--- a/pkg/util/netutils/common_test.go
+++ b/pkg/util/netutils/common_test.go
@@ -6,37 +6,12 @@ import (
 	"testing"
 )
 
-func TestConversion(t *testing.T) {
-	ip := net.ParseIP("10.1.2.3")
-	if ip == nil {
-		t.Fatal("Failed to parse IP")
-	}
-
-	u := IPToUint32(ip)
-	t.Log(u)
-	ip2 := Uint32ToIP(u)
-	t.Log(ip2)
-
-	if !ip2.Equal(ip) {
-		t.Fatal("Conversion back and forth failed")
-	}
-}
-
 func TestGenerateGateway(t *testing.T) {
-	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, nil)
+	_, ipNet, err := net.ParseCIDR("10.1.0.0/24")
 	if err != nil {
-		t.Fatal("Failed to initialize IP allocator: ", err)
+		t.Fatal(err)
 	}
-
-	sn, err := sna.GetNetwork()
-	if err != nil {
-		t.Fatal("Failed to get network: ", err)
-	}
-	if sn.String() != "10.1.0.0/24" {
-		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
-	}
-
-	gatewayIP := GenerateDefaultGateway(sn)
+	gatewayIP := GenerateDefaultGateway(ipNet)
 	if gatewayIP.String() != "10.1.0.1" {
 		t.Fatalf("Did not get expected gateway IP Address (gatewayIP=%s)", gatewayIP.String())
 	}


### PR DESCRIPTION
- Moved subnet allocator from pkg/util/netutils to pkg/network/master
  Subnet allocator is specific to SDN master and not used anywhere.

- Currently, we need to pass all allocated subnets during
subnet allocator creation time (inUse arg to NewSubnetAllocator()).
This means we need to know all existing subnets beforehand.

- This change exposes additional method so that we can mark a
specific subnet as already allocated dynamically (after the subnet
allocator is created).

Precursor for https://github.com/openshift/origin/pull/18911