### PR TITLE
Fix wrong completion oc_stop and add correct compltion oc_observe

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -328,7 +328,7 @@ __custom_func() {
     case ${last_command} in
  
         # first arg is the kind according to ValidArgs, second is resource name
-        oc_get | oc_describe | oc_delete | oc_label | oc_stop | oc_expose | oc_export | oc_patch | oc_annotate | oc_env | oc_edit | oc_volume | oc_scale )
+        oc_get | oc_describe | oc_delete | oc_label | oc_expose | oc_export | oc_patch | oc_annotate | oc_env | oc_edit | oc_volume | oc_scale | oc_observe )
             __oc_get_resource
             return
             ;;

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -470,7 +470,7 @@ __custom_func() {
     case ${last_command} in
  
         # first arg is the kind according to ValidArgs, second is resource name
-        oc_get | oc_describe | oc_delete | oc_label | oc_stop | oc_expose | oc_export | oc_patch | oc_annotate | oc_env | oc_edit | oc_volume | oc_scale )
+        oc_get | oc_describe | oc_delete | oc_label | oc_expose | oc_export | oc_patch | oc_annotate | oc_env | oc_edit | oc_volume | oc_scale | oc_observe )
             __oc_get_resource
             return
             ;;

--- a/pkg/oc/cli/cli_bashcomp_func.go
+++ b/pkg/oc/cli/cli_bashcomp_func.go
@@ -93,7 +93,7 @@ __custom_func() {
     case ${last_command} in
  
         # first arg is the kind according to ValidArgs, second is resource name
-        oc_get | oc_describe | oc_delete | oc_label | oc_stop | oc_expose | oc_export | oc_patch | oc_annotate | oc_env | oc_edit | oc_volume | oc_scale )
+        oc_get | oc_describe | oc_delete | oc_label | oc_expose | oc_export | oc_patch | oc_annotate | oc_env | oc_edit | oc_volume | oc_scale | oc_observe )
             __oc_get_resource
             return
             ;;


### PR DESCRIPTION
Removing `oc_stop` as `oc stop` command does not exist. Instead, adding `oc_observe` as it should have an auto completion for `oc observe RESOURCE <TAB>`.