### PR TITLE
switch reversed old/new objects to validation

### DIFF
--- a/pkg/image/registry/image/strategy.go
+++ b/pkg/image/registry/image/strategy.go
@@ -131,5 +131,5 @@ func (s imageStrategy) PrepareForUpdate(ctx apirequest.Context, obj, old runtime
 
 // ValidateUpdate is the default update validation for an end user.
 func (imageStrategy) ValidateUpdate(ctx apirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateImageUpdate(old.(*imageapi.Image), obj.(*imageapi.Image))
+	return validation.ValidateImageUpdate(obj.(*imageapi.Image), old.(*imageapi.Image))
 }


### PR DESCRIPTION
New objects come first.  This means that our update validation never checked to make sure the new image was valid.  That means we could have invalid data sitting somewhere.  Fun.

@bparees @miminar this is how the annotation from that controller got in there.
@openshift/api-review what shall we do about this one....

/hold

holding while we sort out what to do about the damage.