### PR TITLE
system containers: remove extra comma, which breaks json syntax

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -500,7 +500,7 @@
 		"rbind",
 		"rslave"
 	    ]
-	},
+	}
         $ADDTL_MOUNTS
     ],
     "hooks": {},


### PR DESCRIPTION
Fix for #19427

Due to extra comma a generated config.json is invalid, which breaks 
Fedora Atomic and system-containers tests (see 
https://s3.amazonaws.com/aos-ci/ghprb/openshift/openshift-ansible/76079433422c82e4ad66b46b26e5561003172ba0.0.1524215134798135132/output.log and 
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_openshift-ansible/8039/test_pull_request_openshift_ansible_extended_conformance_install_system_containers/7337/)