### PR TITLE
UPSTREAM: 63926: Avoid unnecessary calls to the cloud provider

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/service/service_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/service/service_controller.go
@@ -282,6 +282,11 @@ func (s *ServiceController) createLoadBalancerIfNeeded(key string, service *v1.S
 	var err error
 
 	if !wantsLoadBalancer(service) {
+		if v1helper.LoadBalancerStatusEqual(previousState, &v1.LoadBalancerStatus{}) {
+			return nil
+		}
+
+		glog.V(3).Infof("Getting load balancer for service %s", key)
 		_, exists, err := s.balancer.GetLoadBalancer(context.TODO(), s.clusterName, service)
 		if err != nil {
 			return fmt.Errorf("error getting LB for service %s: %v", key, err)


### PR DESCRIPTION
If the service controller is processing a service that does not have type LoadBalancer and does not have any external load balancer recorded in its status, do not call the cloud provider to check for an associated load balancer.

This commit fixes bug 1571940.

https://bugzilla.redhat.com/show_bug.cgi?id=1571940

---

Note for backporting: `createLoadBalancersIfNeeded` in 3.9 returns two arguments, so the `return nil` will need to be amended as `return nil, notRetryable` in any backport to 3.9.