### PR TITLE
dind: crio runtime fixes

### DIFF
--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -80,7 +80,7 @@ function start() {
     # dockershim is default and doesn't need an endpoint path
     runtime_endpoint=
   elif [[ "${container_runtime}" = "crio" ]]; then
-    runtime_endpoint="/var/run/crio.sock"
+    runtime_endpoint="unix:///var/run/crio/crio.sock"
   else
     >&2 echo "Invalid container runtime: ${container_runtime}"
     exit 1

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -88,3 +88,6 @@ RUN systemctl enable ovn-kubernetes-node.service
 COPY crio-node.sh /usr/local/bin/
 COPY crio-node.service /etc/systemd/system/
 RUN systemctl enable crio-node.service
+
+# Default crio storage to vfs. overlay on overlayfs is not supported in crio.
+RUN echo "CRIO_STORAGE_OPTIONS=--storage-driver vfs" > /etc/sysconfig/crio-storage

--- a/images/dind/node/crio-node.sh
+++ b/images/dind/node/crio-node.sh
@@ -4,7 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source /usr/local/bin/openshift-dind-lib.sh
 source /data/dind-env
 
 if [[ "${OPENSHIFT_CONTAINER_RUNTIME}" = "crio" ]]; then


### PR DESCRIPTION
- Fix runtime endpoint for crio
- Use vfs storage driver for crio as overlay on overlayfs is not supported