### PR TITLE
Auto egress IP code reorg in prep for future features

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -37,8 +37,6 @@ type egressIPInfo struct {
 
 	assignedNodeIP       string
 	assignedIPTablesMark string
-	assignedVNID         uint32
-	blockedVNIDs         map[uint32]bool
 }
 
 type egressIPWatcher struct {
@@ -54,6 +52,9 @@ type egressIPWatcher struct {
 	nodesByNodeIP    map[string]*nodeEgress
 	namespacesByVNID map[uint32]*namespaceEgress
 	egressIPs        map[string]*egressIPInfo
+
+	changedEgressIPs  []*egressIPInfo
+	changedNamespaces []*namespaceEgress
 
 	localEgressLink netlink.Link
 	localEgressNet  *net.IPNet
@@ -112,32 +113,57 @@ func (eip *egressIPWatcher) ensureEgressIPInfo(egressIP string) *egressIPInfo {
 	return eg
 }
 
-func (eg *egressIPInfo) addNode(node *nodeEgress) {
+func (eip *egressIPWatcher) egressIPChanged(eg *egressIPInfo) {
+	eip.changedEgressIPs = append(eip.changedEgressIPs, eg)
+	for _, ns := range eg.namespaces {
+		eip.changedNamespaces = append(eip.changedNamespaces, ns)
+	}
+}
+
+func (eip *egressIPWatcher) addNode(egressIP string, node *nodeEgress) {
+	eg := eip.ensureEgressIPInfo(egressIP)
 	if len(eg.nodes) != 0 {
 		utilruntime.HandleError(fmt.Errorf("Multiple nodes claiming EgressIP %q (nodes %q, %q)", eg.ip, node.nodeIP, eg.nodes[0].nodeIP))
 	}
 	eg.nodes = append(eg.nodes, node)
+
+	eip.egressIPChanged(eg)
 }
 
-func (eg *egressIPInfo) deleteNode(node *nodeEgress) {
+func (eip *egressIPWatcher) deleteNode(egressIP string, node *nodeEgress) {
+	eg := eip.egressIPs[egressIP]
+	if eg == nil {
+		return
+	}
+
 	for i := range eg.nodes {
 		if eg.nodes[i] == node {
+			eip.egressIPChanged(eg)
 			eg.nodes = append(eg.nodes[:i], eg.nodes[i+1:]...)
 			return
 		}
 	}
 }
 
-func (eg *egressIPInfo) addNamespace(ns *namespaceEgress) {
+func (eip *egressIPWatcher) addNamespace(egressIP string, ns *namespaceEgress) {
+	eg := eip.ensureEgressIPInfo(egressIP)
 	if len(eg.namespaces) != 0 {
 		utilruntime.HandleError(fmt.Errorf("Multiple namespaces claiming EgressIP %q (NetIDs %d, %d)", eg.ip, ns.vnid, eg.namespaces[0].vnid))
 	}
 	eg.namespaces = append(eg.namespaces, ns)
+
+	eip.egressIPChanged(eg)
 }
 
-func (eg *egressIPInfo) deleteNamespace(ns *namespaceEgress) {
+func (eip *egressIPWatcher) deleteNamespace(egressIP string, ns *namespaceEgress) {
+	eg := eip.egressIPs[egressIP]
+	if eg == nil {
+		return
+	}
+
 	for i := range eg.namespaces {
 		if eg.namespaces[i] == ns {
+			eip.egressIPChanged(eg)
 			eg.namespaces = append(eg.namespaces[:i], eg.namespaces[i+1:]...)
 			return
 		}
@@ -183,22 +209,15 @@ func (eip *egressIPWatcher) updateNodeEgress(nodeIP string, nodeEgressIPs []stri
 	oldRequestedIPs := node.requestedIPs
 	node.requestedIPs = sets.NewString(nodeEgressIPs...)
 
-	// Process new EgressIPs
+	// Process new and removed EgressIPs
 	for _, ip := range node.requestedIPs.Difference(oldRequestedIPs).UnsortedList() {
-		eg := eip.ensureEgressIPInfo(ip)
-		eg.addNode(node)
-		eip.syncEgressIP(eg)
+		eip.addNode(ip, node)
+	}
+	for _, ip := range oldRequestedIPs.Difference(node.requestedIPs).UnsortedList() {
+		eip.deleteNode(ip, node)
 	}
 
-	// Process removed EgressIPs
-	for _, ip := range oldRequestedIPs.Difference(node.requestedIPs).UnsortedList() {
-		eg := eip.egressIPs[ip]
-		if eg == nil {
-			continue
-		}
-		eg.deleteNode(node)
-		eip.syncEgressIP(eg)
-	}
+	eip.syncEgressIPs()
 }
 
 func (eip *egressIPWatcher) watchNetNamespaces() {
@@ -247,42 +266,54 @@ func (eip *egressIPWatcher) updateNamespaceEgress(vnid uint32, egressIP string) 
 	}
 
 	if ns.requestedIP != "" {
-		eg := eip.egressIPs[ns.requestedIP]
-		if eg != nil {
-			eg.deleteNamespace(ns)
-			eip.syncEgressIP(eg)
-		}
+		eip.deleteNamespace(ns.requestedIP, ns)
 	}
-
 	ns.requestedIP = egressIP
-	if egressIP == "" {
-		return
+	if ns.requestedIP != "" {
+		eip.addNamespace(ns.requestedIP, ns)
 	}
 
-	eg := eip.ensureEgressIPInfo(egressIP)
-	eg.addNamespace(ns)
-	eip.syncEgressIP(eg)
+	eip.syncEgressIPs()
 }
 
 func (eip *egressIPWatcher) deleteNamespaceEgress(vnid uint32) {
 	eip.updateNamespaceEgress(vnid, "")
 }
 
-func (eip *egressIPWatcher) syncEgressIP(eg *egressIPInfo) {
-	assignedNodeIPChanged := eip.syncEgressIPTablesState(eg)
-	eip.syncEgressOVSState(eg, assignedNodeIPChanged)
+func (eip *egressIPWatcher) syncEgressIPs() {
+	changedEgressIPs := make(map[*egressIPInfo]bool)
+	for _, eg := range eip.changedEgressIPs {
+		changedEgressIPs[eg] = true
+	}
+	eip.changedEgressIPs = eip.changedEgressIPs[:0]
+
+	changedNamespaces := make(map[*namespaceEgress]bool)
+	for _, ns := range eip.changedNamespaces {
+		changedNamespaces[ns] = true
+	}
+	eip.changedNamespaces = eip.changedNamespaces[:0]
+
+	for eg := range changedEgressIPs {
+		eip.syncEgressNodeState(eg)
+	}
+
+	for ns := range changedNamespaces {
+		err := eip.syncEgressNamespaceState(ns)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules for VNID %d: %v", ns.vnid, err))
+		}
+	}
 }
 
-func (eip *egressIPWatcher) syncEgressIPTablesState(eg *egressIPInfo) bool {
+func (eip *egressIPWatcher) syncEgressNodeState(eg *egressIPInfo) {
 	// The egressIPInfo should have an assigned node IP if and only if the
 	// egress IP is active (ie, it is assigned to exactly 1 node and exactly
 	// 1 namespace).
 	egressIPActive := (len(eg.nodes) == 1 && len(eg.namespaces) == 1)
-	assignedNodeIPChanged := false
 	if egressIPActive && eg.assignedNodeIP != eg.nodes[0].nodeIP {
+		glog.V(4).Infof("Assigning egress IP %s to node %s", eg.ip, eg.nodes[0].nodeIP)
 		eg.assignedNodeIP = eg.nodes[0].nodeIP
 		eg.assignedIPTablesMark = getMarkForVNID(eg.namespaces[0].vnid, eip.masqueradeBit)
-		assignedNodeIPChanged = true
 		if eg.assignedNodeIP == eip.localIP {
 			if err := eip.assignEgressIP(eg.ip, eg.assignedIPTablesMark); err != nil {
 				utilruntime.HandleError(fmt.Errorf("Error assigning Egress IP %q: %v", eg.ip, err))
@@ -290,6 +321,7 @@ func (eip *egressIPWatcher) syncEgressIPTablesState(eg *egressIPInfo) bool {
 			}
 		}
 	} else if !egressIPActive && eg.assignedNodeIP != "" {
+		glog.V(4).Infof("Removing egress IP %s from node %s", eg.ip, eg.assignedNodeIP)
 		if eg.assignedNodeIP == eip.localIP {
 			if err := eip.releaseEgressIP(eg.ip, eg.assignedIPTablesMark); err != nil {
 				utilruntime.HandleError(fmt.Errorf("Error releasing Egress IP %q: %v", eg.ip, err))
@@ -297,56 +329,22 @@ func (eip *egressIPWatcher) syncEgressIPTablesState(eg *egressIPInfo) bool {
 		}
 		eg.assignedNodeIP = ""
 		eg.assignedIPTablesMark = ""
-		assignedNodeIPChanged = true
+	} else if !egressIPActive {
+		glog.V(4).Infof("Egress IP %s is not assignable (%d namespaces, %d nodes)", eg.ip, len(eg.namespaces), len(eg.nodes))
 	}
-	return assignedNodeIPChanged
 }
 
-func (eip *egressIPWatcher) syncEgressOVSState(eg *egressIPInfo, assignedNodeIPChanged bool) {
-	var blockedVNIDs map[uint32]bool
-
-	// If multiple namespaces are assigned to the same EgressIP, we need to block
-	// outgoing traffic from all of them.
-	if len(eg.namespaces) > 1 {
-		eg.assignedVNID = 0
-		blockedVNIDs = make(map[uint32]bool)
-		for _, ns := range eg.namespaces {
-			blockedVNIDs[ns.vnid] = true
-			if !eg.blockedVNIDs[ns.vnid] {
-				err := eip.oc.SetNamespaceEgressDropped(ns.vnid)
-				if err != nil {
-					utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules: %v", err))
-				}
-			}
-		}
+func (eip *egressIPWatcher) syncEgressNamespaceState(ns *namespaceEgress) error {
+	if ns.requestedIP == "" {
+		return eip.oc.SetNamespaceEgressNormal(ns.vnid)
 	}
 
-	// If we have, or had, a single egress namespace, then update the OVS flows if
-	// something has changed
-	var err error
-	if len(eg.namespaces) == 1 && (eg.assignedVNID != eg.namespaces[0].vnid || assignedNodeIPChanged) {
-		eg.assignedVNID = eg.namespaces[0].vnid
-		delete(eg.blockedVNIDs, eg.assignedVNID)
-		err = eip.oc.SetNamespaceEgressViaEgressIP(eg.assignedVNID, eg.assignedNodeIP, getMarkForVNID(eg.assignedVNID, eip.masqueradeBit))
-	} else if len(eg.namespaces) == 0 && eg.assignedVNID != 0 {
-		err = eip.oc.SetNamespaceEgressNormal(eg.assignedVNID)
-		eg.assignedVNID = 0
+	eg := eip.egressIPs[ns.requestedIP]
+	if eg != nil && eg.assignedNodeIP != "" {
+		return eip.oc.SetNamespaceEgressViaEgressIP(ns.vnid, eg.assignedNodeIP, eg.assignedIPTablesMark)
+	} else {
+		return eip.oc.SetNamespaceEgressDropped(ns.vnid)
 	}
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules: %v", err))
-	}
-
-	// If we previously had blocked VNIDs, we need to unblock any that have been removed
-	// from the duplicates list
-	for vnid := range eg.blockedVNIDs {
-		if !blockedVNIDs[vnid] {
-			err := eip.oc.SetNamespaceEgressNormal(vnid)
-			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules: %v", err))
-			}
-		}
-	}
-	eg.blockedVNIDs = blockedVNIDs
 }
 
 func (eip *egressIPWatcher) assignEgressIP(egressIP, mark string) error {

--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -158,7 +158,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Assign NetNamespace.EgressIP first, then HostSubnet.EgressIP, with a remote EgressIP
-	eip.updateNamespaceEgress(42, "172.17.0.100")
+	eip.updateNamespaceEgress(42, []string{"172.17.0.100"})
 	err = assertNoNetlinkChanges(eip)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -190,7 +190,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eip.updateNamespaceEgress(43, "172.17.0.105")
+	eip.updateNamespaceEgress(43, []string{"172.17.0.105"})
 	err = assertNoNetlinkChanges(eip)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -201,7 +201,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Change NetNamespace.EgressIP
-	eip.updateNamespaceEgress(43, "172.17.0.101")
+	eip.updateNamespaceEgress(43, []string{"172.17.0.101"})
 	err = assertNoNetlinkChanges(eip)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -212,7 +212,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Assign NetNamespace.EgressIP first, then HostSubnet.EgressIP, with a local EgressIP
-	eip.updateNamespaceEgress(44, "172.17.0.104")
+	eip.updateNamespaceEgress(44, []string{"172.17.0.104"})
 	err = assertNoNetlinkChanges(eip)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -233,7 +233,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Change Namespace EgressIP
-	eip.updateNamespaceEgress(44, "172.17.0.102")
+	eip.updateNamespaceEgress(44, []string{"172.17.0.102"})
 	err = assertNetlinkChange(eip, "release 172.17.0.104", "claim 172.17.0.102")
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -255,7 +255,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eip.updateNamespaceEgress(45, "172.17.0.103")
+	eip.updateNamespaceEgress(45, []string{"172.17.0.103"})
 	err = assertNetlinkChange(eip, "claim 172.17.0.103")
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -277,7 +277,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Add namespace EgressIP back again after having removed it...
-	eip.updateNamespaceEgress(44, "172.17.0.102")
+	eip.updateNamespaceEgress(44, []string{"172.17.0.102"})
 	err = assertNetlinkChange(eip, "claim 172.17.0.102")
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -331,6 +331,113 @@ func TestEgressIP(t *testing.T) {
 	}
 }
 
+func TestMultipleNamespaceEgressIPs(t *testing.T) {
+	eip, flows := setupEgressIPWatcher(t)
+
+	eip.updateNamespaceEgress(42, []string{"172.17.0.100"})
+	eip.updateNodeEgress("172.17.0.3", []string{"172.17.0.100"})
+	err := assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Prepending a second, unavailable, namespace egress IP should block the working
+	// one, because we still only support using the first EgressIP
+	eip.updateNamespaceEgress(42, []string{"172.17.0.101", "172.17.0.100"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Dropped},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assigning that IP to a node should now make it work
+	eip.updateNodeEgress("172.17.0.4", []string{"172.17.0.101"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Local},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Swapping the order in the NetNamespace should bring the original Egress IP back
+	eip.updateNamespaceEgress(42, []string{"172.17.0.100", "172.17.0.101"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the inactive egress IP from its node should have no effect
+	eip.updateNodeEgress("172.17.0.4", []string{"172.17.0.200"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the remaining egress IP should now kill the namespace
+	eip.updateNodeEgress("172.17.0.3", nil)
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Dropped},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now add the egress IPs back...
+	eip.updateNodeEgress("172.17.0.3", []string{"172.17.0.100"})
+	eip.updateNodeEgress("172.17.0.4", []string{"172.17.0.101"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assigning either the used or the unused Egress IP to another namespace should
+	// break this namespace
+	eip.updateNamespaceEgress(43, []string{"172.17.0.100"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Dropped},
+		egressOVSChange{vnid: 43, egress: Dropped},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eip.deleteNamespaceEgress(43)
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"},
+		egressOVSChange{vnid: 43, egress: Normal},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eip.updateNamespaceEgress(44, []string{"172.17.0.101"})
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Dropped},
+		egressOVSChange{vnid: 44, egress: Dropped},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eip.deleteNamespaceEgress(44)
+	err = assertOVSChanges(eip, &flows,
+		egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"},
+		egressOVSChange{vnid: 44, egress: Normal},
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
 func TestNodeIPAsEgressIP(t *testing.T) {
 	eip, flows := setupEgressIPWatcher(t)
 
@@ -349,7 +456,7 @@ func TestNodeIPAsEgressIP(t *testing.T) {
 func TestDuplicateNodeEgressIPs(t *testing.T) {
 	eip, flows := setupEgressIPWatcher(t)
 
-	eip.updateNamespaceEgress(42, "172.17.0.100")
+	eip.updateNamespaceEgress(42, []string{"172.17.0.100"})
 	eip.updateNodeEgress("172.17.0.3", []string{"172.17.0.100"})
 	err := assertOVSChanges(eip, &flows, egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"})
 	if err != nil {
@@ -395,7 +502,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eip.updateNamespaceEgress(42, "172.17.0.100")
+	eip.updateNamespaceEgress(42, []string{"172.17.0.100"})
 	err = assertOVSChanges(eip, &flows, egressOVSChange{vnid: 42, egress: Dropped})
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -413,7 +520,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 	eip, flows := setupEgressIPWatcher(t)
 
-	eip.updateNamespaceEgress(42, "172.17.0.100")
+	eip.updateNamespaceEgress(42, []string{"172.17.0.100"})
 	eip.updateNodeEgress("172.17.0.3", []string{"172.17.0.100"})
 	err := assertOVSChanges(eip, &flows, egressOVSChange{vnid: 42, egress: Remote, remote: "172.17.0.3"})
 	if err != nil {
@@ -422,7 +529,7 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 
 	// Adding the Egress IP to another namespace should not work and should cause both
 	// namespaces to start dropping traffic.
-	eip.updateNamespaceEgress(43, "172.17.0.100")
+	eip.updateNamespaceEgress(43, []string{"172.17.0.100"})
 	err = assertOVSChanges(eip, &flows,
 		egressOVSChange{vnid: 42, egress: Dropped},
 		egressOVSChange{vnid: 43, egress: Dropped},
@@ -442,7 +549,7 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Add duplicate back, re-breaking it
-	eip.updateNamespaceEgress(43, "172.17.0.100")
+	eip.updateNamespaceEgress(43, []string{"172.17.0.100"})
 	err = assertOVSChanges(eip, &flows,
 		egressOVSChange{vnid: 42, egress: Dropped},
 		egressOVSChange{vnid: 43, egress: Dropped},


### PR DESCRIPTION
After talking with @knobunc , here's the first half of #19578 as a separate PR... that way we can merge this sooner and if there are any bugs in the reorg part we'll catch them early.

Mostly this is just code reorganization; the only user-visible change is:

    In preparation for later fully supporting multiple NetNamespace
    EgressIPs, begin sanity-checking all of them (so that if namespace A
    has EgressIPs ["1.2.3.4", "1.2.3.6"] and namespace B has EgressIPs
    ["1.2.3.5", "1.2.3.6"], that's considered an error even though
    "1.2.3.6" would never get used by the current code).

@openshift/sig-networking PTAL