### PR TITLE
Pause the work queue when following, instead of retrying

### DIFF
--- a/pkg/util/writerlease/writerlease.go
+++ b/pkg/util/writerlease/writerlease.go
@@ -247,7 +247,8 @@ func (l *WriterLease) work() bool {
 		// if we are following, continue to defer work until the lease expires
 		if remaining := leaseExpires.Sub(l.nowFn()); remaining > 0 {
 			glog.V(4).Infof("[%s] Follower, %s remaining in lease", l.name, remaining)
-			l.queue.AddAfter(key, remaining)
+			time.Sleep(remaining)
+			l.queue.Add(key)
 			l.queue.Done(key)
 			return true
 		}


### PR DESCRIPTION
Prevent conflicting routers from conflicting as much up front. Prevents out of order actions and requeues causing us to "steal" leadership more often. Should reduce contention.