### PR TITLE
Make router conflict detection work even during initial informer sync

### DIFF
--- a/pkg/cmd/infra/router/f5.go
+++ b/pkg/cmd/infra/router/f5.go
@@ -239,10 +239,11 @@ func (o *F5RouterOptions) Run() error {
 	if o.UpdateStatus {
 		lease := writerlease.New(time.Minute, 3*time.Second)
 		go lease.Run(wait.NeverStop)
-		tracker := controller.NewSimpleContentionTracker(o.ResyncInterval / 10)
+		informer := factory.CreateRoutesSharedInformer()
+		tracker := controller.NewSimpleContentionTracker(informer, o.RouterName, o.ResyncInterval/10)
 		tracker.SetConflictMessage(fmt.Sprintf("The router detected another process is writing conflicting updates to route status with name %q. Please ensure that the configuration of all routers is consistent. Route status will not be updated as long as conflicts are detected.", o.RouterName))
 		go tracker.Run(wait.NeverStop)
-		routeLister := routelisters.NewRouteLister(factory.CreateRoutesSharedInformer().GetIndexer())
+		routeLister := routelisters.NewRouteLister(informer.GetIndexer())
 		status := controller.NewStatusAdmitter(plugin, routeclient.Route(), routeLister, o.RouterName, o.RouterCanonicalHostname, lease, tracker)
 		recorder = status
 		plugin = status

--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -420,10 +420,11 @@ func (o *TemplateRouterOptions) Run() error {
 	if o.UpdateStatus {
 		lease := writerlease.New(time.Minute, 3*time.Second)
 		go lease.Run(wait.NeverStop)
-		tracker := controller.NewSimpleContentionTracker(o.ResyncInterval / 10)
+		informer := factory.CreateRoutesSharedInformer()
+		tracker := controller.NewSimpleContentionTracker(informer, o.RouterName, o.ResyncInterval/10)
 		tracker.SetConflictMessage(fmt.Sprintf("The router detected another process is writing conflicting updates to route status with name %q. Please ensure that the configuration of all routers is consistent. Route status will not be updated as long as conflicts are detected.", o.RouterName))
 		go tracker.Run(wait.NeverStop)
-		routeLister := routelisters.NewRouteLister(factory.CreateRoutesSharedInformer().GetIndexer())
+		routeLister := routelisters.NewRouteLister(informer.GetIndexer())
 		status := controller.NewStatusAdmitter(plugin, routeclient.Route(), routeLister, o.RouterName, o.RouterCanonicalHostname, lease, tracker)
 		recorder = status
 		plugin = status

--- a/pkg/router/controller/contention.go
+++ b/pkg/router/controller/contention.go
@@ -1,0 +1,281 @@
+package controller
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	routeapi "github.com/openshift/origin/pkg/route/apis/route"
+)
+
+// ContentionTracker records modifications to a particular entry to prevent endless
+// loops when multiple routers are configured with conflicting info. A given router
+// process tracks whether the ingress status is change from a correct value to any
+// other value (by invoking IsContended when the state has diverged).
+type ContentionTracker interface {
+	// IsContended should be invoked when the state of the object in storage differs
+	// from the desired state. It will return true if the provided id was recently
+	// reset from the correct state to an incorrect state. The current ingress is the
+	// expected state of the object at this time and may be used by the tracker to
+	// determine if the most recent update was a contention. This method does not
+	// update the state of the tracker.
+	IsChangeContended(id string, now time.Time, current *routeapi.RouteIngress) bool
+	// Clear informs the tracker that the provided ingress state was confirmed to
+	// match the current state of this process. If a subsequent call to IsChangeContended
+	// is made within the expiration window, the object will be considered as contended.
+	Clear(id string, current *routeapi.RouteIngress)
+}
+
+type elementState int
+
+const (
+	stateCandidate elementState = iota
+	stateContended
+)
+
+type trackerElement struct {
+	at    time.Time
+	state elementState
+	last  *routeapi.RouteIngress
+}
+
+// SimpleContentionTracker tracks whether a given identifier is changed from a correct
+// state (set by Clear) to an incorrect state (inferred by calling IsContended).
+type SimpleContentionTracker struct {
+	informer   cache.SharedInformer
+	routerName string
+
+	expires time.Duration
+	// maxContentions is the number of contentions detected before the entire
+	maxContentions int
+	message        string
+
+	lock        sync.Mutex
+	contentions int
+	ids         map[string]trackerElement
+}
+
+// NewSimpleContentionTracker creates a ContentionTracker that will prevent writing
+// to the same route more often than once per interval. A background process will
+// periodically flush old entries (at twice interval) in order to prevent the list
+// growing unbounded if routes are created and deleted frequently. The informer
+// detects changes to ingress records for routerName and will advance the tracker
+// state from candidate to contended if the host, wildcardPolicy, or canonical host
+// name fields are repeatedly updated.
+func NewSimpleContentionTracker(informer cache.SharedInformer, routerName string, interval time.Duration) *SimpleContentionTracker {
+	return &SimpleContentionTracker{
+		informer:       informer,
+		routerName:     routerName,
+		expires:        interval,
+		maxContentions: 5,
+
+		ids: make(map[string]trackerElement),
+	}
+}
+
+// SetConflictMessage will print message whenever contention with another writer
+// is detected.
+func (t *SimpleContentionTracker) SetConflictMessage(message string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.message = message
+}
+
+// Run starts the background cleanup process for expired items.
+func (t *SimpleContentionTracker) Run(stopCh <-chan struct{}) {
+	// Watch the informer for changes to the route ingress we care about (identified
+	// by router name) and if we see it change remember it. This loop can process
+	// changes to routes faster than the router, which means it has more up-to-date
+	// contention info and can detect contention while the main controller is still
+	// syncing.
+	t.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, obj interface{}) {
+			oldRoute, ok := oldObj.(*routeapi.Route)
+			if !ok {
+				return
+			}
+			route, ok := obj.(*routeapi.Route)
+			if !ok {
+				return
+			}
+			if ingress := ingressChanged(oldRoute, route, t.routerName); ingress != nil {
+				t.Changed(string(route.UID), ingress)
+			}
+		},
+	})
+
+	// periodically clean up expired changes
+	ticker := time.NewTicker(t.expires * 2)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			t.flush()
+		}
+	}
+}
+
+func (t *SimpleContentionTracker) flush() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// reset conflicts every expiration interval, but remove tracking info less often
+	contentionExpiration := nowFn().Add(-t.expires)
+	trackerExpiration := contentionExpiration.Add(-2 * t.expires)
+
+	removed := 0
+	contentions := 0
+	for id, last := range t.ids {
+		switch last.state {
+		case stateContended:
+			if last.at.Before(contentionExpiration) {
+				delete(t.ids, id)
+				removed++
+				continue
+			}
+			contentions++
+		default:
+			if last.at.Before(trackerExpiration) {
+				delete(t.ids, id)
+				removed++
+				continue
+			}
+		}
+	}
+	if t.contentions > 0 && len(t.message) > 0 {
+		glog.Warning(t.message)
+	}
+	glog.V(5).Infof("Flushed contention tracker (%s): %d out of %d removed, %d total contentions", t.expires*2, removed, removed+len(t.ids), t.contentions)
+	t.contentions = contentions
+}
+
+// Changed records that a change to an ingress value was detected. This is called from
+// a separate goroutine and may have seen newer events than the current route controller
+// plugins, so we don't do direct time comparisons. Instead we count edge transitions on
+// a given id.
+func (t *SimpleContentionTracker) Changed(id string, current *routeapi.RouteIngress) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// we have detected a sufficient number of conflicts to skip all updates for this interval
+	if t.contentions > t.maxContentions {
+		glog.V(4).Infof("Reached max contentions, stop tracking changes")
+		return
+	}
+
+	// if we have never recorded this object
+	last, ok := t.ids[id]
+	if !ok {
+		t.ids[id] = trackerElement{
+			at:    nowFn().Time,
+			state: stateCandidate,
+			last:  current,
+		}
+		glog.V(4).Infof("Object %s is a candidate for contention", id)
+		return
+	}
+
+	// the previous state matches the current state, nothing to do
+	if ingressEqual(last.last, current) {
+		glog.V(4).Infof("Object %s is unchanged", id)
+		return
+	}
+
+	if last.state == stateContended {
+		t.contentions++
+		glog.V(4).Infof("Object %s is contended and has been modified by another writer", id)
+		return
+	}
+
+	// if it appears that the state is being changed by another party, mark it as contended
+	if last.state == stateCandidate {
+		t.ids[id] = trackerElement{
+			at:    nowFn().Time,
+			state: stateContended,
+			last:  current,
+		}
+		t.contentions++
+		glog.V(4).Infof("Object %s has been modified by another writer", id)
+		return
+	}
+}
+
+func (t *SimpleContentionTracker) IsChangeContended(id string, now time.Time, current *routeapi.RouteIngress) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// we have detected a sufficient number of conflicts to skip all updates for this interval
+	if t.contentions > t.maxContentions {
+		glog.V(4).Infof("Reached max contentions, rejecting all update attempts until the next interval")
+		return true
+	}
+
+	// if we have expired or never recorded this object
+	last, ok := t.ids[id]
+	if !ok || last.at.Add(t.expires).Before(now) {
+		return false
+	}
+
+	// if the object is contended, exit early
+	if last.state == stateContended {
+		glog.V(4).Infof("Object %s is being contended by another writer", id)
+		return true
+	}
+
+	return false
+}
+
+func (t *SimpleContentionTracker) Clear(id string, current *routeapi.RouteIngress) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	last, ok := t.ids[id]
+	if !ok {
+		return
+	}
+	last.last = current
+	last.state = stateCandidate
+	t.ids[id] = last
+}
+
+func ingressEqual(a, b *routeapi.RouteIngress) bool {
+	return a.Host == b.Host && a.RouterCanonicalHostname == b.RouterCanonicalHostname && a.WildcardPolicy == b.WildcardPolicy && a.RouterName == b.RouterName
+}
+
+func ingressConditionTouched(ingress *routeapi.RouteIngress) *metav1.Time {
+	var lastTouch *metav1.Time
+	for _, condition := range ingress.Conditions {
+		if t := condition.LastTransitionTime; t != nil {
+			switch {
+			case lastTouch == nil, t.After(lastTouch.Time):
+				lastTouch = t
+			}
+		}
+	}
+	return lastTouch
+}
+
+func ingressChanged(oldRoute, route *routeapi.Route, routerName string) *routeapi.RouteIngress {
+	var ingress *routeapi.RouteIngress
+	for i := range route.Status.Ingress {
+		if route.Status.Ingress[i].RouterName == routerName {
+			ingress = &route.Status.Ingress[i]
+			for _, old := range oldRoute.Status.Ingress {
+				if old.RouterName == routerName {
+					if !ingressEqual(ingress, &old) {
+						return ingress
+					}
+					return nil
+				}
+			}
+			return nil
+		}
+	}
+	return nil
+}

--- a/pkg/router/controller/router_controller.go
+++ b/pkg/router/controller/router_controller.go
@@ -234,7 +234,7 @@ func (c *RouterController) Commit() {
 
 // processRoute logs and propagates a route event to the plugin
 func (c *RouterController) processRoute(eventType watch.EventType, route *routeapi.Route) {
-	glog.V(4).Infof("Processing Route: %s/%s -> %s", route.Namespace, route.Name, route.Spec.To.Name)
+	glog.V(4).Infof("Processing route: %s/%s -> %s %s", route.Namespace, route.Name, route.Spec.To.Name, route.UID)
 	glog.V(4).Infof("           Alias: %s", route.Spec.Host)
 	if len(route.Spec.Path) > 0 {
 		glog.V(4).Infof("           Path: %s", route.Spec.Path)

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -313,7 +313,7 @@ type SimpleContentionTracker struct {
 func NewSimpleContentionTracker(interval time.Duration) *SimpleContentionTracker {
 	return &SimpleContentionTracker{
 		expires:        interval,
-		maxContentions: 10,
+		maxContentions: 5,
 
 		ids: make(map[string]trackerElement),
 	}
@@ -397,7 +397,7 @@ func (t *SimpleContentionTracker) IsContended(id string, now time.Time, ingress 
 
 	// if the object is contended, exit early
 	if last.state == stateContended {
-		glog.V(4).Infof("Object %s is being written to by another actor", id)
+		glog.V(4).Infof("Object %s is being contended by another writer", id)
 		return true
 	}
 
@@ -408,6 +408,7 @@ func (t *SimpleContentionTracker) IsContended(id string, now time.Time, ingress 
 			state: stateContended,
 		}
 		t.contentions++
+		glog.V(4).Infof("Object %s was previously correct and is now incorrect", id)
 		return true
 	}
 

--- a/pkg/router/controller/status.go
+++ b/pkg/router/controller/status.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -130,10 +129,9 @@ func performIngressConditionUpdate(action string, lease writerlease.Lease, track
 		}
 
 		route = route.DeepCopy()
-		changed, created, now, latest := recordIngressCondition(route, routerName, hostName, condition)
+		changed, created, now, latest, original := recordIngressCondition(route, routerName, hostName, condition)
 		if !changed {
 			glog.V(4).Infof("%s: no changes to route needed: %s/%s", action, route.Namespace, route.Name)
-			tracker.Clear(key, latest)
 			// if the most recent change was to our ingress status, consider the current lease extended
 			if findMostRecentIngress(route) == routerName {
 				lease.Extend(key)
@@ -144,8 +142,8 @@ func performIngressConditionUpdate(action string, lease writerlease.Lease, track
 		// If the tracker determines that another process is attempting to update the ingress to an inconsistent
 		// value, skip updating altogether and rely on the next resync to resolve conflicts. This prevents routers
 		// with different configurations from endlessly updating the route status.
-		if !created && tracker.IsContended(key, now, latest) {
-			glog.V(4).Infof("%s: skipped update due to another process altering the route with a different ingress status value: %s", action, key)
+		if !created && tracker.IsChangeContended(key, now, original) {
+			glog.V(4).Infof("%s: skipped update due to another process altering the route with a different ingress status value: %s %#v", action, key, original)
 			return writerlease.Release, false
 		}
 
@@ -179,7 +177,7 @@ func performIngressConditionUpdate(action string, lease writerlease.Lease, track
 // recordIngressCondition updates the matching ingress on the route (or adds a new one) with the specified
 // condition, returning whether the route was updated or created, the time assigned to the condition, and
 // a pointer to the current ingress record.
-func recordIngressCondition(route *routeapi.Route, name, hostName string, condition routeapi.RouteIngressCondition) (changed, created bool, at time.Time, latest *routeapi.RouteIngress) {
+func recordIngressCondition(route *routeapi.Route, name, hostName string, condition routeapi.RouteIngressCondition) (changed, created bool, at time.Time, latest, original *routeapi.RouteIngress) {
 	for i := range route.Status.Ingress {
 		existing := &route.Status.Ingress[i]
 		if existing.RouterName != name {
@@ -199,8 +197,12 @@ func recordIngressCondition(route *routeapi.Route, name, hostName string, condit
 			}
 		}
 		if !changed {
-			return false, false, time.Time{}, existing
+			return false, false, time.Time{}, existing, existing
 		}
+
+		// preserve a copy of the original ingress without conditions
+		original := *existing
+		original.Conditions = nil
 
 		// generate the correct ingress
 		existing.Host = route.Spec.Host
@@ -215,7 +217,7 @@ func recordIngressCondition(route *routeapi.Route, name, hostName string, condit
 		now := nowFn()
 		existingCondition.LastTransitionTime = &now
 
-		return true, false, now.Time, existing
+		return true, false, now.Time, existing, &original
 	}
 
 	// add a new ingress
@@ -232,7 +234,7 @@ func recordIngressCondition(route *routeapi.Route, name, hostName string, condit
 	now := nowFn()
 	ingress.Conditions[0].LastTransitionTime = &now
 
-	return true, true, now.Time, ingress
+	return true, true, now.Time, ingress, nil
 }
 
 // findMostRecentIngress returns the name of the ingress status with the most recent Admitted condition transition time,
@@ -260,181 +262,4 @@ func findCondition(ingress *routeapi.RouteIngress, t routeapi.RouteIngressCondit
 		return &ingress.Conditions[i]
 	}
 	return nil
-}
-
-// ContentionTracker records modifications to a particular entry to prevent endless
-// loops when multiple routers are configured with conflicting info. A given router
-// process tracks whether the ingress status is change from a correct value to any
-// other value (by invoking IsContended when the state has diverged).
-type ContentionTracker interface {
-	// IsContended should be invoked when the state of the object in storage differs
-	// from the desired state. It will return true if the provided id was recently
-	// reset from the correct state to an incorrect state. The input ingress is the
-	// expected state of the object at this time and may be used by the tracker to
-	// determine if the most recent update was a contention. now is the current time
-	// that should be used to record the change.
-	IsContended(id string, now time.Time, ingress *routeapi.RouteIngress) bool
-	// Clear informs the tracker that the provided ingress state was confirmed to
-	// match the current state of this process. If a subsequent call to IsContended
-	// is made within the expiration window, the object will be considered as contended.
-	Clear(id string, ingress *routeapi.RouteIngress)
-}
-
-type elementState int
-
-const (
-	stateIncorrect elementState = iota
-	stateCorrect
-	stateContended
-)
-
-type trackerElement struct {
-	at    time.Time
-	state elementState
-}
-
-// SimpleContentionTracker tracks whether a given identifier is changed from a correct
-// state (set by Clear) to an incorrect state (inferred by calling IsContended).
-type SimpleContentionTracker struct {
-	expires time.Duration
-	// maxContentions is the number of contentions detected before the entire
-	maxContentions int
-	message        string
-
-	lock        sync.Mutex
-	contentions int
-	ids         map[string]trackerElement
-}
-
-// NewSimpleContentionTracker creates a ContentionTracker that will prevent writing
-// to the same route more often than once per interval. A background process will
-// periodically flush old entries (at twice interval) in order to prevent the list
-// growing unbounded if routes are created and deleted frequently.
-func NewSimpleContentionTracker(interval time.Duration) *SimpleContentionTracker {
-	return &SimpleContentionTracker{
-		expires:        interval,
-		maxContentions: 5,
-
-		ids: make(map[string]trackerElement),
-	}
-}
-
-// SetConflictMessage will print message whenever contention with another writer
-// is detected.
-func (t *SimpleContentionTracker) SetConflictMessage(message string) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	t.message = message
-}
-
-// Run starts the background cleanup process for expired items.
-func (t *SimpleContentionTracker) Run(stopCh <-chan struct{}) {
-	ticker := time.NewTicker(t.expires * 2)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-stopCh:
-			return
-		case <-ticker.C:
-			t.flush()
-		}
-	}
-}
-
-func (t *SimpleContentionTracker) flush() {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
-	// reset conflicts every expiration interval, but remove tracking info less often
-	contentionExpiration := time.Now().Add(-t.expires)
-	trackerExpiration := contentionExpiration.Add(-2 * t.expires)
-
-	removed := 0
-	contentions := 0
-	for id, last := range t.ids {
-		switch last.state {
-		case stateContended:
-			if last.at.Before(contentionExpiration) {
-				delete(t.ids, id)
-				removed++
-				continue
-			}
-			contentions++
-		default:
-			if last.at.Before(trackerExpiration) {
-				delete(t.ids, id)
-				removed++
-				continue
-			}
-		}
-	}
-	if t.contentions > 0 && len(t.message) > 0 {
-		glog.Warning(t.message)
-	}
-	glog.V(5).Infof("Flushed contention tracker (%s): %d out of %d removed, %d total contentions", t.expires*2, removed, removed+len(t.ids), t.contentions)
-	t.contentions = contentions
-}
-
-func (t *SimpleContentionTracker) IsContended(id string, now time.Time, ingress *routeapi.RouteIngress) bool {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
-	// we have detected a sufficient number of conflicts to skip all updates for this interval
-	if t.contentions > t.maxContentions {
-		glog.V(4).Infof("Reached max contentions, rejecting all update attempts until the next interval")
-		return true
-	}
-
-	// if we have expired or never recorded this object
-	last, ok := t.ids[id]
-	if !ok || last.at.Add(t.expires).Before(now) {
-		t.ids[id] = trackerElement{
-			at:    now,
-			state: stateIncorrect,
-		}
-		return false
-	}
-
-	// if the object is contended, exit early
-	if last.state == stateContended {
-		glog.V(4).Infof("Object %s is being contended by another writer", id)
-		return true
-	}
-
-	// if the object was previously correct, someone is contending with us
-	if last.state == stateCorrect {
-		t.ids[id] = trackerElement{
-			at:    now,
-			state: stateContended,
-		}
-		t.contentions++
-		glog.V(4).Infof("Object %s was previously correct and is now incorrect", id)
-		return true
-	}
-
-	return false
-}
-
-func (t *SimpleContentionTracker) Clear(id string, ingress *routeapi.RouteIngress) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	if at := ingressConditionTouched(ingress); at != nil {
-		t.ids[id] = trackerElement{
-			at:    at.Time,
-			state: stateCorrect,
-		}
-	}
-}
-
-func ingressConditionTouched(ingress *routeapi.RouteIngress) *metav1.Time {
-	var lastTouch *metav1.Time
-	for _, condition := range ingress.Conditions {
-		if t := condition.LastTransitionTime; t != nil {
-			switch {
-			case lastTouch == nil, t.After(lastTouch.Time):
-				lastTouch = t
-			}
-		}
-	}
-	return lastTouch
 }


### PR DESCRIPTION
The conflict detection mechanism in the router did not correctly handle sync (which on large clusters could be a huge number of writes).  The informer delivers events in order - all SYNC, then updates.  Two routers starting at the beginning of the sync could conflict without detecting it until they see the first update (so O(2*routes)).  Instead of detecting conflicts in the router plugin, move detection to a side scanner that looks at the informer directly and only processes updates (so we ignore the initial sync and then rapidly start detecting updates).  This causes conflicting routers to converge quickly.

In addition, the stress test is not tuned particularly well for passing.  We create 3 routers with conflicting status and update 10 routes.  The hard stop for conflict detection is at 10 conflicts every 12 seconds.  The test is intended to verify that we hard stop when conflicting, and that a subsequent edit of a route converges at O(routers).

This commit changes the number of conflicts a router tolerates before blocking all updates.  Since conflict detection is reliable (we see a route we changed change to a different status value) the new value 5 is just as safe as the old value of 10.  I've also increased the number of routes - that should more clearly identify the upper bounds of conflict writes (which should be <15 + initial writes detected).