### PR TITLE
Switch conformance tests to release-1.10

### DIFF
--- a/test/extended/conformance-k8s.sh
+++ b/test/extended/conformance-k8s.sh
@@ -43,7 +43,7 @@ To recreate these results
 Nightly conformance tests are run against release branches and reported https://openshift-gce-devel.appspot.com/builds/origin-ci-test/logs/test_branch_origin_extended_conformance_k8s/
 END
 
-version="${KUBERNETES_VERSION:-release-1.8}"
+version="${KUBERNETES_VERSION:-release-1.10}"
 kubernetes="${KUBERNETES_ROOT:-${OS_ROOT}/../../../k8s.io/kubernetes}"
 if [[ -d "${kubernetes}" ]]; then
   git fetch origin --tags


### PR DESCRIPTION
Should have been part of rebase, need to figure out how to make this obvious.