### PR TITLE
Enable custom build on default

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -934,6 +934,9 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbac.ClusterRoleBinding {
 		// Allow all build strategies by default.
 		// Cluster admins can remove these role bindings, and the reconcile-cluster-role-bindings command
 		// run during an upgrade won't re-add the "system:authenticated" group
+		newOriginClusterBinding(BuildStrategyCustomRoleBindingName, BuildStrategyCustomRoleName).
+			Groups(AuthenticatedGroup).
+			BindingOrDie(),
 		newOriginClusterBinding(BuildStrategyDockerRoleBindingName, BuildStrategyDockerRoleName).
 			Groups(AuthenticatedGroup).
 			BindingOrDie(),


### PR DESCRIPTION
Currently, custom build is not enabled on default, which is not consistent with document & comments in the code. This PR fix this inconsistency by enabling custom build on default.