### PR TITLE
Fix for wildcard routes taking precedence over other routes

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -73,8 +73,13 @@ retries=20
 
 
 # sort the path based map files for the haproxy map_beg function
+# Leaving any wildcard route at the end of the resulting file,
+# See https://github.com/openshift/origin/issues/16724 for more details.
 for mapfile in "$haproxy_conf_dir"/*.map; do
-  sort -r "$mapfile" -o "$mapfile"
+  fname=$(basename "$mapfile")
+  grep -v -F '^[^\.]*\' "$mapfile" | sort -r -o "/tmp/$fname"
+  grep -F '^[^\.]*\' "$mapfile" | sort -r >> "/tmp/$fname"
+  mv -f "/tmp/$fname" "$mapfile"
 done
 
 old_pids=$(ps -A -opid,args | grep haproxy | egrep -v -e 'grep|reload-haproxy' | awk '{print $1}' | tr '\n' ' ')


### PR DESCRIPTION
reload-haproxy: changes how map files are sorted

To avoid having wildcard routes (type: Subdomain) override other routes,
we first sort the non-wildcard routes and then we append the wildcard routes
at the end of the file.

First PR was reverted by https://github.com/openshift/origin/pull/19155 due to issues.

related: https://github.com/openshift/origin/issues/16724