### PR TITLE
[WIP] get build logs through the kube-apiserver, not the kubelet

### DIFF
--- a/pkg/apiserver/rest/streamer.go
+++ b/pkg/apiserver/rest/streamer.go
@@ -1,0 +1,31 @@
+package rest
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+type PassThroughStreamer struct {
+	In          io.ReadCloser
+	Flush       bool
+	ContentType string
+}
+
+// a PipeStreamer must implement a rest.ResourceStreamer
+var _ rest.ResourceStreamer = &PassThroughStreamer{}
+
+func (obj *PassThroughStreamer) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (obj *PassThroughStreamer) DeepCopyObject() runtime.Object {
+	panic("passThroughStreamer does not implement DeepCopyObject")
+}
+
+// InputStream returns a stream with the contents of the embedded pipe.
+func (s *PassThroughStreamer) InputStream(apiVersion, acceptHeader string) (stream io.ReadCloser, flush bool, contentType string, err error) {
+	return s.In, s.Flush, s.ContentType, nil
+}

--- a/pkg/apps/registry/deploylog/rest.go
+++ b/pkg/apps/registry/deploylog/rest.go
@@ -2,6 +2,7 @@ package deploylog
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericrest "k8s.io/apiserver/pkg/registry/generic/rest"
@@ -19,8 +21,6 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/controller"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
-	"k8s.io/kubernetes/pkg/registry/core/pod"
 
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	"github.com/openshift/origin/pkg/apps/apis/apps/validation"
@@ -36,29 +36,16 @@ const (
 	defaultInterval = 1 * time.Second
 )
 
-// podGetter implements the ResourceGetter interface. Used by LogLocation to
-// retrieve the deployer pod
-type podGetter struct {
-	pn kcoreclient.PodsGetter
-}
-
-// Get is responsible for retrieving the deployer pod
-func (g *podGetter) Get(ctx apirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	namespace, ok := apirequest.NamespaceFrom(ctx)
-	if !ok {
-		return nil, errors.NewBadRequest("namespace parameter required.")
-	}
-	return g.pn.Pods(namespace).Get(name, *options)
-}
-
 // REST is an implementation of RESTStorage for the api server.
 type REST struct {
-	dn       appsclient.DeploymentConfigsGetter
-	rn       kcoreclient.ReplicationControllersGetter
-	pn       kcoreclient.PodsGetter
-	connInfo kubeletclient.ConnectionInfoGetter
-	timeout  time.Duration
-	interval time.Duration
+	dcClient  appsclient.DeploymentConfigsGetter
+	rcClient  kcoreclient.ReplicationControllersGetter
+	podClient kcoreclient.PodsGetter
+	timeout   time.Duration
+	interval  time.Duration
+
+	// for unit testing
+	getLogsFn func(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error)
 }
 
 // REST implements GetterWithOptions
@@ -68,15 +55,17 @@ var _ = rest.GetterWithOptions(&REST{})
 // one for deployments (replication controllers) and one for pods to get the necessary
 // attributes to assemble the URL to which the request shall be redirected in order to
 // get the deployment logs.
-func NewREST(dn appsclient.DeploymentConfigsGetter, rn kcoreclient.ReplicationControllersGetter, pn kcoreclient.PodsGetter, connectionInfo kubeletclient.ConnectionInfoGetter) *REST {
-	return &REST{
-		dn:       dn,
-		rn:       rn,
-		pn:       pn,
-		connInfo: connectionInfo,
-		timeout:  defaultTimeout,
-		interval: defaultInterval,
+func NewREST(dcClient appsclient.DeploymentConfigsGetter, rcClient kcoreclient.ReplicationControllersGetter, podClient kcoreclient.PodsGetter) *REST {
+	r := &REST{
+		dcClient:  dcClient,
+		rcClient:  rcClient,
+		podClient: podClient,
+		timeout:   defaultTimeout,
+		interval:  defaultInterval,
 	}
+	r.getLogsFn = r.getLogs
+
+	return r
 }
 
 // NewGetOptions returns a new options object for deployment logs
@@ -108,7 +97,7 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 
 	// Fetch deploymentConfig and check latest version; if 0, there are no deployments
 	// for this config
-	config, err := r.dn.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
+	config, err := r.dcClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.NewNotFound(appsapi.Resource("deploymentconfig"), name)
 	}
@@ -154,11 +143,11 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 		}
 		glog.V(4).Infof("Deployment %s is in %s state, waiting for it to start...", appsutil.LabelForDeployment(target), status)
 
-		if err := appsutil.WaitForRunningDeployerPod(r.pn, target, r.timeout); err != nil {
+		if err := appsutil.WaitForRunningDeployerPod(r.podClient, target, r.timeout); err != nil {
 			return nil, errors.NewBadRequest(fmt.Sprintf("failed to run deployer pod %s: %v", podName, err))
 		}
 
-		latest, ok, err := registry.WaitForRunningDeployment(r.rn, target, r.timeout)
+		latest, ok, err := registry.WaitForRunningDeployment(r.rcClient, target, r.timeout)
 		if err != nil {
 			return nil, errors.NewBadRequest(fmt.Sprintf("unable to wait for deployment %s to run: %v", appsutil.LabelForDeployment(target), err))
 		}
@@ -179,18 +168,44 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 	}
 
 	logOpts := appsapi.DeploymentToPodLogOptions(deployLogOpts)
-	location, transport, err := pod.LogLocation(&podGetter{r.pn}, r.connInfo, ctx, podName, logOpts)
+	return r.getLogsFn(namespace, podName, logOpts)
+}
+
+func (r *REST) getLogs(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error) {
+	logRequest := r.podClient.Pods(podNamespace).GetLogs(podName, logOpts)
+
+	readerCloser, err := logRequest.Stream()
 	if err != nil {
-		return nil, errors.NewBadRequest(err.Error())
+		return nil, err
 	}
 
-	return &genericrest.LocationStreamer{
-		Location:        location,
-		Transport:       transport,
-		ContentType:     "text/plain",
-		Flush:           deployLogOpts.Follow,
-		ResponseChecker: genericrest.NewGenericHttpResponseChecker(kapi.Resource("pod"), podName),
+	return &passThroughStreamer{
+		In:          readerCloser,
+		Flush:       logOpts.Follow,
+		ContentType: "text/plain",
 	}, nil
+}
+
+type passThroughStreamer struct {
+	In          io.ReadCloser
+	Flush       bool
+	ContentType string
+}
+
+// a PipeStreamer must implement a rest.ResourceStreamer
+var _ rest.ResourceStreamer = &passThroughStreamer{}
+
+func (obj *passThroughStreamer) GetObjectKind() schema.ObjectKind {
+	return schema.EmptyObjectKind
+}
+
+func (obj *passThroughStreamer) DeepCopyObject() runtime.Object {
+	panic("passThroughStreamer does not implement DeepCopyObject")
+}
+
+// InputStream returns a stream with the contents of the embedded pipe.
+func (s *passThroughStreamer) InputStream(apiVersion, acceptHeader string) (stream io.ReadCloser, flush bool, contentType string, err error) {
+	return s.In, s.Flush, s.ContentType, nil
 }
 
 // waitForExistingDeployment will use the timeout to wait for a deployment to appear.
@@ -201,7 +216,7 @@ func (r *REST) waitForExistingDeployment(namespace, name string) (*kapi.Replicat
 	)
 
 	condition := func() (bool, error) {
-		target, err = r.rn.ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
+		target, err = r.rcClient.ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
 		switch {
 		case errors.IsNotFound(err):
 			return false, nil
@@ -224,7 +239,7 @@ func (r *REST) returnApplicationPodName(target *kapi.ReplicationController) (str
 	selector := labels.SelectorFromValidatedSet(labels.Set(target.Spec.Selector))
 	sortBy := func(pods []*kapiv1.Pod) sort.Interface { return controller.ByLogging(pods) }
 
-	firstPod, _, err := kcmdutil.GetFirstPod(r.pn, target.Namespace, selector.String(), r.timeout, sortBy)
+	firstPod, _, err := kcmdutil.GetFirstPod(r.podClient, target.Namespace, selector.String(), r.timeout, sortBy)
 	if err != nil {
 		return "", errors.NewInternalError(err)
 	}

--- a/pkg/apps/registry/deploylog/rest_test.go
+++ b/pkg/apps/registry/deploylog/rest_test.go
@@ -213,7 +213,6 @@ func TestRESTGet(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			actualPodNamespace := ""
 			actualPodName := ""
-
 			getPodLogsFn := func(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error) {
 				actualPodNamespace = podNamespace
 				actualPodName = podName

--- a/pkg/build/apiserver/apiserver.go
+++ b/pkg/build/apiserver/apiserver.go
@@ -169,7 +169,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	v1Storage := map[string]rest.Storage{}
 	v1Storage["builds"] = buildStorage
 	v1Storage["builds/clone"] = buildclone.NewStorage(buildGenerator)
-	v1Storage["builds/log"] = buildlogregistry.NewREST(buildClient.Build(), kubeInternalClient.Core(), nodeConnectionInfoGetter)
+	v1Storage["builds/log"] = buildlogregistry.NewREST(buildClient.Build(), kubeInternalClient.Core())
 	v1Storage["builds/details"] = buildDetailsStorage
 
 	v1Storage["buildConfigs"] = buildConfigStorage

--- a/pkg/build/registry/buildlog/rest.go
+++ b/pkg/build/registry/buildlog/rest.go
@@ -18,9 +18,8 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
-	"k8s.io/kubernetes/pkg/registry/core/pod"
 
+	apiserverrest "github.com/openshift/origin/pkg/apiserver/rest"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/apis/build/validation"
 	buildstrategy "github.com/openshift/origin/pkg/build/controller/strategy"
@@ -31,23 +30,12 @@ import (
 
 // REST is an implementation of RESTStorage for the api server.
 type REST struct {
-	BuildClient    buildtypedclient.BuildsGetter
-	PodGetter      pod.ResourceGetter
-	ConnectionInfo kubeletclient.ConnectionInfoGetter
-	Timeout        time.Duration
-}
+	BuildClient buildtypedclient.BuildsGetter
+	PodClient   kcoreclient.PodsGetter
+	Timeout     time.Duration
 
-// TODO these wrapers shouldb e removed
-type podGetter struct {
-	kcoreclient.PodsGetter
-}
-
-func (g *podGetter) Get(ctx apirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	ns, ok := apirequest.NamespaceFrom(ctx)
-	if !ok {
-		return nil, errors.NewBadRequest("namespace parameter required.")
-	}
-	return g.Pods(ns).Get(name, *options)
+	// for unit testing
+	getSimpleLogsFn func(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error)
 }
 
 const defaultTimeout time.Duration = 10 * time.Second
@@ -55,13 +43,14 @@ const defaultTimeout time.Duration = 10 * time.Second
 // NewREST creates a new REST for BuildLog
 // Takes build registry and pod client to get necessary attributes to assemble
 // URL to which the request shall be redirected in order to get build logs.
-func NewREST(buildClient buildtypedclient.BuildsGetter, pn kcoreclient.PodsGetter, connectionInfo kubeletclient.ConnectionInfoGetter) *REST {
-	return &REST{
-		BuildClient:    buildClient,
-		PodGetter:      &podGetter{pn},
-		ConnectionInfo: connectionInfo,
-		Timeout:        defaultTimeout,
+func NewREST(buildClient buildtypedclient.BuildsGetter, podClient kcoreclient.PodsGetter) *REST {
+	r := &REST{
+		BuildClient: buildClient,
+		PodClient:   podClient,
+		Timeout:     defaultTimeout,
 	}
+	r.getSimpleLogsFn = r.getSimpleLogs
+	return r
 }
 
 var _ = rest.GetterWithOptions(&REST{})
@@ -126,30 +115,16 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 
 	// if we can't at least get the build pod, we're not going to get very far, so
 	// error out now.
-	obj, err := r.PodGetter.Get(ctx, buildPodName, &metav1.GetOptions{})
+	buildPod, err := r.PodClient.Pods(build.Namespace).Get(buildPodName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.NewBadRequest(err.Error())
 	}
 
 	// check for old style builds with a single container/no initcontainers
 	// and handle them w/ the old logging code.
-	buildPod := obj.(*kapi.Pod)
 	if len(buildPod.Spec.InitContainers) == 0 {
 		logOpts := buildapi.BuildToPodLogOptions(buildLogOpts)
-		location, transport, err := pod.LogLocation(r.PodGetter, r.ConnectionInfo, ctx, buildPodName, logOpts)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil, errors.NewNotFound(kapi.Resource("pod"), buildPodName)
-			}
-			return nil, errors.NewBadRequest(err.Error())
-		}
-		return &genericrest.LocationStreamer{
-			Location:        location,
-			Transport:       transport,
-			ContentType:     "text/plain",
-			Flush:           buildLogOpts.Follow,
-			ResponseChecker: genericrest.NewGenericHttpResponseChecker(kapi.Resource("pod"), buildPodName),
-		}, nil
+		return r.getSimpleLogsFn(build.Namespace, buildPodName, logOpts)
 	}
 
 	// new style builds w/ init containers from here out.
@@ -197,7 +172,7 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 			// assume we are not going to need to iterate again until proven otherwise
 			waitForInitContainers = false
 			// Get the latest version of the pod so we can check init container statuses
-			obj, err = r.PodGetter.Get(ctx, buildPodName, &metav1.GetOptions{})
+			buildPod, err = r.PodClient.Pods(build.Namespace).Get(buildPodName, metav1.GetOptions{})
 			if err != nil {
 				s := fmt.Sprintf("error retrieving build pod %s/%s : %v", build.Namespace, buildPodName, err.Error())
 				// we're sending the error message as the log output so the user at least sees some indication of why
@@ -205,7 +180,6 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 				pipeStreamer.In.Write([]byte(s))
 				return
 			}
-			buildPod = obj.(*kapi.Pod)
 
 			// Walk all the initcontainers in order and dump/stream their logs.  The initcontainers
 			// are defined in order of execution, so that's the order we'll dump their logs in.
@@ -288,13 +262,12 @@ func (r *REST) Get(ctx apirequest.Context, name string, opts runtime.Object) (ru
 			// Wait for the main container to be running, this can take a second after the initcontainers
 			// finish so we have to poll.
 			err := wait.PollImmediate(time.Second, 10*time.Minute, func() (bool, error) {
-				obj, err = r.PodGetter.Get(ctx, buildPodName, &metav1.GetOptions{})
+				buildPod, err = r.PodClient.Pods(build.Namespace).Get(buildPodName, metav1.GetOptions{})
 				if err != nil {
 					s := fmt.Sprintf("error while getting build logs, could not retrieve build pod %s/%s : %v", build.Namespace, buildPodName, err.Error())
 					pipeStreamer.In.Write([]byte(s))
 					return false, err
 				}
-				buildPod = obj.(*kapi.Pod)
 				// we can get logs from a pod in any state other than pending.
 				if buildPod.Status.Phase != kapi.PodPending {
 					return true, nil
@@ -340,38 +313,17 @@ func (r *REST) New() runtime.Object {
 // pipeLogs retrieves the logs for a particular container and streams them into the provided writer.
 func (r *REST) pipeLogs(ctx apirequest.Context, namespace, buildPodName string, containerLogOpts *kapi.PodLogOptions, writer io.Writer) error {
 	glog.V(4).Infof("pulling build pod logs for %s/%s, container %s", namespace, buildPodName, containerLogOpts.Container)
-	location, transport, err := pod.LogLocation(r.PodGetter, r.ConnectionInfo, ctx, buildPodName, containerLogOpts)
+
+	logRequest := r.PodClient.Pods(namespace).GetLogs(buildPodName, containerLogOpts)
+	readerCloser, err := logRequest.Stream()
 	if err != nil {
-		s := fmt.Sprintf("error retrieving logs for build pod: %s/%s container: %s, %v", namespace, buildPodName, containerLogOpts.Container, err.Error())
-		_, err2 := writer.Write([]byte(s))
-		if err2 != nil {
-			glog.Errorf("error: could not write build log error %q to stream due to: %v", s, err2)
-		}
+		glog.Errorf("error: could not write build log for pod %q to stream due to: %v", buildPodName, err)
 		return err
 	}
-	locationStreamer := genericrest.LocationStreamer{
-		Location:        location,
-		Transport:       transport,
-		ContentType:     "text/plain",
-		Flush:           true,
-		ResponseChecker: genericrest.NewGenericHttpResponseChecker(kapi.Resource("pod"), buildPodName),
-	}
-	out, _, _, err := locationStreamer.InputStream("", "")
-	if err != nil {
-		s := fmt.Sprintf("error streaming logs from build pod: %s/%s container: %s, %v", namespace, buildPodName, containerLogOpts.Container, err.Error())
-		_, err2 := writer.Write([]byte(s))
-		if err2 != nil {
-			glog.Errorf("error: could not write build log error %q to stream due to: %v", s, err2)
-		}
-		return err
-	}
-	if out == nil {
-		glog.Warningf("warning: logs for build pod: %s/%s container: %s returned a nil stream", namespace, buildPodName, containerLogOpts.Container)
-		return nil
-	}
+
 	glog.V(4).Infof("retrieved logs for build pod: %s/%s container: %s", namespace, buildPodName, containerLogOpts.Container)
 	// dump all container logs from the log stream into a single output stream that we'll send back to the client.
-	_, err = io.Copy(writer, out)
+	_, err = io.Copy(writer, readerCloser)
 	return err
 }
 
@@ -386,4 +338,19 @@ func selectBuilderContainer(containers []kapi.Container) string {
 		}
 	}
 	return ""
+}
+
+func (r *REST) getSimpleLogs(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error) {
+	logRequest := r.PodClient.Pods(podNamespace).GetLogs(podName, logOpts)
+
+	readerCloser, err := logRequest.Stream()
+	if err != nil {
+		return nil, err
+	}
+
+	return &apiserverrest.PassThroughStreamer{
+		In:          readerCloser,
+		Flush:       logOpts.Follow,
+		ContentType: "text/plain",
+	}, nil
 }

--- a/pkg/build/registry/buildlog/rest_test.go
+++ b/pkg/build/registry/buildlog/rest_test.go
@@ -1,8 +1,6 @@
 package buildlog
 
 import (
-	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -10,51 +8,33 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	genericrest "k8s.io/apiserver/pkg/registry/generic/rest"
 	"k8s.io/apiserver/pkg/registry/rest"
 	clientgotesting "k8s.io/client-go/testing"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildfakeclient "github.com/openshift/origin/pkg/build/generated/internalclientset/fake"
 )
 
-type testPodGetter struct{}
-
-func (p *testPodGetter) Get(ctx apirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	pod := &kapi.Pod{}
-	switch name {
-	case "pending-build":
-		pod = mockPod(kapi.PodPending, name)
-	case "running-build":
-		pod = mockPod(kapi.PodRunning, name)
-	case "succeeded-build":
-		pod = mockPod(kapi.PodSucceeded, name)
-	case "failed-build":
-		pod = mockPod(kapi.PodFailed, name)
-	case "unknown-build":
-		pod = mockPod(kapi.PodUnknown, name)
-	}
-	return pod, nil
+func newPodClient() *fake.Clientset {
+	return fake.NewSimpleClientset(
+		mockPod(kapi.PodPending, "pending-build"),
+		mockPod(kapi.PodRunning, "running-build"),
+		mockPod(kapi.PodSucceeded, "succeeded-build"),
+		mockPod(kapi.PodFailed, "failed-build"),
+		mockPod(kapi.PodUnknown, "unknown-build"),
+	)
 }
 
-type fakeConnectionInfoGetter struct{}
-
-func (*fakeConnectionInfoGetter) GetConnectionInfo(nodeName types.NodeName) (*kubeletclient.ConnectionInfo, error) {
-	rt, err := kubeletclient.MakeTransport(&kubeletclient.KubeletClientConfig{})
-	if err != nil {
-		return nil, err
-	}
-	return &kubeletclient.ConnectionInfo{
-		Scheme:    "https",
-		Hostname:  "foo-host",
-		Port:      "12345",
-		Transport: rt,
-	}, nil
+func anotherNewPodClient() *fake.Clientset {
+	return fake.NewSimpleClientset(
+		mockPod(kapi.PodSucceeded, "bc-1-build"),
+		mockPod(kapi.PodSucceeded, "bc-2-build"),
+		mockPod(kapi.PodSucceeded, "bc-3-build"),
+	)
 }
 
 // TestRegistryResourceLocation tests if proper resource location URL is returned
@@ -62,20 +42,24 @@ func (*fakeConnectionInfoGetter) GetConnectionInfo(nodeName types.NodeName) (*ku
 // Note: For this test, the mocked pod is set to "Running" phase, so the test
 // is evaluating the outcome based only on build state.
 func TestRegistryResourceLocation(t *testing.T) {
-	expectedLocations := map[buildapi.BuildPhase]string{
-		buildapi.BuildPhaseComplete:  fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running-build/foo-container", metav1.NamespaceDefault),
-		buildapi.BuildPhaseFailed:    fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running-build/foo-container", metav1.NamespaceDefault),
-		buildapi.BuildPhaseRunning:   fmt.Sprintf("https://foo-host:12345/containerLogs/%s/running-build/foo-container", metav1.NamespaceDefault),
-		buildapi.BuildPhaseNew:       "",
-		buildapi.BuildPhasePending:   "",
-		buildapi.BuildPhaseError:     "",
-		buildapi.BuildPhaseCancelled: "",
+	expectedLocations := map[buildapi.BuildPhase]struct {
+		namespace string
+		name      string
+		container string
+	}{
+		buildapi.BuildPhaseComplete:  {namespace: "default", name: "running-build", container: ""},
+		buildapi.BuildPhaseFailed:    {namespace: "default", name: "running-build", container: ""},
+		buildapi.BuildPhaseRunning:   {namespace: "default", name: "running-build", container: ""},
+		buildapi.BuildPhaseNew:       {},
+		buildapi.BuildPhasePending:   {},
+		buildapi.BuildPhaseError:     {},
+		buildapi.BuildPhaseCancelled: {},
 	}
 
 	ctx := apirequest.NewDefaultContext()
 
 	for BuildPhase, expectedLocation := range expectedLocations {
-		location, err := resourceLocationHelper(BuildPhase, "running", ctx, 1)
+		actualNamespace, actualPodName, actualContainer, err := resourceLocationHelper(BuildPhase, "running", ctx, 1)
 		switch BuildPhase {
 		case buildapi.BuildPhaseError, buildapi.BuildPhaseCancelled:
 			if err == nil {
@@ -87,8 +71,14 @@ func TestRegistryResourceLocation(t *testing.T) {
 			}
 		}
 
-		if location != expectedLocation {
-			t.Errorf("Status: %s Expected Location: %s, Got %s", BuildPhase, expectedLocation, location)
+		if e, a := expectedLocation.namespace, actualNamespace; e != a {
+			t.Errorf("expected %v, actual %v", e, a)
+		}
+		if e, a := expectedLocation.name, actualPodName; e != a {
+			t.Errorf("expected %v, actual %v", e, a)
+		}
+		if e, a := expectedLocation.container, actualContainer; e != a {
+			t.Errorf("expected %v, actual %v", e, a)
 		}
 	}
 }
@@ -145,11 +135,15 @@ func TestWaitForBuild(t *testing.T) {
 			return true, fakeWatcher, nil
 		})
 		storage := REST{
-			BuildClient:    buildClient.Build(),
-			PodGetter:      &testPodGetter{},
-			ConnectionInfo: &fakeConnectionInfoGetter{},
-			Timeout:        defaultTimeout,
+			BuildClient: buildClient.Build(),
+			PodClient:   newPodClient().Core(),
+			Timeout:     defaultTimeout,
 		}
+		getSimplePodLogsFn := func(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error) {
+			return nil, nil
+		}
+		storage.getSimpleLogsFn = getSimplePodLogsFn
+
 		go func() {
 			for _, status := range tt.status {
 				fakeWatcher.Modify(mockBuild(status, "running", 1))
@@ -170,40 +164,43 @@ func TestWaitForBuildTimeout(t *testing.T) {
 	buildClient := buildfakeclient.NewSimpleClientset(build)
 	ctx := apirequest.NewDefaultContext()
 	storage := REST{
-		BuildClient:    buildClient.Build(),
-		PodGetter:      &testPodGetter{},
-		ConnectionInfo: &fakeConnectionInfoGetter{},
-		Timeout:        100 * time.Millisecond,
+		BuildClient: buildClient.Build(),
+		PodClient:   newPodClient().Core(),
+		Timeout:     100 * time.Millisecond,
 	}
+
 	_, err := storage.Get(ctx, build.Name, &buildapi.BuildLogOptions{})
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("Unexpected error result from waitForBuild: %v\n", err)
 	}
 }
 
-func resourceLocationHelper(BuildPhase buildapi.BuildPhase, podPhase string, ctx apirequest.Context, version int) (string, error) {
+func resourceLocationHelper(BuildPhase buildapi.BuildPhase, podPhase string, ctx apirequest.Context, version int) (string, string, string, error) {
 	expectedBuild := mockBuild(BuildPhase, podPhase, version)
 	buildClient := buildfakeclient.NewSimpleClientset(expectedBuild)
 
 	storage := &REST{
-		BuildClient:    buildClient.Build(),
-		PodGetter:      &testPodGetter{},
-		ConnectionInfo: &fakeConnectionInfoGetter{},
-		Timeout:        defaultTimeout,
+		BuildClient: buildClient.Build(),
+		PodClient:   newPodClient().Core(),
+		Timeout:     defaultTimeout,
 	}
+	actualPodNamespace := ""
+	actualPodName := ""
+	actualContainer := ""
+	getSimplePodLogsFn := func(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error) {
+		actualPodNamespace = podNamespace
+		actualPodName = podName
+		actualContainer = logOpts.Container
+		return nil, nil
+	}
+	storage.getSimpleLogsFn = getSimplePodLogsFn
+
 	getter := rest.GetterWithOptions(storage)
-	obj, err := getter.Get(ctx, expectedBuild.Name, &buildapi.BuildLogOptions{NoWait: true})
+	_, err := getter.Get(ctx, expectedBuild.Name, &buildapi.BuildLogOptions{NoWait: true})
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
-	streamer, ok := obj.(*genericrest.LocationStreamer)
-	if !ok {
-		return "", fmt.Errorf("Result of get not LocationStreamer")
-	}
-	if streamer.Location != nil {
-		return streamer.Location.String(), nil
-	}
-	return "", nil
+	return actualPodNamespace, actualPodName, actualContainer, nil
 
 }
 
@@ -245,21 +242,6 @@ func mockBuild(status buildapi.BuildPhase, podName string, version int) *buildap
 	}
 }
 
-type anotherTestPodGetter struct{}
-
-func (p *anotherTestPodGetter) Get(ctx apirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	pod := &kapi.Pod{}
-	switch name {
-	case "bc-1-build":
-		pod = mockPod(kapi.PodSucceeded, name)
-	case "bc-2-build":
-		pod = mockPod(kapi.PodSucceeded, name)
-	case "bc-3-build":
-		pod = mockPod(kapi.PodSucceeded, name)
-	}
-	return pod, nil
-}
-
 func TestPreviousBuildLogs(t *testing.T) {
 	ctx := apirequest.NewDefaultContext()
 	first := mockBuild(buildapi.BuildPhaseComplete, "bc-1", 1)
@@ -268,30 +250,35 @@ func TestPreviousBuildLogs(t *testing.T) {
 	buildClient := buildfakeclient.NewSimpleClientset(first, second, third)
 
 	storage := &REST{
-		BuildClient:    buildClient.Build(),
-		PodGetter:      &anotherTestPodGetter{},
-		ConnectionInfo: &fakeConnectionInfoGetter{},
-		Timeout:        defaultTimeout,
+		BuildClient: buildClient.Build(),
+		PodClient:   anotherNewPodClient().Core(),
+		Timeout:     defaultTimeout,
 	}
+	actualPodNamespace := ""
+	actualPodName := ""
+	actualContainer := ""
+	getSimplePodLogsFn := func(podNamespace, podName string, logOpts *kapi.PodLogOptions) (runtime.Object, error) {
+		actualPodNamespace = podNamespace
+		actualPodName = podName
+		actualContainer = logOpts.Container
+		return nil, nil
+	}
+	storage.getSimpleLogsFn = getSimplePodLogsFn
+
 	getter := rest.GetterWithOptions(storage)
 	// Will expect the previous from bc-3 aka bc-2
-	obj, err := getter.Get(ctx, "bc-3", &buildapi.BuildLogOptions{NoWait: true, Previous: true})
+	_, err := getter.Get(ctx, "bc-3", &buildapi.BuildLogOptions{NoWait: true, Previous: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	streamer, ok := obj.(*genericrest.LocationStreamer)
-	if !ok {
-		t.Fatalf("unexpected object: %#v", obj)
+	if e, a := "default", actualPodNamespace; e != a {
+		t.Errorf("expected %v, actual %v", e, a)
 	}
-
-	expected := &url.URL{
-		Scheme: "https",
-		Host:   "foo-host:12345",
-		Path:   "/containerLogs/default/bc-2-build/foo-container",
+	if e, a := "bc-2-build", actualPodName; e != a {
+		t.Errorf("expected %v, actual %v", e, a)
 	}
-
-	if exp, got := expected.String(), streamer.Location.String(); exp != got {
-		t.Fatalf("expected location:\n\t%s\ngot location:\n\t%s\n", exp, got)
+	if e, a := "", actualContainer; e != a {
+		t.Errorf("expected %v, actual %v", e, a)
 	}
 }

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -224,10 +224,9 @@ func (c *completedConfig) withAppsAPIServer(delegateAPIServer genericapiserver.D
 		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
 		ExtraConfig: oappsapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
-			KubeletClientConfig:       c.ExtraConfig.KubeletClientConfig,
-			Codecs:                    legacyscheme.Codecs,
-			Registry:                  legacyscheme.Registry,
-			Scheme:                    legacyscheme.Scheme,
+			Codecs:   legacyscheme.Codecs,
+			Registry: legacyscheme.Registry,
+			Scheme:   legacyscheme.Scheme,
 		},
 	}
 	config := cfg.Complete()


### PR DESCRIPTION
Go through the kube-apiserver instead of running direct to the kubelet for easier composition.