### PR TITLE
node, syscontainer: bind mount /opt/cni/bin from the host

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -490,6 +490,15 @@
 		"mode=755",
 		"size=65536k"
 	    ]
+	},
+	{
+	    "destination": "/opt/cni/bin",
+	    "type": "bind",
+	    "source": "/opt/cni/bin",
+	    "options": [
+		"rbind",
+		"rslave"
+	    ]
 	}
         $ADDTL_MOUNTS
     ],


### PR DESCRIPTION
Closes: https://github.com/openshift/openshift-ansible/issues/8159

(cherry picked from commit b7a8834fa9475a9b01b4913e4572f0e1d3d748b3)
(cherry picked from commit e67fbd9346905982247bc3c3ddfcff1cd3ce0b78)
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>