### PR TITLE
Prefix with unix protocol for docker shim socket

### DIFF
--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -271,7 +271,7 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 				obj.ExecHandlerName = configapi.DockerExecHandlerNative
 			}
 			if len(obj.DockerShimSocket) == 0 {
-				obj.DockerShimSocket = "/var/run/sockershim.sock"
+				obj.DockerShimSocket = "unix:///var/run/dockershim.sock"
 			}
 			if len(obj.DockershimRootDirectory) == 0 {
 				obj.DockershimRootDirectory = "/var/lib/dockershim"

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -200,7 +200,7 @@ func SetDefaults_DockerConfig(obj *DockerConfig) {
 		obj.ExecHandlerName = DockerExecHandlerNative
 	}
 	if len(obj.DockerShimSocket) == 0 {
-		obj.DockerShimSocket = "/var/run/dockershim.sock"
+		obj.DockerShimSocket = "unix:///var/run/dockershim.sock"
 	}
 	if len(obj.DockershimRootDirectory) == 0 {
 		obj.DockershimRootDirectory = "/var/lib/dockershim"

--- a/pkg/cmd/server/apis/config/v1/testdata/node-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/node-config.yaml
@@ -12,7 +12,7 @@ dnsNameservers: null
 dnsRecursiveResolvConf: ""
 dockerConfig:
   dockerShimRootDirectory: /var/lib/dockershim
-  dockerShimSocket: /var/run/dockershim.sock
+  dockerShimSocket: unix:///var/run/dockershim.sock
   execHandlerName: native
 enableUnidling: false
 imageConfig:

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -156,6 +156,8 @@ type DockerConfig struct {
 	// commands in Docker containers.
 	ExecHandlerName DockerExecHandlerType `json:"execHandlerName"`
 	// DockerShimSocket is the location of the dockershim socket the kubelet uses.
+	// Currently unix socket is supported on Linux, and tcp is supported on windows.
+	// Examples:'unix:///var/run/dockershim.sock', 'tcp://localhost:3735'
 	DockerShimSocket string `json:"dockerShimSocket"`
 	// DockershimRootDirectory is the dockershim root directory.
 	DockershimRootDirectory string `json:"dockerShimRootDirectory"`

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -343,7 +343,7 @@ func DefaultAllInOneOptions() (*configapi.MasterConfig, *configapi.NodeConfig, *
 		return nil, nil, nil, err
 	}
 
-	nodeConfig.DockerConfig.DockerShimSocket = path.Join(util.GetBaseDir(), "dockershim.sock")
+	nodeConfig.DockerConfig.DockerShimSocket = "unix://" + path.Join(util.GetBaseDir(), "dockershim.sock")
 	nodeConfig.DockerConfig.DockershimRootDirectory = path.Join(util.GetBaseDir(), "dockershim")
 
 	return masterConfig, nodeConfig, startOptions.NodeArgs.Components, nil


### PR DESCRIPTION
- File path without protocol for CRI endpoint is deprecated

```
Apr 04 20:16:05 openshift-node-1 openshift[313]: W0404 20:16:05.768925     313 util_unix.go:75] Using "/var/run/dockershim.sock" as endpoint is deprecated, please consider using full url format "unix:///var/run/dockershim.sock".
Apr 04 20:16:05 openshift-node-1 openshift[313]: I0404 20:16:05.768885     313 remote_runtime.go:43] Connecting to runtime service /var/run/dockershim.sock
```