### PR TITLE
Differentiate liveness and readiness probes for router pods

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -243,6 +243,7 @@ func (o *TemplateRouterOptions) Validate() error {
 // Run launches a template router using the provided options. It never exits.
 func (o *TemplateRouterOptions) Run() error {
 	glog.Infof("Starting template router (%s)", version.Get())
+	var ptrTemplatePlugin *templateplugin.TemplatePlugin
 
 	var reloadCallbacks []func()
 
@@ -310,9 +311,15 @@ func (o *TemplateRouterOptions) Run() error {
 		if err != nil {
 			return fmt.Errorf("ROUTER_METRICS_READY_HTTP_URL must be a valid URL or empty: %v", err)
 		}
-		check := metrics.HTTPBackendAvailable(u)
+		checkBackend := metrics.HTTPBackendAvailable(u)
 		if isTrue(util.Env("ROUTER_USE_PROXY_PROTOCOL", "")) {
-			check = metrics.ProxyProtocolHTTPBackendAvailable(u)
+			checkBackend = metrics.ProxyProtocolHTTPBackendAvailable(u)
+		}
+		checkSync := metrics.HasSynced(&ptrTemplatePlugin)
+		checkController := metrics.ControllerLive()
+		liveChecks := []healthz.HealthzChecker{checkController}
+		if !(isTrue(util.Env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
+			liveChecks = append(liveChecks, checkBackend)
 		}
 
 		kubeconfig := o.Config.KubeConfig()
@@ -353,7 +360,8 @@ func (o *TemplateRouterOptions) Run() error {
 				Resource:        "routers",
 				Name:            o.RouterName,
 			},
-			Checks: []healthz.HealthzChecker{check},
+			LiveChecks:  liveChecks,
+			ReadyChecks: []healthz.HealthzChecker{checkBackend, checkSync},
 		}
 		if certFile := util.Env("ROUTER_METRICS_TLS_CERT_FILE", ""); len(certFile) > 0 {
 			certificate, err := tls.LoadX509KeyPair(certFile, util.Env("ROUTER_METRICS_TLS_KEY_FILE", ""))
@@ -411,6 +419,7 @@ func (o *TemplateRouterOptions) Run() error {
 	if err != nil {
 		return err
 	}
+	ptrTemplatePlugin = templatePlugin
 
 	factory := o.RouterSelection.NewFactory(routeclient, projectclient.Project().Projects(), kc)
 	factory.RouteModifierFn = o.RouteUpdate

--- a/pkg/router/metrics/health.go
+++ b/pkg/router/metrics/health.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/golang/glog"
 
+	templateplugin "github.com/openshift/origin/pkg/router/template"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/kubernetes/pkg/probe"
 	probehttp "k8s.io/kubernetes/pkg/probe/http"
@@ -33,6 +34,28 @@ func HTTPBackendAvailable(u *url.URL) healthz.HealthzChecker {
 		}
 		return nil
 	})
+}
+
+// HasSynced returns a healthz check that verifies the router has been synced at least
+// once.
+func HasSynced(router **templateplugin.TemplatePlugin) healthz.HealthzChecker {
+	return healthz.NamedCheck("has-synced", func(r *http.Request) error {
+		if router != nil {
+			if (*router).Router.SyncedAtLeastOnce() == true {
+				return nil
+			} else {
+				return fmt.Errorf("Router not synced")
+			}
+		}
+		return nil
+	})
+}
+
+func ControllerLive() healthz.HealthzChecker {
+	return healthz.NamedCheck("controller", func(r *http.Request) error {
+		return nil
+	})
+
 }
 
 // ProxyProtocolHTTPBackendAvailable returns a healthz check that verifies a backend supporting

--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -31,12 +31,14 @@ type Listener struct {
 	Authorizer    authorizer.Authorizer
 	Record        authorizer.AttributesRecord
 
-	Checks []healthz.HealthzChecker
+	LiveChecks  []healthz.HealthzChecker
+	ReadyChecks []healthz.HealthzChecker
 }
 
 func (l Listener) handler() http.Handler {
 	mux := http.NewServeMux()
-	healthz.InstallHandler(mux, l.Checks...)
+	healthz.InstallHandler(mux, l.LiveChecks...)
+	healthz.InstallPathHandler(mux, "/healthz/ready", l.ReadyChecks...)
 
 	if l.Authenticator != nil {
 		protected := http.NewServeMux()

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -42,6 +42,38 @@ func TestInstallHandler(t *testing.T) {
 	}
 }
 
+func TestInstallPathHandler(t *testing.T) {
+	mux := http.NewServeMux()
+	InstallPathHandler(mux, "/healthz/test")
+	InstallPathHandler(mux, "/healthz/ready")
+	req, err := http.NewRequest("GET", "http://example.com/healthz/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
+	}
+	if w.Body.String() != "ok" {
+		t.Errorf("expected %v, got %v", "ok", w.Body.String())
+	}
+
+	req, err = http.NewRequest("GET", "http://example.com/healthz/ready", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %v, got %v", http.StatusOK, w.Code)
+	}
+	if w.Body.String() != "ok" {
+		t.Errorf("expected %v, got %v", "ok", w.Body.String())
+	}
+
+}
+
 func TestMulitipleChecks(t *testing.T) {
 	tests := []struct {
 		path             string


### PR DESCRIPTION
Create upstream commit that allows for multiple groups of checks to be associated with health checking. Using the multiple groupings differentiate the liveness and readiness probes for the Haproxy router

Bug [1550007](https://bugzilla.redhat.com/show_bug.cgi?id=1550007)