### PR TITLE
up: make sure we have the remote host directory ready when copying files

### DIFF
--- a/pkg/oc/bootstrap/clusteradd/components/router/router_install.go
+++ b/pkg/oc/bootstrap/clusteradd/components/router/router_install.go
@@ -118,7 +118,7 @@ func (c *RouterComponentOptions) Install(dockerClient dockerhelper.Interface, lo
 	if len(os.Getenv("DOCKER_HOST")) > 0 {
 		hostHelper := host.NewHostHelper(dockerHelper, c.InstallContext.ClientImage())
 		remoteMasterConfigDir := path.Join(host.RemoteHostOriginDir, c.InstallContext.BaseDir(), kubeapiserver.KubeAPIServerDirName)
-		if err := hostHelper.CopyToHost(masterConfigDir, remoteMasterConfigDir); err != nil {
+		if err := hostHelper.CopyToRemoteHost(masterConfigDir, remoteMasterConfigDir); err != nil {
 			return err
 		}
 		masterConfigDir = remoteMasterConfigDir

--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -216,7 +216,7 @@ func (c *ClusterUpConfig) RemoteDirFor(componentName string) string {
 }
 
 func (c *ClusterUpConfig) copyToRemote(source, component string) (string, error) {
-	if err := c.hostHelper.CopyToHost(source, c.RemoteDirFor(component)); err != nil {
+	if err := c.hostHelper.CopyToRemoteHost(source, c.RemoteDirFor(component)); err != nil {
 		return "", err
 	}
 	return c.RemoteDirFor(component), nil


### PR DESCRIPTION
Creating the directory in image entrypoint can race with the streaming to the container. This will make sure we already have the destination dir on the remote host available before we start streaming. The cost here is that we need to run extra container to create the directory. Guess it is worth to sacrify a little speed for stability.

/cc @deads2k (i know you don't like ugly, but this is need to make ugly less ugly)
/cc @soltysh 