### PR TITLE
oc new-app: propagate cmdline env to pipeline/git builds

### DIFF
--- a/pkg/oc/generate/app/app.go
+++ b/pkg/oc/generate/app/app.go
@@ -199,7 +199,9 @@ func (s *BuildStrategyRef) BuildStrategy(env Environment, dockerStrategyOptions 
 	switch s.Strategy {
 	case generate.StrategyPipeline:
 		return &buildapi.BuildStrategy{
-			JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{},
+			JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{
+				Env: env.List(),
+			},
 		}, s.Base.BuildTriggers()
 
 	case generate.StrategyDocker:

--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -1358,7 +1358,7 @@ func TestNewAppRunBuilds(t *testing.T) {
 				}) {
 					return fmt.Errorf("invalid bc.Spec.Source, got %#v", bc.Spec.Source)
 				}
-				if !reflect.DeepEqual(bc.Spec.Strategy, buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}) {
+				if !reflect.DeepEqual(bc.Spec.Strategy, buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{Env: []kapi.EnvVar{}}}) {
 					return fmt.Errorf("invalid bc.Spec.Strategy, got %#v", bc.Spec.Strategy)
 				}
 				return nil
@@ -1398,7 +1398,7 @@ func TestNewAppRunBuilds(t *testing.T) {
 				}) {
 					return fmt.Errorf("invalid bc.Spec.Source, got %#v", bc.Spec.Source.Git)
 				}
-				if !reflect.DeepEqual(bc.Spec.Strategy, buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{}}) {
+				if !reflect.DeepEqual(bc.Spec.Strategy, buildapi.BuildStrategy{JenkinsPipelineStrategy: &buildapi.JenkinsPipelineBuildStrategy{Env: []kapi.EnvVar{}}}) {
 					return fmt.Errorf("invalid bc.Spec.Strategy, got %#v", bc.Spec.Strategy)
 				}
 				return nil


### PR DESCRIPTION
The `oc new-app --build-env` cmdline env variables are propagated to the `BuildConfig` only when using a template. With git repository as a source, env variables can be silently dropped if it contains no template.

This fixes  #19142 ~~by joining the env for `objects` from component references similarly like it is done for `templateObjects` from template component refs in `(c *AppConfig) buildTemplates`.~~

~~Looking at the `BuildConfig` with this fix, env variables are propagated, however, I am not sure how it obtains the Jenkinsfile because neither embedded Jenkinsfile nor path to it contain anything.~~

```json
"Strategy": {
    "DockerStrategy": null,
    "SourceStrategy": null,
    "CustomStrategy": null,
    "JenkinsPipelineStrategy": {
        "JenkinsfilePath": "", 
        "Jenkinsfile": "", 
        "Env": [
           {
                "Name": "PROJECT_NAME",
                "Value": "dev",
                "ValueFrom": null
            }
        ]
    }
},
```

ptal @openshift/sig-developer-experience ~~, I am not sure if this is a valid approach. In the meanwhile, I will try to work on an extended test covering this.~~