### PR TITLE
Updates db replica extended tests to use nfs backed persistent volumes

### DIFF
--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -93,7 +93,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 
 			// create persistent volumes if running persistent jenkins
 			if jenkinsTemplatePath == jenkinsPersistentTemplatePath {
-				_, err := exutil.SetupNFSBackedPersistentVolume(oc, "2Gi")
+				_, err := exutil.SetupNFSBackedPersistentVolumes(oc, "2Gi", 1)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 
@@ -995,7 +995,8 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 		})
 
 		g.AfterEach(func() {
-			defer exutil.RemoveNFSBackedPersistentVolume(oc)
+			defer exutil.RemoveDeploymentConfigs(oc, "jenkins")
+			defer exutil.RemoveNFSBackedPersistentVolumes(oc)
 
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)

--- a/test/extended/image_ecosystem/mongodb_replica_statefulset.go
+++ b/test/extended/image_ecosystem/mongodb_replica_statefulset.go
@@ -10,6 +10,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	dbutil "github.com/openshift/origin/test/extended/util/db"
 	kapiv1 "k8s.io/api/core/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 var _ = g.Describe("[Conformance][image_ecosystem][mongodb][Slow] openshift mongodb replication (with statefulset)", func() {
@@ -22,103 +23,97 @@ var _ = g.Describe("[Conformance][image_ecosystem][mongodb][Slow] openshift mong
 	g.Context("", func() {
 		g.BeforeEach(func() {
 			exutil.DumpDockerInfo()
+			_, err := exutil.SetupNFSBackedPersistentVolumes(oc, "256Mi", 3)
+			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
 		g.AfterEach(func() {
+			defer exutil.RemoveNFSBackedPersistentVolumes(oc)
+			defer exutil.RemoveStatefulSets(oc, "mongodb-replicaset")
+
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
-		})
-
-		g.Describe("creating from a template", func() {
-			g.AfterEach(func() {
-				for i := 0; i < 3; i++ {
-					pod := fmt.Sprintf("mongodb-replicaset-%d", i)
-					podLogs, err := oc.Run("logs").Args(pod, "--timestamps").Output()
-					if err != nil {
-						ginkgolog("error retrieving pod logs for %s: %v", pod, err)
-						continue
-					}
-					ginkgolog("pod logs for %s:\n%s", podLogs, err)
-				}
-			})
-			g.It(fmt.Sprintf("should instantiate the template"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
-
-				g.By("creating persistent volumes")
-				_, err := exutil.SetupHostPathVolumes(oc, "256Mi", 3)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				defer exutil.RemoveHostPathVolumes(oc)
-
-				g.By("creating a new app")
-				o.Expect(
-					oc.Run("new-app").Args(
-						"-f", templatePath,
-						"-p", "VOLUME_CAPACITY=256Mi",
-						"-p", "MEMORY_LIMIT=512Mi",
-						"-p", "MONGODB_IMAGE=centos/mongodb-32-centos7",
-						"-p", "MONGODB_SERVICE_NAME=mongodb-replicaset",
-					).Execute(),
-				).Should(o.Succeed())
-
-				g.By("waiting for all pods to reach ready status")
-				podNames, err := exutil.WaitForPods(
-					oc.KubeClient().Core().Pods(oc.Namespace()),
-					exutil.ParseLabelsOrDie("name=mongodb-replicaset"),
-					exutil.CheckPodIsReadyFn,
-					3,
-					8*time.Minute,
-				)
+			for i := 0; i < 3; i++ {
+				podLogs, err := oc.Run("logs").Args(fmt.Sprintf("mongodb-replicaset-%d", i), "--timestamps").Output()
 				if err != nil {
-					desc, _ := oc.Run("describe").Args("statefulset").Output()
-					ginkgolog("\n\nStatefulset at failure:\n%s\n\n", desc)
-					desc, _ = oc.Run("describe").Args("pods").Output()
-					ginkgolog("\n\nPods at statefulset failure:\n%s\n\n", desc)
+					e2e.Logf("error retrieving pod logs for %s: %v", fmt.Sprintf("mongodb-replicaset-%d", i), err)
+					continue
 				}
-				o.Expect(err).NotTo(o.HaveOccurred())
+				e2e.Logf("pod logs for %s:\n%s", podLogs, err)
+			}
+		})
+		g.It(fmt.Sprintf("should instantiate the template"), func() {
+			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
-				g.By("expecting that we can insert a new record on primary node")
-				mongo := dbutil.NewMongoDB(podNames[0])
-				replicaSet := mongo.(exutil.ReplicaSet)
-				out, err := replicaSet.QueryPrimary(oc, `db.test.save({ "status" : "passed" })`)
-				ginkgolog("save result: %s\n", out)
-				o.Expect(err).ShouldNot(o.HaveOccurred())
+			g.By("creating a new app")
+			o.Expect(
+				oc.Run("new-app").Args(
+					"-f", templatePath,
+					"-p", "VOLUME_CAPACITY=256Mi",
+					"-p", "MEMORY_LIMIT=512Mi",
+					"-p", "MONGODB_IMAGE=centos/mongodb-32-centos7",
+					"-p", "MONGODB_SERVICE_NAME=mongodb-replicaset",
+				).Execute(),
+			).Should(o.Succeed())
 
-				g.By("expecting that we can read a record from all members")
-				for _, podName := range podNames {
-					o.Expect(readRecordFromPod(oc, podName)).To(o.Succeed())
-				}
+			g.By("waiting for all pods to reach ready status")
+			podNames, err := exutil.WaitForPods(
+				oc.KubeClient().Core().Pods(oc.Namespace()),
+				exutil.ParseLabelsOrDie("name=mongodb-replicaset"),
+				exutil.CheckPodIsReadyFn,
+				3,
+				8*time.Minute,
+			)
+			if err != nil {
+				desc, _ := oc.Run("describe").Args("statefulset").Output()
+				e2e.Logf("\n\nStatefulset at failure:\n%s\n\n", desc)
+				desc, _ = oc.Run("describe").Args("pods").Output()
+				e2e.Logf("\n\nPods at statefulset failure:\n%s\n\n", desc)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-				g.By("restarting replica set")
-				err = oc.Run("delete").Args("pods", "--all", "-n", oc.Namespace()).Execute()
-				o.Expect(err).ShouldNot(o.HaveOccurred())
+			g.By("expecting that we can insert a new record on primary node")
+			mongo := dbutil.NewMongoDB(podNames[0])
+			replicaSet := mongo.(exutil.ReplicaSet)
+			out, err := replicaSet.QueryPrimary(oc, `db.test.save({ "status" : "passed" })`)
+			e2e.Logf("save result: %s\n", out)
+			o.Expect(err).ShouldNot(o.HaveOccurred())
 
-				g.By("waiting for all pods to be gracefully deleted")
-				podNames, err = exutil.WaitForPods(
-					oc.KubeClient().Core().Pods(oc.Namespace()),
-					exutil.ParseLabelsOrDie("name=mongodb-replicaset"),
-					func(pod kapiv1.Pod) bool { return pod.DeletionTimestamp != nil },
-					0,
-					4*time.Minute,
-				)
-				o.Expect(err).NotTo(o.HaveOccurred())
+			g.By("expecting that we can read a record from all members")
+			for _, podName := range podNames {
+				o.Expect(readRecordFromPod(oc, podName)).To(o.Succeed())
+			}
 
-				g.By("waiting for all pods to reach ready status")
-				podNames, err = exutil.WaitForPods(
-					oc.KubeClient().Core().Pods(oc.Namespace()),
-					exutil.ParseLabelsOrDie("name=mongodb-replicaset"),
-					exutil.CheckPodIsReadyFn,
-					3,
-					4*time.Minute,
-				)
-				o.Expect(err).NotTo(o.HaveOccurred())
+			g.By("restarting replica set")
+			err = exutil.RemovePodsWithPrefixes(oc, "mongodb-replicaset")
+			o.Expect(err).ShouldNot(o.HaveOccurred())
 
-				g.By("expecting that we can read a record from all members after its restart")
-				for _, podName := range podNames {
-					o.Expect(readRecordFromPod(oc, podName)).To(o.Succeed())
-				}
-			})
+			g.By("waiting for all pods to be gracefully deleted")
+			podNames, err = exutil.WaitForPods(
+				oc.KubeClient().Core().Pods(oc.Namespace()),
+				exutil.ParseLabelsOrDie("name=mongodb-replicaset"),
+				func(pod kapiv1.Pod) bool { return pod.DeletionTimestamp != nil },
+				0,
+				4*time.Minute,
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("waiting for all pods to reach ready status")
+			podNames, err = exutil.WaitForPods(
+				oc.KubeClient().Core().Pods(oc.Namespace()),
+				exutil.ParseLabelsOrDie("name=mongodb-replicaset"),
+				exutil.CheckPodIsReadyFn,
+				3,
+				4*time.Minute,
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("expecting that we can read a record from all members after its restart")
+			for _, podName := range podNames {
+				o.Expect(readRecordFromPod(oc, podName)).To(o.Succeed())
+			}
 		})
 	})
 })

--- a/test/extended/util/deploymentconfigs.go
+++ b/test/extended/util/deploymentconfigs.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+// RemoveDeploymentConfigs deletes the given DeploymentConfigs in a namespace
+func RemoveDeploymentConfigs(oc *CLI, dcs ...string) error {
+	errs := []error{}
+	for _, dc := range dcs {
+		e2e.Logf("Removing deployment config %s/%s", oc.Namespace(), dc)
+		if err := oc.AdminAppsClient().Apps().DeploymentConfigs(oc.Namespace()).Delete(dc, &metav1.DeleteOptions{}); err != nil {
+			e2e.Logf("Error occurred removing deployment config: %v", err)
+			errs = append(errs, err)
+		}
+
+		err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+			pods, err := GetApplicationPods(oc, dc)
+			if err != nil {
+				e2e.Logf("Unable to get pods for dc/%s: %v", dc, err)
+				return false, err
+			}
+			if len(pods.Items) != 0 {
+				return false, nil
+			}
+			return true, nil
+		})
+
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		return kutilerrors.NewAggregate(errs)
+	}
+
+	return nil
+}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -174,6 +174,10 @@ func GetApplicationPods(oc *CLI, dcName string) (*kapiv1.PodList, error) {
 	return oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{LabelSelector: ParseLabelsOrDie(fmt.Sprintf("deploymentconfig=%s", dcName)).String()})
 }
 
+func GetStatefulSetPods(oc *CLI, setName string) (*kapiv1.PodList, error) {
+	return oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{LabelSelector: ParseLabelsOrDie(fmt.Sprintf("name=%s", setName)).String()})
+}
+
 // DumpDeploymentLogs will dump the latest deployment logs for a DeploymentConfig for debug purposes
 func DumpDeploymentLogs(dcName string, version int64, oc *CLI) {
 	e2e.Logf("Dumping deployment logs for deploymentconfig %q\n", dcName)

--- a/test/extended/util/nfs.go
+++ b/test/extended/util/nfs.go
@@ -170,15 +170,6 @@ func RemoveNFSServer(oc *CLI) error {
 	if _, err := oc.AsAdmin().Run("adm").Args("policy", "remove-scc-from-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", oc.Namespace())).Output(); err != nil {
 		errs = append(errs, err)
 	}
-	// The DeploymentConfig in the Jenkins Persistent template uses the "Recreate" strategy, which will cause the
-	// Jenkins pod to recreate after it is deleted.  Since we have to delete the persistent volume at the end of the
-	// tests that use the NFSServer backed persistent volume, this causes the Jenkins pod to stall trying to recreate
-	// without having a valid persistent volume to use, which causes the test cleanup to fail because it can't delete
-	// the namespace.  So we have to delete the Jenkins DeploymentConfig manually instead of allowing the test runner
-	// to clean up the namespace.
-	e2e.Logf("Removing jenkins deployment config")
-	if err := oc.AdminAppsClient().Apps().DeploymentConfigs(oc.Namespace()).Delete("jenkins", &metav1.DeleteOptions{}); err != nil {
-		errs = append(errs, err)
-	}
+
 	return kutilerrors.NewAggregate(errs)
 }

--- a/test/extended/util/pods.go
+++ b/test/extended/util/pods.go
@@ -1,12 +1,17 @@
 package util
 
 import (
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
+// WaitForNoPodsAvailable waits until there are no pods in the
+// given namespace
 func WaitForNoPodsAvailable(oc *CLI) error {
 	return wait.Poll(200*time.Millisecond, 3*time.Minute, func() (bool, error) {
 		pods, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{})
@@ -16,4 +21,29 @@ func WaitForNoPodsAvailable(oc *CLI) error {
 
 		return len(pods.Items) == 0, nil
 	})
+}
+
+// RemovePodsWithPrefixes deletes pods whose name begins with the
+// supplied prefixes
+func RemovePodsWithPrefixes(oc *CLI, prefixes ...string) error {
+	e2e.Logf("Removing pods from namespace %s with prefix(es): %v", oc.Namespace(), prefixes)
+	pods, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	errs := []error{}
+	for _, prefix := range prefixes {
+		for _, pod := range pods.Items {
+			if strings.HasPrefix(pod.Name, prefix) {
+				if err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Delete(pod.Name, &metav1.DeleteOptions{}); err != nil {
+					e2e.Logf("unable to remove pod %s/%s", oc.Namespace(), pod.Name)
+					errs = append(errs, err)
+				}
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return kutilerrors.NewAggregate(errs)
+	}
+	return nil
 }

--- a/test/extended/util/statefulsets.go
+++ b/test/extended/util/statefulsets.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+// RemoveStatefulSets deletes the given stateful sets in a namespace
+func RemoveStatefulSets(oc *CLI, sets ...string) error {
+	errs := []error{}
+	for _, set := range sets {
+		e2e.Logf("Removing stateful set %s/%s", oc.Namespace(), set)
+		if err := oc.AdminKubeClient().Apps().StatefulSets(oc.Namespace()).Delete(set, &metav1.DeleteOptions{}); err != nil {
+			e2e.Logf("Error occurred removing stateful set: %v", err)
+			errs = append(errs, err)
+		}
+
+		err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+			pods, err := GetStatefulSetPods(oc, set)
+			if err != nil {
+				e2e.Logf("Unable to get pods for statefulset/%s: %v", set, err)
+				return false, err
+			}
+			if len(pods.Items) != 0 {
+				return false, nil
+			}
+			return true, nil
+		})
+
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) != 0 {
+		return kutilerrors.NewAggregate(errs)
+	}
+
+	return nil
+}

--- a/test/extended/util/volumes.go
+++ b/test/extended/util/volumes.go
@@ -1,11 +1,8 @@
 package util
 
 import (
+	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 
 	kapiv1 "k8s.io/api/core/v1"
@@ -14,131 +11,10 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-// CreatePersistentVolume creates a HostPath Persistent Volume.
-func CreatePersistentVolume(name, capacity, hostPath string) *kapiv1.PersistentVolume {
-	return &kapiv1.PersistentVolume{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PersistentVolume",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"name": name},
-		},
-		Spec: kapiv1.PersistentVolumeSpec{
-			PersistentVolumeSource: kapiv1.PersistentVolumeSource{
-				HostPath: &kapiv1.HostPathVolumeSource{
-					Path: hostPath,
-				},
-			},
-			Capacity: kapiv1.ResourceList{
-				kapiv1.ResourceStorage: resource.MustParse(capacity),
-			},
-			AccessModes: []kapiv1.PersistentVolumeAccessMode{
-				kapiv1.ReadWriteOnce,
-				kapiv1.ReadOnlyMany,
-				kapiv1.ReadWriteMany,
-			},
-		},
-	}
-}
-
-// SetupHostPathVolumes will create the requested number of persistent volumes with the given capacity
-func SetupHostPathVolumes(oc *CLI, capacity string, count int) (volumes []*kapiv1.PersistentVolume, err error) {
-	c := oc.AdminKubeClient().Core().PersistentVolumes()
-	prefix := oc.Namespace()
-
-	rootDir, err := ioutil.TempDir(TestContext.OutputDir, "persistent-volumes")
-	if err != nil {
-		e2e.Logf("Error creating pv dir %s: %v\n", TestContext.OutputDir, err)
-		return volumes, err
-	}
-	e2e.Logf("Created pv dir %s\n", rootDir)
-	for i := 0; i < count; i++ {
-		dir, err := ioutil.TempDir(rootDir, fmt.Sprintf("%0.4d", i))
-		if err != nil {
-			e2e.Logf("Error creating pv subdir %s: %v\n", rootDir, err)
-			return volumes, err
-		}
-		e2e.Logf("Created pv subdir %s\n", dir)
-		if _, err = exec.LookPath("chcon"); err == nil {
-			e2e.Logf("Found chcon in path\n")
-			out, err := exec.Command("chcon", "-t", "svirt_sandbox_file_t", dir).CombinedOutput()
-			if err != nil {
-				e2e.Logf("Error running chcon on %s, %s, %v\n", dir, string(out), err)
-				return volumes, err
-			}
-			e2e.Logf("Ran chcon on %s\n", dir)
-		}
-		if err != nil {
-			e2e.Logf("Error finding chcon in path: %v\n", err)
-			return volumes, err
-		}
-		if err = os.Chmod(dir, 0777); err != nil {
-			e2e.Logf("Error running chmod on %s, %v\n", dir, err)
-			return volumes, err
-		}
-		e2e.Logf("Ran chmod on %s\n", dir)
-		pv, err := c.Create(CreatePersistentVolume(fmt.Sprintf("%s%s-%0.4d", pvPrefix, prefix, i), capacity, dir))
-		if err != nil {
-			e2e.Logf("Error defining PV %v\n", err)
-			return volumes, err
-		}
-		e2e.Logf("Created PVs\n")
-		volumes = append(volumes, pv)
-	}
-	return volumes, err
-}
-
-// RemoveHostPathVolumes removes all persistent volumes created by SetupHostPathVolumes
-func RemoveHostPathVolumes(oc *CLI) error {
-	c := oc.AdminKubeClient().Core().PersistentVolumes()
-	prefix := oc.Namespace()
-
-	pvs, err := c.List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	prefix = fmt.Sprintf("%s%s-", pvPrefix, prefix)
-	for _, pv := range pvs.Items {
-		if !strings.HasPrefix(pv.Name, prefix) {
-			continue
-		}
-
-		pvInfo, err := c.Get(pv.Name, metav1.GetOptions{})
-		if err != nil {
-			e2e.Logf("WARNING: couldn't get meta info for PV %s: %v\n", pv.Name, err)
-			continue
-		}
-
-		if err = c.Delete(pv.Name, nil); err != nil {
-			e2e.Logf("WARNING: couldn't remove PV %s: %v\n", pv.Name, err)
-			continue
-		}
-
-		volumeDir := pvInfo.Spec.HostPath.Path
-		if err = os.RemoveAll(volumeDir); err != nil {
-			e2e.Logf("WARNING: couldn't remove directory %q: %v\n", volumeDir, err)
-			continue
-		}
-
-		parentDir := filepath.Dir(volumeDir)
-		if parentDir == "." || parentDir == "/" {
-			continue
-		}
-
-		if err = os.Remove(parentDir); err != nil {
-			e2e.Logf("WARNING: couldn't remove directory %q: %v\n", parentDir, err)
-			continue
-		}
-	}
-	return nil
-}
-
 // CreateNFSBackedPersistentVolume creates a persistent volume backed by a pod
 // running nfs
-func CreateNFSBackedPersistentVolume(name, capacity, server string) *kapiv1.PersistentVolume {
-	e2e.Logf("Creating persistent volume")
+func CreateNFSBackedPersistentVolume(name, capacity, server string, number int) *kapiv1.PersistentVolume {
+	e2e.Logf("Creating persistent volume %s", name)
 	return &kapiv1.PersistentVolume{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolume",
@@ -152,24 +28,34 @@ func CreateNFSBackedPersistentVolume(name, capacity, server string) *kapiv1.Pers
 			PersistentVolumeSource: kapiv1.PersistentVolumeSource{
 				NFS: &kapiv1.NFSVolumeSource{
 					Server:   server,
-					Path:     "/exports/data-0",
+					Path:     fmt.Sprintf("/exports/data-%d", number),
 					ReadOnly: false,
 				},
 			},
+			PersistentVolumeReclaimPolicy: kapiv1.PersistentVolumeReclaimDelete,
 			Capacity: kapiv1.ResourceList{
 				kapiv1.ResourceStorage: resource.MustParse(capacity),
 			},
 			AccessModes: []kapiv1.PersistentVolumeAccessMode{
 				kapiv1.ReadWriteMany,
 				kapiv1.ReadWriteOnce,
+				kapiv1.ReadOnlyMany,
 			},
 		},
 	}
 }
 
-// SetupNFSBackedPersistentVolume sets up an NFS backed persistent volume
-func SetupNFSBackedPersistentVolume(oc *CLI, capacity string) (*kapiv1.PersistentVolume, error) {
-	e2e.Logf("Setting up nfs backed persistent volume")
+// SetupNFSBackedPersistentVolumes sets up an NFS backed persistent volume
+// Currently, the image that is used exports 10 nfs shares, so the maximum
+// integer for count would be 10
+func SetupNFSBackedPersistentVolumes(oc *CLI, capacity string, count int) (volumes []*kapiv1.PersistentVolume, err error) {
+	e2e.Logf("Setting up nfs backed persistent volume(s)")
+
+	maxVolumes := 10
+	if count > maxVolumes {
+		return nil, errors.New(fmt.Sprintf("SetupNFSBackedPersistentVolumes only supports a maximum of %d volumes, you specified %d", maxVolumes, count))
+	}
+
 	c := oc.AdminKubeClient().Core().PersistentVolumes()
 	prefix := oc.Namespace()
 
@@ -182,16 +68,19 @@ func SetupNFSBackedPersistentVolume(oc *CLI, capacity string) (*kapiv1.Persisten
 		return nil, err
 	}
 
-	pv, err := c.Create(CreateNFSBackedPersistentVolume(fmt.Sprintf("%s%s", pvPrefix, prefix), capacity, server))
-	if err != nil {
-		e2e.Logf("Error creating persistent volume %v\n", err)
-		return nil, err
+	for i := 0; i < count; i++ {
+		pv, err := c.Create(CreateNFSBackedPersistentVolume(fmt.Sprintf("%s%s-%d", pvPrefix, prefix, i), capacity, server, i))
+		if err != nil {
+			e2e.Logf("Error creating persistent volume %v\n", err)
+			return nil, err
+		}
+		volumes = append(volumes, pv)
 	}
-	return pv, nil
+	return volumes, nil
 }
 
-// RemoveNFSBackedPersistentVolume removes persistent volumes created by SetupNFSBackedPersistentVolume
-func RemoveNFSBackedPersistentVolume(oc *CLI) error {
+// RemoveNFSBackedPersistentVolumes removes persistent volumes created by SetupNFSBackedPersistentVolume
+func RemoveNFSBackedPersistentVolumes(oc *CLI) error {
 	c := oc.AdminKubeClient().Core().PersistentVolumes()
 	prefix := oc.Namespace()
 
@@ -200,7 +89,7 @@ func RemoveNFSBackedPersistentVolume(oc *CLI) error {
 		return err
 	}
 	for _, pv := range pvs.Items {
-		if !strings.HasPrefix(pv.Name, prefix) {
+		if !strings.HasPrefix(pv.Name, fmt.Sprintf("%s%s", pvPrefix, prefix)) {
 			e2e.Logf("Skipping removing persistent volume: %s", pv.Name)
 			continue
 		}


### PR DESCRIPTION
This pull request is intended to build upon the NFS backed persistent volumes introduced in #18708 for the Jenkins extended tests.
The main goal is to remove the dependency on host path volumes for persistent volumes in our tests so that they can be run in parallel across a cluster.

Fixes #7102