### PR TITLE
Prevent rolebinding deletion if it is protected

### DIFF
--- a/pkg/oc/admin/policy/modify_roles.go
+++ b/pkg/oc/admin/policy/modify_roles.go
@@ -569,7 +569,7 @@ func (o *RoleModificationOptions) RemoveRole() error {
 		roleBinding.Subjects, cnt = removeSubjects(roleBinding.Subjects, subjectsToRemove)
 		found += cnt
 
-		if len(roleBinding.Subjects) > 0 {
+		if len(roleBinding.Subjects) > 0 || roleBinding.Annotations[ReconcileProtectAnnotation] == "true" {
 			err = o.RoleBindingAccessor.UpdateRoleBinding(roleBinding)
 		} else {
 			err = o.RoleBindingAccessor.DeleteRoleBinding(roleBinding.Name)

--- a/pkg/oc/admin/policy/modify_roles_test.go
+++ b/pkg/oc/admin/policy/modify_roles_test.go
@@ -202,6 +202,32 @@ func TestModifyNamedClusterRoleBinding(t *testing.T) {
 				},
 			},
 		},
+		// name provided - remove from autoupdate protected
+		"remove-from-protected-clusterrolebinding": {
+			action:               "remove",
+			inputRole:            "edit",
+			inputRoleBindingName: "custom",
+			inputSubjects: []string{
+				"bar",
+			},
+			expectedRoleBindingName: "custom",
+			expectedSubjects:        nil,
+			existingClusterRoleBindings: &authorizationapi.ClusterRoleBindingList{
+				Items: []authorizationapi.ClusterRoleBinding{{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ReconcileProtectAnnotation: "true"},
+						Name:        "custom",
+					},
+					Subjects: []kapi.ObjectReference{{
+						Name: "bar",
+						Kind: authorizationapi.UserKind,
+					}},
+					RoleRef: kapi.ObjectReference{
+						Name: "edit",
+					}},
+				},
+			},
+		},
 	}
 	for tcName, tc := range tests {
 		// Set up modifier options and run AddRole()


### PR DESCRIPTION
When removing a subject from a role we decided to remove the rolebinding
if no subjects are left.
This is normally a good housekeeping operation, however breaks the case
where someone wants to remove subjects from a rolebinding that is
subject to automatic reconciliation because it is part of the bootstrap
set.

Prevent role deletion if the user marks the rolebinding as protected
from reconciliation.

https://bugzilla.redhat.com/show_bug.cgi?id=1580538