### PR TITLE
UPSTREAM: 63848: Deflake discovery timeout test

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -135,7 +135,10 @@ func TestGetServerGroupsWithTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// first we need to write headers, otherwise http client will complain about
 		// exceeding timeout awaiting headers, only after we can block the call
-		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Connection", "keep-alive")
+		if wf, ok := w.(http.Flusher); ok {
+			wf.Flush()
+		}
 		<-done
 	}))
 	defer server.Close()
@@ -144,7 +147,10 @@ func TestGetServerGroupsWithTimeout(t *testing.T) {
 	defaultTimeout = 2 * time.Second
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	_, err := client.ServerGroups()
-	if err == nil || !strings.Contains(err.Error(), "deadline") {
+	// the error we're getting here is wrapped in errors.errorString which makes
+	// it impossible to unwrap and check it's attributes, so instead we're checking
+	// the textual output which is presenting http.httpError with timeout set to true
+	if err == nil || !strings.Contains(err.Error(), "timeout:true") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	done <- true


### PR DESCRIPTION
Currently the server may delay sending out the response (buffering), thus we need to flush the headers always. Additionally, I've changed the error output check looking for timeout:true string, because the error is of errors.errorString type.