### PR TITLE
node, syscontainer: bind mount /opt/cni/bin from the host

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -491,7 +491,16 @@
 		"mode=755",
 		"size=65536k"
 	    ]
-	}
+	},
+	{
+	    "destination": "/opt/cni/bin",
+	    "type": "bind",
+	    "source": "/opt/cni/bin",
+	    "options": [
+		"rbind",
+		"rslave"
+	    ]
+	},
         $ADDTL_MOUNTS
     ],
     "hooks": {},


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1565482