### PR TITLE
Correct default labels for prom recording rule

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -457,7 +457,7 @@ objects:
         - record: container_memory_rss_by_type
           expr: container_memory_rss{id=~"/|/system.slice|/kubepods.slice"} > 0
         - record: container_cpu_usage_percent_by_host
-          expr: sum by (hostname,type)(rate(container_cpu_usage_seconds_total{id="/"}[5m])) / on (hostname,type) machine_cpu_cores
+          expr: sum(rate(container_cpu_usage_seconds_total{id="/"}[5m])) BY(kubernetes_io_hostname) / ON(kubernetes_io_hostname) machine_cpu_cores
         - record: apiserver_request_count_rate_by_resources
           expr: sum without (client,instance,contentType) (rate(apiserver_request_count[5m]))
 

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -14158,7 +14158,7 @@ objects:
         - record: container_memory_rss_by_type
           expr: container_memory_rss{id=~"/|/system.slice|/kubepods.slice"} > 0
         - record: container_cpu_usage_percent_by_host
-          expr: sum by (hostname,type)(rate(container_cpu_usage_seconds_total{id="/"}[5m])) / on (hostname,type) machine_cpu_cores
+          expr: sum(rate(container_cpu_usage_seconds_total{id="/"}[5m])) BY(kubernetes_io_hostname) / ON(kubernetes_io_hostname) machine_cpu_cores
         - record: apiserver_request_count_rate_by_resources
           expr: sum without (client,instance,contentType) (rate(apiserver_request_count[5m]))
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -26246,7 +26246,7 @@ objects:
         - record: container_memory_rss_by_type
           expr: container_memory_rss{id=~"/|/system.slice|/kubepods.slice"} > 0
         - record: container_cpu_usage_percent_by_host
-          expr: sum by (hostname,type)(rate(container_cpu_usage_seconds_total{id="/"}[5m])) / on (hostname,type) machine_cpu_cores
+          expr: sum(rate(container_cpu_usage_seconds_total{id="/"}[5m])) BY(kubernetes_io_hostname) / ON(kubernetes_io_hostname) machine_cpu_cores
         - record: apiserver_request_count_rate_by_resources
           expr: sum without (client,instance,contentType) (rate(apiserver_request_count[5m]))
 


### PR DESCRIPTION
`type` and `hostname` are the old labels, the new standard label is
`kubernetes_io_hostname` and we'll have to live without type.

@pgier