### PR TITLE
install ceph-common in control plane so rbd provisioner can find rbd cli to create rbd images

### DIFF
--- a/images/origin/Dockerfile
+++ b/images/origin/Dockerfile
@@ -6,7 +6,9 @@
 #
 FROM openshift/origin-cli
 
-RUN INSTALL_PKGS="origin" && \
+RUN INSTALL_PKGS="origin ceph-common" && \
+    yum install -y centos-release-ceph-luminous && \
+    rpm -V centos-release-ceph-luminous && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all && \


### PR DESCRIPTION
fix https://bugzilla.redhat.com/show_bug.cgi?id=1582059
