### PR TITLE
cli: get latest rc from a dc when selecting pod to rsh

### DIFF
--- a/pkg/oc/cli/util/clientcmd/factory.go
+++ b/pkg/oc/cli/util/clientcmd/factory.go
@@ -342,20 +342,11 @@ func (f *Factory) PodForResource(resource string, timeout time.Duration) (string
 		if err != nil {
 			return "", err
 		}
-		kc, err := f.ClientSet()
-		if err != nil {
-			return "", err
-		}
 		dc, err := appsClient.Apps().DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
-		selector := labels.SelectorFromSet(dc.Spec.Selector)
-		pod, _, err := kcmdutil.GetFirstPod(kc.Core(), namespace, selector.String(), timeout, sortBy)
-		if err != nil {
-			return "", err
-		}
-		return pod.Name, nil
+		return f.PodForResource(fmt.Sprintf("rc/%s", appsutil.LatestDeploymentNameForConfig(dc)), timeout)
 	case extensions.Resource("daemonsets"):
 		kc, err := f.ClientSet()
 		if err != nil {


### PR DESCRIPTION
fixes: https://github.com/openshift/origin/issues/19089

This will make sure we are using the latest RC when selecting the pod we are going to rsh into. In case the latest rollout does not have any pods created yet, this will fail, which I think is correct, because it won't connect you to the "old" pods which will likely be terminated soon. 

/cc @tnozicka 
/cc @soltysh (as you always appreciate code removal)