### PR TITLE
Hoist sdn informer into Start()

### DIFF
--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -156,6 +156,13 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 		return err
 	}
 
+	// FIXME: this is required to register informers for the types we care about to ensure the informers are started.
+	// FIXME: restructure this controller to add event handlers in Start() before returning, instead of inside startSubSystems.
+	master.nodeInformer.Informer().GetController()
+	master.namespaceInformer.Informer().GetController()
+	master.hostSubnetInformer.Informer().GetController()
+	master.netNamespaceInformer.Informer().GetController()
+
 	go master.startSubSystems(networkConfig.NetworkPluginName)
 
 	return nil


### PR DESCRIPTION
Workaround for #19217

```
Running test/cmd/sdn.sh:27: executing 'oc get netnamespace default -o jsonpath="{.netid}"' expecting success and text '^0$'...
FAILURE after 0.283s: test/cmd/sdn.sh:27: executing 'oc get netnamespace default -o jsonpath="{.netid}"' expecting success and text '^0$': the command returned the wrong error code; the output content test failed
There was no output from the command.
Standard error from the command:
Error from server (NotFound): netnamespaces.network.openshift.io "default" not found
[ERROR] [17:05:28+0000] PID 7491: hack/lib/cmd.sh:241: `return "${return_code}"` exited with status 1.
```