### PR TITLE
start collapsing onto upstream env vars

### DIFF
--- a/pkg/oc/cli/util/clientcmd/factory_client_access.go
+++ b/pkg/oc/cli/util/clientcmd/factory_client_access.go
@@ -270,7 +270,7 @@ func (f *ring0Factory) CanBeAutoscaled(kind schema.GroupKind) error {
 }
 
 func (f *ring0Factory) EditorEnvs() []string {
-	return []string{"OC_EDITOR", "EDITOR"}
+	return []string{"OC_EDITOR", "KUBE_EDITOR", "EDITOR"}
 }
 
 func getPorts(spec kapi.PodSpec) []string {


### PR DESCRIPTION
We have a vanity setting for OC_EDITOR.  There's no real reason, we should use the "standard" from upstream.

/assign @soltysh 

```release-note
oc edit now respects KUBE_EDITOR.  OC_EDITOR support will be removed in a future release, switch to KUBE_EDITOR.
```