### PR TITLE
UPSTREAM: 63875: make TestGetServerGroupsWithTimeout more reliable - partial revert

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -143,18 +143,19 @@ func TestGetServerGroupsWithTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 	defer close(done)
-	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL, Timeout: 2 * time.Second})
+	tmp := defaultTimeout
+	defaultTimeout = 2 * time.Second
+	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	_, err := client.ServerGroups()
 	// the error we're getting here is wrapped in errors.errorString which makes
 	// it impossible to unwrap and check it's attributes, so instead we're checking
 	// the textual output which is presenting http.httpError with timeout set to true
-	if err == nil {
-		t.Fatal("missing error")
-	}
 	if !strings.Contains(err.Error(), "timeout:true") &&
 		!strings.Contains(err.Error(), "context.deadlineExceededError") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	done <- true
+	defaultTimeout = tmp
 }
 
 func TestGetServerResourcesWithV1Server(t *testing.T) {


### PR DESCRIPTION
I want to check if the queue still fails with the bits from #19723 reverted.