### PR TITLE
UPSTREAM: 62914: kubelet: fix flake in TestUpdateExistingNodeStatusTimeout

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_node_status_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_node_status_test.go
@@ -639,8 +639,8 @@ func TestUpdateExistingNodeStatusTimeout(t *testing.T) {
 	assert.Error(t, kubelet.updateNodeStatus())
 
 	// should have attempted multiple times
-	if actualAttempts := atomic.LoadInt64(&attempts); actualAttempts != nodeStatusUpdateRetry {
-		t.Errorf("Expected %d attempts, got %d", nodeStatusUpdateRetry, actualAttempts)
+	if actualAttempts := atomic.LoadInt64(&attempts); actualAttempts < nodeStatusUpdateRetry {
+		t.Errorf("Expected at least %d attempts, got %d", nodeStatusUpdateRetry, actualAttempts)
 	}
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/62914

fixes https://github.com/openshift/origin/issues/19443