### PR TITLE
if the secret is missing, always generate a cert

### DIFF
--- a/pkg/service/controller/servingcert/secret_creating_controller.go
+++ b/pkg/service/controller/servingcert/secret_creating_controller.go
@@ -334,12 +334,12 @@ func (sc *ServiceServingCertController) requiresCertGeneration(service *v1.Servi
 	if getNumFailures(service) >= sc.maxRetries {
 		return false
 	}
-	if service.Annotations[ServingCertCreatedByAnnotation] == sc.ca.Config.Certs[0].Subject.CommonName {
-		return false
-	}
 	_, err := sc.secretLister.Secrets(service.Namespace).Get(secretName)
 	if kapierrors.IsNotFound(err) {
 		return true
+	}
+	if service.Annotations[ServingCertCreatedByAnnotation] == sc.ca.Config.Certs[0].Subject.CommonName {
+		return false
 	}
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Unable to get the secret %s/%s: %v", service.Namespace, secretName, err))


### PR DESCRIPTION
If the secret is missing, the service serving cert signing controller should always create a new one even if other annotations are in place.

/assign @mfojtik 
/assign @soltysh 