### PR TITLE
Remove MarkFlagRequired from oc adm migrate

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -4576,8 +4576,6 @@ _oc_adm_migrate_image-references()
     flags+=("--vmodule=")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -4661,8 +4659,6 @@ _oc_adm_migrate_legacy-hpa()
     flags+=("--vmodule=")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -4746,8 +4742,6 @@ _oc_adm_migrate_storage()
     flags+=("--vmodule=")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -4718,8 +4718,6 @@ _oc_adm_migrate_image-references()
     flags+=("--vmodule=")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -4803,8 +4801,6 @@ _oc_adm_migrate_legacy-hpa()
     flags+=("--vmodule=")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -4888,8 +4884,6 @@ _oc_adm_migrate_storage()
     flags+=("--vmodule=")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--filename=")
-    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }

--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -95,7 +95,6 @@ func (o *ResourceOptions) Bind(c *cobra.Command) {
 
 	usage := "Filename, directory, or URL to docker-compose.yml file to use"
 	kubectl.AddJsonFilenameFlag(c, &o.Filenames, usage)
-	c.MarkFlagRequired("filename")
 }
 
 func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error {


### PR DESCRIPTION
Currently `oc adm migrate {storage, etcd-ttl, legacy-hpa}` does not
display all available options since `MarkFlagRequired` is enabled
for `filename` option.

current:
```
$ oc adm migrate storage -<TAB> <TAB>
-f           --filename=
```

To fix this problem, this patch removes `MarkFlagRequired` from
`migrator.go` and makes completion display all available options.

fixed:
```
$ oc adm migrate storage -<TAB><TAB>
--all-namespaces               --client-certificate=          --filename=                    --logspec=                     --server=                      --to-key=
--allow-missing-template-keys  --client-key=                  --from-key=                    --match-server-version         --show-all                     --user=
  (snip)
```