### PR TITLE
Fix dry-run for oc adm router and registry

### DIFF
--- a/pkg/oc/admin/registry/registry.go
+++ b/pkg/oc/admin/registry/registry.go
@@ -299,9 +299,6 @@ func (opts *RegistryOptions) RunCmdRegistry() error {
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf("can't check for existing docker-registry %q: %v", name, err)
 				}
-				if opts.Config.Action.DryRun {
-					return fmt.Errorf("Docker registry %q service does not exist", name)
-				}
 				generate = true
 			}
 		} else {

--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -123,8 +123,8 @@ type RouterConfig struct {
 	Labels string
 
 	// DryRun specifies that the router command should not launch a router but
-	// should instead exit with code 1 to indicate if a router is already running
-	// or code 0 otherwise.
+	// should instead exit with code 1 to indicate if a router will not be
+	// running or code 0 otherwise.
 	DryRun bool
 
 	// SecretsAsEnv sets the credentials as env vars, instead of secrets.
@@ -590,9 +590,6 @@ func RunCmdRouter(f *clientcmd.Factory, cmd *cobra.Command, out, errout io.Write
 			if !generate {
 				if !errors.IsNotFound(err) {
 					return fmt.Errorf("can't check for existing router %q: %v", name, err)
-				}
-				if !output && cfg.Action.DryRun {
-					return fmt.Errorf("Router %q service does not exist", name)
 				}
 				generate = true
 			}

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -318,7 +318,7 @@ os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/admin/router"
 # Test running a router
-os::cmd::expect_failure_and_text 'oc adm router --dry-run' 'does not exist'
+os::cmd::expect_failure_and_text 'oc adm router --dry-run' 'grant access with oc adm policy add-scc-to-user hostnetwork -z router'
 os::cmd::expect_success "oc adm policy add-scc-to-user privileged system:serviceaccount:default:router"
 os::cmd::expect_success_and_text "oc adm router -o yaml --service-account=router -n default" 'image:.*\-haproxy\-router:'
 os::cmd::expect_success "oc adm router --images='${USE_IMAGES}' --service-account=router -n default"
@@ -330,7 +330,7 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/admin/registry"
 # Test running a registry as a daemonset
 os::cmd::expect_success "oc delete clusterrolebinding/registry-registry-role"
-os::cmd::expect_failure_and_text 'oc adm registry --daemonset --dry-run' 'does not exist'
+os::cmd::expect_success 'oc adm registry --daemonset --dry-run'
 os::cmd::expect_success_and_text "oc adm registry --daemonset -o yaml" 'DaemonSet'
 os::cmd::expect_success "oc adm registry --daemonset --images='${USE_IMAGES}'"
 os::cmd::expect_success_and_text 'oc adm registry --daemonset' 'service exists'
@@ -340,7 +340,7 @@ os::cmd::expect_success "oc adm registry --daemonset -o yaml | oc delete -f - -n
 echo "registry daemonset: ok"
 
 # Test running a registry
-os::cmd::expect_failure_and_text 'oc adm registry --dry-run' 'does not exist'
+os::cmd::expect_success 'oc adm registry --dry-run'
 os::cmd::expect_success_and_text "oc adm registry -o yaml" 'image:.*\-docker\-registry'
 os::cmd::expect_success "oc adm registry --images='${USE_IMAGES}'"
 os::cmd::expect_success_and_text 'oc adm registry' 'service exists'

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -15,7 +15,7 @@ USE_IMAGES=${USE_IMAGES:-$defaultimage}
 
 os::test::junit::declare_suite_start "cmd/router"
 # Test running a router
-os::cmd::expect_failure_and_text 'oc adm router --dry-run' 'does not exist'
+os::cmd::expect_failure_and_text 'oc adm router --dry-run' 'grant access with oc adm policy add-scc-to-user hostnetwork -z router'
 os::cmd::expect_failure_and_text 'oc adm router --dry-run -o yaml' 'service account "router" is not allowed to access the host network on nodes'
 os::cmd::expect_failure_and_text 'oc adm router --dry-run -o yaml' 'name: router'
 os::cmd::expect_failure_and_text 'oc adm router --dry-run --stats-port=1937 -o yaml' 'containerPort: 1937'


### PR DESCRIPTION
Currently `oc adm registry --dry-run` provides error even if
we can deploy registry on the cluster with following error:

This patch removes following error and makes dry-run succeed.

before:
```
$ oc adm registry --dry-run
error: Docker registry "docker-registry" service does not exist
```

after:
```
$  _output/local/bin/linux/amd64/oc adm registry  --dry-run
--> Creating registry registry ...
    serviceaccount "registry" created (dry run)
    clusterrolebinding "registry-registry-role" created (dry run)
    deploymentconfig "docker-registry" created (dry run)
    service "docker-registry" created (dry run)
--> Success (dry run)
```