### PR TITLE
up: fix mount-path for docker registry

### DIFF
--- a/pkg/oc/bootstrap/clusteradd/components/registry/registry_install.go
+++ b/pkg/oc/bootstrap/clusteradd/components/registry/registry_install.go
@@ -67,7 +67,7 @@ func (r *RegistryComponentOptions) Install(dockerClient dockerhelper.Interface, 
 		fmt.Sprintf("--cluster-ip=%s", RegistryServiceClusterIP),
 		fmt.Sprintf("--config=%s", path.Join(masterConfigDir, "admin.kubeconfig")),
 		fmt.Sprintf("--images=%s", r.InstallContext.ImageFormat()),
-		fmt.Sprintf("--mount-host=%s", path.Join(r.InstallContext.BaseDir(), "openshift.local.pv", "registry")),
+		fmt.Sprintf("--mount-host=%s", path.Join(baseDir, "openshift.local.pv", "registry")),
 	}
 	_, rc, err := imageRunHelper.Image(r.InstallContext.ClientImage()).
 		Privileged().

--- a/pkg/oc/bootstrap/docker/down.go
+++ b/pkg/oc/bootstrap/docker/down.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 
@@ -30,7 +29,7 @@ type ClientStopConfig struct {
 }
 
 // NewCmdDown creates a command that stops OpenShift
-func NewCmdDown(name, fullName string, out io.Writer) *cobra.Command {
+func NewCmdDown(name, fullName string) *cobra.Command {
 	config := &ClientStopConfig{}
 	cmd := &cobra.Command{
 		Use:     name,

--- a/pkg/oc/cli/cli.go
+++ b/pkg/oc/cli/cli.go
@@ -109,7 +109,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 				cmd.NewCmdProject(fullName+" project", f, out),
 				cmd.NewCmdProjects(fullName, f, out),
 				cmd.NewCmdExplain(fullName, f, out, errout),
-				cluster.NewCmdCluster(cluster.ClusterRecommendedName, fullName+" "+cluster.ClusterRecommendedName, f, in, out, errout),
+				cluster.NewCmdCluster(cluster.ClusterRecommendedName, fullName+" "+cluster.ClusterRecommendedName, f, out, errout),
 			},
 		},
 		{

--- a/pkg/oc/cli/cmd/cluster/cluster.go
+++ b/pkg/oc/cli/cmd/cluster/cluster.go
@@ -32,7 +32,7 @@ var (
 		routing suffix, use the --routing-suffix flag.`)
 )
 
-func NewCmdCluster(name, fullName string, f *clientcmd.Factory, in io.Reader, out, errout io.Writer) *cobra.Command {
+func NewCmdCluster(name, fullName string, f *clientcmd.Factory, out, errout io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   fmt.Sprintf("%s ACTION", name),
@@ -45,7 +45,7 @@ func NewCmdCluster(name, fullName string, f *clientcmd.Factory, in io.Reader, ou
 
 	cmds.AddCommand(clusterAdd)
 	cmds.AddCommand(docker.NewCmdUp(docker.CmdUpRecommendedName, fullName+" "+docker.CmdUpRecommendedName, out, errout, clusterAdd))
-	cmds.AddCommand(docker.NewCmdDown(docker.CmdDownRecommendedName, fullName+" "+docker.CmdDownRecommendedName, out))
+	cmds.AddCommand(docker.NewCmdDown(docker.CmdDownRecommendedName, fullName+" "+docker.CmdDownRecommendedName))
 	cmds.AddCommand(docker.NewCmdStatus(docker.CmdStatusRecommendedName, fullName+" "+docker.CmdStatusRecommendedName, f, out))
 	return cmds
 }


### PR DESCRIPTION
In remote docker daemon case, the registry host mount path should be prefixed
into /var/lib/origin

Fixes: https://github.com/openshift/origin/pull/19561

/cc @deads2k
/cc @praveenkumar 