### PR TITLE
switch sample jenkins template to ephemeral to match auto provisioner

### DIFF
--- a/pkg/oc/bootstrap/clusteradd/components/sample-templates/sample_templates.go
+++ b/pkg/oc/bootstrap/clusteradd/components/sample-templates/sample_templates.go
@@ -7,17 +7,17 @@ import (
 )
 
 var templateLocations = map[string]string{
-	"mongodb":                     "examples/db-templates/mongodb-persistent-template.json",
-	"mariadb":                     "examples/db-templates/mariadb-persistent-template.json",
-	"mysql":                       "examples/db-templates/mysql-persistent-template.json",
-	"postgresql":                  "examples/db-templates/postgresql-persistent-template.json",
-	"cakephp quickstart":          "examples/quickstarts/cakephp-mysql-persistent.json",
-	"dancer quickstart":           "examples/quickstarts/dancer-mysql-persistent.json",
-	"django quickstart":           "examples/quickstarts/django-postgresql-persistent.json",
-	"nodejs quickstart":           "examples/quickstarts/nodejs-mongodb-persistent.json",
-	"rails quickstart":            "examples/quickstarts/rails-postgresql-persistent.json",
-	"jenkins pipeline persistent": "examples/jenkins/jenkins-persistent-template.json",
-	"sample pipeline":             "examples/jenkins/pipeline/samplepipeline.yaml",
+	"mongodb":                    "examples/db-templates/mongodb-persistent-template.json",
+	"mariadb":                    "examples/db-templates/mariadb-persistent-template.json",
+	"mysql":                      "examples/db-templates/mysql-persistent-template.json",
+	"postgresql":                 "examples/db-templates/postgresql-persistent-template.json",
+	"cakephp quickstart":         "examples/quickstarts/cakephp-mysql-persistent.json",
+	"dancer quickstart":          "examples/quickstarts/dancer-mysql-persistent.json",
+	"django quickstart":          "examples/quickstarts/django-postgresql-persistent.json",
+	"nodejs quickstart":          "examples/quickstarts/nodejs-mongodb-persistent.json",
+	"rails quickstart":           "examples/quickstarts/rails-postgresql-persistent.json",
+	"jenkins pipeline ephemeral": "examples/jenkins/jenkins-ephemeral-template.json",
+	"sample pipeline":            "examples/jenkins/pipeline/samplepipeline.yaml",
 }
 
 type SampleTemplatesComponentOptions struct {

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -209,11 +209,11 @@ function os::test::extended::clusterup::service_catalog() {
     # this is only to allow for the retrieval of the TSB service IP, not actual use of the TSB endpoints
     os::cmd::expect_success "oc policy add-role-to-user view developer -n openshift-template-service-broker"
     os::cmd::expect_success "oc login -u developer"
-    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-persistent -n openshift -o template --template '{{.metadata.uid}}'` ./provision.sh"
+    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-ephemeral -n openshift -o template --template '{{.metadata.uid}}'` ./provision.sh"
     os::cmd::try_until_text "oc get pods" "jenkins-1-deploy" $(( 2*minute )) 1
-    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-persistent -n openshift -o template --template '{{.metadata.uid}}'` ./bind.sh"
-    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-persistent -n openshift -o template --template '{{.metadata.uid}}'` ./unbind.sh"
-    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-persistent -n openshift -o template --template '{{.metadata.uid}}'` ./deprovision.sh"
+    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-ephemeral -n openshift -o template --template '{{.metadata.uid}}'` ./bind.sh"
+    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-ephemeral -n openshift -o template --template '{{.metadata.uid}}'` ./unbind.sh"
+    os::cmd::expect_success "pushd ${OS_ROOT}/pkg/templateservicebroker/servicebroker/test-scripts; serviceUUID=`oc get template jenkins-ephemeral -n openshift -o template --template '{{.metadata.uid}}'` ./deprovision.sh"
     os::cmd::try_until_text "oc get pods" "Terminating" $(( 2*minute )) 1
 }
 


### PR DESCRIPTION
Another minor bit of fallout from the cluster up refactor to discuss

I've submitted this change as much to start the discussion vs. my thinking this is the correct solution.

The particulars / competing concerns:
- we used to expose both jenkins ephemeral and jenkins persistent templates in the openshift namespace via cluster up
- complaints about "why 2" ,etc.
- going with persistent is consistent with the other samples
- but the jenkins autoprovisioner defaults to jenkins-ephemeral if it is not explicitly set (see https://github.com/openshift/origin/blob/master/pkg/cmd/server/apis/config/v1/conversions.go#L50-L52) ... traditionally, meaning when that feature first dropped many moons ago, there were openshift start paths which would not ensure there were PVs set up to leverage, so for "out of the box" to work, go with ephemeral
- with the refactor, the master config is created in vanilla / default fashion via an `openshift start master` (see https://github.com/openshift/origin/blob/master/pkg/oc/bootstrap/docker/run_self_hosted.go#L341-L361)
- where if you want to alter the defaults, you restart the cluster after modifying the master config that was created 
- I could not find any existing plugin points for overriding the master config after the self hosted creation (of course, please enlighten me as needed)
- but the desire  is to have jenkins auto provision work out of the box first time

So,
- can we assume PVs will always be there and change the default
- or can we live with this one "use of ephemeral" exception
- or is there an cluster up override of the master config mechanism we are happy with 

thanks