### PR TITLE
UPSTREAM: 62827: fix csi data race in csi_attacher_test.go

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_attacher_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_attacher_test.go
@@ -165,17 +165,7 @@ func TestAttacherAttach(t *testing.T) {
 }
 
 func TestAttacherWaitForVolumeAttachment(t *testing.T) {
-
-	plug, fakeWatcher, tmpDir := newTestWatchPlugin(t)
-	defer os.RemoveAll(tmpDir)
-
-	attacher, err := plug.NewAttacher()
-	if err != nil {
-		t.Fatalf("failed to create new attacher: %v", err)
-	}
-	csiAttacher := attacher.(*csiAttacher)
 	nodeName := "test-node"
-
 	testCases := []struct {
 		name                 string
 		initAttached         bool
@@ -183,21 +173,18 @@ func TestAttacherWaitForVolumeAttachment(t *testing.T) {
 		trigerWatchEventTime time.Duration
 		initAttachErr        *storage.VolumeError
 		finalAttachErr       *storage.VolumeError
-		sleepTime            time.Duration
 		timeout              time.Duration
 		shouldFail           bool
 	}{
 		{
 			name:         "attach success at get",
 			initAttached: true,
-			sleepTime:    10 * time.Millisecond,
 			timeout:      50 * time.Millisecond,
 			shouldFail:   false,
 		},
 		{
 			name:          "attachment error ant get",
 			initAttachErr: &storage.VolumeError{Message: "missing volume"},
-			sleepTime:     10 * time.Millisecond,
 			timeout:       30 * time.Millisecond,
 			shouldFail:    true,
 		},
@@ -207,7 +194,6 @@ func TestAttacherWaitForVolumeAttachment(t *testing.T) {
 			finalAttached:        true,
 			trigerWatchEventTime: 5 * time.Millisecond,
 			timeout:              50 * time.Millisecond,
-			sleepTime:            5 * time.Millisecond,
 			shouldFail:           false,
 		},
 		{
@@ -216,7 +202,6 @@ func TestAttacherWaitForVolumeAttachment(t *testing.T) {
 			finalAttached:        false,
 			finalAttachErr:       &storage.VolumeError{Message: "missing volume"},
 			trigerWatchEventTime: 5 * time.Millisecond,
-			sleepTime:            10 * time.Millisecond,
 			timeout:              30 * time.Millisecond,
 			shouldFail:           true,
 		},
@@ -226,13 +211,19 @@ func TestAttacherWaitForVolumeAttachment(t *testing.T) {
 			finalAttached:        true,
 			trigerWatchEventTime: 100 * time.Millisecond,
 			timeout:              50 * time.Millisecond,
-			sleepTime:            5 * time.Millisecond,
 			shouldFail:           true,
 		},
 	}
 
 	for i, tc := range testCases {
-		fakeWatcher.Reset()
+		plug, fakeWatcher, tmpDir := newTestWatchPlugin(t)
+		defer os.RemoveAll(tmpDir)
+
+		attacher, err := plug.NewAttacher()
+		if err != nil {
+			t.Fatalf("failed to create new attacher: %v", err)
+		}
+		csiAttacher := attacher.(*csiAttacher)
 		t.Logf("running test: %v", tc.name)
 		pvName := fmt.Sprintf("test-pv-%d", i)
 		volID := fmt.Sprintf("test-vol-%d", i)
@@ -240,18 +231,21 @@ func TestAttacherWaitForVolumeAttachment(t *testing.T) {
 		attachment := makeTestAttachment(attachID, nodeName, pvName)
 		attachment.Status.Attached = tc.initAttached
 		attachment.Status.AttachError = tc.initAttachErr
-		csiAttacher.waitSleepTime = tc.sleepTime
-		_, err := csiAttacher.k8s.StorageV1beta1().VolumeAttachments().Create(attachment)
+		_, err = csiAttacher.k8s.StorageV1beta1().VolumeAttachments().Create(attachment)
 		if err != nil {
 			t.Fatalf("failed to attach: %v", err)
 		}
 
+		trigerWatchEventTime := tc.trigerWatchEventTime
+		finalAttached := tc.finalAttached
+		finalAttachErr := tc.finalAttachErr
 		// after timeout, fakeWatcher will be closed by csiAttacher.waitForVolumeAttachment
 		if tc.trigerWatchEventTime > 0 && tc.trigerWatchEventTime < tc.timeout {
 			go func() {
-				time.Sleep(tc.trigerWatchEventTime)
-				attachment.Status.Attached = tc.finalAttached
-				attachment.Status.AttachError = tc.finalAttachErr
+				time.Sleep(trigerWatchEventTime)
+				attachment := makeTestAttachment(attachID, nodeName, pvName)
+				attachment.Status.Attached = finalAttached
+				attachment.Status.AttachError = finalAttachErr
 				fakeWatcher.Modify(attachment)
 			}()
 		}
@@ -677,14 +671,14 @@ func TestAttacherUnmountDevice(t *testing.T) {
 }
 
 // create a plugin mgr to load plugins and setup a fake client
-func newTestWatchPlugin(t *testing.T) (*csiPlugin, *watch.FakeWatcher, string) {
+func newTestWatchPlugin(t *testing.T) (*csiPlugin, *watch.RaceFreeFakeWatcher, string) {
 	tmpDir, err := utiltesting.MkTmpdir("csi-test")
 	if err != nil {
 		t.Fatalf("can't create temp dir: %v", err)
 	}
 
 	fakeClient := fakeclient.NewSimpleClientset()
-	fakeWatcher := watch.NewFake()
+	fakeWatcher := watch.NewRaceFreeFake()
 	fakeClient.Fake.PrependWatchReactor("*", core.DefaultWatchReactor(fakeWatcher, nil))
 	fakeClient.Fake.WatchReactionChain = fakeClient.Fake.WatchReactionChain[:1]
 	host := volumetest.NewFakeVolumeHost(


### PR DESCRIPTION
xref : https://github.com/openshift/origin/pull/19465

Fixes following error reported from linked PR:

```
=== RUN   TestAttacherAttach
panic: test timed out after 2m0s

goroutine 8 [running]:
testing.startAlarm.func1()
	/usr/local/go/src/testing/testing.go:1145 +0x139
created by time.goFunc
	/usr/local/go/src/time/sleep.go:170 +0x52

goroutine 1 [chan receive, 2 minutes]:
testing.(*T).Run(0xc42017e0f0, 0x1cf5e2d, 0x12, 0x1d70300, 0xc42050fbe8)
	/usr/local/go/src/testing/testing.go:790 +0x59b
testing.runTests.func1(0xc42017e0f0)
	/usr/local/go/src/testing/testing.go:1004 +0xa8
testing.tRunner(0xc42017e0f0, 0xc42050fd28)
	/usr/local/go/src/testing/testing.go:746 +0x16d
testing.runTests(0xc420168a00, 0x28642e0, 0x17, 0x17, 0xc4200e66c8)
	/usr/local/go/src/testing/testing.go:1002 +0x522
testing.(*M).Run(0xc4203adf20, 0x30)
	/usr/local/go/src/testing/testing.go:921 +0x207
main.main()
	github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/volume/csi/_test/_testmain.go:142 +0x2f1

goroutine 19 [chan receive, 2 minutes]:
github.com/openshift/origin/vendor/github.com/golang/glog.(*loggingT).flushDaemon(0x286fe60)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/golang/glog/glog.go:879 +0xc3
created by github.com/openshift/origin/vendor/github.com/golang/glog.init.0
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/golang/glog/glog.go:410 +0x23b

goroutine 36 [chan send, 2 minutes]:
github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/watch.(*FakeWatcher).Modify(...)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/apimachinery/pkg/watch/watch.go:140
github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/volume/csi.TestAttacherAttach(0xc42017e1e0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_attacher_test.go:162 +0x61f
testing.tRunner(0xc42017e1e0, 0x1d70300)
	/usr/local/go/src/testing/testing.go:746 +0x16d
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:789 +0x569
FAIL	github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/volume/csi	120.096s
```

/sig storage

cc @childsb @jsafrane 