### PR TITLE
UPSTREAM: <carry>: pods in openshift-* namespace can be marked critical

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
@@ -287,7 +287,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
 	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
-	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
+	ExperimentalCriticalPodAnnotation:           {Default: true, PreRelease: utilfeature.Alpha},
 	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},
 	DevicePlugins:                               {Default: true, PreRelease: utilfeature.Beta},
 	TaintBasedEvictions:                         {Default: false, PreRelease: utilfeature.Alpha},

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -153,7 +154,11 @@ func IsCriticalPod(pod *v1.Pod) bool {
 func IsCritical(ns string, annotations map[string]string) bool {
 	// Critical pods are restricted to "kube-system" namespace as of now.
 	if ns != kubeapi.NamespaceSystem {
-		return false
+		// <carry>: critical pods may exist in openshift- namespaces
+		// pending priority and preemption support.
+		if !strings.HasPrefix(ns, "openshift-") {
+			return false
+		}
 	}
 	val, ok := annotations[CriticalPodAnnotationKey]
 	if ok && val == "" {

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update_test.go
@@ -167,6 +167,19 @@ func TestIsCriticalPod(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			// <carry> for openshift-system namespace resources pending priority/preemption
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "openshift-system",
+					Annotations: map[string]string{
+						"scheduler.alpha.kubernetes.io/critical-pod": "",
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 	for i, data := range cases {
 		actual := IsCriticalPod(&data.pod)


### PR DESCRIPTION
If we pursue the static pod based deployment topology, we should extend the critical pod support to openshift-* namespaces pending priority/preemption graduation in kubernetes.

input from @smarterclayton @liggitt @sjenning @aveshagarwal appreciated.