### PR TITLE
Remove wrong ValidArgs from rollout latest

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -17379,7 +17379,6 @@ _oc_rollout_latest()
 
     must_have_one_flag=()
     must_have_one_noun=()
-    must_have_one_noun+=("deploymentconfig")
     noun_aliases=()
 }
 

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -17521,7 +17521,6 @@ _oc_rollout_latest()
 
     must_have_one_flag=()
     must_have_one_noun=()
-    must_have_one_noun+=("deploymentconfig")
     noun_aliases=()
 }
 

--- a/pkg/oc/cli/cmd/rollout/latest.go
+++ b/pkg/oc/cli/cmd/rollout/latest.go
@@ -80,7 +80,6 @@ func NewCmdRolloutLatest(fullName string, f *clientcmd.Factory, out io.Writer) *
 			err = opts.RunRolloutLatest()
 			kcmdutil.CheckErr(err)
 		},
-		ValidArgs: []string{"deploymentconfig"},
 	}
 
 	kcmdutil.AddPrinterFlags(cmd)


### PR DESCRIPTION
Just dropping `ValidArgs` as `oc rollout latest will support ` unlikely supports `deployments` in the near future.

Fixes https://github.com/openshift/origin/issues/19088 