### PR TITLE
Add networking team members to pkg/cmd/OWNERS

### DIFF
--- a/pkg/cmd/OWNERS
+++ b/pkg/cmd/OWNERS
@@ -10,6 +10,7 @@ reviewers:
   - adelton
   - mrogers950
   - simo5
+  - knobunc
   - dcbw
 approvers:
   - smarterclayton
@@ -17,4 +18,5 @@ approvers:
   - mfojtik
   - kargakis
   - enj
+  - knobunc
   - dcbw


### PR DESCRIPTION
We occasionally need to change files in this tree so it would be handy to have two team members in the file.  dcbw was added recently.