### PR TITLE
cleanup launch of openshift controller client

### DIFF
--- a/pkg/cmd/openshift-apiserver/server.go
+++ b/pkg/cmd/openshift-apiserver/server.go
@@ -38,7 +38,11 @@ func RunOpenShiftAPIServer(masterConfig *configapi.MasterConfig) error {
 
 	// informers are shared amongst all the various api components we build
 	// TODO the needs of the apiserver and the controllers are drifting. We should consider two different skins here
-	informers, err := origin.NewInformers(*masterConfig)
+	clientConfig, err := configapi.GetClientConfig(masterConfig.MasterClients.OpenShiftLoopbackKubeConfig, masterConfig.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+	if err != nil {
+		return err
+	}
+	informers, err := origin.NewInformers(clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift-controller-manager/controller/config.go
+++ b/pkg/cmd/openshift-controller-manager/controller/config.go
@@ -38,7 +38,7 @@ func envVars(host string, caData []byte, insecure bool, bearerTokenFile string) 
 }
 
 func getOpenShiftClientEnvVars(options configapi.MasterConfig) ([]kapi.EnvVar, error) {
-	_, kclientConfig, err := configapi.GetInternalKubeClient(
+	clientConfig, err := configapi.GetClientConfig(
 		options.MasterClients.OpenShiftLoopbackKubeConfig,
 		options.MasterClients.OpenShiftLoopbackClientConnectionOverrides,
 	)
@@ -46,9 +46,9 @@ func getOpenShiftClientEnvVars(options configapi.MasterConfig) ([]kapi.EnvVar, e
 		return nil, err
 	}
 	return envVars(
-		kclientConfig.Host,
-		kclientConfig.CAData,
-		kclientConfig.Insecure,
+		clientConfig.Host,
+		clientConfig.CAData,
+		clientConfig.Insecure,
 		path.Join(serviceaccountadmission.DefaultAPITokenMountPath, kapi.ServiceAccountTokenKey),
 	), nil
 }

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -45,7 +45,11 @@ func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error
 
 	// informers are shared amongst all the various api components we build
 	// TODO the needs of the apiserver and the controllers are drifting. We should consider two different skins here
-	informers, err := origin.NewInformers(*masterConfig)
+	clientConfig, err := configapi.GetClientConfig(masterConfig.MasterClients.OpenShiftLoopbackKubeConfig, masterConfig.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+	if err != nil {
+		return err
+	}
+	informers, err := origin.NewInformers(clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/kubernetes/node/options/options.go
+++ b/pkg/cmd/server/kubernetes/node/options/options.go
@@ -121,9 +121,12 @@ func ComputeKubeletFlags(startingArgs map[string][]string, options configapi.Nod
 	// TODO: this exists to support legacy cases where the node defaulted to the master's DNS.
 	//   we can remove this when we drop support for master DNS when CoreDNS is in use everywhere.
 	if len(args["cluster-dns"]) == 0 {
-		if externalKubeClient, _, err := configapi.GetExternalKubeClient(options.MasterKubeConfig, options.MasterClientConnectionOverrides); err == nil {
-			args["cluster-dns"] = getClusterDNS(externalKubeClient, args["cluster-dns"])
+		if clientConfig, err := configapi.GetClientConfig(options.MasterKubeConfig, options.MasterClientConnectionOverrides); err == nil {
+			if externalKubeClient, err := kclientsetexternal.NewForConfig(clientConfig); err == nil {
+				args["cluster-dns"] = getClusterDNS(externalKubeClient, args["cluster-dns"])
+			}
 		}
+
 	}
 
 	// there is a special case.  If you set `--cgroups-per-qos=false` and `--enforce-node-allocatable` is

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -133,11 +133,15 @@ func BuildMasterConfig(
 		return nil, err
 	}
 
-	kubeInternalClient, _, err := configapi.GetInternalKubeClient(options.MasterClients.OpenShiftLoopbackKubeConfig, options.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+	privilegedLoopbackConfig, err := configapi.GetClientConfig(options.MasterClients.OpenShiftLoopbackKubeConfig, options.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
 	if err != nil {
 		return nil, err
 	}
-	privilegedLoopbackKubeClientsetExternal, privilegedLoopbackConfig, err := configapi.GetExternalKubeClient(options.MasterClients.OpenShiftLoopbackKubeConfig, options.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+	kubeInternalClient, err := kclientsetinternal.NewForConfig(privilegedLoopbackConfig)
+	if err != nil {
+		return nil, err
+	}
+	privilegedLoopbackKubeClientsetExternal, err := kclientsetexternal.NewForConfig(privilegedLoopbackConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -355,7 +355,7 @@ func (m *Master) Start() error {
 
 	controllersEnabled := m.controllers && len(m.config.ControllerConfig.Controllers) > 0
 	if controllersEnabled {
-		_, privilegedLoopbackConfig, err := configapi.GetExternalKubeClient(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+		privilegedLoopbackConfig, err := configapi.GetClientConfig(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
 		if err != nil {
 			return err
 		}
@@ -426,7 +426,11 @@ func (m *Master) Start() error {
 	if m.api {
 		// informers are shared amongst all the various api components we build
 		// TODO the needs of the apiserver and the controllers are drifting. We should consider two different skins here
-		informers, err := origin.NewInformers(*m.config)
+		clientConfig, err := configapi.GetClientConfig(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+		if err != nil {
+			return err
+		}
+		informers, err := origin.NewInformers(clientConfig)
 		if err != nil {
 			return err
 		}

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -137,7 +137,7 @@ func TSBClient(oc *exutil.CLI) (osbclient.Client, error) {
 
 func dumpObjectReadiness(oc *exutil.CLI, templateInstance *templateapi.TemplateInstance) error {
 	restmapper := restutil.DefaultMultiRESTMapper()
-	_, config, err := configapi.GetInternalKubeClient(exutil.KubeConfigPath(), nil)
+	config, err := configapi.GetClientConfig(exutil.KubeConfigPath(), nil)
 	if err != nil {
 		return err
 	}

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -292,7 +292,7 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 
 		restmapper := restutil.DefaultMultiRESTMapper()
 
-		_, config, err := configapi.GetInternalKubeClient(exutil.KubeConfigPath(), nil)
+		config, err := configapi.GetClientConfig(exutil.KubeConfigPath(), nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// check the namespace is empty

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -196,7 +196,10 @@ func (c *CLI) Verbose() *CLI {
 }
 
 func (c *CLI) AppsClient() appsclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := appsclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -205,7 +208,10 @@ func (c *CLI) AppsClient() appsclientset.Interface {
 }
 
 func (c *CLI) AuthorizationClient() authorizationclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := authorizationclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -214,7 +220,10 @@ func (c *CLI) AuthorizationClient() authorizationclientset.Interface {
 }
 
 func (c *CLI) BuildClient() buildclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := buildclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -223,7 +232,10 @@ func (c *CLI) BuildClient() buildclientset.Interface {
 }
 
 func (c *CLI) ImageClient() imageclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := imageclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -232,7 +244,10 @@ func (c *CLI) ImageClient() imageclientset.Interface {
 }
 
 func (c *CLI) ProjectClient() projectclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := projectclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -241,7 +256,10 @@ func (c *CLI) ProjectClient() projectclientset.Interface {
 }
 
 func (c *CLI) RouteClient() routeclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := routeclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -252,7 +270,10 @@ func (c *CLI) RouteClient() routeclientset.Interface {
 // Client provides an OpenShift client for the current user. If the user is not
 // set, then it provides client for the cluster admin user
 func (c *CLI) TemplateClient() templateclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := templateclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -261,7 +282,10 @@ func (c *CLI) TemplateClient() templateclientset.Interface {
 }
 
 func (c *CLI) UserClient() userclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := userclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -270,7 +294,10 @@ func (c *CLI) UserClient() userclientset.Interface {
 }
 
 func (c *CLI) AdminAppsClient() appsclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := appsclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -279,7 +306,10 @@ func (c *CLI) AdminAppsClient() appsclientset.Interface {
 }
 
 func (c *CLI) AdminAuthorizationClient() authorizationclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := authorizationclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -288,7 +318,10 @@ func (c *CLI) AdminAuthorizationClient() authorizationclientset.Interface {
 }
 
 func (c *CLI) AdminBuildClient() buildclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := buildclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -297,7 +330,10 @@ func (c *CLI) AdminBuildClient() buildclientset.Interface {
 }
 
 func (c *CLI) AdminImageClient() imageclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := imageclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -306,7 +342,10 @@ func (c *CLI) AdminImageClient() imageclientset.Interface {
 }
 
 func (c *CLI) AdminProjectClient() projectclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := projectclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -315,7 +354,10 @@ func (c *CLI) AdminProjectClient() projectclientset.Interface {
 }
 
 func (c *CLI) AdminRouteClient() routeclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := routeclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -325,7 +367,10 @@ func (c *CLI) AdminRouteClient() routeclientset.Interface {
 
 // AdminClient provides an OpenShift client for the cluster admin user.
 func (c *CLI) AdminTemplateClient() templateclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := templateclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -334,7 +379,10 @@ func (c *CLI) AdminTemplateClient() templateclientset.Interface {
 }
 
 func (c *CLI) AdminUserClient() userclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := userclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -343,7 +391,10 @@ func (c *CLI) AdminUserClient() userclientset.Interface {
 }
 
 func (c *CLI) AdminSecurityClient() securityclientset.Interface {
-	_, clientConfig, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
+	if err != nil {
+		FatalErr(err)
+	}
 	client, err := securityclientset.NewForConfig(clientConfig)
 	if err != nil {
 		FatalErr(err)
@@ -353,42 +404,34 @@ func (c *CLI) AdminSecurityClient() securityclientset.Interface {
 
 // KubeClient provides a Kubernetes client for the current namespace
 func (c *CLI) KubeClient() kclientset.Interface {
-	kubeClient, _, err := configapi.GetExternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
 	if err != nil {
 		FatalErr(err)
 	}
-	return kubeClient
+	return kclientset.NewForConfigOrDie(clientConfig)
 }
 
 // KubeClient provides a Kubernetes client for the current namespace
 func (c *CLI) InternalKubeClient() kinternalclientset.Interface {
-	kubeClient, _, err := configapi.GetInternalKubeClient(c.configPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.configPath, nil)
 	if err != nil {
 		FatalErr(err)
 	}
-	return kubeClient
+	return kinternalclientset.NewForConfigOrDie(clientConfig)
 }
 
 // AdminKubeClient provides a Kubernetes client for the cluster admin user.
 func (c *CLI) AdminKubeClient() kclientset.Interface {
-	kubeClient, _, err := configapi.GetExternalKubeClient(c.adminConfigPath, nil)
-	if err != nil {
-		FatalErr(err)
-	}
-	return kubeClient
+	return kclientset.NewForConfigOrDie(c.AdminConfig())
 }
 
 // AdminKubeClient provides a Kubernetes client for the cluster admin user.
 func (c *CLI) InternalAdminKubeClient() kinternalclientset.Interface {
-	kubeClient, _, err := configapi.GetInternalKubeClient(c.adminConfigPath, nil)
-	if err != nil {
-		FatalErr(err)
-	}
-	return kubeClient
+	return kinternalclientset.NewForConfigOrDie(c.AdminConfig())
 }
 
 func (c *CLI) AdminConfig() *restclient.Config {
-	_, clientConfig, err := configapi.GetExternalKubeClient(c.adminConfigPath, nil)
+	clientConfig, err := configapi.GetClientConfig(c.adminConfigPath, nil)
 	if err != nil {
 		FatalErr(err)
 	}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -110,7 +110,7 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (buildtypedc
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	informers, err := origin.NewInformers(*master)
+	informers, err := origin.NewInformers(clusterAdminClientConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/ingressip_test.go
+++ b/test/integration/ingressip_test.go
@@ -36,13 +36,14 @@ func TestIngressIPAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	kc, _, err := configapi.GetExternalKubeClient(clusterAdminKubeConfig, &configapi.ClientConnectionOverrides{
+	clientConfig, err := configapi.GetClientConfig(clusterAdminKubeConfig, &configapi.ClientConnectionOverrides{
 		QPS:   20,
 		Burst: 50,
 	})
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatal(err)
 	}
+	kc := kclientset.NewForConfigOrDie(clientConfig)
 
 	stopChannel := make(chan struct{})
 	defer close(stopChannel)

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -40,19 +40,16 @@ func KubeConfigPath() string {
 }
 
 func GetClusterAdminKubeClient(adminKubeConfigFile string) (kclientset.Interface, error) {
-	c, _, err := configapi.GetInternalKubeClient(adminKubeConfigFile, nil)
+	clientConfig, err := GetClusterAdminClientConfig(adminKubeConfigFile)
 	if err != nil {
 		return nil, err
 	}
-	return c, nil
+
+	return kclientset.NewForConfig(clientConfig)
 }
 
 func GetClusterAdminClientConfig(adminKubeConfigFile string) (*restclient.Config, error) {
-	_, conf, err := configapi.GetInternalKubeClient(adminKubeConfigFile, nil)
-	if err != nil {
-		return nil, err
-	}
-	return conf, nil
+	return configapi.GetClientConfig(adminKubeConfigFile, nil)
 }
 
 // GetClusterAdminClientConfigOrDie returns a REST config for the cluster admin


### PR DESCRIPTION
This pull cleans up a lot of initial client creation so that we can unwind the controller config.  Don't worry, it'll make sense.  This is the non-contentious bit that slims down various helpers and move dependencies closer to the point of use.

@openshift/sig-master 