### PR TITLE
openshift-node-config: resolve cluster-ip when 0.0.0.0 is specified

### DIFF
--- a/cmd/openshift-node-config/openshift-node-config.go
+++ b/cmd/openshift-node-config/openshift-node-config.go
@@ -47,6 +47,11 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("unable to read node config: %v", err)
 			}
+
+			if err := node.FinalizeNodeConfig(nodeConfig); err != nil {
+				return err
+			}
+
 			if glog.V(2) {
 				out, _ := yaml.Marshal(nodeConfig)
 				glog.V(2).Infof("Node config:\n%s", out)

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -237,16 +237,9 @@ func (o NodeOptions) RunNode() error {
 	if addr := o.NodeArgs.ListenArg.ListenAddr; addr.Provided {
 		nodeConfig.ServingInfo.BindAddress = addr.HostPort(o.NodeArgs.ListenArg.ListenAddr.DefaultPort)
 	}
-	// do a local resolution of node config DNS IP, supports bootstrapping cases
-	if nodeConfig.DNSIP == "0.0.0.0" {
-		glog.V(4).Infof("Defaulting to the DNSIP config to the node's IP")
-		nodeConfig.DNSIP = nodeConfig.NodeIP
-		// TODO: the Kubelet should do this defaulting (to the IP it recognizes)
-		if len(nodeConfig.DNSIP) == 0 {
-			if ip, err := cmdutil.DefaultLocalIP4(); err == nil {
-				nodeConfig.DNSIP = ip.String()
-			}
-		}
+
+	if err := originnode.FinalizeNodeConfig(nodeConfig); err != nil {
+		return err
 	}
 
 	var validationResults common.ValidationResults


### PR DESCRIPTION
let "openshift-node-config" and "openshift start node --write-flags"
generate the same --cluster-dns flag when 0.0.0.0 is specified in the
configuration file.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1577886

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>