### PR TITLE
apps: replace kubectl scaler in deployer with direct client call and polling

### DIFF
--- a/pkg/apps/strategy/recreate/recreate.go
+++ b/pkg/apps/strategy/recreate/recreate.go
@@ -14,11 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
-	"k8s.io/kubernetes/pkg/kubectl"
 
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	strat "github.com/openshift/origin/pkg/apps/strategy"
@@ -41,6 +42,8 @@ type RecreateDeploymentStrategy struct {
 	until string
 	// rcClient is a client to access replication controllers
 	rcClient kcoreclient.ReplicationControllersGetter
+	// scaleClient is a client to access scaling
+	scaleClient scale.ScalesGetter
 	// podClient is used to list and watch pods.
 	podClient kcoreclient.PodsGetter
 	// eventClient is a client to access events
@@ -48,23 +51,18 @@ type RecreateDeploymentStrategy struct {
 	// getUpdateAcceptor returns an UpdateAcceptor to verify the first replica
 	// of the deployment.
 	getUpdateAcceptor func(time.Duration, int32) strat.UpdateAcceptor
-	// scaler is used to scale replication controllers.
-	scaler kubectl.Scaler
 	// codec is used to decode DeploymentConfigs contained in deployments.
 	decoder runtime.Decoder
 	// hookExecutor can execute a lifecycle hook.
 	hookExecutor stratsupport.HookExecutor
-	// retryPeriod is how often to try updating the replica count.
-	retryPeriod time.Duration
-	// retryParams encapsulates the retry parameters
-	retryParams *kubectl.RetryParams
 	// events records the events
 	events record.EventSink
 }
 
 // NewRecreateDeploymentStrategy makes a RecreateDeploymentStrategy backed by
 // a real HookExecutor and client.
-func NewRecreateDeploymentStrategy(client kclientset.Interface, tagClient imageclient.ImageStreamTagsGetter, events record.EventSink, decoder runtime.Decoder, out, errOut io.Writer, until string) *RecreateDeploymentStrategy {
+func NewRecreateDeploymentStrategy(client kclientset.Interface, scaleClient scale.ScalesGetter, tagClient imageclient.ImageStreamTagsGetter,
+	events record.EventSink, decoder runtime.Decoder, out, errOut io.Writer, until string) *RecreateDeploymentStrategy {
 	if out == nil {
 		out = ioutil.Discard
 	}
@@ -78,15 +76,14 @@ func NewRecreateDeploymentStrategy(client kclientset.Interface, tagClient imagec
 		events:      events,
 		until:       until,
 		rcClient:    client.Core(),
+		scaleClient: scaleClient,
 		eventClient: client.Core(),
 		podClient:   client.Core(),
 		getUpdateAcceptor: func(timeout time.Duration, minReadySeconds int32) strat.UpdateAcceptor {
 			return stratsupport.NewAcceptAvailablePods(out, client.Core(), timeout)
 		},
-		scaler:       appsutil.NewReplicationControllerV1Scaler(client),
 		decoder:      decoder,
 		hookExecutor: stratsupport.NewHookExecutor(client.Core(), tagClient, client.Core(), os.Stdout, decoder),
-		retryPeriod:  1 * time.Second,
 	}
 }
 
@@ -108,25 +105,22 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 		return fmt.Errorf("couldn't decode config from deployment %s: %v", to.Name, err)
 	}
 
-	retryTimeout := time.Duration(appsapi.DefaultRecreateTimeoutSeconds) * time.Second
+	recreateTimeout := time.Duration(appsapi.DefaultRecreateTimeoutSeconds) * time.Second
 	params := config.Spec.Strategy.RecreateParams
 	rollingParams := config.Spec.Strategy.RollingParams
 
 	if params != nil && params.TimeoutSeconds != nil {
-		retryTimeout = time.Duration(*params.TimeoutSeconds) * time.Second
+		recreateTimeout = time.Duration(*params.TimeoutSeconds) * time.Second
 	}
 
 	// When doing the initial rollout for rolling strategy we use recreate and for that we
 	// have to set the TimeoutSecond based on the rollling strategy parameters.
 	if rollingParams != nil && rollingParams.TimeoutSeconds != nil {
-		retryTimeout = time.Duration(*rollingParams.TimeoutSeconds) * time.Second
+		recreateTimeout = time.Duration(*rollingParams.TimeoutSeconds) * time.Second
 	}
 
-	s.retryParams = kubectl.NewRetryParams(s.retryPeriod, retryTimeout)
-	waitParams := kubectl.NewRetryParams(s.retryPeriod, retryTimeout)
-
 	if updateAcceptor == nil {
-		updateAcceptor = s.getUpdateAcceptor(retryTimeout, config.Spec.MinReadySeconds)
+		updateAcceptor = s.getUpdateAcceptor(recreateTimeout, config.Spec.MinReadySeconds)
 	}
 
 	// Execute any pre-hook.
@@ -147,7 +141,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 	// Scale down the from deployment.
 	if from != nil {
 		fmt.Fprintf(s.out, "--> Scaling %s down to zero\n", from.Name)
-		_, err := s.scaleAndWait(from, 0, s.retryParams, waitParams)
+		_, err := s.scaleAndWait(from, 0, recreateTimeout)
 		if err != nil {
 			return fmt.Errorf("couldn't scale %s to 0: %v", from.Name, err)
 		}
@@ -177,7 +171,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 			// Scale up to 1 and validate the replica,
 			// aborting if the replica isn't acceptable.
 			fmt.Fprintf(s.out, "--> Scaling %s to 1 before performing acceptance check\n", to.Name)
-			updatedTo, err := s.scaleAndWait(to, 1, s.retryParams, waitParams)
+			updatedTo, err := s.scaleAndWait(to, 1, recreateTimeout)
 			if err != nil {
 				return fmt.Errorf("couldn't scale %s to 1: %v", to.Name, err)
 			}
@@ -195,7 +189,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 		// Complete the scale up.
 		if to.Spec.Replicas != int32(desiredReplicas) {
 			fmt.Fprintf(s.out, "--> Scaling %s to %d\n", to.Name, desiredReplicas)
-			updatedTo, err := s.scaleAndWait(to, desiredReplicas, s.retryParams, waitParams)
+			updatedTo, err := s.scaleAndWait(to, desiredReplicas, recreateTimeout)
 			if err != nil {
 				return fmt.Errorf("couldn't scale %s to %d: %v", to.Name, desiredReplicas, err)
 			}
@@ -224,32 +218,50 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *kapi.ReplicationCo
 	return nil
 }
 
-func (s *RecreateDeploymentStrategy) scaleAndWait(deployment *kapi.ReplicationController, replicas int, retry *kubectl.RetryParams, retryParams *kubectl.RetryParams) (*kapi.ReplicationController, error) {
+func (s *RecreateDeploymentStrategy) scaleAndWait(deployment *kapi.ReplicationController, replicas int, retryTimeout time.Duration) (*kapi.ReplicationController, error) {
 	if int32(replicas) == deployment.Spec.Replicas && int32(replicas) == deployment.Status.Replicas {
 		return deployment, nil
 	}
-	var scaleErr error
-	err := wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
-		scaleErr = s.scaler.Scale(deployment.Namespace, deployment.Name, uint(replicas), &kubectl.ScalePrecondition{Size: -1, ResourceVersion: ""}, retry, retryParams)
-		if scaleErr == nil {
-			return true, nil
-		}
+	alreadyScaled := false
+	// Update replication controller scale
+	err := wait.PollImmediate(1*time.Second, retryTimeout, func() (bool, error) {
+		updateScaleErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			curScale, err := s.scaleClient.Scales(deployment.Namespace).Get(kapi.Resource("replicationcontrollers"), deployment.Name)
+			if err != nil {
+				return err
+			}
+			if curScale.Status.Replicas == int32(replicas) {
+				alreadyScaled = true
+				return nil
+			}
+			curScaleCopy := curScale.DeepCopy()
+			curScaleCopy.Spec.Replicas = int32(replicas)
+			_, scaleErr := s.scaleClient.Scales(deployment.Namespace).Update(kapi.Resource("replicationcontrollers"), curScaleCopy)
+			return scaleErr
+		})
 		// This error is returned when the lifecycle admission plugin cache is not fully
 		// synchronized. In that case the scaling should be retried.
 		//
 		// FIXME: The error returned from admission should not be forbidden but come-back-later error.
-		if errors.IsForbidden(scaleErr) && strings.Contains(scaleErr.Error(), "not yet ready to handle request") {
+		if errors.IsForbidden(updateScaleErr) && strings.Contains(updateScaleErr.Error(), "not yet ready to handle request") {
 			return false, nil
 		}
-		return false, scaleErr
+		return true, updateScaleErr
 	})
-	if err == wait.ErrWaitTimeout {
-		return nil, fmt.Errorf("%v: %v", err, scaleErr)
-	}
 	if err != nil {
 		return nil, err
 	}
-
+	// TODO: We need to do polling as the upstream watches are broken atm.
+	// We should replace this with the same solution as kubectl rollout status will use.
+	if !alreadyScaled {
+		err = wait.PollImmediate(1*time.Second, retryTimeout, func() (bool, error) {
+			curScale, err := s.scaleClient.Scales(deployment.Namespace).Get(kapi.Resource("replicationcontrollers"), deployment.Name)
+			if err != nil {
+				return false, err
+			}
+			return curScale.Status.Replicas == int32(replicas), nil
+		})
+	}
 	return s.rcClient.ReplicationControllers(deployment.Namespace).Get(deployment.Name, metav1.GetOptions{})
 }
 

--- a/pkg/apps/strategy/recreate/recreate_test.go
+++ b/pkg/apps/strategy/recreate/recreate_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
@@ -16,366 +19,15 @@ import (
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
 	"github.com/openshift/origin/pkg/apps/strategy"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
-	cmdtest "github.com/openshift/origin/pkg/apps/util/test"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
-type fakeControllerClient struct {
-	deployment *kapi.ReplicationController
-}
-
-func (c *fakeControllerClient) ReplicationControllers(ns string) kcoreclient.ReplicationControllerInterface {
-	return fake.NewSimpleClientset(c.deployment).Core().ReplicationControllers(ns)
-}
-
-type fakePodClient struct {
-	deployerName string
-}
-
-func (c *fakePodClient) Pods(ns string) kcoreclient.PodInterface {
-	deployerPod := &kapi.Pod{}
-	deployerPod.Name = c.deployerName
-	deployerPod.Namespace = ns
-	deployerPod.Status = kapi.PodStatus{}
-	return fake.NewSimpleClientset(deployerPod).Core().Pods(ns)
-}
-
-type hookExecutorImpl struct {
-	executeFunc func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error
-}
-
-func (h *hookExecutorImpl) Execute(hook *appsapi.LifecycleHook, rc *kapi.ReplicationController, suffix, label string) error {
-	return h.executeFunc(hook, rc, suffix, label)
-}
-
-func TestRecreate_initialDeployment(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeScaler{}
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		getUpdateAcceptor: getUpdateAcceptor,
-		scaler:            scaler,
-		eventClient:       fake.NewSimpleClientset().Core(),
-	}
-
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", "", "")
-	deployment, _ = appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 3)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-
-	if e, a := 1, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(3), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
-	}
-}
-
-func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	hookExecuted := false
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		getUpdateAcceptor: getUpdateAcceptor,
-		eventClient:       fake.NewSimpleClientset().Core(),
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				hookExecuted = true
-				return nil
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-	if !hookExecuted {
-		t.Fatalf("expected hook execution")
-	}
-}
-
-func TestRecreate_deploymentPreHookFail(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		getUpdateAcceptor: getUpdateAcceptor,
-		eventClient:       fake.NewSimpleClientset().Core(),
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				return fmt.Errorf("hook execution failure")
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err == nil {
-		t.Fatalf("expected a deploy error")
-	}
-	if len(scaler.Events) > 0 {
-		t.Fatalf("unexpected scaling events: %v", scaler.Events)
-	}
-}
-
-func TestRecreate_deploymentMidHookSuccess(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", appsapi.LifecycleHookFailurePolicyAbort, "")
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion))
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		eventClient:       fake.NewSimpleClientset().Core(),
-		getUpdateAcceptor: getUpdateAcceptor,
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				return fmt.Errorf("hook execution failure")
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err == nil {
-		t.Fatalf("expected a deploy error")
-	}
-	if len(scaler.Events) > 0 {
-		t.Fatalf("unexpected scaling events: %v", scaler.Events)
-	}
-}
-func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	hookExecuted := false
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		eventClient:       fake.NewSimpleClientset().Core(),
-		getUpdateAcceptor: getUpdateAcceptor,
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				hookExecuted = true
-				return nil
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-	if !hookExecuted {
-		t.Fatalf("expected hook execution")
-	}
-}
-
-func TestRecreate_deploymentPostHookFail(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	hookExecuted := false
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		eventClient:       fake.NewSimpleClientset().Core(),
-		getUpdateAcceptor: getUpdateAcceptor,
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				hookExecuted = true
-				return fmt.Errorf("post hook failure")
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err == nil {
-		t.Fatalf("unexpected non deploy error: %#v", err)
-	}
-	if !hookExecuted {
-		t.Fatalf("expected hook execution")
-	}
-}
-
-func TestRecreate_acceptorSuccess(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:         &bytes.Buffer{},
-		errOut:      &bytes.Buffer{},
-		eventClient: fake.NewSimpleClientset().Core(),
-		decoder:     legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod: 1 * time.Millisecond,
-		scaler:      scaler,
-	}
-
-	acceptorCalled := false
-	acceptor := &testAcceptor{
+func getUpdateAcceptor(timeout time.Duration, minReadySeconds int32) strategy.UpdateAcceptor {
+	return &testAcceptor{
 		acceptFn: func(deployment *kapi.ReplicationController) error {
-			acceptorCalled = true
 			return nil
 		},
-	}
-
-	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-
-	if !acceptorCalled {
-		t.Fatalf("expected acceptor to be called")
-	}
-
-	if e, a := 2, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(1), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale down to %d, got %d", e, a)
-	}
-	if e, a := uint(2), scaler.Events[1].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
-	}
-}
-
-func TestRecreate_acceptorSuccessWithColdCaches(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeLaggedScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:         &bytes.Buffer{},
-		errOut:      &bytes.Buffer{},
-		eventClient: fake.NewSimpleClientset().Core(),
-		decoder:     legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod: 1 * time.Millisecond,
-		scaler:      scaler,
-	}
-
-	acceptorCalled := false
-	acceptor := &testAcceptor{
-		acceptFn: func(deployment *kapi.ReplicationController) error {
-			acceptorCalled = true
-			return nil
-		},
-	}
-
-	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-
-	if !acceptorCalled {
-		t.Fatalf("expected acceptor to be called")
-	}
-
-	if e, a := 2, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(1), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale down to %d, got %d", e, a)
-	}
-	if e, a := uint(2), scaler.Events[1].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
-	}
-	if scaler.RetryCount != 2 {
-		t.Errorf("expected retry when the caches are not initialized")
-	}
-}
-
-func TestRecreate_acceptorFail(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:         &bytes.Buffer{},
-		errOut:      &bytes.Buffer{},
-		decoder:     legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod: 1 * time.Millisecond,
-		scaler:      scaler,
-		eventClient: fake.NewSimpleClientset().Core(),
-	}
-
-	acceptor := &testAcceptor{
-		acceptFn: func(deployment *kapi.ReplicationController) error {
-			return fmt.Errorf("rejected")
-		},
-	}
-
-	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
-	if err == nil {
-		t.Fatalf("expected a deployment failure")
-	}
-	t.Logf("got expected error: %v", err)
-
-	if e, a := 1, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(1), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
 	}
 }
 
@@ -411,31 +63,384 @@ func recreateParams(timeout int64, preFailurePolicy, midFailurePolicy, postFailu
 	}
 }
 
-type testControllerClient struct {
-	getReplicationControllerFunc    func(namespace, name string) (*kapi.ReplicationController, error)
-	updateReplicationControllerFunc func(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error)
-}
-
-func (t *testControllerClient) getReplicationController(namespace, name string) (*kapi.ReplicationController, error) {
-	return t.getReplicationControllerFunc(namespace, name)
-}
-
-func (t *testControllerClient) updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-	return t.updateReplicationControllerFunc(namespace, ctrl)
-}
-
-func getUpdateAcceptor(timeout time.Duration, minReadySeconds int32) strategy.UpdateAcceptor {
-	return &testAcceptor{
-		acceptFn: func(deployment *kapi.ReplicationController) error {
-			return nil
-		},
-	}
-}
-
 type testAcceptor struct {
 	acceptFn func(*kapi.ReplicationController) error
 }
 
 func (t *testAcceptor) Accept(deployment *kapi.ReplicationController) error {
 	return t.acceptFn(deployment)
+}
+
+type fakeControllerClient struct {
+	deployment       *kapi.ReplicationController
+	fakeClient       *fake.Clientset
+	scaleEventsCount int
+	scaleEvents      []*autoscaling.Scale
+}
+
+func (c *fakeControllerClient) ReplicationControllers(ns string) kcoreclient.ReplicationControllerInterface {
+	return c.fakeClient.Core().ReplicationControllers(ns)
+}
+
+func newFakeControllerClient(deployment *kapi.ReplicationController) *fakeControllerClient {
+	c := &fakeControllerClient{deployment: deployment}
+	c.fakeClient = fake.NewSimpleClientset(c.deployment)
+	c.scaleEvents = []*autoscaling.Scale{}
+	c.fakeClient.PrependReactor("update", "replicationcontrollers", func(action clientgotesting.Action) (handled bool, ret runtime.Object,
+		err error) {
+		updateAction := action.(clientgotesting.UpdateAction)
+		if updateAction.GetSubresource() == "scale" {
+			scaleObj, ok := updateAction.GetObject().(*autoscaling.Scale)
+			if !ok {
+				return true, nil, fmt.Errorf("unexpected object, expected scale")
+			}
+			deployment.Spec.Replicas = scaleObj.Spec.Replicas
+			deployment.Status.Replicas = scaleObj.Spec.Replicas
+			c.scaleEvents = append(c.scaleEvents, scaleObj)
+			c.scaleEventsCount++
+			return true, scaleObj, nil
+		}
+		return false, nil, nil
+	})
+	c.fakeClient.PrependReactor("get", "replicationcontrollers", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		getAction := action.(clientgotesting.GetAction)
+		if getAction.GetSubresource() == "scale" {
+			scaleObj := &autoscaling.Scale{}
+			scaleObj.Status.Replicas = deployment.Status.Replicas
+			return true, scaleObj, nil
+		}
+		return false, nil, nil
+	})
+	return c
+}
+
+type fakePodClient struct {
+	deployerName string
+}
+
+func (c *fakePodClient) Pods(ns string) kcoreclient.PodInterface {
+	deployerPod := &kapi.Pod{}
+	deployerPod.Name = c.deployerName
+	deployerPod.Namespace = ns
+	deployerPod.Status = kapi.PodStatus{}
+	return fake.NewSimpleClientset(deployerPod).Core().Pods(ns)
+}
+
+type hookExecutorImpl struct {
+	executeFunc func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error
+}
+
+func (h *hookExecutorImpl) Execute(hook *appsapi.LifecycleHook, rc *kapi.ReplicationController, suffix, label string) error {
+	return h.executeFunc(hook, rc, suffix, label)
+}
+
+func TestRecreate_initialDeployment(t *testing.T) {
+	var deployment *kapi.ReplicationController
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       fake.NewSimpleClientset().Core(),
+	}
+
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", "", "")
+	deployment, _ = appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+
+	rcClient := newFakeControllerClient(deployment)
+	strategy.rcClient = rcClient
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 3)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+
+	if rcClient.scaleEventsCount != 1 {
+		t.Fatalf("expected 1 scale calls, got %d", rcClient.scaleEventsCount)
+	}
+}
+
+func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+
+	hookExecuted := false
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		rcClient:          rcClient,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				hookExecuted = true
+				return nil
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+	if !hookExecuted {
+		t.Fatalf("expected hook execution")
+	}
+}
+
+func TestRecreate_deploymentPreHookFail(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		rcClient:          rcClient,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				return fmt.Errorf("hook execution failure")
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err == nil {
+		t.Fatalf("expected a deploy error")
+	}
+
+	if rcClient.scaleEventsCount > 0 {
+		t.Fatalf("unexpected scaling events: %d", rcClient.scaleEventsCount)
+	}
+}
+
+func TestRecreate_deploymentMidHookSuccess(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", appsapi.LifecycleHookFailurePolicyAbort, "")
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion))
+	rcClient := newFakeControllerClient(deployment)
+
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		rcClient:          rcClient,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				return fmt.Errorf("hook execution failure")
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err == nil {
+		t.Fatalf("expected a deploy error")
+	}
+
+	if rcClient.scaleEventsCount > 0 {
+		t.Fatalf("unexpected scaling events: %d", rcClient.scaleEventsCount)
+	}
+}
+
+func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+
+	hookExecuted := false
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		rcClient:          rcClient,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				hookExecuted = true
+				return nil
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+	if !hookExecuted {
+		t.Fatalf("expected hook execution")
+	}
+}
+
+func TestRecreate_deploymentPostHookFail(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+
+	hookExecuted := false
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		rcClient:          rcClient,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				hookExecuted = true
+				return fmt.Errorf("post hook failure")
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err == nil {
+		t.Fatalf("unexpected non deploy error: %#v", err)
+	}
+	if !hookExecuted {
+		t.Fatalf("expected hook execution")
+	}
+}
+
+func TestRecreate_acceptorSuccess(t *testing.T) {
+	var deployment *kapi.ReplicationController
+
+	strategy := &RecreateDeploymentStrategy{
+		out:         &bytes.Buffer{},
+		errOut:      &bytes.Buffer{},
+		eventClient: fake.NewSimpleClientset().Core(),
+		decoder:     legacyscheme.Codecs.UniversalDecoder(),
+	}
+
+	acceptorCalled := false
+	acceptor := &testAcceptor{
+		acceptFn: func(deployment *kapi.ReplicationController) error {
+			acceptorCalled = true
+			return nil
+		},
+	}
+
+	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+	strategy.rcClient = rcClient
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+
+	if !acceptorCalled {
+		t.Fatalf("expected acceptor to be called")
+	}
+
+	if rcClient.scaleEventsCount != 2 {
+		t.Fatalf("expected 2 scale calls, got %d", rcClient.scaleEventsCount)
+	}
+	if r := rcClient.scaleEvents[0].Spec.Replicas; r != 1 {
+		t.Fatalf("expected first scale event to be 1 replica, got %d", r)
+	}
+
+	if r := rcClient.scaleEvents[1].Spec.Replicas; r != 2 {
+		t.Fatalf("expected second scale event to be 2 replica, got %d", r)
+	}
+}
+
+func TestRecreate_acceptorSuccessWithColdCaches(t *testing.T) {
+	var deployment *kapi.ReplicationController
+
+	strategy := &RecreateDeploymentStrategy{
+		out:         &bytes.Buffer{},
+		errOut:      &bytes.Buffer{},
+		eventClient: fake.NewSimpleClientset().Core(),
+		decoder:     legacyscheme.Codecs.UniversalDecoder(),
+	}
+
+	acceptorCalled := false
+	acceptor := &testAcceptor{
+		acceptFn: func(deployment *kapi.ReplicationController) error {
+			acceptorCalled = true
+			return nil
+		},
+	}
+
+	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+
+	rcClient := newFakeControllerClient(deployment)
+	strategy.rcClient = rcClient
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+
+	if !acceptorCalled {
+		t.Fatalf("expected acceptor to be called")
+	}
+
+	if rcClient.scaleEventsCount != 2 {
+		t.Fatalf("expected 2 scale calls, got %d", rcClient.scaleEventsCount)
+	}
+	if r := rcClient.scaleEvents[0]; r.Spec.Replicas != 1 {
+		t.Errorf("expected first scale event to be 1 replica, got %d", r)
+	}
+	if r := rcClient.scaleEvents[1]; r.Spec.Replicas != 2 {
+		t.Errorf("expected second scale event to be 2 replica, got %d", r)
+	}
+}
+
+func TestRecreate_acceptorFail(t *testing.T) {
+	var deployment *kapi.ReplicationController
+
+	strategy := &RecreateDeploymentStrategy{
+		out:         &bytes.Buffer{},
+		errOut:      &bytes.Buffer{},
+		decoder:     legacyscheme.Codecs.UniversalDecoder(),
+		eventClient: fake.NewSimpleClientset().Core(),
+	}
+
+	acceptor := &testAcceptor{
+		acceptFn: func(deployment *kapi.ReplicationController) error {
+			return fmt.Errorf("rejected")
+		},
+	}
+
+	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+	strategy.rcClient = rcClient
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
+	if err == nil {
+		t.Fatalf("expected a deployment failure")
+	}
+	t.Logf("got expected error: %v", err)
+
+	if rcClient.scaleEventsCount != 1 {
+		t.Fatalf("expected 1 scale calls, got %d", rcClient.scaleEventsCount)
+	}
+	if r := rcClient.scaleEvents[0]; r.Spec.Replicas != 1 {
+		t.Errorf("expected first scale event to be 1 replica, got %d", r)
+	}
 }


### PR DESCRIPTION
Alternative to https://github.com/openshift/origin/pull/19296

@deads2k i'm not sure I did the wiring for the client right.. seems to require more than usual client does ;-)

Also fixing the unit tests might be hell :)