### PR TITLE
Remove --extended-test-output-dir and use --report-dir in e2e

### DIFF
--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -44,7 +44,6 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 
 		g.Describe("s2i context directory build", func() {
 			g.It(fmt.Sprintf("should s2i build an application using a context directory"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc create -f %q", appFixture))
@@ -99,7 +98,6 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 
 		g.Describe("docker context directory build", func() {
 			g.It(fmt.Sprintf("should docker build an application using a context directory"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc create -f %q", appFixture))

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -42,7 +42,6 @@ var _ = g.Describe("[Feature:Builds][pullsecret][Conformance] docker build using
 
 		g.Describe("Building from a template", func() {
 			g.It("should create a docker build that pulls using a secret run it", func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc create -f %q", buildFixture))
 				err := oc.Run("create").Args("-f", buildFixture).Execute()

--- a/test/extended/builds/docker_quota.go
+++ b/test/extended/builds/docker_quota.go
@@ -57,7 +57,6 @@ var _ = g.Describe("[Feature:Builds][quota][Slow] docker build with a quota", fu
 		g.Describe("Building from a template", func() {
 			for _, test := range fixtures {
 				g.It(fmt.Sprintf("should create a %s with a quota and run it", test.name), func() {
-					oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 					g.By(fmt.Sprintf("calling oc create -f %q", test.path))
 					err := oc.Run("create").Args("-f", test.path).Execute()

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -37,7 +37,7 @@ USER 1001
 			g.By("waiting for builder service account")
 			err := exutil.WaitForBuilderAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()))
 			o.Expect(err).NotTo(o.HaveOccurred())
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		})
 
 		g.AfterEach(func() {

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -64,7 +64,6 @@ var _ = g.Describe("[Feature:Builds][Slow] can use private repositories as build
 		})
 
 		testGitAuth := func(gitServerYaml, urlTemplate string, secretFunc func() string) {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 			g.By("obtaining the configured API server host from config")
 			adminClientConfig, err := testutil.GetClusterAdminClientConfig(exutil.KubeConfigPath())

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -40,7 +40,6 @@ var _ = g.Describe("[Feature:Builds][Slow][Smoke] result image should have prope
 
 		g.Describe("S2I build from a template", func() {
 			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels", stiBuildFixture), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()
@@ -69,7 +68,6 @@ var _ = g.Describe("[Feature:Builds][Slow][Smoke] result image should have prope
 
 		g.Describe("Docker build from a template", func() {
 			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels", dockerBuildFixture), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()

--- a/test/extended/builds/long_names.go
+++ b/test/extended/builds/long_names.go
@@ -30,7 +30,6 @@ var _ = g.Describe("[Feature:Builds][Slow] extremely long build/bc names are not
 		})
 
 		g.Describe("build with long names", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 			g.It("delete builds with long names without collateral damage", func() {
 				g.By("creating long_names fixtures")

--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -34,7 +34,7 @@ COPY --from=test /usr/bin/curl /test/
 			g.By("waiting for builder service account")
 			err := exutil.WaitForBuilderAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()))
 			o.Expect(err).NotTo(o.HaveOccurred())
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		})
 
 		g.AfterEach(func() {

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] build without output image", f
 		})
 
 		g.Describe("building from templates", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+			fmt.Printf("DEBUG: outputdir=%s\n", exutil.TestContext.OutputDir)
 
 			g.It(fmt.Sprintf("should create an image from a docker template without an output image reference defined"), func() {
 				err := oc.Run("create").Args("-f", dockerImageFixture).Execute()

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -36,7 +36,7 @@ USER 1001
 			g.By("waiting for builder service account")
 			err := exutil.WaitForBuilderAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()))
 			o.Expect(err).NotTo(o.HaveOccurred())
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		})
 
 		g.AfterEach(func() {

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -46,7 +46,6 @@ var _ = g.Describe("[Feature:Builds][Slow] s2i build with environment file in so
 
 		g.Describe("Building from a template", func() {
 			g.It(fmt.Sprintf("should create a image from %q template and run it in a pod", stiEnvBuildFixture), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -46,7 +46,6 @@ var _ = g.Describe("[Feature:Builds][Slow] incremental s2i build", func() {
 
 		g.Describe("Building from a template", func() {
 			g.It(fmt.Sprintf("should create a build from %q template and run it", templateFixture), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc new-app -f %q", templateFixture))
 				err := oc.Run("new-app").Args("-f", templateFixture).Execute()

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -43,7 +43,6 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func(
 
 		g.Describe("Building from a template", func() {
 			g.It("should create an s2i build with a quota and run it", func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc create -f %q", buildFixture))
 				err := oc.Run("create").Args("-f", buildFixture).Execute()

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -38,7 +38,6 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 		})
 
 		g.Describe("build with secrets", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 			g.It("should contain secrets during the source strategy build", func() {
 				g.By("creating secret fixtures")

--- a/test/extended/cli/rsync.go
+++ b/test/extended/cli/rsync.go
@@ -32,7 +32,6 @@ var _ = g.Describe("[cli][Slow] can use rsync to upload files to pods", func() {
 
 	var podName string
 	g.JustBeforeEach(func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 		g.By(fmt.Sprintf("calling oc new-app -f %q", templatePath))
 		err := oc.Run("new-app").Args("-f", templatePath).Execute()

--- a/test/extended/image_ecosystem/mariadb_ephemeral.go
+++ b/test/extended/image_ecosystem/mariadb_ephemeral.go
@@ -34,8 +34,6 @@ var _ = g.Describe("[image_ecosystem][mariadb][Slow] openshift mariadb image", f
 			g.It(fmt.Sprintf("should instantiate the template"), func() {
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
-
 				g.By(fmt.Sprintf("calling oc process -f %q", templatePath))
 				configFile, err := oc.Run("process").Args("-f", templatePath).OutputToFile("config.json")
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/image_ecosystem/mongodb_replica_statefulset.go
+++ b/test/extended/image_ecosystem/mongodb_replica_statefulset.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[Conformance][image_ecosystem][mongodb][Slow] openshift mong
 			}
 		})
 		g.It(fmt.Sprintf("should instantiate the template"), func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 
 			err := oc.Run("create").Args("-f", templatePath).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/image_ecosystem/mysql_ephemeral.go
+++ b/test/extended/image_ecosystem/mysql_ephemeral.go
@@ -31,7 +31,6 @@ var _ = g.Describe("[image_ecosystem][mysql][Slow] openshift mysql image", func(
 
 		g.Describe("Creating from a template", func() {
 			g.It(fmt.Sprintf("should instantiate the template"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				g.By(fmt.Sprintf("calling oc process -f %q", templatePath))
 				configFile, err := oc.Run("process").Args("-f", templatePath).OutputToFile("config.json")

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -67,7 +67,7 @@ func CreateMySQLReplicationHelpers(c kcoreclient.PodInterface, masterDeployment,
 
 func replicationTestFactory(oc *exutil.CLI, tc testCase) func() {
 	return func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 
 		err := testutil.WaitForPolicyUpdate(oc.InternalKubeClient().Authorization(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -86,7 +86,6 @@ func CreatePostgreSQLReplicationHelpers(c kcoreclient.PodInterface, masterDeploy
 
 func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string) func() {
 	return func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 		err := testutil.WaitForPolicyUpdate(oc.InternalKubeClient().Authorization(), oc.Namespace(), "create", templateapi.Resource("templates"), true)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/image_ecosystem/s2i_perl.go
+++ b/test/extended/image_ecosystem/s2i_perl.go
@@ -44,7 +44,6 @@ var _ = g.Describe("[image_ecosystem][perl][Slow] hot deploy for openshift perl 
 
 		g.Describe("hot deploy test", func() {
 			g.It("should work", func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app -f %q", perlTemplate))

--- a/test/extended/image_ecosystem/s2i_php.go
+++ b/test/extended/image_ecosystem/s2i_php.go
@@ -38,7 +38,6 @@ var _ = g.Describe("[image_ecosystem][php][Slow] hot deploy for openshift php im
 
 		g.Describe("CakePHP example", func() {
 			g.It(fmt.Sprintf("should work with hot deploy"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app -f %q -p %q", cakephpTemplate, hotDeployParam))

--- a/test/extended/image_ecosystem/s2i_python.go
+++ b/test/extended/image_ecosystem/s2i_python.go
@@ -45,7 +45,6 @@ var _ = g.Describe("[image_ecosystem][python][Slow] hot deploy for openshift pyt
 
 		g.Describe("Django example", func() {
 			g.It(fmt.Sprintf("should work with hot deploy"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/image_ecosystem/s2i_ruby.go
+++ b/test/extended/image_ecosystem/s2i_ruby.go
@@ -44,7 +44,6 @@ var _ = g.Describe("[image_ecosystem][ruby][Slow] hot deploy for openshift ruby 
 
 		g.Describe("Rails example", func() {
 			g.It(fmt.Sprintf("should work with hot deploy"), func() {
-				oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app -f %q", railsTemplate))

--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -57,7 +57,6 @@ func NewSampleRepoTest(c sampleRepoConfig) func() {
 
 			g.Describe("Building "+c.repoName+" app from new-app", func() {
 				g.It(fmt.Sprintf("should build a "+c.repoName+" image and run it in a pod"), func() {
-					oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 					err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 					o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/imageapis/limitrange_admission.go
+++ b/test/extended/imageapis/limitrange_admission.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image limit range", f
 
 	g.It(fmt.Sprintf("[Skipped] should deny a push of built image exceeding %s limit", imageapi.LimitTypeImage), func() {
 		g.Skip("FIXME: fill image metadata for schema1 in the registry")
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		defer tearDown(oc)
 
 		dClient, err := testutil.NewDockerClient()
@@ -71,7 +71,7 @@ var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image limit range", f
 	})
 
 	g.It(fmt.Sprintf("should deny a push of built image exceeding limit on %s resource", imageapi.ResourceImageStreamImages), func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		defer tearDown(oc)
 
 		limits := kapi.ResourceList{
@@ -124,7 +124,7 @@ var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image limit range", f
 	})
 
 	g.It(fmt.Sprintf("should deny a docker image reference exceeding limit on %s resource", imageapi.ResourceImageStreamTags), func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		defer tearDown(oc)
 
 		tag2Image, err := buildAndPushTestImagesTo(oc, "src", "tag", 2)
@@ -184,7 +184,6 @@ var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image limit range", f
 	})
 
 	g.It(fmt.Sprintf("should deny an import of a repository exceeding limit on %s resource", imageapi.ResourceImageStreamTags), func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
 
 		maxBulkImport, err := getMaxImagesBulkImportedPerRepository()
 		if err != nil {

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[Feature:ImageQuota][registry][Serial] Image resource quota"
 	}
 
 	g.It(fmt.Sprintf("should deny a push of built image exceeding %s quota", imageapi.ResourceImageStreams), func() {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		defer tearDown(oc)
 		dClient, err := testutil.NewDockerClient()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/hardprune.go
+++ b/test/extended/images/hardprune.go
@@ -90,7 +90,7 @@ var _ = g.Describe("[Feature:ImagePrune][registry][Serial] Image hard prune", fu
 	}
 
 	testHardPrune := func(dryRun bool) {
-		oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 		outSink := g.GinkgoWriter
 		registryURL, err := GetDockerRegistryURL(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -424,7 +424,6 @@ func LogRegistryPod(oc *exutil.CLI) error {
 	}
 
 	ocLocal := *oc
-	ocLocal.SetOutputDir(exutil.ArtifactDirPath())
 	path, err := ocLocal.Run("logs").Args("dc/docker-registry").OutputToFile("pod-" + pod.Name + ".log")
 	if err == nil {
 		fmt.Fprintf(g.GinkgoWriter, "written registry pod log to %s\n", path)

--- a/test/extended/images/prune.go
+++ b/test/extended/images/prune.go
@@ -188,7 +188,6 @@ func testPruneImages(oc *exutil.CLI, schemaVersion int) {
 	isName := "prune"
 	repoName := oc.Namespace() + "/" + isName
 
-	oc.SetOutputDir(exutil.TestContext.OutputDir)
 	outSink := g.GinkgoWriter
 
 	cleanUp := NewCleanUpContainer(oc)
@@ -291,7 +290,6 @@ func testPruneImages(oc *exutil.CLI, schemaVersion int) {
 func testSoftPruneImages(oc *exutil.CLI) {
 	isName := "prune"
 
-	oc.SetOutputDir(exutil.TestContext.OutputDir)
 	outSink := g.GinkgoWriter
 
 	cleanUp := NewCleanUpContainer(oc)
@@ -326,7 +324,6 @@ func testPruneAllImages(oc *exutil.CLI, setAllImagesToFalse bool, schemaVersion 
 	isName := fmt.Sprintf("prune-schema%d-all-images-%t", schemaVersion, setAllImagesToFalse)
 	repository := oc.Namespace() + "/" + isName
 
-	oc.SetOutputDir(exutil.TestContext.OutputDir)
 	outSink := g.GinkgoWriter
 
 	cleanUp := NewCleanUpContainer(oc)

--- a/test/extended/jobs/jobs.go
+++ b/test/extended/jobs/jobs.go
@@ -19,7 +19,6 @@ var _ = g.Describe("[job][Conformance] openshift can execute jobs", func() {
 	g.Describe("controller", func() {
 		g.It("should create and run a job in user project", func() {
 			for _, ver := range []string{"v1"} {
-				oc.SetOutputDir(exeutil.TestContext.OutputDir)
 				configPath := exeutil.FixturePath("testdata", "jobs", fmt.Sprintf("%s.yaml", ver))
 				name := fmt.Sprintf("simple%s", ver)
 				labels := fmt.Sprintf("app=%s", name)

--- a/test/extended/localquota/local_fsgroup_quota.go
+++ b/test/extended/localquota/local_fsgroup_quota.go
@@ -124,7 +124,7 @@ var _ = g.Describe("[Conformance][volumes] Test local storage quota", func() {
 
 	g.Describe("FSGroup local storage quota [local]", func() {
 		g.It("should be applied to XFS filesystem when a pod is created", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			project := oc.Namespace()
 
 			// Verify volDir is on XFS, if not this test can't pass:

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 				// if g.CurrentGinkgoTestDescription().Failed
 				dumpRouterHeadersLogs(oc, g.CurrentGinkgoTestDescription().FullTestText)
 			}()
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			ns := oc.KubeFramework().Namespace.Name
 			execPodName := exutil.CreateExecPodOrFail(oc.AdminKubeClient().Core(), ns, "execpod")
 			defer func() { oc.AdminKubeClient().Core().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -66,7 +66,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should serve the correct routes when scoped to a single namespace and label set", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			ns := oc.KubeFramework().Namespace.Name
 			execPodName := exutil.CreateExecPodOrFail(oc.AdminKubeClient().CoreV1(), ns, "execpod")
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
@@ -107,7 +107,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		})
 
 		g.It("should override the route host with a custom value", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			ns := oc.KubeFramework().Namespace.Name
 			execPodName := exutil.CreateExecPodOrFail(oc.AdminKubeClient().CoreV1(), ns, "execpod")
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
@@ -167,7 +167,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		})
 
 		g.It("should override the route host for overridden domains with a custom value", func() {
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			ns := oc.KubeFramework().Namespace.Name
 			execPodName := exutil.CreateExecPodOrFail(oc.AdminKubeClient().CoreV1(), ns, "execpod")
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.Describe("The HAProxy router", func() {
 		g.It("should run even if it has no access to update status", func() {
 			g.Skip("test temporarily disabled")
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			ns := oc.KubeFramework().Namespace.Name
 			execPodName := exutil.CreateExecPodOrFail(oc.AdminKubeClient().CoreV1(), ns, "execpod")
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 					dumpWeightedRouterLogs(oc, g.CurrentGinkgoTestDescription().FullTestText)
 				}
 			}()
-			oc.SetOutputDir(exutil.TestContext.OutputDir)
+
 			ns := oc.KubeFramework().Namespace.Name
 			execPodName := exutil.CreateExecPodOrFail(oc.AdminKubeClient().Core(), ns, "execpod")
 			defer func() { oc.AdminKubeClient().Core().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -50,7 +50,6 @@ type CLI struct {
 	configPath         string
 	adminConfigPath    string
 	username           string
-	outputDir          string
 	globalArgs         []string
 	commandArgs        []string
 	finalArgs          []string
@@ -74,7 +73,6 @@ func NewCLI(project, adminConfigPath string) *CLI {
 
 	client.kubeFramework = e2e.NewDefaultFramework(project)
 	client.kubeFramework.SkipNamespaceCreation = true
-	client.outputDir = os.TempDir()
 	client.username = "admin"
 	client.execPath = "oc"
 	if len(adminConfigPath) == 0 {
@@ -122,7 +120,7 @@ func (c *CLI) ChangeUser(name string) *CLI {
 		FatalErr(err)
 	}
 
-	c.configPath = filepath.Join(c.outputDir, name+".kubeconfig")
+	c.configPath = filepath.Join(e2e.TestContext.OutputDir, name+".kubeconfig")
 	err = clientcmd.WriteToFile(*kubeConfig, c.configPath)
 	if err != nil {
 		FatalErr(err)
@@ -147,12 +145,6 @@ func (c *CLI) SetNamespace(ns string) *CLI {
 func (c CLI) WithoutNamespace() *CLI {
 	c.withoutNamespace = true
 	return &c
-}
-
-// SetOutputDir change the default output directory for temporary files
-func (c *CLI) SetOutputDir(dir string) *CLI {
-	c.outputDir = dir
-	return c
 }
 
 // SetupProject creates a new project and assign a random user to the project.
@@ -471,7 +463,6 @@ func (c *CLI) Run(commands ...string) *CLI {
 		adminConfigPath: c.adminConfigPath,
 		configPath:      c.configPath,
 		username:        c.username,
-		outputDir:       c.outputDir,
 		globalArgs: append(commands, []string{
 			fmt.Sprintf("--config=%s", c.configPath),
 		}...),
@@ -627,7 +618,7 @@ func (c *CLI) OutputToFile(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	path := filepath.Join(c.outputDir, c.Namespace()+"-"+filename)
+	path := filepath.Join(e2e.TestContext.OutputDir, c.Namespace()+"-"+filename)
 	return path, ioutil.WriteFile(path, []byte(content), 0644)
 }
 


### PR DESCRIPTION
We should be consistent with the upstream. The CLI helper should only be
using framework.TestContext.OutputDir for its content. This fixes a bug
when running ginkgo against the extended.test binary where gingko sets
the working directory to a read-only directory (where the extended.test
binary is located) but without output-dir set to anything the CLI helper
defaults to creating the temporary file in the read only directory.

Blocking running e2e inside an image (the binary is in a directory we don't have access to).  With this change the output defaults to `/tmp` like upstream e2e.