### PR TITLE
up: add pull policy to context and pass it properly to cluster add

### DIFF
--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -150,7 +150,7 @@ func (c *ClusterUpConfig) StartSelfHosted(out io.Writer) error {
 		"OPENSHIFT_CONTROLLER_MANAGER_CONFIG_HOST_PATH": configDirs.openshiftControllerConfigDir,
 		"NODE_CONFIG_HOST_PATH":                         configDirs.nodeConfigDir,
 		"KUBEDNS_CONFIG_HOST_PATH":                      configDirs.kubeDNSConfigDir,
-		"OPENSHIFT_PULL_POLICY":                         c.defaultPullPolicy,
+		"OPENSHIFT_PULL_POLICY":                         c.pullPolicy,
 		"LOGLEVEL":                                      fmt.Sprintf("%d", c.ServerLogLevel),
 	}
 
@@ -183,7 +183,7 @@ func (c *ClusterUpConfig) StartSelfHosted(out io.Writer) error {
 		return err
 	}
 
-	installContext, err := componentinstall.NewComponentInstallContext(c.cliImage(), c.imageFormat(), c.defaultPullPolicy, c.BaseDir, c.ServerLogLevel)
+	installContext, err := componentinstall.NewComponentInstallContext(c.cliImage(), c.imageFormat(), c.pullPolicy, c.BaseDir, c.ServerLogLevel)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 		"/path/to/master/config-dir":              configs.masterConfigDir,
 		"/path/to/openshift-apiserver/config-dir": configs.openshiftAPIServerConfigDir,
 		"ETCD_VOLUME":                             "emptyDir:\n",
-		"OPENSHIFT_PULL_POLICY":                   c.defaultPullPolicy,
+		"OPENSHIFT_PULL_POLICY":                   c.pullPolicy,
 	}
 
 	if len(c.HostDataDir) > 0 {

--- a/pkg/oc/bootstrap/docker/up.go
+++ b/pkg/oc/bootstrap/docker/up.go
@@ -172,7 +172,7 @@ type ClusterUpConfig struct {
 	usingDefaultImages         bool
 	usingDefaultOpenShiftImage bool
 
-	defaultPullPolicy string
+	pullPolicy string
 
 	createdUser bool
 }
@@ -230,11 +230,11 @@ func (c *ClusterUpConfig) Complete(cmd *cobra.Command) error {
 
 	// Set the ImagePullPolicy field in static pods and components based in whether users specified
 	// the --tag flag or not.
-	c.defaultPullPolicy = "Always"
+	c.pullPolicy = "Always"
 	if len(c.ImageTag) > 0 {
-		c.defaultPullPolicy = "IfNotPresent"
+		c.pullPolicy = "IfNotPresent"
 	}
-	glog.V(5).Infof("Using %q as default image pull policy", c.defaultPullPolicy)
+	glog.V(5).Infof("Using %q as default image pull policy", c.pullPolicy)
 
 	// Get the default client config for login
 	var err error


### PR DESCRIPTION
This sets the right `imagePullPolicy` for components added by cluster add (which is also called from cluster up). 

/cc @deads2k @soltysh 