### PR TITLE
Remove the 'openshift' names from server certificates

### DIFF
--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -486,10 +486,6 @@ func (args MasterArgs) GetServerCertHostnames() (sets.String, error) {
 
 	allHostnames := sets.NewString(
 		"localhost", "127.0.0.1",
-		"openshift.default.svc.cluster.local",
-		"openshift.default.svc",
-		"openshift.default",
-		"openshift",
 		"kubernetes.default.svc.cluster.local",
 		"kubernetes.default.svc",
 		"kubernetes.default",


### PR DESCRIPTION
We want to trim the static names that go into the server certificates as much as possible.. I don't think we can get rid of the kubernetes names yet.
@liggitt @simo5  @openshift/sig-security 