### PR TITLE
Remove unnecessary open&close cycle in rsync tar strategy

### DIFF
--- a/pkg/oc/cli/cmd/rsync/copytar.go
+++ b/pkg/oc/cli/cmd/rsync/copytar.go
@@ -132,6 +132,7 @@ func (r *tarStrategy) Copy(source, destination *pathSpec, out, errOut io.Writer)
 	if err != nil {
 		return fmt.Errorf("cannot create local temporary file for tar: %v", err)
 	}
+	defer tmp.Close()
 	defer os.Remove(tmp.Name())
 
 	// Create tar
@@ -154,15 +155,9 @@ func (r *tarStrategy) Copy(source, destination *pathSpec, out, errOut io.Writer)
 		}
 	}
 
-	err = tmp.Close()
-	if err != nil {
-		return fmt.Errorf("error closing temporary tar file %s: %v", tmp.Name(), err)
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("error resetting position in a temporary tar file %s: %v", tmp.Name(), err)
 	}
-	tmp, err = os.Open(tmp.Name())
-	if err != nil {
-		return fmt.Errorf("cannot open temporary tar file %s: %v", tmp.Name(), err)
-	}
-	defer tmp.Close()
 
 	// Extract tar
 	if destination.Local() {


### PR DESCRIPTION
This is coming from the discussion I've had with @csrwng in https://github.com/openshift/origin/commit/6213342ef8789b4cc2f4bf6ba9c9a9168a8cb501#r28271910. This replaces open&close with a simple seek operation to reset the position in a file during rsync with tar strategy

@juanvallejo mind double checking if this works ok with that windows machine you have handy?

/assign @csrwng @juanvallejo 