### PR TITLE
run SCC in default

### DIFF
--- a/pkg/admission/namespaceconditions/decorator.go
+++ b/pkg/admission/namespaceconditions/decorator.go
@@ -9,7 +9,7 @@ import (
 
 // this is a list of namespaces with special meaning.  The kube ones are here in particular because
 // we don't control their creation or labeling on their creation
-var runLevelZeroNamespaces = sets.NewString("default", "kube-system", "kube-public")
+var runLevelZeroNamespaces = sets.NewString("kube-system", "kube-public")
 var runLevelOneNamespaces = sets.NewString("openshift-node", "openshift-infra", "openshift")
 
 func init() {

--- a/pkg/oc/bootstrap/clusteradd/componentinstall/apply_template.go
+++ b/pkg/oc/bootstrap/clusteradd/componentinstall/apply_template.go
@@ -50,11 +50,12 @@ done </privileged-sa-list.txt
 ns=""
 if [ -s /namespace-file ]; then
 	ns="--namespace=$(cat /namespace-file) "
-	oc create ns $(cat /namespace-file) --config=/kubeconfig.kubeconfig --dry-run -o yaml | oc apply --config=/kubeconfig.kubeconfig -f -
 fi
 
 if [ -s /namespace.yaml ]; then
 	oc apply --config=/kubeconfig.kubeconfig -f /namespace.yaml
+elif [ -s /namespace-file ]; then
+	oc create ns $(cat /namespace-file) --config=/kubeconfig.kubeconfig --dry-run -o yaml | oc apply --config=/kubeconfig.kubeconfig -f -
 fi
 
 if [ -s /rbac.yaml ]; then

--- a/pkg/quota/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/admission/clusterresourcequota/admission.go
@@ -82,6 +82,11 @@ func (q *clusterQuotaAdmission) Admit(a admission.Attributes) (err error) {
 	if len(a.GetNamespace()) == 0 {
 		return nil
 	}
+	// skip default namespace until we no longer require SCC in that namespace and we can simply exclude all openshift admission
+	// from that namespace
+	if a.GetNamespace() == "default" {
+		return nil
+	}
 
 	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {
 		return admission.NewForbidden(a, errors.New("caches not synchronized"))


### PR DESCRIPTION
I don't think we actually create anything in default that we need until after the openshift apiserver is around.  I've stopped special casing that namespace.

/assign @liggitt 
@liggitt seem safe to you?
@openshift/sig-master I thought I saw an issue about this, but I can't find it now