### PR TITLE
Fix flake in cluster resource quota test

### DIFF
--- a/test/cmd/quota.sh
+++ b/test/cmd/quota.sh
@@ -13,11 +13,13 @@ os::test::junit::declare_suite_start "cmd/quota"
 
 os::test::junit::declare_suite_start "cmd/quota/clusterquota"
 
+# This tests creating a clusterresourcequota against an existing namespace with a known number of resources
 os::cmd::expect_success 'oc new-project quota-foo --as=deads --as-group=system:authenticated --as-group=system:authenticated:oauth'
 os::cmd::expect_success 'oc label namespace/quota-foo owner=deads'
+os::cmd::try_until_text 'oc get secrets -o name -n quota-foo | wc -l' '9'
 os::cmd::expect_success 'oc create clusterquota for-deads --project-label-selector=owner=deads --hard=secrets=10'
 os::cmd::try_until_text 'oc get appliedclusterresourcequota -n quota-foo --as deads -o name' "for-deads"
-os::cmd::try_until_text 'oc get secrets -o name --all-namespaces; oc describe appliedclusterresourcequota/for-deads -n quota-foo --as deads' "secrets.*9"
+os::cmd::try_until_text 'oc get secrets --all-namespaces; oc get appliedclusterresourcequota/for-deads -n quota-foo --as deads -o jsonpath=used={.status.total.used.secrets}' "used=9"
 
 os::cmd::expect_failure_and_text 'oc create clusterquota for-deads-malformed --project-annotation-selector="openshift.#$%/requester=deads"' "prefix part a DNS-1123 subdomain must consist of lower case alphanumeric characters"
 os::cmd::expect_failure_and_text 'oc create clusterquota for-deads-malformed --project-annotation-selector=openshift.io/requester=deads,openshift.io/novalue' "Malformed annotation selector"
@@ -33,7 +35,7 @@ os::cmd::try_until_text 'oc get appliedclusterresourcequota -n quota-asmail --as
 # the create_dockercfg controller can issue multiple creates if the token controller doesn't fill them in, but the creates are duplicates
 # since an annotation tracks the intended secrets to be created.  That results in multi-counting quota until reconciliation runs
 # do not go past 26.  If you get to 27, you might be selecting an extra namespace.
-os::cmd::try_until_text 'oc get secrets -o name --all-namespaces; oc describe appliedclusterresourcequota/for-deads-by-annotation -n quota-bar --as deads' "secrets.*(1[0-9]|20|21|22|23|24|25|26)"
+os::cmd::try_until_text 'oc get secrets --all-namespaces; oc get appliedclusterresourcequota/for-deads-by-annotation -n quota-bar --as deads -o jsonpath=used={.status.total.used.secrets}' "used=(1[0-9]|20|21|22|23|24|25|26)"
 os::cmd::expect_success 'oc delete project quota-foo'
 os::cmd::try_until_not_text 'oc get clusterresourcequota/for-deads-by-annotation -o jsonpath="{.status.namespaces[*].namespace}"' 'quota-foo'
 os::cmd::expect_success 'oc delete project quota-bar'


### PR DESCRIPTION
Fixes https://github.com/openshift/origin/issues/19282

This resolves a long-standing race condition in the first test that was masked by an overly broad output regex that happened to match `-o name` output prior to the 1.10 rebase