### PR TITLE
improving probe defaults in the NodeJS+MongoDB example #19379

### DIFF
--- a/examples/quickstarts/nodejs-mongodb-persistent.json
+++ b/examples/quickstarts/nodejs-mongodb-persistent.json
@@ -213,7 +213,7 @@
                                 "image": " ",
                                 "livenessProbe": {
                                     "httpGet": {
-                                        "path": "/pagecount",
+                                        "path": "/",
                                         "port": 8080
                                     },
                                     "initialDelaySeconds": 30,
@@ -227,7 +227,7 @@
                                 ],
                                 "readinessProbe": {
                                     "httpGet": {
-                                        "path": "/pagecount",
+                                        "path": "/",
                                         "port": 8080
                                     },
                                     "initialDelaySeconds": 3,

--- a/examples/quickstarts/nodejs-mongodb.json
+++ b/examples/quickstarts/nodejs-mongodb.json
@@ -214,7 +214,7 @@
                                 "image": " ",
                                 "livenessProbe": {
                                     "httpGet": {
-                                        "path": "/pagecount",
+                                        "path": "/",
                                         "port": 8080
                                     },
                                     "initialDelaySeconds": 30,
@@ -228,7 +228,7 @@
                                 ],
                                 "readinessProbe": {
                                     "httpGet": {
-                                        "path": "/pagecount",
+                                        "path": "/",
                                         "port": 8080
                                     },
                                     "initialDelaySeconds": 3,


### PR DESCRIPTION
Allow for user customization of the SOURCE_REPOSITORY_URL input (without breaking the existing example)