### PR TITLE
Some route status updates were being lost

### DIFF
--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -275,12 +275,11 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 					case _, ok := <-ch:
 						writes++
 						o.Expect(ok).To(o.BeTrue())
-						o.Expect(i).To(o.BeNumerically("<", 3))
 					case <-timer.C:
 						break Wait
 					}
 				}
-				e2e.Logf("Recorded %d writes total", writes)
+				o.Expect(writes).To(o.BeNumerically("<", 5))
 			}()
 		})
 	})


### PR DESCRIPTION
The new writer lease code when encountering a conflict would drop the queued work, causing status not to be written

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/18930/test_pull_request_origin_extended_conformance_gce/17834/#conformanceareanetworkingfeaturerouter-the-haproxy-router-converges-when-multiple-routers-are-writing-status-suiteopenshiftconformanceparallel

This could cause tests that depend on route status to fail

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/19018/test_pull_request_origin_extended_conformance_gce/17839/#conformanceareanetworkingfeaturerouter-the-haproxy-router-should-support-reencrypt-to-services-backed-by-a-serving-certificate-automatically-suiteopenshiftconformanceparallel