### PR TITLE
prevent oc cluster up from allowing bad KUBECONFIGs

### DIFF
--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -439,7 +439,7 @@ func (c *ClusterUpConfig) Check(out io.Writer) error {
 
 	// OpenShift checks
 	taskPrinter.StartTask("Checking if OpenShift client is configured properly")
-	if err := checkOpenShiftClient(); err != nil {
+	if err := c.checkOpenShiftClient(); err != nil {
 		return taskPrinter.ToError(err)
 	}
 	taskPrinter.Success()
@@ -601,16 +601,33 @@ func defaultPortForwarding() bool {
 
 // checkOpenShiftClient ensures that the client can be configured
 // for the new server
-func checkOpenShiftClient() error {
+func (c *ClusterUpConfig) checkOpenShiftClient() error {
 	kubeConfig := os.Getenv("KUBECONFIG")
 	if len(kubeConfig) == 0 {
 		return nil
 	}
+
+	// if you're trying to use the kubeconfig into a subdirectory of the basedir, you're probably using a KUBECONFIG
+	// location that is going to overwrite a "real" kubeconfig, usually admin.kubeconfig which will break every other component
+	// relying on it being a full power kubeconfig
+	kubeConfigDir := filepath.Dir(kubeConfig)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	absKubeConfigDir, err := cmdutil.MakeAbs(kubeConfigDir, cwd)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(absKubeConfigDir, c.BaseDir+"/") {
+		return fmt.Errorf("cannot choose kubeconfig in subdirectory of the --base-dir: %q", kubeConfig)
+	}
+
 	var (
 		kubeConfigError error
 		f               *os.File
 	)
-	_, err := os.Stat(kubeConfig)
+	_, err = os.Stat(kubeConfig)
 	switch {
 	case os.IsNotExist(err):
 		err = os.MkdirAll(filepath.Dir(kubeConfig), 0755)


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/19230

Setting a KUBECONFIG to something in a subdir under the basedir usually means that you're point at an admin.kubeconfig.  If you're doing that, then you're likely to accidentally mutate the cluster-admin creds that every component uses to install after the fact.  In addition, creating that directly destroys signal information for the creation of configdirs.  Just don't allow anything in a subdir under the basedir.

/assign @mfojtik 
/assign @soltysh 