### PR TITLE
Remove jpeeler from cmd/OWNERS

### DIFF
--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - aveshagarwal
   - pweil-
   - mfojtik
-  - jpeeler
   - soltysh
   - liggitt
   - ironcladlou


### PR DESCRIPTION
Now that service catalog has been moved to a separate repository, I have
no business here.