### PR TITLE
node, syscontainer: bind mount /var/lib/kubelet from the host

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -362,6 +362,17 @@
 	    ]
         },
         {
+	    "type": "bind",
+	    "source": "$KUBELET_DATA_DIR",
+	    "destination": "/var/lib/kubelet",
+	    "options": [
+		"rbind",
+		"rslave",
+		"rw",
+		"mode=755"
+	    ]
+        },
+        {
             "type": "bind",
             "source": "/etc/cni/net.d",
             "destination": "/etc/cni/net.d",

--- a/images/node/system-container/manifest.json
+++ b/images/node/system-container/manifest.json
@@ -4,6 +4,7 @@
         "DNS_DOMAIN": "cluster.local",
         "ORIGIN_CONFIG_DIR": "/etc/origin",
         "ORIGIN_DATA_DIR": "/var/lib/origin",
+        "KUBELET_DATA_DIR": "/var/lib/kubelet",
         "MASTER_SERVICE": "atomic-openshift-master.service",
         "DOCKER_SERVICE": "docker.service",
         "OPENVSWITCH_SERVICE": "openvswitch.service",


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>