### PR TITLE
apps: add sleep to test hook fixture so logs can catch up

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -5444,8 +5444,9 @@ spec:
         execNewPod:
           containerName: myapp
           command:
-          - /bin/echo
-          - test pre hook executed
+          - /bin/bash
+          - -c
+          - "echo 'test pre hook executed' && sleep 5"
   template:
     metadata:
       labels:

--- a/test/extended/testdata/deployments/test-deployment-test.yaml
+++ b/test/extended/testdata/deployments/test-deployment-test.yaml
@@ -14,8 +14,9 @@ spec:
         execNewPod:
           containerName: myapp
           command:
-          - /bin/echo
-          - test pre hook executed
+          - /bin/bash
+          - -c
+          - "echo 'test pre hook executed' && sleep 5"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Attempt to fix https://github.com/openshift/origin/issues/19681

My theory is that the rollout transition fast from running to success and the logs
don't have time to capture the output. This should give the log endpoint time to
catch up with the rollout and stream the logs successfully.

(just a theory, will run this several times to see if this flake keep occuring)

/cc @tnozicka