### PR TITLE
set the dns suffix for docker config secrets

### DIFF
--- a/pkg/cmd/openshift-controller-manager/controller/serviceaccount.go
+++ b/pkg/cmd/openshift-controller-manager/controller/serviceaccount.go
@@ -70,6 +70,7 @@ func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error)
 	dockerRegistryControllerOptions := serviceaccountcontrollers.DockerRegistryServiceControllerOptions{
 		DockercfgController:   dockercfgController,
 		DockerURLsInitialized: dockerURLsInitialized,
+		ClusterDNSSuffix:      "cluster.local",
 	}
 	go serviceaccountcontrollers.NewDockerRegistryServiceController(
 		ctx.ExternalKubeInformers.Core().V1().Secrets(),

--- a/pkg/serviceaccounts/controllers/docker_registry_service_test.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service_test.go
@@ -123,7 +123,7 @@ func TestNoChangeNoOp(t *testing.T) {
 	}
 }
 
-func TestUpdateNewStyleSecret(t *testing.T) {
+func TestUpdateNewStyleSecretAndDNSSuffix(t *testing.T) {
 	stopChannel := make(chan struct{})
 	defer close(stopChannel)
 	received := make(chan bool)
@@ -142,6 +142,7 @@ func TestUpdateNewStyleSecret(t *testing.T) {
 	}
 
 	kubeclient, fakeWatch, controller, informerFactory := controllerSetup([]runtime.Object{newStyleDockercfgSecret}, t, stopChannel)
+	controller.clusterDNSSuffix = "something.else"
 	controller.syncRegistryLocationHandler = wrapHandler(received, controller.syncRegistryLocationChange, t)
 	controller.syncSecretHandler = wrapStringHandler(updatedSecret, controller.syncSecretUpdate, t)
 	controller.initialSecretsCheckDone = false
@@ -179,7 +180,7 @@ func TestUpdateNewStyleSecret(t *testing.T) {
 	}
 
 	expectedDockercfgMap := credentialprovider.DockerConfig{}
-	for _, key := range []string{"172.16.123.123:1235", "docker-registry.default.svc:1235"} {
+	for _, key := range []string{"172.16.123.123:1235", "docker-registry.default.svc:1235", "docker-registry.default.svc.something.else:1235"} {
 		expectedDockercfgMap[key] = credentialprovider.DockerConfigEntry{
 			Username: "serviceaccount",
 			Password: newStyleDockercfgSecret.Annotations[ServiceAccountTokenValueAnnotation],


### PR DESCRIPTION
Adds the dns suffixed version of the docker service dns names to the dockercfg secret.  It's hardcoded because for now we have no way to configure it in openshift clusters.

@mfojtik @sdodson 