### PR TITLE
dind: serialize master and node cert generation

### DIFF
--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -36,11 +36,14 @@ function ensure-master-config() {
     serving_ip_addr="${ip_addr1}"
   fi
 
-  /usr/local/bin/oc adm ca create-master-certs \
-    --overwrite=false \
-    --cert-dir="${master_path}" \
-    --master="https://${serving_ip_addr}:8443" \
-    --hostnames="${ip_addrs},${name}"
+  mkdir -p "${config_path}"
+  (flock 200;
+   /usr/local/bin/oc adm ca create-master-certs \
+     --overwrite=false \
+     --cert-dir="${master_path}" \
+     --master="https://${serving_ip_addr}:8443" \
+     --hostnames="${ip_addrs},${name}"
+  ) 200>"${config_path}"/.openshift-ca.lock
 
   /usr/local/bin/openshift start master --write-config="${master_path}" \
     --master="https://${serving_ip_addr}:8443" \

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -67,7 +67,7 @@ function ensure-node-config() {
        --signer-cert="${master_config_path}/ca.crt" \
        --signer-key="${master_config_path}/ca.key" \
        --signer-serial="${master_config_path}/ca.serial.txt"
-    ) 200>"${config_path}"/.openshift-generate-node-config.lock
+    ) 200>"${config_path}"/.openshift-ca.lock
 
     cat >> "${node_config_file}" <<EOF
 kubeletArguments:


### PR DESCRIPTION
We're ensuring that two nodes don't try to generate their certs at the same time, but we're not ensuring that a node and the master don't both generate certs at the same time. For a long time nothing noticed, but starting a few months ago it will cause the master to fail.

Fixes #18765
