### PR TITLE
Output resource kind with scc{-subject}-review

### DIFF
--- a/pkg/oc/admin/policy/review.go
+++ b/pkg/oc/admin/policy/review.go
@@ -150,10 +150,15 @@ func (o *sccReviewOptions) Run(args []string) error {
 		if err != nil {
 			return err
 		}
+		gvks, _, err := legacyscheme.Scheme.ObjectKinds(info.Object)
+		if err != nil {
+			return err
+		}
+		kind := gvks[0].Kind
 		objectName := info.Name
 		podTemplateSpec, err := GetPodTemplateForObject(info.Object)
 		if err != nil {
-			return fmt.Errorf(" %q cannot create pod: %v", objectName, err)
+			return fmt.Errorf("\"%s/%s\" cannot create pod: %v", kind, objectName, err)
 		}
 		err = CheckStatefulSetWithWolumeClaimTemplates(info.Object)
 		if err != nil {
@@ -167,7 +172,7 @@ func (o *sccReviewOptions) Run(args []string) error {
 		}
 		unversionedObj, err := o.client.PodSecurityPolicyReviews(o.namespace).Create(review)
 		if err != nil {
-			return fmt.Errorf("unable to compute Pod Security Policy Review for %q: %v", objectName, err)
+			return fmt.Errorf("unable to compute Pod Security Policy Review for \"%s/%s\": %v", kind, objectName, err)
 		}
 		if err = o.printer.print(info, unversionedObj, o.out); err != nil {
 			allErrs = append(allErrs, err)

--- a/pkg/oc/admin/policy/subject_review.go
+++ b/pkg/oc/admin/policy/subject_review.go
@@ -156,11 +156,16 @@ func (o *sccSubjectReviewOptions) Run(args []string) error {
 		if err != nil {
 			return err
 		}
+		gvks, _, err := legacyscheme.Scheme.ObjectKinds(info.Object)
+		if err != nil {
+			return err
+		}
+		kind := gvks[0].Kind
 		var response runtime.Object
 		objectName := info.Name
 		podTemplateSpec, err := GetPodTemplateForObject(info.Object)
 		if err != nil {
-			return fmt.Errorf(" %q cannot create pod: %v", objectName, err)
+			return fmt.Errorf("\"%s/%s\" cannot create pod: %v", kind, objectName, err)
 		}
 		err = CheckStatefulSetWithWolumeClaimTemplates(info.Object)
 		if err != nil {
@@ -169,7 +174,7 @@ func (o *sccSubjectReviewOptions) Run(args []string) error {
 		if len(userOrSA) > 0 || len(o.Groups) > 0 {
 			unversionedObj, err := o.pspSubjectReview(userOrSA, podTemplateSpec)
 			if err != nil {
-				return fmt.Errorf("unable to compute Pod Security Policy Subject Review for %q: %v", objectName, err)
+				return fmt.Errorf("unable to compute Pod Security Policy Subject Review for \"%s/%s\": %v", kind, objectName, err)
 			}
 			versionedObj := &securityapiv1.PodSecurityPolicySubjectReview{}
 			if err := legacyscheme.Scheme.Convert(unversionedObj, versionedObj, nil); err != nil {
@@ -179,7 +184,7 @@ func (o *sccSubjectReviewOptions) Run(args []string) error {
 		} else {
 			unversionedObj, err := o.pspSelfSubjectReview(podTemplateSpec)
 			if err != nil {
-				return fmt.Errorf("unable to compute Pod Security Policy Subject Review for %q: %v", objectName, err)
+				return fmt.Errorf("unable to compute Pod Security Policy Subject Review for \"%s/%s\": %v", kind, objectName, err)
 			}
 			versionedObj := &securityapiv1.PodSecurityPolicySelfSubjectReview{}
 			if err := legacyscheme.Scheme.Convert(unversionedObj, versionedObj, nil); err != nil {

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -226,7 +226,7 @@ os::cmd::expect_success_and_text 'oc policy scc-subject-review -z default -g sys
 os::cmd::expect_failure_and_text 'oc policy scc-subject-review -u alice -z default -g system:authenticated -f ${OS_ROOT}/test/testdata/job.yaml' 'error: --user and --serviceaccount are mutually exclusive'
 os::cmd::expect_success_and_text 'oc policy scc-subject-review -z system:serviceaccount:alice:default -g system:authenticated -f ${OS_ROOT}/test/testdata/job.yaml' 'restricted'
 os::cmd::expect_success_and_text 'oc policy scc-subject-review -u alice -g system:authenticated -f ${OS_ROOT}/test/testdata/job.yaml' 'restricted'
-os::cmd::expect_failure_and_text 'oc policy scc-subject-review -u alice -g system:authenticated -n noexist -f ${OS_ROOT}/test/testdata/job.yaml' 'error: unable to compute Pod Security Policy Subject Review for "hello": namespaces "noexist" not found'
+os::cmd::expect_failure_and_text 'oc policy scc-subject-review -u alice -g system:authenticated -n noexist -f ${OS_ROOT}/test/testdata/job.yaml' 'error: unable to compute Pod Security Policy Subject Review for "Job/hello": namespaces "noexist" not found'
 os::cmd::expect_success 'oc create -f ${OS_ROOT}/test/testdata/scc_lax.yaml'
 os::cmd::expect_success "oc login -u bob -p bobpassword"
 os::cmd::expect_success_and_text 'oc policy scc-review -f ${OS_ROOT}/test/testdata/job.yaml --no-headers=true' 'Job/hello   default   lax'
@@ -234,9 +234,9 @@ os::cmd::expect_success_and_text 'oc policy scc-review -z default  -f ${OS_ROOT}
 os::cmd::expect_success_and_text 'oc policy scc-review -z system:serviceaccount:policy-second:default  -f ${OS_ROOT}/test/testdata/job.yaml --no-headers=true' 'Job/hello   default   lax'
 os::cmd::expect_success_and_text 'oc policy scc-review -f ${OS_ROOT}/test/extended/testdata/deployments/deployment-simple.yaml --no-headers=true' 'DeploymentConfig/deployment-simple   default   lax'
 os::cmd::expect_success_and_text 'oc policy scc-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml --no-headers=true' ''
-os::cmd::expect_failure_and_text 'oc policy scc-review -z default -f ${OS_ROOT}/test/testdata/job.yaml --namespace=no-exist' 'error: unable to compute Pod Security Policy Review for "hello": podsecuritypolicyreviews.security.openshift.io is forbidden: User "bob" cannot create podsecuritypolicyreviews.security.openshift.io in the namespace "no-exist": User "bob" cannot create podsecuritypolicyreviews.security.openshift.io in project "no-exist"'
+os::cmd::expect_failure_and_text 'oc policy scc-review -z default -f ${OS_ROOT}/test/testdata/job.yaml --namespace=no-exist' 'error: unable to compute Pod Security Policy Review for "Job/hello": podsecuritypolicyreviews.security.openshift.io is forbidden: User "bob" cannot create podsecuritypolicyreviews.security.openshift.io in the namespace "no-exist": User "bob" cannot create podsecuritypolicyreviews.security.openshift.io in project "no-exist"'
 os::cmd::expect_failure_and_text 'oc policy scc-review -z default -f ${OS_ROOT}/test/testdata/pspreview_unsupported_statefulset.yaml' 'error: StatefulSet "rd" with spec.volumeClaimTemplates currently not supported.'
-os::cmd::expect_failure_and_text 'oc policy scc-review -z no-exist -f ${OS_ROOT}/test/testdata/job.yaml' 'error: unable to compute Pod Security Policy Review for "hello": unable to retrieve ServiceAccount no-exist: serviceaccount "no-exist" not found'
+os::cmd::expect_failure_and_text 'oc policy scc-review -z no-exist -f ${OS_ROOT}/test/testdata/job.yaml' 'error: unable to compute Pod Security Policy Review for "Job/hello": unable to retrieve ServiceAccount no-exist: serviceaccount "no-exist" not found'
 os::cmd::expect_success "oc login -u system:admin -n '${project}'"
 os::cmd::expect_success 'oc delete project policy-second'
 


### PR DESCRIPTION
As an OpenShift user, we usually use `scc{-subject}-review` with List of resources. For example:

- Checking with `oc new-app`:

~~~
# oc new-app jenkins --dry-run -o yaml |  oc adm policy scc-subject-review -n nonexist  -f  -
 "jenkins:2" cannot create pod: No PodSpec available for this object
unable to compute Pod Security Policy Subject Review for "jenkins": namespaces "nonexist" not found
 "jenkins" cannot create pod: No PodSpec available for this object
~~~

- Checking with `oc adm regitry`

~~~
# oc adm registry --dry-run -o yaml |  oc adm policy scc-subject-review -n nonexist  -f  -
 "registry" cannot create pod: No PodSpec available for this object
 "registry-registry-role" cannot create pod: No PodSpec available for this object
unable to compute Pod Security Policy Subject Review for "docker-registry": namespaces "nonexist" not found
 "docker-registry" cannot create pod: No PodSpec available for this object
~~~

However, as you can see above, all resources have similar name in the list, so we cannot distinguish what resources got what error.

So, this patch changes to output resource kind for the errors.

AFTER:

~~~
# oc new-app jenkins --dry-run -o yaml |  ./oc adm policy scc-subject-review -n nonexist  -f  -
"ImageStreamTag/jenkins:2" cannot create pod: No PodSpec available for this object
unable to compute Pod Security Policy Subject Review for "DeploymentConfig/jenkins": namespaces "nonexist" not found
"Service/jenkins" cannot create pod: No PodSpec available for this object

# oc adm registry --dry-run -o yaml |  ./oc adm policy scc-subject-review -n nonexist  -f  -
"ServiceAccount/registry" cannot create pod: No PodSpec available for this object
"ClusterRoleBinding/registry-registry-role" cannot create pod: No PodSpec available for this object
unable to compute Pod Security Policy Subject Review for "DeploymentConfig/docker-registry": namespaces "nonexist" not found
"Service/docker-registry" cannot create pod: No PodSpec available for this object
~~~