### PR TITLE
[3.9] Make NewCommandStartNode() handle SIGTERM and SIGINT

### DIFF
--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"time"
 
+	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
 
 	"github.com/openshift/origin/pkg/cmd/openshift"
@@ -32,7 +33,7 @@ func main() {
 	}
 
 	basename := filepath.Base(os.Args[0])
-	command := openshift.CommandFor(basename)
+	command := openshift.CommandFor(basename, server.SetupSignalHandler())
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -39,7 +39,7 @@ var (
 
 // CommandFor returns the appropriate command for this base name,
 // or the global OpenShift command
-func CommandFor(basename string) *cobra.Command {
+func CommandFor(basename string, stopCh <-chan struct{}) *cobra.Command {
 	var cmd *cobra.Command
 
 	out := os.Stdout
@@ -70,9 +70,9 @@ func CommandFor(basename string) *cobra.Command {
 	case "openshift-extract-image-content":
 		cmd = builder.NewCommandExtractImageContent(basename)
 	case "origin":
-		cmd = NewCommandOpenShift(basename)
+		cmd = NewCommandOpenShift(basename, stopCh)
 	default:
-		cmd = NewCommandOpenShift("openshift")
+		cmd = NewCommandOpenShift("openshift", stopCh)
 	}
 
 	if cmd.UsageFunc() == nil {
@@ -84,7 +84,7 @@ func CommandFor(basename string) *cobra.Command {
 }
 
 // NewCommandOpenShift creates the standard OpenShift command
-func NewCommandOpenShift(name string) *cobra.Command {
+func NewCommandOpenShift(name string, stopCh <-chan struct{}) *cobra.Command {
 	out, errout := os.Stdout, os.Stderr
 
 	root := &cobra.Command{
@@ -94,7 +94,7 @@ func NewCommandOpenShift(name string) *cobra.Command {
 		Run:   kcmdutil.DefaultSubCommandRun(out),
 	}
 
-	startAllInOne, _ := start.NewCommandStartAllInOne(name, out, errout)
+	startAllInOne, _ := start.NewCommandStartAllInOne(name, out, errout, stopCh)
 	root.AddCommand(startAllInOne)
 	root.AddCommand(newCompletionCommand("completion", name+" completion"))
 	root.AddCommand(cmdversion.NewCmdVersion(name, osversion.Get(), os.Stdout))

--- a/pkg/cmd/openshift/openshift_test.go
+++ b/pkg/cmd/openshift/openshift_test.go
@@ -3,15 +3,17 @@ package openshift
 import (
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestCommandFor(t *testing.T) {
-	cmd := CommandFor("openshift-router")
+	cmd := CommandFor("openshift-router", wait.NeverStop)
 	if !strings.HasPrefix(cmd.Use, "openshift-router ") {
 		t.Errorf("expected command to start with prefix: %#v", cmd)
 	}
 
-	cmd = CommandFor("unknown")
+	cmd = CommandFor("unknown", wait.NeverStop)
 	if cmd.Use != "openshift" {
 		t.Errorf("expected command to be openshift: %#v", cmd)
 	}

--- a/pkg/cmd/server/start/command_test.go
+++ b/pkg/cmd/server/start/command_test.go
@@ -19,6 +19,7 @@ import (
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
+	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 )
 
@@ -227,7 +228,7 @@ func executeAllInOneCommandWithConfigs(args []string) (*MasterArgs, *configapi.M
 		},
 	}
 
-	openshiftStartCommand, cfg := NewCommandStartAllInOne("openshift start", os.Stdout, os.Stderr)
+	openshiftStartCommand, cfg := NewCommandStartAllInOne("openshift start", os.Stdout, os.Stderr, wait.NeverStop)
 	root.AddCommand(openshiftStartCommand)
 	root.SetArgs(argsToUse)
 	root.Execute()

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -65,7 +65,7 @@ var allInOneLong = templates.LongDesc(`
 	You may also pass --etcd=<address> to connect to an external etcd server.`)
 
 // NewCommandStartAllInOne provides a CLI handler for 'start' command
-func NewCommandStartAllInOne(basename string, out, errout io.Writer) (*cobra.Command, *AllInOneOptions) {
+func NewCommandStartAllInOne(basename string, out, errout io.Writer, stopCh <-chan struct{}) (*cobra.Command, *AllInOneOptions) {
 	options := &AllInOneOptions{
 		MasterOptions: &MasterOptions{
 			Output: out,
@@ -122,7 +122,7 @@ func NewCommandStartAllInOne(basename string, out, errout io.Writer) (*cobra.Com
 	BindImageFormatArgs(imageFormatArgs, flags, "")
 
 	startMaster, _ := NewCommandStartMaster(basename, out, errout)
-	startNode, _ := NewCommandStartNode(basename, out, errout)
+	startNode, _ := NewCommandStartNode(basename, out, errout, stopCh)
 	startNodeNetwork, _ := NewCommandStartNetwork(basename, out, errout)
 	startEtcdServer, _ := NewCommandStartEtcdServer(RecommendedStartEtcdServerName, basename, out, errout)
 	startTSBServer := tsbcmd.NewCommandStartTemplateServiceBrokerServer(out, errout, wait.NeverStop)

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -67,7 +67,7 @@ var nodeLong = templates.LongDesc(`
 	`)
 
 // NewCommandStartNode provides a CLI handler for 'start node' command
-func NewCommandStartNode(basename string, out, errout io.Writer) (*cobra.Command, *NodeOptions) {
+func NewCommandStartNode(basename string, out, errout io.Writer, stopCh <-chan struct{}) (*cobra.Command, *NodeOptions) {
 	options := &NodeOptions{
 		ExpireDays: crypto.DefaultCertificateLifetimeInDays,
 		Output:     out,
@@ -78,7 +78,7 @@ func NewCommandStartNode(basename string, out, errout io.Writer) (*cobra.Command
 		Short: "Launch a node",
 		Long:  fmt.Sprintf(nodeLong, basename),
 		Run: func(c *cobra.Command, args []string) {
-			options.Run(c, errout, args)
+			options.Run(c, errout, args, stopCh)
 		},
 	}
 
@@ -121,7 +121,7 @@ func NewCommandStartNetwork(basename string, out, errout io.Writer) (*cobra.Comm
 		Short: "Launch node network",
 		Long:  fmt.Sprintf(networkLong, basename),
 		Run: func(c *cobra.Command, args []string) {
-			options.Run(c, errout, args)
+			options.Run(c, errout, args, wait.NeverStop)
 		},
 	}
 
@@ -142,13 +142,13 @@ func NewCommandStartNetwork(basename string, out, errout io.Writer) (*cobra.Comm
 	return cmd, options
 }
 
-func (options *NodeOptions) Run(c *cobra.Command, errout io.Writer, args []string) {
+func (options *NodeOptions) Run(c *cobra.Command, errout io.Writer, args []string, stopCh <-chan struct{}) {
 	kcmdutil.CheckErr(options.Complete(c))
 	kcmdutil.CheckErr(options.Validate(args))
 
 	startProfiler()
 
-	if err := options.StartNode(); err != nil {
+	if err := options.StartNode(stopCh); err != nil {
 		if kerrors.IsInvalid(err) {
 			if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
 				fmt.Fprintf(errout, "Invalid %s %s\n", details.Kind, details.Name)
@@ -207,7 +207,7 @@ func (o NodeOptions) Complete(cmd *cobra.Command) error {
 }
 
 // StartNode calls RunNode and then waits forever
-func (o NodeOptions) StartNode() error {
+func (o NodeOptions) StartNode(stopCh <-chan struct{}) error {
 	if err := o.RunNode(); err != nil {
 		return err
 	}
@@ -217,7 +217,8 @@ func (o NodeOptions) StartNode() error {
 	}
 
 	go daemon.SdNotify(false, "READY=1")
-	select {}
+	<-stopCh
+	return nil
 }
 
 // RunNode takes the options and:

--- a/tools/clicheck/check_cli_conventions.go
+++ b/tools/clicheck/check_cli_conventions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/openshift"
 	cmdsanity "github.com/openshift/origin/tools/clicheck/sanity"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
@@ -22,7 +23,7 @@ var (
 func main() {
 	errors := []error{}
 
-	oc := openshift.NewCommandOpenShift("openshift")
+	oc := openshift.NewCommandOpenShift("openshift", wait.NeverStop)
 	result := cmdsanity.CheckCmdTree(oc, cmdsanity.AllCmdChecks, skip)
 	errors = append(errors, result...)
 

--- a/tools/genman/gen_man.go
+++ b/tools/genman/gen_man.go
@@ -12,6 +12,7 @@ import (
 	mangen "github.com/openshift/origin/tools/genman/md2man"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/cmd/genutils"
 )
 
@@ -24,7 +25,7 @@ func main() {
 	if strings.HasSuffix(os.Args[2], "oc") {
 		genCmdMan("oc", cli.NewCommandCLI("oc", "oc", &bytes.Buffer{}, os.Stdout, ioutil.Discard))
 	} else if strings.HasSuffix(os.Args[2], "openshift") {
-		genCmdMan("openshift", openshift.NewCommandOpenShift("openshift"))
+		genCmdMan("openshift", openshift.NewCommandOpenShift("openshift", wait.NeverStop))
 	} else {
 		fmt.Fprintf(os.Stderr, "Root command not specified (oc | openshift).")
 		os.Exit(1)


### PR DESCRIPTION
This commit threads a stop channel into NewCommandOpenShift() so that
SIGTERM and SIGINT can be handled gracefully.

This commit only updates NewCommandStartNode() to handle the stop
channel, which is only signalled on receipt of either SIGTERM or
SIGINT. Existing usages of NewCommandStart*() (e.g., StartMaster(),
StartNetwork(), StartEtcdServer(), StartTemplateServiceBroker(), et
al) remain as is.

Now when you run:

    # systemctl stop atomic-openshift-node
    # systemctl status atomic-openshift-node

it has the opportunity to unwind and return EXIT_SUCCESS (i.e., 0).
For example:

    Process: 6801 ExecStart=/usr/bin/openshift start node \
        --config=${CONFIG_FILE} $OPTIONS (code=exited, status=0/SUCCESS)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1557851

Picked from: https://github.com/openshift/origin/pull/19063