### PR TITLE
Removed an unused variable from reload-haproxy

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -4,7 +4,6 @@ set -o nounset
 
 config_file=/var/lib/haproxy/conf/haproxy.config
 pid_file=/var/lib/haproxy/run/haproxy.pid
-old_pid=""
 haproxy_conf_dir=/var/lib/haproxy/conf
 readonly max_wait_time=30
 readonly timeout_opts="-m 1 --connect-timeout 1"


### PR DESCRIPTION
We initialized and never used $old_pid ($old_pids is initialized and
used later).