### PR TITLE
add reading, merging, and ensuring logic for webconsole operator

### DIFF
--- a/pkg/cmd/openshift-operators/util/resourceapply/apiextensions.go
+++ b/pkg/cmd/openshift-operators/util/resourceapply/apiextensions.go
@@ -1,0 +1,29 @@
+package resourceapply
+
+import (
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/util/resourcemerge"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclientv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ApplyCustomResourceDefinition(client apiextensionsclientv1beta1.CustomResourceDefinitionsGetter, required *apiextensionsv1beta1.CustomResourceDefinition) (bool, error) {
+	existing, err := client.CustomResourceDefinitions().Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.CustomResourceDefinitions().Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureCustomResourceDefinition(modified, existing, *required)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.CustomResourceDefinitions().Update(existing)
+	return true, err
+}

--- a/pkg/cmd/openshift-operators/util/resourceapply/apps.go
+++ b/pkg/cmd/openshift-operators/util/resourceapply/apps.go
@@ -1,0 +1,50 @@
+package resourceapply
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/util/resourcemerge"
+)
+
+func ApplyDaemonSet(client appsclientv1.DaemonSetsGetter, required *appsv1.DaemonSet) (bool, error) {
+	existing, err := client.DaemonSets(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.DaemonSets(required.Namespace).Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureDaemonSet(modified, existing, *required)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.DaemonSets(required.Namespace).Update(existing)
+	return true, err
+}
+
+func ApplyDeployment(client appsclientv1.DeploymentsGetter, required *appsv1.Deployment) (*appsv1.Deployment, bool, error) {
+	existing, err := client.Deployments(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		actual, err := client.Deployments(required.Namespace).Create(required)
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureDeployment(modified, existing, *required)
+	if !*modified {
+		return existing, false, nil
+	}
+
+	actual, err := client.Deployments(required.Namespace).Update(existing)
+	return actual, true, err
+}

--- a/pkg/cmd/openshift-operators/util/resourceapply/core.go
+++ b/pkg/cmd/openshift-operators/util/resourceapply/core.go
@@ -1,0 +1,90 @@
+package resourceapply
+
+import (
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/util/resourcemerge"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func ApplyNamespace(client coreclientv1.NamespacesGetter, required *corev1.Namespace) (bool, error) {
+	existing, err := client.Namespaces().Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.Namespaces().Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.Namespaces().Update(existing)
+	return true, err
+}
+
+func ApplyService(client coreclientv1.ServicesGetter, required *corev1.Service) (bool, error) {
+	existing, err := client.Services(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.Services(required.Namespace).Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureService(modified, existing, *required)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.Services(required.Namespace).Update(existing)
+	return true, err
+}
+
+func ApplyServiceAccount(client coreclientv1.ServiceAccountsGetter, required *corev1.ServiceAccount) (bool, error) {
+	existing, err := client.ServiceAccounts(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.ServiceAccounts(required.Namespace).Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.ServiceAccounts(required.Namespace).Update(existing)
+	return true, err
+}
+
+func ApplyConfigMap(client coreclientv1.ConfigMapsGetter, required *corev1.ConfigMap) (bool, error) {
+	existing, err := client.ConfigMaps(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.ConfigMaps(required.Namespace).Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureConfigMap(modified, existing, *required)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.ConfigMaps(required.Namespace).Update(existing)
+	return true, err
+}

--- a/pkg/cmd/openshift-operators/util/resourceapply/operators.go
+++ b/pkg/cmd/openshift-operators/util/resourceapply/operators.go
@@ -1,0 +1,29 @@
+package resourceapply
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	webconsolev1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/webconsole/v1alpha1"
+	webconsoleclientv1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/generated/clientset/versioned/typed/webconsole/v1alpha1"
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/util/resourcemerge"
+)
+
+func ApplyWebConsoleOperatorConfig(client webconsoleclientv1alpha1.OpenShiftWebConsoleConfigsGetter, required *webconsolev1alpha1.OpenShiftWebConsoleConfig) (bool, error) {
+	existing, err := client.OpenShiftWebConsoleConfigs().Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.OpenShiftWebConsoleConfigs().Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureWebConsoleOperatorConfig(modified, existing, *required)
+	if !*modified {
+		return false, nil
+	}
+	_, err = client.OpenShiftWebConsoleConfigs().Update(existing)
+	return true, err
+}

--- a/pkg/cmd/openshift-operators/util/resourceapply/rbac.go
+++ b/pkg/cmd/openshift-operators/util/resourceapply/rbac.go
@@ -1,0 +1,30 @@
+package resourceapply
+
+import (
+	"github.com/openshift/origin/pkg/cmd/openshift-operators/util/resourcemerge"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+)
+
+func ApplyClusterRoleBinding(client rbacclientv1.ClusterRoleBindingsGetter, required *rbacv1.ClusterRoleBinding) (bool, error) {
+	existing, err := client.ClusterRoleBindings().Get(required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err := client.ClusterRoleBindings().Create(required)
+		return true, err
+	}
+	if err != nil {
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureClusterRoleBinding(modified, existing, *required)
+	if !*modified {
+		return false, nil
+	}
+
+	_, err = client.ClusterRoleBindings().Update(existing)
+	return true, err
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/apiservice.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/apiservice.go
@@ -1,0 +1,16 @@
+package resourcemerge
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+)
+
+func EnsureAPIService(modified *bool, existing *apiregistrationv1beta1.APIService, required apiregistrationv1beta1.APIService) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	// we stomp everything
+	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
+		*modified = true
+		existing.Spec = required.Spec
+	}
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/clusterrolebinding.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/clusterrolebinding.go
@@ -1,0 +1,20 @@
+package resourcemerge
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// TODO do something real like reconciliation
+func EnsureClusterRoleBinding(modified *bool, existing *rbacv1.ClusterRoleBinding, required rbacv1.ClusterRoleBinding) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	if !equality.Semantic.DeepEqual(existing.Subjects, required.Subjects) {
+		*modified = true
+		existing.Subjects = required.Subjects
+	}
+	if !equality.Semantic.DeepEqual(existing.RoleRef, required.RoleRef) {
+		*modified = true
+		existing.RoleRef = required.RoleRef
+	}
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/configmap.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/configmap.go
@@ -1,0 +1,12 @@
+package resourcemerge
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func EnsureConfigMap(modified *bool, existing *corev1.ConfigMap, required corev1.ConfigMap) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	// our configmap data always wins.  Users can create their own
+	SetMapStringString(modified, &existing.Data, required.Data)
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/customresourcedefintion.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/customresourcedefintion.go
@@ -1,0 +1,16 @@
+package resourcemerge
+
+import (
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func EnsureCustomResourceDefinition(modified *bool, existing *apiextensionsv1beta1.CustomResourceDefinition, required apiextensionsv1beta1.CustomResourceDefinition) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	// we stomp everything
+	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
+		*modified = true
+		existing.Spec = required.Spec
+	}
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/daemonset.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/daemonset.go
@@ -1,0 +1,21 @@
+package resourcemerge
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func EnsureDaemonSet(modified *bool, existing *appsv1.DaemonSet, required appsv1.DaemonSet) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	if existing.Spec.Selector == nil {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec.Selector, required.Spec.Selector) {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+
+	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/deployment.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/deployment.go
@@ -1,0 +1,21 @@
+package resourcemerge
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func EnsureDeployment(modified *bool, existing *appsv1.Deployment, required appsv1.Deployment) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	if existing.Spec.Selector == nil {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+	if !equality.Semantic.DeepEqual(existing.Spec.Selector, required.Spec.Selector) {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+
+	ensurePodTemplateSpec(modified, &existing.Spec.Template, required.Spec.Template)
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/object_merger.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/object_merger.go
@@ -1,0 +1,151 @@
+package resourcemerge
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func EnsureObjectMeta(modified *bool, existing *metav1.ObjectMeta, required metav1.ObjectMeta) {
+	SetStringIfSet(modified, &existing.Namespace, required.Namespace)
+	SetStringIfSet(modified, &existing.Name, required.Name)
+	MergeMap(modified, &existing.Labels, required.Labels)
+	MergeMap(modified, &existing.Annotations, required.Annotations)
+}
+
+func stringPtr(val string) *string {
+	return &val
+}
+
+func SetString(modified *bool, existing *string, required string) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func SetStringIfSet(modified *bool, existing *string, required string) {
+	if len(required) == 0 {
+		return
+	}
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setStringPtr(modified *bool, existing **string, required *string) {
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	SetString(modified, *existing, *required)
+}
+
+func SetStringSlice(modified *bool, existing *[]string, required []string) {
+	if !reflect.DeepEqual(required, *existing) {
+		*existing = required
+		*modified = true
+	}
+}
+
+func SetStringSliceIfSet(modified *bool, existing *[]string, required []string) {
+	if required == nil {
+		return
+	}
+	if !reflect.DeepEqual(required, *existing) {
+		*existing = required
+		*modified = true
+	}
+}
+
+func BoolPtr(val bool) *bool {
+	return &val
+}
+
+func SetBool(modified *bool, existing *bool, required bool) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setBoolPtr(modified *bool, existing **bool, required *bool) {
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	SetBool(modified, *existing, *required)
+}
+
+func int64Ptr(val int64) *int64 {
+	return &val
+}
+
+func SetInt32(modified *bool, existing *int32, required int32) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func SetInt32IfSet(modified *bool, existing *int32, required int32) {
+	if required == 0 {
+		return
+	}
+
+	SetInt32(modified, existing, required)
+}
+
+func SetInt64(modified *bool, existing *int64, required int64) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setInt64Ptr(modified *bool, existing **int64, required *int64) {
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	SetInt64(modified, *existing, *required)
+}
+
+func MergeMap(modified *bool, existing *map[string]string, required map[string]string) {
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+	for k, v := range required {
+		if existingV, ok := (*existing)[k]; !ok || v != existingV {
+			*modified = true
+			(*existing)[k] = v
+		}
+	}
+}
+
+func SetMapStringString(modified *bool, existing *map[string]string, required map[string]string) {
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+
+	if !reflect.DeepEqual(*existing, required) {
+		*existing = required
+	}
+}
+
+func SetMapStringStringIfSet(modified *bool, existing *map[string]string, required map[string]string) {
+	if required == nil {
+		return
+	}
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+
+	if !reflect.DeepEqual(*existing, required) {
+		*existing = required
+	}
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/operators.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/operators.go
@@ -1,0 +1,18 @@
+package resourcemerge
+
+import (
+	webconsolev1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/webconsole/v1alpha1"
+)
+
+func EnsureWebConsoleOperatorConfig(modified *bool, existing *webconsolev1alpha1.OpenShiftWebConsoleConfig, required webconsolev1alpha1.OpenShiftWebConsoleConfig) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	if existing.Spec.ManagementState != required.Spec.ManagementState {
+		*modified = true
+		existing.Spec.ManagementState = required.Spec.ManagementState
+	}
+
+	SetStringIfSet(modified, &existing.Spec.ImagePullSpec, required.Spec.ImagePullSpec)
+	SetStringIfSet(modified, &existing.Spec.Version, required.Spec.Version)
+	SetInt64(modified, &existing.Spec.Logging.LogLevel, required.Spec.Logging.LogLevel)
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/pod.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/pod.go
@@ -1,0 +1,200 @@
+package resourcemerge
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func ensurePodTemplateSpec(modified *bool, existing *corev1.PodTemplateSpec, required corev1.PodTemplateSpec) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	ensurePodSpec(modified, &existing.Spec, required.Spec)
+}
+
+func ensurePodSpec(modified *bool, existing *corev1.PodSpec, required corev1.PodSpec) {
+	// any container we specify, we require.  Any extra container is removed
+	for _, required := range required.Containers {
+		var existingCurr *corev1.Container
+		for j, curr := range existing.Containers {
+			if curr.Name == required.Name {
+				existingCurr = &existing.Containers[j]
+				break
+			}
+		}
+		if existingCurr == nil {
+			*modified = true
+			existing.Containers = append(existing.Containers, corev1.Container{})
+			existingCurr = &existing.Containers[len(existing.Containers)-1]
+		}
+		ensureContainer(modified, existingCurr, required)
+	}
+	deleted := 0
+	for i, curr := range existing.Containers {
+		found := false
+		for _, required := range required.Containers {
+			if curr.Name == required.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			j := i - deleted
+			existing.Containers = existing.Containers[:j+copy(existing.Containers[j:], existing.Containers[j+1:])]
+		}
+	}
+
+	// any volume we specify, we require
+	// TODO perhaps this should be relaxed.  If someone wants to mount them from somewhere else, we should allow it
+	for _, required := range required.Volumes {
+		var existingCurr *corev1.Volume
+		for j, curr := range existing.Volumes {
+			if curr.Name == required.Name {
+				existingCurr = &existing.Volumes[j]
+				break
+			}
+		}
+		if existingCurr == nil {
+			*modified = true
+			existing.Volumes = append(existing.Volumes, corev1.Volume{})
+			existingCurr = &existing.Volumes[len(existing.Volumes)-1]
+		}
+		ensureVolume(modified, existingCurr, required)
+	}
+
+	if len(required.RestartPolicy) > 0 {
+		if existing.RestartPolicy != required.RestartPolicy {
+			*modified = true
+			existing.RestartPolicy = required.RestartPolicy
+		}
+	}
+
+	SetString(modified, &existing.ServiceAccountName, required.ServiceAccountName)
+	SetBool(modified, &existing.HostNetwork, required.HostNetwork)
+}
+
+func ensureContainer(modified *bool, existing *corev1.Container, required corev1.Container) {
+	SetString(modified, &existing.Name, required.Name)
+	SetString(modified, &existing.Image, required.Image)
+
+	// if you want modify the launch, you need to modify it in the config, not in the launch args
+	SetStringSlice(modified, &existing.Command, required.Command)
+	SetStringSlice(modified, &existing.Args, required.Args)
+
+	SetStringIfSet(modified, &existing.WorkingDir, required.WorkingDir)
+
+	// any port we specify, we require
+	for _, required := range required.Ports {
+		var existingCurr *corev1.ContainerPort
+		for j, curr := range existing.Ports {
+			if curr.Name == required.Name {
+				existingCurr = &existing.Ports[j]
+				break
+			}
+		}
+		if existingCurr == nil {
+			*modified = true
+			existing.Ports = append(existing.Ports, corev1.ContainerPort{})
+			existingCurr = &existing.Ports[len(existing.Ports)-1]
+		}
+		ensureContainerPort(modified, existingCurr, required)
+	}
+
+	// any volume mount we specify, we require
+	for _, required := range required.VolumeMounts {
+		var existingCurr *corev1.VolumeMount
+		for j, curr := range existing.VolumeMounts {
+			if curr.Name == required.Name {
+				existingCurr = &existing.VolumeMounts[j]
+				break
+			}
+		}
+		if existingCurr == nil {
+			*modified = true
+			existing.VolumeMounts = append(existing.VolumeMounts, corev1.VolumeMount{})
+			existingCurr = &existing.VolumeMounts[len(existing.VolumeMounts)-1]
+		}
+		ensureVolumeMount(modified, existingCurr, required)
+	}
+
+	if required.LivenessProbe != nil {
+		ensureProbePtr(modified, &existing.LivenessProbe, required.LivenessProbe)
+	}
+	if required.ReadinessProbe != nil {
+		ensureProbePtr(modified, &existing.ReadinessProbe, required.ReadinessProbe)
+	}
+
+	// our security context should always win
+	ensureSecurityContextPtr(modified, &existing.SecurityContext, required.SecurityContext)
+}
+
+func ensureProbePtr(modified *bool, existing **corev1.Probe, required *corev1.Probe) {
+	// if we have no required, then we don't care what someone else has set
+	if required == nil {
+		return
+	}
+	if *existing == nil {
+		*modified = true
+		*existing = required
+		return
+	}
+	ensureProbe(modified, *existing, *required)
+}
+
+func ensureProbe(modified *bool, existing *corev1.Probe, required corev1.Probe) {
+	SetInt32IfSet(modified, &existing.InitialDelaySeconds, required.InitialDelaySeconds)
+
+	ensureProbeHandler(modified, &existing.Handler, required.Handler)
+}
+
+func ensureProbeHandler(modified *bool, existing *corev1.Handler, required corev1.Handler) {
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
+	}
+}
+
+func ensureContainerPort(modified *bool, existing *corev1.ContainerPort, required corev1.ContainerPort) {
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
+	}
+}
+
+func ensureVolumeMount(modified *bool, existing *corev1.VolumeMount, required corev1.VolumeMount) {
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
+	}
+}
+
+func ensureVolume(modified *bool, existing *corev1.Volume, required corev1.Volume) {
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
+	}
+}
+
+func ensureSecurityContext(modified *bool, existing *corev1.SecurityContext, required corev1.SecurityContext) {
+	// these are missing for now
+	//Capabilities *Capabilities `json:"capabilities,omitempty" protobuf:"bytes,1,opt,name=capabilities"`
+	//SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty" protobuf:"bytes,3,opt,name=seLinuxOptions"`
+	setBoolPtr(modified, &existing.Privileged, required.Privileged)
+	setInt64Ptr(modified, &existing.RunAsUser, required.RunAsUser)
+	setBoolPtr(modified, &existing.RunAsNonRoot, required.RunAsNonRoot)
+	setBoolPtr(modified, &existing.ReadOnlyRootFilesystem, required.ReadOnlyRootFilesystem)
+	setBoolPtr(modified, &existing.AllowPrivilegeEscalation, required.AllowPrivilegeEscalation)
+}
+
+func ensureSecurityContextPtr(modified *bool, existing **corev1.SecurityContext, required *corev1.SecurityContext) {
+	// if we have no required, then we don't care what someone else has set
+	if required == nil {
+		return
+	}
+
+	if *existing == nil {
+		*modified = true
+		*existing = required
+		return
+	}
+	ensureSecurityContext(modified, *existing, *required)
+}

--- a/pkg/cmd/openshift-operators/util/resourcemerge/service.go
+++ b/pkg/cmd/openshift-operators/util/resourcemerge/service.go
@@ -1,0 +1,41 @@
+package resourcemerge
+
+import (
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func EnsureService(modified *bool, existing *corev1.Service, required corev1.Service) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	if !reflect.DeepEqual(existing.Spec.Selector, required.Spec.Selector) {
+		*modified = true
+		existing.Spec.Selector = required.Spec.Selector
+	}
+
+	// any port we specify, we require
+	for _, required := range required.Spec.Ports {
+		var existingCurr *corev1.ServicePort
+		for j, curr := range existing.Spec.Ports {
+			if curr.Name == required.Name {
+				existingCurr = &existing.Spec.Ports[j]
+				break
+			}
+		}
+		if existingCurr == nil {
+			*modified = true
+			existing.Spec.Ports = append(existing.Spec.Ports, corev1.ServicePort{})
+			existingCurr = &existing.Spec.Ports[len(existing.Spec.Ports)-1]
+		}
+		ensureServicePort(modified, existingCurr, required)
+	}
+}
+
+func ensureServicePort(modified *bool, existing *corev1.ServicePort, required corev1.ServicePort) {
+	if !equality.Semantic.DeepEqual(required, *existing) {
+		*modified = true
+		*existing = required
+	}
+}

--- a/pkg/cmd/openshift-operators/util/resourceread/apiextensions.go
+++ b/pkg/cmd/openshift-operators/util/resourceread/apiextensions.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	apiExtensionsScheme = runtime.NewScheme()
+	apiExtensionsCodecs = serializer.NewCodecFactory(apiExtensionsScheme)
+)
+
+func init() {
+	if err := apiextensionsv1beta1.AddToScheme(apiExtensionsScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadCustomResourceDefinitionOrDie(objBytes []byte) *apiextensionsv1beta1.CustomResourceDefinition {
+	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextensionsv1beta1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*apiextensionsv1beta1.CustomResourceDefinition)
+}

--- a/pkg/cmd/openshift-operators/util/resourceread/apps.go
+++ b/pkg/cmd/openshift-operators/util/resourceread/apps.go
@@ -1,0 +1,34 @@
+package resourceread
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	appsScheme = runtime.NewScheme()
+	appsCodecs = serializer.NewCodecFactory(appsScheme)
+)
+
+func init() {
+	if err := appsv1.AddToScheme(appsScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadDeploymentOrDie(objBytes []byte) *appsv1.Deployment {
+	requiredObj, err := runtime.Decode(appsCodecs.UniversalDecoder(appsv1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*appsv1.Deployment)
+}
+
+func ReadDaemonSetOrDie(objBytes []byte) *appsv1.DaemonSet {
+	requiredObj, err := runtime.Decode(appsCodecs.UniversalDecoder(appsv1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*appsv1.DaemonSet)
+}

--- a/pkg/cmd/openshift-operators/util/resourceread/core.go
+++ b/pkg/cmd/openshift-operators/util/resourceread/core.go
@@ -1,0 +1,42 @@
+package resourceread
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	coreScheme = runtime.NewScheme()
+	coreCodecs = serializer.NewCodecFactory(coreScheme)
+)
+
+func init() {
+	if err := corev1.AddToScheme(coreScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadConfigMapOrDie(objBytes []byte) *corev1.ConfigMap {
+	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(corev1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*corev1.ConfigMap)
+}
+
+func ReadServiceOrDie(objBytes []byte) *corev1.Service {
+	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(corev1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*corev1.Service)
+}
+
+func ReadNamespaceOrDie(objBytes []byte) *corev1.Namespace {
+	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(corev1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*corev1.Namespace)
+}

--- a/pkg/cmd/openshift-operators/util/resourceread/operators.go
+++ b/pkg/cmd/openshift-operators/util/resourceread/operators.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	webconsolev1alpha1 "github.com/openshift/origin/pkg/cmd/openshift-operators/apis/webconsole/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	operatorsScheme = runtime.NewScheme()
+	operatorsCodecs = serializer.NewCodecFactory(operatorsScheme)
+)
+
+func init() {
+	if err := webconsolev1alpha1.AddToScheme(operatorsScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadWebConsoleOperatorConfigOrDie(objBytes []byte) *webconsolev1alpha1.OpenShiftWebConsoleConfig {
+	requiredObj, err := runtime.Decode(operatorsCodecs.UniversalDecoder(webconsolev1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*webconsolev1alpha1.OpenShiftWebConsoleConfig)
+}

--- a/pkg/cmd/openshift-operators/util/resourceread/rbac.go
+++ b/pkg/cmd/openshift-operators/util/resourceread/rbac.go
@@ -1,0 +1,26 @@
+package resourceread
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	rbacScheme = runtime.NewScheme()
+	rbacCodecs = serializer.NewCodecFactory(rbacScheme)
+)
+
+func init() {
+	if err := rbacv1.AddToScheme(rbacScheme); err != nil {
+		panic(err)
+	}
+}
+
+func ReadClusterRoleBindingOrDie(objBytes []byte) *rbacv1.ClusterRoleBinding {
+	requiredObj, err := runtime.Decode(rbacCodecs.UniversalDecoder(rbacv1.SchemeGroupVersion), []byte(objBytes))
+	if err != nil {
+		panic(err)
+	}
+	return requiredObj.(*rbacv1.ClusterRoleBinding)
+}


### PR DESCRIPTION
Alright, here is where we get contentious.  At some point we have to decide what resource we're going to try to keep.  Let's start in the post-coreos render step.  We have a resource manifest the controller wants and we have an existing state that may or may not have been dirtied by a user.  At a high level, we have a few coarse options. 

 1. Use generic patch/apply logic to create a patch that we issue to the resource.  This allows a user to change many fields on the live objects, but some fields (fields we "care" about) are stomped or we detect a conflict and stop.  Detecting a conflict and then deciding whether to allow the current, stomp the current, or fail requires enumeration.  Changing a workload type is somewhat fraught, but you can probably pull the podspec and re-inject.   It's my understand that this is what @abhinavdahiya and  @aaronlevy have today.  

 2. Use specific patch logic to merge together an object to update.  Conflicts can be detected as "modifed" (could later be a list of jsonpaths).  We make a choice whether or not we stomp the field.  The custom merge logic allows things like "touch this and own all of it" and is effectively the same as enumerating which things we stomp, allow, or conflict on from case one.  Doing this also ensures that we never have to deal with the "but strategic merge patch and/or json merge patch and/or jsonpatch didn't work right!" that we chased forever and never satisfactorily fixed (requires a new format I think).  Changing a workload type is somewhat fraught, but you can probably pull the podspec and re-inject.
  This is what this pull provides.

 3. We never allow a user to change the workload object/podspec/other resource.  Instead, we allow parameterization or injection of every legal option to change.  Neither existing product chose to do this, but if we constrained the set of customization sufficiently, it may be possible.  I think this is what @liggitt wants, what @smarterclayton specifically said no to (parameterize the world and we've lost), and what I have no interest in doing unless we massively constrain choice.  If we constrain choice enough, this could be viable.  Given config driven components, we may actually be able to constrain it enough.

We face a similar choice for the serialized config types for each process.  OpenShift already has this and kube is on its way.  Superficially, it seems like we'd want the same mechanism.  However, we could choose to manage the two differently.

@openshift/sig-master fyi
@aaronlevy, @smarterclayton @liggitt let's sort out where to go.  This is for a toy operator for cluster-up, so we can try anything and change our mind later.  

I may use the hack day tomorrow to try to figure out just how much enumerated choice we care about, so listing them here may help.  I'll start.
 1. resources
 2. volume mounts
 3. say no to env vars
 4. say no to securitycontext changes
 5. say no to command line changes
 7. say no to everything else.

If we do that, then we probably hand-roll adding customized resources and volume mounts, but nothing else.  The config types are small enough to be noise.