### PR TITLE
Change the order of Validate() and Complete() for oc set volume

### DIFF
--- a/pkg/oc/cli/cmd/set/volume_test.go
+++ b/pkg/oc/cli/cmd/set/volume_test.go
@@ -346,7 +346,7 @@ func TestValidateAddOptions(t *testing.T) {
 
 	for _, testCase := range tests {
 		addOpts := testCase.addOpts
-		err := addOpts.Validate(true)
+		err := addOpts.Validate()
 		if testCase.expectedError == nil && err != nil {
 			t.Errorf("Expected nil error for %s got %s", testCase.name, err)
 			continue


### PR DESCRIPTION
When `oc set volum` was run, cli proceeds
`Validate()`->`Complete()`. This order is different from any other
cli implementations. Currently there are no isseus, but this may
effect future implementation so fix it now.