### PR TITLE
Prometheus metrics for image import controllers

### DIFF
--- a/pkg/image/controller/imagestream_controller_test.go
+++ b/pkg/image/controller/imagestream_controller_test.go
@@ -334,7 +334,7 @@ func TestHandleImageStream(t *testing.T) {
 		fake := imageclient.NewSimpleClientset()
 		other := test.stream.DeepCopy()
 
-		if err := handleImageStream(test.stream, fake.Image(), nil); err != nil {
+		if _, err := handleImageStream(test.stream, fake.Image(), nil); err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 		}
 		if test.expected != nil {

--- a/pkg/image/controller/metrics.go
+++ b/pkg/image/controller/metrics.go
@@ -1,0 +1,224 @@
+package controller
+
+import (
+	"fmt"
+	"sync"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	metrics "github.com/openshift/origin/pkg/image/metrics/prometheus"
+)
+
+const reasonUnknown = "Unknown"
+const reasonInvalidImageReference = "InvalidImageReference"
+
+// ImportMetricCounter counts numbers of successful and failed imports for the purpose of metrics collection.
+type ImportMetricCounter struct {
+	counterMutex        sync.Mutex
+	importSuccessCounts metrics.ImportSuccessCounts
+	importErrorCounts   metrics.ImportErrorCounts
+}
+
+// NewImportMetricCounter returns a new ImportMetricCounter
+func NewImportMetricCounter() *ImportMetricCounter {
+	return &ImportMetricCounter{
+		importSuccessCounts: make(metrics.ImportSuccessCounts),
+		importErrorCounts:   make(metrics.ImportErrorCounts),
+	}
+}
+
+// Increment processes the given image stream import object as a result of successful or failed import and
+// increments the counters. The given error will be used to construct reason of the error_count metric unless
+// any reason is found in the image stream import object. It's safe to call this method with any of the
+// parameters nil.
+func (c *ImportMetricCounter) Increment(isi *imageapi.ImageStreamImport, err error) {
+	if isi == nil {
+		if err == nil {
+			return
+		}
+
+		c.counterMutex.Lock()
+		defer c.counterMutex.Unlock()
+		info := defaultErrorInfoReason(&metrics.ImportErrorInfo{}, err)
+		c.importErrorCounts[*info]++
+		return
+	}
+
+	c.countRepositoryImport(isi, err)
+
+	if len(isi.Status.Images) == 0 {
+		return
+	}
+
+	c.counterMutex.Lock()
+	defer c.counterMutex.Unlock()
+
+	enumerateIsImportStatuses(isi, func(info *metrics.ImportErrorInfo) {
+		if len(info.Reason) == 0 {
+			c.importSuccessCounts[info.Registry]++
+		} else {
+			c.importErrorCounts[*defaultErrorInfoReason(info, err)]++
+		}
+	})
+}
+
+// countRepositoryImport increments either success or error counter if the isimport contains repository
+// request.
+func (c *ImportMetricCounter) countRepositoryImport(isi *imageapi.ImageStreamImport, err error) {
+	errInfo := getIsImportRepositoryInfo(isi)
+	if errInfo == nil {
+		return
+	}
+
+	c.counterMutex.Lock()
+	defer c.counterMutex.Unlock()
+
+	if len(errInfo.Reason) == 0 {
+		c.importSuccessCounts[errInfo.Registry]++
+	} else {
+		c.importErrorCounts[*defaultErrorInfoReason(errInfo, err)]++
+	}
+}
+
+// Collect is supposed to be called by the metrics collector. It returns the actual state of counters.
+func (c *ImportMetricCounter) Collect() (metrics.ImportSuccessCounts, metrics.ImportErrorCounts, error) {
+	c.counterMutex.Lock()
+	defer c.counterMutex.Unlock()
+
+	success := metrics.ImportSuccessCounts{}
+	for registry, count := range c.importSuccessCounts {
+		success[registry] = count
+	}
+
+	failures := metrics.ImportErrorCounts{}
+	for info, count := range c.importErrorCounts {
+		failures[info] = count
+	}
+
+	return success, failures, nil
+}
+
+// getIsImportRepositoryInfo returns an import error info if the given isi contains repository request.
+// If the request succeeded, its Reason will be empty.
+func getIsImportRepositoryInfo(isi *imageapi.ImageStreamImport) *metrics.ImportErrorInfo {
+	if isi.Status.Repository == nil || isi.Spec.Repository == nil {
+		return nil
+	}
+	ref := isi.Spec.Repository.From
+	if ref.Kind != "DockerImage" {
+		return nil
+	}
+	imgRef, err := imageapi.ParseDockerImageReference(ref.Name)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf(
+			"failed to parse isi.spec.repository.from.name %q: %v",
+			ref.Name, err))
+		return nil
+	}
+
+	info := mkImportInfo(imgRef.DockerClientDefaults().Registry, &isi.Status.Repository.Status)
+	return &info
+}
+
+// enumerateIsImportStatuses iterates over images of the given image stream import. For any valid recorded
+// import the cb callback will be colled with the obtains information.
+// If the image import is successful, the object passed to the cb will contain empty Reason.
+func enumerateIsImportStatuses(isi *imageapi.ImageStreamImport, cb func(*metrics.ImportErrorInfo)) {
+	if len(isi.Status.Images) == 0 {
+		return
+	}
+
+	for i, status := range isi.Status.Images {
+		var registry string
+
+		imgRef, err := getImageDockerReferenceForImage(isi, i)
+		if err != nil {
+			utilruntime.HandleError(err)
+		} else {
+			if imgRef == nil {
+				continue
+			}
+			registry = imgRef.DockerClientDefaults().Registry
+		}
+
+		info := mkImportInfo(registry, &status.Status)
+		if err != nil {
+			info.Reason = reasonInvalidImageReference
+		}
+		cb(&info)
+	}
+}
+
+func getImageDockerReferenceForImage(
+	isi *imageapi.ImageStreamImport,
+	index int,
+) (*imageapi.DockerImageReference, error) {
+	var (
+		imgRef imageapi.DockerImageReference
+		err    error
+	)
+
+	// prefer the specification as the source of truth because the reference in status may belong to an
+	// older image imported from somewhere else
+	if index >= 0 && index < len(isi.Spec.Images) {
+		imgSpec := &isi.Spec.Images[index]
+		if imgSpec.From.Kind == "DockerImage" {
+			imgRef, err = imageapi.ParseDockerImageReference(imgSpec.From.Name)
+			if err == nil {
+				return &imgRef, nil
+			}
+			err = fmt.Errorf("failed to parse isi.spec.images[%d].from.name %q: %v",
+				index, imgSpec.From.Name, err)
+		}
+	}
+
+	// fall-back to the image in status
+	if index < 0 || index >= len(isi.Status.Images) {
+		return nil, err
+	}
+
+	img := isi.Status.Images[index].Image
+	if img == nil {
+		return nil, err
+	}
+
+	imgRef, err = imageapi.ParseDockerImageReference(img.DockerImageReference)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to parse isi.status.images[%d].image.dockerImageReference %q: %v",
+			index, img.DockerImageReference, err)
+	}
+
+	return &imgRef, nil
+}
+
+// mkImportInfo returns an import error info for the given status. If the import succeeded, the Reason field
+// will be empty.
+func mkImportInfo(registry string, status *metav1.Status) metrics.ImportErrorInfo {
+	var reason string
+	if status.Status != metav1.StatusSuccess {
+		reason = string(status.Reason)
+		if len(reason) == 0 {
+			reason = reasonUnknown
+		}
+	}
+	return metrics.ImportErrorInfo{
+		Registry: registry,
+		Reason:   reason,
+	}
+}
+
+// defaultErrorInfoReason fills the Reason field of the import error info from the given error unless already
+// set.
+func defaultErrorInfoReason(info *metrics.ImportErrorInfo, err error) *metrics.ImportErrorInfo {
+	if len(info.Reason) == 0 && err != nil {
+		info.Reason = string(apierrs.ReasonForError(err))
+		if len(info.Reason) == 0 {
+			info.Reason = reasonUnknown
+		}
+	}
+	return info
+}

--- a/pkg/image/metrics/prometheus/metrics.go
+++ b/pkg/image/metrics/prometheus/metrics.go
@@ -1,0 +1,139 @@
+package prometheus
+
+import (
+	"sync"
+
+	"github.com/golang/glog"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	separator          = "_"
+	metricController   = "openshift_imagestreamcontroller"
+	metricCount        = "count"
+	metricSuccessCount = metricController + separator + "success" + separator + metricCount
+	metricErrorCount   = metricController + separator + "error" + separator + metricCount
+
+	labelScheduled = "scheduled"
+	labelRegistry  = "registry"
+	labelReason    = "reason"
+)
+
+// ImportErrorInfo contains dimensions of metricErrorCount
+type ImportErrorInfo struct {
+	Registry string
+	Reason   string
+}
+
+// ImportSuccessCounts maps registry hostname (with port) to the count of successful imports. It serves as a
+// container of counters for the success_count metric.
+type ImportSuccessCounts map[string]uint64
+
+// ImportErrorCounts serves as a container of counters for the error_count metric.
+type ImportErrorCounts map[ImportErrorInfo]uint64
+
+// QueuedImageStreamFetcher is a callback passed to the importStatusCollector that is supposed to be invoked
+// by image import controller with the current state of counters.
+type QueuedImageStreamFetcher func() (ImportSuccessCounts, ImportErrorCounts, error)
+
+var (
+	successCountDesc = prometheus.NewDesc(
+		metricSuccessCount,
+		"Counts successful image stream imports - both scheduled and not scheduled - per image registry",
+		[]string{labelScheduled, labelRegistry},
+		nil,
+	)
+	errorCountDesc = prometheus.NewDesc(
+		metricErrorCount,
+		"Counts number of failed image stream imports - both scheduled and not scheduled"+
+			" - per image registry and failure reason",
+		[]string{labelScheduled, labelRegistry, labelReason},
+		nil,
+	)
+
+	isc                 = importStatusCollector{}
+	registerLock        = sync.Mutex{}
+	collectorRegistered = false
+)
+
+type importStatusCollector struct {
+	cbCollectISCounts        QueuedImageStreamFetcher
+	cbCollectScheduledCounts QueuedImageStreamFetcher
+}
+
+// InitializeImportCollector is supposed to be called by image import controllers when they are prepared to
+// serve requests. Once all the controllers register their callbacks, the collector registers the metrics with
+// the prometheus.
+func InitializeImportCollector(
+	scheduled bool,
+	cbCollectISCounts QueuedImageStreamFetcher,
+) {
+	registerLock.Lock()
+	defer registerLock.Unlock()
+
+	if scheduled {
+		isc.cbCollectScheduledCounts = cbCollectISCounts
+	} else {
+		isc.cbCollectISCounts = cbCollectISCounts
+	}
+
+	if collectorRegistered {
+		return
+	}
+
+	if isc.cbCollectISCounts != nil && isc.cbCollectScheduledCounts != nil {
+		prometheus.MustRegister(&isc)
+		collectorRegistered = true
+		glog.V(4).Info("Image import controller metrics registered with prometherus")
+	}
+}
+
+func (isc *importStatusCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- successCountDesc
+	ch <- errorCountDesc
+}
+
+func (isc *importStatusCollector) Collect(ch chan<- prometheus.Metric) {
+	successCounts, errorCounts, err := isc.cbCollectISCounts()
+	if err != nil {
+		glog.Errorf("Failed to collect image import metrics: %v", err)
+		ch <- prometheus.NewInvalidMetric(successCountDesc, err)
+	} else {
+		pushSuccessCounts("false", successCounts, ch)
+		pushErrorCounts("false", errorCounts, ch)
+	}
+
+	successCounts, errorCounts, err = isc.cbCollectScheduledCounts()
+	if err != nil {
+		glog.Errorf("Failed to collect scheduled image import metrics: %v", err)
+		ch <- prometheus.NewInvalidMetric(errorCountDesc, err)
+		return
+	}
+
+	pushSuccessCounts("true", successCounts, ch)
+	pushErrorCounts("true", errorCounts, ch)
+}
+
+func pushSuccessCounts(scheduled string, counts ImportSuccessCounts, ch chan<- prometheus.Metric) {
+	for registry, count := range counts {
+		ch <- prometheus.MustNewConstMetric(
+			successCountDesc,
+			prometheus.CounterValue,
+			float64(count),
+			scheduled,
+			registry)
+	}
+}
+
+func pushErrorCounts(scheduled string, counts ImportErrorCounts, ch chan<- prometheus.Metric) {
+	for info, count := range counts {
+		ch <- prometheus.MustNewConstMetric(
+			errorCountDesc,
+			prometheus.CounterValue,
+			float64(count),
+			scheduled,
+			info.Registry,
+			info.Reason)
+	}
+}


### PR DESCRIPTION
Implemented two counters:

    openshift_imagestreamcontroller_success_count{
        // processed in scheduled or new queue
        scheduled: bool,
        // just the registry's hostname
        registry: "...",        // e.g. docker.io
    }

    openshift_imagestreamcontroller_error_count{
        // processed in scheduled or new queue
        scheduled: bool,
        registry: "...",
        // e.g. “Unauthorized”
        reason: tagEventList.Conditions[0].Reason,
    }