### PR TITLE
Handle project existence in cluster-loader

### DIFF
--- a/test/extended/cluster/context.go
+++ b/test/extended/cluster/context.go
@@ -8,6 +8,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	IF_EXISTS_DELETE = "delete"
+	IF_EXISTS_REUSE  = "reuse"
+)
+
 // ContextType is the root config struct
 type ContextType struct {
 	ClusterLoader struct {
@@ -22,6 +27,7 @@ type ContextType struct {
 type ClusterLoaderType struct {
 	Number     int `mapstructure:"num" yaml:"num"`
 	Basename   string
+	IfExists   string                    `json:"ifexists"`
 	Labels     map[string]string         `yaml:",omitempty"`
 	Tuning     string                    `yaml:",omitempty"`
 	Configmaps map[string]interface{}    `yaml:",omitempty"`


### PR DESCRIPTION
This function is defined in the python version [1]. We implement
it with the following modifications:

ifexists: parameter accepts values : reuse/delete. This specifies
the action to take if a namespace/project already exists. This
field is *mandatory*.

* reuse: Reuse the existing project and create all the specified
  objects under it. If the projects do not exist, an error will
  be raised.
* delete: If exists, delete the project and proceed.

[1]. https://github.com/openshift/svt/blob/master/openshift_scalability/README.md