### PR TITLE
Add parameter to allow user to specify custom Labels

### DIFF
--- a/pkg/templateservicebroker/openservicebroker/api/helpers.go
+++ b/pkg/templateservicebroker/openservicebroker/api/helpers.go
@@ -23,6 +23,10 @@ func InternalServerError(err error) *Response {
 	return NewResponse(http.StatusInternalServerError, nil, err)
 }
 
+func InvalidCustomLabelParameter(err error) *Response {
+	return NewResponse(http.StatusUnprocessableEntity, nil, err)
+}
+
 // ConvertUserToTemplateInstanceRequester copies analogous fields from user.Info to TemplateInstanceRequester
 func ConvertUserToTemplateInstanceRequester(u user.Info) templateapi.TemplateInstanceRequester {
 	templatereq := templateapi.TemplateInstanceRequester{}

--- a/pkg/templateservicebroker/servicebroker/catalog.go
+++ b/pkg/templateservicebroker/servicebroker/catalog.go
@@ -19,7 +19,7 @@ const (
 	noDescriptionProvided   = "No description provided."
 	customLabelsParamName   = "customLabelParam"
 	customLabelsTitle       = "Custom Labels"
-	customLabelsDescription = "e.g. label1 = value1, label2 = value2, label3 = label 3, ... "
+	customLabelsDescription = "e.g. label1 = value1, label2, label3 = label3, ... "
 	customLabelsDefault     = ""
 )
 

--- a/pkg/templateservicebroker/servicebroker/catalog.go
+++ b/pkg/templateservicebroker/servicebroker/catalog.go
@@ -16,7 +16,11 @@ import (
 )
 
 const (
-	noDescriptionProvided = "No description provided."
+	noDescriptionProvided   = "No description provided."
+	customLabelsParamName   = "customLabelParam"
+	customLabelsTitle       = "Custom Labels"
+	customLabelsDescription = "e.g. label1 = value1, label2 = value2, label3 = label 3, ... "
+	customLabelsDefault     = ""
 )
 
 // Map OpenShift template annotations to open service broker metadata field
@@ -55,6 +59,15 @@ func serviceFromTemplate(template *templateapiv1.Template) *api.Service {
 		}
 		paramOrdering = append(paramOrdering, param.Name)
 	}
+
+	// Add Custom Label Parameter
+	properties[customLabelsParamName] = &jsschema.Schema{
+		Title:       customLabelsTitle,
+		Description: customLabelsDescription,
+		Default:     customLabelsDefault,
+		Type:        []jsschema.PrimitiveType{jsschema.StringType},
+	}
+	paramOrdering = append(paramOrdering, customLabelsParamName)
 
 	bindable := strings.ToLower(template.Annotations[templateapi.BindableAnnotation]) != "false"
 

--- a/pkg/templateservicebroker/servicebroker/catalog_test.go
+++ b/pkg/templateservicebroker/servicebroker/catalog_test.go
@@ -79,6 +79,7 @@ func TestServiceFromTemplate(t *testing.T) {
 									"param2",
 									"param3",
 									"param4",
+									customLabelsParamName,
 								},
 							},
 						},
@@ -109,6 +110,12 @@ func TestServiceFromTemplate(t *testing.T) {
 									"param4": {
 										Default: "",
 										Type:    schema.PrimitiveTypes{schema.StringType},
+									},
+									customLabelsParamName: {
+										Title:       customLabelsTitle,
+										Description: customLabelsDescription,
+										Default:     customLabelsDefault,
+										Type:        schema.PrimitiveTypes{schema.StringType},
 									},
 								},
 							},

--- a/pkg/templateservicebroker/servicebroker/provision.go
+++ b/pkg/templateservicebroker/servicebroker/provision.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	invalidCustomLabelMsg = "Invalid Custom Label Parameter Value!"
-	missingLabelKeyMsg    = "Label Key Cannot Be Empty!"
-	invalidKeyValueStrMsg = "Key/Value String Cannot Contain Spaces!"
+	invalidCustomLabelMsg = "Invalid Custom Label Parameter Value"
+	missingLabelKeyMsg    = "Label Key Cannot Be Empty"
+	invalidKeyValueStrMsg = "Key/Value String Cannot Contain Spaces"
 )
 
 // ensureSecret ensures the existence of a Secret object containing the template

--- a/pkg/templateservicebroker/servicebroker/provision_test.go
+++ b/pkg/templateservicebroker/servicebroker/provision_test.go
@@ -86,7 +86,13 @@ func TestCustomLabels(t *testing.T) {
 	}
 
 	// valid label values
-	resp = b.ensureCustomLabel(&fakeTemplate, "k1=v1, k2, k3=v3")
+	resp = b.ensureCustomLabel(&fakeTemplate, "k1 = v1, k2, k3=v3")
+	if resp != nil {
+		t.Errorf("got response %#v, expected nil", *resp)
+	}
+
+	// valid label values
+	resp = b.ensureCustomLabel(&fakeTemplate, "k1, k2=v2,")
 	if resp != nil {
 		t.Errorf("got response %#v, expected nil", *resp)
 	}
@@ -94,6 +100,18 @@ func TestCustomLabels(t *testing.T) {
 	// invalid values
 	resp = b.ensureCustomLabel(&fakeTemplate, "label1=L1*, label2=L2:")
 	if !reflect.DeepEqual(resp, api.InvalidCustomLabelParameter(errors.New(invalidCustomLabelMsg))) {
+		t.Errorf("got response %#v, expected 422/StatusUnprocessableEntity", *resp)
+	}
+
+	// invalid values (empty key string)
+	resp = b.ensureCustomLabel(&fakeTemplate, "label1=L1, =L2")
+	if !reflect.DeepEqual(resp, api.InvalidCustomLabelParameter(errors.New(missingLabelKeyMsg))) {
+		t.Errorf("got response %#v, expected 422/StatusUnprocessableEntity", *resp)
+	}
+
+	// invalid values (spaces in key/value string)
+	resp = b.ensureCustomLabel(&fakeTemplate, " label 1=L1, label2=L 2 ")
+	if !reflect.DeepEqual(resp, api.InvalidCustomLabelParameter(errors.New(invalidKeyValueStrMsg))) {
 		t.Errorf("got response %#v, expected 422/StatusUnprocessableEntity", *resp)
 	}
 }


### PR DESCRIPTION
Implements https://trello.com/c/7upa8IX4

Allows custom labels to be entered in as a parameter in the Template Service Broker provisioning of an existing template.

Invalid entries will fail the provision, and any predefined/existing values will be overwritten with the newly specified value.  