### PR TITLE
update publishing rules for 1.10.2

### DIFF
--- a/publishing-kube-rules.yaml
+++ b/publishing-kube-rules.yaml
@@ -1,53 +1,53 @@
 skip-godeps: true
 rules:
-# origin-3.10-kubernetes-1.10.0
+# origin-3.10-kubernetes-1.10.2
 - destination: kubernetes-code-generator
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/code-generator
 - destination: kubernetes-apimachinery
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/apimachinery
 - destination: kubernetes-api
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/api
 - destination: kubernetes-client-go
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/client-go
 - destination: kubernetes-metrics
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/metrics
 - destination: kubernetes-apiserver
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/apiserver
 - destination: kubernetes-kube-aggregator
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/kube-aggregator
 - destination: kubernetes-apiextensions-apiserver
   branches:
-  - name: origin-3.10-kubernetes-1.10.0
+  - name: origin-3.10-kubernetes-1.10.2
     source:
-      branch: origin-3.10-kubernetes-1.10.0
+      branch: origin-3.10-kubernetes-1.10.2
       dir: staging/src/k8s.io/apiextensions-apiserver
 
 # release-1.9.1

--- a/publishing-rules.yaml
+++ b/publishing-rules.yaml
@@ -2,9 +2,13 @@ skip-godeps: true
 rules:
 - destination: kubernetes
   branches:
-  - name: release-1.9.1
+  - name: origin-3.10-kubernetes-1.10.2
     source:
       branch: master
+      dir: vendor/k8s.io/kubernetes
+  - name: release-1.9.1
+    source:
+      branch: release-3.9
       dir: vendor/k8s.io/kubernetes
 - destination: kubernetes-gengo
   branches:


### PR DESCRIPTION
openshift/kubernetes has the 1.10.2 branch merged and the fork repos have the branch created. need the publish bot to start fanning those out, then will bump deps in https://github.com/openshift/origin/pull/19684