### PR TITLE
turn off jenkins update center sync in extended tests, save cpu/mem, …

### DIFF
--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -98,7 +98,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 			}
 
 			// our pipeline jobs, between jenkins and oc invocations, need more mem than the default
-			newAppArgs := []string{"-f", jenkinsTemplatePath, "-p", "MEMORY_LIMIT=2Gi"}
+			newAppArgs := []string{"-f", jenkinsTemplatePath, "-p", "MEMORY_LIMIT=2Gi", "-p", "DISABLE_ADMINISTRATIVE_MONITORS=true"}
 			clientPluginNewAppArgs, useClientPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalClientPluginSnapshotEnvVarName, localClientPluginSnapshotImage, localClientPluginSnapshotImageStream, newAppArgs, oc)
 			syncPluginNewAppArgs, useSyncPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalSyncPluginSnapshotEnvVarName, localSyncPluginSnapshotImage, localSyncPluginSnapshotImageStream, newAppArgs, oc)
 

--- a/test/extended/image_ecosystem/jenkins_plugin.go
+++ b/test/extended/image_ecosystem/jenkins_plugin.go
@@ -175,7 +175,8 @@ var _ = g.Describe("[image_ecosystem][jenkins][Slow] openshift pipeline plugin",
 			var licensePrefix, pluginName string
 			// with the startup costs now of jenkins 2.89 or greater and trying to incur those during startup, need more memory
 			// to avoid deployment timeouts
-			newAppArgs := []string{"-f", exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json"), "-p", "MEMORY_LIMIT=2Gi"}
+			newAppArgs := []string{"-f", exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json"), "-p", "MEMORY_LIMIT=2Gi", "-p", "DISABLE_ADMINISTRATIVE_MONITORS=true"}
+
 			useSnapshotImage := false
 			origPluginNewAppArgs, useOrigPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalPluginSnapshotEnvVarName, localPluginSnapshotImage, localPluginSnapshotImageStream, newAppArgs, oc)
 			loginPluginNewAppArgs, useLoginPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalLoginPluginSnapshotEnvVarName, localLoginPluginSnapshotImage, localLoginPluginSnapshotImageStream, newAppArgs, oc)


### PR DESCRIPTION
…prevent test flakes

@openshift/sig-developer-experience fyi / ptal

this is the last of the currently known set of changes to minimize jenkins ext test flakes resulting from constrained mem/cpu

fyi, the `DISABLE_ADMINISTRATIVE_MONITORS=true` in particular is something @bparees and I have discussed as an item we want done in starter online ... just need to figure out how to manage that, but not set it in OCP and our default templates, etc.