### PR TITLE
up: validate usage of enable on initialized cluster

### DIFF
--- a/pkg/oc/bootstrap/docker/errors/docker.go
+++ b/pkg/oc/bootstrap/docker/errors/docker.go
@@ -32,17 +32,11 @@ const (
 Please install Docker tools by following instructions at:
 
    https://docs.docker.com/mac/
-
-Once installed, run this command with the --create-machine
-argument to create a new Docker machine that will run OpenShift.
 `
 	NoDockerWindowsSolution = `
 Please install Docker tools by following instructions at:
 
    https://docs.docker.com/windows/
-
-Once installed, run this command with the --create-machine argument to create a
-new Docker machine that will run OpenShift.
 `
 	NoDockerLinuxSolution = `
 Ensure that Docker is installed and accessible in your environment.

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -269,6 +269,14 @@ func (c *ClusterUpConfig) Complete(cmd *cobra.Command, out io.Writer) error {
 		c.BaseDir = absHostDir
 	}
 
+	// Check if users are not trying to re-run cluster up on existing configuration
+	// but with different components enabled.
+	if !sets.NewString(c.UserEnabledComponents...).Equal(sets.NewString("*")) {
+		if _, err := os.Stat(filepath.Join(c.BaseDir, "etcd")); err == nil {
+			return fmt.Errorf("cannot use --enable when the cluster is already initialized, use cluster add instead")
+		}
+	}
+
 	for _, currComponent := range knownComponents.UnsortedList() {
 		if isComponentEnabled(currComponent, componentsDisabledByDefault, c.UserEnabledComponents...) {
 			c.ComponentsToEnable = append(c.ComponentsToEnable, currComponent)
@@ -398,11 +406,6 @@ func (c *ClusterUpConfig) Complete(cmd *cobra.Command, out io.Writer) error {
 func (c *ClusterUpConfig) Validate(errout io.Writer) error {
 	if c.dockerClient == nil {
 		return fmt.Errorf("missing dockerClient")
-	}
-	if !sets.NewString(c.UserEnabledComponents...).Equal(sets.NewString("*")) {
-		if _, err := os.Stat(filepath.Join(c.BaseDir, "etcd")); err == nil {
-			return fmt.Errorf("cannot use --enable when the cluster is already initialized, use cluster add instead")
-		}
 	}
 	cmdutil.WarnAboutCommaSeparation(errout, c.Environment, "--env")
 	return nil

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -399,6 +399,11 @@ func (c *ClusterUpConfig) Validate(errout io.Writer) error {
 	if c.dockerClient == nil {
 		return fmt.Errorf("missing dockerClient")
 	}
+	if !sets.NewString(c.UserEnabledComponents...).Equal(sets.NewString("*")) {
+		if _, err := os.Stat(filepath.Join(c.BaseDir, "etcd")); err == nil {
+			return fmt.Errorf("cannot use --enable when the cluster is already initialized, use cluster add instead")
+		}
+	}
 	cmdutil.WarnAboutCommaSeparation(errout, c.Environment, "--env")
 	return nil
 }

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -173,6 +173,14 @@ function os::test::extended::clusterup::noargs () {
       ${@}
 }
 
+# Test the usage of --enable flag
+function os::test::extended::clusterup::enable () {
+    local base_dir
+    base_dir=$(os::test::extended::clusterup::make_base_dir "enable")
+    os::cmd::expect_success "oc cluster up --loglevel=5 --base-dir=${base_dir} --tag=${ORIGIN_COMMIT} --enable=* --write-config"
+    os::cmd::expect_failure_and_text "oc cluster up --loglevel=5 --base-dir=${base_dir} --tag=${ORIGIN_COMMIT} --enable=foo" 'use cluster add instead'
+}
+
 # Tests creating a cluster with specific host directories
 function os::test::extended::clusterup::hostdirs () {
     local base_dir


### PR DESCRIPTION
When the cluster is already initialized in baseDir, we should not allow to specify `--enable` flag but users should use oc cluster add instead.

/cc @deads2k 