### PR TITLE
tsb: disable tsb cluster up test due to failing image import

### DIFF
--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -323,7 +323,8 @@ function os::test::extended::clusterup::portinuse_cleanup () {
 
 
 readonly default_tests=(
-    "service_catalog"
+# FIXME: Disabled temporarely as the jenkins:2 images is failing import from RH registry
+#    "service_catalog"
     "noargs"
     "hostdirs"
     "publichostname"


### PR DESCRIPTION
Disable the offending test in attempt to unblock the queue.
Tracked as P0 issue: https://github.com/openshift/origin/issues/19785

/cc @bparees