### PR TITLE
apps: retry when scaler hits the conflict

### DIFF
--- a/pkg/apps/strategy/recreate/recreate.go
+++ b/pkg/apps/strategy/recreate/recreate.go
@@ -234,6 +234,10 @@ func (s *RecreateDeploymentStrategy) scaleAndWait(deployment *kapi.ReplicationCo
 		if scaleErr == nil {
 			return true, nil
 		}
+		// Handle conflicts (shouldn't this be already handled by the scaler?)
+		if errors.IsConflict(scaleErr) {
+			return false, nil
+		}
 		// This error is returned when the lifecycle admission plugin cache is not fully
 		// synchronized. In that case the scaling should be retried.
 		//


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/19270

This is weird, seems like the new `genericScaler` does not handle the conflicts? Probably need more investigation. 

//cc @tnozicka 
//cc @DirectXMan12 