### PR TITLE
support the --output flag in 'oc create route'

### DIFF
--- a/pkg/oc/cli/cmd/create/route.go
+++ b/pkg/oc/cli/cmd/create/route.go
@@ -164,7 +164,12 @@ func CreateEdgeRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Command, ar
 	}
 
 	shortOutput := kcmdutil.GetFlagString(cmd, "output") == "name"
-	kcmdutil.PrintSuccess(shortOutput, out, actualRoute, dryRun, "created")
+	if !shortOutput && kcmdutil.GetFlagString(cmd, "output") != "" {
+		kcmdutil.PrintObject(cmd, actualRoute, out)
+	} else {
+		kcmdutil.PrintSuccess(shortOutput, out, actualRoute, dryRun, "created")
+	}
+
 	return nil
 }
 
@@ -267,7 +272,12 @@ func CreatePassthroughRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comm
 	}
 
 	shortOutput := kcmdutil.GetFlagString(cmd, "output") == "name"
-	kcmdutil.PrintSuccess(shortOutput, out, actualRoute, dryRun, "created")
+	if !shortOutput && kcmdutil.GetFlagString(cmd, "output") != "" {
+		kcmdutil.PrintObject(cmd, actualRoute, out)
+	} else {
+		kcmdutil.PrintSuccess(shortOutput, out, actualRoute, dryRun, "created")
+	}
+
 	return nil
 }
 
@@ -402,7 +412,12 @@ func CreateReencryptRoute(f *clientcmd.Factory, out io.Writer, cmd *cobra.Comman
 	}
 
 	shortOutput := kcmdutil.GetFlagString(cmd, "output") == "name"
-	kcmdutil.PrintSuccess(shortOutput, out, actualRoute, dryRun, "created")
+	if !shortOutput && kcmdutil.GetFlagString(cmd, "output") != "" {
+		kcmdutil.PrintObject(cmd, actualRoute, out)
+	} else {
+		kcmdutil.PrintSuccess(shortOutput, out, actualRoute, dryRun, "created")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
currently using the --output flag with 'oc create route does not show the resulting object. I changed
that so the the file is printed reflecting the information provided in the help text

bug 1418021
https://bugzilla.redhat.com/show_bug.cgi?id=1418021