### PR TITLE
Give the SDN permission to create Events

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -678,6 +678,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule(read...).Groups(extensionsGroup).Resources("networkpolicies").RuleOrDie(),
 				rbac.NewRule(read...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbac.NewRule("get").Groups(networkGroup, legacyNetworkGroup).Resources("clusternetworks").RuleOrDie(),
+				rbac.NewRule("create", "update", "patch").Groups(kapiGroup).Resources("events").RuleOrDie(),
 			},
 		},
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2098,6 +2098,14 @@ items:
     - clusternetworks
     verbs:
     - get
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -2098,6 +2098,14 @@ items:
     - clusternetworks
     verbs:
     - get
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
#16745 made the SDN log an event on startup, but the `system:sdn-reader` group doesn't actually have permission to create Events; it was just stealing it from `system:node`. Now that the SDN is running separately, it needs to explicitly have that permission.

    events is forbidden: User "system:serviceaccount:openshift-sdn:sdn" cannot create events in the namespace "default"

Current version of this PR just adds event create permission to `system:sdn-reader`, which is probably wrong I guess since "create" != "read". So do we need to create a new `system:sdn` group for the SDN pod to run under? And deprecate `sdn-reader` since it would no longer serve any purpose?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581538