### PR TITLE
router - add "option tcplog" to frontend public_ssl

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -172,6 +172,9 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
+    {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
+  option tcplog
+    {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :::{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v4v6
     {{- else if eq "v6" $router_ip_v4_v6_mode }}


### PR DESCRIPTION
when using env variable ROUTER_SYSLOG_ADDRESS the haproxy router
issues this warning

[WARNING] 010/021149 (26) : parsing [/var/lib/haproxy/conf/haproxy.config:31] : 'option httplog' not usable with frontend 'public_ssl' (needs 'mode http'). Falling back to 'option tcplog'.

Since the router falls back on 'option tcplog' we add a switch to add 'option tcplog' to frontend public_ssl when ROUTER_SYSLOG_ADDRESS is set

bug 1533346
https://bugzilla.redhat.com/show_bug.cgi?id=1533346