### PR TITLE
log OVS commands at level 4

### DIFF
--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -142,7 +142,7 @@ func (ovsif *ovsExec) exec(cmd string, args ...string) (string, error) {
 	if cmd == OVS_OFCTL {
 		args = append([]string{"-O", "OpenFlow13"}, args...)
 	}
-	glog.V(5).Infof("Executing: %s %s", cmd, strings.Join(args, " "))
+	glog.V(4).Infof("Executing: %s %s", cmd, strings.Join(args, " "))
 
 	output, err := ovsif.execer.Command(cmd, args...).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Log OVS comments at V(4) rather than V(5), so that they end up in test output by default. V(5) is considered a more "spammy" level, and OVS changes are not frequent enough that we need to worry about them spamming the logs.

(This was inspired by trying to debug https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/19080/test_pull_request_origin_extended_conformance_gce/18196/, which is hard without being able to see what OVS flows were in effect...)