### PR TITLE
make kubemasterconfig non-pointer since it is required

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -1,8 +1,6 @@
 package openshift_kube_apiserver
 
 import (
-	"fmt"
-
 	"github.com/golang/glog"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,10 +27,6 @@ func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error
 			HostIPCSources:     []string{kubelettypes.ApiserverSource, kubelettypes.FileSource},
 		},
 	})
-
-	if masterConfig.KubernetesMasterConfig == nil {
-		return fmt.Errorf("KubernetesMasterConfig is required to start this server - use of external Kubernetes is no longer supported.")
-	}
 
 	// install aggregator types into the scheme so that "normal" RESTOptionsGetters can work for us.
 	// done in Start() prior to doing any other initialization so we don't mutate the scheme after it is being used by clients in other goroutines.

--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -145,16 +145,14 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = append(refs, &config.AdmissionConfig.PluginConfig[k].Location)
 	}
 
-	if config.KubernetesMasterConfig != nil {
-		refs = append(refs, &config.KubernetesMasterConfig.SchedulerConfigFile)
+	refs = append(refs, &config.KubernetesMasterConfig.SchedulerConfigFile)
 
-		refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.CertFile)
-		refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.KeyFile)
+	refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.CertFile)
+	refs = append(refs, &config.KubernetesMasterConfig.ProxyClientInfo.KeyFile)
 
-		refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.APIServerArguments)
-		refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.SchedulerArguments)
-		refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.ControllerArguments)
-	}
+	refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.APIServerArguments)
+	refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.SchedulerArguments)
+	refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.ControllerArguments)
 
 	if config.AuthConfig.RequestHeader != nil {
 		refs = append(refs, &config.AuthConfig.RequestHeader.ClientCA)

--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -90,7 +90,7 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 
 			// Populate the new NetworkConfig.ServiceNetworkCIDR field from the KubernetesMasterConfig.ServicesSubnet field if needed
 			if len(obj.NetworkConfig.ServiceNetworkCIDR) == 0 {
-				if obj.KubernetesMasterConfig != nil && len(obj.KubernetesMasterConfig.ServicesSubnet) > 0 {
+				if len(obj.KubernetesMasterConfig.ServicesSubnet) > 0 {
 					// if a subnet is set in the kubernetes master config, use that
 					obj.NetworkConfig.ServiceNetworkCIDR = obj.KubernetesMasterConfig.ServicesSubnet
 				} else {
@@ -123,8 +123,7 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 			}
 
 			// TODO stop duplicating the conversion in the test.
-			kubeConfig := obj.KubernetesMasterConfig
-			noCloudProvider := kubeConfig != nil && (len(kubeConfig.ControllerArguments["cloud-provider"]) == 0 || kubeConfig.ControllerArguments["cloud-provider"][0] == "")
+			noCloudProvider := (len(obj.KubernetesMasterConfig.ControllerArguments["cloud-provider"]) == 0 || obj.KubernetesMasterConfig.ControllerArguments["cloud-provider"][0] == "")
 			if noCloudProvider && len(obj.NetworkConfig.IngressIPNetworkCIDR) == 0 {
 				cidr := configapi.DefaultIngressIPNetworkCIDR
 				setCIDR := true

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -376,7 +376,7 @@ type MasterConfig struct {
 	KubeletClientInfo KubeletConnectionInfo
 
 	// KubernetesMasterConfig, if present start the kubernetes master in this process
-	KubernetesMasterConfig *KubernetesMasterConfig
+	KubernetesMasterConfig KubernetesMasterConfig
 	// EtcdConfig, if present start etcd in this process
 	EtcdConfig *EtcdConfig
 	// OAuthConfig, if present start the /oauth endpoint in this process

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -75,7 +75,7 @@ func SetDefaults_MasterConfig(obj *MasterConfig) {
 
 	// Populate the new NetworkConfig.ServiceNetworkCIDR field from the KubernetesMasterConfig.ServicesSubnet field if needed
 	if len(obj.NetworkConfig.ServiceNetworkCIDR) == 0 {
-		if obj.KubernetesMasterConfig != nil && len(obj.KubernetesMasterConfig.ServicesSubnet) > 0 {
+		if len(obj.KubernetesMasterConfig.ServicesSubnet) > 0 {
 			// if a subnet is set in the kubernetes master config, use that
 			obj.NetworkConfig.ServiceNetworkCIDR = obj.KubernetesMasterConfig.ServicesSubnet
 		} else {
@@ -85,8 +85,7 @@ func SetDefaults_MasterConfig(obj *MasterConfig) {
 	}
 
 	// TODO Detect cloud provider when not using built-in kubernetes
-	kubeConfig := obj.KubernetesMasterConfig
-	noCloudProvider := kubeConfig != nil && (len(kubeConfig.ControllerArguments["cloud-provider"]) == 0 || kubeConfig.ControllerArguments["cloud-provider"][0] == "")
+	noCloudProvider := (len(obj.KubernetesMasterConfig.ControllerArguments["cloud-provider"]) == 0 || obj.KubernetesMasterConfig.ControllerArguments["cloud-provider"][0] == "")
 
 	if noCloudProvider && len(obj.NetworkConfig.IngressIPNetworkCIDR) == 0 {
 		cidr := internal.DefaultIngressIPNetworkCIDR

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -239,7 +239,7 @@ type MasterConfig struct {
 	KubeletClientInfo KubeletConnectionInfo `json:"kubeletClientInfo"`
 
 	// KubernetesMasterConfig, if present start the kubernetes master in this process
-	KubernetesMasterConfig *KubernetesMasterConfig `json:"kubernetesMasterConfig"`
+	KubernetesMasterConfig KubernetesMasterConfig `json:"kubernetesMasterConfig"`
 	// EtcdConfig, if present start etcd in this process
 	EtcdConfig *EtcdConfig `json:"etcdConfig"`
 	// OAuthConfig, if present start the /oauth endpoint in this process

--- a/pkg/cmd/server/apis/config/v1/types_test.go
+++ b/pkg/cmd/server/apis/config/v1/types_test.go
@@ -191,7 +191,7 @@ func TestMasterConfig(t *testing.T) {
 				NamedCertificates: []internal.NamedCertificate{{}},
 			},
 		},
-		KubernetesMasterConfig: &internal.KubernetesMasterConfig{},
+		KubernetesMasterConfig: internal.KubernetesMasterConfig{},
 		EtcdConfig:             &internal.EtcdConfig{},
 		OAuthConfig: &internal.OAuthConfig{
 			IdentityProviders: []internal.IdentityProvider{

--- a/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
@@ -1186,15 +1186,7 @@ func (in *MasterConfig) DeepCopyInto(out *MasterConfig) {
 	out.EtcdStorageConfig = in.EtcdStorageConfig
 	in.EtcdClientInfo.DeepCopyInto(&out.EtcdClientInfo)
 	out.KubeletClientInfo = in.KubeletClientInfo
-	if in.KubernetesMasterConfig != nil {
-		in, out := &in.KubernetesMasterConfig, &out.KubernetesMasterConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(KubernetesMasterConfig)
-			(*in).DeepCopyInto(*out)
-		}
-	}
+	in.KubernetesMasterConfig.DeepCopyInto(&out.KubernetesMasterConfig)
 	if in.EtcdConfig != nil {
 		in, out := &in.EtcdConfig, &out.EtcdConfig
 		if *in == nil {

--- a/pkg/cmd/server/apis/config/v1/zz_generated.defaults.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.defaults.go
@@ -21,9 +21,7 @@ func SetObjectDefaults_MasterConfig(in *MasterConfig) {
 	SetDefaults_MasterConfig(in)
 	SetDefaults_ServingInfo(&in.ServingInfo.ServingInfo)
 	SetDefaults_EtcdStorageConfig(&in.EtcdStorageConfig)
-	if in.KubernetesMasterConfig != nil {
-		SetDefaults_KubernetesMasterConfig(in.KubernetesMasterConfig)
-	}
+	SetDefaults_KubernetesMasterConfig(&in.KubernetesMasterConfig)
 	if in.EtcdConfig != nil {
 		SetDefaults_ServingInfo(&in.EtcdConfig.ServingInfo)
 		SetDefaults_ServingInfo(&in.EtcdConfig.PeerServingInfo)

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -103,15 +103,12 @@ func ValidateMasterConfig(config *configapi.MasterConfig, fldPath *field.Path) V
 
 	validationResults.AddErrors(ValidateKubeletConnectionInfo(config.KubeletClientInfo, fldPath.Child("kubeletClientInfo"))...)
 
-	builtInKubernetes := config.KubernetesMasterConfig != nil
-	if config.KubernetesMasterConfig != nil {
-		validationResults.Append(ValidateKubernetesMasterConfig(config.KubernetesMasterConfig, fldPath.Child("kubernetesMasterConfig")))
-	}
+	validationResults.Append(ValidateKubernetesMasterConfig(config.KubernetesMasterConfig, fldPath.Child("kubernetesMasterConfig")))
 
 	if len(config.NetworkConfig.ServiceNetworkCIDR) > 0 {
 		if _, _, err := net.ParseCIDR(strings.TrimSpace(config.NetworkConfig.ServiceNetworkCIDR)); err != nil {
 			validationResults.AddErrors(field.Invalid(fldPath.Child("networkConfig", "serviceNetworkCIDR"), config.NetworkConfig.ServiceNetworkCIDR, "must be a valid CIDR notation IP range (e.g. 172.30.0.0/16)"))
-		} else if config.KubernetesMasterConfig != nil && len(config.KubernetesMasterConfig.ServicesSubnet) > 0 && config.KubernetesMasterConfig.ServicesSubnet != config.NetworkConfig.ServiceNetworkCIDR {
+		} else if len(config.KubernetesMasterConfig.ServicesSubnet) > 0 && config.KubernetesMasterConfig.ServicesSubnet != config.NetworkConfig.ServiceNetworkCIDR {
 			validationResults.AddErrors(field.Invalid(fldPath.Child("networkConfig", "serviceNetworkCIDR"), config.NetworkConfig.ServiceNetworkCIDR, fmt.Sprintf("must match kubernetesMasterConfig.servicesSubnet value of %q", config.KubernetesMasterConfig.ServicesSubnet)))
 		}
 	}
@@ -136,7 +133,8 @@ func ValidateMasterConfig(config *configapi.MasterConfig, fldPath *field.Path) V
 			validationResults.AddErrors(field.Invalid(fldPath.Child("authConfig", "oauthMetadataFile"), config.AuthConfig.OAuthMetadataFile, "Cannot specify external OAuth Metadata when the internal Oauth Server is configured"))
 		}
 	}
-	validationResults.Append(ValidateServiceAccountConfig(config.ServiceAccountConfig, builtInKubernetes, fldPath.Child("serviceAccountConfig")))
+
+	validationResults.Append(ValidateServiceAccountConfig(config.ServiceAccountConfig, fldPath.Child("serviceAccountConfig")))
 
 	validationResults.Append(ValidateHTTPServingInfo(config.ServingInfo, fldPath.Child("servingInfo")))
 
@@ -395,7 +393,7 @@ func ValidateStorageVersionLevel(level string, knownAPILevels, deadAPILevels []s
 	return allErrs
 }
 
-func ValidateServiceAccountConfig(config configapi.ServiceAccountConfig, builtInKubernetes bool, fldPath *field.Path) ValidationResults {
+func ValidateServiceAccountConfig(config configapi.ServiceAccountConfig, fldPath *field.Path) ValidationResults {
 	validationResults := ValidationResults{}
 
 	managedNames := sets.NewString(config.ManagedNames...)
@@ -406,7 +404,7 @@ func ValidateServiceAccountConfig(config configapi.ServiceAccountConfig, builtIn
 	if !managedNames.Has(bootstrappolicy.DeployerServiceAccountName) {
 		validationResults.AddWarnings(field.Invalid(managedNamesPath, "", fmt.Sprintf("missing %q, which will require manual creation in each namespace before deployments can run", bootstrappolicy.DeployerServiceAccountName)))
 	}
-	if builtInKubernetes && !managedNames.Has(bootstrappolicy.DefaultServiceAccountName) {
+	if !managedNames.Has(bootstrappolicy.DefaultServiceAccountName) {
 		validationResults.AddWarnings(field.Invalid(managedNamesPath, "", fmt.Sprintf("missing %q, which will prevent creation of pods that do not specify a valid service account", bootstrappolicy.DefaultServiceAccountName)))
 	}
 
@@ -423,7 +421,7 @@ func ValidateServiceAccountConfig(config configapi.ServiceAccountConfig, builtIn
 		} else if _, err := cert.PrivateKeyFromFile(config.PrivateKeyFile); err != nil {
 			validationResults.AddErrors(field.Invalid(privateKeyFilePath, config.PrivateKeyFile, err.Error()))
 		}
-	} else if builtInKubernetes {
+	} else {
 		validationResults.AddWarnings(field.Invalid(fldPath.Child("privateKeyFile"), "", "no service account tokens will be generated, which could prevent builds and deployments from working"))
 	}
 
@@ -441,7 +439,7 @@ func ValidateServiceAccountConfig(config configapi.ServiceAccountConfig, builtIn
 
 	if len(config.MasterCA) > 0 {
 		validationResults.AddErrors(ValidateFile(config.MasterCA, fldPath.Child("masterCA"))...)
-	} else if builtInKubernetes {
+	} else {
 		validationResults.AddWarnings(field.Invalid(fldPath.Child("masterCA"), "", "master CA information will not be automatically injected into pods, which will prevent verification of the API server from inside a pod"))
 	}
 
@@ -510,7 +508,7 @@ func ValidateKubeletConnectionInfo(config configapi.KubeletConnectionInfo, fldPa
 	return allErrs
 }
 
-func ValidateKubernetesMasterConfig(config *configapi.KubernetesMasterConfig, fldPath *field.Path) ValidationResults {
+func ValidateKubernetesMasterConfig(config configapi.KubernetesMasterConfig, fldPath *field.Path) ValidationResults {
 	validationResults := ValidationResults{}
 
 	if len(config.MasterIP) > 0 {
@@ -696,7 +694,7 @@ func ValidateIngressIPNetworkCIDR(config *configapi.MasterConfig, fldPath *field
 
 	// TODO Detect cloud provider when not using built-in kubernetes
 	kubeConfig := config.KubernetesMasterConfig
-	noCloudProvider := kubeConfig != nil && (len(kubeConfig.ControllerArguments["cloud-provider"]) == 0 || kubeConfig.ControllerArguments["cloud-provider"][0] == "")
+	noCloudProvider := (len(kubeConfig.ControllerArguments["cloud-provider"]) == 0 || kubeConfig.ControllerArguments["cloud-provider"][0] == "")
 
 	if noCloudProvider {
 		for _, entry := range config.NetworkConfig.ClusterNetworks {

--- a/pkg/cmd/server/apis/config/validation/master_test.go
+++ b/pkg/cmd/server/apis/config/validation/master_test.go
@@ -285,7 +285,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 		{
 			name: "specified kube admission order 02",
 			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+				KubernetesMasterConfig: configapi.KubernetesMasterConfig{
 					APIServerArguments: configapi.ExtendedArguments{
 						"admission-control": []string{"foo"},
 					},
@@ -305,7 +305,7 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 		{
 			name: "specified kube admission config file",
 			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+				KubernetesMasterConfig: configapi.KubernetesMasterConfig{
 					APIServerArguments: configapi.ExtendedArguments{
 						"admission-control-config-file": []string{"foo"},
 					},
@@ -432,7 +432,7 @@ func TestValidateIngressIPNetworkCIDR(t *testing.T) {
 	}
 	for _, test := range testCases {
 		config := &configapi.MasterConfig{
-			KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+			KubernetesMasterConfig: configapi.KubernetesMasterConfig{
 				ControllerArguments: configapi.ExtendedArguments{
 					"cloud-provider": []string{test.cloudProvider},
 				},

--- a/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
@@ -1172,15 +1172,7 @@ func (in *MasterConfig) DeepCopyInto(out *MasterConfig) {
 	out.EtcdStorageConfig = in.EtcdStorageConfig
 	in.EtcdClientInfo.DeepCopyInto(&out.EtcdClientInfo)
 	out.KubeletClientInfo = in.KubeletClientInfo
-	if in.KubernetesMasterConfig != nil {
-		in, out := &in.KubernetesMasterConfig, &out.KubernetesMasterConfig
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(KubernetesMasterConfig)
-			(*in).DeepCopyInto(*out)
-		}
-	}
+	in.KubernetesMasterConfig.DeepCopyInto(&out.KubernetesMasterConfig)
 	if in.EtcdConfig != nil {
 		in, out := &in.EtcdConfig, &out.EtcdConfig
 		if *in == nil {

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -94,9 +94,6 @@ var LegacyAPIGroupPrefixes = sets.NewString(apiserver.DefaultLegacyAPIPrefix, ap
 // BuildKubeAPIserverOptions constructs the appropriate kube-apiserver run options.
 // It returns an error if no KubernetesMasterConfig was defined.
 func BuildKubeAPIserverOptions(masterConfig configapi.MasterConfig) (*kapiserveroptions.ServerRunOptions, error) {
-	if masterConfig.KubernetesMasterConfig == nil {
-		return nil, fmt.Errorf("no kubernetesMasterConfig defined, unable to load settings")
-	}
 	host, portString, err := net.SplitHostPort(masterConfig.ServingInfo.BindAddress)
 	if err != nil {
 		return nil, err
@@ -721,14 +718,14 @@ func getAPIResourceConfig(options configapi.MasterConfig) apiserverstorage.APIRe
 	resourceConfig := apiserverstorage.NewResourceConfig()
 
 	for group := range configapi.KnownKubeAPIGroups {
-		for _, version := range configapi.GetEnabledAPIVersionsForGroup(*options.KubernetesMasterConfig, group) {
+		for _, version := range configapi.GetEnabledAPIVersionsForGroup(options.KubernetesMasterConfig, group) {
 			gv := schema.GroupVersion{Group: group, Version: version}
 			resourceConfig.EnableVersions(gv)
 		}
 	}
 
 	for group := range options.KubernetesMasterConfig.DisabledAPIGroupVersions {
-		for _, version := range configapi.GetDisabledAPIVersionsForGroup(*options.KubernetesMasterConfig, group) {
+		for _, version := range configapi.GetDisabledAPIVersionsForGroup(options.KubernetesMasterConfig, group) {
 			gv := schema.GroupVersion{Group: group, Version: version}
 			resourceConfig.DisableVersions(gv)
 		}

--- a/pkg/cmd/server/kubernetes/master/master_config_test.go
+++ b/pkg/cmd/server/kubernetes/master/master_config_test.go
@@ -399,7 +399,7 @@ func TestGetAPIGroupVersionOverrides(t *testing.T) {
 	}
 
 	for k, tc := range testcases {
-		config := configapi.MasterConfig{KubernetesMasterConfig: &configapi.KubernetesMasterConfig{DisabledAPIGroupVersions: tc.DisabledVersions}}
+		config := configapi.MasterConfig{KubernetesMasterConfig: configapi.KubernetesMasterConfig{DisabledAPIGroupVersions: tc.DisabledVersions}}
 		overrides := getAPIResourceConfig(config)
 
 		for _, expected := range tc.ExpectedDisabledVersions {

--- a/pkg/cmd/server/origin/admission/config_test.go
+++ b/pkg/cmd/server/origin/admission/config_test.go
@@ -101,7 +101,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 		{
 			name: "stock everything",
 			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{},
+				KubernetesMasterConfig: configapi.KubernetesMasterConfig{},
 			},
 			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, options configapi.MasterConfig, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error) {
 				if !reflect.DeepEqual(pluginNames, combinedAdmissionControlPlugins) {
@@ -113,7 +113,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 		{
 			name: "specified origin admission order",
 			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{},
+				KubernetesMasterConfig: configapi.KubernetesMasterConfig{},
 				AdmissionConfig: configapi.AdmissionConfig{
 					PluginOrderOverride: []string{"foo"},
 				},
@@ -134,7 +134,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 		{
 			name: "specified kube admission config file",
 			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
+				KubernetesMasterConfig: configapi.KubernetesMasterConfig{
 					APIServerArguments: configapi.ExtendedArguments{
 						"admission-control-config-file": []string{"foo"},
 					},
@@ -152,7 +152,7 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 		{
 			name: "specified, non-conflicting plugin configs 01",
 			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{},
+				KubernetesMasterConfig: configapi.KubernetesMasterConfig{},
 				AdmissionConfig: configapi.AdmissionConfig{
 					PluginConfig: map[string]*configapi.AdmissionPluginConfig{
 						"foo": {

--- a/pkg/cmd/server/start/start_api.go
+++ b/pkg/cmd/server/start/start_api.go
@@ -93,18 +93,16 @@ func NewCommandStartMasterAPI(name, basename string, out, errout io.Writer) (*co
 	options.MasterArgs.OverrideConfig = func(config *configapi.MasterConfig) error {
 		// we do not currently enable multi host etcd for the cluster
 		config.EtcdConfig = nil
-		if config.KubernetesMasterConfig != nil {
-			if masterAddr.Provided {
-				if ip := net.ParseIP(masterAddr.Host); ip != nil {
-					glog.V(2).Infof("Using a masterIP override %q", ip)
-					config.KubernetesMasterConfig.MasterIP = ip.String()
-				}
+		if masterAddr.Provided {
+			if ip := net.ParseIP(masterAddr.Host); ip != nil {
+				glog.V(2).Infof("Using a masterIP override %q", ip)
+				config.KubernetesMasterConfig.MasterIP = ip.String()
 			}
-			if listenArg.ListenAddr.Provided {
-				addr := listenArg.ListenAddr.URL.Host
-				glog.V(2).Infof("Using a listen address override %q", addr)
-				applyBindAddressOverride(addr, config)
-			}
+		}
+		if listenArg.ListenAddr.Provided {
+			addr := listenArg.ListenAddr.URL.Host
+			glog.V(2).Infof("Using a listen address override %q", addr)
+			applyBindAddressOverride(addr, config)
 		}
 		return nil
 	}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -104,7 +104,7 @@ func NewCommandStartMaster(basename string, out, errout io.Writer) (*cobra.Comma
 	options.MasterArgs.StartAPI = true
 	options.MasterArgs.StartControllers = true
 	options.MasterArgs.OverrideConfig = func(config *configapi.MasterConfig) error {
-		if config.KubernetesMasterConfig != nil && options.MasterArgs.MasterAddr.Provided {
+		if options.MasterArgs.MasterAddr.Provided {
 			if ip := net.ParseIP(options.MasterArgs.MasterAddr.Host); ip != nil {
 				glog.V(2).Infof("Using a masterIP override %q", ip)
 				config.KubernetesMasterConfig.MasterIP = ip.String()
@@ -351,10 +351,6 @@ func (m *Master) Start() error {
 			HostIPCSources:     []string{kubelettypes.ApiserverSource, kubelettypes.FileSource},
 		},
 	})
-
-	if m.config.KubernetesMasterConfig == nil {
-		return fmt.Errorf("KubernetesMasterConfig is required to start this server - use of external Kubernetes is no longer supported.")
-	}
 
 	// install aggregator types into the scheme so that "normal" RESTOptionsGetters can work for us.
 	// done in Start() prior to doing any other initialization so we don't mutate the scheme after it is being used by clients in other goroutines.

--- a/test/integration/api_paths_test.go
+++ b/test/integration/api_paths_test.go
@@ -49,7 +49,7 @@ func TestRootAPIPaths(t *testing.T) {
 	// We need to make sure that any APILevels specified in the config are present in the RootPaths, and that
 	// any not specified are not
 	expectedOpenShiftAPILevels := sets.NewString(masterConfig.APILevels...)
-	expectedKubeAPILevels := sets.NewString(configapi.GetEnabledAPIVersionsForGroup(*masterConfig.KubernetesMasterConfig, kapi.GroupName)...)
+	expectedKubeAPILevels := sets.NewString(configapi.GetEnabledAPIVersionsForGroup(masterConfig.KubernetesMasterConfig, kapi.GroupName)...)
 	actualOpenShiftAPILevels := sets.String{}
 	actualKubeAPILevels := sets.String{}
 	for _, route := range broadcastRootPaths.Paths {

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -125,9 +125,6 @@ func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.Cl
 		t.Fatal(err)
 	}
 	// fill in possibly-empty config values
-	if masterConfig.KubernetesMasterConfig == nil {
-		masterConfig.KubernetesMasterConfig = &config.KubernetesMasterConfig{}
-	}
 	if masterConfig.AdmissionConfig.PluginConfig == nil {
 		masterConfig.AdmissionConfig.PluginConfig = map[string]*config.AdmissionPluginConfig{}
 	}


### PR DESCRIPTION
The `KubeMasterConfig` in a master-config.yaml hasn't been optional in a long while.  The server refused to start it wasn't present.  This makes it a non-pointer so that all the conditional checks in the code can drop out.  No serialization changes.

/assign @mfojtik 
@openshift/api-review fyi