### PR TITLE
Update console liveness probe

### DIFF
--- a/install/origin-web-console/console-template.yaml
+++ b/install/origin-web-console/console-template.yaml
@@ -71,12 +71,12 @@ objects:
             exec:
               command:
                 - /bin/sh
-                - -i
                 - -c
                 - |-
                   if [[ ! -f /tmp/webconsole-config.hash ]]; then \
                     md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
                   elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    echo 'webconsole-config.yaml has changed.'; \
                     exit 1; \
                   fi && curl -k -f https://0.0.0.0:8443/console/
           resources:

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -16201,12 +16201,12 @@ objects:
             exec:
               command:
                 - /bin/sh
-                - -i
                 - -c
                 - |-
                   if [[ ! -f /tmp/webconsole-config.hash ]]; then \
                     md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
                   elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    echo 'webconsole-config.yaml has changed.'; \
                     exit 1; \
                   fi && curl -k -f https://0.0.0.0:8443/console/
           resources:

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -30996,12 +30996,12 @@ objects:
             exec:
               command:
                 - /bin/sh
-                - -i
                 - -c
                 - |-
                   if [[ ! -f /tmp/webconsole-config.hash ]]; then \
                     md5sum /var/webconsole-config/webconsole-config.yaml > /tmp/webconsole-config.hash; \
                   elif [[ $(md5sum /var/webconsole-config/webconsole-config.yaml) != $(cat /tmp/webconsole-config.hash) ]]; then \
+                    echo 'webconsole-config.yaml has changed.'; \
                     exit 1; \
                   fi && curl -k -f https://0.0.0.0:8443/console/
           resources:


### PR DESCRIPTION
Avoid error:
cannot set terminal process group (-1):
Inappropriate ioctl for device bash: no job control in this shell exit

Add message:
webconsole-config.yaml has changed.

![screen shot 2018-04-05 at 1 44 23 pm](https://user-images.githubusercontent.com/1167259/38383134-a952b610-38d9-11e8-8734-ad1bdf70ea56.png)

/assign @jwforres 
cc @smarterclayton 