### PR TITLE
Add custom JSON marshaling implementations, metrics broken into lib

### DIFF
--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -16,6 +16,7 @@ import (
 
 	oapi "github.com/openshift/origin/pkg/api"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
+	metrics "github.com/openshift/origin/test/extended/cluster/metrics"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -179,8 +180,8 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 		}
 
 		// Calculate and log test duration
-		metrics := []Metrics{NewTestDuration("cluster-loader-test", testStartTime, time.Since(testStartTime))}
-		err := LogMetrics(metrics)
+		m := []metrics.Metrics{metrics.NewTestDuration("cluster-loader-test", testStartTime, time.Since(testStartTime))}
+		err := metrics.LogMetrics(m)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// If config context set to cleanup on completion


### PR DESCRIPTION
Prequisite work to have the scraper read JSON metrics from the Cluster Loader stdout log.

Go doesn't handle serializing/deserializing `time.Duration` into anything meaningful, so we need some trickery... Didn't want to make alias types altogether.

Now we can just import the metrics library into the scraper and it will handle it magically.