### PR TITLE
Allow authorization of SCC use via RBAC

### DIFF
--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -462,6 +462,7 @@ func (c *completedConfig) withSecurityAPIServer(delegateAPIServer genericapiserv
 			SCCStorage:            c.ExtraConfig.SCCStorage,
 			SecurityInformers:     c.ExtraConfig.SecurityInformers,
 			KubeInternalInformers: c.ExtraConfig.KubeInternalInformers,
+			Authorizer:            c.GenericConfig.Authorization.Authorizer,
 			Codecs:                legacyscheme.Codecs,
 			Registry:              legacyscheme.Registry,
 			Scheme:                legacyscheme.Scheme,

--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -906,7 +906,7 @@ func validateServiceAccount(client securityclientinternal.Interface, ns string, 
 	// get set of sccs applicable to the service account
 	userInfo := serviceaccount.UserInfo(ns, serviceAccount, "")
 	for _, scc := range sccList.Items {
-		if oscc.ConstraintAppliesTo(&scc, userInfo) {
+		if oscc.ConstraintAppliesTo(&scc, userInfo, "", nil) {
 			switch {
 			case hostPorts && scc.AllowHostPorts:
 				return nil

--- a/pkg/security/admission/scc_exec.go
+++ b/pkg/security/admission/scc_exec.go
@@ -5,7 +5,9 @@ import (
 	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	admission "k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
@@ -22,9 +24,12 @@ func RegisterSCCExecRestrictions(plugins *admission.Plugins) {
 		})
 }
 
-var _ admission.Interface = &sccExecRestrictions{}
-var _ = oadmission.WantsSecurityInformer(&constraint{})
-var _ = kadmission.WantsInternalKubeClientSet(&sccExecRestrictions{})
+var (
+	_ = admission.Interface(&sccExecRestrictions{})
+	_ = initializer.WantsAuthorizer(&sccExecRestrictions{})
+	_ = oadmission.WantsSecurityInformer(&sccExecRestrictions{})
+	_ = kadmission.WantsInternalKubeClientSet(&sccExecRestrictions{})
+)
 
 // sccExecRestrictions is an implementation of admission.Interface which says no to a pod/exec on
 // a pod that the user would not be allowed to create
@@ -75,6 +80,10 @@ func (d *sccExecRestrictions) SetInternalKubeClientSet(c kclientset.Interface) {
 
 func (d *sccExecRestrictions) SetSecurityInformers(informers securityinformer.SharedInformerFactory) {
 	d.constraintAdmission.SetSecurityInformers(informers)
+}
+
+func (d *sccExecRestrictions) SetAuthorizer(authorizer authorizer.Authorizer) {
+	d.constraintAdmission.SetAuthorizer(authorizer)
 }
 
 // Validate defines actions to validate sccExecRestrictions

--- a/pkg/security/registry/podsecuritypolicyreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicyreview/rest.go
@@ -68,7 +68,7 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ rest.Validat
 	newStatus := securityapi.PodSecurityPolicyReviewStatus{}
 	for _, sa := range serviceAccounts {
 		userInfo := serviceaccount.UserInfo(ns, sa.Name, "")
-		saConstraints, err := r.sccMatcher.FindApplicableSCCs(userInfo)
+		saConstraints, err := r.sccMatcher.FindApplicableSCCs(userInfo, ns)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("unable to find SecurityContextConstraints for ServiceAccount %s: %v", sa.Name, err))
 			continue

--- a/pkg/security/registry/podsecuritypolicyselfsubjectreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicyselfsubjectreview/rest.go
@@ -55,14 +55,14 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ rest.Validat
 		return nil, kapierrors.NewBadRequest("namespace parameter required.")
 	}
 
-	matchedConstraints, err := r.sccMatcher.FindApplicableSCCs(userInfo)
+	matchedConstraints, err := r.sccMatcher.FindApplicableSCCs(userInfo, ns)
 	if err != nil {
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("unable to find SecurityContextConstraints: %v", err))
 	}
 	saName := pspssr.Spec.Template.Spec.ServiceAccountName
 	if len(saName) > 0 {
 		saUserInfo := serviceaccount.UserInfo(ns, saName, "")
-		saConstraints, err := r.sccMatcher.FindApplicableSCCs(saUserInfo)
+		saConstraints, err := r.sccMatcher.FindApplicableSCCs(saUserInfo, ns)
 		if err != nil {
 			return nil, kapierrors.NewBadRequest(fmt.Sprintf("unable to find SecurityContextConstraints: %v", err))
 		}

--- a/pkg/security/registry/podsecuritypolicysubjectreview/rest.go
+++ b/pkg/security/registry/podsecuritypolicysubjectreview/rest.go
@@ -58,7 +58,7 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ rest.Validat
 	}
 
 	userInfo := &user.DefaultInfo{Name: pspsr.Spec.User, Groups: pspsr.Spec.Groups}
-	matchedConstraints, err := r.sccMatcher.FindApplicableSCCs(userInfo)
+	matchedConstraints, err := r.sccMatcher.FindApplicableSCCs(userInfo, ns)
 	if err != nil {
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("unable to find SecurityContextConstraints: %v", err))
 	}
@@ -66,7 +66,7 @@ func (r *REST) Create(ctx apirequest.Context, obj runtime.Object, _ rest.Validat
 	saName := pspsr.Spec.Template.Spec.ServiceAccountName
 	if len(saName) > 0 {
 		saUserInfo := serviceaccount.UserInfo(ns, saName, "")
-		saConstraints, err := r.sccMatcher.FindApplicableSCCs(saUserInfo)
+		saConstraints, err := r.sccMatcher.FindApplicableSCCs(saUserInfo, ns)
 		if err != nil {
 			return nil, kapierrors.NewBadRequest(fmt.Sprintf("unable to find SecurityContextConstraints: %v", err))
 		}

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -203,7 +203,10 @@ os::cmd::expect_failure_and_text 'oc policy scc-subject-review -z system:service
 os::cmd::expect_failure_and_text 'oc policy scc-review -f ${OS_ROOT}/test/testdata/pspreview_unsupported_statefulset.yaml' 'error: StatefulSet "rd" with spec.volumeClaimTemplates currently not supported.'
 os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/job.yaml -o=jsonpath={.status.AllowedBy.name}' 'anyuid'
 os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/redis-slave.yaml -o=jsonpath={.status.AllowedBy.name}' 'anyuid'
-os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml -o=jsonpath={.status.AllowedBy.name}' 'privileged'
+# In the past system:admin only had access to a few SCCs, so the following command resulted in the privileged SCC being used
+# Since SCCs are now authorized via RBAC, and system:admin can perform all RBAC actions == system:admin can access all SCCs now
+# Thus the following command now results in the use of the hostnetwork SCC which is the most restrictive SCC that still allows the pod to run
+os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml -o=jsonpath={.status.AllowedBy.name}' 'hostnetwork'
 os::cmd::expect_success "oc login -u bob -p bobpassword"
 os::cmd::expect_success_and_text 'oc whoami' 'bob'
 os::cmd::expect_success 'oc new-project policy-second'

--- a/test/integration/scc_test.go
+++ b/test/integration/scc_test.go
@@ -1,12 +1,17 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 
+	"github.com/openshift/origin/pkg/security/apis/security"
+	securityclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -43,19 +48,9 @@ func TestPodUpdateSCCEnforcement(t *testing.T) {
 
 	// so cluster-admin can create privileged pods, but harold cannot.  This means that harold should not be able
 	// to update the privileged pods either, even if he lies about its privileged nature
-	privilegedPod := &kapi.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "unsafe"},
-		Spec: kapi.PodSpec{
-			Containers: []kapi.Container{
-				{Name: "first", Image: "something-innocuous"},
-			},
-			SecurityContext: &kapi.PodSecurityContext{
-				HostPID: true,
-			},
-		},
-	}
+	privilegedPod := getPrivilegedPod("unsafe")
 
-	if _, err := haroldKubeClient.Core().Pods(projectName).Create(privilegedPod); !kapierror.IsForbidden(err) {
+	if _, err := haroldKubeClient.Core().Pods(projectName).Create(privilegedPod); !isForbiddenBySCC(err) {
 		t.Fatalf("missing forbidden: %v", err)
 	}
 
@@ -65,7 +60,7 @@ func TestPodUpdateSCCEnforcement(t *testing.T) {
 	}
 
 	actualPod.Spec.Containers[0].Image = "something-nefarious"
-	if _, err := haroldKubeClient.Core().Pods(projectName).Update(actualPod); !kapierror.IsForbidden(err) {
+	if _, err := haroldKubeClient.Core().Pods(projectName).Update(actualPod); !isForbiddenBySCC(err) {
 		t.Fatalf("missing forbidden: %v", err)
 	}
 
@@ -73,5 +68,200 @@ func TestPodUpdateSCCEnforcement(t *testing.T) {
 	actualPod.Spec.SecurityContext.HostPID = false
 	if _, err := haroldKubeClient.Core().Pods(projectName).Update(actualPod); err == nil {
 		t.Fatalf("missing error: %v", err)
+	}
+}
+
+func TestAllowedSCCViaRBAC(t *testing.T) {
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMaster()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+	clusterAdminKubeClientset, err := testutil.GetClusterAdminKubeClient(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project1 := "project1"
+	project2 := "project2"
+
+	user1 := "user1"
+	user2 := "user2"
+
+	clusterRole := "all-scc"
+	rule := rbac.NewRule("use").Groups("security.openshift.io").Resources("securitycontextconstraints").RuleOrDie()
+
+	// set a up cluster role that allows access to all SCCs
+	if _, err := clusterAdminKubeClientset.Rbac().ClusterRoles().Create(
+		&rbac.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterRole},
+			Rules:      []rbac.PolicyRule{rule},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// set up 2 projects for 2 users
+
+	user1Client, user1Config, err := testserver.CreateNewProject(clusterAdminClientConfig, project1, user1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user1SecurityClient := securityclient.NewForConfigOrDie(user1Config)
+
+	user2Client, user2Config, err := testserver.CreateNewProject(clusterAdminClientConfig, project2, user2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user2SecurityClient := securityclient.NewForConfigOrDie(user2Config)
+
+	// make sure the SAs are ready so we can deploy pods
+
+	if err := testserver.WaitForServiceAccounts(user1Client, project1, []string{"default"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testserver.WaitForServiceAccounts(user2Client, project2, []string{"default"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// user1 cannot make a privileged pod
+	if _, err := user1Client.Core().Pods(project1).Create(getPrivilegedPod("test1")); !isForbiddenBySCC(err) {
+		t.Fatalf("missing forbidden for user1: %v", err)
+	}
+
+	// user2 cannot make a privileged pod
+	if _, err := user2Client.Core().Pods(project2).Create(getPrivilegedPod("test2")); !isForbiddenBySCC(err) {
+		t.Fatalf("missing forbidden for user2: %v", err)
+	}
+
+	// this should allow user1 to make a privileged pod in project1
+	rb := rbac.NewRoleBindingForClusterRole(clusterRole, project1).Users(user1).BindingOrDie()
+	if _, err := clusterAdminKubeClientset.Rbac().RoleBindings(project1).Create(&rb); err != nil {
+		t.Fatal(err)
+	}
+
+	// this should allow user1 to make pods in project2
+	rbEditUser1Project2 := rbac.NewRoleBindingForClusterRole("edit", project2).Users(user1).BindingOrDie()
+	if _, err := clusterAdminKubeClientset.Rbac().RoleBindings(project2).Create(&rbEditUser1Project2); err != nil {
+		t.Fatal(err)
+	}
+
+	// this should allow user2 to make pods in project1
+	rbEditUser2Project1 := rbac.NewRoleBindingForClusterRole("edit", project1).Users(user2).BindingOrDie()
+	if _, err := clusterAdminKubeClientset.Rbac().RoleBindings(project1).Create(&rbEditUser2Project1); err != nil {
+		t.Fatal(err)
+	}
+
+	// this should allow user2 to make a privileged pod in all projects
+	crb := rbac.NewClusterBinding(clusterRole).Users(user2).BindingOrDie()
+	if _, err := clusterAdminKubeClientset.Rbac().ClusterRoleBindings().Create(&crb); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for RBAC to catch up to user1 role binding for SCC
+	if err := testutil.WaitForPolicyUpdate(user1Client.Authorization(), project1, rule.Verbs[0],
+		schema.GroupResource{Group: rule.APIGroups[0], Resource: rule.Resources[0]}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for RBAC to catch up to user1 role binding for edit
+	if err := testutil.WaitForPolicyUpdate(user1Client.Authorization(), project2, "create",
+		schema.GroupResource{Resource: "pods"}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for RBAC to catch up to user2 role binding
+	if err := testutil.WaitForPolicyUpdate(user2Client.Authorization(), project1, "create",
+		schema.GroupResource{Resource: "pods"}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for RBAC to catch up to user2 cluster role binding
+	if err := testutil.WaitForClusterPolicyUpdate(user2Client.Authorization(), rule.Verbs[0],
+		schema.GroupResource{Group: rule.APIGroups[0], Resource: rule.Resources[0]}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// user1 can make a privileged pod in project1
+	if _, err := user1Client.Core().Pods(project1).Create(getPrivilegedPod("test3")); err != nil {
+		t.Fatalf("user1 failed to create pod in project1 via local binding: %v", err)
+	}
+
+	// user1 cannot make a privileged pod in project2
+	if _, err := user1Client.Core().Pods(project2).Create(getPrivilegedPod("test4")); !isForbiddenBySCC(err) {
+		t.Fatalf("missing forbidden for user1 in project2: %v", err)
+	}
+
+	// user2 can make a privileged pod in project1
+	if _, err := user2Client.Core().Pods(project1).Create(getPrivilegedPod("test5")); err != nil {
+		t.Fatalf("user2 failed to create pod in project1 via cluster binding: %v", err)
+	}
+
+	// user2 can make a privileged pod in project2
+	if _, err := user2Client.Core().Pods(project2).Create(getPrivilegedPod("test6")); err != nil {
+		t.Fatalf("user2 failed to create pod in project2 via cluster binding: %v", err)
+	}
+
+	// make sure PSP self subject review works since that is based by the same SCC logic but has different wiring
+
+	// user1 can make a privileged pod in project1
+	user1PSPReview, err := user1SecurityClient.PodSecurityPolicySelfSubjectReviews(project1).Create(runAsRootPSPSSR())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowedBy := user1PSPReview.Status.AllowedBy; allowedBy == nil || allowedBy.Name != "anyuid" {
+		t.Fatalf("user1 failed PSP SSR in project1: %v", allowedBy)
+	}
+
+	// user2 can make a privileged pod in project2
+	user2PSPReview, err := user2SecurityClient.PodSecurityPolicySelfSubjectReviews(project2).Create(runAsRootPSPSSR())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowedBy := user2PSPReview.Status.AllowedBy; allowedBy == nil || allowedBy.Name != "anyuid" {
+		t.Fatalf("user2 failed PSP SSR in project2: %v", allowedBy)
+	}
+}
+
+func isForbiddenBySCC(err error) bool {
+	return kapierror.IsForbidden(err) && strings.Contains(err.Error(), "unable to validate against any security context constraint")
+}
+
+func getPrivilegedPod(name string) *kapi.Pod {
+	return &kapi.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kapi.PodSpec{
+			Containers: []kapi.Container{
+				{Name: "first", Image: "something-innocuous"},
+			},
+			SecurityContext: &kapi.PodSecurityContext{
+				HostPID: true,
+			},
+		},
+	}
+}
+
+func runAsRootPSPSSR() *security.PodSecurityPolicySelfSubjectReview {
+	return &security.PodSecurityPolicySelfSubjectReview{
+		Spec: security.PodSecurityPolicySelfSubjectReviewSpec{
+			Template: kapi.PodTemplateSpec{
+				Spec: kapi.PodSpec{
+					Containers: []kapi.Container{
+						{
+							Name:  "fake",
+							Image: "fake",
+							SecurityContext: &kapi.SecurityContext{
+								RunAsUser: new(int64), // root
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
Allow authorization of SCC use via RBAC

This change adds the minimal logic required to support the following
SAR check as a means to allow access to a specific SCC in a specific
namespace:

```
Verb:      use
Namespace: <namespace>
Name:      <scc name>
APIGroup:  security.openshift.io
Resource:  securitycontextconstraints
```

This SAR check mimics the upstream PSP check but with the SCC group
and resource.  This has the added benefit of allowing namespace
scoped SCC access.

It does not update any bootstrap data to use this method.  It does
not update the router command's SCC check to use this method.  Thus
nothing currently relies on this method as a means of SCC access.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

https://trello.com/c/LkCMxnjt
/assign @simo5 @deads2k @php-coder
/hold
Holding since cannot go in until 3.11.