### PR TITLE
catalog: start controller with --cluster-id-configmap-namespace

### DIFF
--- a/examples/service-catalog/service-catalog.yaml
+++ b/examples/service-catalog/service-catalog.yaml
@@ -144,6 +144,7 @@ objects:
           - "6443"
           - -v
           - "3"
+          - --cluster-id-configmap-namespace=kube-service-catalog
           - --leader-election-namespace
           - kube-service-catalog
           - --leader-elect-resource-lock

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -16285,6 +16285,7 @@ objects:
           - "6443"
           - -v
           - "3"
+          - --cluster-id-configmap-namespace=kube-service-catalog
           - --leader-election-namespace
           - kube-service-catalog
           - --leader-elect-resource-lock


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1578936

I0516 14:16:29.464865       1 controller.go:294] error getting the cluster info configmap: "configmaps \"cluster-info\" is forbidden: User \"system:serviceaccount:kube-service-catalog:service-catalog-controller\" cannot get configmaps in the namespace \"default\": User \"system:serviceaccount:kube-service-catalog:service-catalog-controller\" cannot get configmaps in project \"default\""
