### PR TITLE
TestValidateSecurityContextConstraints: fix "index out of range" panic when there no errors encountered

### DIFF
--- a/pkg/security/apis/security/validation/validation_test.go
+++ b/pkg/security/apis/security/validation/validation_test.go
@@ -207,9 +207,7 @@ func TestValidateSecurityContextConstraints(t *testing.T) {
 	for k, v := range errorCases {
 		t.Run(k, func(t *testing.T) {
 			if errs := ValidateSecurityContextConstraints(v.scc); len(errs) == 0 || errs[0].Type != v.errorType || errs[0].Detail != v.errorDetail {
-				t.Errorf("Expected %q got %q", v.errorType, errs[0].Type)
-				t.Errorf("Expected %q got %q", v.errorDetail, errs[0].Detail)
-				t.Errorf("got all these %v", errs)
+				t.Errorf("Expected error type %q with detail %q, got %v", v.errorType, v.errorDetail, errs)
 			}
 		})
 	}


### PR DESCRIPTION
`TestValidateSecurityContextConstraints` panics when expected error isn't present. This is a regression from https://github.com/openshift/origin/commit/6c585668f03ae5958f25aae65290a507f87a6a9f#diff-f8c7bee9ffab811e5d3d9938626f89dfL208 (#17576, 1.9.0 rebase).

This PR reverts that change to make it work again.