### PR TITLE
 remove direct kubelet connection for binary builds

### DIFF
--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -295,7 +295,11 @@ func applyClientConnectionOverrides(overrides *ClientConnectionOverrides, kubeCo
 // DefaultClientTransport sets defaults for a client Transport that are suitable
 // for use by infrastructure components.
 func DefaultClientTransport(rt http.RoundTripper) http.RoundTripper {
-	transport := rt.(*http.Transport)
+	transport, ok := rt.(*http.Transport)
+	if !ok {
+		return rt
+	}
+
 	// TODO: this should be configured by the caller, not in this method.
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -50,7 +50,6 @@ func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Confi
 		ExtraConfig: OpenshiftAPIExtraConfig{
 			KubeAPIServerClientConfig:          &c.PrivilegedLoopbackClientConfig,
 			KubeClientInternal:                 c.PrivilegedLoopbackKubernetesClientsetInternal,
-			KubeletClientConfig:                c.KubeletClientConfig,
 			KubeInternalInformers:              c.InternalKubeInformers,
 			QuotaInformers:                     c.QuotaInformers,
 			SecurityInformers:                  c.SecurityInformers,

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -23,7 +23,6 @@ import (
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	rbacinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/rbac/internalversion"
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	kubeapiserver "k8s.io/kubernetes/pkg/master"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
@@ -74,8 +73,6 @@ type MasterConfig struct {
 	// RegistryHostnameRetriever retrieves the name of the integrated registry, or false if no such registry
 	// is available.
 	RegistryHostnameRetriever imageapi.RegistryHostnameRetriever
-
-	KubeletClientConfig *kubeletclient.KubeletClientConfig
 
 	// PrivilegedLoopbackClientConfig is the client configuration used to call OpenShift APIs from system components
 	// To apply different access control to a system component, create a client config specifically for that component.
@@ -153,8 +150,6 @@ func BuildMasterConfig(
 		return nil, fmt.Errorf("OPENSHIFT_DEFAULT_REGISTRY variable is invalid %q: %v", defaultRegistry, err)
 	}
 
-	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
-
 	authenticator, authenticatorPostStartHooks, err := NewAuthenticator(options, privilegedLoopbackConfig, informers)
 	if err != nil {
 		return nil, err
@@ -223,8 +218,6 @@ func BuildMasterConfig(
 		ClusterQuotaMappingController: clusterQuotaMappingController,
 
 		RegistryHostnameRetriever: imageapi.DefaultRegistryHostnameRetriever(defaultRegistryFunc, options.ImagePolicyConfig.ExternalRegistryHostname, options.ImagePolicyConfig.InternalRegistryHostname),
-
-		KubeletClientConfig: kubeletClientConfig,
 
 		PrivilegedLoopbackClientConfig:                *privilegedLoopbackConfig,
 		PrivilegedLoopbackKubernetesClientsetInternal: kubeInternalClient,

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -25,7 +25,6 @@ import (
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
@@ -77,7 +76,6 @@ import (
 type OpenshiftAPIExtraConfig struct {
 	KubeAPIServerClientConfig *restclient.Config
 	KubeClientInternal        kclientsetinternal.Interface
-	KubeletClientConfig       *kubeletclient.KubeletClientConfig
 	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 
 	QuotaInformers    quotainformer.SharedInformerFactory
@@ -118,9 +116,6 @@ func (c *OpenshiftAPIExtraConfig) Validate() error {
 
 	if c.KubeClientInternal == nil {
 		ret = append(ret, fmt.Errorf("KubeClientInternal is required"))
-	}
-	if c.KubeletClientConfig == nil {
-		ret = append(ret, fmt.Errorf("KubeletClientConfig is required"))
 	}
 	if c.KubeInternalInformers == nil {
 		ret = append(ret, fmt.Errorf("KubeInternalInformers is required"))
@@ -276,10 +271,9 @@ func (c *completedConfig) withBuildAPIServer(delegateAPIServer genericapiserver.
 		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
 		ExtraConfig: buildapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
-			KubeletClientConfig:       c.ExtraConfig.KubeletClientConfig,
-			Codecs:                    legacyscheme.Codecs,
-			Registry:                  legacyscheme.Registry,
-			Scheme:                    legacyscheme.Scheme,
+			Codecs:   legacyscheme.Codecs,
+			Registry: legacyscheme.Registry,
+			Scheme:   legacyscheme.Scheme,
 		},
 	}
 	config := cfg.Complete()

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -11,7 +11,6 @@ import (
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	fakeinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 
 	_ "github.com/openshift/origin/pkg/api/install"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
@@ -94,7 +93,6 @@ func fakeOpenshiftAPIServerConfig() *OpenshiftAPIConfig {
 		},
 		ExtraConfig: OpenshiftAPIExtraConfig{
 			KubeClientInternal:            &kclientsetinternal.Clientset{},
-			KubeletClientConfig:           &kubeletclient.KubeletClientConfig{},
 			KubeInternalInformers:         internalkubeInformerFactory,
 			QuotaInformers:                quotaInformerFactory,
 			SecurityInformers:             securityInformerFactory,


### PR DESCRIPTION
This cleans out the last need for a direct kubelet connection from the openshift apiserver.  I'm assuming that extended build tests will check binary builds for us.

/assign @soltysh 