### PR TITLE
Fix jenkins plugin hang

### DIFF
--- a/test/extended/builds/jenkins_plugin.go
+++ b/test/extended/builds/jenkins_plugin.go
@@ -1,4 +1,4 @@
-package image_ecosystem
+package builds
 
 import (
 	"bytes"
@@ -112,7 +112,7 @@ func validateCreateDelete(create bool, key, out string, err error) {
 	}
 }
 
-var _ = g.Describe("[image_ecosystem][jenkins][Slow] openshift pipeline plugin", func() {
+var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("jenkins-plugin", exutil.KubeConfigPath())
 	var j *jenkins.JenkinsRef

--- a/test/extended/image_ecosystem/jenkins_plugin.go
+++ b/test/extended/image_ecosystem/jenkins_plugin.go
@@ -135,13 +135,14 @@ var _ = g.Describe("[image_ecosystem][jenkins][Slow] openshift pipeline plugin",
 			exutil.DumpApplicationPodLogs("jenkins", oc)
 
 			if dcLogFollow != nil && dcLogStdOut != nil && dcLogStdErr != nil {
-				e2e.Logf("Waiting for Jenkins DC log follow to terminate")
-				dcLogFollow.Process.Wait()
+				e2e.Logf("Killing Jenkins DC log follow")
+				dcLogFollow.Process.Kill()
 				e2e.Logf("Jenkins server logs from test:\nstdout>\n%s\n\nstderr>\n%s\n\n", string(dcLogStdOut.Bytes()), string(dcLogStdErr.Bytes()))
 				dcLogFollow = nil
 			} else {
 				e2e.Logf("Logs were not captured!\n%v\n%v\n%v\n", dcLogFollow, dcLogStdOut, dcLogStdErr)
 			}
+
 		})
 
 		g.BeforeEach(func() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -8584,16 +8584,6 @@ var _testExtendedTestdataJenkinsPluginSharedResourcesTemplateJson = []byte(`{
       }
     },
     {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nodejs-010-centos7"
-      },
-      "spec": {
-        "dockerImageRepository": "${NAMESPACE}/nodejs-010-centos7"
-      }
-    },
-    {
       "kind": "BuildConfig",
       "apiVersion": "v1",
       "metadata": {
@@ -8628,7 +8618,8 @@ var _testExtendedTestdataJenkinsPluginSharedResourcesTemplateJson = []byte(`{
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "nodejs-010-centos7:latest"
+              "namespace": "openshift",
+              "name": "nodejs:latest"
             }
           }
         },

--- a/test/extended/testdata/jenkins-plugin/shared-resources-template.json
+++ b/test/extended/testdata/jenkins-plugin/shared-resources-template.json
@@ -171,16 +171,6 @@
       }
     },
     {
-      "kind": "ImageStream",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nodejs-010-centos7"
-      },
-      "spec": {
-        "dockerImageRepository": "${NAMESPACE}/nodejs-010-centos7"
-      }
-    },
-    {
       "kind": "BuildConfig",
       "apiVersion": "v1",
       "metadata": {
@@ -215,7 +205,8 @@
           "sourceStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "nodejs-010-centos7:latest"
+              "namespace": "openshift",
+              "name": "nodejs:latest"
             }
           }
         },


### PR DESCRIPTION
@openshift/sig-developer-experience ptal

the wait used to work when jenkins was in a separate project which we deleted before this point .. the project delete would terminate jenkins

now that we are deferring project delete, we cannot depend on that for the `oc logs dc/jenkins -f` ... but we can just kill that when we are done and dump the data we got 