### PR TITLE
Remove duplicate WantsAuthorizer interface

### DIFF
--- a/pkg/cmd/openshift-controller-manager/controller/build.go
+++ b/pkg/cmd/openshift-controller-manager/controller/build.go
@@ -10,7 +10,6 @@ import (
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	sccadmission "github.com/openshift/origin/pkg/security/admission"
 )
 
 type BuildControllerConfig struct {
@@ -23,13 +22,6 @@ type BuildControllerConfig struct {
 
 // RunController starts the build sync loop for builds and buildConfig processing.
 func (c *BuildControllerConfig) RunController(ctx ControllerContext) (bool, error) {
-	sccAdmission := sccadmission.NewConstraint()
-	sccAdmission.SetSecurityInformers(ctx.SecurityInformers)
-	sccAdmission.SetInternalKubeClientSet(ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraBuildControllerServiceAccountName))
-	if err := sccAdmission.ValidateInitialization(); err != nil {
-		return true, err
-	}
-
 	buildDefaults, err := builddefaults.NewBuildDefaults(c.AdmissionPluginConfig)
 	if err != nil {
 		return true, err

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -59,20 +59,17 @@ func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	if wantsOpenshiftQuotaClient, ok := plugin.(WantsOpenshiftInternalQuotaClient); ok {
 		wantsOpenshiftQuotaClient.SetOpenshiftInternalQuotaClient(i.OpenshiftInternalQuotaClient)
 	}
-	if WantsOpenshiftInternalTemplateClient, ok := plugin.(WantsOpenshiftInternalTemplateClient); ok {
-		WantsOpenshiftInternalTemplateClient.SetOpenshiftInternalTemplateClient(i.OpenshiftInternalTemplateClient)
+	if wantsOpenshiftInternalTemplateClient, ok := plugin.(WantsOpenshiftInternalTemplateClient); ok {
+		wantsOpenshiftInternalTemplateClient.SetOpenshiftInternalTemplateClient(i.OpenshiftInternalTemplateClient)
 	}
-	if WantsOpenshiftInternalUserClient, ok := plugin.(WantsOpenshiftInternalUserClient); ok {
-		WantsOpenshiftInternalUserClient.SetOpenshiftInternalUserClient(i.OpenshiftInternalUserClient)
+	if wantsOpenshiftInternalUserClient, ok := plugin.(WantsOpenshiftInternalUserClient); ok {
+		wantsOpenshiftInternalUserClient.SetOpenshiftInternalUserClient(i.OpenshiftInternalUserClient)
 	}
 	if wantsProjectCache, ok := plugin.(WantsProjectCache); ok {
 		wantsProjectCache.SetProjectCache(i.ProjectCache)
 	}
 	if wantsOriginQuotaRegistry, ok := plugin.(WantsOriginQuotaRegistry); ok {
 		wantsOriginQuotaRegistry.SetOriginQuotaRegistry(i.OriginQuotaRegistry)
-	}
-	if wantsAuthorizer, ok := plugin.(WantsAuthorizer); ok {
-		wantsAuthorizer.SetAuthorizer(i.Authorizer)
 	}
 	if kubeWantsAuthorizer, ok := plugin.(initializer.WantsAuthorizer); ok {
 		kubeWantsAuthorizer.SetAuthorizer(i.Authorizer)

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -2,7 +2,6 @@ package admission
 
 import (
 	"k8s.io/apiserver/pkg/admission"
-	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	restclient "k8s.io/client-go/rest"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/quota"
@@ -69,13 +68,6 @@ type WantsProjectCache interface {
 // WantsQuotaRegistry should be implemented by admission plugins that need a quota registry
 type WantsOriginQuotaRegistry interface {
 	SetOriginQuotaRegistry(quota.Registry)
-	admission.InitializationValidator
-}
-
-// WantsAuthorizer should be implemented by admission plugins that
-// need access to the Authorizer interface
-type WantsAuthorizer interface {
-	SetAuthorizer(kauthorizer.Authorizer)
 	admission.InitializationValidator
 }
 

--- a/pkg/ingress/admission/ingress_admission.go
+++ b/pkg/ingress/admission/ingress_admission.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kextensions "k8s.io/kubernetes/pkg/apis/extensions"
 
-	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/ingress/admission/apis/ingressadmission"
 )
@@ -41,7 +41,7 @@ type ingressAdmission struct {
 	authorizer authorizer.Authorizer
 }
 
-var _ = oadmission.WantsAuthorizer(&ingressAdmission{})
+var _ = initializer.WantsAuthorizer(&ingressAdmission{})
 
 func NewIngressAdmission(config *ingressadmission.IngressAdmissionConfig) *ingressAdmission {
 	return &ingressAdmission{

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -10,13 +10,13 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	admission "k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
 	"github.com/openshift/origin/pkg/api/meta"
-	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints"
 )
@@ -79,7 +79,7 @@ func shouldCheckResource(resource schema.GroupResource, kind schema.GroupKind) (
 	return true, nil
 }
 
-var _ = oadmission.WantsAuthorizer(&podNodeConstraints{})
+var _ = initializer.WantsAuthorizer(&podNodeConstraints{})
 
 func readConfig(reader io.Reader) (*podnodeconstraints.PodNodeConstraintsConfig, error) {
 	if reader == nil || reflect.ValueOf(reader).IsNil() {

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -19,7 +20,6 @@ import (
 	_ "github.com/openshift/origin/pkg/api/install"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	"github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
@@ -104,7 +104,7 @@ func TestPodNodeConstraints(t *testing.T) {
 		var expectedError error
 		errPrefix := fmt.Sprintf("%d", i)
 		prc := NewPodNodeConstraints(tc.config)
-		prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
+		prc.(initializer.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
 		err := prc.(admission.InitializationValidator).ValidateInitialization()
 		if err != nil {
 			checkAdmitError(t, err, expectedError, errPrefix)
@@ -124,7 +124,7 @@ func TestPodNodeConstraintsPodUpdate(t *testing.T) {
 	var expectedError error
 	errPrefix := "PodUpdate"
 	prc := NewPodNodeConstraints(testConfig())
-	prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
+	prc.(initializer.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
 	err := prc.(admission.InitializationValidator).ValidateInitialization()
 	if err != nil {
 		checkAdmitError(t, err, expectedError, errPrefix)
@@ -140,7 +140,7 @@ func TestPodNodeConstraintsNonHandledResources(t *testing.T) {
 	errPrefix := "ResourceQuotaTest"
 	var expectedError error
 	prc := NewPodNodeConstraints(testConfig())
-	prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
+	prc.(initializer.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
 	err := prc.(admission.InitializationValidator).ValidateInitialization()
 	if err != nil {
 		checkAdmitError(t, err, expectedError, errPrefix)
@@ -258,7 +258,7 @@ func TestPodNodeConstraintsResources(t *testing.T) {
 					var expectedError error
 					errPrefix := fmt.Sprintf("%s; %s; %s", tr.prefix, tp.prefix, top.operation)
 					prc := NewPodNodeConstraints(tc.config)
-					prc.(oadmission.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
+					prc.(initializer.WantsAuthorizer).SetAuthorizer(fakeAuthorizer(t))
 					err := prc.(admission.InitializationValidator).ValidateInitialization()
 					if err != nil {
 						checkAdmitError(t, err, expectedError, errPrefix)

--- a/pkg/security/registry/podsecuritypolicyselfsubjectreview/rest_test.go
+++ b/pkg/security/registry/podsecuritypolicyselfsubjectreview/rest_test.go
@@ -20,34 +20,6 @@ import (
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
-func validPodTemplateSpec() kapi.PodTemplateSpec {
-	activeDeadlineSeconds := int64(1)
-	return kapi.PodTemplateSpec{
-		Spec: kapi.PodSpec{
-			Volumes: []kapi.Volume{
-				{Name: "vol", VolumeSource: kapi.VolumeSource{EmptyDir: &kapi.EmptyDirVolumeSource{}}},
-			},
-			Containers: []kapi.Container{
-				{
-					Name:                     "ctr",
-					Image:                    "image",
-					ImagePullPolicy:          "IfNotPresent",
-					TerminationMessagePolicy: kapi.TerminationMessageReadFile,
-				},
-			},
-			RestartPolicy: kapi.RestartPolicyAlways,
-			NodeSelector: map[string]string{
-				"key": "value",
-			},
-			NodeName:              "foobar",
-			DNSPolicy:             kapi.DNSClusterFirst,
-			ActiveDeadlineSeconds: &activeDeadlineSeconds,
-			ServiceAccountName:    "acct",
-			SchedulerName:         kapi.DefaultSchedulerName,
-		},
-	}
-}
-
 func TestPodSecurityPolicySelfSubjectReview(t *testing.T) {
 	testcases := map[string]struct {
 		sccs  []*securityapi.SecurityContextConstraints

--- a/pkg/service/admission/endpoint_admission.go
+++ b/pkg/service/admission/endpoint_admission.go
@@ -6,9 +6,8 @@ import (
 	"net"
 	"reflect"
 
-	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
-
-	admission "k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -29,7 +28,7 @@ type restrictedEndpointsAdmission struct {
 	restrictedNetworks []*net.IPNet
 }
 
-var _ = oadmission.WantsAuthorizer(&restrictedEndpointsAdmission{})
+var _ = initializer.WantsAuthorizer(&restrictedEndpointsAdmission{})
 
 // ParseSimpleCIDRRules parses a list of CIDR strings
 func ParseSimpleCIDRRules(rules []string) (networks []*net.IPNet, err error) {


### PR DESCRIPTION
Upstream has the same interface, so there is no need for us to have a copy of it.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Remove decode code related to PSP Subject Reviews

This change removes the dead admission code from the build controller.  That controller uses PodSecurityPolicySubjectReviews to avoid having to be tied directly to admission.

Also removed an unused function in the PSP Self Subject Review unit test.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/kind cleanup
/assign @deads2k