### PR TITLE
Fix Idling extended test resource name for DC

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -259,7 +259,7 @@ var _ = g.Describe("idling and unidling", func() {
 			})
 
 			g.It("should idle the service and DeploymentConfig properly", func() {
-				checkSingleIdle(oc, idlingFile, resources, "deploymentconfig", "DeploymentConfig")
+				checkSingleIdle(oc, idlingFile, resources, "deploymentconfig.apps.openshift.io", "DeploymentConfig")
 			})
 		})
 


### PR DESCRIPTION
The idling extended test looks up resoures from `oc create` by resource
name.  The resource name of deploymentconfigs change to the fully
qualified group name, so we need to look them up by that now.