### PR TITLE
remove internal openshift refs from oauthserver

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -363,6 +363,7 @@
     ],
     "allowedImportPackages": [
       "vendor/github.com/golang/glog",
+      "vendor/github.com/davecgh/go-spew/spew",
       "github.com/openshift/origin/pkg/authorization/authorizer/scope",
       "github.com/openshift/origin/pkg/oauth/apis/oauth/validation",
       "github.com/openshift/origin/pkg/oauth/scope",
@@ -373,10 +374,6 @@
       "github.com/openshift/origin/pkg/cmd/server/apis/config/install",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/latest",
       "github.com/openshift/origin/pkg/serviceaccounts/oauthclient",
-      "github.com/openshift/origin/pkg/user/apis/user/v1",
-      "github.com/openshift/origin/pkg/user/apis/user",
-      "github.com/openshift/origin/pkg/user/registry/test",
-      "github.com/openshift/origin/pkg/user/registry/useridentitymapping",
       "github.com/openshift/origin/pkg/util/http/links",
       "github.com/openshift/origin/pkg/util/httprequest"
     ]

--- a/pkg/oauthserver/userregistry/identitymapper/lookup_test.go
+++ b/pkg/oauthserver/userregistry/identitymapper/lookup_test.go
@@ -1,22 +1,14 @@
 package identitymapper
 
 import (
-	"context"
-	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/davecgh/go-spew/spew"
 	"k8s.io/apimachinery/pkg/runtime"
-	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/registry/rest"
+	clienttesting "k8s.io/client-go/testing"
 
-	userapi "github.com/openshift/api/user/v1"
+	userv1fakeclient "github.com/openshift/client-go/user/clientset/versioned/fake"
 	authapi "github.com/openshift/origin/pkg/oauthserver/api"
-	userapiinternal "github.com/openshift/origin/pkg/user/apis/user"
-	userapiconversion "github.com/openshift/origin/pkg/user/apis/user/v1"
-	"github.com/openshift/origin/pkg/user/registry/test"
-	mappingregistry "github.com/openshift/origin/pkg/user/registry/useridentitymapping"
 )
 
 // TODO this is actually testing the user identity mapping registry
@@ -25,226 +17,76 @@ func TestLookup(t *testing.T) {
 		ProviderName     string
 		ProviderUserName string
 
-		ExistingIdentity *userapi.Identity
-		ExistingUser     *userapi.User
+		ExistingResources []runtime.Object
 
-		ExpectedActions  []test.Action
+		ValidateActions  func(t *testing.T, actions []clienttesting.Action)
 		ExpectedError    bool
 		ExpectedUserName string
 	}{
-		"no identity": {
+		"no valid mapping": {
 			ProviderName:     "idp",
 			ProviderUserName: "bob",
 
-			ExistingIdentity: nil,
-			ExistingUser:     nil,
+			// have a user, but no mapping
+			ExistingResources: []runtime.Object{
+				makeUser("bobUserUID", "bob", "idp:bob"),
+			},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetIdentity", Object: "idp:bob"},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "useridentitymappings") {
+					t.Error(spew.Sdump(actions))
+				}
 			},
 			ExpectedError: true,
 		},
 
-		"existing identity, no user reference": {
-			ProviderName:     "idp",
-			ProviderUserName: "bob",
-
-			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "", ""),
-			ExistingUser:     nil,
-
-			ExpectedActions: []test.Action{
-				{Name: "GetIdentity", Object: "idp:bob"},
-			},
-			ExpectedError: true,
-		},
-		"existing identity, missing user reference": {
-			ProviderName:     "idp",
-			ProviderUserName: "bob",
-
-			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
-			ExistingUser:     nil,
-
-			ExpectedActions: []test.Action{
-				{Name: "GetIdentity", Object: "idp:bob"},
-				{Name: "GetUser", Object: "bob"},
-			},
-			ExpectedError: true,
-		},
-		"existing identity, invalid user UID reference": {
-			ProviderName:     "idp",
-			ProviderUserName: "bob",
-
-			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUIDInvalid", "bob"),
-			ExistingUser:     makeUser("bobUserUID", "bob", "idp:bob"),
-
-			ExpectedActions: []test.Action{
-				{Name: "GetIdentity", Object: "idp:bob"},
-				{Name: "GetUser", Object: "bob"},
-			},
-			ExpectedError: true,
-		},
-		"existing identity, user reference without identity backreference": {
-			ProviderName:     "idp",
-			ProviderUserName: "bob",
-
-			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
-			ExistingUser:     makeUser("bobUserUID", "bob" /*, "idp:bob"*/),
-
-			ExpectedActions: []test.Action{
-				{Name: "GetIdentity", Object: "idp:bob"},
-				{Name: "GetUser", Object: "bob"},
-			},
-			ExpectedError: true,
-		},
 		"existing identity, user reference": {
 			ProviderName:     "idp",
 			ProviderUserName: "bob",
 
-			ExistingIdentity: makeIdentity("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
-			ExistingUser:     makeUser("bobUserUID", "bob", "idp:bob"),
+			// have a user and a mapping
+			ExistingResources: []runtime.Object{
+				makeUserIdentityMapping("bobIdentityUID", "idp", "bob", "bobUserUID", "bob"),
+				makeUser("bobUserUID", "bob", "idp:bob"),
+			},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetIdentity", Object: "idp:bob"},
-				{Name: "GetUser", Object: "bob"},
-				{Name: "GetUser", Object: "bob"}, // extra request is for group lookup
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "useridentitymappings") {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("get", "users") || actions[1].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
 			},
 			ExpectedUserName: "bob",
 		},
 	}
 
 	for k, tc := range testcases {
-		actions := []test.Action{}
-		identityRegistry := &test.IdentityRegistry{
-			GetIdentities: map[string]*userapi.Identity{},
-			Actions:       &actions,
-		}
-		userRegistry := &test.UserRegistry{
-			GetUsers: map[string]*userapi.User{},
-			Actions:  &actions,
-		}
-		if tc.ExistingIdentity != nil {
-			identityRegistry.GetIdentities[tc.ExistingIdentity.Name] = tc.ExistingIdentity
-		}
-		if tc.ExistingUser != nil {
-			userRegistry.GetUsers[tc.ExistingUser.Name] = tc.ExistingUser
-		}
+		t.Run(k, func(t *testing.T) {
+			fakeClientSet := userv1fakeclient.NewSimpleClientset(tc.ExistingResources...)
 
-		mappingStorage := mappingregistry.NewREST(userRegistry, identityRegistry)
-		mappingRegistry := NewRegistry(mappingStorage)
-
-		lookupMapper := &lookupIdentityMapper{
-			mappings: &FakeMappingClient{mappingRegistry},
-			users:    userRegistry,
-		}
-
-		identity := authapi.NewDefaultUserIdentityInfo(tc.ProviderName, tc.ProviderUserName)
-		user, err := lookupMapper.UserFor(identity)
-		if tc.ExpectedError != (err != nil) {
-			t.Errorf("%s: Expected error=%v, got %v", k, tc.ExpectedError, err)
-			continue
-		}
-		if !tc.ExpectedError && user.GetName() != tc.ExpectedUserName {
-			t.Errorf("%s: Expected username %v, got %v", k, tc.ExpectedUserName, user.GetName())
-			continue
-		}
-
-		for i, action := range actions {
-			if len(tc.ExpectedActions) <= i {
-				t.Fatalf("%s: expected %d actions, got extras: %#v", k, len(tc.ExpectedActions), actions[i:])
-				continue
+			lookupMapper := &lookupIdentityMapper{
+				mappings: fakeClientSet.UserV1().UserIdentityMappings(),
+				users:    fakeClientSet.UserV1().Users(),
 			}
-			expectedAction := tc.ExpectedActions[i]
-			if !reflect.DeepEqual(expectedAction, action) {
-				t.Fatalf("%s: expected\n\t%s %#v\nGot\n\t%s %#v", k, expectedAction.Name, expectedAction.Object, action.Name, action.Object)
-				continue
+
+			identity := authapi.NewDefaultUserIdentityInfo(tc.ProviderName, tc.ProviderUserName)
+			user, err := lookupMapper.UserFor(identity)
+			if tc.ExpectedError != (err != nil) {
+				t.Fatalf("Expected error=%v, got %v", tc.ExpectedError, err)
 			}
-		}
-		if len(actions) < len(tc.ExpectedActions) {
-			t.Errorf("Missing %d additional actions:\n\t%#v", len(tc.ExpectedActions)-len(actions), tc.ExpectedActions[len(actions):])
-		}
+			if !tc.ExpectedError && user.GetName() != tc.ExpectedUserName {
+				t.Fatalf("Expected username %v, got %v", tc.ExpectedUserName, user.GetName())
+			}
+
+			tc.ValidateActions(t, fakeClientSet.Actions())
+		})
 	}
-}
-
-type FakeMappingClient struct {
-	mappingRegistry mappingRegistry
-}
-
-func (f *FakeMappingClient) Create(obj *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
-	return f.mappingRegistry.CreateUserIdentityMapping(context.TODO(), obj)
-}
-func (f *FakeMappingClient) Update(obj *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
-	return f.mappingRegistry.UpdateUserIdentityMapping(context.TODO(), obj)
-}
-func (f *FakeMappingClient) Delete(name string, options *v1.DeleteOptions) error {
-	return f.mappingRegistry.DeleteUserIdentityMapping(context.TODO(), name)
-}
-func (f *FakeMappingClient) Get(name string, options v1.GetOptions) (*userapi.UserIdentityMapping, error) {
-	return f.mappingRegistry.GetUserIdentityMapping(context.TODO(), name, &options)
-}
-
-// Registry is an interface implemented by things that know how to store UserIdentityMapping objects.
-type mappingRegistry interface {
-	// GetUserIdentityMapping returns a UserIdentityMapping for the named identity
-	GetUserIdentityMapping(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.UserIdentityMapping, error)
-	// CreateUserIdentityMapping associates a user and an identity
-	CreateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error)
-	// UpdateUserIdentityMapping updates an associated user and identity
-	UpdateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error)
-	// DeleteUserIdentityMapping removes the user association for the named identity
-	DeleteUserIdentityMapping(ctx apirequest.Context, name string) error
-}
-
-// Storage is an interface for a standard REST Storage backend
-// TODO: move me somewhere common
-type mappingStorage interface {
-	rest.Getter
-	rest.GracefulDeleter
-
-	Create(ctx apirequest.Context, obj runtime.Object, createValidate rest.ValidateObjectFunc, _ bool) (runtime.Object, error)
-	Update(ctx apirequest.Context, name string, objInfo rest.UpdatedObjectInfo, createValidate rest.ValidateObjectFunc, updateValidate rest.ValidateObjectUpdateFunc) (runtime.Object, bool, error)
-}
-
-// storage puts strong typing around storage calls
-type storage struct {
-	mappingStorage
-}
-
-// NewRegistry returns a new Registry interface for the given Storage. Any mismatched
-// types will panic.
-func NewRegistry(s mappingStorage) mappingRegistry {
-	return &storage{s}
-}
-
-func (s *storage) GetUserIdentityMapping(ctx apirequest.Context, name string, options *metav1.GetOptions) (*userapi.UserIdentityMapping, error) {
-	obj, err := s.Get(ctx, name, options)
-	if err != nil {
-		return nil, err
-	}
-	out := &userapi.UserIdentityMapping{}
-	if err := userapiconversion.Convert_user_UserIdentityMapping_To_v1_UserIdentityMapping(obj.(*userapiinternal.UserIdentityMapping), out, nil); err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (s *storage) CreateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
-	obj, err := s.Create(ctx, mapping, rest.ValidateAllObjectFunc, false)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*userapi.UserIdentityMapping), nil
-}
-
-func (s *storage) UpdateUserIdentityMapping(ctx apirequest.Context, mapping *userapi.UserIdentityMapping) (*userapi.UserIdentityMapping, error) {
-	obj, _, err := s.Update(ctx, mapping.Name, rest.DefaultUpdatedObjectInfo(mapping), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc)
-	if err != nil {
-		return nil, err
-	}
-	return obj.(*userapi.UserIdentityMapping), nil
-}
-
-//
-func (s *storage) DeleteUserIdentityMapping(ctx apirequest.Context, name string) error {
-	_, _, err := s.Delete(ctx, name, nil)
-	return err
 }

--- a/pkg/oauthserver/userregistry/identitymapper/strategy_add_test.go
+++ b/pkg/oauthserver/userregistry/identitymapper/strategy_add_test.go
@@ -3,8 +3,13 @@ package identitymapper
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/davecgh/go-spew/spew"
 	userapi "github.com/openshift/api/user/v1"
-	"github.com/openshift/origin/pkg/user/registry/test"
 )
 
 func TestStrategyAdd(t *testing.T) {
@@ -14,12 +19,22 @@ func TestStrategyAdd(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			CreateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
-
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "CreateUser", Object: makeUser("", "bob", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("", "bob", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
+
 			ExpectedUserName:   "bob",
 			ExpectedInitialize: true,
 		},
@@ -28,13 +43,24 @@ func TestStrategyAdd(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob")},
-			UpdateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+			ExistingUsers: []runtime.Object{makeUser("bobUserUID", "bob")},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "UpdateUser", Object: makeUser("bobUserUID", "bob", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("bobUserUID", "bob", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
+
 			ExpectedUserName:   "bob",
 			ExpectedInitialize: true,
 		},
@@ -43,12 +69,22 @@ func TestStrategyAdd(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob", "otheridp:user")},
-			UpdateResponse: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"),
+			ExistingUsers: []runtime.Object{makeUser("bobUserUID", "bob", "otheridp:user")},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "UpdateUser", Object: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
 			ExpectedUserName:   "bob",
 			ExpectedInitialize: false,

--- a/pkg/oauthserver/userregistry/identitymapper/strategy_claim_test.go
+++ b/pkg/oauthserver/userregistry/identitymapper/strategy_claim_test.go
@@ -3,8 +3,13 @@ package identitymapper
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/davecgh/go-spew/spew"
 	userapi "github.com/openshift/api/user/v1"
-	"github.com/openshift/origin/pkg/user/registry/test"
 )
 
 func TestStrategyClaim(t *testing.T) {
@@ -14,11 +19,20 @@ func TestStrategyClaim(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			CreateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
-
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "CreateUser", Object: makeUser("", "bob", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("", "bob", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
 			ExpectedUserName:   "bob",
 			ExpectedInitialize: true,
@@ -28,12 +42,22 @@ func TestStrategyClaim(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob")},
-			UpdateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
+			ExistingUsers: []runtime.Object{makeUser("bobUserUID", "bob")},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "UpdateUser", Object: makeUser("bobUserUID", "bob", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("update", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("bobUserUID", "bob", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
 			ExpectedUserName:   "bob",
 			ExpectedInitialize: true,
@@ -43,11 +67,15 @@ func TestStrategyClaim(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob", "otheridp:user")},
-			UpdateResponse: makeUser("bobUserUID", "bob", "otheridp:user", "idp:bob"),
+			ExistingUsers: []runtime.Object{makeUser("bobUserUID", "bob", "otheridp:user")},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
 			},
 			ExpectedError:      true,
 			ExpectedUserName:   "",

--- a/pkg/oauthserver/userregistry/identitymapper/strategy_generate_test.go
+++ b/pkg/oauthserver/userregistry/identitymapper/strategy_generate_test.go
@@ -3,8 +3,13 @@ package identitymapper
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/davecgh/go-spew/spew"
 	userapi "github.com/openshift/api/user/v1"
-	"github.com/openshift/origin/pkg/user/registry/test"
 )
 
 func TestStrategyGenerate(t *testing.T) {
@@ -14,11 +19,20 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			CreateResponse: makeUser("bobUserUID", "bob", "idp:bob"),
-
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "CreateUser", Object: makeUser("", "bob", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("create", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[1].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("", "bob", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
 			ExpectedUserName:   "bob",
 			ExpectedInitialize: true,
@@ -28,13 +42,25 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob")},
-			CreateResponse: makeUser("bob2UserUID", "bob2", "idp:bob"),
+			ExistingUsers: []runtime.Object{makeUser("bobUserUID", "bob")},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "GetUser", Object: "bob2"},
-				{Name: "CreateUser", Object: makeUser("", "bob2", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("get", "users") || actions[1].(clienttesting.GetAction).GetName() != "bob2" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[2].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("", "bob2", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
 			ExpectedUserName:   "bob2",
 			ExpectedInitialize: true,
@@ -44,13 +70,25 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers:  []*userapi.User{makeUser("bobUserUID", "bob", "otheridp:user")},
-			CreateResponse: makeUser("bob2UserUID", "bob2", "idp:bob"),
+			ExistingUsers: []runtime.Object{makeUser("bobUserUID", "bob", "otheridp:user")},
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "GetUser", Object: "bob2"},
-				{Name: "CreateUser", Object: makeUser("", "bob2", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 3 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("get", "users") || actions[1].(clienttesting.GetAction).GetName() != "bob2" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("create", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[2].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("", "bob2", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
 			ExpectedUserName:   "bob2",
 			ExpectedInitialize: true,
@@ -60,18 +98,33 @@ func TestStrategyGenerate(t *testing.T) {
 			PreferredUsername: "bob",
 			Identity:          makeIdentity("", "idp", "bob", "", ""),
 
-			ExistingUsers: []*userapi.User{
+			ExistingUsers: []runtime.Object{
 				makeUser("bobUserUID", "bob", "otheridp:user"),
 				makeUser("bob2UserUID", "bob2", "otheridp:user2"),
 			},
-			CreateResponse: makeUser("bob3UserUID", "bob3", "idp:bob"),
 
-			ExpectedActions: []test.Action{
-				{Name: "GetUser", Object: "bob"},
-				{Name: "GetUser", Object: "bob2"},
-				{Name: "GetUser", Object: "bob3"},
-				{Name: "CreateUser", Object: makeUser("", "bob3", "idp:bob")},
+			ValidateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 4 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "users") || actions[0].(clienttesting.GetAction).GetName() != "bob" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[1].Matches("get", "users") || actions[1].(clienttesting.GetAction).GetName() != "bob2" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[2].Matches("get", "users") || actions[2].(clienttesting.GetAction).GetName() != "bob3" {
+					t.Error(spew.Sdump(actions))
+				}
+				if !actions[3].Matches("create", "users") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[3].(clienttesting.CreateAction).GetObject().(*userapi.User)
+				if expected := makeUser("", "bob3", "idp:bob"); !equality.Semantic.DeepEqual(expected, actual) {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
 			},
+
 			ExpectedUserName:   "bob3",
 			ExpectedInitialize: true,
 		},


### PR DESCRIPTION
Updates oauthserver tests to use clients for mocks instead of internal registry shims from the storage.

@openshift/sig-security 