### PR TITLE
Use OpenShift version instead of k8s version for recycler image tag

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_imagetemplate.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_imagetemplate.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/version"
+	"github.com/openshift/origin/pkg/version"
 
 	"github.com/golang/glog"
 )


### PR DESCRIPTION
This is to address https://bugzilla.redhat.com/show_bug.cgi?id=1550372

Before this change:

```
$ sed -n 's/.*\("image":"[^"]*"\).*/\1/p' /tmp/openshift-recycler-template-*
"image":"openshift/origin-recycler:v1.9.1"
```

After this change:

```
$ sed -n 's/.*\("image":"[^"]*"\).*/\1/p' /tmp/openshift-recycler-template-*
"image":"openshift/origin-recycler:v3.9.0"
```