### PR TITLE
add a simple web console operator

### DIFF
--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/openshift/origin/pkg/cmd/openshift-experimental"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -66,6 +67,9 @@ func NewHyperShiftCommand() *cobra.Command {
 
 	startOpenShiftControllerManager := openshift_controller_manager.NewOpenShiftControllerManagerCommand(openshift_controller_manager.RecommendedStartControllerManagerName, "hypershift", os.Stdout, os.Stderr)
 	cmd.AddCommand(startOpenShiftControllerManager)
+
+	experimental := openshift_experimental.NewExperimentalCommand(os.Stdout, os.Stderr)
+	cmd.AddCommand(experimental)
 
 	return cmd
 }

--- a/install/openshift-web-console-operator/install-rbac.yaml
+++ b/install/openshift-web-console-operator/install-rbac.yaml
@@ -1,0 +1,19 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: NAMESPACE
+  value: openshift-core-operators
+objects:
+
+# When we have an orchestrating operator
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:operator:web-console
+  roleRef:
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: openshift-web-console-operator

--- a/install/openshift-web-console-operator/install.yaml
+++ b/install/openshift-web-console-operator/install.yaml
@@ -1,0 +1,77 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: IMAGE
+  value: openshift/origin:latest
+- name: NAMESPACE
+  # This namespace must not be changed.
+  value: openshift-core-operators
+- name: LOGLEVEL
+  value: "0"
+- name: COMPONENT_LOGLEVEL
+  value: "0"
+- name: COMPONENT_IMAGE
+  value: openshift/origin-web-console:latest
+- name: NODE_SELECTOR
+  value: "{}"
+objects:
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: openshiftwebconsoleconfigs.webconsole.operator.openshift.io
+  spec:
+    scope: Cluster
+    group: webconsole.operator.openshift.io
+    version: v1alpha1
+    names:
+      kind: OpenShiftWebConsoleConfig
+      plural: openshiftwebconsoleconfigs
+      singular: openshiftwebconsoleconfig
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-web-console-operator
+    labels:
+      app: openshift-web-console-operator
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: openshift-web-console-operator
+    template:
+      metadata:
+        name: openshift-web-console-operator
+        labels:
+          app: openshift-web-console-operator
+      spec:
+        serviceAccountName: openshift-web-console-operator
+        containers:
+        - name: operator
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["hypershift", "experimental", "openshift-webconsole-operator"]
+          args:
+          - "-v=${LOGLEVEL}"
+        nodeSelector: "${{NODE_SELECTOR}}"
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-web-console-operator
+    labels:
+      app: openshift-web-console-operator
+
+- apiVersion: webconsole.operator.openshift.io/v1alpha1
+  kind: OpenShiftWebConsoleConfig
+  metadata:
+    name: instance
+  spec:
+    managementState: Managed
+    imagePullSpec: ${COMPONENT_IMAGE}
+    version: 3.10.0
+    logging:
+      level: ${{COMPONENT_LOGLEVEL}}

--- a/pkg/cmd/openshift-experimental/cmd.go
+++ b/pkg/cmd/openshift-experimental/cmd.go
@@ -1,0 +1,25 @@
+package openshift_experimental
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/webconsole-operator"
+)
+
+func NewExperimentalCommand(out, errout io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "experimental",
+		Short: "Experimental commands for OpenShift",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	cmd.AddCommand(webconsole_operator.NewWebConsoleOperatorCommand(webconsole_operator.RecommendedWebConsoleOperatorName, out, errout))
+
+	return cmd
+}

--- a/pkg/cmd/openshift-operators/apis/operators/v1alpha1/types.go
+++ b/pkg/cmd/openshift-operators/apis/operators/v1alpha1/types.go
@@ -44,9 +44,9 @@ const (
 	ConditionFalse   ConditionStatus = "False"
 	ConditionUnknown ConditionStatus = "Unknown"
 
-	OperatorStatusTypeAvailable = "Available"
-	OperatorStatusTypeMigrating = "Migrating"
-	OperatorStatusTypeFailing   = "Failing"
+	OperatorStatusTypeAvailable      = "Available"
+	OperatorStatusTypeMigrating      = "Migrating"
+	OperatorStatusTypeSyncSuccessful = "SyncSuccessful"
 )
 
 type OperatorCondition struct {

--- a/pkg/cmd/openshift-operators/apis/operators/v1alpha1helpers/helpers.go
+++ b/pkg/cmd/openshift-operators/apis/operators/v1alpha1helpers/helpers.go
@@ -2,22 +2,26 @@ package v1alpha1helpers
 
 import (
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorsv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/operators/v1alpha1"
 )
 
-func SetErrors(versionAvailability *operatorsv1alpha1apiWebConsoleVersionAvailablity, errors ...error) {
+func SetErrors(versionAvailability *operatorsv1alpha1.VersionAvailablity, errors ...error) {
 	versionAvailability.Errors = []string{}
 	for _, err := range errors {
 		versionAvailability.Errors = append(versionAvailability.Errors, err.Error())
 	}
 }
 
-func SetOperatorCondition(conditions *[]operatorsv1alpha1apiOpenShiftOperatorCondition, newCondition operatorsv1alpha1apiOpenShiftOperatorCondition) {
+func SetOperatorCondition(conditions *[]operatorsv1alpha1.OperatorCondition, newCondition operatorsv1alpha1.OperatorCondition) {
 	if conditions == nil {
-		conditions = &[]operatorsv1alpha1apiOpenShiftOperatorCondition{}
+		conditions = &[]operatorsv1alpha1.OperatorCondition{}
 	}
 	existingCondition := FindOperatorCondition(*conditions, newCondition.Type)
 	if existingCondition == nil {
-		newCondition.LastTransitionTime = metaoperatorsv1alpha1apiNewTime(time.Now())
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 		*conditions = append(*conditions, newCondition)
 		return
 	}
@@ -31,11 +35,11 @@ func SetOperatorCondition(conditions *[]operatorsv1alpha1apiOpenShiftOperatorCon
 	existingCondition.Message = newCondition.Message
 }
 
-func RemoveOperatorCondition(conditions *[]operatorsv1alpha1apiOpenShiftOperatorCondition, conditionType string) {
+func RemoveOperatorCondition(conditions *[]operatorsv1alpha1.OperatorCondition, conditionType string) {
 	if conditions == nil {
-		conditions = &[]operatorsv1alpha1apiOpenShiftOperatorCondition{}
+		conditions = &[]operatorsv1alpha1.OperatorCondition{}
 	}
-	newConditions := []operatorsv1alpha1apiOpenShiftOperatorCondition{}
+	newConditions := []operatorsv1alpha1.OperatorCondition{}
 	for _, condition := range *conditions {
 		if condition.Type != conditionType {
 			newConditions = append(newConditions, condition)
@@ -45,7 +49,7 @@ func RemoveOperatorCondition(conditions *[]operatorsv1alpha1apiOpenShiftOperator
 	conditions = &newConditions
 }
 
-func FindOperatorCondition(conditions []operatorsv1alpha1apiOpenShiftOperatorCondition, conditionType string) *operatorsv1alpha1apiOpenShiftOperatorCondition {
+func FindOperatorCondition(conditions []operatorsv1alpha1.OperatorCondition, conditionType string) *operatorsv1alpha1.OperatorCondition {
 	for i := range conditions {
 		if conditions[i].Type == conditionType {
 			return &conditions[i]
@@ -55,15 +59,15 @@ func FindOperatorCondition(conditions []operatorsv1alpha1apiOpenShiftOperatorCon
 	return nil
 }
 
-func IsOperatorConditionTrue(conditions []operatorsv1alpha1apiOpenShiftOperatorCondition, conditionType string) bool {
-	return IsOperatorConditionPresentAndEqual(conditions, conditionType, operatorsv1alpha1apiConditionTrue)
+func IsOperatorConditionTrue(conditions []operatorsv1alpha1.OperatorCondition, conditionType string) bool {
+	return IsOperatorConditionPresentAndEqual(conditions, conditionType, operatorsv1alpha1.ConditionTrue)
 }
 
-func IsOperatorConditionFalse(conditions []operatorsv1alpha1apiOpenShiftOperatorCondition, conditionType string) bool {
-	return IsOperatorConditionPresentAndEqual(conditions, conditionType, operatorsv1alpha1apiConditionFalse)
+func IsOperatorConditionFalse(conditions []operatorsv1alpha1.OperatorCondition, conditionType string) bool {
+	return IsOperatorConditionPresentAndEqual(conditions, conditionType, operatorsv1alpha1.ConditionFalse)
 }
 
-func IsOperatorConditionPresentAndEqual(conditions []operatorsv1alpha1apiOpenShiftOperatorCondition, conditionType string, status operatorsv1alpha1apiConditionStatus) bool {
+func IsOperatorConditionPresentAndEqual(conditions []operatorsv1alpha1.OperatorCondition, conditionType string, status operatorsv1alpha1.ConditionStatus) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
 			return condition.Status == status

--- a/pkg/cmd/openshift-operators/apis/webconsole/v1alpha1/register.go
+++ b/pkg/cmd/openshift-operators/apis/webconsole/v1alpha1/register.go
@@ -14,6 +14,10 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&OpenShiftWebConsoleConfig{},

--- a/pkg/cmd/openshift-operators/webconsole-operator/cmd.go
+++ b/pkg/cmd/openshift-operators/webconsole-operator/cmd.go
@@ -1,0 +1,100 @@
+package webconsole_operator
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/client/leaderelectionconfig"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+const (
+	RecommendedWebConsoleOperatorName = "openshift-webconsole-operator"
+)
+
+type WebConsoleOperatorCommandOptions struct {
+	Output io.Writer
+}
+
+var longDescription = templates.LongDesc(`
+	Install the OpenShift webconsole`)
+
+func NewWebConsoleOperatorCommand(name string, out, errout io.Writer) *cobra.Command {
+	options := &WebConsoleOperatorCommandOptions{Output: out}
+
+	cmd := &cobra.Command{
+		Use:   name,
+		Short: "Install the OpenShift webconsole",
+		Long:  longDescription,
+		RunE: func(c *cobra.Command, args []string) error {
+			kcmdutil.CheckErr(options.Validate())
+
+			return options.RunWebConsoleOperator()
+		},
+	}
+
+	return cmd
+}
+
+func (o *WebConsoleOperatorCommandOptions) Validate() error {
+	return nil
+}
+
+func (o *WebConsoleOperatorCommandOptions) RunWebConsoleOperator() error {
+	clientConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	operator := &WebConsoleOperatorStarter{
+		ClientConfig: clientConfig,
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
+	eventRecorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "openshift-webconsole"})
+	rl, err := resourcelock.New(
+		resourcelock.ConfigMapsResourceLock,
+		"openshift-core-operators",
+		RecommendedWebConsoleOperatorName,
+		kubeClient.CoreV1(),
+		resourcelock.ResourceLockConfig{
+			Identity:      string(uuid.NewUUID()),
+			EventRecorder: eventRecorder,
+		})
+	if err != nil {
+		return err
+	}
+	leaderelection.RunOrDie(leaderelection.LeaderElectionConfig{
+		Lock:          rl,
+		LeaseDuration: leaderelectionconfig.DefaultLeaseDuration,
+		RenewDeadline: leaderelectionconfig.DefaultRenewDeadline,
+		RetryPeriod:   leaderelectionconfig.DefaultRetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: operator.Run,
+			OnStoppedLeading: func() {
+				glog.Fatalf("leaderelection lost")
+			},
+		},
+	})
+
+	return fmt.Errorf("exiting")
+}

--- a/pkg/cmd/openshift-operators/webconsole-operator/starter.go
+++ b/pkg/cmd/openshift-operators/webconsole-operator/starter.go
@@ -1,0 +1,43 @@
+package webconsole_operator
+
+import (
+	"time"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	webconsoleclient "github.com/openshift/origin/pkg/cmd/openshift-operators/generated/clientset/versioned"
+	webconsoleinformers "github.com/openshift/origin/pkg/cmd/openshift-operators/generated/informers/externalversions"
+)
+
+type WebConsoleOperatorStarter struct {
+	ClientConfig *rest.Config
+}
+
+func (o *WebConsoleOperatorStarter) Run(stopCh <-chan struct{}) {
+	kubeClient, err := kubernetes.NewForConfig(o.ClientConfig)
+	if err != nil {
+		panic(err)
+	}
+	webconsoleClient, err := webconsoleclient.NewForConfig(o.ClientConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	operatorInformers := webconsoleinformers.NewSharedInformerFactory(webconsoleClient, 10*time.Minute)
+	kubeInformersNamespaced := informers.NewFilteredSharedInformerFactory(kubeClient, 10*time.Minute, targetNamespaceName, nil)
+
+	operator := NewWebConsoleOperator(
+		operatorInformers.Webconsole().V1alpha1().OpenShiftWebConsoleConfigs(),
+		kubeInformersNamespaced,
+		webconsoleClient.WebconsoleV1alpha1(),
+		kubeClient.AppsV1(),
+		kubeClient.CoreV1(),
+	)
+
+	operatorInformers.Start(stopCh)
+	kubeInformersNamespaced.Start(stopCh)
+
+	operator.Run(1, stopCh)
+}

--- a/pkg/cmd/openshift-operators/webconsole-operator/sync_v310_00.go
+++ b/pkg/cmd/openshift-operators/webconsole-operator/sync_v310_00.go
@@ -1,0 +1,21 @@
+package webconsole_operator
+
+import (
+	operatorsv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/operators/v1alpha1"
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/apis/operators/v1alpha1helpers"
+	webconsolev1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/webconsole/v1alpha1"
+)
+
+// most of the time the sync method will be good for a large span of minor versions
+func sync_v310_00_to_00(c WebConsoleOperator, operatorConfig *webconsolev1alpha1.OpenShiftWebConsoleConfig) (operatorsv1alpha1.VersionAvailablity, []error) {
+	versionAvailability := operatorsv1alpha1.VersionAvailablity{
+		Version: operatorConfig.Spec.Version,
+	}
+
+	errors := []error{}
+	// TODO do some work
+
+	v1alpha1helpers.SetErrors(&versionAvailability, errors...)
+
+	return versionAvailability, errors
+}

--- a/pkg/cmd/openshift-operators/webconsole-operator/webconsole_operator_trigger.go
+++ b/pkg/cmd/openshift-operators/webconsole-operator/webconsole_operator_trigger.go
@@ -1,0 +1,275 @@
+package webconsole_operator
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	apiregistrationclientv1beta1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1"
+
+	operatorsv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/operators/v1alpha1"
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/apis/operators/v1alpha1helpers"
+	webconsoleclientv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/generated/clientset/versioned/typed/webconsole/v1alpha1"
+	webconsoleinformerv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/generated/informers/externalversions/webconsole/v1alpha1"
+)
+
+const targetNamespaceName = "openshift-web-console"
+
+type WebConsoleOperator struct {
+	operatorConfigClient webconsoleclientv1alpha1.OpenShiftWebConsoleConfigsGetter
+
+	appsv1Client      appsclientv1.AppsV1Interface
+	corev1Client      coreclientv1.CoreV1Interface
+	apiServicesClient apiregistrationclientv1beta1.APIServicesGetter
+
+	// queue only ever has one item, but it has nice error handling backoff/retry semantics
+	queue workqueue.RateLimitingInterface
+}
+
+func NewWebConsoleOperator(
+	webconsoleConfigInformer webconsoleinformerv1alpha1.OpenShiftWebConsoleConfigInformer,
+	webconsoleNamespacedKubeInformers informers.SharedInformerFactory,
+	operatorConfigClient webconsoleclientv1alpha1.OpenShiftWebConsoleConfigsGetter,
+	appsv1Client appsclientv1.AppsV1Interface,
+	corev1Client coreclientv1.CoreV1Interface,
+) *WebConsoleOperator {
+	c := &WebConsoleOperator{
+		operatorConfigClient: operatorConfigClient,
+		appsv1Client:         appsv1Client,
+		corev1Client:         corev1Client,
+
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "WebConsoleOperator"),
+	}
+
+	webconsoleConfigInformer.Informer().AddEventHandler(c.eventHandler())
+	webconsoleNamespacedKubeInformers.Core().V1().ConfigMaps().Informer().AddEventHandler(c.eventHandler())
+	webconsoleNamespacedKubeInformers.Core().V1().ServiceAccounts().Informer().AddEventHandler(c.eventHandler())
+	webconsoleNamespacedKubeInformers.Core().V1().Services().Informer().AddEventHandler(c.eventHandler())
+	webconsoleNamespacedKubeInformers.Apps().V1().Deployments().Informer().AddEventHandler(c.eventHandler())
+
+	// we only watch some namespaces
+	webconsoleNamespacedKubeInformers.Core().V1().Namespaces().Informer().AddEventHandler(c.namespaceEventHandler())
+
+	return c
+}
+
+func (c WebConsoleOperator) sync() error {
+	operatorConfig, err := c.operatorConfigClient.OpenShiftWebConsoleConfigs().Get("instance", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	switch operatorConfig.Spec.ManagementState {
+	case operatorsv1alpha1.Unmanaged:
+		return nil
+
+	case operatorsv1alpha1.Removed:
+		// TODO probably need to watch until the NS is really gone
+		if err := c.corev1Client.Namespaces().Delete(targetNamespaceName, nil); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		operatorConfig.Status.TaskSummary = "Remove"
+		operatorConfig.Status.TargetAvailability = nil
+		operatorConfig.Status.CurrentAvailability = nil
+		operatorConfig.Status.Conditions = []operatorsv1alpha1.OperatorCondition{
+			{
+				Type:   operatorsv1alpha1.OperatorStatusTypeAvailable,
+				Status: operatorsv1alpha1.ConditionFalse,
+			},
+		}
+		if _, err := c.operatorConfigClient.OpenShiftWebConsoleConfigs().Update(operatorConfig); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	var currentActualVerion *semver.Version
+
+	if operatorConfig.Status.CurrentAvailability != nil {
+		ver, err := semver.Parse(operatorConfig.Status.CurrentAvailability.Version)
+		if err != nil {
+			utilruntime.HandleError(err)
+		} else {
+			currentActualVerion = &ver
+		}
+	}
+	desiredVersion, err := semver.Parse(operatorConfig.Spec.Version)
+	if err != nil {
+		// TODO report failing status, we may actually attempt to do this in the "normal" error handling
+		return err
+	}
+
+	errors := []error{}
+	switch {
+	case betweenOrEmpty(currentActualVerion, "3.10.0", "3.10.1") && between(&desiredVersion, "3.10.0", "3.10.1"):
+		var versionAvailability operatorsv1alpha1.VersionAvailablity
+		operatorConfig.Status.TaskSummary = "sync-[3.10.0,3.10.1)"
+		operatorConfig.Status.TargetAvailability = nil
+		versionAvailability, errors = sync_v310_00_to_00(c, operatorConfig)
+		operatorConfig.Status.CurrentAvailability = &versionAvailability
+
+	default:
+		operatorConfig.Status.TaskSummary = "unrecognized"
+		if _, err := c.operatorConfigClient.OpenShiftWebConsoleConfigs().Update(operatorConfig); err != nil {
+			utilruntime.HandleError(err)
+		}
+
+		return fmt.Errorf("unrecognized state")
+	}
+
+	// given the VersionAvailability and the status.Version, we can compute availability
+	availableCondition := operatorsv1alpha1.OperatorCondition{
+		Type:   operatorsv1alpha1.OperatorStatusTypeAvailable,
+		Status: operatorsv1alpha1.ConditionUnknown,
+	}
+	if operatorConfig.Status.CurrentAvailability != nil && operatorConfig.Status.CurrentAvailability.ReadyReplicas > 0 {
+		availableCondition.Status = operatorsv1alpha1.ConditionTrue
+	} else {
+		availableCondition.Status = operatorsv1alpha1.ConditionFalse
+	}
+	v1alpha1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, availableCondition)
+
+	syncSuccessfulCondition := operatorsv1alpha1.OperatorCondition{
+		Type:   operatorsv1alpha1.OperatorStatusTypeSyncSuccessful,
+		Status: operatorsv1alpha1.ConditionTrue,
+	}
+	if operatorConfig.Status.CurrentAvailability != nil && len(operatorConfig.Status.CurrentAvailability.Errors) > 0 {
+		syncSuccessfulCondition.Status = operatorsv1alpha1.ConditionFalse
+		syncSuccessfulCondition.Message = strings.Join(operatorConfig.Status.CurrentAvailability.Errors, "\n")
+	}
+	if operatorConfig.Status.TargetAvailability != nil && len(operatorConfig.Status.TargetAvailability.Errors) > 0 {
+		syncSuccessfulCondition.Status = operatorsv1alpha1.ConditionFalse
+		if len(syncSuccessfulCondition.Message) == 0 {
+			syncSuccessfulCondition.Message = strings.Join(operatorConfig.Status.TargetAvailability.Errors, "\n")
+		} else {
+			syncSuccessfulCondition.Message = availableCondition.Message + "\n" + strings.Join(operatorConfig.Status.TargetAvailability.Errors, "\n")
+		}
+	}
+	v1alpha1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, syncSuccessfulCondition)
+
+	if _, err := c.operatorConfigClient.OpenShiftWebConsoleConfigs().Update(operatorConfig); err != nil {
+		errors = append(errors, err)
+	}
+
+	return utilerrors.NewAggregate(errors)
+}
+
+func between(needle *semver.Version, lowerInclusive, upperExclusive string) bool {
+	lower := semver.MustParse(lowerInclusive)
+	upper := semver.MustParse(upperExclusive)
+	return needle.GTE(lower) && needle.LT(upper)
+}
+
+func betweenOrEmpty(needle *semver.Version, lowerInclusive, upperExclusive string) bool {
+	if needle == nil {
+		return true
+	}
+	lower := semver.MustParse(lowerInclusive)
+	upper := semver.MustParse(upperExclusive)
+	return needle.GTE(lower) && needle.LT(upper)
+}
+
+// Run starts the webconsole and blocks until stopCh is closed.
+func (c *WebConsoleOperator) Run(workers int, stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	glog.Infof("Starting WebConsoleOperator")
+	defer glog.Infof("Shutting down WebConsoleOperator")
+
+	// doesn't matter what workers say, only start one.
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *WebConsoleOperator) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *WebConsoleOperator) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(dsKey)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	c.queue.AddRateLimited(dsKey)
+
+	return true
+}
+
+// eventHandler queues the operator to check spec and status
+func (c *WebConsoleOperator) eventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add("key") },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add("key") },
+		DeleteFunc: func(obj interface{}) { c.queue.Add("key") },
+	}
+}
+
+// this set of namespaces will include things like logging and metrics which are used to drive
+var interestingNamespaces = sets.NewString(targetNamespaceName)
+
+func (c *WebConsoleOperator) namespaceEventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			ns, ok := obj.(*corev1.Namespace)
+			if !ok {
+				c.queue.Add("key")
+			}
+			if ns.Name == targetNamespaceName {
+				c.queue.Add("key")
+			}
+		},
+		UpdateFunc: func(old, new interface{}) {
+			ns, ok := old.(*corev1.Namespace)
+			if !ok {
+				c.queue.Add("key")
+			}
+			if ns.Name == targetNamespaceName {
+				c.queue.Add("key")
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			ns, ok := obj.(*corev1.Namespace)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+					return
+				}
+				ns, ok = tombstone.Obj.(*corev1.Namespace)
+				if !ok {
+					utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Namespace %#v", obj))
+					return
+				}
+			}
+			if ns.Name == targetNamespaceName {
+				c.queue.Add("key")
+			}
+		},
+	}
+}

--- a/pkg/cmd/openshift-operators/webconsole-operator/webconsole_operator_trigger.go
+++ b/pkg/cmd/openshift-operators/webconsole-operator/webconsole_operator_trigger.go
@@ -28,7 +28,10 @@ import (
 	webconsoleinformerv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/generated/informers/externalversions/webconsole/v1alpha1"
 )
 
-const targetNamespaceName = "openshift-web-console"
+const (
+	targetNamespaceName = "openshift-web-console"
+	workQueueKey        = "key"
+)
 
 type WebConsoleOperator struct {
 	operatorConfigClient webconsoleclientv1alpha1.OpenShiftWebConsoleConfigsGetter
@@ -224,9 +227,9 @@ func (c *WebConsoleOperator) processNextWorkItem() bool {
 // eventHandler queues the operator to check spec and status
 func (c *WebConsoleOperator) eventHandler() cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.queue.Add("key") },
-		UpdateFunc: func(old, new interface{}) { c.queue.Add("key") },
-		DeleteFunc: func(obj interface{}) { c.queue.Add("key") },
+		AddFunc:    func(obj interface{}) { c.queue.Add(workQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(workQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(workQueueKey) },
 	}
 }
 
@@ -238,19 +241,19 @@ func (c *WebConsoleOperator) namespaceEventHandler() cache.ResourceEventHandler 
 		AddFunc: func(obj interface{}) {
 			ns, ok := obj.(*corev1.Namespace)
 			if !ok {
-				c.queue.Add("key")
+				c.queue.Add(workQueueKey)
 			}
 			if ns.Name == targetNamespaceName {
-				c.queue.Add("key")
+				c.queue.Add(workQueueKey)
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
 			ns, ok := old.(*corev1.Namespace)
 			if !ok {
-				c.queue.Add("key")
+				c.queue.Add(workQueueKey)
 			}
 			if ns.Name == targetNamespaceName {
-				c.queue.Add("key")
+				c.queue.Add(workQueueKey)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -268,7 +271,7 @@ func (c *WebConsoleOperator) namespaceEventHandler() cache.ResourceEventHandler 
 				}
 			}
 			if ns.Name == targetNamespaceName {
-				c.queue.Add("key")
+				c.queue.Add(workQueueKey)
 			}
 		},
 	}

--- a/pkg/oc/bootstrap/clusteradd/cmd.go
+++ b/pkg/oc/bootstrap/clusteradd/cmd.go
@@ -7,14 +7,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/default-imagestreams"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/registry"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/router"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/sample-templates"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/service-catalog"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/template-service-broker"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/web-console"
-	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/components/persistent-volumes"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -24,6 +16,15 @@ import (
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/componentinstall"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/default-imagestreams"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/registry"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/router"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/sample-templates"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/service-catalog"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/template-service-broker"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/web-console"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/components/web-console-operator"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/components/persistent-volumes"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper"
 	"github.com/openshift/origin/pkg/version"
@@ -74,6 +75,9 @@ var availableComponents = map[string]func(ctx componentinstall.Context) componen
 	},
 	"web-console": func(ctx componentinstall.Context) componentinstall.Component {
 		return &web_console.WebConsoleComponentOptions{InstallContext: ctx}
+	},
+	"web-console-operator": func(ctx componentinstall.Context) componentinstall.Component {
+		return &web_console_operator.WebConsoleOperatorComponentOptions{InstallContext: ctx}
 	},
 }
 

--- a/pkg/oc/bootstrap/clusteradd/components/web-console-operator/OWNERS
+++ b/pkg/oc/bootstrap/clusteradd/components/web-console-operator/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - deads2k
+approvers:
+  - deads2k

--- a/pkg/oc/bootstrap/clusteradd/components/web-console-operator/web_console_operator.go
+++ b/pkg/oc/bootstrap/clusteradd/components/web-console-operator/web_console_operator.go
@@ -1,0 +1,58 @@
+package web_console_operator
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/origin/pkg/cmd/util/variable"
+	"github.com/openshift/origin/pkg/oc/bootstrap"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusteradd/componentinstall"
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper"
+)
+
+const (
+	namespace = "openshift-core-operators"
+)
+
+type WebConsoleOperatorComponentOptions struct {
+	InstallContext componentinstall.Context
+}
+
+func (c *WebConsoleOperatorComponentOptions) Name() string {
+	return "openshift-web-console-operator"
+}
+
+func (c *WebConsoleOperatorComponentOptions) Install(dockerClient dockerhelper.Interface, logdir string) error {
+	//kubeAdminClient, err := kubernetes.NewForConfig(c.InstallContext.ClusterAdminClientConfig())
+	//if err != nil {
+	//	return errors.NewError("cannot obtain API clients").WithCause(err)
+	//}
+	// create the actual resources required
+	imageTemplate := variable.NewDefaultImageTemplate()
+	imageTemplate.Format = c.InstallContext.ImageFormat()
+	imageTemplate.Latest = false
+
+	params := map[string]string{
+		"IMAGE":              c.InstallContext.ClientImage(),
+		"LOGLEVEL":           fmt.Sprintf("%d", c.InstallContext.ComponentLogLevel()),
+		"COMPONENT_IMAGE":    imageTemplate.ExpandOrDie("web-console"),
+		"COMPONENT_LOGLEVEL": fmt.Sprintf("%d", c.InstallContext.ComponentLogLevel()),
+		"NAMESPACE":          namespace,
+	}
+	glog.V(2).Infof("instantiating template service broker template with parameters %v", params)
+
+	component := componentinstall.Template{
+		Name:            "openshift-web-console-operator",
+		Namespace:       namespace,
+		RBACTemplate:    bootstrap.MustAsset("install/openshift-web-console-operator/install-rbac.yaml"),
+		InstallTemplate: bootstrap.MustAsset("install/openshift-web-console-operator/install.yaml"),
+
+		// TODO wait until the webconsole is up
+	}
+
+	return component.MakeReady(
+		c.InstallContext.ClientImage(),
+		c.InstallContext.BaseDir(),
+		params).Install(dockerClient, logdir)
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -261,6 +261,8 @@
 // install/kube-scheduler/kube-scheduler.yaml
 // install/openshift-apiserver/install.yaml
 // install/openshift-controller-manager/install.yaml
+// install/openshift-web-console-operator/install-rbac.yaml
+// install/openshift-web-console-operator/install.yaml
 // install/origin-web-console/console-config.yaml
 // install/origin-web-console/console-template.yaml
 // install/service-catalog-broker-resources/template-service-broker-registration.yaml
@@ -31983,6 +31985,136 @@ func installOpenshiftControllerManagerInstallYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installOpenshiftWebConsoleOperatorInstallRbacYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: NAMESPACE
+  value: openshift-core-operators
+objects:
+
+# When we have an orchestrating operator
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:operator:web-console
+  roleRef:
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: openshift-web-console-operator
+`)
+
+func installOpenshiftWebConsoleOperatorInstallRbacYamlBytes() ([]byte, error) {
+	return _installOpenshiftWebConsoleOperatorInstallRbacYaml, nil
+}
+
+func installOpenshiftWebConsoleOperatorInstallRbacYaml() (*asset, error) {
+	bytes, err := installOpenshiftWebConsoleOperatorInstallRbacYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/openshift-web-console-operator/install-rbac.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installOpenshiftWebConsoleOperatorInstallYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: IMAGE
+  value: openshift/origin:latest
+- name: NAMESPACE
+  # This namespace must not be changed.
+  value: openshift-core-operators
+- name: LOGLEVEL
+  value: "0"
+- name: COMPONENT_LOGLEVEL
+  value: "0"
+- name: COMPONENT_IMAGE
+  value: openshift/origin-web-console:latest
+- name: NODE_SELECTOR
+  value: "{}"
+objects:
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: openshiftwebconsoleconfigs.webconsole.operator.openshift.io
+  spec:
+    scope: Cluster
+    group: webconsole.operator.openshift.io
+    version: v1alpha1
+    names:
+      kind: OpenShiftWebConsoleConfig
+      plural: openshiftwebconsoleconfigs
+      singular: openshiftwebconsoleconfig
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-web-console-operator
+    labels:
+      app: openshift-web-console-operator
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: openshift-web-console-operator
+    template:
+      metadata:
+        name: openshift-web-console-operator
+        labels:
+          app: openshift-web-console-operator
+      spec:
+        serviceAccountName: openshift-web-console-operator
+        containers:
+        - name: operator
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["hypershift", "experimental", "openshift-webconsole-operator"]
+          args:
+          - "-v=${LOGLEVEL}"
+        nodeSelector: "${{NODE_SELECTOR}}"
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-web-console-operator
+    labels:
+      app: openshift-web-console-operator
+
+- apiVersion: webconsole.operator.openshift.io/v1alpha1
+  kind: OpenShiftWebConsoleConfig
+  metadata:
+    name: instance
+  spec:
+    managementState: Managed
+    imagePullSpec: ${COMPONENT_IMAGE}
+    version: 3.10.0
+    logging:
+      level: ${{COMPONENT_LOGLEVEL}}
+`)
+
+func installOpenshiftWebConsoleOperatorInstallYamlBytes() ([]byte, error) {
+	return _installOpenshiftWebConsoleOperatorInstallYaml, nil
+}
+
+func installOpenshiftWebConsoleOperatorInstallYaml() (*asset, error) {
+	bytes, err := installOpenshiftWebConsoleOperatorInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/openshift-web-console-operator/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installOriginWebConsoleConsoleConfigYaml = []byte(`apiVersion: webconsole.config.openshift.io/v1
 kind: WebConsoleConfiguration
 clusterInfo:
@@ -32804,6 +32936,8 @@ var _bindata = map[string]func() (*asset, error){
 	"install/kube-scheduler/kube-scheduler.yaml": installKubeSchedulerKubeSchedulerYaml,
 	"install/openshift-apiserver/install.yaml": installOpenshiftApiserverInstallYaml,
 	"install/openshift-controller-manager/install.yaml": installOpenshiftControllerManagerInstallYaml,
+	"install/openshift-web-console-operator/install-rbac.yaml": installOpenshiftWebConsoleOperatorInstallRbacYaml,
+	"install/openshift-web-console-operator/install.yaml": installOpenshiftWebConsoleOperatorInstallYaml,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
 	"install/origin-web-console/console-template.yaml": installOriginWebConsoleConsoleTemplateYaml,
 	"install/service-catalog-broker-resources/template-service-broker-registration.yaml": installServiceCatalogBrokerResourcesTemplateServiceBrokerRegistrationYaml,
@@ -32942,6 +33076,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 		"openshift-controller-manager": &bintree{nil, map[string]*bintree{
 			"install.yaml": &bintree{installOpenshiftControllerManagerInstallYaml, map[string]*bintree{}},
+		}},
+		"openshift-web-console-operator": &bintree{nil, map[string]*bintree{
+			"install-rbac.yaml": &bintree{installOpenshiftWebConsoleOperatorInstallRbacYaml, map[string]*bintree{}},
+			"install.yaml": &bintree{installOpenshiftWebConsoleOperatorInstallYaml, map[string]*bintree{}},
 		}},
 		"origin-web-console": &bintree{nil, map[string]*bintree{
 			"console-config.yaml": &bintree{installOriginWebConsoleConsoleConfigYaml, map[string]*bintree{}},


### PR DESCRIPTION
This adds a simple skeleton of a CRD driven controller that uses leader election and then wires it through `oc cluster add` for proof that it runs.  This is all boilerplate code.

/assign @soltysh 
/assign @mfojtik 

@openshift/sig-master 