### PR TITLE
Fix multicast test problems

### DIFF
--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -104,9 +104,7 @@ func testMulticast(f *e2e.Framework, oc *testexutil.CLI) error {
 	for i := range pod {
 		pod[i] = fmt.Sprintf("multicast-%d", i)
 		ip[i], err[i] = launchTestMulticastPod(f, nodes.Items[i/2].Name, pod[i])
-		if err[i] != nil {
-			return err[i]
-		}
+		expectNoError(err[i])
 		var zero int64
 		defer f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(pod[i], &metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		matchIP[i] = regexp.MustCompile(ip[i] + ".*multicast.*1/1/0%")

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -431,3 +431,24 @@ func InNetworkPolicyContext(body func()) {
 		body()
 	})
 }
+
+func InPluginContext(plugins []string, body func()) {
+	Context(fmt.Sprintf("when using one of the plugins '%s'", strings.Join(plugins, ", ")),
+		func() {
+			BeforeEach(func() {
+				found := false
+				for _, plugin := range plugins {
+					if networkPluginName() == plugin {
+						found = true
+						break
+					}
+				}
+				if !found {
+					e2e.Skipf("Not using one of the specified plugins")
+				}
+			})
+
+			body()
+		},
+	)
+}


### PR DESCRIPTION
Re-attempt of #18978 which mistakenly merged in a broken state (due to disabled CI tests) and then had to be reverted.

1. Makes the multicast test get run under ovs-networkpolicy
2. Makes the "ensure multicast doesn't work" tests fail rather than passing if the test can't even be set up
3. Makes the multicast test clear namespace node-selectors and also try to obey scheduling restrictions. (This is redundant but it's what the other networking tests do, probably because there's no way to figure out the cluster-wide default node selector.)
