### PR TITLE
extended tests: use leaner image in valuefrom.go

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4002,10 +4002,8 @@ spec:
   triggers: []
   runPolicy: Serial
   source:
-    type: Git
-    git:
-      uri: 'https://github.com/sclorg/s2i-php-container'
-    contextDir: '7.0'
+    dockerfile:
+      'FROM busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6'
   strategy:
     type: Docker
     dockerStrategy:
@@ -4133,10 +4131,8 @@ spec:
   triggers: []
   runPolicy: Serial
   source:
-    type: Git
-    git:
-      uri: 'https://github.com/sclorg/s2i-php-container'
-    contextDir: '7.0'
+    dockerfile:
+      'FROM busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6'
   strategy:
     type: Docker
     dockerStrategy:

--- a/test/extended/testdata/builds/valuefrom/failed-docker-build-value-from-config.yaml
+++ b/test/extended/testdata/builds/valuefrom/failed-docker-build-value-from-config.yaml
@@ -9,10 +9,8 @@ spec:
   triggers: []
   runPolicy: Serial
   source:
-    type: Git
-    git:
-      uri: 'https://github.com/sclorg/s2i-php-container'
-    contextDir: '7.0'
+    dockerfile:
+      'FROM busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6'
   strategy:
     type: Docker
     dockerStrategy:

--- a/test/extended/testdata/builds/valuefrom/successful-docker-build-value-from-config.yaml
+++ b/test/extended/testdata/builds/valuefrom/successful-docker-build-value-from-config.yaml
@@ -9,10 +9,8 @@ spec:
   triggers: []
   runPolicy: Serial
   source:
-    type: Git
-    git:
-      uri: 'https://github.com/sclorg/s2i-php-container'
-    contextDir: '7.0'
+    dockerfile:
+      'FROM busybox@sha256:a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6'
   strategy:
     type: Docker
     dockerStrategy:


### PR DESCRIPTION
Another candidate for potential speedup https://github.com/openshift/origin/issues/19077, I added build logs to the test output (https://github.com/wozniakjan/origin/pull/1) so I have a better idea what was taking so long in waiting forv the build such as in `valuefrom.go`:
```
Apr 10 08:49:49.583: INFO: Waiting for mydockertest-1 to complete 
Apr 10 08:56:35.591: INFO: Done waiting for mydockertest-1: util.BuildResult{BuildPath:"build/mydockertest-1", BuildName:"mydockertest-1", StartBuildStdErr:"", StartBuildStdOut:"build/mydockertest-1", StartBuil>
```
and the culprits are confirmed:
```
docker build: 280s 
  2018-04-10T08:50:10.666080715Z Step 1/16 : FROM centos/s2i-base-centos7
  2018-04-10T08:54:50.094010994Z Successfully built f3d34cd6d7d3
docker push: 102s 
  2018-04-10T08:54:50.12807908Z Pushing image docker-registry.default.svc:5000/extended-test-build-valuefrom-hbzcm-klmds/test:latest ...
  2018-04-10T08:56:32.612492912Z Push successful
```

I kept looking at other tests and found out the fastest image for testing is based on busybox
```
test_extended_builds_hooks.go:42
docker build: 3s
  2018-04-10T08:22:42.029395739Z Step 1/3 : FROM busybox@sha256:186694df7e479d2b8bf075d9e1b1d7a884c6de60470006d572350573bfa6dcd2
  2018-04-10T08:22:45.080542237Z Successfully built d54ac4a9ba55
```

@openshift/sig-developer-experience do we have any github repository with something that I could use instead of https://github.com/wozniakjan/bc-with-pr-ref/tree/master/build ?

Locally build time improves from 2min to 15s and I suspect smaller image will improve the push time as well
```
NAME                      TYPE      FROM          STATUS     STARTED             DURATION
builds/mydockertest-1     Docker    Git@40ccf8a   Complete   About an hour ago   1m57s
builds/mydockertest-2     Docker    Git@85a5f18   Complete   2 minutes ago       15s
```