### PR TITLE
UPSTREAM: 61713: kubectl: fix a panic when createGeneratedObject failed

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/run.go
@@ -293,14 +293,14 @@ func RunRun(f cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr
 
 	params["env"] = cmdutil.GetFlagStringArray(cmd, "env")
 
-	allErrs := []error{}
-	var runObjectMap = map[string]*RunObject{}
+	var createdObjects = []*RunObject{}
 	runObject, err := createGeneratedObject(f, cmd, generator, names, params, cmdutil.GetFlagString(cmd, "overrides"), namespace)
 	if err != nil {
-		allErrs = append(allErrs, err)
+		return err
 	} else {
-		runObjectMap[generatorName] = runObject
+		createdObjects = append(createdObjects, runObject)
 	}
+	allErrs := []error{}
 	if cmdutil.GetFlagBool(cmd, "expose") {
 		serviceGenerator := cmdutil.GetFlagString(cmd, "service-generator")
 		if len(serviceGenerator) == 0 {
@@ -310,7 +310,7 @@ func RunRun(f cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr
 		if err != nil {
 			allErrs = append(allErrs, err)
 		} else {
-			runObjectMap[generatorName] = serviceRunObject
+			createdObjects = append(createdObjects, serviceRunObject)
 		}
 	}
 
@@ -362,7 +362,7 @@ func RunRun(f cmdutil.Factory, opts *RunOptions, cmdIn io.Reader, cmdOut, cmdErr
 		}
 
 		if remove {
-			for _, obj := range runObjectMap {
+			for _, obj := range createdObjects {
 				namespace, err = obj.Mapping.MetadataAccessor.Namespace(obj.Object)
 				if err != nil {
 					return err


### PR DESCRIPTION
fixes panic in kubectl

xref https://bugzilla.redhat.com/show_bug.cgi?id=1577334

@derekwaynecarr