### PR TITLE
remove dead auth related master-config fields

### DIFF
--- a/pkg/cmd/openshift-controller-manager/controller/config.go
+++ b/pkg/cmd/openshift-controller-manager/controller/config.go
@@ -10,6 +10,7 @@ import (
 	serviceaccountadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
 
@@ -179,7 +180,7 @@ func BuildOpenshiftControllerConfig(options configapi.MasterConfig) (*OpenshiftC
 
 	// TODO this goes away with a truly generic autoscaler
 	ret.HorizontalPodAutoscalerControllerConfig = HorizontalPodAutoscalerControllerConfig{
-		HeapsterNamespace: options.PolicyConfig.OpenShiftInfrastructureNamespace,
+		HeapsterNamespace: bootstrappolicy.DefaultOpenShiftInfraNamespace,
 	}
 
 	return ret, nil

--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -179,8 +179,6 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 	refs = append(refs, &config.MasterClients.OpenShiftLoopbackKubeConfig)
 	refs = append(refs, &config.MasterClients.ExternalKubernetesKubeConfig)
 
-	refs = append(refs, &config.PolicyConfig.BootstrapPolicyFile)
-
 	if config.ControllerConfig.ServiceServingCert.Signer != nil {
 		refs = append(refs, &config.ControllerConfig.ServiceServingCert.Signer.CertFile)
 		refs = append(refs, &config.ControllerConfig.ServiceServingCert.Signer.KeyFile)

--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -21,7 +21,6 @@ import (
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	configapiv1 "github.com/openshift/origin/pkg/cmd/server/apis/config/v1"
-	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	imagepolicyapi "github.com/openshift/origin/pkg/image/admission/apis/imagepolicy"
 	podnodeapi "github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints"
 
@@ -65,9 +64,6 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 			}
 			if obj.ServingInfo.MaxRequestsInFlight == 0 {
 				obj.ServingInfo.MaxRequestsInFlight = 1200
-			}
-			if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
-				obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace
 			}
 			if len(obj.RoutingConfig.Subdomain) == 0 {
 				obj.RoutingConfig.Subdomain = "router.default.svc.cluster.local"

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -621,15 +621,6 @@ type SecurityAllocator struct {
 }
 
 type PolicyConfig struct {
-	// BootstrapPolicyFile points to a template that contains roles and rolebindings that will be created if no policy object exists in the master namespace
-	BootstrapPolicyFile string
-
-	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)
-	OpenShiftSharedResourcesNamespace string
-
-	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
-	OpenShiftInfrastructureNamespace string
-
 	// UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
 	UserAgentMatchingConfig UserAgentMatchingConfig
 }

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/origin/pkg/api/apihelpers"
 	internal "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -44,9 +43,6 @@ func SetDefaults_MasterConfig(obj *MasterConfig) {
 	}
 	if obj.ServingInfo.MaxRequestsInFlight == 0 {
 		obj.ServingInfo.MaxRequestsInFlight = 1200
-	}
-	if len(obj.PolicyConfig.OpenShiftInfrastructureNamespace) == 0 {
-		obj.PolicyConfig.OpenShiftInfrastructureNamespace = bootstrappolicy.DefaultOpenShiftInfraNamespace
 	}
 	if len(obj.RoutingConfig.Subdomain) == 0 {
 		obj.RoutingConfig.Subdomain = "router.default.svc.cluster.local"

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -371,9 +371,6 @@ oauthConfig:
     authorizeTokenMaxAgeSeconds: 0
 pauseControllers: false
 policyConfig:
-  bootstrapPolicyFile: ""
-  openshiftInfrastructureNamespace: openshift-infra
-  openshiftSharedResourcesNamespace: ""
   userAgentMatchingConfig:
     defaultRejectionMessage: ""
     deniedClients: null

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -481,15 +481,6 @@ type SecurityAllocator struct {
 
 //  holds the necessary configuration options for
 type PolicyConfig struct {
-	// BootstrapPolicyFile points to a template that contains roles and rolebindings that will be created if no policy object exists in the master namespace
-	BootstrapPolicyFile string `json:"bootstrapPolicyFile"`
-
-	// OpenShiftSharedResourcesNamespace is the namespace where shared OpenShift resources live (like shared templates)
-	OpenShiftSharedResourcesNamespace string `json:"openshiftSharedResourcesNamespace"`
-
-	// OpenShiftInfrastructureNamespace is the namespace where OpenShift infrastructure resources live (like controller service accounts)
-	OpenShiftInfrastructureNamespace string `json:"openshiftInfrastructureNamespace"`
-
 	// UserAgentMatchingConfig controls how API calls from *voluntarily* identifying clients will be handled.  THIS DOES NOT DEFEND AGAINST MALICIOUS CLIENTS!
 	UserAgentMatchingConfig UserAgentMatchingConfig `json:"userAgentMatchingConfig"`
 }

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -582,9 +582,6 @@ func ValidateKubernetesMasterConfig(config *configapi.KubernetesMasterConfig, fl
 func ValidatePolicyConfig(config configapi.PolicyConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftSharedResourcesNamespace, fldPath.Child("openShiftSharedResourcesNamespace"))...)
-	allErrs = append(allErrs, ValidateNamespace(config.OpenShiftInfrastructureNamespace, fldPath.Child("openShiftInfrastructureNamespace"))...)
-
 	for i, matchingRule := range config.UserAgentMatchingConfig.DeniedClients {
 		_, err := regexp.Compile(matchingRule.Regex)
 		if err != nil {

--- a/pkg/cmd/server/apis/config/validation/validation.go
+++ b/pkg/cmd/server/apis/config/validation/validation.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	kvalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 
 	"github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
@@ -337,18 +336,6 @@ func ValidateURL(urlString string, fldPath *field.Path) (*url.URL, field.ErrorLi
 		allErrs = append(allErrs, field.Invalid(fldPath, urlString, "must contain a host"))
 	}
 	return urlObj, allErrs
-}
-
-func ValidateNamespace(namespace string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if len(namespace) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, ""))
-	} else if reasons := kvalidation.ValidateNamespaceName(namespace, false); len(reasons) != 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, namespace, "must be a valid namespace"))
-	}
-
-	return allErrs
 }
 
 func ValidateFile(path string, fldPath *field.Path) field.ErrorList {

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -115,11 +115,6 @@ func NewDefaultMasterArgs() *MasterArgs {
 	return config
 }
 
-// GetPolicyFile returns the policy filepath for master
-func (args MasterArgs) GetPolicyFile() string {
-	return path.Join(args.ConfigDir.Value(), "policy.json")
-}
-
 // GetConfigFileToWrite returns the configuration filepath for master
 func (args MasterArgs) GetConfigFileToWrite() string {
 	return path.Join(args.ConfigDir.Value(), "master-config.yaml")
@@ -248,11 +243,6 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 
 		KubeletClientInfo: configapi.KubeletConnectionInfo{
 			Port: ports.KubeletPort,
-		},
-
-		PolicyConfig: configapi.PolicyConfig{
-			BootstrapPolicyFile:               args.GetPolicyFile(),
-			OpenShiftSharedResourcesNamespace: bootstrappolicy.DefaultOpenShiftSharedResourcesNamespace,
 		},
 
 		ImageConfig: configapi.ImageConfig{


### PR DESCRIPTION
These values weren't respected anywhere (barring a single accidental reference for heapster).

@openshift/api-review 
@openshift/sig-security fyi
/assign @mfojtik 