### PR TITLE
Add registry.fedoraproject.org to default whitelist

### DIFF
--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -221,6 +221,7 @@ func DefaultMasterOptionsWithTweaks(useDefaultPort bool) (*configapi.MasterConfi
 		{DomainName: "gcr.io"},
 		{DomainName: "quay.io"},
 		{DomainName: "registry.centos.org"},
+		{DomainName: "registry.fedoraproject.org"},
 		{DomainName: "registry.redhat.io"},
 	}
 


### PR DESCRIPTION
For the same reason we added registry.centos.org.  I was experimenting with
a rpm-ostree build container using Fedora base images; there are a lot
of reasons to want to have access to newer base userspace components.