### PR TITLE
Add openshift profiling to kubelet

### DIFF
--- a/pkg/cmd/server/origin/profiler.go
+++ b/pkg/cmd/server/origin/profiler.go
@@ -3,6 +3,7 @@ package origin
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"runtime"
 
 	"github.com/golang/glog"

--- a/vendor/k8s.io/kubernetes/cmd/kubelet/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubelet/app/server.go
@@ -94,6 +94,8 @@ import (
 	"k8s.io/kubernetes/pkg/util/rlimit"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/version/verflag"
+
+	"github.com/openshift/origin/pkg/cmd/server/origin"
 )
 
 const (
@@ -227,6 +229,9 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 					glog.Fatal(err)
 				}
 			}
+
+			// inject openshift profiling logic into kubelet
+			origin.StartProfiler()
 
 			// run the kubelet
 			if err := Run(kubeletServer, kubeletDeps); err != nil {


### PR DESCRIPTION
Always import net/http/pprof when OPENSHIFT_PROFILE=web is used

This guarantees that we always register the debug pprof endpoints into the default serve mux when openshift profiling is used.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

UPSTREAM: `<carry>`: Add openshift profiling to kubelet

This change adds support for OPENSHIFT_PROFILE=web into to the kubelet.  This behavior was lost during the move to hyperkube.

Bug 1572919

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/kind bug
/assign @sjenning
@openshift/sig-pod @openshift/sig-master
https://bugzilla.redhat.com/show_bug.cgi?id=1572919