### PR TITLE
switch the sdn to use external types

### DIFF
--- a/pkg/cmd/openshift-controller-manager/controller/interfaces.go
+++ b/pkg/cmd/openshift-controller-manager/controller/interfaces.go
@@ -9,7 +9,6 @@ import (
 	kexternalinformers "k8s.io/client-go/informers"
 	controllerapp "k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/controller"
 
 	routeinformer "github.com/openshift/client-go/route/informers/externalversions"
@@ -40,7 +39,6 @@ type ControllerContext struct {
 	ClientBuilder ControllerClientBuilder
 
 	ExternalKubeInformers   kexternalinformers.SharedInformerFactory
-	InternalKubeInformers   kinternalinformers.SharedInformerFactory
 	AppInformers            appinformer.SharedInformerFactory
 	BuildInformers          buildinformer.SharedInformerFactory
 	ImageInformers          imageinformer.SharedInformerFactory

--- a/pkg/cmd/openshift-controller-manager/controller/network_sdn.go
+++ b/pkg/cmd/openshift-controller-manager/controller/network_sdn.go
@@ -21,8 +21,8 @@ func (c *SDNControllerConfig) RunController(ctx ControllerContext) (bool, error)
 	if err := sdnmaster.Start(
 		c.NetworkConfig,
 		ctx.ClientBuilder.OpenshiftInternalNetworkClientOrDie(bootstrappolicy.InfraSDNControllerServiceAccountName),
-		ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraSDNControllerServiceAccountName),
-		ctx.InternalKubeInformers,
+		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraSDNControllerServiceAccountName),
+		ctx.ExternalKubeInformers,
 		ctx.NetworkInformers,
 	); err != nil {
 		return false, fmt.Errorf("failed to start SDN plugin controller: %v", err)

--- a/pkg/cmd/openshift-controller-manager/controller_manager.go
+++ b/pkg/cmd/openshift-controller-manager/controller_manager.go
@@ -161,7 +161,6 @@ func newControllerContext(
 				Namespace:            bootstrappolicy.DefaultOpenShiftInfraNamespace,
 			},
 		},
-		InternalKubeInformers:   informers.GetInternalKubeInformers(),
 		ExternalKubeInformers:   informers.GetExternalKubeInformers(),
 		AppInformers:            informers.GetAppInformers(),
 		AuthorizationInformers:  informers.GetAuthorizationInformers(),

--- a/pkg/cmd/server/origin/admission/plugin_initializer.go
+++ b/pkg/cmd/server/origin/admission/plugin_initializer.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/client-go/discovery"
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
 	kexternalinformers "k8s.io/client-go/informers"
-	kubeclientgoinformers "k8s.io/client-go/informers"
 	kubeclientgoclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
@@ -52,7 +51,6 @@ import (
 type InformerAccess interface {
 	GetInternalKubeInformers() kinternalinformers.SharedInformerFactory
 	GetExternalKubeInformers() kexternalinformers.SharedInformerFactory
-	GetClientGoKubeInformers() kubeclientgoinformers.SharedInformerFactory
 	GetImageInformers() imageinformer.SharedInformerFactory
 	GetQuotaInformers() quotainformer.SharedInformerFactory
 	GetSecurityInformers() securityinformer.SharedInformerFactory
@@ -139,7 +137,7 @@ func NewPluginInitializer(
 	// note: we are passing a combined quota registry here...
 	genericInitializer := initializer.New(
 		kubeClientGoClientSet,
-		informers.GetClientGoKubeInformers(),
+		informers.GetExternalKubeInformers(),
 		authorizer,
 		legacyscheme.Scheme,
 	)
@@ -169,7 +167,7 @@ func NewPluginInitializer(
 
 	webhookInitializer := webhookinitializer.NewPluginInitializer(
 		webhookAuthResolverWrapper,
-		aggregatorapiserver.NewClusterIPServiceResolver(informers.GetClientGoKubeInformers().Core().V1().Services().Lister()),
+		aggregatorapiserver.NewClusterIPServiceResolver(informers.GetExternalKubeInformers().Core().V1().Services().Lister()),
 	)
 
 	openshiftPluginInitializer := &oadmission.PluginInitializer{

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -106,7 +106,6 @@ type MasterConfig struct {
 type InformerAccess interface {
 	GetInternalKubeInformers() kinternalinformers.SharedInformerFactory
 	GetExternalKubeInformers() kinformers.SharedInformerFactory
-	GetClientGoKubeInformers() kubeclientgoinformers.SharedInformerFactory
 	GetAppInformers() appinformer.SharedInformerFactory
 	GetAuthorizationInformers() authorizationinformer.SharedInformerFactory
 	GetBuildInformers() buildinformer.SharedInformerFactory
@@ -228,7 +227,7 @@ func BuildMasterConfig(
 		PrivilegedLoopbackKubernetesClientsetExternal: privilegedLoopbackKubeClientsetExternal,
 
 		InternalKubeInformers:  informers.GetInternalKubeInformers(),
-		ClientGoKubeInformers:  informers.GetClientGoKubeInformers(),
+		ClientGoKubeInformers:  informers.GetExternalKubeInformers(),
 		AuthorizationInformers: informers.GetAuthorizationInformers(),
 		QuotaInformers:         informers.GetQuotaInformers(),
 		SecurityInformers:      informers.GetSecurityInformers(),

--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	kapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
@@ -124,7 +124,7 @@ func (ni *NetworkInfo) CheckClusterObjects(subnets []networkapi.HostSubnet, pods
 		}
 	}
 	for _, pod := range pods {
-		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.HostNetwork {
+		if pod.Spec.HostNetwork {
 			continue
 		}
 		if _, contains := ClusterNetworkListContains(ni.ClusterNetworks, net.ParseIP(pod.Status.PodIP)); !contains && pod.Status.PodIP != "" {

--- a/pkg/network/common/common_test.go
+++ b/pkg/network/common/common_test.go
@@ -7,8 +7,8 @@ import (
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 
+	kapi "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 )
 
 func mustParseCIDR(cidr string) *net.IPNet {

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -6,16 +6,16 @@ import (
 
 	"github.com/golang/glog"
 
+	kapi "k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	kcoreinformers "k8s.io/client-go/informers/core/v1"
+	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
-	kcoreinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/core/internalversion"
 
 	osconfigapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/network"
@@ -53,7 +53,7 @@ type OsdnMaster struct {
 }
 
 func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkclient.Interface,
-	kClient kclientset.Interface, kubeInformers kinternalinformers.SharedInformerFactory,
+	kClient kclientset.Interface, kubeInformers informers.SharedInformerFactory,
 	networkInformers networkinternalinformers.SharedInformerFactory) error {
 	glog.Infof("Initializing SDN master of type %q", networkConfig.NetworkPluginName)
 
@@ -61,8 +61,8 @@ func Start(networkConfig osconfigapi.MasterNetworkConfig, networkClient networkc
 		kClient:       kClient,
 		networkClient: networkClient,
 
-		nodeInformer:         kubeInformers.Core().InternalVersion().Nodes(),
-		namespaceInformer:    kubeInformers.Core().InternalVersion().Namespaces(),
+		nodeInformer:         kubeInformers.Core().V1().Nodes(),
+		namespaceInformer:    kubeInformers.Core().V1().Namespaces(),
 		hostSubnetInformer:   networkInformers.Network().InternalVersion().HostSubnets(),
 		netNamespaceInformer: networkInformers.Network().InternalVersion().NetNamespaces(),
 

--- a/pkg/network/master/subnets.go
+++ b/pkg/network/master/subnets.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/golang/glog"
 
+	kapi "k8s.io/api/core/v1"
 	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	"github.com/openshift/origin/pkg/network"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"

--- a/pkg/network/master/vnids.go
+++ b/pkg/network/master/vnids.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/golang/glog"
 
+	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	"github.com/openshift/origin/pkg/network"
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -172,7 +172,6 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (buildtypedc
 			},
 		},
 		ExternalKubeInformers: informers.GetExternalKubeInformers(),
-		InternalKubeInformers: informers.GetInternalKubeInformers(),
 		AppInformers:          informers.GetAppInformers(),
 		BuildInformers:        informers.GetBuildInformers(),
 		ImageInformers:        informers.GetImageInformers(),


### PR DESCRIPTION
This eliminate the only use of the internal kube client and types we have in the openshift-controllers. We need to remove the dependency for ease of maintenance.

@openshift/sig-master 
@openshift/sig-networking 