### PR TITLE
Remove deprecated envvar-based credential support from images

### DIFF
--- a/pkg/cmd/infra/router/clientcmd.go
+++ b/pkg/cmd/infra/router/clientcmd.go
@@ -2,11 +2,8 @@ package router
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -16,73 +13,36 @@ import (
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-
-	"github.com/openshift/origin/pkg/cmd/flagtypes"
-	"github.com/openshift/origin/pkg/cmd/util"
 )
-
-const ConfigSyntax = " --master=<addr>"
 
 // Config contains all the necessary bits for client configuration
 type Config struct {
-	// MasterAddr is the address the master can be reached on (host, host:port, or URL).
-	MasterAddr flagtypes.Addr
-	// KubernetesAddr is the address of the Kubernetes server (host, host:port, or URL).
-	// If omitted defaults to the master.
-	KubernetesAddr flagtypes.Addr
 	// CommonConfig is the shared base config for both the OpenShift config and Kubernetes config
 	CommonConfig restclient.Config
 	// Namespace is the namespace to act in
 	Namespace string
 
-	// If set, allow kubeconfig file loading
-	FromFile bool
-	// If true, no environment is loaded (for testing, primarily)
-	SkipEnv      bool
 	clientConfig clientcmd.ClientConfig
 }
 
 // NewConfig returns a new configuration
 func NewConfig() *Config {
-	return &Config{
-		MasterAddr:     flagtypes.Addr{Value: "localhost:8080", DefaultScheme: "http", DefaultPort: 8080, AllowPrefix: true}.Default(),
-		KubernetesAddr: flagtypes.Addr{Value: "localhost:8080", DefaultScheme: "http", DefaultPort: 8080}.Default(),
-		CommonConfig:   restclient.Config{},
-	}
+	return &Config{}
 }
 
 // Bind binds configuration values to the passed flagset
 func (cfg *Config) Bind(flags *pflag.FlagSet) {
-	flags.Var(&cfg.MasterAddr, "master", "The address the master can be reached on (host, host:port, or URL).")
-	flags.Var(&cfg.KubernetesAddr, "kubernetes", "The address of the Kubernetes server (host, host:port, or URL). If omitted defaults to the master.")
-
-	if cfg.FromFile {
-		cfg.clientConfig = DefaultClientConfig(flags)
-	} else {
-		BindClientConfigSecurityFlags(&cfg.CommonConfig, flags)
-	}
-}
-
-// OpenShiftConfig returns the OpenShift configuration
-func (cfg *Config) OpenShiftConfig() *restclient.Config {
-	err := cfg.bindEnv()
-	if err != nil {
-		glog.Error(err)
-	}
-
-	osConfig := cfg.CommonConfig
-	if len(osConfig.Host) == 0 || cfg.MasterAddr.Provided {
-		osConfig.Host = cfg.MasterAddr.String()
-	}
-
-	return &osConfig
+	cfg.clientConfig = DefaultClientConfig(flags)
 }
 
 // Clients returns an OpenShift and a Kubernetes client from a given configuration
 func (cfg *Config) Clients() (kclientset.Interface, error) {
-	cfg.bindEnv()
+	config, _, err := cfg.KubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to configure Kubernetes client: %v", err)
+	}
 
-	kubeClientset, err := kclientset.NewForConfig(cfg.KubeConfig())
+	kubeClientset, err := kclientset.NewForConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to configure Kubernetes client: %v", err)
 	}
@@ -100,100 +60,16 @@ func BindClientConfigSecurityFlags(config *restclient.Config, flags *pflag.FlagS
 }
 
 // KubeConfig returns the Kubernetes configuration
-func (cfg *Config) KubeConfig() *restclient.Config {
-	err := cfg.bindEnv()
+func (cfg *Config) KubeConfig() (*restclient.Config, string, error) {
+	clientConfig, err := cfg.clientConfig.ClientConfig()
 	if err != nil {
-		glog.Error(err)
+		return nil, "", err
 	}
-
-	kaddr := cfg.KubernetesAddr
-	if !kaddr.Provided {
-		kaddr = cfg.MasterAddr
+	namespace, _, err := cfg.clientConfig.Namespace()
+	if err != nil {
+		return nil, "", err
 	}
-
-	kConfig := cfg.CommonConfig
-	kConfig.Host = kaddr.URL.String()
-
-	return &kConfig
-}
-
-func (cfg *Config) bindEnv() error {
-	// bypass loading from env
-	if cfg.SkipEnv {
-		return nil
-	}
-	var err error
-
-	// callers may not use the config file if they have specified a master directly, for backwards
-	// compatibility with components that used to use env, switch to service account token, and have
-	// config defined in env.
-	_, masterSet := util.GetEnv("OPENSHIFT_MASTER")
-	specifiedMaster := masterSet || cfg.MasterAddr.Provided
-
-	if cfg.clientConfig != nil && !specifiedMaster {
-		clientConfig, err := cfg.clientConfig.ClientConfig()
-		if err != nil {
-			return err
-		}
-		cfg.CommonConfig = *clientConfig
-		cfg.Namespace, _, err = cfg.clientConfig.Namespace()
-		if err != nil {
-			return err
-		}
-
-		if !cfg.MasterAddr.Provided {
-			cfg.MasterAddr.Set(cfg.CommonConfig.Host)
-		}
-		if !cfg.KubernetesAddr.Provided {
-			cfg.KubernetesAddr.Set(cfg.CommonConfig.Host)
-		}
-		return nil
-	}
-
-	// Legacy path - preserve env vars set on pods that previously were honored.
-	if value, ok := util.GetEnv("KUBERNETES_MASTER"); ok && !cfg.KubernetesAddr.Provided {
-		cfg.KubernetesAddr.Set(value)
-	}
-	if value, ok := util.GetEnv("OPENSHIFT_MASTER"); ok && !cfg.MasterAddr.Provided {
-		cfg.MasterAddr.Set(value)
-	}
-	if value, ok := util.GetEnv("BEARER_TOKEN"); ok && len(cfg.CommonConfig.BearerToken) == 0 {
-		cfg.CommonConfig.BearerToken = value
-	}
-	if value, ok := util.GetEnv("BEARER_TOKEN_FILE"); ok && len(cfg.CommonConfig.BearerToken) == 0 {
-		if tokenData, tokenErr := ioutil.ReadFile(value); tokenErr == nil {
-			cfg.CommonConfig.BearerToken = strings.TrimSpace(string(tokenData))
-			if len(cfg.CommonConfig.BearerToken) == 0 {
-				err = fmt.Errorf("BEARER_TOKEN_FILE %q was empty", value)
-			}
-		} else {
-			err = fmt.Errorf("Error reading BEARER_TOKEN_FILE %q: %v", value, tokenErr)
-		}
-	}
-
-	if value, ok := util.GetEnv("OPENSHIFT_CA_FILE"); ok && len(cfg.CommonConfig.CAFile) == 0 {
-		cfg.CommonConfig.CAFile = value
-	} else if value, ok := util.GetEnv("OPENSHIFT_CA_DATA"); ok && len(cfg.CommonConfig.CAData) == 0 {
-		cfg.CommonConfig.CAData = []byte(value)
-	}
-
-	if value, ok := util.GetEnv("OPENSHIFT_CERT_FILE"); ok && len(cfg.CommonConfig.CertFile) == 0 {
-		cfg.CommonConfig.CertFile = value
-	} else if value, ok := util.GetEnv("OPENSHIFT_CERT_DATA"); ok && len(cfg.CommonConfig.CertData) == 0 {
-		cfg.CommonConfig.CertData = []byte(value)
-	}
-
-	if value, ok := util.GetEnv("OPENSHIFT_KEY_FILE"); ok && len(cfg.CommonConfig.KeyFile) == 0 {
-		cfg.CommonConfig.KeyFile = value
-	} else if value, ok := util.GetEnv("OPENSHIFT_KEY_DATA"); ok && len(cfg.CommonConfig.KeyData) == 0 {
-		cfg.CommonConfig.KeyData = []byte(value)
-	}
-
-	if value, ok := util.GetEnv("OPENSHIFT_INSECURE"); ok && len(value) != 0 {
-		cfg.CommonConfig.Insecure = value == "true"
-	}
-
-	return err
+	return clientConfig, namespace, nil
 }
 
 func DefaultClientConfig(flags *pflag.FlagSet) kclientcmd.ClientConfig {

--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -140,10 +140,9 @@ func NewCommandF5Router(name string) *cobra.Command {
 	options := &F5RouterOptions{
 		Config: NewConfig(),
 	}
-	options.Config.FromFile = true
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s%s", name, ConfigSyntax),
+		Use:   name,
 		Short: "Start an F5 route synchronizer",
 		Long:  f5Long,
 		Run: func(c *cobra.Command, args []string) {
@@ -222,11 +221,15 @@ func (o *F5RouterOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	routeclient, err := routeinternalclientset.NewForConfig(o.Config.OpenShiftConfig())
+	config, _, err := o.Config.KubeConfig()
 	if err != nil {
 		return err
 	}
-	projectclient, err := projectinternalclientset.NewForConfig(o.Config.OpenShiftConfig())
+	routeclient, err := routeinternalclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	projectclient, err := projectinternalclientset.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -140,10 +140,9 @@ func NewCommandTemplateRouter(name string) *cobra.Command {
 	options := &TemplateRouterOptions{
 		Config: NewConfig(),
 	}
-	options.Config.FromFile = true
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s%s", name, ConfigSyntax),
+		Use:   name,
 		Short: "Start a router",
 		Long:  routerLong,
 		Run: func(c *cobra.Command, args []string) {
@@ -315,7 +314,10 @@ func (o *TemplateRouterOptions) Run() error {
 			check = metrics.ProxyProtocolHTTPBackendAvailable(u)
 		}
 
-		kubeconfig := o.Config.KubeConfig()
+		kubeconfig, _, err := o.Config.KubeConfig()
+		if err != nil {
+			return err
+		}
 		client, err := authorizationclient.NewForConfig(kubeconfig)
 		if err != nil {
 			return err
@@ -397,11 +399,15 @@ func (o *TemplateRouterOptions) Run() error {
 	if err != nil {
 		return err
 	}
-	routeclient, err := routeinternalclientset.NewForConfig(o.Config.OpenShiftConfig())
+	config, _, err := o.Config.KubeConfig()
 	if err != nil {
 		return err
 	}
-	projectclient, err := projectinternalclientset.NewForConfig(o.Config.OpenShiftConfig())
+	routeclient, err := routeinternalclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+	projectclient, err := projectinternalclientset.NewForConfig(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift/openshift_test.go
+++ b/pkg/cmd/openshift/openshift_test.go
@@ -1,7 +1,6 @@
 package openshift
 
 import (
-	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -9,7 +8,7 @@ import (
 
 func TestCommandFor(t *testing.T) {
 	cmd := CommandFor("openshift-router", wait.NeverStop)
-	if !strings.HasPrefix(cmd.Use, "openshift-router ") {
+	if cmd.Use != "openshift-router" {
 		t.Errorf("expected command to start with prefix: %#v", cmd)
 	}
 


### PR DESCRIPTION
Drops long-deprecated (deprecated in 3.4) support for specifying credential info via envvars or a mix of kubeconfig and `--master` flags in favor of in-cluster config or explicit `--config` file