### PR TITLE
Default config no longer sets a whitelist

### DIFF
--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -135,25 +135,6 @@ var (
 	}
 	KnownKubeAPIGroups   = sets.StringKeySet(KubeAPIGroupsToAllowedVersions)
 	KnownOriginAPIGroups = sets.StringKeySet(OriginAPIGroupsToAllowedVersions)
-
-	// List public registries that we are allowing to import images from by default.
-	// By default all registries have set to be "secure", iow. the port for them is
-	// defaulted to "443".
-	// If the registry you are adding here is insecure, you can add 'Insecure: true' to
-	// make it default to port '80'.
-	// If the registry you are adding use custom port, you have to specify the port as
-	// part of the domain name.
-	DefaultAllowedRegistriesForImport = &AllowedRegistries{
-		{DomainName: "docker.io"},
-		{DomainName: "*.docker.io"},  // registry-1.docker.io
-		{DomainName: "*.redhat.com"}, // registry.connect.redhat.com and registry.access.redhat.com
-		{DomainName: "gcr.io"},
-		{DomainName: "quay.io"},
-		{DomainName: "registry.centos.org"},
-		{DomainName: "registry.redhat.io"},
-		// FIXME: Probably need to have more fine-tuned pattern defined
-		{DomainName: "*.amazonaws.com"},
-	}
 )
 
 type ExtendedArguments map[string][]string

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -241,16 +241,7 @@ func (args MasterArgs) BuildSerializeableMasterConfig() (*configapi.MasterConfig
 			Latest: args.ImageFormatArgs.ImageTemplate.Latest,
 		},
 
-		// List public registries that we are allowing to import images from by default.
-		// By default all registries have set to be "secure", iow. the port for them is
-		// defaulted to "443".
-		// If the registry you are adding here is insecure, you can add 'Insecure: true' which
-		// in that case it will default to port '80'.
-		// If the registry you are adding use custom port, you have to specify the port as
-		// part of the domain name.
-		ImagePolicyConfig: configapi.ImagePolicyConfig{
-			AllowedRegistriesForImport: configapi.DefaultAllowedRegistriesForImport,
-		},
+		ImagePolicyConfig: configapi.ImagePolicyConfig{},
 
 		ProjectConfig: configapi.ProjectConfig{
 			DefaultNodeSelector:    "",

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -207,9 +207,26 @@ func DefaultMasterOptionsWithTweaks(useDefaultPort bool) (*configapi.MasterConfi
 		masterConfig.EtcdClientInfo.URLs = []string{"https://" + masterConfig.EtcdConfig.Address}
 	}
 
+	// List public registries that make sense to allow importing images from by default.
+	// By default all registries have set to be "secure", iow. the port for them is
+	// defaulted to "443".
+	// If the registry you are adding here is insecure, you can add 'Insecure: true' to
+	// make it default to port '80'.
+	// If the registry you are adding use custom port, you have to specify the port as
+	// part of the domain name.
+	recommendedAllowedRegistriesForImport := configapi.AllowedRegistries{
+		{DomainName: "docker.io"},
+		{DomainName: "*.docker.io"},  // registry-1.docker.io
+		{DomainName: "*.redhat.com"}, // registry.connect.redhat.com and registry.access.redhat.com
+		{DomainName: "gcr.io"},
+		{DomainName: "quay.io"},
+		{DomainName: "registry.centos.org"},
+		{DomainName: "registry.redhat.io"},
+	}
+
 	masterConfig.ImagePolicyConfig.ScheduledImageImportMinimumIntervalSeconds = 1
 	allowedRegistries := append(
-		*configapi.DefaultAllowedRegistriesForImport,
+		recommendedAllowedRegistriesForImport,
 		configapi.RegistryLocation{DomainName: "127.0.0.1:*"},
 	)
 	for r := range util.GetAdditionalAllowedRegistries() {


### PR DESCRIPTION
Add an integration test that validates the whitelist. We don't set this
by default in installer, and in the future we want it to by dynamic on a
cluster.  In general, this is an optional setting.

@bparees

Enables openshift/image-registry#88