### PR TITLE
stop adding controller version to build pod

### DIFF
--- a/pkg/build/apis/build/types.go
+++ b/pkg/build/apis/build/types.go
@@ -39,9 +39,6 @@ const (
 	BuildRunPolicyLabel = "openshift.io/build.start-policy"
 	// DefaultDockerLabelNamespace is the key of a Build label, whose values are build metadata.
 	DefaultDockerLabelNamespace = "io.openshift."
-	// OriginVersion is an environment variable key that indicates the version of origin that
-	// created this build definition.
-	OriginVersion = "ORIGIN_VERSION"
 	// AllowedUIDs is an environment variable that contains ranges of UIDs that are allowed in
 	// Source builder images
 	AllowedUIDs = "ALLOWED_UIDS"

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -25,7 +25,6 @@ import (
 	builderutil "github.com/openshift/origin/pkg/build/builder/util"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	"github.com/openshift/origin/pkg/git"
-	"github.com/openshift/origin/pkg/version"
 )
 
 type builder interface {
@@ -70,14 +69,6 @@ func newBuilderConfigFromEnvironment(out io.Writer, needsDocker bool) (*builderC
 			return nil, fmt.Errorf("unable to serialize build: %v", err)
 		}
 		glog.V(4).Infof("redacted build: %v", string(bytes))
-	}
-
-	masterVersion := os.Getenv(builderutil.OriginVersion)
-	thisVersion := version.Get().String()
-	if len(masterVersion) != 0 && masterVersion != thisVersion {
-		glog.V(3).Infof("warning: OpenShift server version %q differs from this image %q\n", masterVersion, thisVersion)
-	} else {
-		glog.V(4).Infof("Master version %q, Builder version %q", masterVersion, thisVersion)
 	}
 
 	// sourceSecretsDir (SOURCE_SECRET_PATH)

--- a/pkg/build/builder/util/consts.go
+++ b/pkg/build/builder/util/consts.go
@@ -2,10 +2,6 @@ package util
 
 const (
 
-	// OriginVersion is an environment variable key that indicates the version of origin that
-	// created this build definition.
-	OriginVersion = "ORIGIN_VERSION"
-
 	// AllowedUIDs is an environment variable that contains ranges of UIDs that are allowed in
 	// Source builder images
 	AllowedUIDs = "ALLOWED_UIDS"

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -49,7 +49,6 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 	if build.Spec.Source.Git != nil {
 		addSourceEnvVars(build.Spec.Source, &containerEnv)
 	}
-	addOriginVersionVar(&containerEnv)
 
 	if build.Spec.Output.To != nil {
 		addOutputEnvVars(build.Spec.Output.To, &containerEnv)

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -81,7 +81,7 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	errorCases := map[int][]string{
 		0: {"BUILD", string(buildJSON)},
 	}
-	standardEnv := []string{"SOURCE_REPOSITORY", "SOURCE_URI", "SOURCE_CONTEXT_DIR", "SOURCE_REF", "OUTPUT_IMAGE", "OUTPUT_REGISTRY", buildapi.OriginVersion}
+	standardEnv := []string{"SOURCE_REPOSITORY", "SOURCE_URI", "SOURCE_CONTEXT_DIR", "SOURCE_REF", "OUTPUT_IMAGE", "OUTPUT_REGISTRY"}
 	for index, exp := range errorCases {
 		if e := container.Env[index]; e.Name != exp[0] || e.Value != exp[1] {
 			t.Errorf("Expected %s:%s, got %s:%s!\n", exp[0], exp[1], e.Name, e.Value)

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -36,7 +36,6 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 	}
 
 	addSourceEnvVars(build.Spec.Source, &containerEnv)
-	addOriginVersionVar(&containerEnv)
 
 	if len(strategy.Env) > 0 {
 		buildutil.MergeTrustedEnvWithoutDuplicates(buildutil.CopyApiEnvVarToV1EnvVar(strategy.Env), &containerEnv, true)

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -55,7 +55,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if actual.Spec.RestartPolicy != v1.RestartPolicyNever {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
-	expectedKeys := map[string]string{"BUILD": "", "SOURCE_REPOSITORY": "", "SOURCE_URI": "", "SOURCE_CONTEXT_DIR": "", "SOURCE_REF": "", "ORIGIN_VERSION": "", "BUILD_LOGLEVEL": "", "PUSH_DOCKERCFG_PATH": "", "PULL_DOCKERCFG_PATH": ""}
+	expectedKeys := map[string]string{"BUILD": "", "SOURCE_REPOSITORY": "", "SOURCE_URI": "", "SOURCE_CONTEXT_DIR": "", "SOURCE_REF": "", "BUILD_LOGLEVEL": "", "PUSH_DOCKERCFG_PATH": "", "PULL_DOCKERCFG_PATH": ""}
 	gotKeys := map[string]string{}
 	for _, k := range container.Env {
 		gotKeys[k.Name] = ""

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -47,7 +47,6 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildapi.Build) (*v1.Pod, e
 	}
 
 	addSourceEnvVars(build.Spec.Source, &containerEnv)
-	addOriginVersionVar(&containerEnv)
 
 	strategy := build.Spec.Strategy.SourceStrategy
 	if len(strategy.Env) > 0 {

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -90,7 +90,7 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 
 	// strategy ENV variables are whitelisted(filtered) into the container environment, and not all
 	// the values are allowed, so don't expect to see the filtered values in the result.
-	expectedKeys := map[string]string{"BUILD": "", "SOURCE_REPOSITORY": "", "SOURCE_URI": "", "SOURCE_CONTEXT_DIR": "", "SOURCE_REF": "", "ORIGIN_VERSION": "", "BUILD_LOGLEVEL": "", "PUSH_DOCKERCFG_PATH": "", "PULL_DOCKERCFG_PATH": ""}
+	expectedKeys := map[string]string{"BUILD": "", "SOURCE_REPOSITORY": "", "SOURCE_URI": "", "SOURCE_CONTEXT_DIR": "", "SOURCE_REF": "", "BUILD_LOGLEVEL": "", "PUSH_DOCKERCFG_PATH": "", "PULL_DOCKERCFG_PATH": ""}
 	if !rootAllowed {
 		expectedKeys["ALLOWED_UIDS"] = ""
 		expectedKeys["DROP_CAPS"] = ""

--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openshift/origin/pkg/api/apihelpers"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
-	"github.com/openshift/origin/pkg/version"
 )
 
 const (
@@ -230,16 +229,6 @@ func addSourceEnvVars(source buildapi.BuildSource, output *[]v1.EnvVar) {
 		sourceVars = append(sourceVars, v1.EnvVar{Name: "SOURCE_REF", Value: source.Git.Ref})
 	}
 	*output = append(*output, sourceVars...)
-}
-
-// TODO figure out why we provide this information to a pod
-func addOriginVersionVar(output *[]v1.EnvVar) {
-	versionEnv := v1.EnvVar{Name: buildapi.OriginVersion, Value: version.Get().String()}
-	// this mirrors old behavior.
-	if len(version.Get().String()) == 0 {
-		versionEnv.Value = "unknown"
-	}
-	*output = append(*output, versionEnv)
 }
 
 // addOutputEnvVars adds env variables that provide information about the output


### PR DESCRIPTION
We were setting an `ORIGIN_VERSION` env var to an unstructured, human readable output value on the build pods that we create.  Being unstructured, it wasn't stable.  Being the version of the controllers, it wasn't guaranteed to match other versions in the system.  As it stands now, versions skew during every update.  As components are split apart, versions will skew forever.  This removes that particular env var.

/assign @bparees 