### PR TITLE
snip links to libraries that cannot be included in library-go

### DIFF
--- a/pkg/cmd/server/crypto/crypto.go
+++ b/pkg/cmd/server/crypto/crypto.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -26,10 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
-
-	"sort"
-
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"k8s.io/client-go/util/cert"
 )
 
 var versions = map[string]uint16{
@@ -245,23 +243,6 @@ func (c *TLSCertificateConfig) GetPEMBytes() ([]byte, []byte, error) {
 	return certBytes, keyBytes, nil
 }
 
-func GetTLSCARoots(caFile string) (*TLSCARoots, error) {
-	if len(caFile) == 0 {
-		return nil, errors.New("caFile missing")
-	}
-
-	caPEMBlock, err := ioutil.ReadFile(caFile)
-	if err != nil {
-		return nil, err
-	}
-	roots, err := cmdutil.CertificatesFromPEM(caPEMBlock)
-	if err != nil {
-		return nil, fmt.Errorf("Error reading %s: %s", caFile, err)
-	}
-
-	return &TLSCARoots{roots}, nil
-}
-
 func GetTLSCertificateConfig(certFile, keyFile string) (*TLSCertificateConfig, error) {
 	if len(certFile) == 0 {
 		return nil, errors.New("certFile missing")
@@ -274,7 +255,7 @@ func GetTLSCertificateConfig(certFile, keyFile string) (*TLSCertificateConfig, e
 	if err != nil {
 		return nil, err
 	}
-	certs, err := cmdutil.CertificatesFromPEM(certPEMBlock)
+	certs, err := cert.ParseCertsPEM(certPEMBlock)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading %s: %s", certFile, err)
 	}

--- a/pkg/cmd/util/crypto.go
+++ b/pkg/cmd/util/crypto.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io/ioutil"
+
+	"k8s.io/client-go/util/cert"
 )
 
 func CertPoolFromFile(filename string) (*x509.CertPool, error) {
@@ -20,7 +21,7 @@ func CertPoolFromFile(filename string) (*x509.CertPool, error) {
 		return nil, err
 	}
 
-	certs, err := CertificatesFromPEM(pemBlock)
+	certs, err := cert.ParseCertsPEM(pemBlock)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading %s: %s", filename, err)
 	}
@@ -40,37 +41,9 @@ func CertificatesFromFile(file string) ([]*x509.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	certs, err := CertificatesFromPEM(pemBlock)
+	certs, err := cert.ParseCertsPEM(pemBlock)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading %s: %s", file, err)
-	}
-	return certs, nil
-}
-
-func CertificatesFromPEM(pemCerts []byte) ([]*x509.Certificate, error) {
-	ok := false
-	certs := []*x509.Certificate{}
-	for len(pemCerts) > 0 {
-		var block *pem.Block
-		block, pemCerts = pem.Decode(pemCerts)
-		if block == nil {
-			break
-		}
-		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
-			continue
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return certs, err
-		}
-
-		certs = append(certs, cert)
-		ok = true
-	}
-
-	if !ok {
-		return certs, errors.New("Could not read any certificates")
 	}
 	return certs, nil
 }

--- a/pkg/route/apis/route/validation/validation.go
+++ b/pkg/route/apis/route/validation/validation.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 
-	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 )
 
@@ -246,7 +246,7 @@ func ExtendedValidateRoute(route *routeapi.Route) field.ErrorList {
 
 	if len(tlsConfig.CACertificate) > 0 {
 		certPool := x509.NewCertPool()
-		if certs, err := cmdutil.CertificatesFromPEM([]byte(tlsConfig.CACertificate)); err != nil {
+		if certs, err := cert.ParseCertsPEM([]byte(tlsConfig.CACertificate)); err != nil {
 			errmsg := fmt.Sprintf("failed to parse CA certificate: %v", err)
 			result = append(result, field.Invalid(tlsFieldPath.Child("caCertificate"), "redacted ca certificate data", errmsg))
 		} else {
@@ -299,7 +299,7 @@ func ExtendedValidateRoute(route *routeapi.Route) field.ErrorList {
 	}
 
 	if len(tlsConfig.DestinationCACertificate) > 0 {
-		if _, err := cmdutil.CertificatesFromPEM([]byte(tlsConfig.DestinationCACertificate)); err != nil {
+		if _, err := cert.ParseCertsPEM([]byte(tlsConfig.DestinationCACertificate)); err != nil {
 			errmsg := fmt.Sprintf("failed to parse destination CA certificate: %v", err)
 			result = append(result, field.Invalid(tlsFieldPath.Child("destinationCACertificate"), "redacted destination ca certificate data", errmsg))
 		} else {
@@ -426,7 +426,7 @@ func validateInsecureEdgeTerminationPolicy(tls *routeapi.TLSConfig, fldPath *fie
 // validateCertificatePEM checks if a certificate PEM is valid and
 // optionally verifies the certificate using the options.
 func validateCertificatePEM(certPEM string, options *x509.VerifyOptions) ([]*x509.Certificate, error) {
-	certs, err := cmdutil.CertificatesFromPEM([]byte(certPEM))
+	certs, err := cert.ParseCertsPEM([]byte(certPEM))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/controller/servingcert/cryptoextensions/doc.go
+++ b/pkg/service/controller/servingcert/cryptoextensions/doc.go
@@ -1,4 +1,4 @@
 // Package extensions defines cryptographic extensions for OpenShift. This
 // package contains x509 extension object identifier constants and helpers
 // for generating certificates on an OpenShift cluster.
-package extensions
+package cryptoextensions

--- a/pkg/service/controller/servingcert/cryptoextensions/extensions.go
+++ b/pkg/service/controller/servingcert/cryptoextensions/extensions.go
@@ -1,4 +1,4 @@
-package extensions
+package cryptoextensions
 
 import (
 	"encoding/asn1"

--- a/pkg/service/controller/servingcert/cryptoextensions/serversigning.go
+++ b/pkg/service/controller/servingcert/cryptoextensions/serversigning.go
@@ -1,4 +1,4 @@
-package extensions
+package cryptoextensions
 
 import (
 	"crypto/x509"

--- a/pkg/service/controller/servingcert/secret_creating_controller.go
+++ b/pkg/service/controller/servingcert/secret_creating_controller.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
-	"github.com/openshift/origin/pkg/cmd/server/crypto/extensions"
 	ocontroller "github.com/openshift/origin/pkg/controller"
+	"github.com/openshift/origin/pkg/service/controller/servingcert/cryptoextensions"
 )
 
 const (
@@ -234,7 +234,7 @@ func (sc *ServiceServingCertController) syncService(key string) error {
 	servingCert, err := sc.ca.MakeServerCert(
 		sets.NewString(dnsName, fqDNSName),
 		certificateLifetime,
-		extensions.ServiceServerCertificateExtensionV1(serviceCopy),
+		cryptoextensions.ServiceServerCertificateExtensionV1(serviceCopy),
 	)
 	if err != nil {
 		return err

--- a/pkg/service/controller/servingcert/secret_creating_controller_test.go
+++ b/pkg/service/controller/servingcert/secret_creating_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/cmd/server/admin"
-	"github.com/openshift/origin/pkg/cmd/server/crypto/extensions"
+	"github.com/openshift/origin/pkg/service/controller/servingcert/cryptoextensions"
 )
 
 func controllerSetup(startingObjects []runtime.Object, stopChannel chan struct{}, t *testing.T) ( /*caName*/ string, *fake.Clientset, *watch.RaceFreeFakeWatcher, *watch.RaceFreeFakeWatcher, *ServiceServingCertController, informers.SharedInformerFactory) {
@@ -95,7 +95,7 @@ func checkGeneratedCertificate(t *testing.T, certData []byte, service *v1.Servic
 
 	found := true
 	for _, ext := range cert.Extensions {
-		if extensions.OpenShiftServerSigningServiceUIDOID.Equal(ext.Id) {
+		if cryptoextensions.OpenShiftServerSigningServiceUIDOID.Equal(ext.Id) {
 			var value string
 			if _, err := asn1.Unmarshal(ext.Value, &value); err != nil {
 				t.Errorf("unable to parse certificate extension: %v", ext.Value)

--- a/pkg/service/controller/servingcert/secret_updating_controller.go
+++ b/pkg/service/controller/servingcert/secret_updating_controller.go
@@ -19,8 +19,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/openshift/origin/pkg/cmd/server/crypto"
-	"github.com/openshift/origin/pkg/cmd/server/crypto/extensions"
 	ocontroller "github.com/openshift/origin/pkg/controller"
+	"github.com/openshift/origin/pkg/service/controller/servingcert/cryptoextensions"
 )
 
 // ServiceServingCertUpdateController is responsible for synchronizing Service objects stored
@@ -188,7 +188,7 @@ func (sc *ServiceServingCertUpdateController) syncSecret(key string) error {
 	servingCert, err := sc.ca.MakeServerCert(
 		sets.NewString(dnsName, fqDNSName),
 		certificateLifetime,
-		extensions.ServiceServerCertificateExtensionV1(service),
+		cryptoextensions.ServiceServerCertificateExtensionV1(service),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
`pkg/cmd/server/crypto` is used by everything that serves endpoints and by client and controller code for using certificates.  This snips the links to code that doesn't need to move to library-go.

/assign @liggitt 