### PR TITLE
Prevent incorrect deletion of HostSubnet OVS flows

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -114,8 +114,6 @@ type OsdnNode struct {
 	host             knetwork.Host
 	kubeletCniPlugin knetwork.NetworkPlugin
 
-	hostSubnetMap map[string]*networkapi.HostSubnet
-
 	kubeInformers    kinternalinformers.SharedInformerFactory
 	networkInformers networkinformers.SharedInformerFactory
 
@@ -183,7 +181,6 @@ func New(c *OsdnNodeConfig) (network.NodeInterface, error) {
 		mtu:                c.MTU,
 		egressPolicies:     make(map[uint32][]networkapi.EgressNetworkPolicy),
 		egressDNS:          common.NewEgressDNS(),
-		hostSubnetMap:      make(map[string]*networkapi.HostSubnet),
 		kubeInformers:      c.KubeInformers,
 		networkInformers:   c.NetworkInformers,
 		egressIP:           newEgressIPWatcher(oc, c.SelfIP, c.MasqueradeBit),
@@ -333,7 +330,8 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("node SDN setup failed: %v", err)
 	}
 
-	node.SubnetStartNode()
+	hsw := newHostSubnetWatcher(node.oc, node.localIP, node.networkInfo)
+	hsw.Start(node.networkInformers)
 
 	if err = node.policy.Start(node); err != nil {
 		return err

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -3,6 +3,7 @@
 package node
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"net"
 	"sort"
@@ -34,7 +35,7 @@ const (
 	Vxlan0 = "vxlan0"
 
 	// rule versioning; increment each time flow rules change
-	ruleVersion = 6
+	ruleVersion = 7
 
 	ruleVersionTable = 253
 )
@@ -503,26 +504,34 @@ func (oc *ovsController) UpdateEgressNetworkPolicyRules(policies []networkapi.Eg
 	}
 }
 
+func hostSubnetCookie(subnet *networkapi.HostSubnet) uint32 {
+	hash := sha256.Sum256([]byte(subnet.UID))
+	return (uint32(hash[0]) << 24) | (uint32(hash[1]) << 16) | (uint32(hash[2]) << 8) | uint32(hash[3])
+}
+
 func (oc *ovsController) AddHostSubnetRules(subnet *networkapi.HostSubnet) error {
+	cookie := hostSubnetCookie(subnet)
 	otx := oc.ovs.NewTransaction()
 
-	otx.AddFlow("table=10, priority=100, tun_src=%s, actions=goto_table:30", subnet.HostIP)
+	otx.AddFlow("table=10, priority=100, cookie=0x%08x, tun_src=%s, actions=goto_table:30", cookie, subnet.HostIP)
 	if vnid, ok := subnet.Annotations[networkapi.FixedVNIDHostAnnotation]; ok {
-		otx.AddFlow("table=50, priority=100, arp, nw_dst=%s, actions=load:%s->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, vnid, subnet.HostIP)
-		otx.AddFlow("table=90, priority=100, ip, nw_dst=%s, actions=load:%s->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, vnid, subnet.HostIP)
+		otx.AddFlow("table=50, priority=100, cookie=0x%08x, arp, nw_dst=%s, actions=load:%s->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet.Subnet, vnid, subnet.HostIP)
+		otx.AddFlow("table=90, priority=100, cookie=0x%08x, ip, nw_dst=%s, actions=load:%s->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet.Subnet, vnid, subnet.HostIP)
 	} else {
-		otx.AddFlow("table=50, priority=100, arp, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, subnet.HostIP)
-		otx.AddFlow("table=90, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", subnet.Subnet, subnet.HostIP)
+		otx.AddFlow("table=50, priority=100, cookie=0x%08x, arp, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet.Subnet, subnet.HostIP)
+		otx.AddFlow("table=90, priority=100, cookie=0x%08x, ip, nw_dst=%s, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet.Subnet, subnet.HostIP)
 	}
 
 	return otx.EndTransaction()
 }
 
 func (oc *ovsController) DeleteHostSubnetRules(subnet *networkapi.HostSubnet) error {
+	cookie := hostSubnetCookie(subnet)
+
 	otx := oc.ovs.NewTransaction()
-	otx.DeleteFlows("table=10, tun_src=%s", subnet.HostIP)
-	otx.DeleteFlows("table=50, arp, nw_dst=%s", subnet.Subnet)
-	otx.DeleteFlows("table=90, ip, nw_dst=%s", subnet.Subnet)
+	otx.DeleteFlows("table=10, cookie=0x%08x, tun_src=%s", cookie, subnet.HostIP)
+	otx.DeleteFlows("table=50, cookie=0x%08x, arp, nw_dst=%s", cookie, subnet.Subnet)
+	otx.DeleteFlows("table=90, cookie=0x%08x, ip, nw_dst=%s", cookie, subnet.Subnet)
 	return otx.EndTransaction()
 }
 

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -103,62 +103,6 @@ func assertFlowChanges(origFlows, newFlows []string, changes ...flowChange) erro
 	return nil
 }
 
-func TestOVSHostSubnet(t *testing.T) {
-	ovsif, oc, origFlows := setupOVSController(t)
-
-	hs := networkapi.HostSubnet{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "HostSubnet",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "node2",
-		},
-		Host:   "node2",
-		HostIP: "192.168.1.2",
-		Subnet: "10.129.0.0/23",
-	}
-	err := oc.AddHostSubnetRules(&hs)
-	if err != nil {
-		t.Fatalf("Unexpected error adding HostSubnet rules: %v", err)
-	}
-
-	flows, err := ovsif.DumpFlows("")
-	if err != nil {
-		t.Fatalf("Unexpected error dumping flows: %v", err)
-	}
-	err = assertFlowChanges(origFlows, flows,
-		flowChange{
-			kind:  flowAdded,
-			match: []string{"table=10", "tun_src=192.168.1.2"},
-		},
-		flowChange{
-			kind:  flowAdded,
-			match: []string{"table=50", "arp", "arp_tpa=10.129.0.0/23", "192.168.1.2->tun_dst"},
-		},
-		flowChange{
-			kind:  flowAdded,
-			match: []string{"table=90", "ip", "nw_dst=10.129.0.0/23", "192.168.1.2->tun_dst"},
-		},
-	)
-	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
-	}
-
-	err = oc.DeleteHostSubnetRules(&hs)
-	if err != nil {
-		t.Fatalf("Unexpected error deleting HostSubnet rules: %v", err)
-	}
-	flows, err = ovsif.DumpFlows("")
-	if err != nil {
-		t.Fatalf("Unexpected error dumping flows: %v", err)
-	}
-	err = assertFlowChanges(origFlows, flows) // no changes
-
-	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
-	}
-}
-
 func TestOVSService(t *testing.T) {
 	ovsif, oc, origFlows := setupOVSController(t)
 
@@ -361,10 +305,9 @@ func TestGetPodDetails(t *testing.T) {
 	}
 }
 
-func TestOVSMulticast(t *testing.T) {
+func TestOVSLocalMulticast(t *testing.T) {
 	ovsif, oc, origFlows := setupOVSController(t)
 
-	// local flows
 	err := oc.UpdateLocalMulticastFlows(99, true, []int{4, 5, 6})
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
@@ -402,67 +345,6 @@ func TestOVSMulticast(t *testing.T) {
 	}
 
 	err = oc.UpdateLocalMulticastFlows(99, false, []int{4, 5})
-	if err != nil {
-		t.Fatalf("Unexpected error adding multicast flows: %v", err)
-	}
-	flows, err = ovsif.DumpFlows("")
-	if err != nil {
-		t.Fatalf("Unexpected error dumping flows: %v", err)
-	}
-	err = assertFlowChanges(origFlows, flows) // no changes
-	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
-	}
-
-	// VXLAN
-	err = oc.UpdateVXLANMulticastFlows([]string{"192.168.1.2", "192.168.1.5", "192.168.1.3"})
-	if err != nil {
-		t.Fatalf("Unexpected error adding multicast flows: %v", err)
-	}
-	flows, err = ovsif.DumpFlows("")
-	if err != nil {
-		t.Fatalf("Unexpected error dumping flows: %v", err)
-	}
-	err = assertFlowChanges(origFlows, flows,
-		flowChange{
-			kind:    flowRemoved,
-			match:   []string{"table=111", "goto_table:120"},
-			noMatch: []string{"->tun_dst"},
-		},
-		flowChange{
-			kind:  flowAdded,
-			match: []string{"table=111", "192.168.1.2->tun_dst", "192.168.1.3->tun_dst", "192.168.1.5->tun_dst"},
-		},
-	)
-	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
-	}
-
-	err = oc.UpdateVXLANMulticastFlows([]string{"192.168.1.5", "192.168.1.3"})
-	if err != nil {
-		t.Fatalf("Unexpected error adding multicast flows: %v", err)
-	}
-	flows, err = ovsif.DumpFlows("")
-	if err != nil {
-		t.Fatalf("Unexpected error dumping flows: %v", err)
-	}
-	err = assertFlowChanges(origFlows, flows,
-		flowChange{
-			kind:    flowRemoved,
-			match:   []string{"table=111", "goto_table:120"},
-			noMatch: []string{"->tun_dst"},
-		},
-		flowChange{
-			kind:    flowAdded,
-			match:   []string{"table=111", "192.168.1.3->tun_dst", "192.168.1.5->tun_dst"},
-			noMatch: []string{"192.168.1.2"},
-		},
-	)
-	if err != nil {
-		t.Fatalf("Unexpected flow changes: %v\nOrig: %#v\nNew: %#v", err, origFlows, flows)
-	}
-
-	err = oc.UpdateVXLANMulticastFlows([]string{})
 	if err != nil {
 		t.Fatalf("Unexpected error adding multicast flows: %v", err)
 	}

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/golang/glog"
 
-	networkapi "github.com/openshift/origin/pkg/network/apis/network"
-	"github.com/openshift/origin/pkg/network/common"
 	"github.com/openshift/origin/pkg/util/netutils"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -205,20 +203,6 @@ func (plugin *OsdnNode) updateEgressNetworkPolicyRules(vnid uint32) {
 	namespaces := plugin.policy.GetNamespaces(vnid)
 	if err := plugin.oc.UpdateEgressNetworkPolicyRules(policies, vnid, namespaces, plugin.egressDNS); err != nil {
 		utilruntime.HandleError(fmt.Errorf("Error updating OVS flows for EgressNetworkPolicy: %v", err))
-	}
-}
-
-func (plugin *OsdnNode) AddHostSubnetRules(subnet *networkapi.HostSubnet) {
-	glog.Infof("AddHostSubnetRules for %s", common.HostSubnetToString(subnet))
-	if err := plugin.oc.AddHostSubnetRules(subnet); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error adding OVS flows for subnet %q: %v", subnet.Subnet, err))
-	}
-}
-
-func (plugin *OsdnNode) DeleteHostSubnetRules(subnet *networkapi.HostSubnet) {
-	glog.Infof("DeleteHostSubnetRules for %s", common.HostSubnetToString(subnet))
-	if err := plugin.oc.DeleteHostSubnetRules(subnet); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error deleting OVS flows for subnet %q: %v", subnet.Subnet, err))
 	}
 }
 

--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -76,7 +76,7 @@ func (hsw *hostSubnetWatcher) updateHostSubnet(hs *networkapi.HostSubnet) error 
 		}
 	}
 	if err := hsw.networkInfo.ValidateNodeIP(hs.HostIP); err != nil {
-		return fmt.Errorf("Ignoring invalid subnet for node %s: %v", hs.HostIP, err)
+		return fmt.Errorf("ignoring invalid subnet for node %s: %v", hs.HostIP, err)
 	}
 
 	hsw.hostSubnetMap[hs.UID] = hs

--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -10,21 +10,118 @@ import (
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/common"
+	networkinformers "github.com/openshift/origin/pkg/network/generated/informers/internalversion"
 )
 
-func (node *OsdnNode) SubnetStartNode() {
-	node.watchSubnets()
+type hostSubnetWatcher struct {
+	oc          *ovsController
+	localIP     string
+	networkInfo *common.NetworkInfo
+
+	hostSubnetMap map[ktypes.UID]*networkapi.HostSubnet
 }
 
-func (node *OsdnNode) watchSubnets() {
-	funcs := common.InformerFuncs(&networkapi.HostSubnet{}, node.handleAddOrUpdateHostSubnet, node.handleDeleteHostSubnet)
-	node.networkInformers.Network().InternalVersion().HostSubnets().Informer().AddEventHandler(funcs)
+func newHostSubnetWatcher(oc *ovsController, localIP string, networkInfo *common.NetworkInfo) *hostSubnetWatcher {
+	return &hostSubnetWatcher{
+		oc:          oc,
+		localIP:     localIP,
+		networkInfo: networkInfo,
+
+		hostSubnetMap: make(map[ktypes.UID]*networkapi.HostSubnet),
+	}
+}
+
+func (hsw *hostSubnetWatcher) Start(networkInformers networkinformers.SharedInformerFactory) {
+	funcs := common.InformerFuncs(&networkapi.HostSubnet{}, hsw.handleAddOrUpdateHostSubnet, hsw.handleDeleteHostSubnet)
+	networkInformers.Network().InternalVersion().HostSubnets().Informer().AddEventHandler(funcs)
+}
+
+func (hsw *hostSubnetWatcher) handleAddOrUpdateHostSubnet(obj, _ interface{}, eventType watch.EventType) {
+	hs := obj.(*networkapi.HostSubnet)
+	glog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
+
+	if err := hsw.updateHostSubnet(hs); err != nil {
+		utilruntime.HandleError(err)
+	}
+}
+
+func (hsw *hostSubnetWatcher) handleDeleteHostSubnet(obj interface{}) {
+	hs := obj.(*networkapi.HostSubnet)
+	glog.V(5).Infof("Watch %s event for HostSubnet %q", watch.Deleted, hs.Name)
+
+	if err := hsw.deleteHostSubnet(hs); err != nil {
+		utilruntime.HandleError(err)
+	}
+}
+
+func (hsw *hostSubnetWatcher) updateHostSubnet(hs *networkapi.HostSubnet) error {
+	if hs.HostIP == hsw.localIP {
+		return nil
+	}
+	oldSubnet, exists := hsw.hostSubnetMap[hs.UID]
+	if exists {
+		if oldSubnet.HostIP == hs.HostIP {
+			return nil
+		} else {
+			// Delete old subnet rules (ignore errors)
+			hsw.oc.DeleteHostSubnetRules(oldSubnet)
+		}
+	}
+	if err := hsw.networkInfo.ValidateNodeIP(hs.HostIP); err != nil {
+		return fmt.Errorf("Ignoring invalid subnet for node %s: %v", hs.HostIP, err)
+	}
+
+	hsw.hostSubnetMap[hs.UID] = hs
+
+	errList := []error{}
+	if err := hsw.oc.AddHostSubnetRules(hs); err != nil {
+		errList = append(errList, fmt.Errorf("error adding OVS flows for subnet %q: %v", hs.Subnet, err))
+	}
+	// Update multicast rules after all other changes have been processed
+	if err := hsw.updateVXLANMulticastRules(); err != nil {
+		errList = append(errList, fmt.Errorf("error updating OVS VXLAN multicast flows: %v", err))
+	}
+
+	return kerrors.NewAggregate(errList)
+}
+
+func (hsw *hostSubnetWatcher) deleteHostSubnet(hs *networkapi.HostSubnet) error {
+	if hs.HostIP == hsw.localIP {
+		return nil
+	}
+	if _, exists := hsw.hostSubnetMap[hs.UID]; !exists {
+		return nil
+	}
+
+	delete(hsw.hostSubnetMap, hs.UID)
+
+	errList := []error{}
+	if err := hsw.oc.DeleteHostSubnetRules(hs); err != nil {
+		errList = append(errList, fmt.Errorf("error deleting OVS flows for subnet %q: %v", hs.Subnet, err))
+	}
+	if err := hsw.updateVXLANMulticastRules(); err != nil {
+		errList = append(errList, fmt.Errorf("error updating OVS VXLAN multicast flows: %v", err))
+	}
+
+	return kerrors.NewAggregate(errList)
+}
+
+func (hsw *hostSubnetWatcher) updateVXLANMulticastRules() error {
+	remoteIPs := make([]string, 0, len(hsw.hostSubnetMap))
+	for _, subnet := range hsw.hostSubnetMap {
+		if subnet.HostIP != hsw.localIP {
+			remoteIPs = append(remoteIPs, subnet.HostIP)
+		}
+	}
+	return hsw.oc.UpdateVXLANMulticastFlows(remoteIPs)
 }
 
 func (node *OsdnNode) getLocalSubnet() (string, error) {
@@ -67,60 +164,4 @@ func (node *OsdnNode) getLocalSubnet() (string, error) {
 	}
 
 	return subnet.Subnet, nil
-}
-
-func (node *OsdnNode) handleAddOrUpdateHostSubnet(obj, _ interface{}, eventType watch.EventType) {
-	hs := obj.(*networkapi.HostSubnet)
-	glog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
-
-	if hs.HostIP == node.localIP {
-		return
-	}
-	oldSubnet, exists := node.hostSubnetMap[string(hs.UID)]
-	if exists {
-		if oldSubnet.HostIP == hs.HostIP {
-			return
-		} else {
-			// Delete old subnet rules
-			node.DeleteHostSubnetRules(oldSubnet)
-		}
-	}
-	if err := node.networkInfo.ValidateNodeIP(hs.HostIP); err != nil {
-		glog.Warningf("Ignoring invalid subnet for node %s: %v", hs.HostIP, err)
-		return
-	}
-	node.AddHostSubnetRules(hs)
-	node.hostSubnetMap[string(hs.UID)] = hs
-
-	// Update multicast rules after all other changes have been processed
-	node.updateVXLANMulticastRules()
-}
-
-func (node *OsdnNode) handleDeleteHostSubnet(obj interface{}) {
-	hs := obj.(*networkapi.HostSubnet)
-	glog.V(5).Infof("Watch %s event for HostSubnet %q", watch.Deleted, hs.Name)
-
-	if hs.HostIP == node.localIP {
-		return
-	}
-	if _, exists := node.hostSubnetMap[string(hs.UID)]; !exists {
-		return
-	}
-
-	delete(node.hostSubnetMap, string(hs.UID))
-	node.DeleteHostSubnetRules(hs)
-
-	node.updateVXLANMulticastRules()
-}
-
-func (node *OsdnNode) updateVXLANMulticastRules() {
-	remoteIPs := make([]string, 0, len(node.hostSubnetMap))
-	for _, subnet := range node.hostSubnetMap {
-		if subnet.HostIP != node.localIP {
-			remoteIPs = append(remoteIPs, subnet.HostIP)
-		}
-	}
-	if err := node.oc.UpdateVXLANMulticastFlows(remoteIPs); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error updating OVS VXLAN multicast flows: %v", err))
-	}
 }

--- a/pkg/network/node/subnets_test.go
+++ b/pkg/network/node/subnets_test.go
@@ -1,0 +1,201 @@
+package node
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+
+	networkapi "github.com/openshift/origin/pkg/network/apis/network"
+	"github.com/openshift/origin/pkg/network/common"
+)
+
+func assertHostSubnetFlowChanges(hsw *hostSubnetWatcher, flows *[]string, changes ...flowChange) error {
+	oldFlows := *flows
+	newFlows, err := hsw.oc.ovs.DumpFlows("")
+	if err != nil {
+		return fmt.Errorf("unexpected error dumping OVS flows: %v", err)
+	}
+
+	err = assertFlowChanges(oldFlows, newFlows, changes...)
+	if err != nil {
+		return fmt.Errorf("unexpected flow changes: %v\nOrig:\n%s\nNew:\n%s", err,
+			strings.Join(oldFlows, "\n"), strings.Join(newFlows, "\n"))
+	}
+
+	*flows = newFlows
+	return nil
+}
+
+func setupHostSubnetWatcher(t *testing.T) (*hostSubnetWatcher, []string) {
+	_, oc, _ := setupOVSController(t)
+
+	networkInfo, err := common.ParseNetworkInfo(
+		[]networkapi.ClusterNetworkEntry{
+			{
+				CIDR:             "10.128.0.0/14",
+				HostSubnetLength: 9,
+			},
+		},
+		"172.30.0.0/16",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error parsing network info: %v", err)
+	}
+
+	hsw := newHostSubnetWatcher(oc, oc.localIP, networkInfo)
+
+	flows, err := hsw.oc.ovs.DumpFlows("")
+	if err != nil {
+		t.Fatalf("unexpected error dumping OVS flows: %v", err)
+	}
+
+	return hsw, flows
+}
+
+func makeHostSubnet(name, hostIP, subnet string) *networkapi.HostSubnet {
+	return &networkapi.HostSubnet{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "HostSubnet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  ktypes.UID(name + "-uid"),
+		},
+		Host:   name,
+		HostIP: hostIP,
+		Subnet: subnet,
+	}
+}
+
+func TestHostSubnetWatcher(t *testing.T) {
+	hsw, flows := setupHostSubnetWatcher(t)
+
+	hs1 := makeHostSubnet("node1", "192.168.0.2", "10.128.0.0/23")
+	hs2 := makeHostSubnet("node2", "192.168.1.2", "10.129.0.0/23")
+
+	err := hsw.updateHostSubnet(hs1)
+	if err != nil {
+		t.Fatalf("Unexpected error adding HostSubnet: %v", err)
+	}
+	err = assertHostSubnetFlowChanges(hsw, &flows,
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=10", "tun_src=192.168.0.2"},
+		},
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=50", "arp", "arp_tpa=10.128.0.0/23", "192.168.0.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=90", "ip", "nw_dst=10.128.0.0/23", "192.168.0.2->tun_dst"},
+		},
+		flowChange{
+			kind:    flowRemoved,
+			match:   []string{"table=111", "goto_table:120"},
+			noMatch: []string{"->tun_dst"},
+		},
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=111", "192.168.0.2->tun_dst"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	err = hsw.updateHostSubnet(hs2)
+	if err != nil {
+		t.Fatalf("Unexpected error adding HostSubnet: %v", err)
+	}
+	err = assertHostSubnetFlowChanges(hsw, &flows,
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=10", "tun_src=192.168.1.2"},
+		},
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=50", "arp", "arp_tpa=10.129.0.0/23", "192.168.1.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=90", "ip", "nw_dst=10.129.0.0/23", "192.168.1.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=111", "192.168.0.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowAdded,
+			match: []string{"table=111", "192.168.0.2->tun_dst", "192.168.1.2->tun_dst"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	err = hsw.deleteHostSubnet(hs1)
+	if err != nil {
+		t.Fatalf("Unexpected error deleting HostSubnet: %v", err)
+	}
+	err = assertHostSubnetFlowChanges(hsw, &flows,
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=10", "tun_src=192.168.0.2"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=50", "arp", "arp_tpa=10.128.0.0/23", "192.168.0.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=90", "ip", "nw_dst=10.128.0.0/23", "192.168.0.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=111", "192.168.0.2->tun_dst", "192.168.1.2->tun_dst"},
+		},
+		flowChange{
+			kind:    flowAdded,
+			match:   []string{"table=111", "192.168.1.2->tun_dst"},
+			noMatch: []string{"192.168.0.2"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	err = hsw.deleteHostSubnet(hs2)
+	if err != nil {
+		t.Fatalf("Unexpected error deleting HostSubnet: %v", err)
+	}
+	err = assertHostSubnetFlowChanges(hsw, &flows,
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=10", "tun_src=192.168.1.2"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=50", "arp", "arp_tpa=10.129.0.0/23", "192.168.1.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=90", "ip", "nw_dst=10.129.0.0/23", "192.168.1.2->tun_dst"},
+		},
+		flowChange{
+			kind:  flowRemoved,
+			match: []string{"table=111", "192.168.1.2->tun_dst"},
+		},
+		flowChange{
+			kind:    flowAdded,
+			match:   []string{"table=111", "goto_table:120"},
+			noMatch: []string{"tun_dst"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}


### PR DESCRIPTION
In certain circumstances we can end up with two HostSubnets having the same HostIP, which will then eventually cause nodes to delete the wrong flows:

1. node1 and node2 register with the master, the SDN master creates HostSubnets for them, and node0 observes this and creates OVS flows for them
2. The underlying VMs (or whatever) backing node1 and node2 are deleted. However, their Node objects are *not* deleted (and therefore neither are their HostSubnets).
3. node1 and node2 are recreated. Node2 comes up first, requests an IP address from its cloud/hypervisor, **and is given node1's old IP address**. It registers with the master, updating node2's Node with the new IP address. (There are now two Node objects claiming the same IP. This is apparently allowed.)
4. The SDN master sees that node2's Node's IP has changed, and changes node2's HostSubnet to match.  (There are now two HostSubnet objects claiming the same IP.)
5. node0 sees the HostSubnet update and responds by deleting its old node2 flows and creating new ones. (There are now two sets of OVS flows referring to the same node IP.)
6. Now node1 finishes booting, gets a new IP address, and updates its Node. The SDN master updates its HostSubnet. And node0 sees the update and tries to delete its old node1 flows, and accidentally ends up deleting one of the new node2 flows instead, because of the reused IP address.

This is related to #18617 but it's not the same bug; there the HostSubnet.Subnet field is changing, which would require that the HostSubnet was actually deleted and recreated. (Which means I still don't know what's really going on in #18617.)

Anyway, the fix I went with is to add a cookie based on the HostSubnet.UID to the OVS flows, and then delete based on that rather than on the HostIP/Subnet.

I don't think this problem affects any other OVS flows; pod and service IPs should actually be enforced to be unique, so this wouldn't be able to happen. But maybe we should do UID-based cookies on everything anyway?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538220