### PR TITLE
glide: fix go4.org repo url and bump the k8s.io shas to match forks

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cd1b2b62f8b1308def80c2261d71ffebf07fae4bd39ae00480e75f620b8498e8
-updated: 2018-04-17T09:45:43.895406-04:00
+hash: f9577985ef9884297c3c94191d038d50acde60bb9744c4d5523acc7a5d57003f
+updated: 2018-04-19T12:28:43.694392977+02:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -1148,6 +1148,7 @@ imports:
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: go4.org
   version: 03efcb870d84809319ea509714dd6d19a1498483
+  repo: https://github.com/go4org/go4
   subpackages:
   - errorutil
 - name: golang.org/x/crypto
@@ -1564,7 +1565,7 @@ imports:
   - plugin/pkg/authenticator/token/webhook
   - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
-  version: 02a694aa912314cd4288c176a39b888888ad6765
+  version: 59deff23e848e82e0c2db847cf65c74446fee309
   repo: https://github.com/openshift/kubernetes-client-go.git
   subpackages:
   - discovery
@@ -1796,7 +1797,7 @@ imports:
   - pkg/util/proto
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: 4b6cb539104d70486c9eee6afa7a2f26d07c4b5a
+  version: e6e9f2d5e18b7948030382ed17c2e10ca914efcf
   repo: https://github.com/openshift/kubernetes.git
   subpackages:
   - cmd/controller-manager/app

--- a/glide.yaml
+++ b/glide.yaml
@@ -181,6 +181,13 @@ import:
 - package: google.golang.org/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
 
+# to avoid go4.org website outages on glide update
+- package: go4.org
+  repo: https://github.com/go4org/go4
+  version: 03efcb870d84809319ea509714dd6d19a1498483
+  subpackages:
+  - errorutil
+
 # force glide to pull this in
 - package: github.com/google/uuid
 


### PR DESCRIPTION
@liggitt @deads2k lets do this separately from the etcd pull. 