### PR TITLE
infra: add pid-file flag for hypershift commands

### DIFF
--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	goflag "flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/openshift/origin/pkg/cmd/openshift-experimental"
@@ -42,6 +44,26 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
+
+}
+
+// addPidFileHandler handles writing PID files for hypershift commands
+// TODO: This should be not needed after 3.10 -> 3.11 transition to operators. In 3.10 this is needed to handle systemd shims.
+func addPidFileHandler(cmd *cobra.Command) {
+	var pidFile string
+	flags := cmd.Flags()
+	flags.StringVar(&pidFile, "pid-file", "", "A file name where the command should write its PID.")
+	flags.MarkHidden("pid-file")
+
+	cmd.PreRun = func(c *cobra.Command, args []string) {
+		if len(pidFile) == 0 {
+			return
+		}
+		if err := ioutil.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0666); err != nil {
+			fmt.Fprintf(os.Stderr, fmt.Sprintf("error writing PID to file %q: %v", pidFile, err))
+			os.Exit(1)
+		}
+	}
 }
 
 func NewHyperShiftCommand() *cobra.Command {
@@ -60,12 +82,15 @@ func NewHyperShiftCommand() *cobra.Command {
 	cmd.AddCommand(startEtcd)
 
 	startOpenShiftAPIServer := openshift_apiserver.NewOpenShiftAPIServerCommand(openshift_apiserver.RecommendedStartAPIServerName, "hypershift", os.Stdout, os.Stderr)
+	addPidFileHandler(startOpenShiftAPIServer)
 	cmd.AddCommand(startOpenShiftAPIServer)
 
 	startOpenShiftKubeAPIServer := openshift_kube_apiserver.NewOpenShiftKubeAPIServerServerCommand(openshift_kube_apiserver.RecommendedStartAPIServerName, "hypershift", os.Stdout, os.Stderr)
+	addPidFileHandler(startOpenShiftKubeAPIServer)
 	cmd.AddCommand(startOpenShiftKubeAPIServer)
 
 	startOpenShiftControllerManager := openshift_controller_manager.NewOpenShiftControllerManagerCommand(openshift_controller_manager.RecommendedStartControllerManagerName, "hypershift", os.Stdout, os.Stderr)
+	addPidFileHandler(startOpenShiftControllerManager)
 	cmd.AddCommand(startOpenShiftControllerManager)
 
 	experimental := openshift_experimental.NewExperimentalCommand(os.Stdout, os.Stderr)


### PR DESCRIPTION
This will add a hidden `--pid-file=PATH` flag to all hypershift commands we use to run the API server and the controller manager. Now the question is how much useful this is outside the container if inside the container I guess we are always going to write 1 into the file.

@twiest @derekwaynecarr @deads2k lets talk here
