### PR TITLE
Fix use of cookies in HostSubnet deletion

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -529,9 +529,9 @@ func (oc *ovsController) DeleteHostSubnetRules(subnet *networkapi.HostSubnet) er
 	cookie := hostSubnetCookie(subnet)
 
 	otx := oc.ovs.NewTransaction()
-	otx.DeleteFlows("table=10, cookie=0x%08x, tun_src=%s", cookie, subnet.HostIP)
-	otx.DeleteFlows("table=50, cookie=0x%08x, arp, nw_dst=%s", cookie, subnet.Subnet)
-	otx.DeleteFlows("table=90, cookie=0x%08x, ip, nw_dst=%s", cookie, subnet.Subnet)
+	otx.DeleteFlows("table=10, cookie=0x%08x/0xffffffff, tun_src=%s", cookie, subnet.HostIP)
+	otx.DeleteFlows("table=50, cookie=0x%08x/0xffffffff, arp, nw_dst=%s", cookie, subnet.Subnet)
+	otx.DeleteFlows("table=90, cookie=0x%08x/0xffffffff, ip, nw_dst=%s", cookie, subnet.Subnet)
 	return otx.EndTransaction()
 }
 


### PR DESCRIPTION
Fix-up to #19080: when passing a cookie to del-flows (or dump-flows), you have to use the `cookie=value/mask` syntax: saying `cookie=value` without the mask always means "set the cookie to `value`", not "match a cookie with `value`". This fixes that and also fixes fake_ovs so that this would have been caught in the unit tests.

(The bug is only in master; we hadn't backported #19080 yet.)