### PR TITLE
Add ability to capture request/response headers and cookies

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -137,6 +137,13 @@ listen stats
 
 {{ if .BindPorts -}}
 frontend public
+
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_HEADERS") ":" }}
+  capture request header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_COOKIES") ":" }}
+  capture cookie {{ $value }} len {{ env "CAPTURED_COOKIE_LENGTH" "25" }}
+    {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v4v6
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
@@ -172,6 +179,13 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_HEADERS") ":" }}
+  capture request header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_REQUEST_COOKIES") ":" }}
+  capture cookie {{ $value }} len {{ env "CAPTURED_COOKIE_LENGTH" "25" }}
+    {{- end }}
+
     {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
   option tcplog
     {{- end }}

--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -144,6 +144,9 @@ frontend public
     {{ range $idx,$value := split (env "CAPTURE_REQUEST_COOKIES") ":" }}
   capture cookie {{ $value }} len {{ env "CAPTURED_COOKIE_LENGTH" "25" }}
     {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_RESPONSE_HEADERS") ":" }}
+  capture response header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
+    {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v4v6
     {{- else if eq "v6" $router_ip_v4_v6_mode }}
@@ -184,6 +187,9 @@ frontend public_ssl
     {{- end }}
     {{ range $idx,$value := split (env "CAPTURE_REQUEST_COOKIES") ":" }}
   capture cookie {{ $value }} len {{ env "CAPTURED_COOKIE_LENGTH" "25" }}
+    {{- end }}
+    {{ range $idx,$value := split (env "CAPTURE_RESPONSE_HEADERS") ":" }}
+  capture response header {{ $value }} len {{ env "CAPTURED_HEADER_LENGTH" "25" }}
     {{- end }}
 
     {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}

--- a/pkg/router/template/template_helper.go
+++ b/pkg/router/template/template_helper.go
@@ -270,4 +270,5 @@ var helperFunctions = template.FuncMap{
 	"getPrimaryAliasKey":          getPrimaryAliasKey,          //returns the key of the primary alias for a group of aliases
 
 	"generateHAProxyMap": generateHAProxyMap, //generates a haproxy map content
+	"split":              strings.Split,      //split slices s into all substrings separated by sep and returns a slice of the substrings between those separators
 }


### PR DESCRIPTION
HAProxy allows to capture request/response headers and cookies, this PR make users able to capture these headers or cookies and print them in a log.
Also added strings.Split to template helpers functions that could be very useful in a future.