### PR TITLE
Further dind start certificate generation serialization

### DIFF
--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -43,12 +43,12 @@ function ensure-master-config() {
      --cert-dir="${master_path}" \
      --master="https://${serving_ip_addr}:8443" \
      --hostnames="${ip_addrs},${name}"
-  ) 200>"${config_path}"/.openshift-ca.lock
 
-  /usr/local/bin/openshift start master --write-config="${master_path}" \
-    --master="https://${serving_ip_addr}:8443" \
-    --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
-    ${OPENSHIFT_ADDITIONAL_ARGS}
+   /usr/local/bin/openshift start master --write-config="${master_path}" \
+     --master="https://${serving_ip_addr}:8443" \
+     --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
+     ${OPENSHIFT_ADDITIONAL_ARGS}
+  ) 200>"${config_path}"/.openshift-ca.lock
 
   # ensure the configuration can be used outside of the container
   chmod -R ga+rX "${master_path}"


### PR DESCRIPTION
#19188 didn't fix the dind startup certificate-generation race condition, it just pushed it around. It turns out that `openshift start master --write-config` also does stuff with the CA, so we need that be inside the lock too.

