### PR TITLE
Add default label to DC created by oc create deploymentconfig

### DIFF
--- a/pkg/oc/cli/cmd/create/deploymentconfig.go
+++ b/pkg/oc/cli/cmd/create/deploymentconfig.go
@@ -80,7 +80,7 @@ func (o *CreateDeploymentConfigOptions) Complete(cmd *cobra.Command, f *clientcm
 
 	o.DryRun = cmdutil.GetFlagBool(cmd, "dry-run")
 	o.DC = &appsapi.DeploymentConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: args[0]},
+		ObjectMeta: metav1.ObjectMeta{Name: args[0], Labels: labels},
 		Spec: appsapi.DeploymentConfigSpec{
 			Selector: labels,
 			Replicas: 1,


### PR DESCRIPTION
When we create a dc by `oc create deploymentconfig`, the label is
not set to the created DC, even though PodTemplateSpec has the
label. Due to this, `# oc delete all -l deployment-config.name=test`
does not clean up DC.

~~~
// This command just clean up pods created by the DC.
# oc delete all -l deployment-config.name=test
~~~

This patch adds the default label (`deployment-config.name=NAME`) to
the DC created by `oc create deploymentconfig`.
