### PR TITLE
Add ValidArgs to rollout cancel

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -17230,6 +17230,7 @@ _oc_rollout_cancel()
 
     must_have_one_flag=()
     must_have_one_noun=()
+    must_have_one_noun+=("deploymentconfig")
     noun_aliases=()
 }
 

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -17372,6 +17372,7 @@ _oc_rollout_cancel()
 
     must_have_one_flag=()
     must_have_one_noun=()
+    must_have_one_noun+=("deploymentconfig")
     noun_aliases=()
 }
 

--- a/pkg/oc/cli/cmd/rollout/cancel.go
+++ b/pkg/oc/cli/cmd/rollout/cancel.go
@@ -64,6 +64,7 @@ func NewCmdRolloutCancel(fullName string, f *clientcmd.Factory, out io.Writer) *
 			kcmdutil.CheckErr(opts.Complete(f, cmd, out, args))
 			kcmdutil.CheckErr(opts.Run())
 		},
+		ValidArgs: []string{"deploymentconfig"},
 	}
 	usage := "Filename, directory, or URL to a file identifying the resource to get from a server."
 	kcmdutil.AddFilenameOptionFlags(cmd, &opts.FilenameOptions, usage)


### PR DESCRIPTION
This patch makes a tiny change to add ValidArgs so that  users can get
completion when it runs `oc rollout cancel <TAB><TAB>`.