### PR TITLE
remove dead client from config

### DIFF
--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -178,7 +178,6 @@ func GetMasterFileReferences(config *MasterConfig) []*string {
 	}
 
 	refs = append(refs, &config.MasterClients.OpenShiftLoopbackKubeConfig)
-	refs = append(refs, &config.MasterClients.ExternalKubernetesKubeConfig)
 
 	refs = append(refs, &config.PolicyConfig.BootstrapPolicyFile)
 

--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -91,24 +91,6 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 			if len(obj.MasterClients.OpenShiftLoopbackClientConnectionOverrides.ContentType) == 0 {
 				obj.MasterClients.OpenShiftLoopbackClientConnectionOverrides.ContentType = "test/fifth"
 			}
-			if obj.MasterClients.ExternalKubernetesClientConnectionOverrides == nil {
-				obj.MasterClients.ExternalKubernetesClientConnectionOverrides = &configapi.ClientConnectionOverrides{
-					AcceptContentTypes: "test/other",
-					ContentType:        "test/third",
-				}
-			}
-			if obj.MasterClients.ExternalKubernetesClientConnectionOverrides.QPS <= 0 {
-				obj.MasterClients.ExternalKubernetesClientConnectionOverrides.QPS = 2.0
-			}
-			if obj.MasterClients.ExternalKubernetesClientConnectionOverrides.Burst <= 0 {
-				obj.MasterClients.ExternalKubernetesClientConnectionOverrides.Burst = 2
-			}
-			if len(obj.MasterClients.ExternalKubernetesClientConnectionOverrides.AcceptContentTypes) == 0 {
-				obj.MasterClients.ExternalKubernetesClientConnectionOverrides.AcceptContentTypes = "test/fourth"
-			}
-			if len(obj.MasterClients.ExternalKubernetesClientConnectionOverrides.ContentType) == 0 {
-				obj.MasterClients.ExternalKubernetesClientConnectionOverrides.ContentType = "test/fifth"
-			}
 
 			// Populate the new NetworkConfig.ServiceNetworkCIDR field from the KubernetesMasterConfig.ServicesSubnet field if needed
 			if len(obj.NetworkConfig.ServiceNetworkCIDR) == 0 {

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -780,13 +780,9 @@ type HTTPServingInfo struct {
 type MasterClients struct {
 	// OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master
 	OpenShiftLoopbackKubeConfig string
-	// ExternalKubernetesKubeConfig is a .kubeconfig filename for proxying to kubernetes
-	ExternalKubernetesKubeConfig string
 
 	// OpenShiftLoopbackClientConnectionOverrides specifies client overrides for system components to loop back to this master.
 	OpenShiftLoopbackClientConnectionOverrides *ClientConnectionOverrides
-	// ExternalKubernetesClientConnectionOverrides specifies client overrides for proxying to Kubernetes.
-	ExternalKubernetesClientConnectionOverrides *ClientConnectionOverrides
 }
 
 type ClientConnectionOverrides struct {

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -77,18 +77,6 @@ func SetDefaults_MasterConfig(obj *MasterConfig) {
 	}
 	SetDefaults_ClientConnectionOverrides(obj.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
 
-	if obj.MasterClients.ExternalKubernetesClientConnectionOverrides == nil {
-		obj.MasterClients.ExternalKubernetesClientConnectionOverrides = &ClientConnectionOverrides{}
-	}
-	// historical values
-	if obj.MasterClients.ExternalKubernetesClientConnectionOverrides.QPS <= 0 {
-		obj.MasterClients.ExternalKubernetesClientConnectionOverrides.QPS = 100.0
-	}
-	if obj.MasterClients.ExternalKubernetesClientConnectionOverrides.Burst <= 0 {
-		obj.MasterClients.ExternalKubernetesClientConnectionOverrides.Burst = 200
-	}
-	SetDefaults_ClientConnectionOverrides(obj.MasterClients.ExternalKubernetesClientConnectionOverrides)
-
 	// Populate the new NetworkConfig.ServiceNetworkCIDR field from the KubernetesMasterConfig.ServicesSubnet field if needed
 	if len(obj.NetworkConfig.ServiceNetworkCIDR) == 0 {
 		if obj.KubernetesMasterConfig != nil && len(obj.KubernetesMasterConfig.ServicesSubnet) > 0 {

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -118,12 +118,6 @@ kubernetesMasterConfig:
   servicesSubnet: ""
   staticNodeNames: null
 masterClients:
-  externalKubernetesClientConnectionOverrides:
-    acceptContentTypes: application/json
-    burst: 200
-    contentType: application/json
-    qps: 100
-  externalKubernetesKubeConfig: ""
   openshiftLoopbackClientConnectionOverrides:
     acceptContentTypes: application/json
     burst: 300

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -673,13 +673,9 @@ type HTTPServingInfo struct {
 type MasterClients struct {
 	// OpenShiftLoopbackKubeConfig is a .kubeconfig filename for system components to loopback to this master
 	OpenShiftLoopbackKubeConfig string `json:"openshiftLoopbackKubeConfig"`
-	// ExternalKubernetesKubeConfig is a .kubeconfig filename for proxying to Kubernetes
-	ExternalKubernetesKubeConfig string `json:"externalKubernetesKubeConfig"`
 
 	// OpenShiftLoopbackClientConnectionOverrides specifies client overrides for system components to loop back to this master.
 	OpenShiftLoopbackClientConnectionOverrides *ClientConnectionOverrides `json:"openshiftLoopbackClientConnectionOverrides"`
-	// ExternalKubernetesClientConnectionOverrides specifies client overrides for proxying to Kubernetes.
-	ExternalKubernetesClientConnectionOverrides *ClientConnectionOverrides `json:"externalKubernetesClientConnectionOverrides"`
 }
 
 // ClientConnectionOverrides are a set of overrides to the default client connection settings.

--- a/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
@@ -1157,15 +1157,6 @@ func (in *MasterClients) DeepCopyInto(out *MasterClients) {
 			**out = **in
 		}
 	}
-	if in.ExternalKubernetesClientConnectionOverrides != nil {
-		in, out := &in.ExternalKubernetesClientConnectionOverrides, &out.ExternalKubernetesClientConnectionOverrides
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ClientConnectionOverrides)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/pkg/cmd/server/apis/config/v1/zz_generated.defaults.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.defaults.go
@@ -41,9 +41,6 @@ func SetObjectDefaults_MasterConfig(in *MasterConfig) {
 	if in.MasterClients.OpenShiftLoopbackClientConnectionOverrides != nil {
 		SetDefaults_ClientConnectionOverrides(in.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
 	}
-	if in.MasterClients.ExternalKubernetesClientConnectionOverrides != nil {
-		SetDefaults_ClientConnectionOverrides(in.MasterClients.ExternalKubernetesClientConnectionOverrides)
-	}
 	SetDefaults_ImagePolicyConfig(&in.ImagePolicyConfig)
 	if in.ProjectConfig.SecurityAllocator != nil {
 		SetDefaults_SecurityAllocator(in.ProjectConfig.SecurityAllocator)

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -106,12 +106,6 @@ func ValidateMasterConfig(config *configapi.MasterConfig, fldPath *field.Path) V
 	if config.KubernetesMasterConfig != nil {
 		validationResults.Append(ValidateKubernetesMasterConfig(config.KubernetesMasterConfig, fldPath.Child("kubernetesMasterConfig")))
 	}
-	if (config.KubernetesMasterConfig == nil) && (len(config.MasterClients.ExternalKubernetesKubeConfig) == 0) {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("kubernetesMasterConfig"), config.KubernetesMasterConfig, "either kubernetesMasterConfig or masterClients.externalKubernetesKubeConfig must have a value"))
-	}
-	if (config.KubernetesMasterConfig != nil) && (len(config.MasterClients.ExternalKubernetesKubeConfig) != 0) {
-		validationResults.AddErrors(field.Invalid(fldPath.Child("kubernetesMasterConfig"), config.KubernetesMasterConfig, "kubernetesMasterConfig and masterClients.externalKubernetesKubeConfig are mutually exclusive"))
-	}
 
 	if len(config.NetworkConfig.ServiceNetworkCIDR) > 0 {
 		if _, _, err := net.ParseCIDR(strings.TrimSpace(config.NetworkConfig.ServiceNetworkCIDR)); err != nil {
@@ -133,10 +127,6 @@ func ValidateMasterConfig(config *configapi.MasterConfig, fldPath *field.Path) V
 	validationResults.Append(ValidateDeprecatedClusterNetworkConfig(config, fldPath.Child("networkConfig")))
 
 	validationResults.AddErrors(ValidateKubeConfig(config.MasterClients.OpenShiftLoopbackKubeConfig, fldPath.Child("masterClients", "openShiftLoopbackKubeConfig"))...)
-
-	if len(config.MasterClients.ExternalKubernetesKubeConfig) > 0 {
-		validationResults.AddErrors(ValidateKubeConfig(config.MasterClients.ExternalKubernetesKubeConfig, fldPath.Child("masterClients", "externalKubernetesKubeConfig"))...)
-	}
 
 	validationResults.AddErrors(ValidatePolicyConfig(config.PolicyConfig, fldPath.Child("policyConfig"))...)
 	if config.OAuthConfig != nil {

--- a/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
@@ -1143,15 +1143,6 @@ func (in *MasterClients) DeepCopyInto(out *MasterClients) {
 			**out = **in
 		}
 	}
-	if in.ExternalKubernetesClientConnectionOverrides != nil {
-		in, out := &in.ExternalKubernetesClientConnectionOverrides, &out.ExternalKubernetesClientConnectionOverrides
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(ClientConnectionOverrides)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -238,8 +238,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 		},
 
 		MasterClients: configapi.MasterClients{
-			OpenShiftLoopbackKubeConfig:  admin.DefaultKubeConfigFilename(args.ConfigDir.Value(), bootstrappolicy.MasterUnqualifiedUsername),
-			ExternalKubernetesKubeConfig: args.KubeConnectionArgs.ClientConfigLoadingRules.ExplicitPath,
+			OpenShiftLoopbackKubeConfig: admin.DefaultKubeConfigFilename(args.ConfigDir.Value(), bootstrappolicy.MasterUnqualifiedUsername),
 		},
 
 		EtcdClientInfo: configapi.EtcdConnectionInfo{
@@ -355,7 +354,6 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 
 	// When creating a new config, use Protobuf
 	configapi.SetProtobufClientDefaults(config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
-	configapi.SetProtobufClientDefaults(config.MasterClients.ExternalKubernetesClientConnectionOverrides)
 
 	// Default storage backend to etcd3 with protobuf storage for our innate config when starting both
 	// Kubernetes and etcd.


### PR DESCRIPTION
We have a completely dead option the master-config for a client we don't support.  Found it on my quest to unwind client connections.

/assign @mfojtik 