### PR TITLE
Fix NetworkPolicy tests to be skipped under kubenet

### DIFF
--- a/test/extended/cni_vendor_test.sh
+++ b/test/extended/cni_vendor_test.sh
@@ -2,14 +2,12 @@
 
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
-# Uncomment this if the plugin does not implement NetworkPolicy:
+# Set this to false if the plugin does not implement NetworkPolicy:
+export NETWORKING_E2E_NETWORKPOLICY="${NETWORKING_E2E_NETWORKPOLICY:-true}"
 
-# export NETWORKING_E2E_NETWORKPOLICY=false
-
-# Uncomment this if the plugin implements isolation in the same manner as
+# Set this to true if the plugin implements isolation in the same manner as
 # redhat/openshift-ovs-multitenant:
-
-# export NETWORKING_E2E_ISOLATION=true
+export NETWORKING_E2E_ISOLATION="${NETWORKING_E2E_ISOLATION:-false}"
 
 export NETWORKING_E2E_FOCUS="${NETWORKING_E2E_FOCUS:-\[Area:Networking\]}"
 export NETWORKING_E2E_EXTERNAL=1

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -283,13 +283,16 @@ func pluginIsolatesNamespaces() bool {
 }
 
 func pluginImplementsNetworkPolicy() bool {
-	if os.Getenv("NETWORKING_E2E_NETWORKPOLICY") == "false" {
+	switch {
+	case os.Getenv("NETWORKING_E2E_NETWORKPOLICY") == "true":
+		return true
+	case networkPluginName() == network.NetworkPolicyPluginName:
+		return true
+	default:
+		// If we can't detect the plugin, we assume it doesn't support
+		// NetworkPolicy, so the tests will work under kubenet
 		return false
 	}
-	// Assume that all plugins except the OpenShift SDN "subnet" and "multitenant"
-	// plugins implement NetworkPolicy
-	return networkPluginName() != network.SingleTenantPluginName &&
-		networkPluginName() != network.MultiTenantPluginName
 }
 
 func makeNamespaceGlobal(ns *corev1.Namespace) {


### PR DESCRIPTION
The networking tests currently assume that all network plugins other than ovs-subnet and ovs-multitenant implement NetworkPolicy. But that means that running the extended test suite under kubenet (as in the OSE CI) will fail. Seen in https://github.com/openshift/ose/issues/1149 though this isn't a fix for the other failures discussed there.

This fixes `cni_vendor_test.sh` to explicitly set `NETWORKING_E2E_NETWORKPOLICY=true` (by default) so that the tests can then assume that if that isn't set, and we're not using ovs-networkpolicy, then it should disable the NetworkPolicy tests. (The tests can't autodetect the plugin if it's not an SDN plugin.)