### PR TITLE
add --enable=openshift-logging

### DIFF
--- a/install/openshift-logging/install.yaml
+++ b/install/openshift-logging/install.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: openshift-logging-apb
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-logging-apb-admin-config
+  type: Opaque
+  data:
+    admin.kubeconfig: "${ADMIN_KUBECONFIG}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-logging-apb-certs
+  type: Opaque
+
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: openshift-logging-apb
+    namespace: "${NAMESPACE}"
+  spec:
+    backoffLimit: 5
+    activeDeadlineSeconds: 1800
+    template:
+      spec:
+        restartPolicy: OnFailure
+        containers:
+        - image: docker.io/ansibleplaybookbundle/openshift-logging-apb:latest
+          name: openshift-logging-apb
+          args: [ "provision", "-e", "public_hostname=${PUBLIC_HOSTNAME}" ]
+          volumeMounts:
+          - mountPath: /tmp/logging-config
+            name: admin-kubeconfig
+          - mountPath: /tmp/logging-certs
+            name: certs
+        volumes:
+        - name: admin-kubeconfig
+          secret:
+            defaultMode: 444
+            secretName: openshift-logging-apb-admin-config
+        - name: certs
+          secret:
+            defaultMode: 444
+            secretName: openshift-logging-apb-certs
+
+parameters:
+- description: Namespace of the project that is being deploy
+  displayname: broker client cert key
+  name: NAMESPACE
+  value: "openshift-logging"
+
+- description: Cluster public hostname
+  displayname: public hostname
+  name: PUBLIC_HOSTNAME
+
+- description: admin.kubeconfig file
+  displayname: admin.kubeconfig
+  name: ADMIN_KUBECONFIG

--- a/pkg/oc/clusteradd/cmd.go
+++ b/pkg/oc/clusteradd/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/origin/pkg/oc/clusteradd/componentinstall"
 	"github.com/openshift/origin/pkg/oc/clusteradd/components/automation-service-broker"
 	"github.com/openshift/origin/pkg/oc/clusteradd/components/default-imagestreams"
+	"github.com/openshift/origin/pkg/oc/clusteradd/components/openshift-logging"
 	"github.com/openshift/origin/pkg/oc/clusteradd/components/registry"
 	"github.com/openshift/origin/pkg/oc/clusteradd/components/router"
 	"github.com/openshift/origin/pkg/oc/clusteradd/components/sample-templates"
@@ -50,6 +51,9 @@ var (
 var availableComponents = map[string]func(ctx componentinstall.Context) componentinstall.Component{
 	"automation-service-broker": func(ctx componentinstall.Context) componentinstall.Component {
 		return &automation_service_broker.AutomationServiceBrokerComponentOptions{InstallContext: ctx}
+	},
+	"openshift-logging": func(ctx componentinstall.Context) componentinstall.Component {
+		return &openshift_logging.OpenshiftLoggingComponentOptions{InstallContext: ctx}
 	},
 	"centos-imagestreams": func(ctx componentinstall.Context) componentinstall.Component {
 		return &default_imagestreams.CentosImageStreamsComponentOptions{InstallContext: ctx}

--- a/pkg/oc/clusteradd/componentinstall/apply_template.go
+++ b/pkg/oc/clusteradd/componentinstall/apply_template.go
@@ -130,7 +130,7 @@ func (opt installReadyTemplate) Install(dockerClient dockerhelper.Interface) err
 		return nil
 	}
 
-	if err := wait.PollImmediate(time.Second, 5*time.Minute, opt.template.WaitCondition); err != nil {
+	if err := wait.PollImmediate(time.Second, 20*time.Minute, opt.template.WaitCondition); err != nil {
 		return err
 	}
 

--- a/pkg/oc/clusteradd/components/openshift-logging/OWNERS
+++ b/pkg/oc/clusteradd/components/openshift-logging/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - jcantrill
+  - ewolinetz
+approvers:
+  - jcantrill
+  - ewolinetz

--- a/pkg/oc/clusteradd/components/openshift-logging/openshift-logging.go
+++ b/pkg/oc/clusteradd/components/openshift-logging/openshift-logging.go
@@ -1,0 +1,99 @@
+package openshift_logging
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/golang/glog"
+	"io/ioutil"
+	"net/url"
+	"path"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/origin/pkg/oc/clusteradd/componentinstall"
+	"github.com/openshift/origin/pkg/oc/clusterup/coreinstall/kubeapiserver"
+	"github.com/openshift/origin/pkg/oc/clusterup/docker/dockerhelper"
+	"github.com/openshift/origin/pkg/oc/clusterup/manifests"
+	"github.com/openshift/origin/pkg/oc/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	olNamespace = "openshift-logging"
+)
+
+type OpenshiftLoggingComponentOptions struct {
+	InstallContext componentinstall.Context
+}
+
+func (c *OpenshiftLoggingComponentOptions) Name() string {
+	return "openshift-logging"
+}
+
+func (c *OpenshiftLoggingComponentOptions) Install(dockerClient dockerhelper.Interface) error {
+	adminKubeConfigBytes, err := ioutil.ReadFile(path.Join(c.InstallContext.BaseDir(), kubeapiserver.KubeAPIServerDirName, "admin.kubeconfig"))
+	adminKubeConfigString := base64.StdEncoding.EncodeToString(adminKubeConfigBytes)
+
+	configBytes, err := ioutil.ReadFile(path.Join(c.InstallContext.BaseDir(), kubeapiserver.KubeAPIServerDirName, "master-config.yaml"))
+	if err != nil {
+		return err
+	}
+	configObj, err := runtime.Decode(configapilatest.Codec, configBytes)
+	if err != nil {
+		return err
+	}
+	masterConfig, ok := configObj.(*configapi.MasterConfig)
+	if !ok {
+		return fmt.Errorf("the %#v is not MasterConfig", configObj)
+	}
+	masterUrl, err := url.Parse(masterConfig.MasterPublicURL)
+	if err != nil {
+		return err
+	}
+
+	kubeAdminClient, err := kubernetes.NewForConfig(c.InstallContext.ClusterAdminClientConfig())
+	if err != nil {
+		return errors.NewError("cannot obtain API clients").WithCause(err)
+	}
+
+	params := map[string]string{
+		"NAMESPACE":        olNamespace,
+		"PUBLIC_HOSTNAME":  masterUrl.Hostname(),
+		"ADMIN_KUBECONFIG": adminKubeConfigString,
+	}
+	glog.V(2).Infof("instantiating openshift logging template with parameters %v", params)
+
+	err = kubeAdminClient.BatchV1().Jobs(olNamespace).Delete("openshift-logging-apb", metav1.NewDeleteOptions(0))
+	if err != nil && !kerrs.IsNotFound(err) {
+		return err
+	}
+
+	component := componentinstall.Template{
+		Name:            "openshift-logging",
+		Namespace:       olNamespace,
+		InstallTemplate: manifests.MustAsset("install/openshift-logging/install.yaml"),
+
+		WaitCondition: func() (bool, error) {
+			glog.V(2).Infof("polling for openshift-logging-apb to complete")
+			job, err := kubeAdminClient.BatchV1().Jobs(olNamespace).Get("openshift-logging-apb", metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if job.Status.Succeeded > 0 {
+				return true, nil
+			}
+			return false, nil
+
+		},
+	}
+
+	return component.MakeReady(
+		c.InstallContext.ClientImage(),
+		c.InstallContext.BaseDir(),
+		params).Install(dockerClient)
+
+}

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -49,6 +49,7 @@
 // install/openshift-apiserver/install.yaml
 // install/openshift-controller-manager/install-rbac.yaml
 // install/openshift-controller-manager/install.yaml
+// install/openshift-logging/install.yaml
 // install/openshift-web-console-operator/install-rbac.yaml
 // install/openshift-web-console-operator/install.yaml
 // install/origin-web-console/console-config.yaml
@@ -17654,6 +17655,87 @@ func installOpenshiftControllerManagerInstallYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installOpenshiftLoggingInstallYaml = []byte(`apiVersion: v1
+kind: Template
+metadata:
+  name: openshift-logging-apb
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-logging-apb-admin-config
+  type: Opaque
+  data:
+    admin.kubeconfig: "${ADMIN_KUBECONFIG}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-logging-apb-certs
+  type: Opaque
+
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: openshift-logging-apb
+    namespace: "${NAMESPACE}"
+  spec:
+    backoffLimit: 5
+    activeDeadlineSeconds: 1800
+    template:
+      spec:
+        restartPolicy: OnFailure
+        containers:
+        - image: docker.io/ansibleplaybookbundle/openshift-logging-apb:latest
+          name: openshift-logging-apb
+          args: [ "provision", "-e", "public_hostname=${PUBLIC_HOSTNAME}" ]
+          volumeMounts:
+          - mountPath: /tmp/logging-config
+            name: admin-kubeconfig
+          - mountPath: /tmp/logging-certs
+            name: certs
+        volumes:
+        - name: admin-kubeconfig
+          secret:
+            defaultMode: 444
+            secretName: openshift-logging-apb-admin-config
+        - name: certs
+          secret:
+            defaultMode: 444
+            secretName: openshift-logging-apb-certs
+
+parameters:
+- description: Namespace of the project that is being deploy
+  displayname: broker client cert key
+  name: NAMESPACE
+  value: "openshift-logging"
+
+- description: Cluster public hostname
+  displayname: public hostname
+  name: PUBLIC_HOSTNAME
+
+- description: admin.kubeconfig file
+  displayname: admin.kubeconfig
+  name: ADMIN_KUBECONFIG
+`)
+
+func installOpenshiftLoggingInstallYamlBytes() ([]byte, error) {
+	return _installOpenshiftLoggingInstallYaml, nil
+}
+
+func installOpenshiftLoggingInstallYaml() (*asset, error) {
+	bytes, err := installOpenshiftLoggingInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/openshift-logging/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installOpenshiftWebConsoleOperatorInstallRbacYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 parameters:
@@ -18462,6 +18544,7 @@ var _bindata = map[string]func() (*asset, error){
 	"install/openshift-apiserver/install.yaml": installOpenshiftApiserverInstallYaml,
 	"install/openshift-controller-manager/install-rbac.yaml": installOpenshiftControllerManagerInstallRbacYaml,
 	"install/openshift-controller-manager/install.yaml": installOpenshiftControllerManagerInstallYaml,
+	"install/openshift-logging/install.yaml": installOpenshiftLoggingInstallYaml,
 	"install/openshift-web-console-operator/install-rbac.yaml": installOpenshiftWebConsoleOperatorInstallRbacYaml,
 	"install/openshift-web-console-operator/install.yaml": installOpenshiftWebConsoleOperatorInstallYaml,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
@@ -18598,6 +18681,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"openshift-controller-manager": &bintree{nil, map[string]*bintree{
 			"install-rbac.yaml": &bintree{installOpenshiftControllerManagerInstallRbacYaml, map[string]*bintree{}},
 			"install.yaml": &bintree{installOpenshiftControllerManagerInstallYaml, map[string]*bintree{}},
+		}},
+		"openshift-logging": &bintree{nil, map[string]*bintree{
+			"install.yaml": &bintree{installOpenshiftLoggingInstallYaml, map[string]*bintree{}},
 		}},
 		"openshift-web-console-operator": &bintree{nil, map[string]*bintree{
 			"install-rbac.yaml": &bintree{installOpenshiftWebConsoleOperatorInstallRbacYaml, map[string]*bintree{}},

--- a/pkg/oc/clusterup/up.go
+++ b/pkg/oc/clusterup/up.go
@@ -207,6 +207,7 @@ var (
 		"sample-templates",
 		"persistent-volumes",
 		"automation-service-broker",
+		"openshift-logging",
 		"service-catalog",
 		"template-service-broker",
 		"web-console",
@@ -214,6 +215,7 @@ var (
 
 	componentsDisabledByDefault = sets.NewString(
 		"automation-service-broker",
+		"openshift-logging",
 		"service-catalog",
 		"template-service-broker")
 )

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -270,6 +270,7 @@
 // install/openshift-apiserver/install.yaml
 // install/openshift-controller-manager/install-rbac.yaml
 // install/openshift-controller-manager/install.yaml
+// install/openshift-logging/install.yaml
 // install/openshift-web-console-operator/install-rbac.yaml
 // install/openshift-web-console-operator/install.yaml
 // install/origin-web-console/console-config.yaml
@@ -32846,6 +32847,87 @@ func installOpenshiftControllerManagerInstallYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installOpenshiftLoggingInstallYaml = []byte(`apiVersion: v1
+kind: Template
+metadata:
+  name: openshift-logging-apb
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-logging-apb-admin-config
+  type: Opaque
+  data:
+    admin.kubeconfig: "${ADMIN_KUBECONFIG}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-logging-apb-certs
+  type: Opaque
+
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: openshift-logging-apb
+    namespace: "${NAMESPACE}"
+  spec:
+    backoffLimit: 5
+    activeDeadlineSeconds: 1800
+    template:
+      spec:
+        restartPolicy: OnFailure
+        containers:
+        - image: docker.io/ansibleplaybookbundle/openshift-logging-apb:latest
+          name: openshift-logging-apb
+          args: [ "provision", "-e", "public_hostname=${PUBLIC_HOSTNAME}" ]
+          volumeMounts:
+          - mountPath: /tmp/logging-config
+            name: admin-kubeconfig
+          - mountPath: /tmp/logging-certs
+            name: certs
+        volumes:
+        - name: admin-kubeconfig
+          secret:
+            defaultMode: 444
+            secretName: openshift-logging-apb-admin-config
+        - name: certs
+          secret:
+            defaultMode: 444
+            secretName: openshift-logging-apb-certs
+
+parameters:
+- description: Namespace of the project that is being deploy
+  displayname: broker client cert key
+  name: NAMESPACE
+  value: "openshift-logging"
+
+- description: Cluster public hostname
+  displayname: public hostname
+  name: PUBLIC_HOSTNAME
+
+- description: admin.kubeconfig file
+  displayname: admin.kubeconfig
+  name: ADMIN_KUBECONFIG
+`)
+
+func installOpenshiftLoggingInstallYamlBytes() ([]byte, error) {
+	return _installOpenshiftLoggingInstallYaml, nil
+}
+
+func installOpenshiftLoggingInstallYaml() (*asset, error) {
+	bytes, err := installOpenshiftLoggingInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/openshift-logging/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installOpenshiftWebConsoleOperatorInstallRbacYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 parameters:
@@ -33839,6 +33921,7 @@ var _bindata = map[string]func() (*asset, error){
 	"install/openshift-apiserver/install.yaml": installOpenshiftApiserverInstallYaml,
 	"install/openshift-controller-manager/install-rbac.yaml": installOpenshiftControllerManagerInstallRbacYaml,
 	"install/openshift-controller-manager/install.yaml": installOpenshiftControllerManagerInstallYaml,
+	"install/openshift-logging/install.yaml": installOpenshiftLoggingInstallYaml,
 	"install/openshift-web-console-operator/install-rbac.yaml": installOpenshiftWebConsoleOperatorInstallRbacYaml,
 	"install/openshift-web-console-operator/install.yaml": installOpenshiftWebConsoleOperatorInstallYaml,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
@@ -33984,6 +34067,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"openshift-controller-manager": &bintree{nil, map[string]*bintree{
 			"install-rbac.yaml": &bintree{installOpenshiftControllerManagerInstallRbacYaml, map[string]*bintree{}},
 			"install.yaml": &bintree{installOpenshiftControllerManagerInstallYaml, map[string]*bintree{}},
+		}},
+		"openshift-logging": &bintree{nil, map[string]*bintree{
+			"install.yaml": &bintree{installOpenshiftLoggingInstallYaml, map[string]*bintree{}},
 		}},
 		"openshift-web-console-operator": &bintree{nil, map[string]*bintree{
 			"install-rbac.yaml": &bintree{installOpenshiftWebConsoleOperatorInstallRbacYaml, map[string]*bintree{}},


### PR DESCRIPTION
This will enable installing openshift-logging via `oc cluster up --enable=openshift-logging` as it has been reported that the old method `oc cluster up --logging=true` no longer works in https://bugzilla.redhat.com/show_bug.cgi?id=1558864.

The APB container runs the logging roles from https://github.com/openshift/openshift-ansible against the cluster.

When complete it is possible to login at https://kibana.public_hostname to view logs and graphs, create reports, etc.