### PR TITLE
dind: restart ovn-kubernetes-node via systemd if it fails

### DIFF
--- a/images/dind/node/ovn-kubernetes-node.service
+++ b/images/dind/node/ovn-kubernetes-node.service
@@ -7,6 +7,8 @@ After=ovn-kubernetes-node-setup.service
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/ovn-kubernetes-node.sh
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=openshift-node.service


### PR DESCRIPTION
Just like we do for openshift-node/SDN itself.

@danwinship @knobunc @rajatchopra @pravisankar @openshift/networking 