### PR TITLE
Adding additional logging for tests that use nfs backed persistent volumes

### DIFF
--- a/test/extended/util/deploymentconfigs.go
+++ b/test/extended/util/deploymentconfigs.go
@@ -25,13 +25,16 @@ func RemoveDeploymentConfigs(oc *CLI, dcs ...string) error {
 				e2e.Logf("Unable to get pods for dc/%s: %v", dc, err)
 				return false, err
 			}
-			if len(pods.Items) != 0 {
+			if len(pods.Items) > 0 {
+				e2e.Logf("Waiting for pods for dc/%s to terminate", dc)
 				return false, nil
 			}
+			e2e.Logf("Pods for dc/%s have terminated", dc)
 			return true, nil
 		})
 
 		if err != nil {
+			e2e.Logf("Error occurred waiting for pods to terminate for dc/%s: %v", dc, err)
 			errs = append(errs, err)
 		}
 	}

--- a/test/extended/util/statefulsets.go
+++ b/test/extended/util/statefulsets.go
@@ -25,13 +25,16 @@ func RemoveStatefulSets(oc *CLI, sets ...string) error {
 				e2e.Logf("Unable to get pods for statefulset/%s: %v", set, err)
 				return false, err
 			}
-			if len(pods.Items) != 0 {
+			if len(pods.Items) > 0 {
+				e2e.Logf("Waiting for pods for statefulset/%s to terminate", set)
 				return false, nil
 			}
+			e2e.Logf("Pods for statefulset/%s have terminated", set)
 			return true, nil
 		})
 
 		if err != nil {
+			e2e.Logf("Error occurred waiting for pods to terminate for statefulset/%s: %v", set, err)
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
 - Adds additional debugging information for tests that use persistent volumes
 - Ensures that the tests use the persistent volumes that are backed by the NFS server in their namespace

Created in reference to https://github.com/openshift/jenkins-sync-plugin/pull/215#issuecomment-375974185