### PR TITLE
Remove unncessary if glog.Is(0) condition

### DIFF
--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -302,12 +302,10 @@ func extractGitSource(ctx context.Context, gitClient GitClient, gitSource *build
 		}
 	}
 
-	if glog.Is(0) {
-		if information, gitErr := gitClient.GetInfo(dir); len(gitErr) == 0 {
-			glog.Infof("\tCommit:\t%s (%s)\n", information.CommitID, information.Message)
-			glog.Infof("\tAuthor:\t%s <%s>\n", information.AuthorName, information.AuthorEmail)
-			glog.Infof("\tDate:\t%s\n", information.Date)
-		}
+	if information, gitErr := gitClient.GetInfo(dir); len(gitErr) == 0 {
+		glog.Infof("\tCommit:\t%s (%s)\n", information.CommitID, information.Message)
+		glog.Infof("\tAuthor:\t%s <%s>\n", information.AuthorName, information.AuthorEmail)
+		glog.Infof("\tDate:\t%s\n", information.Date)
 	}
 
 	return true, nil


### PR DESCRIPTION
glog.Is(0) is the lowest loglevel, so the if statement is not
necessary. This patch removes it.