### PR TITLE
Fix broken web profiling

### DIFF
--- a/pkg/cmd/server/origin/profiler.go
+++ b/pkg/cmd/server/origin/profiler.go
@@ -3,6 +3,7 @@ package origin
 import (
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"runtime"
 
 	"github.com/golang/glog"
@@ -13,11 +14,22 @@ import (
 func StartProfiler() {
 	if cmdutil.Env("OPENSHIFT_PROFILE", "") == "web" {
 		go func() {
+			serveMux := http.NewServeMux()
+			serveMux.HandleFunc("/debug/pprof/", pprof.Index)
+			serveMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			serveMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			serveMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			serveMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
 			runtime.SetBlockProfileRate(1)
 			profilePort := cmdutil.Env("OPENSHIFT_PROFILE_PORT", "6060")
 			profileHost := cmdutil.Env("OPENSHIFT_PROFILE_HOST", "127.0.0.1")
 			glog.Infof(fmt.Sprintf("Starting profiling endpoint at http://%s:%s/debug/pprof/", profileHost, profilePort))
-			glog.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%s", profileHost, profilePort), nil))
+			server := http.Server{
+				Addr:    fmt.Sprintf("%s:%s", profileHost, profilePort),
+				Handler: serveMux,
+			}
+			glog.Fatal(server.ListenAndServe())
 		}()
 	}
 }


### PR DESCRIPTION
After 3.9, the web profiling approach was changed and the new approach seems to be incomplete. There isn't anything that handles profiling requests. This PR switches the web profiler to use a dedicated HTTP server and associated `ServeMux` and adds handler for all of the profiler URLs.