### PR TITLE
Provide feedback on progression for extracting of binary build

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -234,14 +235,35 @@ func ExtractInputBinary(in io.Reader, source *buildapiv1.BinaryBuildSource, dir 
 
 	glog.V(0).Infof("Receiving source from STDIN as archive ...")
 
-	cmd := exec.Command("bsdtar", "-x", "-o", "-m", "-f", "-", "-C", dir)
+	cmd := exec.Command("bsdtar", "-v", "-x", "-o", "-m", "-f", "-", "-C", dir)
 	cmd.Stdin = in
-	out, err := cmd.CombinedOutput()
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		glog.V(0).Infof("Extracting...\n%s", string(out))
-		return fmt.Errorf("unable to extract binary build input, must be a zip, tar, or gzipped tar, or specified as a file: %v", err)
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	// combine stdout and stderr
+	cmdReader := io.MultiReader(stdout, stderr)
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+	if glog.Is(4) {
+		scanner := bufio.NewScanner(cmdReader)
+		glog.Infof("Extracting...")
+		for scanner.Scan() {
+			glog.Infof(scanner.Text())
+		}
+	}
+	exitStatus := cmd.Wait()
+	if exitStatus != nil {
+		return fmt.Errorf("unable to extract binary build input, must be a zip, tar, or gzipped tar, or specified as a file: %v", exitStatus)
 	}
 
+	glog.V(4).Infof("Successfuly extracted")
 	return nil
 }
 


### PR DESCRIPTION
When build stopped with the message `"Receiving source from STDIN as
archive ..."`, it is hard to debug and so would be nice to get some
progress status.

This patch changes to output the bsdtar command stdout and stderr with
BUILD_LOGLEVEL 4 in real time.

Fixes https://github.com/openshift/origin/issues/13612
(Also https://bugzilla.redhat.com/show_bug.cgi?id=1462069)