### PR TITLE
[diagnostics] Use masterConfig in a field member of MasterConfigCheck struct

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics/host/check_master_config.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/host/check_master_config.go
@@ -50,7 +50,7 @@ func (d *MasterConfigCheck) CanRun() (bool, error) {
 func (d *MasterConfigCheck) Check() types.DiagnosticResult {
 	r := types.NewDiagnosticResult(MasterConfigCheckName)
 
-	results := configvalidation.ValidateMasterConfig(masterConfig, nil)
+	results := configvalidation.ValidateMasterConfig(d.masterConfig, nil)
 	if len(results.Errors) > 0 {
 		errText := fmt.Sprintf("Validation of master config file '%s' failed:\n", d.MasterConfigFile)
 		for _, err := range results.Errors {


### PR DESCRIPTION
Although masterConfig was set in a filed of `MasterConfigCheck` at
`complete()`:

https://github.com/openshift/origin/blob/f3ca235771db1294c30a2f60fd892e5aed9876e0/pkg/oc/admin/diagnostics/diagnostics/host/check_master_config.go#L38

the set value is not used, but used from `util.go`'s global value:

https://github.com/openshift/origin/blob/f3ca235771db1294c30a2f60fd892e5aed9876e0/pkg/oc/admin/diagnostics/diagnostics/host/check_master_config.go#L53

(though I think that there is no remarkable issue due to this at this
moment) this patch updates to use proper value.