### PR TITLE
Explicitly set the MTU on the tun0 interface

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -62,7 +62,7 @@ func (oc *ovsController) AlreadySetUp() bool {
 	return false
 }
 
-func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway string) error {
+func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway string, mtu uint32) error {
 	err := oc.ovs.DeleteBridge(true)
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 		return err
 	}
 	_ = oc.ovs.DeletePort(Tun0)
-	_, err = oc.ovs.AddPort(Tun0, 2, "type=internal")
+	_, err = oc.ovs.AddPort(Tun0, 2, "type=internal", fmt.Sprintf("mtu_request=%d", mtu))
 	if err != nil {
 		return err
 	}

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -23,7 +23,7 @@ func setupOVSController(t *testing.T) (ovs.Interface, *ovsController, []string) 
 	ovsif := ovs.NewFake(Br0)
 	oc := NewOVSController(ovsif, 0, true, "172.17.0.4")
 	oc.tunMAC = "c6:ac:2c:13:48:4b"
-	err := oc.SetupOVS([]string{"10.128.0.0/14"}, "172.30.0.0/16", "10.128.0.0/23", "10.128.0.1")
+	err := oc.SetupOVS([]string{"10.128.0.0/14"}, "172.30.0.0/16", "10.128.0.0/23", "10.128.0.1", 1450)
 	if err != nil {
 		t.Fatalf("Unexpected error setting up OVS: %v", err)
 	}

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -154,7 +154,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 func (plugin *OsdnNode) setup(clusterNetworkCIDRs []string, localSubnetCIDR, localSubnetGateway, gwCIDR string) error {
 	serviceNetworkCIDR := plugin.networkInfo.ServiceNetwork.String()
 
-	if err := plugin.oc.SetupOVS(clusterNetworkCIDRs, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway); err != nil {
+	if err := plugin.oc.SetupOVS(clusterNetworkCIDRs, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway, plugin.mtu); err != nil {
 		return err
 	}
 
@@ -165,9 +165,6 @@ func (plugin *OsdnNode) setup(clusterNetworkCIDRs []string, localSubnetCIDR, loc
 		if err == nil {
 			defer deleteLocalSubnetRoute(Tun0, localSubnetCIDR)
 		}
-	}
-	if err == nil {
-		err = netlink.LinkSetMTU(l, int(plugin.mtu))
 	}
 	if err == nil {
 		err = netlink.LinkSetUp(l)


### PR DESCRIPTION
Before this, we did not set the MTU on the tun0 interface explicitly.
Since that interface is of type internal it is created and managed by
OVS.  Because it is managed by OVS, the MTU changes when pods are
added and removed from the bridge.  With a pod we see the desired MTU
on tun0, but when there are no pods, the MTU goes back to 1500.  This
is normally fine, but if there are packets above the MTU going between
nodes using their SDN addresses, then those packets will get dropped
when there are no pods using the SDN on one of those nodes.

The change is to request the correct MTU when we add the port to OVS.

Fixes bug 1564346 (https://bugzilla.redhat.com/show_bug.cgi?id=1564346)