### PR TITLE
Fix invalid link for kubeconfig

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -708,7 +708,7 @@ This destroys the session token, preventing further access until next login (wit
 
 ### oc config
 
-This manages the OpenShift [kubeconfig files](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/kubeconfig-file.md).
+This manages the OpenShift [kubeconfig files](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 The general form is:
 
 ```bash

--- a/pkg/oc/cli/cmd/wrappers.go
+++ b/pkg/oc/cli/cmd/wrappers.go
@@ -723,7 +723,7 @@ var (
 		config). When you login the first time, a new config file is created, and subsequent project changes with the
 		'project' command will set the current context. These subcommands allow you to manage the config directly.
 
-		Reference: https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/kubeconfig-file.md`)
+		Reference: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/`)
 
 	configExample = templates.Examples(`
 		# Change the config context to use


### PR DESCRIPTION
Original link was https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/user-guide/kubeconfig-file.md .

I wondered updating to https://docs.openshift.org/latest/cli_reference/get_started_cli.html, but probably https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/ is close.