### PR TITLE
Use CRI interface instead of docker calls in network diagnostics

### DIFF
--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -28,7 +28,8 @@ RUN dnf -y update && dnf -y install\
  python2-pyroute2\
  python2-requests\
  PyYAML\
- cri-o
+ cri-o\
+ cri-tools
 
 # Remove the CRI-O CNI network configs so openshift-sdn's will be used instead
 RUN rm -f /etc/cni/net.d/*

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/cmd.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/cmd.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 
 	networkclientinternal "github.com/openshift/origin/pkg/network/generated/internalclientset"
+	netutil "github.com/openshift/origin/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util"
 	"github.com/openshift/origin/pkg/oc/cli/admin/diagnostics/diagnostics/log"
 	"github.com/openshift/origin/pkg/oc/cli/admin/diagnostics/diagnostics/types"
 	"github.com/openshift/origin/pkg/oc/cli/admin/diagnostics/options"
@@ -131,12 +132,18 @@ func (o NetworkPodDiagnosticsOptions) buildNetworkPodDiagnostics() ([]types.Diag
 		return nil, err
 	}
 
+	runtime, err := netutil.GetRuntime()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, diagnosticName := range requestedDiagnostics {
 		switch diagnosticName {
 
 		case CheckNodeNetworkName:
 			diagnostics = append(diagnostics, CheckNodeNetwork{
 				KubeClient: kubeClient,
+				Runtime:    runtime,
 			})
 
 		case CheckPodNetworkName:
@@ -144,6 +151,7 @@ func (o NetworkPodDiagnosticsOptions) buildNetworkPodDiagnostics() ([]types.Diag
 				KubeClient:           kubeClient,
 				NetNamespacesClient:  networkClient.Network(),
 				ClusterNetworkClient: networkClient.Network(),
+				Runtime:              runtime,
 			})
 
 		case CheckExternalNetworkName:
@@ -154,11 +162,13 @@ func (o NetworkPodDiagnosticsOptions) buildNetworkPodDiagnostics() ([]types.Diag
 				KubeClient:           kubeClient,
 				NetNamespacesClient:  networkClient.Network(),
 				ClusterNetworkClient: networkClient.Network(),
+				Runtime:              runtime,
 			})
 
 		case CollectNetworkInfoName:
 			diagnostics = append(diagnostics, CollectNetworkInfo{
 				KubeClient: kubeClient,
+				Runtime:    runtime,
 			})
 
 		default:

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/collect.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/collect.go
@@ -18,6 +18,7 @@ const (
 // CollectNetworkInfo is a Diagnostic to collect network information in the cluster.
 type CollectNetworkInfo struct {
 	KubeClient kclientset.Interface
+	Runtime    *util.Runtime
 }
 
 // Name is part of the Diagnostic interface and just returns name.
@@ -56,6 +57,6 @@ func (d CollectNetworkInfo) Check() types.DiagnosticResult {
 		Result: r,
 		Logdir: filepath.Join(util.NetworkDiagDefaultLogDir, util.NetworkDiagNodeLogDirPrefix, nodeName),
 	}
-	l.LogNode(d.KubeClient)
+	l.LogNode(d.KubeClient, d.Runtime)
 	return r
 }

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/node.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/node.go
@@ -7,7 +7,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/utils/exec"
 
 	"github.com/openshift/origin/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util"
@@ -75,8 +74,7 @@ func (d CheckNodeNetwork) checkNodeConnection(pod *kapi.Pod, nodeIP string, r ty
 		return
 	}
 
-	containerID := kcontainer.ParseContainerID(pod.Status.ContainerStatuses[0].ContainerID).ID
-	pid, err := d.Runtime.GetContainerPid(containerID)
+	pid, err := d.Runtime.GetContainerPid(pod.Status.ContainerStatuses[0].ContainerID)
 	if err != nil {
 		r.Error("DNodeNet1004", err, err.Error())
 		return

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/pod.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/pod.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/utils/exec"
 
 	"github.com/openshift/origin/pkg/network"
@@ -173,14 +174,20 @@ func (d CheckPodNetwork) checkPodToPodConnection(fromPod, toPod *kapi.Pod) {
 
 	success := util.ExpectedConnectionStatus(fromPod.Namespace, toPod.Namespace, d.vnidMap)
 
-	kexecer := kexec.New()
-	containerID := util.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
-	pid, err := kexecer.Command("docker", "inspect", "-f", "{{.State.Pid}}", containerID).CombinedOutput()
+	runtime, err := util.GetRuntime()
 	if err != nil {
-		d.res.Error("DPodNet1007", err, fmt.Sprintf("Fetching pid for pod %q, container %q failed. Error: %s", util.PrintPod(fromPod), containerID, err))
+		d.res.Error("DPodNet1012", err, fmt.Sprintf("Failed to get CRI runtime: %v", err))
 		return
 	}
 
+	containerID := kcontainer.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
+	pid, err := runtime.GetContainerPid(containerID)
+	if err != nil {
+		d.res.Error("DPodNet1007", err, err.Error())
+		return
+	}
+
+	kexecer := kexec.New()
 	out, err := kexecer.Command("nsenter", "-n", "-t", strings.Trim(fmt.Sprintf("%s", pid), "\n"), "--", "ping", "-c1", "-W2", toPod.Status.PodIP).CombinedOutput()
 	if success && err != nil {
 		d.res.Error("DPodNet1008", err, fmt.Sprintf("Connectivity from pod %q to pod %q failed. Error: %s, Out: %s", util.PrintPod(fromPod), util.PrintPod(toPod), err, string(out)))

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/pod.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/pod.go
@@ -26,6 +26,7 @@ type CheckPodNetwork struct {
 	KubeClient           kclientset.Interface
 	NetNamespacesClient  networktypedclient.NetNamespacesGetter
 	ClusterNetworkClient networktypedclient.ClusterNetworksGetter
+	Runtime              *util.Runtime
 
 	vnidMap map[string]uint32
 	res     types.DiagnosticResult
@@ -174,14 +175,8 @@ func (d CheckPodNetwork) checkPodToPodConnection(fromPod, toPod *kapi.Pod) {
 
 	success := util.ExpectedConnectionStatus(fromPod.Namespace, toPod.Namespace, d.vnidMap)
 
-	runtime, err := util.GetRuntime()
-	if err != nil {
-		d.res.Error("DPodNet1012", err, fmt.Sprintf("Failed to get CRI runtime: %v", err))
-		return
-	}
-
 	containerID := kcontainer.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
-	pid, err := runtime.GetContainerPid(containerID)
+	pid, err := d.Runtime.GetContainerPid(containerID)
 	if err != nil {
 		d.res.Error("DPodNet1007", err, err.Error())
 		return

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/pod.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/pod.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/utils/exec"
 
 	"github.com/openshift/origin/pkg/network"
@@ -175,8 +174,7 @@ func (d CheckPodNetwork) checkPodToPodConnection(fromPod, toPod *kapi.Pod) {
 
 	success := util.ExpectedConnectionStatus(fromPod.Namespace, toPod.Namespace, d.vnidMap)
 
-	containerID := kcontainer.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
-	pid, err := d.Runtime.GetContainerPid(containerID)
+	pid, err := d.Runtime.GetContainerPid(fromPod.Status.ContainerStatuses[0].ContainerID)
 	if err != nil {
 		d.res.Error("DPodNet1007", err, err.Error())
 		return

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/service.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/service.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/utils/exec"
 
 	"github.com/openshift/origin/pkg/network"
@@ -174,11 +175,16 @@ func (d CheckServiceNetwork) checkPodToServiceConnection(fromPod *kapi.Pod, toSe
 
 	success := util.ExpectedConnectionStatus(fromPod.Namespace, toService.Namespace, d.vnidMap)
 
-	kexecer := kexec.New()
-	containerID := util.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
-	pid, err := kexecer.Command("docker", "inspect", "-f", "{{.State.Pid}}", containerID).CombinedOutput()
+	runtime, err := util.GetRuntime()
 	if err != nil {
-		d.res.Error("DSvcNet1009", err, fmt.Sprintf("Fetching pid for pod %q failed. Error: %s", util.PrintPod(fromPod), err))
+		d.res.Error("DSvcNet1014", err, fmt.Sprintf("Failed to get CRI runtime: %v", err))
+		return
+	}
+
+	containerID := kcontainer.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
+	pid, err := runtime.GetContainerPid(containerID)
+	if err != nil {
+		d.res.Error("DSvcNet1009", err, err.Error())
 		return
 	}
 
@@ -187,6 +193,8 @@ func (d CheckServiceNetwork) checkPodToServiceConnection(fromPod *kapi.Pod, toSe
 	// like in the pod connectivity check because only connections to the correct port
 	// get redirected by the iptables rules.
 	srvConCmd := fmt.Sprintf("echo -n '' > /dev/%s/%s/%d", strings.ToLower(string(toService.Spec.Ports[0].Protocol)), toService.Spec.ClusterIP, toService.Spec.Ports[0].Port)
+
+	kexecer := kexec.New()
 	out, err := kexecer.Command("nsenter", "-n", "-t", strings.Trim(fmt.Sprintf("%s", pid), "\n"), "--", "timeout", "1", "bash", "-c", srvConCmd).CombinedOutput()
 	if success && err != nil {
 		d.res.Error("DSvcNet1010", err, fmt.Sprintf("Connectivity from pod %q to service %q failed. Error: %s, Out: %s", util.PrintPod(fromPod), printService(toService), err, string(out)))

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/service.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/service.go
@@ -8,7 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kexec "k8s.io/utils/exec"
 
 	"github.com/openshift/origin/pkg/network"
@@ -176,8 +175,7 @@ func (d CheckServiceNetwork) checkPodToServiceConnection(fromPod *kapi.Pod, toSe
 
 	success := util.ExpectedConnectionStatus(fromPod.Namespace, toService.Namespace, d.vnidMap)
 
-	containerID := kcontainer.ParseContainerID(fromPod.Status.ContainerStatuses[0].ContainerID).ID
-	pid, err := d.Runtime.GetContainerPid(containerID)
+	pid, err := d.Runtime.GetContainerPid(fromPod.Status.ContainerStatuses[0].ContainerID)
 	if err != nil {
 		d.res.Error("DSvcNet1009", err, err.Error())
 		return

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
@@ -169,11 +169,11 @@ func (l *LogInterface) logRuntime(runtime *Runtime) {
 func (l *LogInterface) logRuntimeNetworkFile(name string) {
 	out, err := exec.Command("systemctl", "cat", fmt.Sprintf("%s.service", name)).CombinedOutput()
 	if err != nil {
-		l.Run(fmt.Sprintf("echo '%s'", string(out)), fmt.Sprintf("%s-network-file", name))
+		l.Run(fmt.Sprintf("cat /etc/sysconfig/%s-network", name), fmt.Sprintf("%s-network-file", name))
 		return
 	}
 
-	re := regexp.MustCompile("EnvironmentFile=-(.*openshift-sdn.*)")
+	re := regexp.MustCompile("EnvironmentFile=-(.*-network)")
 	match := re.FindStringSubmatch(string(out))
 	if len(match) > 1 {
 		l.Run(fmt.Sprintf("cat %s", match[1]), fmt.Sprintf("%s-network-file", name))

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
@@ -21,7 +21,7 @@ type LogInterface struct {
 	Logdir string
 }
 
-func (l *LogInterface) LogNode(kubeClient kclientset.Interface) {
+func (l *LogInterface) LogNode(kubeClient kclientset.Interface, runtime *Runtime) {
 	l.LogSystem()
 	l.LogServices()
 
@@ -30,12 +30,6 @@ func (l *LogInterface) LogNode(kubeClient kclientset.Interface) {
 	l.Run("tc qdisc show", "tc-qdisc")
 	l.Run("tc class show", "tc-class")
 	l.Run("tc filter show", "tc-filter")
-
-	runtime, err := GetRuntime()
-	if err != nil {
-		l.Result.Error("DLogNet1009", err, fmt.Sprintf("Failed to get CRI runtime: %v", err))
-		return
-	}
 
 	l.logRuntime(runtime)
 	l.logPodInfo(kubeClient, runtime)

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kruntimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -228,41 +227,4 @@ func (l *LogInterface) getConfigFileForService(serviceName, serviceArgs string) 
 		return ""
 	}
 	return string(out[:])
-}
-
-// ContainerID is a type that identifies a container.
-type ContainerID struct {
-	// The type of the container runtime. e.g. 'docker', 'rkt'.
-	Type string
-	// The identification of the container, this is comsumable by
-	// the underlying container runtime. (Note that the container
-	// runtime interface still takes the whole struct as input).
-	ID string
-}
-
-// Convenience method for creating a ContainerID from an ID string.
-func ParseContainerID(containerID string) ContainerID {
-	var id ContainerID
-	if err := id.ParseString(containerID); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to parse containerID: %v", err))
-	}
-	return id
-}
-
-func (c *ContainerID) ParseString(data string) error {
-	// Trim the quotes and split the type and ID.
-	parts := strings.Split(strings.Trim(data, "\""), "://")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid container ID: %q", data)
-	}
-	c.Type, c.ID = parts[0], parts[1]
-	return nil
-}
-
-func (c *ContainerID) String() string {
-	return fmt.Sprintf("%s://%s", c.Type, c.ID)
-}
-
-func (c *ContainerID) IsEmpty() bool {
-	return *c == ContainerID{}
 }

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/runtime.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/runtime.go
@@ -1,0 +1,107 @@
+package util
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	kubeletapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
+	kruntimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+	kubeletremote "k8s.io/kubernetes/pkg/kubelet/remote"
+)
+
+const (
+	crioRuntimeName         = "crio"
+	dockerRuntimeName       = "docker"
+	defaultCRIOShimSocket   = "unix:///var/run/crio/crio.sock"
+	defaultDockerShimSocket = "unix:///var/run/dockershim.sock"
+
+	// 2 minutes is the current default value used in kubelet
+	defaultRuntimeRequestTimeout = 2 * time.Minute
+)
+
+type Runtime struct {
+	Name    string
+	Service kubeletapi.RuntimeService
+}
+
+func GetRuntime() (*Runtime, error) {
+	runtimeName, runtimeEndpoint, err := getDefaultRuntimeEndpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeService, err := kubeletremote.NewRemoteRuntimeService(runtimeEndpoint, defaultRuntimeRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	// Timeout ~30 seconds
+	err = kwait.ExponentialBackoff(
+		kwait.Backoff{
+			Duration: 100 * time.Millisecond,
+			Factor:   1.2,
+			Steps:    24,
+		},
+		func() (bool, error) {
+			// Ensure the runtime is actually alive; gRPC may create the client but
+			// it may not be responding to requests yet
+			if _, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{}); err != nil {
+				// Wait longer
+				return false, nil
+			}
+			return true, nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch runtime service: %v", err)
+	}
+
+	return &Runtime{
+		Name:    runtimeName,
+		Service: runtimeService,
+	}, nil
+}
+
+func getDefaultRuntimeEndpoint() (string, string, error) {
+	isCRIO, err := filePathExists(defaultCRIOShimSocket)
+	if err != nil {
+		return "", "", err
+	}
+
+	isDocker, err := filePathExists(defaultDockerShimSocket)
+	if err != nil {
+		return "", "", err
+	}
+
+	// TODO: Instead of trying to detect the runtime make this as config option
+	if isDocker && isCRIO {
+		glog.Warningf("Found both crio and docker socket files, defaulting to crio")
+		return crioRuntimeName, defaultCRIOShimSocket, nil
+	} else if isCRIO {
+		return crioRuntimeName, defaultCRIOShimSocket, nil
+	} else if isDocker {
+		return dockerRuntimeName, defaultDockerShimSocket, nil
+	}
+
+	return "", "", fmt.Errorf("supported runtime socket files not found")
+}
+
+func filePathExists(endpoint string) (bool, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := os.Stat(u.Path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/run_pod.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/run_pod.go
@@ -214,11 +214,10 @@ func (d *NetworkDiagnostic) runNetworkDiagnostic() {
 		// Do not bail out here, collect what ever info is available from all valid nodes
 	}
 
-	if err := d.CollectNetworkInfo(diagsFailed); err != nil {
-		d.res.Error("DNet2011", err, err.Error())
-	}
-
 	if diagsFailed {
+		if err := d.CollectNetworkInfo(); err != nil {
+			d.res.Error("DNet2011", err, err.Error())
+		}
 		d.res.Info("DNet2012", fmt.Sprintf("Additional info collected under %q for further analysis", d.LogDir))
 	}
 	return


### PR DESCRIPTION
Trello card: https://trello.com/c/YlLoBpg5/16-5-make-network-diagnostics-work-with-cri-o-runtime