### PR TITLE
Replace deployment-config.name with app for label and selector key of oc create dc

### DIFF
--- a/pkg/oc/cli/cmd/create/deploymentconfig.go
+++ b/pkg/oc/cli/cmd/create/deploymentconfig.go
@@ -72,10 +72,9 @@ func (o *CreateDeploymentConfigOptions) Complete(cmd *cobra.Command, f *clientcm
 		(argsLenAtDash == 0),
 		(argsLenAtDash > 1):
 		return fmt.Errorf("NAME is required: %v", args)
-
 	}
 
-	labels := map[string]string{"deployment-config.name": args[0]}
+	labels := map[string]string{"deployment-config.name": args[0], "app": args[0]}
 
 	o.DryRun = cmdutil.GetFlagBool(cmd, "dry-run")
 	o.DC = &appsapi.DeploymentConfig{


### PR DESCRIPTION
When we create a dc with `oc create deploymentconfig`, the key of lable
and selector are set as
`deployment-config.name`. It is not commonly used, but `app` is used by
other commands such as `oc new app` and `oc create deployment`.

So, this PR changes default selector and label key to `app` from
`deployment-config.name`

before:
```
$ oc create deploymentconfig sample-app --image=nginx --dry-run -o yaml | grep -A1 -E "selector|labels"
  selector:
    deployment-config.name: sample-app
--
      labels:
        deployment-config.name: sample-app
```

after:
```
$ oc create deploymentconfig sample-app --image=nginx --dry-run -o yaml | grep -A1 -E "selector|labels"
  selector:
    app: sample-app
--
      labels:
        app: sample-app

```