### PR TITLE
Default the kubelet IPTablesMasqueradeBit to the same value as the kube-proxy IPTablesMasqueradeBit

### DIFF
--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -84,6 +84,13 @@ func ComputeKubeletFlags(startingArgs map[string][]string, options configapi.Nod
 	setIfUnset(args, "authorization-webhook-cache-authorized-ttl", options.AuthConfig.AuthorizationCacheTTL)
 	setIfUnset(args, "authorization-webhook-cache-unauthorized-ttl", options.AuthConfig.AuthorizationCacheTTL)
 
+	// Override kubelet iptables-masquerade-bit value to match overridden kube-proxy
+	// iptables-masquerade-bit value, UNLESS the user has overridden kube-proxy to match the
+	// previously-not-overridden kubelet value, in which case we don't want to re-break them.
+	if len(options.ProxyArguments["iptables-masquerade-bit"]) != 1 || options.ProxyArguments["iptables-masquerade-bit"][0] != "14" {
+		setIfUnset(args, "iptables-masquerade-bit", "0")
+	}
+
 	if network.IsOpenShiftNetworkPlugin(options.NetworkConfig.NetworkPluginName) {
 		// SDN plugin pod setup/teardown is implemented as a CNI plugin
 		setIfUnset(args, "network-plugin", kubeletcni.CNIPluginName)


### PR DESCRIPTION
TL;DR: OpenShift is overriding IPTablesMasqueradeBit in the proxy configuration, but upstream requires that if you override it there, you have to override it in the kubelet config too, which we were not doing.

Upstream kubernetes has two separate codepaths for dealing with iptables masquerade and drop rules; one in kubelet for hostports, and one in kube-proxy for services. They attempt to coordinate with each other (by both using the same iptables chain names), but since kubelet and kube-proxy are configured separately, they have to both be given the same alternative configuration if you want to change something.

We have been overriding the IPTablesMasqueradeBit value in kube-proxy from bit 14 to bit 0 for a long time now. (I don't know why.) But we weren't overriding the corresponding value in kubelet. This means that kubelet will periodically insert a rule into the KUBE-MARK-MASQ chain to masquerade any packet with bit 14 set in its mark, but then iptables will delete that rule the next time it updates anything. This doesn't affect service or hostsubnet functioning (it just means that at certain times, packets destined to be masqueraded get marked with two separate bits, and then we masquerade them if they have either of those two bits set) but it can cause problems with other people trying to use the mark for other things (like egress IPs).

This patch fixes things by overriding the kubelet default value to match what we're overriding the kube-proxy default value to. Except that in theory, some users might have already worked around the bug in the opposite direction, by overriding kube-proxy to use the kubelet/upstream-kube-proxy default value. So if they're doing that then we use that value for both kube-proxy and kubelet to avoid breaking them. Other than that though, if they are explicitly setting the kube-proxy and kubelet arguments to different values, then this lets them lose, just like before and just like upstream. (Though maybe we shouldn't?)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552869