### PR TITLE
Create a groups of sub commands of oc adm diagnostics

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics.go
+++ b/pkg/oc/admin/diagnostics/diagnostics.go
@@ -135,6 +135,12 @@ func NewCmdDiagnostics(name string, fullName string, out io.Writer) *cobra.Comma
 		},
 	})
 	groups.Add(cmd)
+
+	// add hidden in-pod subcommands
+	cmd.AddCommand(
+		poddiag.NewCommandPodDiagnostics(poddiag.InPodDiagnosticRecommendedName, out),
+		networkpoddiag.NewCommandNetworkPodDiagnostics(networkpoddiag.InPodNetworkCheckRecommendedName, out),
+	)
 	templates.ActsAsRootCommand(cmd, []string{"options"}, groups...)
 
 	return cmd
@@ -149,7 +155,7 @@ func createCommnadGroups(fullName string, out io.Writer) ktemplates.CommandGroup
 	for _, diag := range availableClientDiagnostics() {
 		cmd = append(cmd, NewCmdDiagnosticsIndividual(strings.ToLower(diag.Name()), fullName+" "+strings.ToLower(diag.Name()), out, diag))
 	}
-	groups = append(groups, ktemplates.CommandGroup{"Clinent Diagnostics:", cmd})
+	groups = append(groups, ktemplates.CommandGroup{"Client Diagnostics:", cmd})
 
 	// Cluster Diagnostics
 	cmd = []*cobra.Command{}
@@ -165,12 +171,6 @@ func createCommnadGroups(fullName string, out io.Writer) ktemplates.CommandGroup
 	}
 	groups = append(groups, ktemplates.CommandGroup{"Host Diagnostics:", cmd})
 
-	// Network Diagnostics
-	cmd = []*cobra.Command{
-		poddiag.NewCommandPodDiagnostics(poddiag.InPodDiagnosticRecommendedName, out),
-		networkpoddiag.NewCommandNetworkPodDiagnostics(networkpoddiag.InPodNetworkCheckRecommendedName, out),
-	}
-	groups = append(groups, ktemplates.CommandGroup{"Netowrk Diagnostics:", cmd})
 	return groups
 }
 

--- a/pkg/oc/admin/diagnostics/diagnostics/host/etcd.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/host/etcd.go
@@ -113,7 +113,7 @@ func (d *EtcdWriteVolume) Check() types.DiagnosticResult {
 		fmt.Fprintf(tw, "%s\t%6d\t%5.1f%%\n", b.Name, b.Count, float64(b.Count)/float64(keyStats.count)*100)
 	}
 	tw.Flush()
-	r.Info("DEw2004", fmt.Sprintf("Measured %.1f writes/sec\n", float64(keyStats.count)/float64(d.duration/time.Second))+buf.String())
+	r.Info("DE2004", fmt.Sprintf("Measured %.1f writes/sec\n", float64(keyStats.count)/float64(d.duration/time.Second))+buf.String())
 
 	return r
 }


### PR DESCRIPTION
oc adm diagnostics have many subcommands currently. So, as an
OpenShift user, it is difficult to distinguish who(admin or client)
can use what sbucommands and when. This patch makes groups to display
categorized subcommands for `oc adm diagnostics -h`.