### PR TITLE
UPSTREAM: <carry>: enable CRD subresources

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
@@ -50,5 +50,5 @@ func init() {
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 	CustomResourceValidation:   {Default: true, PreRelease: utilfeature.Beta},
-	CustomResourceSubresources: {Default: false, PreRelease: utilfeature.Alpha},
+	CustomResourceSubresources: {Default: true, PreRelease: utilfeature.Alpha},
 }


### PR DESCRIPTION
@sttts any reason we shouldn't enable the CRDs subresources by default?  I made use of the status subresource to drive generations in my operator here: https://github.com/openshift/origin/pull/19498 .

@openshift/api-review I'm going off now to find the flag that wires this on, but I figured I'd open a pull to debate whether we should just turn this one on.