### PR TITLE
Clear error message when input too short name

### DIFF
--- a/pkg/oc/generate/app/uniquenamegenerator.go
+++ b/pkg/oc/generate/app/uniquenamegenerator.go
@@ -53,7 +53,7 @@ func (ung *uniqueNameGenerator) ensureValidName(name string) (string, error) {
 
 	// Ensure that name meets length requirements
 	if len(name) < 2 {
-		return "", fmt.Errorf("invalid name: %s", name)
+		return "", fmt.Errorf("invalid name: %s. Must be 2 or more characters", name)
 	}
 
 	if !IsParameterizableValue(name) {


### PR DESCRIPTION
When input a name with 1 length char to oc new-{app,build}, it fails
with `invalid name`, which is not clear.

This patch makes a tiny change to output the name was invalid with the
suggestion.

Before:
```
$ oc new-build --strategy=docker --binary=true --name=a
error: can't build "": invalid name: a
```

After:
```
$ oc new-build --strategy=docker --binary=true --name=a
error: can't build "": invalid name: a. Must be 2 or more characters
```