### PR TITLE
Fix flake for router status update

### DIFF
--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -260,7 +260,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 						break Wait
 					}
 				}
-				o.Expect(writes).To(o.BeNumerically("<", 10))
+				o.Expect(writes).To(o.BeNumerically("<", 20))
 			}()
 
 			// the os_http_be.map file will vary, so only check the haproxy config


### PR DESCRIPTION
Fix the condition in stress test. 
As per logs in: https://openshift-gce-devel.appspot.com//build/origin-ci-test/pr-logs/pull/19317/test_pull_request_origin_extended_conformance_gce/18958/
, there are actually 2 different routers running. 
So in the worst case scenario this could be 19 (not 9) conflicting updates. 

@smarterclayton  @knobunc 