### PR TITLE
UPSTREAM: 62344: kubelet: send systemd ready signal before waiting on CSR approval

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap/BUILD
@@ -21,6 +21,7 @@ go_library(
     srcs = ["bootstrap.go"],
     importpath = "k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap",
     deps = [
+        "//vendor/github.com/coreos/go-systemd/daemon:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/coreos/go-systemd/daemon"
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -101,6 +102,10 @@ func LoadClientCert(kubeconfigPath string, bootstrapPath string, certDir string,
 			}
 		}
 	}()
+	// If systemd is used, notify it that we reached the point of the certificate request.
+	// This will allow any configuration management to proceed with the CSR approval
+	// rather than hanging on the kubelet activation.
+	go daemon.SdNotify(false, "READY=1")
 	certData, err := csr.RequestNodeCertificate(bootstrapClient.CertificateSigningRequests(), keyData, nodeName)
 	if err != nil {
 		return err


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/62344

fixes https://github.com/openshift/openshift-ansible/issues/7882

Went ahead and picked this so I could use the CI built RPMs to verify the fix.

@smarterclayton @derekwaynecarr 