### PR TITLE
UPSTREAM: 63966: kubectl: fix Flatten() when used without Latest()

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/resource/builder.go
@@ -933,12 +933,12 @@ func (b *Builder) visitByPaths() *Result {
 		visitors = VisitorList(b.paths)
 	}
 
+	if b.flatten {
+		visitors = NewFlattenListVisitor(visitors, b.mapper)
+	}
+
 	// only items from disk can be refetched
 	if b.latest {
-		// must flatten lists prior to fetching
-		if b.flatten {
-			visitors = NewFlattenListVisitor(visitors, b.mapper)
-		}
 		// must set namespace prior to fetching
 		if b.defaultNamespace {
 			visitors = NewDecoratedVisitor(visitors, SetNamespace(b.namespace))


### PR DESCRIPTION
Fixes: https://github.com/openshift/origin/issues/19746

Seems like this has been broken since 3.7

/cc @soltysh
/sig master