### PR TITLE
Template helper code to sort map files

### DIFF
--- a/images/router/haproxy/Dockerfile
+++ b/images/router/haproxy/Dockerfile
@@ -10,7 +10,7 @@ RUN INSTALL_PKGS="haproxy18" && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /var/lib/haproxy/router/{certs,cacerts} && \
-    mkdir -p /var/lib/haproxy/{conf,run,bin,log} && \
+    mkdir -p /var/lib/haproxy/{conf/.tmp,run,bin,log} && \
     touch /var/lib/haproxy/conf/{{os_http_be,os_edge_reencrypt_be,os_tcp_be,os_sni_passthrough,os_route_http_redirect,cert_config,os_wildcard_domain}.map,haproxy.config} && \
     setcap 'cap_net_bind_service=ep' /usr/sbin/haproxy && \
     chown -R :0 /var/lib/haproxy && \

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -471,7 +471,7 @@ backend be_tcp:{{$cfgIdx}}
 			[sub]domain regexps. This map is used to check if
 			a host matches a [sub]domain with has wildcard support.
 */}}
-{{ define "/var/lib/haproxy/conf/os_wildcard_domain.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/os_wildcard_domain.map" -}}
 {{     if isTrue (env "ROUTER_ALLOW_WILDCARD_ROUTES") -}}
 {{       range $idx, $cfg := .State -}}
 {{         if ne $cfg.Host "" -}}
@@ -480,9 +480,14 @@ backend be_tcp:{{$cfgIdx}}
 {{           end -}}
 {{         end -}}
 {{       end -}}
-{{     end -}}{{/* end if router allows wildcard routes */}}
-{{ end -}}{{/* end wildcard domain map template */}}
+{{     end -}}{{/* end if router allows wildcard routes */ -}}
+{{ end -}}{{/* end temporary wildcard domain map template */}}
 
+{{ define "/var/lib/haproxy/conf/os_wildcard_domain.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/os_wildcard_domain.map" true -}}
+{{ $data }}
+{{     end -}}
+{{ end -}}{{/* end wildcard domain map template */}}
 
 
 {{/*
@@ -491,7 +496,7 @@ backend be_tcp:{{$cfgIdx}}
                                                 be_edge_http for edge routes with InsecureEdgeTerminationPolicy Allow
                                                 be_secure for reencrypt routes with InsecureEdgeTerminationPolicy Allow
 */}}
-{{ define "/var/lib/haproxy/conf/os_http_be.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/os_http_be.map" -}}
 {{     range $idx, $cfg := .State -}}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "") -}}
 {{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} be_http:{{$idx}}
@@ -506,12 +511,19 @@ backend be_tcp:{{$cfgIdx}}
 {{     end -}}
 {{ end -}}
 
+{{ define "/var/lib/haproxy/conf/os_http_be.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/os_http_be.map" true -}}
+{{ $data }}
+{{     end -}}
+{{ end -}}{{/* end http host map template */}}
+
+
 {{/*
     os_edge_reencrypt_be.map : contains a mapping of www.example.com -> <service name>. This map is similar to os_http_be.map but for tls routes.
                          by attaching prefix: be_edge_http for edge terminated routes
                                               be_secure for reencrypt routes
 */}}
-{{ define "/var/lib/haproxy/conf/os_edge_reencrypt_be.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/os_edge_reencrypt_be.map" -}}
 {{     range $idx, $cfg := .State -}}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "edge") -}}
 {{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} be_edge_http:{{$idx}}
@@ -519,6 +531,12 @@ backend be_tcp:{{$cfgIdx}}
 {{       if and (ne $cfg.Host "") (eq $cfg.TLSTermination "reencrypt") -}}
 {{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} be_secure:{{$idx}}
 {{       end -}}
+{{     end -}}
+{{ end -}}{{/* end temporary edge http host map template */}}
+
+{{ define "/var/lib/haproxy/conf/os_edge_reencrypt_be.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/os_edge_reencrypt_be.map" true -}}
+{{ $data }}
 {{     end -}}
 {{ end -}}{{/* end edge http host map template */}}
 
@@ -528,11 +546,17 @@ backend be_tcp:{{$cfgIdx}}
     Map is used to redirect insecure traffic to use a secure scheme (https)
     if acls match for routes that have the insecure option set to redirect.
 */}}
-{{ define "/var/lib/haproxy/conf/os_route_http_redirect.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/os_route_http_redirect.map" -}}
 {{     range $idx, $cfg := .State -}}
 {{       if and (ne $cfg.Host "") (eq $cfg.InsecureEdgeTerminationPolicy "Redirect") -}}
 {{generateRouteRegexp $cfg.Host $cfg.Path $cfg.IsWildcard}} {{$idx}}
 {{       end -}}
+{{     end -}}
+{{ end -}}{{/* end temporary redirect http host map template */}}
+
+{{ define "/var/lib/haproxy/conf/os_route_http_redirect.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/os_route_http_redirect.map" true -}}
+{{ $data }}
 {{     end -}}
 {{ end -}}{{/* end redirect http host map template */}}
 
@@ -541,23 +565,36 @@ backend be_tcp:{{$cfgIdx}}
     os_tcp_be.map: contains a mapping of www.example.com -> <service name>.  This map is used to discover the correct backend
                         by attaching a prefix (be_tcp: or be_secure:) by use_backend statements if acls are matched.
 */}}
-{{ define "/var/lib/haproxy/conf/os_tcp_be.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/os_tcp_be.map" -}}
 {{     range $idx, $cfg := .State -}}
 {{       if and (eq $cfg.Path "") (and (ne $cfg.Host "") (matchValues (print $cfg.TLSTermination) "passthrough" "reencrypt")) -}}
 {{generateRouteRegexp $cfg.Host "" $cfg.IsWildcard}} {{$idx}}
 {{       end -}}
 {{     end -}}
+{{ end -}}{{/* end temporary tcp host map template */}}
+
+{{ define "/var/lib/haproxy/conf/os_tcp_be.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/os_tcp_be.map" true -}}
+{{ $data }}
+{{     end -}}
 {{ end -}}{{/* end tcp host map template */}}
+
 
 {{/*
     os_sni_passthrough.map: contains a mapping of routes that expect to have an sni header and should be passed
     					through to the host_be.  Driven by the termination type of the ServiceAliasConfigs
 */}}
-{{ define "/var/lib/haproxy/conf/os_sni_passthrough.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/os_sni_passthrough.map" -}}
 {{     range $idx, $cfg := .State -}}
 {{       if and (eq $cfg.Path "") (eq $cfg.TLSTermination "passthrough") -}}
 {{generateRouteRegexp $cfg.Host "" $cfg.IsWildcard}} 1
 {{       end -}}
+{{     end -}}
+{{ end -}}{{/* end temporary sni passthrough map template */}}
+
+{{ define "/var/lib/haproxy/conf/os_sni_passthrough.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/os_sni_passthrough.map" true -}}
+{{ $data }}
 {{     end -}}
 {{ end -}}{{/* end sni passthrough map template */}}
 
@@ -569,7 +606,7 @@ backend be_tcp:{{$cfgIdx}}
           "<cert>: <domain-set>" is important as this allows us to use
          wildcards and/or use a deny set with !<domain> in the future.
 */}}
-{{ define "/var/lib/haproxy/conf/cert_config.map" -}}
+{{ define "/var/lib/haproxy/conf/.tmp/cert_config.map" -}}
 {{     $workingDir := .WorkingDir -}}
 {{     range $idx, $cfg := .State -}}
 {{       if and (ne $cfg.Host "") (matchValues (print $cfg.TLSTermination) "edge" "reencrypt") -}}
@@ -579,4 +616,10 @@ backend be_tcp:{{$cfgIdx}}
 {{         end -}}
 {{      end -}}
 {{     end -}}
-{{ end }}{{/* end cert_config map template */}}
+{{ end }}{{/* end temporary cert_config map template */}}
+
+{{ define "/var/lib/haproxy/conf/cert_config.map" -}}
+{{     range $idx, $data := sortedMapData "/var/lib/haproxy/conf/.tmp/cert_config.map" false -}}
+{{ $data }}
+{{     end -}}
+{{ end -}}{{/* end cert_config map template */}}

--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -72,11 +72,6 @@ function haproxyHealthCheck() {
 retries=20
 
 
-# sort the path based map files for the haproxy map_beg function
-for mapfile in "$haproxy_conf_dir"/*.map; do
-  sort -r "$mapfile" -o "$mapfile"
-done
-
 old_pids=$(ps -A -opid,args | grep haproxy | egrep -v -e 'grep|reload-haproxy' | awk '{print $1}' | tr '\n' ' ')
 
 reload_status=0

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"text/template"
@@ -400,7 +401,13 @@ func (r *templateRouter) writeConfig() error {
 
 	glog.V(4).Infof("Router certificate manager config committed")
 
-	for path, template := range r.templates {
+	pathNames := make([]string, 0)
+	for k := range r.templates {
+		pathNames = append(pathNames, k)
+	}
+	sort.Strings(pathNames)
+	for _, path := range pathNames {
+		template := r.templates[path]
 		file, err := os.Create(path)
 		if err != nil {
 			return fmt.Errorf("error creating config file %s: %v", path, err)

--- a/pkg/router/template/util/map_paths.go
+++ b/pkg/router/template/util/map_paths.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"sort"
+	"strings"
+)
+
+// sorterFunc is the type of "Less" function that defines map path order.
+type sorterFunc func(s1, s2 string) bool
+
+// mapPathSorter sorts a slice of map paths using the sort function.
+type mapPathSorter struct {
+	data []string
+	fn   sorterFunc // closure used in the Less method.
+}
+
+// Len returns the length of the data and is part of sort.Interface
+func (s *mapPathSorter) Len() int {
+	return len(s.data)
+}
+
+// Swap swaps the entries for the given indexes and (part of sort.Interface)
+func (s *mapPathSorter) Swap(i, j int) {
+	s.data[i], s.data[j] = s.data[j], s.data[i]
+}
+
+// Less compares two map paths using a closure and is part of sort.Interface
+func (s *mapPathSorter) Less(i, j int) bool {
+	return s.fn(s.data[i], s.data[j])
+}
+
+// sortByGroup sorts the data with any matching prefixes sorted last.
+// `reverse` indicates whether or not the data in each group (with and
+// without prefixes) needs to be reverse sorted.
+// Note that the matching prefixes are sorted based on length.
+func sortByGroup(data []string, prefix string, reverse bool) []string {
+	patternsAtEnd := func(s1, s2 string) bool {
+		if len(prefix) > 0 {
+			if strings.HasPrefix(s1, prefix) {
+				if !strings.HasPrefix(s2, prefix) {
+					return false
+				}
+			} else if strings.HasPrefix(s2, prefix) {
+				return true
+			}
+		}
+
+		// No prefix or both or neither strings have the prefix.
+		if reverse {
+			return s1 > s2
+		}
+
+		return s1 < s2
+	}
+
+	mps := &mapPathSorter{data: data, fn: patternsAtEnd}
+	sort.Sort(mps)
+	return mps.data
+}
+
+// SortMapPaths sorts the data by groups with any matching prefixes sorted at
+// the end. The data in each group is reverse sorted.
+func SortMapPaths(data []string, prefix string) []string {
+	return sortByGroup(data, prefix, true)
+}

--- a/pkg/router/template/util/map_paths_test.go
+++ b/pkg/router/template/util/map_paths_test.go
@@ -1,0 +1,226 @@
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func checkSortExpectation(data, suffixOrder []string) error {
+	if len(data) != len(suffixOrder) {
+		return fmt.Errorf("sorted data length %d did not match expected length %d", len(data), len(suffixOrder))
+	}
+
+	for idx, suffix := range suffixOrder {
+		if !strings.HasSuffix(data[idx], suffix) {
+			return fmt.Errorf("sorted data %s at index %d did not match expectation %s", data[idx], idx, suffix)
+		}
+	}
+
+	return nil
+}
+
+func shuffle(data []string) []string {
+	shuffled := make([]string, len(data))
+	copy(shuffled, data)
+
+	for idx := range shuffled {
+		k := rand.Intn(idx + 1)
+		shuffled[idx], shuffled[k] = shuffled[k], shuffled[idx]
+	}
+
+	return shuffled
+}
+
+func TestSortMapPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		paths       []string
+		pattern     string
+		expectation []string
+	}{
+		{
+			name: "simple",
+			paths: []string{
+				`a\.test\.org a:a`,
+				`d\.test\.org d:d`,
+				`f\.test\.org f:f`,
+				`c\.test\.org c:c`,
+				`e\.test\.org e:e`,
+				`b\.test\.org b:b`,
+			},
+			pattern:     "",
+			expectation: []string{"f:f", "e:e", "d:d", "c:c", "b:b", "a:a"},
+		},
+		{
+			name: "simple with pattern",
+			paths: []string{
+				`a\.test\.org a:a`,
+				`d\.test\.org d:d`,
+				`zzz\.zzz.test\.org zzz:zzz`,
+				`f\.test\.org f:f`,
+				`zzz\.test\.org zzz:too`,
+				`c\.test\.org c:c`,
+				`e\.test\.org e:e`,
+				`b\.test\.org b:b`,
+			},
+			pattern:     `zzz`,
+			expectation: []string{"f:f", "e:e", "d:d", "c:c", "b:b", "a:a", "zzz:zzz", "zzz:too"},
+		},
+		{
+			name: "simple with template used pattern",
+			paths: []string{
+				`a\.test\.org a:a`,
+				`d\.test\.org d:d`,
+				`f\.test\.org f:f`,
+				`^[^\.]*\.test\.org aces:wild`,
+				`c\.test\.org c:c`,
+				`e\.test\.org e:e`,
+				`b\.test\.org b:b`,
+			},
+			pattern:     `^[^\.]*\.`,
+			expectation: []string{"f:f", "e:e", "d:d", "c:c", "b:b", "a:a", "aces:wild"},
+		},
+		{
+			name: "simple with multiple template used patterns",
+			paths: []string{
+				`a\.test\.org a:a`,
+				`d\.test\.org d:d`,
+				`f\.test\.org f:f`,
+				`^[^\.]*\.test\.org aces:wild`,
+				`c\.test\.org c:c`,
+				`^[^\.]*\.trey\.test\.org wild:threes`,
+				`^[^\.]*\.tens\.test\.org wild:tens`,
+				`e\.test\.org e:e`,
+				`^[^\.]*\.deuces\.test\.org deuces:wild`,
+				`b\.test\.org b:b`,
+			},
+			pattern:     `^[^\.]*\.`,
+			expectation: []string{"f:f", "e:e", "d:d", "c:c", "b:b", "a:a", "wild:threes", "aces:wild", "wild:tens", "deuces:wild"},
+		},
+		{
+			name: "data without wildcards",
+			paths: []string{
+				`^reencrypt\.header\.test(:[0-9]+)?(/.*)?$ be_secure:default:reencrypt`,
+				`^annotated\.reencrypt\.header\.test(:[0-9]+)?(/.*)?$ be_secure:default:annotated-reencrypt`,
+				`^3hello\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ be_edge_http:zzztest:hello03`,
+				`^www\.example2\.com(:[0-9]+)?(/.*)?$ be_edge_http:default:example-route`,
+				`^redirect\.blueprints\.org(:[0-9]+)?(/.*)?$ be_edge_http:blueprints:blueprint-redirect`,
+				`^annotated\.blueprints\.org(:[0-9]+)?(/.*)?$ be_edge_http:blueprints:blueprint-annotated`,
+				`^something\.edge\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:wildcard-redirect-to-https`,
+				`^allow-http\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:allow`,
+				`^edge2\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:edge2`,
+				`^annotated-ok\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:annotated-ok`,
+				`^annotated\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:annotated`,
+				`^reencrypt\.blueprints\.org(:[0-9]+)?(/.*)?$ be_secure:blueprints:blueprint-reencrypt`,
+				`^edge1\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:edge1`,
+			},
+			pattern: `^[^\.]*\.`,
+			expectation: []string{
+				"be_edge_http:default:example-route",
+				"be_edge_http:default:wildcard-redirect-to-https",
+				"be_secure:default:reencrypt",
+				"be_secure:blueprints:blueprint-reencrypt",
+				"be_edge_http:blueprints:blueprint-redirect",
+				"be_edge_http:default:edge2",
+				"be_edge_http:default:edge1",
+				"be_secure:default:annotated-reencrypt",
+				"be_edge_http:default:annotated",
+				"be_edge_http:blueprints:blueprint-annotated",
+				"be_edge_http:default:annotated-ok",
+				"be_edge_http:default:allow",
+				"be_edge_http:zzztest:hello03",
+			},
+		},
+		{
+			name: "data with wildcards",
+			paths: []string{
+				`^reencrypt\.header\.test(:[0-9]+)?(/.*)?$ be_secure:default:reencrypt`,
+				`^[^\.]*\.bar\.wildcard\.test(:[0-9]+)?(/.*)?$ be_edge_http:bar:wildcard-test`,
+				`^annotated\.reencrypt\.header\.test(:[0-9]+)?(/.*)?$ be_secure:default:annotated-reencrypt`,
+				`^3hello\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ be_edge_http:zzztest:hello03`,
+				`^www\.example2\.com(:[0-9]+)?(/.*)?$ be_edge_http:default:example-route`,
+				`^[^\.]*\.wild\.io(:[0-9]+)?/a/bc/def(/.*)?$ be_edge_http:default:wildcard-path-route`,
+				`^redirect\.blueprints\.org(:[0-9]+)?(/.*)?$ be_edge_http:blueprints:blueprint-redirect`,
+				`^annotated\.blueprints\.org(:[0-9]+)?(/.*)?$ be_edge_http:blueprints:blueprint-annotated`,
+				`^something\.edge\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:wildcard-redirect-to-https`,
+				`^allow-http\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:allow`,
+				`^[^\.]*\.foo\.wildcard\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:foo-wildcard-test`,
+				`^edge2\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:edge2`,
+				`^annotated-ok\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:annotated-ok`,
+				`^[^\.]*\.wildcard\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:wildcard-test`,
+				`^annotated\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:annotated`,
+				`^reencrypt\.blueprints\.org(:[0-9]+)?(/.*)?$ be_secure:blueprints:blueprint-reencrypt`,
+				`^edge1\.header\.test(:[0-9]+)?(/.*)?$ be_edge_http:default:edge1`,
+			},
+			pattern: `^[^\.]*\.`,
+			expectation: []string{
+				"be_edge_http:default:example-route",
+				"be_edge_http:default:wildcard-redirect-to-https",
+				"be_secure:default:reencrypt",
+				"be_secure:blueprints:blueprint-reencrypt",
+				"be_edge_http:blueprints:blueprint-redirect",
+				"be_edge_http:default:edge2",
+				"be_edge_http:default:edge1",
+				"be_secure:default:annotated-reencrypt",
+				"be_edge_http:default:annotated",
+				"be_edge_http:blueprints:blueprint-annotated",
+				"be_edge_http:default:annotated-ok",
+				"be_edge_http:default:allow",
+				"be_edge_http:zzztest:hello03",
+				"be_edge_http:default:wildcard-test",
+				"be_edge_http:default:wildcard-path-route",
+				"be_edge_http:default:foo-wildcard-test",
+				"be_edge_http:bar:wildcard-test",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		for i := 0; i < 25; i++ {
+			data := shuffle(tc.paths)
+			SortMapPaths(data, tc.pattern)
+
+			err := checkSortExpectation(data, tc.expectation)
+			if err != nil {
+				t.Errorf("%s: data check expectation failed: %v", tc.name, err)
+			}
+		}
+	}
+}
+
+func TestSortMapPathWithWildcards(t *testing.T) {
+	testData := []string{
+		`^api-stg\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ stg:api-route`,
+		`^api-prod\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ prod:api-route`,
+		`^[^\.]*\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ prod:wildcard-route`,
+		`^3dev\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ dev:api-route`,
+		`^api-prod\.127\.0\.0\.1\.nip\.io(:[0-9]+)?/x/y/z(/.*)?$ prod:api-path-route`,
+		`^3app-admin\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ dev:admin-route`,
+		`^[^\.]*\.foo\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ devel2:foo-wildcard-route`,
+		`^zzz-production\.wildcard\.test(:[0-9]+)?/x/y/z(/.*)?$ test:api-route`,
+		`^backend-app\.127\.0\.0\.1\.nip\.io(:[0-9]+)?(/.*)?$ prod:backend-route`,
+		`^[^\.]*\.foo\.wildcard\.test(:[0-9]+)?(/.*)?$ devel2:foo-wildcard-test`,
+	}
+
+	expectedBackendOrder := []string{
+		"test:api-route",
+		"prod:backend-route",
+		"stg:api-route",
+		"prod:api-path-route",
+		"prod:api-route",
+		"dev:api-route",
+		"dev:admin-route",
+		"devel2:foo-wildcard-test",
+		"devel2:foo-wildcard-route",
+		"prod:wildcard-route",
+	}
+
+	data := SortMapPaths(testData, `^[^\.]*`)
+
+	err := checkSortExpectation(data, expectedBackendOrder)
+	if err != nil {
+		t.Errorf("TestSortMapPathWithWildcards sort expectation failed: %v", err)
+	}
+}


### PR DESCRIPTION
Add template helper code to sort haproxy map files so that wildcard routes don't 
take precedence over routes that start with a number.
Based on discussions in PR #19076   to fix issue #16724

@smarterclayton @jmprusi 