### PR TITLE
up: set MountPropagation=false on osx to bypass shared mount

### DIFF
--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -348,6 +348,13 @@ func (c *ClusterUpConfig) makeKubeletFlags(out io.Writer, nodeConfigDir string) 
 		flags = append(flags, "--cgroup-driver=cgroupfs")
 	}
 
+	// TODO: OSX snowflake
+	// Default changed in kube 1.10. This ultimately breaks Docker For Mac as every hostPath
+	// mount must be shared or rslave.
+	if runtime.GOOS == "darwin" {
+		flags = append(flags, "--feature-gates=MountPropagation=false")
+	}
+
 	return flags, nil
 }
 
@@ -431,7 +438,6 @@ func (c *ClusterUpConfig) startKubelet(out io.Writer, masterConfigDir, nodeConfi
 	if err != nil {
 		return "", fmt.Errorf("error creating node config: %v", err)
 	}
-
 	return kubeletContainerID, nil
 }
 


### PR DESCRIPTION
@deads2k found it: https://github.com/kubernetes/kubernetes/pull/61126

This ultimately breaks Docker for Mac, as there is no way you can run the `mount --make-rshared /` in Docker VM and the shared folders use `fuse.osxfs` and are dynamically mounted into containers...

This patch will disable `MountPropagation` for OSX (wonder if we should do the same for Linux).