### PR TITLE
Print pod logs for tests

### DIFF
--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -167,5 +167,14 @@ func launchTestMulticastPod(f *e2e.Framework, nodeName string, podName string) (
 		podIP = pod.Status.PodIP
 		return (podIP != "" && pod.Status.Phase != kapiv1.PodPending), nil
 	})
+
+	if err != nil {
+		logs, logErr := e2e.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, fmt.Sprintf("%s-pod", podName))
+		if logErr != nil {
+			e2e.Failf("Error getting container logs: %s", logErr)
+		}
+		e2e.Logf("Could not launch pod %s\nPod logs:\n%s", podName, logs)
+	}
+
 	return podIP, err
 }


### PR DESCRIPTION
In order to help debugging problems print the pod log if the multicast test fails while launching the pod.

NOTE: ¿Should we look for a generic solution for printing pod logs in tests?

Fixes partially: rhbz#1557487