### PR TITLE
flatten oc cluster up directory path

### DIFF
--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -69,7 +69,7 @@ oc cluster up --server-loglevel=4 --tag="${TAG}" \
 oc cluster up --server-loglevel=4 --tag="${TAG}" \
         --base-dir="${CLUSTERUP_DIR}"
 
-MASTER_CONFIG_DIR="${CLUSTERUP_DIR}/oc-cluster-up-kube-apiserver/master"
+MASTER_CONFIG_DIR="${CLUSTERUP_DIR}/kube-apiserver"
 
 os::test::junit::declare_suite_start "setup/start-oc_cluster_up"
 os::cmd::try_until_success "oc cluster status" "$((5*TIME_MIN))" "10"

--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/config.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/config.go
@@ -13,9 +13,9 @@ import (
 	"github.com/openshift/origin/pkg/oc/errors"
 )
 
-const KubeAPIServerDirName = "oc-cluster-up-kube-apiserver"
-const OpenShiftAPIServerDirName = "oc-cluster-up-openshift-apiserver"
-const OpenShiftControllerManagerDirName = "oc-cluster-up-openshift-controller-manager"
+const KubeAPIServerDirName = "kube-apiserver"
+const OpenShiftAPIServerDirName = "openshift-apiserver"
+const OpenShiftControllerManagerDirName = "openshift-controller-manager"
 
 type KubeAPIServerStartConfig struct {
 	// MasterImage is the docker image for openshift start master
@@ -64,15 +64,14 @@ func (opt KubeAPIServerStartConfig) MakeMasterConfig(dockerClient dockerhelper.I
 	}
 
 	// TODO eliminate the linkage that other tasks have on this particular structure
-	tempDir := path.Join(basedir, KubeAPIServerDirName)
-	masterDir := path.Join(tempDir, "master")
+	masterDir := path.Join(basedir, KubeAPIServerDirName)
 	if err := os.MkdirAll(masterDir, 0755); err != nil {
 		return "", err
 	}
-	glog.V(1).Infof("Copying OpenShift config to local directory %s", tempDir)
+	glog.V(1).Infof("Copying OpenShift config to local directory %s", masterDir)
 	if err = dockerhelper.DownloadDirFromContainer(dockerClient, containerId, "/var/lib/origin/openshift.local.config", masterDir); err != nil {
-		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
-			glog.V(2).Infof("Error removing temporary config dir %s: %v", tempDir, removeErr)
+		if removeErr := os.RemoveAll(masterDir); removeErr != nil {
+			glog.V(2).Infof("Error removing temporary config dir %s: %v", masterDir, removeErr)
 		}
 		return "", err
 	}

--- a/pkg/oc/bootstrap/clusterup/kubelet/config.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/config.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	NodeConfigDirName  = "oc-cluster-up-node"
-	KubeDNSDirName     = "oc-cluster-up-kubedns"
-	PodManifestDirName = "oc-cluster-up-pod-manifest"
+	NodeConfigDirName  = "node"
+	KubeDNSDirName     = "kubedns"
+	PodManifestDirName = "static-pod-manifests"
 )
 
 type NodeStartConfig struct {

--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -256,7 +256,7 @@ func (h *Helper) GetNodeConfigFromLocalDir(configDir string) (*configapi.NodeCon
 }
 
 func (h *Helper) GetConfigFromLocalDir(configDir string) (*configapi.MasterConfig, string, error) {
-	configPath := filepath.Join(configDir, "master", "master-config.yaml")
+	configPath := filepath.Join(configDir, "master-config.yaml")
 	glog.V(1).Infof("Reading master config from %s", configPath)
 	cfg, err := configapilatest.ReadMasterConfig(configPath)
 	if err != nil {

--- a/pkg/oc/bootstrap/docker/openshift/login.go
+++ b/pkg/oc/bootstrap/docker/openshift/login.go
@@ -26,7 +26,7 @@ func Login(username, password, server, configDir string, f *clientcmd.Factory, c
 		}
 		existingConfig = *(kclientcmdapi.NewConfig())
 	}
-	adminConfig, err := kclientcmd.LoadFromFile(filepath.Join(configDir, "master", "admin.kubeconfig"))
+	adminConfig, err := kclientcmd.LoadFromFile(filepath.Join(configDir, "admin.kubeconfig"))
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/bootstrap/docker/openshift/servicecatalog.go
+++ b/pkg/oc/bootstrap/docker/openshift/servicecatalog.go
@@ -102,7 +102,7 @@ func (h *Helper) InstallServiceCatalog(f *clientcmd.Factory, configDir, publicMa
 		return errors.NewError(fmt.Sprintf("failed to create an api aggregation registration client: %v", err))
 	}
 
-	serviceCA, err := ioutil.ReadFile(filepath.Join(configDir, "master", "service-signer.crt"))
+	serviceCA, err := ioutil.ReadFile(filepath.Join(configDir, "service-signer.crt"))
 	if err != nil {
 		return errors.NewError(fmt.Sprintf("failed to read the service certificate signer CA bundle: %v", err))
 	}

--- a/pkg/oc/bootstrap/docker/openshift/templateservicebroker.go
+++ b/pkg/oc/bootstrap/docker/openshift/templateservicebroker.go
@@ -74,7 +74,7 @@ func (h *Helper) RegisterTemplateServiceBroker(clusterAdminKubeConfig []byte, co
 	// Register the template broker with the service catalog
 	glog.V(2).Infof("registering the template broker with the service catalog")
 
-	serviceCABytes, err := ioutil.ReadFile(filepath.Join(configDir, "master", "service-signer.crt"))
+	serviceCABytes, err := ioutil.ReadFile(filepath.Join(configDir, "service-signer.crt"))
 	serviceCAString := base64.StdEncoding.EncodeToString(serviceCABytes)
 	if err != nil {
 		return errors.NewError("unable to read service signer cert").WithCause(err)

--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -169,7 +169,7 @@ func (c *ClusterUpConfig) StartSelfHosted(out io.Writer) error {
 		clusterAdminKubeConfig,
 		templateSubstitutionValues,
 		c.GetDockerClient(),
-		path.Join(c.BaseDir, "logs"),
+		c.GetLogDir(),
 	)
 	if err != nil {
 		return err
@@ -203,14 +203,11 @@ func (c *ClusterUpConfig) StartSelfHosted(out io.Writer) error {
 		clusterAdminKubeConfig,
 		templateSubstitutionValues,
 		c.GetDockerClient(),
-		path.Join(c.BaseDir, "logs"),
+		c.GetLogDir(),
 	)
 	if err != nil {
 		return err
 	}
-
-	// TODO remove this linkage.  State like this doesn't belong on the struct and should be passed through for each invocation
-	c.LocalConfigDir = path.Dir(configDirs.masterConfigDir)
 
 	return nil
 }
@@ -227,7 +224,7 @@ type configDirs struct {
 
 func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 	configLocations := &configDirs{
-		masterConfigDir:              filepath.Join(c.BaseDir, kubeapiserver.KubeAPIServerDirName, "master"),
+		masterConfigDir:              filepath.Join(c.BaseDir, kubeapiserver.KubeAPIServerDirName),
 		openshiftAPIServerConfigDir:  filepath.Join(c.BaseDir, kubeapiserver.OpenShiftAPIServerDirName),
 		openshiftControllerConfigDir: filepath.Join(c.BaseDir, kubeapiserver.OpenShiftControllerManagerDirName),
 		nodeConfigDir:                filepath.Join(c.BaseDir, kubelet.NodeConfigDirName),

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -156,7 +156,7 @@ function os::test::extended::clusterup::internal::hostdirs () {
         ${@}
 
 	local sudo="${USE_SUDO:+sudo}"
-    os::cmd::expect_success "${sudo} ls ${base_dir}/oc-cluster-up-kube-apiserver/master/master-config.yaml"
+    os::cmd::expect_success "${sudo} ls ${base_dir}/kube-apiserver/master-config.yaml"
     os::cmd::expect_success "${sudo} ls ${base_dir}/openshift.local.pv/pv0100"
     os::cmd::expect_success "${sudo} ls ${base_dir}/etcd/member"
 }
@@ -226,7 +226,7 @@ function os::test::extended::clusterup::publichostname () {
         --base-dir="${base_dir}" \
         --tag="$ORIGIN_COMMIT" \
         ${@}
-    os::cmd::expect_success_and_text "cat ${base_dir}/oc-cluster-up-kube-apiserver/master/master-config.yaml" "masterPublicURL.*myserver\.127\.0\.0\.1\.nip\.io"
+    os::cmd::expect_success_and_text "cat ${base_dir}/kube-apiserver/master-config.yaml" "masterPublicURL.*myserver\.127\.0\.0\.1\.nip\.io"
 }
 
 # Tests creating a cluster with a numeric public hostname
@@ -246,7 +246,7 @@ function os::test::extended::clusterup::numerichostname () {
         --base-dir="${base_dir}" \
         --tag="$ORIGIN_COMMIT" \
         ${@}
-    os::cmd::expect_success_and_text "cat ${base_dir}/oc-cluster-up-kube-apiserver/master/master-config.yaml" "masterPublicURL.*127\.0\.0\.1"
+    os::cmd::expect_success_and_text "cat ${base_dir}/kube-apiserver/master-config.yaml" "masterPublicURL.*127\.0\.0\.1"
 }
 
 # Tests installation of console components


### PR DESCRIPTION
Now that everything is under a `base-dir`, we don't need to repeat `oc-cluster-up-` and directory prefixes and now that we've refactored enough to find them, we can eliminate the `kube-apiserver/master` assumption in the code.  This does both.

/assign @mfojtik 
/assign @soltysh 