### PR TITLE
Remove old service dependencies from node system container

### DIFF
--- a/images/node/system-container/manifest.json
+++ b/images/node/system-container/manifest.json
@@ -5,7 +5,6 @@
         "ORIGIN_CONFIG_DIR": "/etc/origin",
         "ORIGIN_DATA_DIR": "/var/lib/origin",
         "KUBELET_DATA_DIR": "/var/lib/kubelet",
-        "MASTER_SERVICE": "atomic-openshift-master.service",
         "DOCKER_SERVICE": "docker.service",
         "ADDTL_MOUNTS": ""
     }

--- a/images/node/system-container/service.template
+++ b/images/node/system-container/service.template
@@ -1,8 +1,6 @@
 [Unit]
 After=${DOCKER_SERVICE}
 Wants=${DOCKER_SERVICE}
-After=$NAME-dep.service
-After=${MASTER_SERVICE}
 Requires=dnsmasq.service
 After=dnsmasq.service
 


### PR DESCRIPTION
Both of these services have been removed in 3.10.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572868

/cc @giuseppe @smarterclayton 
/assign @giuseppe @smarterclayton 