### PR TITLE
Fix minor inconsistencies

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -51,7 +51,7 @@ func originFuzzer(t *testing.T, seed int64) *fuzz.Fuzzer {
 		// Roles and RoleBindings maps are never nil
 		func(j *authorizationapi.Policy, c fuzz.Continue) {
 			c.FuzzNoCustom(j)
-			if j.Roles != nil {
+			if j.Roles == nil {
 				j.Roles = make(map[string]*authorizationapi.Role)
 			}
 			for k, v := range j.Roles {
@@ -83,7 +83,9 @@ func originFuzzer(t *testing.T, seed int64) *fuzz.Fuzzer {
 			}
 		},
 		func(j *authorizationapi.ClusterPolicyBinding, c fuzz.Continue) {
-			j.RoleBindings = make(map[string]*authorizationapi.ClusterRoleBinding)
+			if j.RoleBindings == nil {
+				j.RoleBindings = make(map[string]*authorizationapi.ClusterRoleBinding)
+			}
 		},
 		func(j *authorizationapi.RoleBinding, c fuzz.Continue) {
 			c.FuzzNoCustom(j)

--- a/pkg/cmd/server/apis/config/v1/stringsource.go
+++ b/pkg/cmd/server/apis/config/v1/stringsource.go
@@ -20,7 +20,7 @@ func (s *StringSource) UnmarshalJSON(value []byte) error {
 // MarshalJSON implements the json.Marshaller interface.
 // If the StringSource contains only a string Value (or is empty), it is marshaled as a JSON string.
 // Otherwise, the StringSourceSpec struct is marshaled as a JSON object.
-func (s StringSource) MarshalJSON() ([]byte, error) {
+func (s *StringSource) MarshalJSON() ([]byte, error) {
 	// If we have only a cleartext value set, do a simple string marshal
 	if s.StringSourceSpec == (StringSourceSpec{Value: s.Value}) {
 		return json.Marshal(s.Value)


### PR DESCRIPTION
Fix inconsistency in authorization fuzzer

This fixes incorrect nil checks in the authorization object fuzzer. The types round tripped correctly so there is no actual "bug" here.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Fix inconsistency in StringSource MarshalJSON

The method should be bound to *StringSource like every other type in the codebase.  The unintentional copy did not result in any behavioral changes.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @simo5 @php-coder