### PR TITLE
UPSTREAM: 63206: Partial pick of restmapper fixes

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -89,8 +89,7 @@ func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, err
 		groupResources, err = discovery.GetAPIGroupResources(discoveryClient)
 	}
 	if err != nil {
-		glog.V(3).Infof("Unable to retrieve API resources, falling back to hardcoded types: %v", err)
-		return legacyscheme.Registry.RESTMapper(), legacyscheme.Scheme, nil
+		return nil, nil, err
 	}
 
 	// allow conversion between typed and unstructured objects

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
@@ -631,6 +631,11 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 		// if we error out here, it is because we could not match a resource or a kind
 		// for the given argument. To maintain consistency with previous behavior,
 		// announce that a resource type could not be found.
+		// if the error is a URL error, then we had trouble doing discovery, so we should return the original
+		// error since it may help a user diagnose what is actually wrong
+		if _, ok := err.(*url.Error); ok {
+			return nil, err
+		}
 		return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 	}
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1577520

Partially picks ef0d1ab81927214db80c30d5af491f67546d790b from upstream PR https://github.com/kubernetes/kubernetes/pull/63206 to prevent squashing url errors when attempting to discover a resource list from the server.

Partially picks 5432ef5c4557fc47c97f631ac3b23738bbd27115 from upstream PR https://github.com/kubernetes/kubernetes/pull/63250 to prevent squashing url errors when attempting to find a REST mapping for a resource.

**Before**
```
# with no connection to a cluster
$ oc get dc
error: the server doesn't have a resource type "dc"
```

**After**
```
# with no connection to a cluster
$ oc get dc
The connection to the server 127.0.0.1:8443 was refused - did you specify the right host or port?
```

cc @smarterclayton @deads2k @soltysh 