### PR TITLE
Docker client CloseWrite follow-up

### DIFF
--- a/vendor/github.com/docker/docker/client/hijack.go
+++ b/vendor/github.com/docker/docker/client/hijack.go
@@ -193,7 +193,7 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 		// object that implements CloseWrite iff the underlying connection
 		// implements it.
 		if _, ok := c.(types.CloseWriter); ok {
-			c = &hijackedConnCloseWriter{c, br}
+			c = &hijackedConnCloseWriter{&hijackedConn{c, br}}
 		} else {
 			c = &hijackedConn{c, br}
 		}
@@ -221,7 +221,9 @@ func (c *hijackedConn) Read(b []byte) (int, error) {
 // CloseWrite().  It is returned by setupHijackConn in the case that a) there
 // was already buffered data in the http layer when Hijack() was called, and b)
 // the underlying net.Conn *does* implement CloseWrite().
-type hijackedConnCloseWriter hijackedConn
+type hijackedConnCloseWriter struct {
+	*hijackedConn
+}
 
 var _ types.CloseWriter = &hijackedConnCloseWriter{}
 

--- a/vendor/github.com/docker/docker/client/hijack.go
+++ b/vendor/github.com/docker/docker/client/hijack.go
@@ -189,8 +189,14 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 
 	c, br := clientconn.Hijack()
 	if br.Buffered() > 0 {
-		// If there is buffered content, wrap the connection
-		c = &hijackedConn{c, br}
+		// If there is buffered content, wrap the connection.  We return an
+		// object that implements CloseWrite iff the underlying connection
+		// implements it.
+		if _, ok := c.(types.CloseWriter); ok {
+			c = &hijackedConnCloseWriter{c, br}
+		} else {
+			c = &hijackedConn{c, br}
+		}
 	} else {
 		br.Reset(nil)
 	}
@@ -198,6 +204,10 @@ func (cli *Client) setupHijackConn(req *http.Request, proto string) (net.Conn, e
 	return c, nil
 }
 
+// hijackedConn wraps a net.Conn and is returned by setupHijackConn in the case
+// that a) there was already buffered data in the http layer when Hijack() was
+// called, and b) the underlying net.Conn does *not* implement CloseWrite().
+// hijackedConn does not implement CloseWrite() either.
 type hijackedConn struct {
 	net.Conn
 	r *bufio.Reader
@@ -207,9 +217,15 @@ func (c *hijackedConn) Read(b []byte) (int, error) {
 	return c.r.Read(b)
 }
 
-func (c *hijackedConn) CloseWrite() error {
-	if conn, ok := c.Conn.(types.CloseWriter); ok {
-		return conn.CloseWrite()
-	}
-	return nil
+// hijackedConnCloseWriter is a hijackedConn which additionally implements
+// CloseWrite().  It is returned by setupHijackConn in the case that a) there
+// was already buffered data in the http layer when Hijack() was called, and b)
+// the underlying net.Conn *does* implement CloseWrite().
+type hijackedConnCloseWriter hijackedConn
+
+var _ types.CloseWriter = &hijackedConnCloseWriter{}
+
+func (c *hijackedConnCloseWriter) CloseWrite() error {
+	conn := c.Conn.(types.CloseWriter)
+	return conn.CloseWrite()
 }


### PR DESCRIPTION
Follow up of #18882 based on reworkings upstream (the original work was apparently problematic when the docker client was connecting to the server over TLS).