### PR TITLE
Ensure /tmp does not write to container

### DIFF
--- a/examples/jenkins/jenkins-persistent-template.json
+++ b/examples/jenkins/jenkins-persistent-template.json
@@ -150,6 +150,10 @@
                                     {
                                         "mountPath": "/var/lib/jenkins",
                                         "name": "${JENKINS_SERVICE_NAME}-data"
+                                    },
+                                    {
+                                        "mountPath": "/tmp",
+                                        "name": "temp-dir"
                                     }
                                 ]
                             }
@@ -163,6 +167,10 @@
                                 "persistentVolumeClaim": {
                                     "claimName": "${JENKINS_SERVICE_NAME}"
                                 }
+                            },
+                            {
+                                "name": "temp-dir",
+                                "emptyDir": {}
                             }
                         ]
                     }


### PR DESCRIPTION
Jenkins monitors free temp space for the master build executor, the free disk space threshold is normally set to 1GB.  If you're running docker on devicemapper-lvm then the amount of disk space allocated to / inside the container can be quite low, sometimes less than 1GB, meaning that jenkins fails to operate.

By mounting `/tmp` to `emptyDir: {}`, then it'll use the node filesystem which is much more likely to have a decent amount of free space.