### PR TITLE
UPSTREAM: 63349: Decorate function not called on Create

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -360,7 +360,7 @@ func (e *Store) Create(ctx genericapirequest.Context, obj runtime.Object, create
 		}
 	}
 	if e.Decorator != nil {
-		if err := e.Decorator(obj); err != nil {
+		if err := e.Decorator(out); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
The wrong object was being decorated, which prevented image streams from
having the correct image registry URL status set.