### PR TITLE
Creating an image stream tag is too likely to conflict

### DIFF
--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -626,9 +626,6 @@ func TestRegistryWhitelistingValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if istag.Annotations[imageapi.InsecureRepositoryAnnotation] != "true" {
-		t.Fatalf("missing %q annotation to image stream tag", imageapi.InsecureRepositoryAnnotation)
-	}
 
 	istag.Tag.From = &kapi.ObjectReference{
 		Kind: "DockerImage",


### PR DESCRIPTION
Because image stream tags are virtual, it's very likely that creating
two IST's on the same stream at the same time will conflict. We can't
use patch because they're virtual on the lower registry, but we can do a
conflict retry loop.

Found this while getting ready for the ci-operator - it creates multiple image stream tags on the same stream and was flaking >50% of the time.

@bparees