### PR TITLE
stop using factory.OpenshiftClientConfig

### DIFF
--- a/pkg/oc/admin/diagnostics/config.go
+++ b/pkg/oc/admin/diagnostics/config.go
@@ -15,7 +15,7 @@ import (
 
 // use the base factory to return a raw config (not specific to a context)
 func (o DiagnosticsOptions) buildRawConfig() (*clientcmdapi.Config, error) {
-	kubeConfig, configErr := o.Factory.OpenShiftClientConfig().RawConfig()
+	kubeConfig, configErr := o.Factory.RawConfig()
 	if configErr != nil {
 		return nil, configErr
 	}

--- a/pkg/oc/admin/image/verify-signature.go
+++ b/pkg/oc/admin/image/verify-signature.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -84,8 +83,6 @@ type VerifyImageSignatureOptions struct {
 
 	ImageClient imageclient.ImageInterface
 
-	clientConfig kclientcmd.ClientConfig
-
 	Out    io.Writer
 	ErrOut io.Writer
 }
@@ -96,9 +93,8 @@ const (
 
 func NewCmdVerifyImageSignature(name, fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
 	opts := &VerifyImageSignatureOptions{
-		ErrOut:       errOut,
-		Out:          out,
-		clientConfig: f.OpenShiftClientConfig(),
+		ErrOut: errOut,
+		Out:    out,
 		// TODO: This improves the error message users get when containers/image is not able
 		// to locate the pubring.gpg file (which is default).
 		// This should be improved/fixed in containers/image.
@@ -169,7 +165,8 @@ func (o *VerifyImageSignatureOptions) Complete(f *clientcmd.Factory, cmd *cobra.
 		return err
 	} else {
 		o.CurrentUser = me.Name
-		if config, err := o.clientConfig.ClientConfig(); err != nil {
+
+		if config, err := f.ClientConfig(); err != nil {
 			return err
 		} else {
 			if o.CurrentUserToken = config.BearerToken; len(o.CurrentUserToken) == 0 {

--- a/pkg/oc/cli/cmd/login/login.go
+++ b/pkg/oc/cli/cmd/login/login.go
@@ -97,7 +97,7 @@ func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out,
 }
 
 func (o *LoginOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string, commandName string) error {
-	kubeconfig, err := f.OpenShiftClientConfig().RawConfig()
+	kubeconfig, err := f.RawConfig()
 	o.StartingKubeConfig = &kubeconfig
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/pkg/oc/cli/cmd/login/logout.go
+++ b/pkg/oc/cli/cmd/login/logout.go
@@ -80,13 +80,13 @@ func NewCmdLogout(name, fullName, ocLoginFullCommand string, f *osclientcmd.Fact
 }
 
 func (o *LogoutOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string) error {
-	kubeconfig, err := f.OpenShiftClientConfig().RawConfig()
+	kubeconfig, err := f.RawConfig()
 	o.StartingKubeConfig = &kubeconfig
 	if err != nil {
 		return err
 	}
 
-	o.Config, err = f.OpenShiftClientConfig().ClientConfig()
+	o.Config, err = f.ClientConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/cmd/project.go
+++ b/pkg/oc/cli/cmd/project.go
@@ -100,7 +100,7 @@ func (o *ProjectOptions) Complete(f *clientcmd.Factory, args []string, out io.Wr
 		o.ProjectName = args[0]
 	}
 
-	o.Config, err = f.OpenShiftClientConfig().RawConfig()
+	o.Config, err = f.RawConfig()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (o *ProjectOptions) Complete(f *clientcmd.Factory, args []string, out io.Wr
 
 		// since we failed to retrieve ClientConfig for the current server,
 		// fetch local OpenShift client config
-		o.ClientConfig, err = f.OpenShiftClientConfig().ClientConfig()
+		o.ClientConfig, err = f.ClientConfig()
 		if err != nil {
 			return err
 		}

--- a/pkg/oc/cli/cmd/projects.go
+++ b/pkg/oc/cli/cmd/projects.go
@@ -92,12 +92,12 @@ func (o *ProjectsOptions) Complete(f *clientcmd.Factory, args []string, commandN
 	o.CommandName = commandName
 
 	var err error
-	o.Config, err = f.OpenShiftClientConfig().RawConfig()
+	o.Config, err = f.RawConfig()
 	if err != nil {
 		return err
 	}
 
-	o.ClientConfig, err = f.OpenShiftClientConfig().ClientConfig()
+	o.ClientConfig, err = f.ClientConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/cmd/request_project.go
+++ b/pkg/oc/cli/cmd/request_project.go
@@ -115,7 +115,7 @@ func (o *NewProjectOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, a
 			return err
 		}
 	} else {
-		clientConfig, err := f.OpenShiftClientConfig().ClientConfig()
+		clientConfig, err := f.ClientConfig()
 		if err != nil {
 			return err
 		}

--- a/pkg/oc/cli/cmd/startbuild_test.go
+++ b/pkg/oc/cli/cmd/startbuild_test.go
@@ -60,7 +60,7 @@ func TestStartBuildWebHook(t *testing.T) {
 	buf := &bytes.Buffer{}
 	o := &StartBuildOptions{
 		Out:          buf,
-		ClientConfig: cfg,
+		ClientConfig: cfg.Client,
 		FromWebhook:  server.URL + "/webhook",
 		Mapper:       legacyscheme.Registry.RESTMapper(),
 	}
@@ -75,30 +75,6 @@ func TestStartBuildWebHook(t *testing.T) {
 		GitPostReceive: "unknownpath",
 	}
 	if err := o.Run(); err == nil {
-		t.Fatalf("unexpected non-error: %v", err)
-	}
-}
-
-func TestStartBuildWebHookHTTPS(t *testing.T) {
-	invoked := make(chan struct{}, 1)
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		invoked <- struct{}{}
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-
-	testErr := errors.New("not enabled")
-	cfg := &FakeClientConfig{
-		Err: testErr,
-	}
-	buf := &bytes.Buffer{}
-	o := &StartBuildOptions{
-		Out:          buf,
-		ClientConfig: cfg,
-		FromWebhook:  server.URL + "/webhook",
-		Mapper:       legacyscheme.Registry.RESTMapper(),
-	}
-	if err := o.Run(); err == nil || !strings.Contains(err.Error(), "certificate signed by unknown authority") {
 		t.Fatalf("unexpected non-error: %v", err)
 	}
 }
@@ -129,7 +105,7 @@ func TestStartBuildHookPostReceive(t *testing.T) {
 	buf := &bytes.Buffer{}
 	o := &StartBuildOptions{
 		Out:            buf,
-		ClientConfig:   cfg,
+		ClientConfig:   cfg.Client,
 		FromWebhook:    server.URL + "/webhook",
 		GitPostReceive: f.Name(),
 		Mapper:         legacyscheme.Registry.RESTMapper(),

--- a/pkg/oc/cli/cmd/status.go
+++ b/pkg/oc/cli/cmd/status.go
@@ -130,12 +130,12 @@ func (o *StatusOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, baseC
 		return err
 	}
 
-	config, err := f.OpenShiftClientConfig().ClientConfig()
+	config, err := f.ClientConfig()
 	if err != nil {
 		return err
 	}
 
-	rawConfig, err := f.OpenShiftClientConfig().RawConfig()
+	rawConfig, err := f.RawConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/cmd/whoami.go
+++ b/pkg/oc/cli/cmd/whoami.go
@@ -61,7 +61,7 @@ func (o WhoAmIOptions) WhoAmI() (*userapi.User, error) {
 
 func RunWhoAmI(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []string, o *WhoAmIOptions) error {
 	if kcmdutil.GetFlagBool(cmd, "show-token") {
-		cfg, err := f.OpenShiftClientConfig().ClientConfig()
+		cfg, err := f.ClientConfig()
 		if err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func RunWhoAmI(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []s
 		return nil
 	}
 	if kcmdutil.GetFlagBool(cmd, "show-context") {
-		cfg, err := f.OpenShiftClientConfig().RawConfig()
+		cfg, err := f.RawConfig()
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func RunWhoAmI(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, args []s
 		return nil
 	}
 	if kcmdutil.GetFlagBool(cmd, "show-server") {
-		cfg, err := f.OpenShiftClientConfig().ClientConfig()
+		cfg, err := f.ClientConfig()
 		if err != nil {
 			return err
 		}

--- a/pkg/oc/cli/sa/create_kubeconfig.go
+++ b/pkg/oc/cli/sa/create_kubeconfig.go
@@ -94,7 +94,7 @@ func (o *CreateKubeconfigOptions) Complete(args []string, f *clientcmd.Factory, 
 		return err
 	}
 
-	o.RawConfig, err = f.OpenShiftClientConfig().RawConfig()
+	o.RawConfig, err = f.RawConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/util/clientcmd/factory_builder.go
+++ b/pkg/oc/cli/util/clientcmd/factory_builder.go
@@ -68,7 +68,7 @@ func (f *ring2Factory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error)
 		if err != nil {
 			return nil, err
 		}
-		config, err := f.clientAccessFactory.OpenShiftClientConfig().ClientConfig()
+		config, err := f.clientAccessFactory.ClientConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +134,7 @@ func (f *ring2Factory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error)
 			securityClient.Security().SecurityContextConstraints(),
 		), nil
 	case buildapi.IsKindOrLegacy("BuildConfig", gk):
-		config, err := f.clientAccessFactory.OpenShiftClientConfig().ClientConfig()
+		config, err := f.clientAccessFactory.ClientConfig()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oc/cli/util/clientcmd/factory_object_mapping.go
+++ b/pkg/oc/cli/util/clientcmd/factory_object_mapping.go
@@ -192,7 +192,7 @@ func (f *ring1Factory) HistoryViewer(mapping *meta.RESTMapping) (kubectl.History
 
 func (f *ring1Factory) Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker, error) {
 	if appsapi.IsKindOrLegacy("DeploymentConfig", mapping.GroupVersionKind.GroupKind()) {
-		config, err := f.clientAccessFactory.OpenShiftClientConfig().ClientConfig()
+		config, err := f.clientAccessFactory.ClientConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func (f *ring1Factory) Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker
 }
 
 func (f *ring1Factory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusViewer, error) {
-	config, err := f.clientAccessFactory.OpenShiftClientConfig().ClientConfig()
+	config, err := f.clientAccessFactory.ClientConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory.go
@@ -86,6 +86,8 @@ type DiscoveryClientFactory interface {
 // Generally provides discovery, negotiation, and no-dep calls.
 // TODO The polymorphic calls probably deserve their own interface.
 type ClientAccessFactory interface {
+	OpenShiftClientAccessFactory
+
 	// Returns a discovery client
 	DiscoveryClient() (discovery.CachedDiscoveryInterface, error)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/patch_factory.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/patch_factory.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// OpenShiftClientAccessFactory is a delta interface that we require for openshift on the factory.
+type OpenShiftClientAccessFactory interface {
+	RawConfig() (clientcmdapi.Config, error)
+}
+
+func (f *ring0Factory) RawConfig() (clientcmdapi.Config, error) {
+	return f.clientConfig.RawConfig()
+}


### PR DESCRIPTION
This method prevents collapsing onto the upstream factory because it relies on direct kubeconfig access which is hidden/abstracted via a factory.

We've now got a patch to indicate that delta that we carry.

/assign @soltysh 
/assign @juanvallejo 