### PR TITLE
switch over to k8s nfs image extension for image_eco, build extended …

### DIFF
--- a/test/extended/util/nfs.go
+++ b/test/extended/util/nfs.go
@@ -5,171 +5,66 @@ import (
 	"time"
 
 	kapiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-// CreateNFSServerReplicationController creates an nfs server replication controller
-func CreateNFSServerReplicationController(name, capacity string) *kapiv1.ReplicationController {
-	replicas := int32(1)
-	privileged := true
-
-	return &kapiv1.ReplicationController{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ReplicationController",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"name": name},
-		},
-		Spec: kapiv1.ReplicationControllerSpec{
-			Replicas: &replicas,
-			Selector: map[string]string{
-				"role": "nfs-server",
-			},
-			Template: &kapiv1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"role": "nfs-server"},
-				},
-				Spec: kapiv1.PodSpec{
-					Containers: []kapiv1.Container{
-						{
-							Name: "nfs-server",
-							// The code for this image is located at https://github.com/coreydaley/nfs-server
-							// The image exports 10 mounts, /exports/data-0 through /exports/data-9
-							Image: "docker.io/coreydaley/nfs-server",
-							Ports: []kapiv1.ContainerPort{
-								{ContainerPort: 2049, Name: "nfs"},
-								{ContainerPort: 2049, Name: "nfs-udp", Protocol: "UDP"},
-								{ContainerPort: 20048, Name: "mountd"},
-								{ContainerPort: 111, Name: "rpcbind"},
-								{ContainerPort: 111, Name: "rpcbind-udp", Protocol: "UDP"},
-							},
-							Resources: kapiv1.ResourceRequirements{
-								Requests: kapiv1.ResourceList{
-									kapiv1.ResourceMemory: resource.MustParse(capacity),
-								},
-							},
-							SecurityContext: &kapiv1.SecurityContext{
-								Privileged: &privileged,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// CreateNFSServerService creates a service for the nfs replication controller
-func CreateNFSServerService(name string) *kapiv1.Service {
-	return &kapiv1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"name": name},
-		},
-		Spec: kapiv1.ServiceSpec{
-			Ports: []kapiv1.ServicePort{
-				{Port: 2049, Name: "nfs"},
-				{Port: 2049, Name: "nfs-udp", Protocol: "UDP"},
-				{Port: 20048, Name: "mountd"},
-				{Port: 111, Name: "rpcbind"},
-				{Port: 111, Name: "rpcbind-udp", Protocol: "UDP"},
-			},
-			Selector: map[string]string{
-				"role": "nfs-server",
-			},
-		},
-	}
-}
-
-// SetupNFSServer sets up an nfs server replication controller with the given capacity
-// and the nfs service
-func SetupNFSServer(oc *CLI, capacity string) (*kapiv1.ReplicationController, *kapiv1.Service, error) {
-	e2e.Logf("Setting up the nfs server")
-	prefix := oc.Namespace()
-	errs := []error{}
-
+// SetupK8SNFSServerAndVolume sets up an nfs server pod with count number of persistent volumes
+func SetupK8SNFSServerAndVolume(oc *CLI, count int) (*kapiv1.Pod, []*kapiv1.PersistentVolume, error) {
 	e2e.Logf("Adding privileged scc from system:serviceaccount:%s:default", oc.Namespace())
-	if _, err := oc.AsAdmin().Run("adm").Args("policy", "add-scc-to-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", oc.Namespace())).Output(); err != nil {
+	_, err := oc.AsAdmin().Run("adm").Args("policy", "add-scc-to-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", oc.Namespace())).Output()
+	if err != nil {
 		return nil, nil, err
 	}
 
-	e2e.Logf("Setting up the nfs server replication controller")
-	rc, err := oc.AdminKubeClient().Core().ReplicationControllers(oc.Namespace()).Create(CreateNFSServerReplicationController(fmt.Sprintf("%s%s", nfsPrefix, prefix), capacity))
-	if err != nil {
-		e2e.Logf("WARNING: unable to create replication controller %s%s: %v\n", nfsPrefix, prefix, err)
-		errs = append(errs, err)
+	e2e.Logf(fmt.Sprintf("Creating NFS server"))
+	config := e2e.VolumeTestConfig{
+		Namespace: oc.Namespace(),
+		Prefix:    "nfs",
+		// this image is an extension of k8s.gcr.io/volume-nfs:0.8 that adds
+		// additional nfs mounts to allow for openshift extended tests with
+		// replicas and shared state (mongo, postgresql, mysql, etc.); defined
+		// in repo https://github.com/gmontero/nfs-server
+		ServerImage:   "docker.io/gmontero/nfs-server:latest",
+		ServerPorts:   []int{2049},
+		ServerVolumes: map[string]string{"": "/exports"},
 	}
-	err = wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
-		e2e.Logf("Checking replication controller status")
-		readyReplicas, err := oc.AsAdmin().Run("get").Args("replicationcontrollers", rc.Name, "--template", "{{.status.readyReplicas}}").Output()
+	pod, ip := e2e.CreateStorageServer(oc.AsAdmin().KubeFramework().ClientSet, config)
+	e2e.Logf("Waiting for pod running")
+	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+		phase, err := oc.AsAdmin().Run("get").Args("pods", pod.Name, "--template", "{{.status.phase}}").Output()
 		if err != nil {
 			return false, nil
 		}
-		availableReplicas, err := oc.AsAdmin().Run("get").Args("replicationcontrollers", rc.Name, "--template", "{{.status.availableReplicas}}").Output()
-		if err != nil {
-			return false, nil
-		}
-		e2e.Logf("readyReplicas: %s, availableReplicas: %s", readyReplicas, availableReplicas)
-		if readyReplicas != "1" || availableReplicas != "1" {
+		if phase != "Running" {
 			return false, nil
 		}
 		return true, nil
 	})
-	describe, err := oc.AsAdmin().Run("describe").Args(fmt.Sprintf("rc/%s", rc.Name)).Output()
-	e2e.Logf("Describing rc/%s\n%v", rc.Name, describe)
-	if err != nil {
-		return nil, nil, err
+
+	pvs := []*kapiv1.PersistentVolume{}
+	volLabel := labels.Set{e2e.VolumeSelectorKey: oc.Namespace()}
+	for i := 0; i < count; i++ {
+		e2e.Logf(fmt.Sprintf("Creating persistent volume %d", i))
+		pvConfig := e2e.PersistentVolumeConfig{
+			NamePrefix: "nfs-",
+			Labels:     volLabel,
+			PVSource: kapiv1.PersistentVolumeSource{
+				NFS: &kapiv1.NFSVolumeSource{
+					Server:   ip,
+					Path:     fmt.Sprintf("/exports/data-%d", i),
+					ReadOnly: false,
+				},
+			},
+		}
+		pvTemplate := e2e.MakePersistentVolume(pvConfig)
+		pv, err := oc.AdminKubeClient().Core().PersistentVolumes().Create(pvTemplate)
+		if err != nil {
+			e2e.Logf("error creating persistent volume %#v", err)
+		}
+		e2e.Logf("Created persistent volume %#v", pv)
+		pvs = append(pvs, pv)
 	}
-
-	e2e.Logf("Setting up the nfs server service")
-	svc, err := oc.AdminKubeClient().Core().Services(oc.Namespace()).Create(CreateNFSServerService(fmt.Sprintf("%s%s", nfsPrefix, prefix)))
-	if err != nil {
-		e2e.Logf("WARNING: unable to create service %s%s: %v\n", nfsPrefix, prefix, err)
-		errs = append(errs, err)
-	}
-	describe, err = oc.AsAdmin().Run("describe").Args(fmt.Sprintf("svc/%s", svc.Name)).Output()
-	e2e.Logf("Describing svc/%s\n%v", svc.Name, describe)
-
-	e2e.Logf("Waiting for svc/%s endpoints to become available", svc.Name)
-	if err = WaitForEndpointsAvailable(oc, svc.Name); err != nil {
-		return nil, nil, err
-	}
-
-	return rc, svc, kutilerrors.NewAggregate(errs)
-}
-
-// RemoveNFSServer removes the nfs server replication controller and nfs service
-func RemoveNFSServer(oc *CLI) error {
-	e2e.Logf("Removing the nfs server")
-	prefix := oc.Namespace()
-	errs := []error{}
-
-	e2e.Logf("Removing the nfs server service")
-	if err := oc.AdminKubeClient().Core().Services(oc.Namespace()).Delete(fmt.Sprintf("%s%s", nfsPrefix, prefix), nil); err != nil {
-		e2e.Logf("WARNING: unable to remove service %s%s: %v\n", nfsPrefix, prefix, err)
-		errs = append(errs, err)
-	}
-
-	e2e.Logf("Removing the nfs server replication controller")
-	if err := oc.AdminKubeClient().Core().ReplicationControllers(oc.Namespace()).Delete(fmt.Sprintf("%s%s", nfsPrefix, prefix), nil); err != nil {
-		e2e.Logf("WARNING: unable to remove replication controller %s%s: %v\n", nfsPrefix, prefix, err)
-		errs = append(errs, err)
-	}
-
-	e2e.Logf("Removing privileged scc from system:serviceaccount:%s:default", oc.Namespace())
-	if _, err := oc.AsAdmin().Run("adm").Args("policy", "remove-scc-from-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", oc.Namespace())).Output(); err != nil {
-		errs = append(errs, err)
-	}
-
-	return kutilerrors.NewAggregate(errs)
+	return pod, pvs, err
 }

--- a/test/extended/util/volumes.go
+++ b/test/extended/util/volumes.go
@@ -1,125 +1,29 @@
 package util
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 
-	kapiv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-// CreateNFSBackedPersistentVolume creates a persistent volume backed by a pod
-// running nfs
-func CreateNFSBackedPersistentVolume(name, namespace, capacity, server string, number int) *kapiv1.PersistentVolume {
-	e2e.Logf("Creating persistent volume %s", name)
-	return &kapiv1.PersistentVolume{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PersistentVolume",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: map[string]string{"name": name, "namespace": namespace},
-		},
-		Spec: kapiv1.PersistentVolumeSpec{
-			PersistentVolumeSource: kapiv1.PersistentVolumeSource{
-				NFS: &kapiv1.NFSVolumeSource{
-					Server:   server,
-					Path:     fmt.Sprintf("/exports/data-%d", number),
-					ReadOnly: false,
-				},
-			},
-			PersistentVolumeReclaimPolicy: kapiv1.PersistentVolumeReclaimDelete,
-			Capacity: kapiv1.ResourceList{
-				kapiv1.ResourceStorage: resource.MustParse(capacity),
-			},
-			AccessModes: []kapiv1.PersistentVolumeAccessMode{
-				kapiv1.ReadWriteMany,
-				kapiv1.ReadWriteOnce,
-				kapiv1.ReadOnlyMany,
-			},
-		},
-	}
-}
-
-// SetupNFSBackedPersistentVolumes sets up an NFS backed persistent volume
-// Currently, the image that is used exports 10 nfs shares, so the maximum
-// integer for count would be 10
-func SetupNFSBackedPersistentVolumes(oc *CLI, capacity string, count int) (volumes []*kapiv1.PersistentVolume, err error) {
-	e2e.Logf("Setting up nfs backed persistent volume(s)")
-
-	maxVolumes := 10
-	if count > maxVolumes {
-		return nil, errors.New(fmt.Sprintf("SetupNFSBackedPersistentVolumes only supports a maximum of %d volumes, you specified %d", maxVolumes, count))
-	}
-
-	c := oc.AdminKubeClient().Core().PersistentVolumes()
-	prefix := oc.Namespace()
-
-	_, svc, err := SetupNFSServer(oc, capacity)
+func DeletePVCsForDeployment(client clientset.Interface, oc *CLI, deploymentPrefix string) {
+	pvclist, err := client.CoreV1().PersistentVolumeClaims(oc.Namespace()).List(metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		e2e.Logf("pvc list error %#v\n", err)
 	}
-	server, err := oc.Run("get").Args("service", svc.Name, "--template", "{{.spec.clusterIP}}").Output()
-	if err != nil {
-		return nil, err
-	}
-
-	for i := 0; i < count; i++ {
-		pv, err := c.Create(CreateNFSBackedPersistentVolume(fmt.Sprintf("%s%s-%d", pvPrefix, prefix, i), oc.Namespace(), capacity, server, i))
-		if err != nil {
-			e2e.Logf("Error creating persistent volume %v\n", err)
-			return nil, err
+	for _, pvc := range pvclist.Items {
+		e2e.Logf("found pvc %s\n", pvc.Name)
+		if strings.HasPrefix(pvc.Name, deploymentPrefix) {
+			err = client.CoreV1().PersistentVolumeClaims(oc.Namespace()).Delete(pvc.Name, nil)
+			if err != nil {
+				e2e.Logf("pvc del error %#v\n", err)
+			} else {
+				e2e.Logf("deleted pvc %s\n", pvc.Name)
+			}
 		}
-		volumes = append(volumes, pv)
 	}
-	return volumes, nil
-}
-
-// RemoveNFSBackedPersistentVolumes removes persistent volumes created by SetupNFSBackedPersistentVolume
-func RemoveNFSBackedPersistentVolumes(oc *CLI) error {
-	c := oc.AdminKubeClient().Core().PersistentVolumes()
-	prefix := oc.Namespace()
-
-	pvs, err := c.List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, pv := range pvs.Items {
-		if !strings.HasPrefix(pv.Name, fmt.Sprintf("%s%s", pvPrefix, prefix)) {
-			e2e.Logf("Skipping removing persistent volume: %s", pv.Name)
-			continue
-		}
-
-		if err = c.Delete(pv.Name, nil); err != nil {
-			e2e.Logf("WARNING: couldn't remove PV %s: %v\n", pv.Name, err)
-			continue
-		}
-		e2e.Logf("Removed persistent volume: %s", pv.Name)
-	}
-
-	if err = RemoveNFSServer(oc); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func AddNamespaceLabelToPersistentVolumeClaimsInTemplate(oc *CLI, templateName string) error {
-	e2e.Logf("Looking for persistent volume claims in template/%s", templateName)
-	template, err := oc.TemplateClient().Template().Templates(oc.Namespace()).Get(templateName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	for i := range template.Objects {
-		oc.Run("patch").Args(fmt.Sprintf("template/%s", templateName), "--type", "json", "-p", fmt.Sprintf("[{\"op\": \"test\", \"path\": \"/objects/%d/kind\", \"value\":\"PersistentVolumeClaim\"},{\"op\": \"add\", \"path\":\"/objects/%d/spec/selector\", \"value\": {\"matchLabels\":{\"namespace\":\"%s\"}}}]", i, i, oc.Namespace())).Output()
-	}
-
-	return nil
-
 }
 
 func DumpPersistentVolumeInfo(oc *CLI) {


### PR DESCRIPTION
…tests

@openshift/sig-developer-experience ptal

This 
1) pulls in the new nfs image (which is a bit of the k8s test image, a bit of @coreydaley 's image that we used to use, and a couple of adds based on my testing to overcome the blockers that recently emerged)
2) leverage k8s e2e framework when possible
for our PV related extended tests

Aside from converting existing usage to this, I've re-introduced the mongodb stateful set replica test back in.

For the mysql, while I changed it such that if you run it, the deployments succeed and the PVCs are satisfied, I still saw odd master/slave comm errors towards the end of the test when running locally.  I do not *think* they are PV related, so it remains commented out.

I want to get this chunk of change reviewed and merged, then circle back and dive into the mysql oddities.