### PR TITLE
travis: Don't send IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,4 @@ install:
 script:
   - make verify-commits
 
-notifications:
-  irc: "chat.freenode.net#openshift-dev"
-
 sudo: false


### PR DESCRIPTION
I'd like to use the #openshift-dev channel more but I feel the
build status notifications are noisy.  Anyone who is interested
in that can follow things via the existing github email notifications.