### PR TITLE
diagnostics: Break a loop when config file found

### DIFF
--- a/pkg/oc/admin/diagnostics/config.go
+++ b/pkg/oc/admin/diagnostics/config.go
@@ -52,9 +52,10 @@ func (o DiagnosticsOptions) detectClientConfig() (expected bool, detected bool) 
 			}
 		}
 
-		if o.canOpenConfigFile(path, errmsg) && len(foundPath) == 0 {
+		if o.canOpenConfigFile(path, errmsg) {
 			successfulLoad = true
 			foundPath = path
+			break
 		}
 	}
 	if len(foundPath) > 0 {


### PR DESCRIPTION
`--config` option for oc adm diagnostics is not clear what config was read.

When we specify `--config`, the log message displays below:

```
# oc adm diagnostics NetworkCheck --config=myconfig
[Note] Determining if client configuration exists for client/cluster diagnostics
Info:  Successfully read a client config file at 'myconfig'
Info:  Successfully read a client config file at '/root/.kube/config'
```

This looks like `'/root/.kube/config'` was read over after `myconfig` was
read. (Actually it was NOT, though.)

This patch breaks the loop when config file found.