### PR TITLE
ext_tests: make mongodb check tolerate any non zero pagecount

### DIFF
--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -15,7 +15,9 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-type SampleRepoConfig struct {
+var htmlCountValueNonZeroRegexp = `<span class="code" id="count-value">[^0][0-9]*</span>`
+
+type sampleRepoConfig struct {
 	repoName               string
 	templateURL            string
 	buildConfigName        string
@@ -30,7 +32,7 @@ type SampleRepoConfig struct {
 // NewSampleRepoTest creates a function for a new ginkgo test case that will instantiate a template
 // from a url, kick off the buildconfig defined in that template, wait for the build/deploy,
 // and then confirm the application is serving an expected string value.
-func NewSampleRepoTest(c SampleRepoConfig) func() {
+func NewSampleRepoTest(c sampleRepoConfig) func() {
 	return func() {
 		defer g.GinkgoRecover()
 		var oc = exutil.NewCLI(c.repoName+"-repo-test", exutil.KubeConfigPath())
@@ -114,7 +116,7 @@ func NewSampleRepoTest(c SampleRepoConfig) func() {
 						e2e.Logf("url check got %s, expected it to contain %s", response, c.expectedString)
 						return false, nil
 					})
-					o.Expect(response).Should(o.ContainSubstring(c.expectedString))
+					o.Expect(response).Should(o.MatchRegexp(c.expectedString))
 				})
 			})
 		})
@@ -124,129 +126,129 @@ func NewSampleRepoTest(c SampleRepoConfig) func() {
 var _ = g.Describe("[image_ecosystem][Slow] openshift sample application repositories", func() {
 
 	g.Describe("[image_ecosystem][ruby] test ruby images with rails-ex db repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"rails-postgresql",
-			"https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json",
-			"rails-postgresql-example",
-			"rails-postgresql-example",
-			"rails-postgresql-example",
-			"Listing articles",
-			"/articles",
-			"postgresql",
-			"postgresql",
+		sampleRepoConfig{
+			repoName:               "rails-postgresql",
+			templateURL:            "https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json",
+			buildConfigName:        "rails-postgresql-example",
+			serviceName:            "rails-postgresql-example",
+			deploymentConfigName:   "rails-postgresql-example",
+			expectedString:         "Listing articles",
+			appPath:                "/articles",
+			dbDeploymentConfigName: "postgresql",
+			dbServiceName:          "postgresql",
 		},
 	))
 
 	g.Describe("[image_ecosystem][python] test python images with django-ex db repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"django-psql",
-			"https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django-postgresql.json",
-			"django-psql-example",
-			"django-psql-example",
-			"django-psql-example",
-			"Page views: 1",
-			"",
-			"postgresql",
-			"postgresql",
+		sampleRepoConfig{
+			repoName:               "django-psql",
+			templateURL:            "https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django-postgresql.json",
+			buildConfigName:        "django-psql-example",
+			serviceName:            "django-psql-example",
+			deploymentConfigName:   "django-psql-example",
+			expectedString:         "Page views: 1",
+			appPath:                "",
+			dbDeploymentConfigName: "postgresql",
+			dbServiceName:          "postgresql",
 		},
 	))
 
 	g.Describe("[image_ecosystem][nodejs] test nodejs images with nodejs-ex db repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"nodejs-mongodb",
-			"https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json",
-			"nodejs-mongodb-example",
-			"nodejs-mongodb-example",
-			"nodejs-mongodb-example",
-			"<span class=\"code\" id=\"count-value\">1</span>",
-			"",
-			"mongodb",
-			"mongodb",
+		sampleRepoConfig{
+			repoName:               "nodejs-mongodb",
+			templateURL:            "https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json",
+			buildConfigName:        "nodejs-mongodb-example",
+			serviceName:            "nodejs-mongodb-example",
+			deploymentConfigName:   "nodejs-mongodb-example",
+			expectedString:         htmlCountValueNonZeroRegexp,
+			appPath:                "",
+			dbDeploymentConfigName: "mongodb",
+			dbServiceName:          "mongodb",
 		},
 	))
 
 	var _ = g.Describe("[image_ecosystem][php] test php images with cakephp-ex db repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"cakephp-mysql",
-			"https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp-mysql.json",
-			"cakephp-mysql-example",
-			"cakephp-mysql-example",
-			"cakephp-mysql-example",
-			"<span class=\"code\" id=\"count-value\">1</span>",
-			"",
-			"mysql",
-			"mysql",
+		sampleRepoConfig{
+			repoName:               "cakephp-mysql",
+			templateURL:            "https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp-mysql.json",
+			buildConfigName:        "cakephp-mysql-example",
+			serviceName:            "cakephp-mysql-example",
+			deploymentConfigName:   "cakephp-mysql-example",
+			expectedString:         htmlCountValueNonZeroRegexp,
+			appPath:                "",
+			dbDeploymentConfigName: "mysql",
+			dbServiceName:          "mysql",
 		},
 	))
 
 	var _ = g.Describe("[image_ecosystem][perl] test perl images with dancer-ex db repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"dancer-mysql",
-			"https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer-mysql.json",
-			"dancer-mysql-example",
-			"dancer-mysql-example",
-			"dancer-mysql-example",
-			"<span class=\"code\" id=\"count-value\">1</span>",
-			"",
-			"database",
-			"database",
+		sampleRepoConfig{
+			repoName:               "dancer-mysql",
+			templateURL:            "https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer-mysql.json",
+			buildConfigName:        "dancer-mysql-example",
+			serviceName:            "dancer-mysql-example",
+			deploymentConfigName:   "dancer-mysql-example",
+			expectedString:         htmlCountValueNonZeroRegexp,
+			appPath:                "",
+			dbDeploymentConfigName: "database",
+			dbServiceName:          "database",
 		},
 	))
 
 	// test the no-db templates too
 	g.Describe("[image_ecosystem][python] test python images with django-ex repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"django",
-			"https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django.json",
-			"django-example",
-			"django-example",
-			"django-example",
-			"Welcome",
-			"",
-			"",
-			"",
+		sampleRepoConfig{
+			repoName:               "django",
+			templateURL:            "https://raw.githubusercontent.com/openshift/django-ex/master/openshift/templates/django.json",
+			buildConfigName:        "django-example",
+			serviceName:            "django-example",
+			deploymentConfigName:   "django-example",
+			expectedString:         "Welcome",
+			appPath:                "",
+			dbDeploymentConfigName: "",
+			dbServiceName:          "",
 		},
 	))
 
 	g.Describe("[image_ecosystem][nodejs] images with nodejs-ex repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"nodejs",
-			"https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs.json",
-			"nodejs-example",
-			"nodejs-example",
-			"nodejs-example",
-			"Welcome",
-			"",
-			"",
-			"",
+		sampleRepoConfig{
+			repoName:               "nodejs",
+			templateURL:            "https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs.json",
+			buildConfigName:        "nodejs-example",
+			serviceName:            "nodejs-example",
+			deploymentConfigName:   "nodejs-example",
+			expectedString:         "Welcome",
+			appPath:                "",
+			dbDeploymentConfigName: "",
+			dbServiceName:          "",
 		},
 	))
 
 	var _ = g.Describe("[image_ecosystem][php] test php images with cakephp-ex repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"cakephp",
-			"https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp.json",
-			"cakephp-example",
-			"cakephp-example",
-			"cakephp-example",
-			"Welcome",
-			"",
-			"",
-			"",
+		sampleRepoConfig{
+			repoName:               "cakephp",
+			templateURL:            "https://raw.githubusercontent.com/openshift/cakephp-ex/master/openshift/templates/cakephp.json",
+			buildConfigName:        "cakephp-example",
+			serviceName:            "cakephp-example",
+			deploymentConfigName:   "cakephp-example",
+			expectedString:         "Welcome",
+			appPath:                "",
+			dbDeploymentConfigName: "",
+			dbServiceName:          "",
 		},
 	))
 
 	var _ = g.Describe("[image_ecosystem][perl] test perl images with dancer-ex repo", NewSampleRepoTest(
-		SampleRepoConfig{
-			"dancer",
-			"https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer.json",
-			"dancer-example",
-			"dancer-example",
-			"dancer-example",
-			"Welcome",
-			"",
-			"",
-			"",
+		sampleRepoConfig{
+			repoName:               "dancer",
+			templateURL:            "https://raw.githubusercontent.com/openshift/dancer-ex/master/openshift/templates/dancer.json",
+			buildConfigName:        "dancer-example",
+			serviceName:            "dancer-example",
+			deploymentConfigName:   "dancer-example",
+			expectedString:         "Welcome",
+			appPath:                "",
+			dbDeploymentConfigName: "",
+			dbServiceName:          "",
 		},
 	))
 


### PR DESCRIPTION
Making the mongodb tests less strict about how the example app counts the pagecount.

`SampleRepoConfig` is never used outside of this package and it probably makes sense only for its package so making it non-exported.

Slightly improved readability of instantiating the `sampleRepoConfig`, given all its fields are `string`, it was easy to get confused with the order.

relevant to: https://github.com/openshift/origin/issues/19379

ptal @openshift/sig-developer-experience