### PR TITLE
Distinguish warning message between --build-loglevel and --env with binary builds

### DIFF
--- a/pkg/oc/cli/cmd/startbuild.go
+++ b/pkg/oc/cli/cmd/startbuild.go
@@ -88,7 +88,11 @@ var (
 
 // NewCmdStartBuild implements the OpenShift cli start-build command
 func NewCmdStartBuild(fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
-	o := &StartBuildOptions{}
+	o := &StartBuildOptions{
+		In:     in,
+		Out:    out,
+		ErrOut: errout,
+	}
 
 	cmd := &cobra.Command{
 		Use:        "start-build (BUILDCONFIG | --from-build=BUILD)",
@@ -97,7 +101,8 @@ func NewCmdStartBuild(fullName string, f *clientcmd.Factory, in io.Reader, out, 
 		Example:    fmt.Sprintf(startBuildExample, fullName),
 		SuggestFor: []string{"build", "builds"},
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(f, in, out, errout, cmd, fullName, args))
+			kcmdutil.CheckErr(o.Complete(f, cmd, fullName, args))
+			kcmdutil.CheckErr(o.Validate())
 			kcmdutil.CheckErr(o.Run())
 		},
 	}
@@ -168,11 +173,8 @@ type StartBuildOptions struct {
 	Namespace   string
 }
 
-func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, errout io.Writer, cmd *cobra.Command, cmdFullName string, args []string) error {
+func (o *StartBuildOptions) Complete(f *clientcmd.Factory, cmd *cobra.Command, cmdFullName string, args []string) error {
 	var err error
-	o.In = in
-	o.Out = out
-	o.ErrOut = errout
 	o.Git = git.NewRepository()
 	o.ClientConfig, err = f.ClientConfig()
 	if err != nil {
@@ -220,18 +222,12 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 			return kcmdutil.UsageErrorf(cmd, "The '--from-webhook' flag is incompatible with arguments and all '--from-*' flags")
 		}
 		if !strings.HasSuffix(webhook, "/generic") {
-			fmt.Fprintf(errout, "warning: the '--from-webhook' flag should be called with a generic webhook URL.\n")
+			fmt.Fprintf(o.ErrOut, "warning: the '--from-webhook' flag should be called with a generic webhook URL.\n")
 		}
 		return nil
 
 	case len(args) != 1 && len(buildName) == 0:
 		return kcmdutil.UsageErrorf(cmd, "Must pass a name of a build config or specify build name with '--from-build' flag.\nUse \"%s get bc\" to list all available build configs.", cmdFullName)
-	}
-
-	if len(buildName) != 0 && o.AsBinary {
-		// TODO: we should support this, it should be possible to clone a build to run again with new uploaded artifacts.
-		// Doing so requires introducing a new clonebinary endpoint.
-		return kcmdutil.UsageErrorf(cmd, "Cannot use '--from-build' flag with binary builds")
 	}
 
 	namespace, _, err := f.DefaultNamespace()
@@ -288,16 +284,12 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 		name = ref.Name
 	}
 
-	if len(name) == 0 {
-		return fmt.Errorf("a resource name is required either as an argument or by using --from-build")
-	}
-
 	o.Namespace = namespace
 	o.Name = name
 
 	// Handle environment variables
 	cmdutil.WarnAboutCommaSeparation(o.ErrOut, o.Env, "--env")
-	env, _, err := utilenv.ParseEnv(o.Env, in)
+	env, _, err := utilenv.ParseEnv(o.Env, o.In)
 	if err != nil {
 		return err
 	}
@@ -308,11 +300,38 @@ func (o *StartBuildOptions) Complete(f *clientcmd.Factory, in io.Reader, out, er
 
 	// Handle Docker build arguments. In order to leverage existing logic, we
 	// first create an EnvVar array, then convert it to []docker.BuildArg
-	buildArgs, err := utilenv.ParseBuildArg(o.Args, in)
+	buildArgs, err := utilenv.ParseBuildArg(o.Args, o.In)
 	if err != nil {
 		return err
 	}
 	o.BuildArgs = buildArgs
+
+	return nil
+}
+
+// Validate returns validation errors regarding start-build
+func (o *StartBuildOptions) Validate() error {
+	if o.AsBinary {
+		if len(o.LogLevel) > 0 {
+			fmt.Fprintf(o.ErrOut, "WARNING: Specifying --build-loglevel with binary builds is not supported.\n")
+		}
+		if len(o.EnvVar) > 1 || (len(o.LogLevel) == 0 && len(o.EnvVar) > 0) {
+			fmt.Fprintf(o.ErrOut, "WARNING: Specifying environment variables with binary builds is not supported.\n")
+		}
+		if len(o.BuildArgs) > 0 {
+			fmt.Fprintf(o.ErrOut, "WARNING: Specifying build arguments with binary builds is not supported.\n")
+		}
+	}
+
+	if len(o.FromBuild) != 0 && o.AsBinary {
+		// TODO: we should support this, it should be possible to clone a build to run again with new uploaded artifacts.
+		// Doing so requires introducing a new clonebinary endpoint.
+		return fmt.Errorf("Cannot use '--from-build' flag with binary builds")
+	}
+
+	if len(o.Name) == 0 && len(o.FromWebhook) == 0 && len(o.FromBuild) == 0 {
+		return fmt.Errorf("a resource name is required either as an argument or by using --from-build")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Currently `--build-loglevel` with binary build outputs warning as
"Specifyinig environment variables is not supported". It is difficult
to find out why `--build-loglevel` option causes this warning.

This patch changes the warning message to `--build-loglevel` so that
it makes clear.

Before:
```
$ oc start-build --build-loglevel=3 myapp --from-dir="." --follow
WARNING: Specifying environment variables with binary builds is not supported.
```

After:
```
$ oc start-build --build-loglevel=3 myapp --from-dir="." --follow
WARNING: Specifying --build-loglevel with binary builds is not supported.
Uploading directory "." as binary input for the build ...

$ _output/local/bin/linux/amd64/oc start-build  myapp --from-dir="." --follow -e foo=bar
WARNING: Specifying environment variables with binary builds is not supported.
Uploading directory "." as binary input for the build ...

$ _output/local/bin/linux/amd64/oc start-build  myapp --from-dir="." --follow -e foo=bar --build-loglevel=5
WARNING: Specifying --build-loglevel with binary builds is not supported.
WARNING: Specifying environment variables with binary builds is not supported.
Uploading directory "." as binary input for the build ...
```