### PR TITLE
add rsync include,exclude support

### DIFF
--- a/pkg/oc/cli/rsync/util.go
+++ b/pkg/oc/cli/rsync/util.go
@@ -87,14 +87,31 @@ func rsyncFlagsFromOptions(o *RsyncOptions) []string {
 	return flags
 }
 
-func rsyncSpecificFlags(o *RsyncOptions) []string {
+func tarFlagsFromOptions(o *RsyncOptions) []string {
 	flags := []string{}
+	if !o.Quiet {
+		flags = append(flags, "-v")
+	}
 	if len(o.RsyncInclude) > 0 {
-		flags = append(flags, "--include")
+		for _, include := range o.RsyncInclude {
+			flags = append(flags, fmt.Sprintf("**/%s", include))
+		}
+
+		// if we have explicit files or a pattern of filenames to include,
+		// maintain similar behavior to tar, and include anything else
+		// that would have otherwise been included
+		flags = append(flags, "*")
 	}
 	if len(o.RsyncExclude) > 0 {
-		flags = append(flags, "--exclude")
+		for _, exclude := range o.RsyncExclude {
+			flags = append(flags, fmt.Sprintf("--exclude=%s", exclude))
+		}
 	}
+	return flags
+}
+
+func rsyncSpecificFlags(o *RsyncOptions) []string {
+	flags := []string{}
 	if o.RsyncProgress {
 		flags = append(flags, "--progress")
 	}

--- a/test/cmd/rsync.sh
+++ b/test/cmd/rsync.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+# Cleanup cluster resources created by this test
+(
+  set +e
+  oc delete all --all
+  exit 0
+) &>/dev/null
+
+os::test::junit::declare_suite_start "cmd/rsync"
+# This test validates the rsync command
+os::cmd::expect_success 'oc create -f - << __EOF__
+apiVersion: v1
+kind: Pod
+metadata:
+  name: valid-pod
+  labels:
+    name: valid-pod
+spec:
+  containers:
+  - name: kubernetes-serve-hostname
+    image: k8s.gcr.io/serve_hostname
+    resources:
+      limits:
+        cpu: "1"
+        memory: 512Mi
+__EOF__'
+
+temp_dir=$(mktemp -d)
+include_file=$(mktemp -p $temp_dir)
+exclude_file=$(mktemp -p $temp_dir)
+
+# we don't actually have a kubelet running, so no "tar" binary will be available in container because there will be no container.
+# instead, ensure that the tar command to be executed is formatted correctly based on our --include and --exclude values
+os::cmd::expect_failure_and_text "oc rsync --strategy=tar --include=$include_file --exclude=$exclude_file $temp_dir valid-pod:/tmp --loglevel 4" "running command: tar.*\*\*\/$include_file.*--exclude=$exclude_file"
+
+echo "rsync: ok"
+os::test::junit::declare_suite_end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1559693

Adds support for `--include` and `--exclude` flags with the tar strategy.

cc @soltysh @smarterclayton 