### PR TITLE
Add database type, host, port & uri to secret in all database templates

### DIFF
--- a/examples/db-templates/mariadb-ephemeral-template.json
+++ b/examples/db-templates/mariadb-ephemeral-template.json
@@ -32,6 +32,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",

--- a/examples/db-templates/mariadb-persistent-template.json
+++ b/examples/db-templates/mariadb-persistent-template.json
@@ -32,6 +32,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",

--- a/examples/db-templates/mongodb-ephemeral-template.json
+++ b/examples/db-templates/mongodb-ephemeral-template.json
@@ -32,6 +32,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mongodb",
+                "database-uri": "mongodb://${DATABASE_SERVICE_NAME}:27017",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "27017",
                 "database-admin-password": "${MONGODB_ADMIN_PASSWORD}",
                 "database-name": "${MONGODB_DATABASE}",
                 "database-password": "${MONGODB_PASSWORD}",

--- a/examples/db-templates/mongodb-persistent-template.json
+++ b/examples/db-templates/mongodb-persistent-template.json
@@ -32,6 +32,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mongodb",
+                "database-uri": "mongodb://${DATABASE_SERVICE_NAME}:27017",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "27017",
                 "database-admin-password": "${MONGODB_ADMIN_PASSWORD}",
                 "database-name": "${MONGODB_DATABASE}",
                 "database-password": "${MONGODB_PASSWORD}",

--- a/examples/db-templates/mysql-ephemeral-template.json
+++ b/examples/db-templates/mysql-ephemeral-template.json
@@ -32,6 +32,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",

--- a/examples/db-templates/mysql-persistent-template.json
+++ b/examples/db-templates/mysql-persistent-template.json
@@ -32,6 +32,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",

--- a/examples/db-templates/postgresql-ephemeral-template.json
+++ b/examples/db-templates/postgresql-ephemeral-template.json
@@ -31,6 +31,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "postgresql",
+                "database-uri": "postgres://${DATABASE_SERVICE_NAME}:5432",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "5432",
                 "database-name": "${POSTGRESQL_DATABASE}",
                 "database-password": "${POSTGRESQL_PASSWORD}",
                 "database-user": "${POSTGRESQL_USER}"

--- a/examples/db-templates/postgresql-persistent-template.json
+++ b/examples/db-templates/postgresql-persistent-template.json
@@ -31,6 +31,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "postgresql",
+                "database-uri": "postgres://${DATABASE_SERVICE_NAME}:5432",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "5432",
                 "database-name": "${POSTGRESQL_DATABASE}",
                 "database-password": "${POSTGRESQL_PASSWORD}",
                 "database-user": "${POSTGRESQL_USER}"

--- a/examples/db-templates/redis-ephemeral-template.json
+++ b/examples/db-templates/redis-ephemeral-template.json
@@ -29,6 +29,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "redis",
+                "database-uri": "redis://${DATABASE_SERVICE_NAME}:6379",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "6379",
                 "database-password": "${REDIS_PASSWORD}"
             }
         },

--- a/examples/db-templates/redis-persistent-template.json
+++ b/examples/db-templates/redis-persistent-template.json
@@ -29,6 +29,10 @@
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "redis",
+                "database-uri": "redis://${DATABASE_SERVICE_NAME}:6379",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "6379",
                 "database-password": "${REDIS_PASSWORD}"
             }
         },

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -2804,6 +2804,10 @@ var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -3078,6 +3082,10 @@ var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -3376,6 +3384,10 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mongodb",
+                "database-uri": "mongodb://${DATABASE_SERVICE_NAME}:27017",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "27017",
                 "database-admin-password": "${MONGODB_ADMIN_PASSWORD}",
                 "database-name": "${MONGODB_DATABASE}",
                 "database-password": "${MONGODB_PASSWORD}",
@@ -3669,6 +3681,10 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mongodb",
+                "database-uri": "mongodb://${DATABASE_SERVICE_NAME}:27017",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "27017",
                 "database-admin-password": "${MONGODB_ADMIN_PASSWORD}",
                 "database-name": "${MONGODB_DATABASE}",
                 "database-password": "${MONGODB_PASSWORD}",
@@ -3986,6 +4002,10 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -4279,6 +4299,10 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -4576,6 +4600,10 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "postgresql",
+                "database-uri": "postgres://${DATABASE_SERVICE_NAME}:5432",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "5432",
                 "database-name": "${POSTGRESQL_DATABASE}",
                 "database-password": "${POSTGRESQL_PASSWORD}",
                 "database-user": "${POSTGRESQL_USER}"
@@ -4850,6 +4878,10 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "postgresql",
+                "database-uri": "postgres://${DATABASE_SERVICE_NAME}:5432",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "5432",
                 "database-name": "${POSTGRESQL_DATABASE}",
                 "database-password": "${POSTGRESQL_PASSWORD}",
                 "database-user": "${POSTGRESQL_USER}"
@@ -5146,6 +5178,10 @@ var _examplesDbTemplatesRedisEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "redis",
+                "database-uri": "redis://${DATABASE_SERVICE_NAME}:6379",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "6379",
                 "database-password": "${REDIS_PASSWORD}"
             }
         },
@@ -5383,6 +5419,10 @@ var _examplesDbTemplatesRedisPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "redis",
+                "database-uri": "redis://${DATABASE_SERVICE_NAME}:6379",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "6379",
                 "database-password": "${REDIS_PASSWORD}"
             }
         },

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -12574,6 +12574,10 @@ var _examplesDbTemplatesMariadbEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -12848,6 +12852,10 @@ var _examplesDbTemplatesMariadbPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -13146,6 +13154,10 @@ var _examplesDbTemplatesMongodbEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mongodb",
+                "database-uri": "mongodb://${DATABASE_SERVICE_NAME}:27017",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "27017",
                 "database-admin-password": "${MONGODB_ADMIN_PASSWORD}",
                 "database-name": "${MONGODB_DATABASE}",
                 "database-password": "${MONGODB_PASSWORD}",
@@ -13439,6 +13451,10 @@ var _examplesDbTemplatesMongodbPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mongodb",
+                "database-uri": "mongodb://${DATABASE_SERVICE_NAME}:27017",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "27017",
                 "database-admin-password": "${MONGODB_ADMIN_PASSWORD}",
                 "database-name": "${MONGODB_DATABASE}",
                 "database-password": "${MONGODB_PASSWORD}",
@@ -13756,6 +13772,10 @@ var _examplesDbTemplatesMysqlEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -14049,6 +14069,10 @@ var _examplesDbTemplatesMysqlPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "mysql",
+                "database-uri": "mysql://${DATABASE_SERVICE_NAME}:3306",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "3306",
                 "database-name": "${MYSQL_DATABASE}",
                 "database-password": "${MYSQL_PASSWORD}",
                 "database-root-password": "${MYSQL_ROOT_PASSWORD}",
@@ -14346,6 +14370,10 @@ var _examplesDbTemplatesPostgresqlEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "postgresql",
+                "database-uri": "postgres://${DATABASE_SERVICE_NAME}:5432",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "5432",
                 "database-name": "${POSTGRESQL_DATABASE}",
                 "database-password": "${POSTGRESQL_PASSWORD}",
                 "database-user": "${POSTGRESQL_USER}"
@@ -14620,6 +14648,10 @@ var _examplesDbTemplatesPostgresqlPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "postgresql",
+                "database-uri": "postgres://${DATABASE_SERVICE_NAME}:5432",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "5432",
                 "database-name": "${POSTGRESQL_DATABASE}",
                 "database-password": "${POSTGRESQL_PASSWORD}",
                 "database-user": "${POSTGRESQL_USER}"
@@ -14916,6 +14948,10 @@ var _examplesDbTemplatesRedisEphemeralTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "redis",
+                "database-uri": "redis://${DATABASE_SERVICE_NAME}:6379",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "6379",
                 "database-password": "${REDIS_PASSWORD}"
             }
         },
@@ -15153,6 +15189,10 @@ var _examplesDbTemplatesRedisPersistentTemplateJson = []byte(`{
                 "name": "${DATABASE_SERVICE_NAME}"
             },
             "stringData": {
+                "database-type": "redis",
+                "database-uri": "redis://${DATABASE_SERVICE_NAME}:6379",
+                "database-host": "${DATABASE_SERVICE_NAME}",
+                "database-port": "6379",
                 "database-password": "${REDIS_PASSWORD}"
             }
         },


### PR DESCRIPTION
This brings the secrets in the templates very close (if not identical)
to the secrets that get created when you provision & bind a database
through the service catalog.

The database type allows the service consumer (application) to choose
the proper database driver. The uri, host & port allow the consumer to
get the location of the database from the secret - without having to
be aware that a Service resource exists for the database.

Together, all these additional properties will allow various middleware
templates to be used with any of these database templates without
requiring additional configuration of the service consumer.