### PR TITLE
Fixes case when OS_ROOT has spaces in it

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -35,9 +35,9 @@ OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
 cd "${OS_ROOT}"
 
-for library_file in $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' ); do
-	source "${library_file}"
-done
+while IFS= read -r -d '' library_file; do
+	source $file
+done < <(find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh')
 
 unset library_files library_file init_source
 

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -36,7 +36,7 @@ export OS_ROOT
 cd "${OS_ROOT}"
 
 while IFS= read -r -d '' library_file; do
-	source $file
+	source "$library_file"
 done < <(find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh')
 
 unset library_files library_file init_source

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -37,7 +37,7 @@ cd "${OS_ROOT}"
 
 while IFS= read -r -d '' library_file; do
 	source "$library_file"
-done < <(find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh')
+done < <(find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -path '*/hack/lib/init.sh' -print0)
 
 unset library_files library_file init_source
 


### PR DESCRIPTION
https://mywiki.wooledge.org/BashPitfalls#for_i_in_.24.28ls_.2A.mp3.29