### PR TITLE
http port should not be configured for ssl

### DIFF
--- a/images/router/nginx/conf/nginx-config.template
+++ b/images/router/nginx/conf/nginx-config.template
@@ -51,7 +51,6 @@ http {
  {{- if (eq $cfg.TLSTermination "") }}
     listen          80;
  {{- else }}
-    listen          80 ssl;
     listen          443 ssl;
  {{ end -}}
  


### PR DESCRIPTION
Minor fix. Or when both ssl/plain routes are present, the health checks begin to fail.