### PR TITLE
Unable to build rpms due to tito's failing on OS_GIT_PATCH unbound va…

### DIFF
--- a/.tito/lib/origin/common.py
+++ b/.tito/lib/origin/common.py
@@ -31,7 +31,7 @@ def get_os_git_vars():
     shell utilities. The git tree state is spoofed.
     """
     git_vars = {}
-    for var in ["COMMIT", "VERSION", "MAJOR", "MINOR", "CATALOG_VERSION"]:
+    for var in ["COMMIT", "VERSION", "MAJOR", "MINOR", "PATCH", "CATALOG_VERSION"]:
         var_name = "OS_GIT_{}".format(var)
         git_vars[var_name] = run_command(
             "bash -c 'source ./hack/lib/init.sh; os::build::version::openshift_vars; echo ${}'".format(var_name)


### PR DESCRIPTION
…riable

While trying to build the Centos rpms came across this error thrown by tito

`"/builddir/build/BUILD/origin-git-0.ad1d6df/hack/lib/build/binaries.sh: line 267: OS_GIT_PATCH: unbound variable"`

For now is [fixed](https://github.com/CentOS-PaaS-SIG/paas-sig-ci/pull/69) in the `paas-ci-sig` repo but will be good to get this merged so can remove the task from the automation code.

@tdawson @sdodson @arilivigni fyi