### PR TITLE
Update glide to use HTTPS instead of SSH for forks

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9d6b54e00b963bd054a285134fd1664d9832fc1315e92b928bb3db9e56ab78bd
-updated: 2018-04-09T11:30:42.785065601-04:00
+hash: 5368c1f7a27d6c64dc9da4b8515917874f617fb65be7b86fea959b8db47ec12f
+updated: 2018-04-17T10:03:57.349745-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -166,7 +166,7 @@ imports:
   - pkg/utils/hwaddr
 - name: github.com/containers/image
   version: 9dc3776eaea701cad0c09f04ec489c35a520e2b2
-  repo: git@github.com:openshift/containers-image
+  repo: https://github.com/openshift/containers-image
   subpackages:
   - docker
   - docker/policyconfiguration
@@ -306,7 +306,7 @@ imports:
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/distribution
   version: a8549110ba0fed84a3b91dc12c84457c775224f1
-  repo: git@github.com:openshift/docker-distribution
+  repo: https://github.com/openshift/docker-distribution
   subpackages:
   - context
   - digestset
@@ -326,7 +326,7 @@ imports:
   - uuid
 - name: github.com/docker/docker
   version: fcdab531a6d9b133eaa3f2a3f6c11fd02a97de75
-  repo: git@github.com:openshift/moby-moby
+  repo: https://github.com/openshift/moby-moby
   subpackages:
   - api
   - api/types
@@ -408,7 +408,7 @@ imports:
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/fsouza/go-dockerclient
   version: 7511300f03c521cfc8e07e88ea8c915add790f50
-  repo: git@github.com:openshift/go-dockerclient
+  repo: https://github.com/openshift/go-dockerclient
 - name: github.com/getsentry/raven-go
   version: 32a13797442ccb601b11761d74232773c1402d14
 - name: github.com/ghodss/yaml
@@ -502,7 +502,7 @@ imports:
   version: e89373fe6b4a7413d7acd6da1725b83ef713e6e4
 - name: github.com/google/cadvisor
   version: 2e02d28350c5fbbad9cfb7e5a1733468b75ab3f9
-  repo: git@github.com:openshift/google-cadvisor
+  repo: https://github.com/openshift/google-cadvisor
   subpackages:
   - accelerators
   - api
@@ -548,7 +548,7 @@ imports:
   - zfs
 - name: github.com/google/certificate-transparency
   version: f9b891ace55b3d45f6c40d313b3b7a5fc258f96b
-  repo: git@github.com:openshift/google-certificate-transparency
+  repo: https://github.com/openshift/google-certificate-transparency
   subpackages:
   - go
   - go/asn1
@@ -746,7 +746,7 @@ imports:
   version: 56545f4a5d46df9a6648819d1664c3a03a13ffdb
 - name: github.com/onsi/ginkgo
   version: 6e93088a6ab736ec6a12d10ef99962f8d9e435ee
-  repo: git@github.com:openshift/onsi-ginkgo
+  repo: https://github.com/openshift/onsi-ginkgo
   subpackages:
   - config
   - internal/codelocation
@@ -790,7 +790,7 @@ imports:
   - specs-go/v1
 - name: github.com/opencontainers/runc
   version: e356024f90bda9b7701fb80a11428fcc75185cf5
-  repo: git@github.com:openshift/opencontainers-runc
+  repo: https://github.com/openshift/opencontainers-runc
   subpackages:
   - libcontainer
   - libcontainer/apparmor
@@ -835,6 +835,7 @@ imports:
   - security/v1
   - template/v1
   - user/v1
+  - webconsole/v1
 - name: github.com/openshift/client-go
   version: b3f4c8b4682c151defdd33ce75acfbf5fb30bccc
   subpackages:
@@ -914,8 +915,10 @@ imports:
   - route/informers/externalversions/route/v1
   - route/listers/route/v1
   - security/clientset/versioned
+  - security/clientset/versioned/fake
   - security/clientset/versioned/scheme
   - security/clientset/versioned/typed/security/v1
+  - security/clientset/versioned/typed/security/v1/fake
   - security/informers/externalversions
   - security/informers/externalversions/internalinterfaces
   - security/informers/externalversions/security
@@ -1315,7 +1318,7 @@ imports:
   version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
   version: 73d903622b7391f3312dcbac6483fed484e185f8
-  repo: git@github.com:openshift/kubernetes-api
+  repo: https://github.com/openshift/kubernetes-api
   subpackages:
   - admission/v1beta1
   - admissionregistration/v1alpha1
@@ -1349,7 +1352,7 @@ imports:
   - storage/v1beta1
 - name: k8s.io/apiextensions-apiserver
   version: beccac1d4d580600fc916aed05c5a9cea7a3e0d8
-  repo: git@github.com:openshift/kubernetes-apiextensions-apiserver
+  repo: https://github.com/openshift/kubernetes-apiextensions-apiserver
   subpackages:
   - pkg/apis/apiextensions
   - pkg/apis/apiextensions/install
@@ -1382,8 +1385,8 @@ imports:
   - pkg/registry/customresourcedefinition
   - test/integration/testserver
 - name: k8s.io/apimachinery
-  version: b97cf8c83d11530d075ba4e5d531ef03bd42496f
-  repo: git@github.com:openshift/kubernetes-apimachinery
+  version: d9f2381c8e7aeae6fbfed4b416470eb4df5562f7
+  repo: https://github.com/openshift/kubernetes-apimachinery
   subpackages:
   - pkg/api/equality
   - pkg/api/errors
@@ -1451,7 +1454,7 @@ imports:
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
   version: 663bcc4caab0f1391a0086ff9a91afe52bca9b13
-  repo: git@github.com:openshift/kubernetes-apiserver
+  repo: https://github.com/openshift/kubernetes-apiserver
   subpackages:
   - pkg/admission
   - pkg/admission/configuration
@@ -1561,8 +1564,8 @@ imports:
   - plugin/pkg/authenticator/token/webhook
   - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
-  version: 89a57e0dbb9df369bcf272370cd350ab65f5b8c0
-  repo: git@github.com:openshift/kubernetes-client-go
+  version: 02a694aa912314cd4288c176a39b888888ad6765
+  repo: https://github.com/openshift/kubernetes-client-go
   subpackages:
   - discovery
   - discovery/cached
@@ -1704,6 +1707,7 @@ imports:
   - rest/fake
   - rest/watch
   - scale
+  - scale/fake
   - scale/scheme
   - scale/scheme/appsint
   - scale/scheme/appsv1beta1
@@ -1744,7 +1748,7 @@ imports:
   - util/workqueue
 - name: k8s.io/code-generator
   version: c65da8a8ad6dd88d0651d59ed0fecd30124f28a4
-  repo: git@github.com:openshift/kubernetes-code-generator
+  repo: https://github.com/openshift/kubernetes-code-generator
 - name: k8s.io/gengo
   version: 01a732e01d00cb9a81bb0ca050d3e6d2b947927b
 - name: k8s.io/heapster
@@ -1753,7 +1757,7 @@ imports:
   - metrics/api/v1/types
 - name: k8s.io/kube-aggregator
   version: 7c941b8dfe9c0ccf82ce9e09ec296b85b15892d9
-  repo: git@github.com:openshift/kube-aggregator
+  repo: https://github.com/openshift/kube-aggregator
   subpackages:
   - pkg/apis/apiregistration
   - pkg/apis/apiregistration/install
@@ -1792,8 +1796,8 @@ imports:
   - pkg/util/proto
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: d0746cd474201890c12f8a906085394451952df6
-  repo: git@github.com:openshift/kubernetes
+  version: 4b6cb539104d70486c9eee6afa7a2f26d07c4b5a
+  repo: https://github.com/openshift/kubernetes
   subpackages:
   - cmd/controller-manager/app
   - cmd/controller-manager/app/options
@@ -2109,6 +2113,7 @@ imports:
   - pkg/kubectl/cmd/config
   - pkg/kubectl/cmd/resource
   - pkg/kubectl/cmd/rollout
+  - pkg/kubectl/cmd/scalejob
   - pkg/kubectl/cmd/set
   - pkg/kubectl/cmd/templates
   - pkg/kubectl/cmd/util
@@ -2543,6 +2548,7 @@ imports:
   - plugin/pkg/auth/authorizer/rbac/bootstrappolicy
   - staging/src/k8s.io/apimachinery/pkg/labels
   - staging/src/k8s.io/apimachinery/pkg/util/diff
+  - staging/src/k8s.io/apimachinery/pkg/util/wait
   - test/e2e
   - test/e2e/common
   - test/e2e/framework
@@ -2561,7 +2567,7 @@ imports:
   - third_party/forked/gonum/graph/traverse
 - name: k8s.io/metrics
   version: 189abc117eb81f7d175c212fdb09e334e10a7182
-  repo: git@github.com:openshift/kubernetes-metrics
+  repo: https://github.com/openshift/kubernetes-metrics
   subpackages:
   - pkg/apis/custom_metrics
   - pkg/apis/custom_metrics/v1beta1

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,31 +9,31 @@ import:
 - package: k8s.io/kube-openapi
   version: 50ae88d24ede7b8bad68e23c805b5d3da5c8abaf
 - package: k8s.io/code-generator
-  repo:    git@github.com:openshift/kubernetes-code-generator
+  repo:    https://github.com/openshift/kubernetes-code-generator
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/apimachinery
-  repo:    git@github.com:openshift/kubernetes-apimachinery
+  repo:    https://github.com/openshift/kubernetes-apimachinery
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/api
-  repo:    git@github.com:openshift/kubernetes-api
+  repo:    https://github.com/openshift/kubernetes-api
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/client-go
-  repo:    git@github.com:openshift/kubernetes-client-go
+  repo:    https://github.com/openshift/kubernetes-client-go
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/metrics
-  repo:    git@github.com:openshift/kubernetes-metrics
+  repo:    https://github.com/openshift/kubernetes-metrics
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/apiserver
-  repo:    git@github.com:openshift/kubernetes-apiserver
+  repo:    https://github.com/openshift/kubernetes-apiserver
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/kube-aggregator
-  repo:    git@github.com:openshift/kube-aggregator
+  repo:    https://github.com/openshift/kube-aggregator
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/apiextensions-apiserver
-  repo:    git@github.com:openshift/kubernetes-apiextensions-apiserver
+  repo:    https://github.com/openshift/kubernetes-apiextensions-apiserver
   version: origin-3.10-kubernetes-1.10.0
 - package: k8s.io/kubernetes
-  repo:    git@github.com:openshift/kubernetes
+  repo:    https://github.com/openshift/kubernetes
   version: origin-3.10-kubernetes-1.10.0
 
 # openshift second
@@ -47,7 +47,7 @@ import:
 # forks third
 # master
 - package: github.com/google/certificate-transparency
-  repo:    git@github.com:openshift/google-certificate-transparency
+  repo:    https://github.com/openshift/google-certificate-transparency
   version: master
 # master
 - package: github.com/emicklei/go-restful-swagger12
@@ -63,26 +63,26 @@ import:
   version: release-2.5.3a
 # master
 - package: github.com/onsi/ginkgo
-  repo:    git@github.com:openshift/onsi-ginkgo
+  repo:    https://github.com/openshift/onsi-ginkgo
   version: release-v1.2.0
 - package: github.com/containers/image
-  repo:    git@github.com:openshift/containers-image
+  repo:    https://github.com/openshift/containers-image
   version: openshift-3.8
 # pod - sjenning
 - package: github.com/opencontainers/runc
-  repo:    git@github.com:openshift/opencontainers-runc
+  repo:    https://github.com/openshift/opencontainers-runc
   version: openshift-3.10-runc-595bea0
 # pod - sjenning
 - package: github.com/google/cadvisor
-  repo:    git@github.com:openshift/google-cadvisor
+  repo:    https://github.com/openshift/google-cadvisor
   version: openshift-3.10-cadvisor-v0.29.1
 # cli
 - package: github.com/docker/distribution
-  repo:    git@github.com:openshift/docker-distribution
+  repo:    https://github.com/openshift/docker-distribution
   version: openshift-3.10-docker-edc3ab2
 # close-write carry
 - package: github.com/docker/docker
-  repo:    git@github.com:openshift/moby-moby
+  repo:    https://github.com/openshift/moby-moby
   version: openshift-3.10-docker-b68221c
 
 # ours: shared with kube, but forced by openshift
@@ -135,7 +135,7 @@ import:
   version: ~0.6.0
 # builds
 - package: github.com/fsouza/go-dockerclient
-  repo:    git@github.com:openshift/go-dockerclient
+  repo:    https://github.com/openshift/go-dockerclient
   version: openshift-3.9
 # auth (for testing)
 - package: github.com/vjeantet/ldapserver


### PR DESCRIPTION
Addresses issues using SSH for cloning Github repos with Glide.