### PR TITLE
oc new-app: allow 'dot' in ENV variable names

### DIFF
--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -98,9 +98,10 @@ os::cmd::try_until_success 'oc get imagestreamtags tag:8'
 os::cmd::expect_success 'oc create imagestreamtag tag:9 --scheduled --reference-policy=Local --from-image=mysql:latest'
 os::cmd::expect_success 'oc create imagestream tag-b'
 os::cmd::expect_success 'oc create imagestreamtag tag-b:1 --from=wildfly:12.0'
+os::cmd::expect_success 'oc create imagestreamtag tag-c:1 -A annotation.with.dots=are.ok'
 
 os::cmd::expect_failure_and_text 'oc create imagestreamtag tag-c --from-image=mysql:latest' 'must be of the form <stream_name>:<tag>'
-os::cmd::expect_failure_and_text 'oc create imagestreamtag tag-c:1 -A foo' 'annotations must be of the form key=value'
+os::cmd::expect_failure_and_text 'oc create imagestreamtag tag-c:1 -A foo' 'annotations must be of the form key=value, but is "foo"'
 os::cmd::expect_failure_and_text 'oc create imagestreamtag tag-c:2 --from=mysql --from-image=mysql:latest' '\--from and --from-image may not be used together'
 
 os::cmd::expect_success_and_text 'oc get istag/tag:1 -o jsonpath={.image.dockerImageReference}' 'wildfly.*@sha256:'


### PR DESCRIPTION
fixes: https://github.com/openshift/origin/issues/8771

reuses validators from https://github.com/kubernetes/kubernetes/pull/48986

ptal @openshift/sig-developer-experience 