### PR TITLE
UPSTREAM: 64049: Fix race in TestSchedulerWithVolumeBinding to avoid setting predicate ordering.

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/scheduler/scheduler_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/scheduler/scheduler_test.go
@@ -659,8 +659,6 @@ func makePredicateError(failReason string) error {
 }
 
 func TestSchedulerWithVolumeBinding(t *testing.T) {
-	order := []string{predicates.CheckVolumeBindingPred, predicates.GeneralPred}
-	predicates.SetPredicatesOrdering(order)
 	findErr := fmt.Errorf("find err")
 	assumeErr := fmt.Errorf("assume err")
 	bindErr := fmt.Errorf("bind err")


### PR DESCRIPTION
@sjenning @smarterclayton 

To address: https://openshift-gce-devel.appspot.com//build/origin-ci-test/pr-logs/pull/19720/test_pull_request_origin_unit/13193/