### PR TITLE
up: use YAML instead of JSON for configs

### DIFF
--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_apiserver.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_apiserver.go
@@ -36,7 +36,7 @@ func MakeOpenShiftAPIServerConfig(existingMasterConfig string, routingSuffix, ba
 	// hardcode the route suffix to the old default.  If anyone wants to change it, they can modify their config.
 	masterconfig.RoutingConfig.Subdomain = routingSuffix
 
-	configBytes, err := runtime.Encode(configapilatest.Codec, masterconfig)
+	configBytes, err := configapilatest.WriteYAML(masterconfig)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_controller.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/openshift_controller.go
@@ -33,7 +33,7 @@ func MakeOpenShiftControllerConfig(existingMasterConfig string, basedir string) 
 	masterconfig := configObj.(*configapi.MasterConfig)
 	masterconfig.ServingInfo.BindAddress = "0.0.0.0:8444"
 
-	configBytes, err := runtime.Encode(configapilatest.Codec, masterconfig)
+	configBytes, err := configapilatest.WriteYAML(masterconfig)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/oc/bootstrap/clusterup/kubelet/dns.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/dns.go
@@ -46,7 +46,7 @@ func MakeKubeDNSConfig(existingNodeConfig string, basedir string) (string, error
 	nodeConfig := configObj.(*configapi.NodeConfig)
 	nodeConfig.DNSBindAddress = "0.0.0.0:53"
 	nodeConfig.DNSRecursiveResolvConf = "resolv.conf"
-	configBytes, err := runtime.Encode(configapilatest.Codec, nodeConfig)
+	configBytes, err := configapilatest.WriteYAML(nodeConfig)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Write YAML to disk instead of JSON as projects using cluster up might depend on patching
the YAML and having JSON makes their live harder.

Fixes: https://github.com/openshift/origin/issues/19671

/cc @deads2k