### PR TITLE
Adjust defaults to better handle self-hosting and bootstrapping

### DIFF
--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -70,7 +70,6 @@ func ComputeKubeletFlags(startingArgs map[string][]string, options configapi.Nod
 	setIfUnset(args, "file-check-frequency", fmt.Sprintf("%ds", fileCheckInterval))
 	setIfUnset(args, "pod-infra-container-image", imageTemplate.ExpandOrDie("pod"))
 	setIfUnset(args, "max-pods", "250")
-	setIfUnset(args, "pods-per-core", "10")
 	setIfUnset(args, "cgroup-driver", "systemd")
 	setIfUnset(args, "container-runtime-endpoint", options.DockerConfig.DockerShimSocket)
 	setIfUnset(args, "image-service-endpoint", options.DockerConfig.DockerShimSocket)

--- a/pkg/cmd/server/start/start_kube_controller_manager.go
+++ b/pkg/cmd/server/start/start_kube_controller_manager.go
@@ -63,9 +63,6 @@ func computeKubeControllerManagerArgs(kubeconfigFile, saPrivateKeyFile, saRootCA
 	if _, ok := cmdLineArgs["cluster-signing-key-file"]; !ok {
 		cmdLineArgs["cluster-signing-key-file"] = []string{""}
 	}
-	if _, ok := cmdLineArgs["experimental-cluster-signing-duration"]; !ok {
-		cmdLineArgs["experimental-cluster-signing-duration"] = []string{"720h"}
-	}
 	if _, ok := cmdLineArgs["leader-elect-retry-period"]; !ok {
 		cmdLineArgs["leader-elect-retry-period"] = []string{"3s"}
 	}


### PR DESCRIPTION
@deads2k as discussed although I bumped the default for pods-per-core rather than removing.