### PR TITLE
Fix service-catalog serviceclass-viewer role

### DIFF
--- a/examples/service-catalog/service-catalog-rbac.yaml
+++ b/examples/service-catalog/service-catalog-rbac.yaml
@@ -26,8 +26,9 @@ objects:
   roleRef:
     kind: ClusterRole
     name: servicecatalog-serviceclass-viewer
-  groupNames:
-  - system:authenticated
+  subjects:
+  - kind: Group
+    name: system:authenticated
 
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -15781,8 +15781,9 @@ objects:
   roleRef:
     kind: ClusterRole
     name: servicecatalog-serviceclass-viewer
-  groupNames:
-  - system:authenticated
+  subjects:
+  - kind: Group
+    name: system:authenticated
 
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole


### PR DESCRIPTION
Fixes the serviceclass-viewer role to correctly work with the `system:authenticated` group.