### PR TITLE
remove illegal and dead kubemasterconfig fields

### DIFF
--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -154,10 +154,6 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 		refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.APIServerArguments)
 		refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.SchedulerArguments)
 		refs = appendFlagsWithFileExtensions(refs, config.KubernetesMasterConfig.ControllerArguments)
-
-		for k := range config.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
-			refs = append(refs, &config.KubernetesMasterConfig.AdmissionConfig.PluginConfig[k].Location)
-		}
 	}
 
 	if config.AuthConfig.RequestHeader != nil {

--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -191,25 +191,7 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 					obj.AdmissionConfig.PluginConfig[pluginName] = &configapi.AdmissionPluginConfig{}
 				}
 			}
-			if obj.KubernetesMasterConfig != nil {
-				for pluginName := range obj.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
-					if obj.KubernetesMasterConfig.AdmissionConfig.PluginConfig[pluginName] == nil {
-						obj.KubernetesMasterConfig.AdmissionConfig.PluginConfig[pluginName] = &configapi.AdmissionPluginConfig{}
-					}
-				}
-			}
 
-			// test a Kubernetes admission plugin nested for round tripping
-			if obj.KubernetesMasterConfig != nil && c.RandBool() {
-				obj.KubernetesMasterConfig.AdmissionConfig.PluginConfig = map[string]*configapi.AdmissionPluginConfig{
-					"abc": {
-						Location: "test",
-						Configuration: &configapi.LDAPSyncConfig{
-							URL: "ldap://some:other@server:8080/test",
-						},
-					},
-				}
-			}
 			if obj.OAuthConfig != nil && c.RandBool() {
 				obj.OAuthConfig.IdentityProviders = []configapi.IdentityProvider{
 					{
@@ -234,9 +216,6 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 		},
 		func(obj *configapi.KubernetesMasterConfig, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
-			if obj.MasterCount == 0 {
-				obj.MasterCount = 1
-			}
 			if len(obj.ServicesNodePortRange) == 0 {
 				obj.ServicesNodePortRange = "30000-32767"
 			}

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -1214,9 +1214,6 @@ type KubernetesMasterConfig struct {
 
 	// MasterIP is the public IP address of kubernetes stuff.  If empty, the first result from net.InterfaceAddrs will be used.
 	MasterIP string
-	// MasterCount is the number of expected masters that should be running. This value defaults to 1 and may be set to a positive integer,
-	// or if set to -1, indicates this is part of a cluster.
-	MasterCount int
 	// MasterEndpointReconcileTTL sets the time to live in seconds of an endpoint record recorded by each master. The endpoints are checked
 	// at an interval that is 2/3 of this value and this value defaults to 15s if unset. In very large clusters, this value may be increased to
 	// reduce the possibility that the master endpoint record expires (due to other load on the etcd server) and causes masters to drop in and
@@ -1226,8 +1223,6 @@ type KubernetesMasterConfig struct {
 	ServicesSubnet string
 	// ServicesNodePortRange is the range to use for assigning service public ports on a host.
 	ServicesNodePortRange string
-	// StaticNodeNames is the list of nodes that are statically known
-	StaticNodeNames []string
 
 	// SchedulerConfigFile points to a file that describes how to set up the scheduler. If empty, you get the default scheduling rules.
 	SchedulerConfigFile string
@@ -1238,9 +1233,6 @@ type KubernetesMasterConfig struct {
 
 	// ProxyClientInfo specifies the client cert/key to use when proxying to pods
 	ProxyClientInfo CertInfo
-
-	// AdmissionConfig contains admission control plugin configuration.
-	AdmissionConfig AdmissionConfig
 
 	// APIServerArguments are key value pairs that will be passed directly to the Kube apiserver that match the apiservers's
 	// command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -146,9 +146,6 @@ func SetDefaults_MasterConfig(obj *MasterConfig) {
 }
 
 func SetDefaults_KubernetesMasterConfig(obj *KubernetesMasterConfig) {
-	if obj.MasterCount == 0 {
-		obj.MasterCount = 1
-	}
 	if obj.MasterEndpointReconcileTTL == 0 {
 		obj.MasterEndpointReconcileTTL = 15
 	}
@@ -160,12 +157,6 @@ func SetDefaults_KubernetesMasterConfig(obj *KubernetesMasterConfig) {
 	}
 	if len(obj.PodEvictionTimeout) == 0 {
 		obj.PodEvictionTimeout = "5m"
-	}
-	// Ensure no nil plugin config stanzas
-	for pluginName := range obj.AdmissionConfig.PluginConfig {
-		if obj.AdmissionConfig.PluginConfig[pluginName] == nil {
-			obj.AdmissionConfig.PluginConfig[pluginName] = &AdmissionPluginConfig{}
-		}
 	}
 }
 func SetDefaults_NodeConfig(obj *NodeConfig) {
@@ -465,12 +456,6 @@ func (c *MasterConfig) DecodeNestedObjects(d runtime.Decoder) error {
 		apihelpers.DecodeNestedRawExtensionOrUnknown(d, &v.Configuration)
 		c.AdmissionConfig.PluginConfig[k] = v
 	}
-	if c.KubernetesMasterConfig != nil {
-		for k, v := range c.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
-			apihelpers.DecodeNestedRawExtensionOrUnknown(d, &v.Configuration)
-			c.KubernetesMasterConfig.AdmissionConfig.PluginConfig[k] = v
-		}
-	}
 	if c.OAuthConfig != nil {
 		for i := range c.OAuthConfig.IdentityProviders {
 			apihelpers.DecodeNestedRawExtensionOrUnknown(d, &c.OAuthConfig.IdentityProviders[i].Provider)
@@ -490,14 +475,6 @@ func (c *MasterConfig) EncodeNestedObjects(e runtime.Encoder) error {
 			return err
 		}
 		c.AdmissionConfig.PluginConfig[k] = v
-	}
-	if c.KubernetesMasterConfig != nil {
-		for k, v := range c.KubernetesMasterConfig.AdmissionConfig.PluginConfig {
-			if err := apihelpers.EncodeNestedRawExtension(e, &v.Configuration); err != nil {
-				return err
-			}
-			c.KubernetesMasterConfig.AdmissionConfig.PluginConfig[k] = v
-		}
 	}
 	if c.OAuthConfig != nil {
 		for i := range c.OAuthConfig.IdentityProviders {

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -91,21 +91,10 @@ kubeletClientInfo:
   keyFile: ""
   port: 0
 kubernetesMasterConfig:
-  admissionConfig:
-    pluginConfig:
-      plugin:
-        configuration:
-          apiVersion: v1
-          data: ""
-          kind: AdmissionPluginTestConfig
-        location: ""
-    pluginOrderOverride:
-    - plugin
   apiLevels: null
   apiServerArguments: null
   controllerArguments: null
   disabledAPIGroupVersions: {}
-  masterCount: 1
   masterEndpointReconcileTTL: 15
   masterIP: ""
   podEvictionTimeout: 5m
@@ -116,7 +105,6 @@ kubernetesMasterConfig:
   schedulerConfigFile: ""
   servicesNodePortRange: 30000-32767
   servicesSubnet: ""
-  staticNodeNames: null
 masterClients:
   externalKubernetesClientConnectionOverrides:
     acceptContentTypes: application/json

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -1139,9 +1139,6 @@ type KubernetesMasterConfig struct {
 
 	// MasterIP is the public IP address of kubernetes stuff.  If empty, the first result from net.InterfaceAddrs will be used.
 	MasterIP string `json:"masterIP"`
-	// MasterCount is the number of expected masters that should be running. This value defaults to 1 and may be set to a positive integer,
-	// or if set to -1, indicates this is part of a cluster.
-	MasterCount int `json:"masterCount"`
 	// MasterEndpointReconcileTTL sets the time to live in seconds of an endpoint record recorded by each master. The endpoints are checked
 	// at an interval that is 2/3 of this value and this value defaults to 15s if unset. In very large clusters, this value may be increased to
 	// reduce the possibility that the master endpoint record expires (due to other load on the etcd server) and causes masters to drop in and
@@ -1151,8 +1148,6 @@ type KubernetesMasterConfig struct {
 	ServicesSubnet string `json:"servicesSubnet"`
 	// ServicesNodePortRange is the range to use for assigning service public ports on a host.
 	ServicesNodePortRange string `json:"servicesNodePortRange"`
-	// StaticNodeNames is the list of nodes that are statically known
-	StaticNodeNames []string `json:"staticNodeNames"`
 
 	// SchedulerConfigFile points to a file that describes how to set up the scheduler. If empty, you get the default scheduling rules.
 	SchedulerConfigFile string `json:"schedulerConfigFile"`
@@ -1162,9 +1157,6 @@ type KubernetesMasterConfig struct {
 	PodEvictionTimeout string `json:"podEvictionTimeout"`
 	// ProxyClientInfo specifies the client cert/key to use when proxying to pods
 	ProxyClientInfo CertInfo `json:"proxyClientInfo"`
-
-	// AdmissionConfig contains admission control plugin configuration.
-	AdmissionConfig AdmissionConfig `json:"admissionConfig"`
 
 	// APIServerArguments are key value pairs that will be passed directly to the Kube apiserver that match the apiservers's
 	// command line arguments.  These are not migrated, but if you reference a value that does not exist the server will not

--- a/pkg/cmd/server/apis/config/v1/types_test.go
+++ b/pkg/cmd/server/apis/config/v1/types_test.go
@@ -191,17 +191,8 @@ func TestMasterConfig(t *testing.T) {
 				NamedCertificates: []internal.NamedCertificate{{}},
 			},
 		},
-		KubernetesMasterConfig: &internal.KubernetesMasterConfig{
-			AdmissionConfig: internal.AdmissionConfig{
-				PluginConfig: map[string]*internal.AdmissionPluginConfig{ // test config as an embedded object
-					"plugin": {
-						Configuration: &testtypes.AdmissionPluginTestConfig{},
-					},
-				},
-				PluginOrderOverride: []string{"plugin"}, // explicitly set this field because it's omitempty
-			},
-		},
-		EtcdConfig: &internal.EtcdConfig{},
+		KubernetesMasterConfig: &internal.KubernetesMasterConfig{},
+		EtcdConfig:             &internal.EtcdConfig{},
 		OAuthConfig: &internal.OAuthConfig{
 			IdentityProviders: []internal.IdentityProvider{
 				{Provider: &internal.BasicAuthPasswordIdentityProvider{}},

--- a/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
@@ -873,13 +873,7 @@ func (in *KubernetesMasterConfig) DeepCopyInto(out *KubernetesMasterConfig) {
 			}
 		}
 	}
-	if in.StaticNodeNames != nil {
-		in, out := &in.StaticNodeNames, &out.StaticNodeNames
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	out.ProxyClientInfo = in.ProxyClientInfo
-	in.AdmissionConfig.DeepCopyInto(&out.AdmissionConfig)
 	if in.APIServerArguments != nil {
 		in, out := &in.APIServerArguments, &out.APIServerArguments
 		*out = make(ExtendedArguments, len(*in))

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -518,10 +518,6 @@ func ValidateKubernetesMasterConfig(config *configapi.KubernetesMasterConfig, fl
 		validationResults.AddErrors(ValidateSpecifiedIP(config.MasterIP, fldPath.Child("masterIP"))...)
 	}
 
-	if config.MasterCount == 0 || config.MasterCount < -1 {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("masterCount"), config.MasterCount, "must be a positive integer or -1"))
-	}
-
 	validationResults.AddErrors(ValidateCertInfo(config.ProxyClientInfo, false, fldPath.Child("proxyClientInfo"))...)
 	if len(config.ProxyClientInfo.CertFile) == 0 && len(config.ProxyClientInfo.KeyFile) == 0 {
 		validationResults.AddWarnings(field.Invalid(fldPath.Child("proxyClientInfo"), "", "if no client certificate is specified, TLS pods and services cannot validate requests came from the proxy"))
@@ -541,14 +537,6 @@ func ValidateKubernetesMasterConfig(config *configapi.KubernetesMasterConfig, fl
 
 	if len(config.SchedulerConfigFile) > 0 {
 		validationResults.AddErrors(ValidateFile(config.SchedulerConfigFile, fldPath.Child("schedulerConfigFile"))...)
-	}
-
-	for i, nodeName := range config.StaticNodeNames {
-		if len(nodeName) == 0 {
-			validationResults.AddErrors(field.Invalid(fldPath.Child("staticNodeName").Index(i), nodeName, "may not be empty"))
-		} else {
-			validationResults.AddWarnings(field.Invalid(fldPath.Child("staticNodeName").Index(i), nodeName, "static nodes are not supported"))
-		}
 	}
 
 	if len(config.PodEvictionTimeout) > 0 {
@@ -574,13 +562,6 @@ func ValidateKubernetesMasterConfig(config *configapi.KubernetesMasterConfig, fl
 				validationResults.AddWarnings(field.NotSupported(keyPath.Index(i), version, allowedVersions.List()))
 			}
 		}
-	}
-
-	if config.AdmissionConfig.PluginConfig != nil {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("admissionConfig", "pluginConfig"), config.AdmissionConfig.PluginConfig, "separate admission chains are no longer allowed.  Convert to admissionConfig.pluginConfig."))
-	}
-	if len(config.AdmissionConfig.PluginOrderOverride) != 0 {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("admissionConfig", "pluginOrderOverride"), config.AdmissionConfig.PluginOrderOverride, "separate admission chains are no longer allowed.  Convert to DefaultAdmissionConfig in admissionConfig.pluginConfig."))
 	}
 
 	validationResults.Append(ValidateAPIServerExtendedArguments(config.APIServerArguments, fldPath.Child("apiServerArguments")))

--- a/pkg/cmd/server/apis/config/validation/master_test.go
+++ b/pkg/cmd/server/apis/config/validation/master_test.go
@@ -282,17 +282,6 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 			name: "stock everything",
 		},
 		{
-			name: "specified kube admission order 01",
-			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
-					AdmissionConfig: configapi.AdmissionConfig{
-						PluginOrderOverride: []string{"foo"},
-					},
-				},
-			},
-			errorFields: []string{"kubernetesMasterConfig.admissionConfig.pluginOrderOverride"},
-		},
-		{
 			name: "specified kube admission order 02",
 			options: configapi.MasterConfig{
 				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
@@ -334,69 +323,6 @@ func TestValidateAdmissionPluginConfigConflicts(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "specified, non-conflicting plugin configs 02",
-			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
-					AdmissionConfig: configapi.AdmissionConfig{
-						PluginConfig: map[string]*configapi.AdmissionPluginConfig{
-							"foo": {
-								Location: "bar",
-							},
-							"third": {
-								Location: "bar",
-							},
-						},
-					},
-				},
-				AdmissionConfig: configapi.AdmissionConfig{
-					PluginConfig: map[string]*configapi.AdmissionPluginConfig{
-						"foo": {
-							Location: "bar",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "specified, non-conflicting plugin configs 03",
-			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
-					AdmissionConfig: configapi.AdmissionConfig{
-						PluginConfig: map[string]*configapi.AdmissionPluginConfig{
-							"foo": {
-								Location: "bar",
-							},
-							"third": {
-								Location: "bar",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "specified conflicting plugin configs 01",
-			options: configapi.MasterConfig{
-				KubernetesMasterConfig: &configapi.KubernetesMasterConfig{
-					AdmissionConfig: configapi.AdmissionConfig{
-						PluginConfig: map[string]*configapi.AdmissionPluginConfig{
-							"foo": {
-								Location: "different",
-							},
-						},
-					},
-				},
-				AdmissionConfig: configapi.AdmissionConfig{
-					PluginConfig: map[string]*configapi.AdmissionPluginConfig{
-						"foo": {
-							Location: "bar",
-						},
-					},
-				},
-			},
-			errorFields: []string{"kubernetesMasterConfig.admissionConfig.pluginConfig"},
 		},
 	}
 

--- a/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
@@ -859,13 +859,7 @@ func (in *KubernetesMasterConfig) DeepCopyInto(out *KubernetesMasterConfig) {
 			}
 		}
 	}
-	if in.StaticNodeNames != nil {
-		in, out := &in.StaticNodeNames, &out.StaticNodeNames
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	out.ProxyClientInfo = in.ProxyClientInfo
-	in.AdmissionConfig.DeepCopyInto(&out.AdmissionConfig)
 	if in.APIServerArguments != nil {
 		in, out := &in.APIServerArguments, &out.APIServerArguments
 		*out = make(ExtendedArguments, len(*in))


### PR DESCRIPTION
Removes the admission config, mastercount, and static node names from the kubemasterconfig.

The admissionconfig was a validation error before, so the server wouldn't start and the staticnodenames appears to have been completely dead.

/assign @mfojtik 
@openshift/api-review 