### PR TITLE
images: remove duplicate packages

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -18,7 +18,7 @@ RUN INSTALL_PKGS=" \
       socat ethtool device-mapper iptables nmap-ncat e2fsprogs \
       xfsprogs device-mapper-persistent-data ceph-common \
       libmnl libnetfilter_conntrack conntrack-tools \
-      libnfnetlink iptables iproute bridge-utils procps-ng ethtool socat openssl \
+      libnfnetlink iproute bridge-utils procps-ng openssl \
       binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
       iscsi-initiator-utils bind-utils \
       " && \


### PR DESCRIPTION
As a result of https://github.com/openshift/origin/pull/19509, packages `iptables`, `ethtool`, and `socat` ended up being defined twice in `yum install`. This removes duplicate packages in the same command.

It is no issue, only cosmetic change