### PR TITLE
oc new-app: correctly evaluate env vars in multiple EXPOSE

### DIFF
--- a/pkg/util/docker/dockerfile/dockerfile_test.go
+++ b/pkg/util/docker/dockerfile/dockerfile_test.go
@@ -460,6 +460,32 @@ ENV PORT 8080
 EXPOSE ${PORT}-8090`,
 			want: []string{"8080"},
 		},
+		"EXPOSE redefined ENV": {
+			in: `FROM centos:7
+ENV PORT 8080
+ENV PORT 8081
+EXPOSE $PORT`,
+			want: []string{"8081"},
+		},
+		"Multiple EXPOSE": {
+			in: `FROM centos:7
+ENV PORT 8080
+EXPOSE $PORT
+ENV PORT2 8081
+EXPOSE $PORT2`,
+			want: []string{"8080", "8081"},
+		},
+		"Multiple EXPOSE and ENV redefined": {
+			in: `FROM centos:7
+ENV PORT 8080
+EXPOSE $PORT
+ENV PORT2 8081
+ENV PORT 8082
+EXPOSE $PORT2 $PORT
+ENV PORT=8083 PORT2=8084
+EXPOSE $PORT $PORT2`,
+			want: []string{"8080", "8081", "8082", "8083", "8084"},
+		},
 	}
 	for name, tc := range testCases {
 		node, err := parser.Parse(strings.NewReader(tc.in))


### PR DESCRIPTION
There were two issues with my earlier implementation:
1) The env vars in `EXPOSE` should be processed while processing the Dockerfile AST along with processing `ARG` and `ENV` labels in order to be correctly evaluated. Previously AST was processed for `ARG` and `ENV` first and then the `EXPOSE` ports were processed.

2) `ShellLex` iterates the array of env variables from start to end, in order for latter ENV label to take effect, new env variables should be prepended to the env variables array. Previously were appended

This PR allows following dockerfile to expose ports 8080, 8081
```dockerfile
FROM centos
ENV port=8080
EXPOSE $port
ENV port=8081
EXPOSE $port
```

@wzheng1 , feel free to re-test, I have covered the combinations I didn't previously think of in unit tests as well as in https://github.com/wozniakjan/oc_newapp_expose

@bparees , ptal