### PR TITLE
Enable async binding in service-catalog

### DIFF
--- a/examples/OWNERS
+++ b/examples/OWNERS
@@ -9,3 +9,4 @@ approvers:
   - bparees
   - smarterclayton
   - csrwng
+  - pmorie

--- a/examples/service-catalog/service-catalog.yaml
+++ b/examples/service-catalog/service-catalog.yaml
@@ -366,6 +366,8 @@ objects:
           - "5m"
           - --feature-gates
           - OriginatingIdentity=true
+          - --feature-gates
+          - AsyncBindingOperations=true
           image: ${SERVICE_CATALOG_IMAGE}
           imagePullPolicy: IfNotPresent
           name: controller-manager

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14838,6 +14838,8 @@ objects:
           - "5m"
           - --feature-gates
           - OriginatingIdentity=true
+          - --feature-gates
+          - AsyncBindingOperations=true
           image: ${SERVICE_CATALOG_IMAGE}
           imagePullPolicy: IfNotPresent
           name: controller-manager


### PR DESCRIPTION
Enables the async binding feature of service catalog when created with `oc cluster up`