### PR TITLE
Bug 1567532 - Unidle handling in router should ignore headless services

### DIFF
--- a/pkg/router/template/plugin.go
+++ b/pkg/router/template/plugin.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
 
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
@@ -239,7 +240,7 @@ func createRouterEndpoints(endpoints *kapi.Endpoints, excludeUDP bool, lookupSvc
 			return []Endpoint{}
 		}
 
-		if service.Spec.ClusterIP == "" {
+		if !kapihelper.IsServiceIPSet(service) {
 			utilruntime.HandleError(fmt.Errorf("headless service %s/%s was marked as idled, but cannot setup unidling without a cluster IP", endpoints.Namespace, endpoints.Name))
 			return []Endpoint{}
 		}


### PR DESCRIPTION
- Currently, service with empty ClusterIP is ignored but headless services
can have ClusterIP="None" and those need to be ignored as well.

Found this problem on ca-central starter cluster where router reload failed due to incorrect haproxy config:
```
limiter.go:137] error reloading router: exit status 1
: parsing [/var/lib/haproxy/conf/haproxy.config:63325] : 'server ept:mysql:None:3306' : could not resolve address 'None'.
: Failed to initialize server(s) addr.
```
`None` in `endpoint.ID` came from `service.Spec.ClusterIP` 