### PR TITLE
Pick build container for logs with istio auto-inject - fixes #18997

### DIFF
--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -87,7 +87,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 			ServiceAccountName: serviceAccount,
 			Containers: []v1.Container{
 				{
-					Name:  "custom-build",
+					Name:  customBuild,
 					Image: strategy.From.Name,
 					Env:   containerEnv,
 					// TODO: run unprivileged https://github.com/openshift/origin/issues/662

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -51,8 +51,8 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	}
 
 	container := actual.Spec.Containers[0]
-	if container.Name != "custom-build" {
-		t.Errorf("Expected custom-build, but got %s!", container.Name)
+	if container.Name != customBuild {
+		t.Errorf("Expected %s, but got %s!", customBuild, container.Name)
 	}
 	if container.ImagePullPolicy != v1.PullIfNotPresent {
 		t.Errorf("Expected %v, got %v", v1.PullIfNotPresent, container.ImagePullPolicy)

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -57,7 +57,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 			ServiceAccountName: serviceAccount,
 			Containers: []v1.Container{
 				{
-					Name:    "docker-build",
+					Name:    dockerBuild,
 					Image:   bs.Image,
 					Command: []string{"openshift-docker-build"},
 					Env:     copyEnvVarSlice(containerEnv),

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -43,8 +43,8 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	}
 
 	container := actual.Spec.Containers[0]
-	if container.Name != "docker-build" {
-		t.Errorf("Expected docker-build, but got %s!", container.Name)
+	if container.Name != dockerBuild {
+		t.Errorf("Expected %s, but got %s!", dockerBuild, container.Name)
 	}
 	if container.Image != strategy.Image {
 		t.Errorf("Expected %s image, got %s!", container.Image, strategy.Image)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -80,7 +80,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 			ServiceAccountName: serviceAccount,
 			Containers: []v1.Container{
 				{
-					Name:    "sti-build",
+					Name:    stiBuild,
 					Image:   bs.Image,
 					Command: []string{"openshift-sti-build"},
 					Env:     copyEnvVarSlice(containerEnv),

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -75,8 +75,8 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	}
 
 	container := actual.Spec.Containers[0]
-	if container.Name != "sti-build" {
-		t.Errorf("Expected sti-build, but got %s!", container.Name)
+	if container.Name != stiBuild {
+		t.Errorf("Expected %s, but got %s!", stiBuild, container.Name)
 	}
 	if container.Image != strategy.Image {
 		t.Errorf("Expected %s image, got %s!", container.Image, strategy.Image)

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -40,6 +40,14 @@ const (
 	GitCloneContainer = "git-clone"
 )
 
+const (
+	customBuild = "custom-build"
+	stiBuild    = "sti-build"
+	dockerBuild = "docker-build"
+)
+
+var BuildContainerNames = []string{customBuild, stiBuild, dockerBuild}
+
 var (
 	// BuildControllerRefKind contains the schema.GroupVersionKind for builds.
 	// This is used in the ownerRef of builder pods.


### PR DESCRIPTION
When using istio auto-inject, the build pod is enhanced with a container sidecar - proxy https://github.com/openshift/origin/issues/18997

Given the build pod container name can change and istio appends its containers to the end of the container list, it should be possible to treat the first container in the pod's container list as the desired build container.

@openshift/sig-developer-experience any better suggestions? Do we want to stream the logs from all containers in builder pod instead?