### PR TITLE
UPSTREAM: 62584: Make x-kubernetes-print-column print handling opt-in

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/resource/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/resource/get.go
@@ -736,7 +736,7 @@ func (options *GetOptions) printGeneric(printer printers.ResourcePrinter, r *res
 }
 
 func addOpenAPIPrintColumnFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(useOpenAPIPrintColumnFlagLabel, true, "If true, use x-kubernetes-print-column metadata (if present) from the OpenAPI schema for displaying a resource.")
+	cmd.Flags().Bool(useOpenAPIPrintColumnFlagLabel, false, "If true, use x-kubernetes-print-column metadata (if present) from the OpenAPI schema for displaying a resource.")
 }
 
 func addServerPrintColumnFlags(cmd *cobra.Command) {


### PR DESCRIPTION
Fixes issue with openapi schema being retrieved on every `oc get` request