### PR TITLE
Fix path

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -137,7 +137,7 @@ $ hack/env make release
 In order to make use of the binaries from your shell, add the build output
 directory to the `$PATH`:
 ----
-$ export PATH="${PATH}:$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::build::host_platform )/" )"
+$ export PATH="$( source hack/lib/init.sh; echo "${OS_OUTPUT_BINPATH}/$( os::build::host_platform )/" ):${PATH}"
 ----
 
 See more information in https://github.com/openshift/origin/blob/master/HACKING.md#building-on-non-linux-systems[`HACKING.md`]

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -130,7 +130,7 @@ function start() {
   bin_path="$(os::build::get-bin-output-path "${OS_ROOT}")"
   cat >"${rc_file}" <<EOF
 export KUBECONFIG="${admin_config}"
-export PATH="\$PATH:${bin_path}"
+export PATH="${bin_path}:\$PATH"
 
 export OPENSHIFT_CLUSTER_ID="${cluster_id}"
 export OPENSHIFT_CONFIG_ROOT="${config_root}"


### PR DESCRIPTION
If you have already installed the binaries on your system (e.g. oc), having the PATH  before the local binary folder cause that you cannot use the compiled binaries.

Also fixed the documentation