### PR TITLE
bump(dns): pin to ~v1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 62c15c18799a47447136eb51dc09b52ad4c8e4a11a78ecfea753b0b33073b704
-updated: 2018-03-29T13:28:08.580252-04:00
+hash: 977eea94230d67ba609f55ba1b06f26ad5125d063de000057a8c95baf0ae7fec
+updated: 2018-03-30T10:33:22.769638-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -719,7 +719,7 @@ imports:
 - name: github.com/Microsoft/hcsshim
   version: 6ea7fe54f719d95721e7d9b26ac0add224c9b923
 - name: github.com/miekg/dns
-  version: 22cb769f47009091f1bc4bf9fffa398bbf6ca68f
+  version: 5364553f1ee9cddc7ac8b62dce148309c386695b
 - name: github.com/mindprince/gonvml
   version: fee913ce8fb235edf54739d259ca0ecc226c7b8a
 - name: github.com/mistifyio/go-zfs

--- a/glide.yaml
+++ b/glide.yaml
@@ -169,7 +169,7 @@ import:
   version: b64f5908f4945f4b11ed4a0a9d3cc1e23350866d
 # keep us up to date with latest DNS security fixes
 - package: github.com/miekg/dns
-  version: master
+  version: ~v1
 # etcd pins a very old version that has contention issues
 - package: github.com/google/btree
   version: master

--- a/vendor/github.com/miekg/dns/client.go
+++ b/vendor/github.com/miekg/dns/client.go
@@ -21,6 +21,8 @@ type Conn struct {
 	net.Conn                         // a net.Conn holding the connection
 	UDPSize        uint16            // minimum receive buffer for UDP messages
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	rtt            time.Duration
+	t              time.Time
 	tsigRequestMAC string
 }
 
@@ -175,9 +177,8 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 	}
 
 	co.TsigSecret = c.TsigSecret
-	t := time.Now()
 	// write with the appropriate write timeout
-	co.SetWriteDeadline(t.Add(c.getTimeoutForRequest(c.writeTimeout())))
+	co.SetWriteDeadline(time.Now().Add(c.getTimeoutForRequest(c.writeTimeout())))
 	if err = co.WriteMsg(m); err != nil {
 		return nil, 0, err
 	}
@@ -187,8 +188,7 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 	if err == nil && r.Id != m.Id {
 		err = ErrId
 	}
-	rtt = time.Since(t)
-	return r, rtt, err
+	return r, co.rtt, err
 }
 
 // ReadMsg reads a message from the connection co.
@@ -240,6 +240,7 @@ func (co *Conn) ReadMsgHeader(hdr *Header) ([]byte, error) {
 		}
 		p = make([]byte, l)
 		n, err = tcpRead(r, p)
+		co.rtt = time.Since(co.t)
 	default:
 		if co.UDPSize > MinMsgSize {
 			p = make([]byte, co.UDPSize)
@@ -247,6 +248,7 @@ func (co *Conn) ReadMsgHeader(hdr *Header) ([]byte, error) {
 			p = make([]byte, MinMsgSize)
 		}
 		n, err = co.Read(p)
+		co.rtt = time.Since(co.t)
 	}
 
 	if err != nil {
@@ -359,6 +361,7 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 	if err != nil {
 		return err
 	}
+	co.t = time.Now()
 	if _, err = co.Write(out); err != nil {
 		return err
 	}

--- a/vendor/github.com/miekg/dns/clientconfig.go
+++ b/vendor/github.com/miekg/dns/clientconfig.go
@@ -91,7 +91,7 @@ func ClientConfigFromReader(resolvconf io.Reader) (*ClientConfig, error) {
 						n = 1
 					}
 					c.Timeout = n
-				case len(s) >= 9 && s[:9] == "attempts:":
+				case len(s) >= 8 && s[:9] == "attempts:":
 					n, _ := strconv.Atoi(s[9:])
 					if n < 1 {
 						n = 1

--- a/vendor/github.com/miekg/dns/clientconfig_test.go
+++ b/vendor/github.com/miekg/dns/clientconfig_test.go
@@ -59,35 +59,7 @@ func TestNdots(t *testing.T) {
 			t.Errorf("Ndots not properly parsed: (Expected: %d / Was: %d)", ndotsVariants[data], cc.Ndots)
 		}
 	}
-}
 
-func TestClientConfigFromReaderAttempts(t *testing.T) {
-	testCases := []struct {
-		data     string
-		expected int
-	}{
-		{data: "options attempts:0", expected: 1},
-		{data: "options attempts:1", expected: 1},
-		{data: "options attempts:15", expected: 15},
-		{data: "options attempts:16", expected: 16},
-		{data: "options attempts:-1", expected: 1},
-		{data: "options attempt:", expected: 2},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(strings.Replace(test.data, ":", " ", -1), func(t *testing.T) {
-			t.Parallel()
-
-			cc, err := ClientConfigFromReader(strings.NewReader(test.data))
-			if err != nil {
-				t.Errorf("error parsing resolv.conf: %v", err)
-			}
-			if cc.Attempts != test.expected {
-				t.Errorf("A attempts not properly parsed: (Expected: %d / Was: %d)", test.expected, cc.Attempts)
-			}
-		})
-	}
 }
 
 func TestReadFromFile(t *testing.T) {

--- a/vendor/github.com/miekg/dns/msg.go
+++ b/vendor/github.com/miekg/dns/msg.go
@@ -595,13 +595,6 @@ func UnpackRR(msg []byte, off int) (rr RR, off1 int, err error) {
 	if err != nil {
 		return nil, len(msg), err
 	}
-
-	return UnpackRRWithHeader(h, msg, off)
-}
-
-// UnpackRRWithHeader unpacks the record type specific payload given an existing
-// RR_Header.
-func UnpackRRWithHeader(h RR_Header, msg []byte, off int) (rr RR, off1 int, err error) {
 	end := off + int(h.Rdlength)
 
 	if fn, known := typeToUnpack[h.Rrtype]; !known {


### PR DESCRIPTION
dns dev has been more active, we want to track latest releases (for security fixes), but not master