### PR TITLE
extended tests: use faster built repo for bc with PR

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -70,8 +70,8 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 
 			g.Describe("oc start-build with pr ref", func() {
 				g.It("should start a build from a PR ref, wait for the build to complete, and confirm the right level was used", func() {
-					g.By("make sure wildly imagestream has latest tag")
-					err := exutil.WaitForAnImageStreamTag(oc.AsAdmin(), "openshift", "wildfly", "latest")
+					g.By("make sure python imagestream has latest tag")
+					err := exutil.WaitForAnImageStreamTag(oc.AsAdmin(), "openshift", "python", "latest")
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					g.By("create build config")
@@ -88,20 +88,20 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					out, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
-					// the repo at the PR level noted in bcWithPRRef had a pom.xml level of "0.1-SNAPSHOT" (we are well past that now)
-					// so simply looking for that string in the mvn output is indicative of being at that level
+					// the repo has a dependency 'gunicorn', referenced PR removes this dependency
+					// from requirements.txt so it should not appear in the output anymore
 					g.By("confirm the correct commit level was retrieved")
-					o.Expect(out).Should(o.ContainSubstring("0.1-SNAPSHOT"))
+					o.Expect(out).Should(o.Not(o.ContainSubstring("gunicorn")))
 
 					istag, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("bc-with-pr-ref:latest", metav1.GetOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(istag.Image.DockerImageMetadata.Config.Labels).To(o.HaveKeyWithValue("io.openshift.build.commit.ref", "refs/pull/1/head"))
-					o.Expect(istag.Image.DockerImageMetadata.Config.Env).To(o.ContainElement("OPENSHIFT_BUILD_REFERENCE=refs/pull/1/head"))
+					o.Expect(istag.Image.DockerImageMetadata.Config.Labels).To(o.HaveKeyWithValue("io.openshift.build.commit.ref", "refs/pull/121/head"))
+					o.Expect(istag.Image.DockerImageMetadata.Config.Env).To(o.ContainElement("OPENSHIFT_BUILD_REFERENCE=refs/pull/121/head"))
 
 					istag, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("bc-with-pr-ref-docker:latest", metav1.GetOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(istag.Image.DockerImageMetadata.Config.Labels).To(o.HaveKeyWithValue("io.openshift.build.commit.ref", "refs/pull/1/head"))
-					o.Expect(istag.Image.DockerImageMetadata.Config.Env).To(o.ContainElement("OPENSHIFT_BUILD_REFERENCE=refs/pull/1/head"))
+					o.Expect(istag.Image.DockerImageMetadata.Config.Labels).To(o.HaveKeyWithValue("io.openshift.build.commit.ref", "refs/pull/121/head"))
+					o.Expect(istag.Image.DockerImageMetadata.Config.Env).To(o.ContainElement("OPENSHIFT_BUILD_REFERENCE=refs/pull/121/head"))
 				})
 
 			})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -1812,14 +1812,14 @@ items:
     source:
       type: Git
       git:
-        uri: https://github.com/openshift/jenkins-openshift-login-plugin.git
-        ref: refs/pull/1/head
+        uri: https://github.com/sclorg/django-ex.git
+        ref: refs/pull/121/head
     strategy:
       type: Source
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: wildfly:latest
+          name: python:latest
           namespace: openshift
     output:
       to:
@@ -1833,15 +1833,15 @@ items:
     source:
       type: Git
       git:
-        uri: https://github.com/openshift/jenkins-openshift-login-plugin.git
-        ref: refs/pull/1/head
-      dockerfile: FROM centos/ruby-22-centos7
+        uri: https://github.com/sclorg/django-ex.git
+        ref: refs/pull/121/head
+      dockerfile: FROM centos/python-36-centos7
     strategy:
       type: Docker
       dockerStrategy:
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/python-36-centos7
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/builds/test-bc-with-pr-ref.yaml
+++ b/test/extended/testdata/builds/test-bc-with-pr-ref.yaml
@@ -17,14 +17,14 @@ items:
     source:
       type: Git
       git:
-        uri: https://github.com/openshift/jenkins-openshift-login-plugin.git
-        ref: refs/pull/1/head
+        uri: https://github.com/sclorg/django-ex.git
+        ref: refs/pull/121/head
     strategy:
       type: Source
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: wildfly:latest
+          name: python:latest
           namespace: openshift
     output:
       to:
@@ -38,15 +38,15 @@ items:
     source:
       type: Git
       git:
-        uri: https://github.com/openshift/jenkins-openshift-login-plugin.git
-        ref: refs/pull/1/head
-      dockerfile: FROM centos/ruby-22-centos7
+        uri: https://github.com/sclorg/django-ex.git
+        ref: refs/pull/121/head
+      dockerfile: FROM centos/python-36-centos7
     strategy:
       type: Docker
       dockerStrategy:
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/python-36-centos7
     output:
       to:
         kind: ImageStreamTag


### PR DESCRIPTION
An effort to speed up one of the slower extended tests, `start.go` - https://github.com/openshift/origin/issues/19077

The ruby `sample-build` is faster than mvn build of jenkins plugin, but https://github.com/wozniakjan/bc-with-pr-ref is even faster and allows to validate the output of the build - that it was executed from the specified PR

|repository used in `BuildConfig` | average build time |
|-|-|
|https://github.com/openshift/jenkins-openshift-login-plugin.git | ~5min|
|https://github.com/openshift/ruby-hello-world.git | ~1min|
|https://github.com/wozniakjan/bc-with-pr-ref | ~15s|

@openshift/sig-developer-experience ptal. If this passes our review, the `bc-with-pr-ref` repo should probably reside under openshift wings.
