### PR TITLE
apps: use scale client to scale replication controllers

### DIFF
--- a/pkg/apps/strategy/recreate/recreate_test.go
+++ b/pkg/apps/strategy/recreate/recreate_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	scalefake "k8s.io/client-go/scale/fake"
+	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
@@ -16,366 +20,15 @@ import (
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
 	"github.com/openshift/origin/pkg/apps/strategy"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
-	cmdtest "github.com/openshift/origin/pkg/apps/util/test"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
-type fakeControllerClient struct {
-	deployment *kapi.ReplicationController
-}
-
-func (c *fakeControllerClient) ReplicationControllers(ns string) kcoreclient.ReplicationControllerInterface {
-	return fake.NewSimpleClientset(c.deployment).Core().ReplicationControllers(ns)
-}
-
-type fakePodClient struct {
-	deployerName string
-}
-
-func (c *fakePodClient) Pods(ns string) kcoreclient.PodInterface {
-	deployerPod := &kapi.Pod{}
-	deployerPod.Name = c.deployerName
-	deployerPod.Namespace = ns
-	deployerPod.Status = kapi.PodStatus{}
-	return fake.NewSimpleClientset(deployerPod).Core().Pods(ns)
-}
-
-type hookExecutorImpl struct {
-	executeFunc func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error
-}
-
-func (h *hookExecutorImpl) Execute(hook *appsapi.LifecycleHook, rc *kapi.ReplicationController, suffix, label string) error {
-	return h.executeFunc(hook, rc, suffix, label)
-}
-
-func TestRecreate_initialDeployment(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeScaler{}
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		getUpdateAcceptor: getUpdateAcceptor,
-		scaler:            scaler,
-		eventClient:       fake.NewSimpleClientset().Core(),
-	}
-
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", "", "")
-	deployment, _ = appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 3)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-
-	if e, a := 1, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(3), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
-	}
-}
-
-func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	hookExecuted := false
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		getUpdateAcceptor: getUpdateAcceptor,
-		eventClient:       fake.NewSimpleClientset().Core(),
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				hookExecuted = true
-				return nil
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-	if !hookExecuted {
-		t.Fatalf("expected hook execution")
-	}
-}
-
-func TestRecreate_deploymentPreHookFail(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		getUpdateAcceptor: getUpdateAcceptor,
-		eventClient:       fake.NewSimpleClientset().Core(),
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				return fmt.Errorf("hook execution failure")
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err == nil {
-		t.Fatalf("expected a deploy error")
-	}
-	if len(scaler.Events) > 0 {
-		t.Fatalf("unexpected scaling events: %v", scaler.Events)
-	}
-}
-
-func TestRecreate_deploymentMidHookSuccess(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", appsapi.LifecycleHookFailurePolicyAbort, "")
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion))
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		eventClient:       fake.NewSimpleClientset().Core(),
-		getUpdateAcceptor: getUpdateAcceptor,
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				return fmt.Errorf("hook execution failure")
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err == nil {
-		t.Fatalf("expected a deploy error")
-	}
-	if len(scaler.Events) > 0 {
-		t.Fatalf("unexpected scaling events: %v", scaler.Events)
-	}
-}
-func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	hookExecuted := false
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		eventClient:       fake.NewSimpleClientset().Core(),
-		getUpdateAcceptor: getUpdateAcceptor,
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				hookExecuted = true
-				return nil
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-	if !hookExecuted {
-		t.Fatalf("expected hook execution")
-	}
-}
-
-func TestRecreate_deploymentPostHookFail(t *testing.T) {
-	config := appstest.OkDeploymentConfig(1)
-	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
-	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	scaler := &cmdtest.FakeScaler{}
-
-	hookExecuted := false
-	strategy := &RecreateDeploymentStrategy{
-		out:               &bytes.Buffer{},
-		errOut:            &bytes.Buffer{},
-		decoder:           legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod:       1 * time.Millisecond,
-		rcClient:          &fakeControllerClient{deployment: deployment},
-		eventClient:       fake.NewSimpleClientset().Core(),
-		getUpdateAcceptor: getUpdateAcceptor,
-		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
-				hookExecuted = true
-				return fmt.Errorf("post hook failure")
-			},
-		},
-		scaler: scaler,
-	}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.Deploy(nil, deployment, 2)
-	if err == nil {
-		t.Fatalf("unexpected non deploy error: %#v", err)
-	}
-	if !hookExecuted {
-		t.Fatalf("expected hook execution")
-	}
-}
-
-func TestRecreate_acceptorSuccess(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:         &bytes.Buffer{},
-		errOut:      &bytes.Buffer{},
-		eventClient: fake.NewSimpleClientset().Core(),
-		decoder:     legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod: 1 * time.Millisecond,
-		scaler:      scaler,
-	}
-
-	acceptorCalled := false
-	acceptor := &testAcceptor{
+func getUpdateAcceptor(timeout time.Duration, minReadySeconds int32) strategy.UpdateAcceptor {
+	return &testAcceptor{
 		acceptFn: func(deployment *kapi.ReplicationController) error {
-			acceptorCalled = true
 			return nil
 		},
-	}
-
-	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-
-	if !acceptorCalled {
-		t.Fatalf("expected acceptor to be called")
-	}
-
-	if e, a := 2, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(1), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale down to %d, got %d", e, a)
-	}
-	if e, a := uint(2), scaler.Events[1].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
-	}
-}
-
-func TestRecreate_acceptorSuccessWithColdCaches(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeLaggedScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:         &bytes.Buffer{},
-		errOut:      &bytes.Buffer{},
-		eventClient: fake.NewSimpleClientset().Core(),
-		decoder:     legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod: 1 * time.Millisecond,
-		scaler:      scaler,
-	}
-
-	acceptorCalled := false
-	acceptor := &testAcceptor{
-		acceptFn: func(deployment *kapi.ReplicationController) error {
-			acceptorCalled = true
-			return nil
-		},
-	}
-
-	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-
-	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
-	if err != nil {
-		t.Fatalf("unexpected deploy error: %#v", err)
-	}
-
-	if !acceptorCalled {
-		t.Fatalf("expected acceptor to be called")
-	}
-
-	if e, a := 2, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(1), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale down to %d, got %d", e, a)
-	}
-	if e, a := uint(2), scaler.Events[1].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
-	}
-	if scaler.RetryCount != 2 {
-		t.Errorf("expected retry when the caches are not initialized")
-	}
-}
-
-func TestRecreate_acceptorFail(t *testing.T) {
-	var deployment *kapi.ReplicationController
-	scaler := &cmdtest.FakeScaler{}
-
-	strategy := &RecreateDeploymentStrategy{
-		out:         &bytes.Buffer{},
-		errOut:      &bytes.Buffer{},
-		decoder:     legacyscheme.Codecs.UniversalDecoder(),
-		retryPeriod: 1 * time.Millisecond,
-		scaler:      scaler,
-		eventClient: fake.NewSimpleClientset().Core(),
-	}
-
-	acceptor := &testAcceptor{
-		acceptFn: func(deployment *kapi.ReplicationController) error {
-			return fmt.Errorf("rejected")
-		},
-	}
-
-	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
-	strategy.rcClient = &fakeControllerClient{deployment: deployment}
-	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
-	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
-	if err == nil {
-		t.Fatalf("expected a deployment failure")
-	}
-	t.Logf("got expected error: %v", err)
-
-	if e, a := 1, len(scaler.Events); e != a {
-		t.Fatalf("expected %d scale calls, got %d", e, a)
-	}
-	if e, a := uint(1), scaler.Events[0].Size; e != a {
-		t.Errorf("expected scale up to %d, got %d", e, a)
 	}
 }
 
@@ -411,31 +64,387 @@ func recreateParams(timeout int64, preFailurePolicy, midFailurePolicy, postFailu
 	}
 }
 
-type testControllerClient struct {
-	getReplicationControllerFunc    func(namespace, name string) (*kapi.ReplicationController, error)
-	updateReplicationControllerFunc func(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error)
-}
-
-func (t *testControllerClient) getReplicationController(namespace, name string) (*kapi.ReplicationController, error) {
-	return t.getReplicationControllerFunc(namespace, name)
-}
-
-func (t *testControllerClient) updateReplicationController(namespace string, ctrl *kapi.ReplicationController) (*kapi.ReplicationController, error) {
-	return t.updateReplicationControllerFunc(namespace, ctrl)
-}
-
-func getUpdateAcceptor(timeout time.Duration, minReadySeconds int32) strategy.UpdateAcceptor {
-	return &testAcceptor{
-		acceptFn: func(deployment *kapi.ReplicationController) error {
-			return nil
-		},
-	}
-}
-
 type testAcceptor struct {
 	acceptFn func(*kapi.ReplicationController) error
 }
 
 func (t *testAcceptor) Accept(deployment *kapi.ReplicationController) error {
 	return t.acceptFn(deployment)
+}
+
+type fakeControllerClient struct {
+	deployment *kapi.ReplicationController
+	fakeClient *fake.Clientset
+
+	scaleEvents []*autoscalingv1.Scale
+}
+
+func (c *fakeControllerClient) ReplicationControllers(ns string) kcoreclient.ReplicationControllerInterface {
+	return c.fakeClient.Core().ReplicationControllers(ns)
+}
+
+func (c *fakeControllerClient) scaledOnce() bool {
+	return len(c.scaleEvents) == 1
+}
+
+func (c *fakeControllerClient) fakeScaleClient() *scalefake.FakeScaleClient {
+	scaleFakeClient := &scalefake.FakeScaleClient{}
+	scaleFakeClient.AddReactor("get", "replicationcontrollers", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		obj := &autoscalingv1.Scale{}
+		obj.Status.Replicas = c.deployment.Status.Replicas
+		return true, obj, nil
+	})
+	scaleFakeClient.AddReactor("update", "replicationcontrollers", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		updateAction := action.(clientgotesting.UpdateAction)
+		scaleObj := updateAction.GetObject().(*autoscalingv1.Scale)
+		c.scaleEvents = append(c.scaleEvents, scaleObj)
+		c.deployment.Spec.Replicas = scaleObj.Spec.Replicas
+		c.deployment.Status.Replicas = scaleObj.Spec.Replicas
+		return true, scaleObj, nil
+	})
+	return scaleFakeClient
+}
+
+func newFakeControllerClient(deployment *kapi.ReplicationController) *fakeControllerClient {
+	c := &fakeControllerClient{deployment: deployment}
+	c.fakeClient = fake.NewSimpleClientset(c.deployment)
+	return c
+}
+
+type fakePodClient struct {
+	deployerName string
+}
+
+func (c *fakePodClient) Pods(ns string) kcoreclient.PodInterface {
+	deployerPod := &kapi.Pod{}
+	deployerPod.Name = c.deployerName
+	deployerPod.Namespace = ns
+	deployerPod.Status = kapi.PodStatus{}
+	return fake.NewSimpleClientset(deployerPod).Core().Pods(ns)
+}
+
+type hookExecutorImpl struct {
+	executeFunc func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error
+}
+
+func (h *hookExecutorImpl) Execute(hook *appsapi.LifecycleHook, rc *kapi.ReplicationController, suffix, label string) error {
+	return h.executeFunc(hook, rc, suffix, label)
+}
+
+func TestRecreate_initialDeployment(t *testing.T) {
+	var deployment *kapi.ReplicationController
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       fake.NewSimpleClientset().Core(),
+	}
+
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", "", "")
+	deployment, _ = appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+
+	controllerClient := newFakeControllerClient(deployment)
+	strategy.rcClient = controllerClient
+	strategy.scaleClient = controllerClient.fakeScaleClient()
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 3)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+
+	if !controllerClient.scaledOnce() {
+		t.Fatalf("expected 1 scale calls, got %d", len(controllerClient.scaleEvents))
+	}
+}
+
+func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	controllerClient := newFakeControllerClient(deployment)
+
+	hookExecuted := false
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		rcClient:          controllerClient,
+		scaleClient:       controllerClient.fakeScaleClient(),
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				hookExecuted = true
+				return nil
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+	if !hookExecuted {
+		t.Fatalf("expected hook execution")
+	}
+}
+
+func TestRecreate_deploymentPreHookFail(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, appsapi.LifecycleHookFailurePolicyAbort, "", "")
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	controllerClient := newFakeControllerClient(deployment)
+
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		eventClient:       fake.NewSimpleClientset().Core(),
+		rcClient:          controllerClient,
+		scaleClient:       controllerClient.fakeScaleClient(),
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				return fmt.Errorf("hook execution failure")
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err == nil {
+		t.Fatalf("expected a deploy error")
+	}
+
+	if len(controllerClient.scaleEvents) > 0 {
+		t.Fatalf("unexpected scaling events: %d", controllerClient.scaleEvents)
+	}
+}
+
+func TestRecreate_deploymentMidHookSuccess(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", appsapi.LifecycleHookFailurePolicyAbort, "")
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion))
+	controllerClient := newFakeControllerClient(deployment)
+
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		rcClient:          controllerClient,
+		scaleClient:       controllerClient.fakeScaleClient(),
+		eventClient:       fake.NewSimpleClientset().Core(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				return fmt.Errorf("hook execution failure")
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err == nil {
+		t.Fatalf("expected a deploy error")
+	}
+
+	if len(controllerClient.scaleEvents) > 0 {
+		t.Fatalf("unexpected scaling events: %d", controllerClient.scaleEvents)
+	}
+}
+
+func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	controllerClient := newFakeControllerClient(deployment)
+
+	hookExecuted := false
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		rcClient:          controllerClient,
+		scaleClient:       controllerClient.fakeScaleClient(),
+		eventClient:       fake.NewSimpleClientset().Core(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				hookExecuted = true
+				return nil
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+	if !hookExecuted {
+		t.Fatalf("expected hook execution")
+	}
+}
+
+func TestRecreate_deploymentPostHookFail(t *testing.T) {
+	config := appstest.OkDeploymentConfig(1)
+	config.Spec.Strategy = recreateParams(30, "", "", appsapi.LifecycleHookFailurePolicyAbort)
+	deployment, _ := appsutil.MakeDeployment(config, legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	controllerClient := newFakeControllerClient(deployment)
+
+	hookExecuted := false
+	strategy := &RecreateDeploymentStrategy{
+		out:               &bytes.Buffer{},
+		errOut:            &bytes.Buffer{},
+		decoder:           legacyscheme.Codecs.UniversalDecoder(),
+		rcClient:          controllerClient,
+		scaleClient:       controllerClient.fakeScaleClient(),
+		eventClient:       fake.NewSimpleClientset().Core(),
+		getUpdateAcceptor: getUpdateAcceptor,
+		hookExecutor: &hookExecutorImpl{
+			executeFunc: func(hook *appsapi.LifecycleHook, deployment *kapi.ReplicationController, suffix, label string) error {
+				hookExecuted = true
+				return fmt.Errorf("post hook failure")
+			},
+		},
+	}
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.Deploy(nil, deployment, 2)
+	if err == nil {
+		t.Fatalf("unexpected non deploy error: %#v", err)
+	}
+	if !hookExecuted {
+		t.Fatalf("expected hook execution")
+	}
+}
+
+func TestRecreate_acceptorSuccess(t *testing.T) {
+	var deployment *kapi.ReplicationController
+	strategy := &RecreateDeploymentStrategy{
+		out:         &bytes.Buffer{},
+		errOut:      &bytes.Buffer{},
+		eventClient: fake.NewSimpleClientset().Core(),
+		decoder:     legacyscheme.Codecs.UniversalDecoder(),
+	}
+
+	acceptorCalled := false
+	acceptor := &testAcceptor{
+		acceptFn: func(deployment *kapi.ReplicationController) error {
+			acceptorCalled = true
+			return nil
+		},
+	}
+
+	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	controllerClient := newFakeControllerClient(deployment)
+	strategy.rcClient = controllerClient
+	strategy.scaleClient = controllerClient.fakeScaleClient()
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+
+	if !acceptorCalled {
+		t.Fatalf("expected acceptor to be called")
+	}
+
+	if len(controllerClient.scaleEvents) != 2 {
+		t.Fatalf("expected 2 scale calls, got %d", len(controllerClient.scaleEvents))
+	}
+	if r := controllerClient.scaleEvents[0].Spec.Replicas; r != 1 {
+		t.Fatalf("expected first scale event to be 1 replica, got %d", r)
+	}
+
+	if r := controllerClient.scaleEvents[1].Spec.Replicas; r != 2 {
+		t.Fatalf("expected second scale event to be 2 replica, got %d", r)
+	}
+}
+
+func TestRecreate_acceptorSuccessWithColdCaches(t *testing.T) {
+	var deployment *kapi.ReplicationController
+	strategy := &RecreateDeploymentStrategy{
+		out:         &bytes.Buffer{},
+		errOut:      &bytes.Buffer{},
+		eventClient: fake.NewSimpleClientset().Core(),
+		decoder:     legacyscheme.Codecs.UniversalDecoder(),
+	}
+
+	acceptorCalled := false
+	acceptor := &testAcceptor{
+		acceptFn: func(deployment *kapi.ReplicationController) error {
+			acceptorCalled = true
+			return nil
+		},
+	}
+
+	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	controllerClient := newFakeControllerClient(deployment)
+
+	strategy.rcClient = controllerClient
+	strategy.scaleClient = controllerClient.fakeScaleClient()
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+
+	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
+	if err != nil {
+		t.Fatalf("unexpected deploy error: %#v", err)
+	}
+
+	if !acceptorCalled {
+		t.Fatalf("expected acceptor to be called")
+	}
+
+	if len(controllerClient.scaleEvents) != 2 {
+		t.Fatalf("expected 2 scale calls, got %d", len(controllerClient.scaleEvents))
+	}
+	if r := controllerClient.scaleEvents[0]; r.Spec.Replicas != 1 {
+		t.Errorf("expected first scale event to be 1 replica, got %d", r)
+	}
+	if r := controllerClient.scaleEvents[1]; r.Spec.Replicas != 2 {
+		t.Errorf("expected second scale event to be 2 replica, got %d", r)
+	}
+}
+
+func TestRecreate_acceptorFail(t *testing.T) {
+	var deployment *kapi.ReplicationController
+
+	strategy := &RecreateDeploymentStrategy{
+		out:         &bytes.Buffer{},
+		errOut:      &bytes.Buffer{},
+		decoder:     legacyscheme.Codecs.UniversalDecoder(),
+		eventClient: fake.NewSimpleClientset().Core(),
+	}
+
+	acceptor := &testAcceptor{
+		acceptFn: func(deployment *kapi.ReplicationController) error {
+			return fmt.Errorf("rejected")
+		},
+	}
+
+	oldDeployment, _ := appsutil.MakeDeployment(appstest.OkDeploymentConfig(1), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	deployment, _ = appsutil.MakeDeployment(appstest.OkDeploymentConfig(2), legacyscheme.Codecs.LegacyCodec(legacyscheme.Registry.GroupOrDie(kapi.GroupName).GroupVersions[0]))
+	rcClient := newFakeControllerClient(deployment)
+	strategy.rcClient = rcClient
+	strategy.scaleClient = rcClient.fakeScaleClient()
+	strategy.podClient = &fakePodClient{deployerName: appsutil.DeployerPodNameForDeployment(deployment.Name)}
+	err := strategy.DeployWithAcceptor(oldDeployment, deployment, 2, acceptor)
+	if err == nil {
+		t.Fatalf("expected a deployment failure")
+	}
+	t.Logf("got expected error: %v", err)
+
+	if len(rcClient.scaleEvents) != 1 {
+		t.Fatalf("expected 1 scale calls, got %d", len(rcClient.scaleEvents))
+	}
+	if r := rcClient.scaleEvents[0]; r.Spec.Replicas != 1 {
+		t.Errorf("expected first scale event to be 1 replica, got %d", r)
+	}
 }

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -105,7 +105,7 @@ func (cfg *config) RunDeployer() error {
 	if err != nil {
 		return err
 	}
-	kc, err := kclientset.NewForConfig(kcfg)
+	kubeInternalClient, err := kclientset.NewForConfig(kcfg)
 	if err != nil {
 		return err
 	}
@@ -114,12 +114,13 @@ func (cfg *config) RunDeployer() error {
 		return err
 	}
 
-	deployer := NewDeployer(kc, openshiftInternalImageClient, cfg.Out, cfg.ErrOut, cfg.Until)
+	deployer := NewDeployer(kubeInternalClient, openshiftInternalImageClient, cfg.Out, cfg.ErrOut, cfg.Until)
 	return deployer.Deploy(cfg.Namespace, cfg.rcName)
 }
 
 // NewDeployer makes a new Deployer from a kube client.
-func NewDeployer(client kclientset.Interface, images imageclientinternal.Interface, out, errOut io.Writer, until string) *Deployer {
+func NewDeployer(client kclientset.Interface, images imageclientinternal.Interface, out, errOut io.Writer,
+	until string) *Deployer {
 	return &Deployer{
 		out:    out,
 		errOut: errOut,
@@ -134,9 +135,11 @@ func NewDeployer(client kclientset.Interface, images imageclientinternal.Interfa
 		strategyFor: func(config *appsapi.DeploymentConfig) (strategy.DeploymentStrategy, error) {
 			switch config.Spec.Strategy.Type {
 			case appsapi.DeploymentStrategyTypeRecreate:
-				return recreate.NewRecreateDeploymentStrategy(client, images.Image(), &kv1core.EventSinkImpl{Interface: kv1core.New(client.Core().RESTClient()).Events("")}, legacyscheme.Codecs.UniversalDecoder(), out, errOut, until), nil
+				return recreate.NewRecreateDeploymentStrategy(client, images.Image(),
+					&kv1core.EventSinkImpl{Interface: kv1core.New(client.Core().RESTClient()).Events("")}, legacyscheme.Codecs.UniversalDecoder(), out, errOut, until), nil
 			case appsapi.DeploymentStrategyTypeRolling:
-				recreateDeploymentStrategy := recreate.NewRecreateDeploymentStrategy(client, images.Image(), &kv1core.EventSinkImpl{Interface: kv1core.New(client.Core().RESTClient()).Events("")}, legacyscheme.Codecs.UniversalDecoder(), out, errOut, until)
+				recreateDeploymentStrategy := recreate.NewRecreateDeploymentStrategy(client, images.Image(),
+					&kv1core.EventSinkImpl{Interface: kv1core.New(client.Core().RESTClient()).Events("")}, legacyscheme.Codecs.UniversalDecoder(), out, errOut, until)
 				return rolling.NewRollingDeploymentStrategy(config.Namespace, client, images.Image(), legacyscheme.Codecs.UniversalDecoder(), recreateDeploymentStrategy, out, errOut, until), nil
 			default:
 				return nil, fmt.Errorf("unsupported strategy type: %s", config.Spec.Strategy.Type)


### PR DESCRIPTION
This will switch the kubectl scaler in deployer pod to use the scale client to scale replication controllers.
It builds on @deads2k https://github.com/openshift/origin/pull/19275 (only last commit is new) and replaces https://github.com/openshift/origin/pull/19299 and https://github.com/openshift/origin/pull/19296.

There was a discussion under #19299 about mutating the spec.replicas field on RC directly with a benefit of not needed a new client and being able to do atomic updates if we need to change other fields during scaling operation. The scale client has benefit of not needing to encode entire RC when updating one field and is preferred way to execute the "scale" operation upstream (HPA use the same mechanism).

I will squash this after @deads2k PR merges.

/cc @deads2k @tnozicka 