### PR TITLE
SDN: In maybeAddMacvlan(), print the error returned from ns.GetNS

### DIFF
--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -389,7 +389,7 @@ func maybeAddMacvlan(pod *kapi.Pod, netns string) error {
 
 	podNs, err := ns.GetNS(netns)
 	if err != nil {
-		return fmt.Errorf("could not open netns %q", netns)
+		return fmt.Errorf("could not open netns %q: %v", netns, err)
 	}
 	defer podNs.Close()
 


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1562783