### PR TITLE
Use `openshift start node --write-flags`

### DIFF
--- a/images/node/scripts/openshift-node
+++ b/images/node/scripts/openshift-node
@@ -14,5 +14,5 @@ config=/etc/origin/node/bootstrap-node-config.yaml
 if [[ -f /etc/origin/node/node-config.yaml ]]; then
   config=/etc/origin/node/node-config.yaml
 fi
-flags=$( /usr/bin/openshift-node-config "--config=${config}" )
+flags=$( /usr/bin/openshift start node --write-flags "--config=${config}" --loglevel=${DEBUG_LOGLEVEL:-2} )
 exec /usr/bin/hyperkube kubelet --v=${DEBUG_LOGLEVEL:-2} ${flags}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1577886

openshift-node-config generated incorrect flags for items like
cluster-dns