### PR TITLE
Move ssl-default-bind-options under ROUTER_CIPHERS related blocks.

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -39,25 +39,31 @@ global
   tune.maxrewrite 8192
   tune.bufsize 32768
 
-  # Prevent vulnerability to POODLE attacks
-  ssl-default-bind-options no-sslv3
-
 # The default cipher suite can be selected from the three sets recommended by https://wiki.mozilla.org/Security/Server_Side_TLS,
 # or the user can provide one using the ROUTER_CIPHERS environment variable.
 # By default when a cipher set is not provided, intermediate is used.
 {{- if eq (env "ROUTER_CIPHERS" "intermediate") "modern" }}
+  # Force TLSv1.2. Compliant to recommended Modern compatibility.
+  ssl-default-bind-options ssl-min-ver TLSv1.2
+
   # Modern cipher suite (no legacy browser support) from https://wiki.mozilla.org/Security/Server_Side_TLS
   tune.ssl.default-dh-param 2048
   ssl-default-bind-ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
 {{ else }}
 
   {{- if eq (env "ROUTER_CIPHERS" "intermediate") "intermediate" }}
+  # Prevent vulnerability to POODLE attacks
+  ssl-default-bind-options no-sslv3
+
   # Intermediate cipher suite (default) from https://wiki.mozilla.org/Security/Server_Side_TLS
   tune.ssl.default-dh-param 2048
   ssl-default-bind-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
   {{ else }}
 
     {{- if eq (env "ROUTER_CIPHERS" "intermediate") "old" }}
+
+  # Insecure configuration: does not prevent POODLE attacks
+  ssl-default-bind-options ssl-min-ver SSLv3
 
   # Old cipher suite (maximum compatibility but insecure) from https://wiki.mozilla.org/Security/Server_Side_TLS
   tune.ssl.default-dh-param 1024


### PR DESCRIPTION
This is a single commit PR to move **ssl-default-bind-options** under **ROUTER_CIPHERS** related blocks in the router haprox-config.template to support compliancy with Mozilla recommended configurations defined in [https://wiki.mozilla.org/Security/Server_Side_TLS](https://wiki.mozilla.org/Security/Server_Side_TLS).
Currently only the Cipher suites are implemented in order to respects the recommendations. SSL/TLS versions are not managed and the parameter **ssl-default-bind-options** only applies **no-sslv3**.

This change defines the following:

- ROUTER_CIPHERS=modern -> ssl-default-bind-options ssl-min-ver TLSv1.2  
- ROUTER_CIPHERS=intermediate -> ssl-default-bind-options no-sslv3 (this is the default)
- ROUTER_CIPHERS=old -> ssl-default-bind-options ssl-min-ver SSLv3 (insecure from POODLE attacks)
