### PR TITLE
new-app: remove check for volumes in new-app test

### DIFF
--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -367,10 +367,8 @@ os::cmd::expect_success_and_text 'oc new-app ruby~https://github.com/sclorg/s2i-
 os::cmd::expect_success_and_text 'oc new-app ruby~https://github.com/openshift/ruby-hello-world.git --strategy=docker -o yaml' 'dockerStrategy'
 os::cmd::expect_success_and_text 'oc new-app https://github.com/openshift/ruby-hello-world.git --strategy=source -o yaml' 'sourceStrategy'
 
-# prints volume and root user info
-os::cmd::expect_success_and_text 'oc new-app --dry-run mysql' 'This image declares volumes'
+# prints root user info
 os::cmd::expect_success_and_not_text 'oc new-app --dry-run mysql' "runs as the 'root' user"
-os::cmd::expect_success_and_text 'oc new-app --dry-run --docker-image=mysql' 'This image declares volumes'
 os::cmd::expect_success_and_text 'oc new-app --dry-run --docker-image=mysql' "WARNING: Image \"mysql\" runs as the 'root' user"
 
 # verify multiple errors are displayed together, a nested error is returned, and that the usage message is displayed


### PR DESCRIPTION
Should fix https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/19339/test_pull_request_origin_cmd/12853/

Seems like the mysql 5.7 removed the volumes?

```
~/.../openshift/origin → docker inspect centos/mysql-57-centos7 | grep Volume
            "Volumes": null,
            "Volumes": null,
```

/cc @bparees 