### PR TITLE
Fix ruby version skew in imagestream extended tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -3502,7 +3502,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       customStrategy:
         from:
@@ -3549,7 +3549,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       dockerStrategy:
         from:
@@ -3596,7 +3596,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         from:
@@ -3640,7 +3640,7 @@ items:
       dockerStrategy:
         from: 
           kind: ImageStreamTag
-          name: ruby:2.3
+          name: ruby:2.2
           namespace: openshift
 - apiVersion: v1
   kind: BuildConfig
@@ -3662,7 +3662,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         forcePull: true
@@ -3690,7 +3690,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       dockerStrategy:
         forcePull: true

--- a/test/extended/testdata/builds/test-imageresolution-custom-build.yaml
+++ b/test/extended/testdata/builds/test-imageresolution-custom-build.yaml
@@ -22,7 +22,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       customStrategy:
         from:

--- a/test/extended/testdata/builds/test-imageresolution-docker-build.yaml
+++ b/test/extended/testdata/builds/test-imageresolution-docker-build.yaml
@@ -22,7 +22,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       dockerStrategy:
         from:

--- a/test/extended/testdata/builds/test-imageresolution-s2i-build.yaml
+++ b/test/extended/testdata/builds/test-imageresolution-s2i-build.yaml
@@ -22,7 +22,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         from:

--- a/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
@@ -19,7 +19,7 @@ items:
       dockerStrategy:
         from: 
           kind: ImageStreamTag
-          name: ruby:2.3
+          name: ruby:2.2
           namespace: openshift
 - apiVersion: v1
   kind: BuildConfig
@@ -41,7 +41,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       sourceStrategy:
         forcePull: true
@@ -69,7 +69,7 @@ items:
           name: inputimage:latest
         paths:
         - destinationDir: injected/dir
-          sourcePath: /opt/rh/rh-ruby23/root/usr/bin/ruby
+          sourcePath: /opt/rh/rh-ruby22/root/usr/bin/ruby
     strategy:
       dockerStrategy:
         forcePull: true


### PR DESCRIPTION
Ruby examples in image stream test rely on ruby 2.2, tests images were built on ruby 2.3. Leads to test flake where scl cannot find ruby 2.2.


