### PR TITLE
Remove labels and annotations validations check for imagesignature

### DIFF
--- a/pkg/image/apis/image/validation/validation.go
+++ b/pkg/image/apis/image/validation/validation.go
@@ -87,13 +87,6 @@ func ValidateImageSignature(signature *imageapi.ImageSignature) field.ErrorList 
 
 func validateImageSignature(signature *imageapi.ImageSignature, fldPath *field.Path) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&signature.ObjectMeta, false, path.ValidatePathSegmentName, fldPath.Child("metadata"))
-	if len(signature.Labels) > 0 {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("metadata").Child("labels"), "signature labels cannot be set"))
-	}
-	if len(signature.Annotations) > 0 {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("metadata").Child("annotations"), "signature annotations cannot be set"))
-	}
-
 	if _, _, err := imageapi.SplitImageSignatureName(signature.Name); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("metadata").Child("name"), signature.Name, "name must be of format <imageName>@<signatureName>"))
 	}

--- a/pkg/image/apis/image/validation/validation_test.go
+++ b/pkg/image/apis/image/validation/validation_test.go
@@ -191,23 +191,6 @@ func TestValidateImageSignature(t *testing.T) {
 		},
 
 		{
-			name: "adding labels and anotations",
-			signature: imageapi.ImageSignature{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "img@annotated",
-					Annotations: map[string]string{"key": "value"},
-					Labels:      map[string]string{"label": "value"},
-				},
-				Type:    "valid",
-				Content: []byte("blob"),
-			},
-			expected: field.ErrorList{
-				field.Forbidden(field.NewPath("metadata").Child("labels"), "signature labels cannot be set"),
-				field.Forbidden(field.NewPath("metadata").Child("annotations"), "signature annotations cannot be set"),
-			},
-		},
-
-		{
 			name: "filled metadata for unknown signature state",
 			signature: imageapi.ImageSignature{
 				ObjectMeta: metav1.ObjectMeta{Name: "img@metadatafilled"},


### PR DESCRIPTION
Currently, labels and annotaions for ImageSignature are regarded as
invalid in validation check. However, OpenShift puts
`SignatureManagedAnnotation: "true"` in `DownloadImageSignatures()` by
itself*1.

This patch changes to remove the validations.

*1 https://github.com/openshift/origin/blob/release-3.7/pkg/image/controller/signature/container_image_downloader.go#L65-L67