### PR TITLE
Include the keyword Area:Networking for NetworkPolicy tests

### DIFF
--- a/test/extended/networking/networkpolicy.go
+++ b/test/extended/networking/networkpolicy.go
@@ -45,7 +45,7 @@ connections from one of the clients. The test then asserts that the clients
 failed or succesfully connected as expected.
 */
 
-var _ = Describe("NetworkPolicy", func() {
+var _ = Describe("[Area:Networking] NetworkPolicy", func() {
 	InNetworkPolicyContext(func() {
 		f := framework.NewDefaultFramework("network-policy")
 


### PR DESCRIPTION
The cni vendor tests were not including the Network Policy tests by default. Fix the ginkgo keyword so that they are included.

Signed-off-by: Rajat Chopra <rchopra@redhat.com>