### PR TITLE
up: remove support for remote docker host

### DIFF
--- a/pkg/oc/clusteradd/components/router/router_install.go
+++ b/pkg/oc/clusteradd/components/router/router_install.go
@@ -11,8 +11,6 @@ import (
 	goruntime "runtime"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/oc/clusterup/docker/host"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -109,19 +107,6 @@ func (c *RouterComponentOptions) Install(dockerClient dockerhelper.Interface) er
 		filepath.Join(masterConfigDir, "ca.crt"))
 	if err != nil {
 		return errors.NewError("cannot create aggregate router cert").WithCause(err)
-	}
-
-	dockerHelper := dockerhelper.NewHelper(dockerClient)
-
-	// This snowflake makes sure that when the Docker is on remote host, we copy the generated cert into
-	// the Docker host master config dir.
-	if len(os.Getenv("DOCKER_HOST")) > 0 {
-		hostHelper := host.NewHostHelper(dockerHelper, c.InstallContext.ClientImage())
-		remoteMasterConfigDir := path.Join(host.RemoteHostOriginDir, c.InstallContext.BaseDir(), kubeapiserver.KubeAPIServerDirName)
-		if err := hostHelper.CopyToHost(masterConfigDir, remoteMasterConfigDir); err != nil {
-			return err
-		}
-		masterConfigDir = remoteMasterConfigDir
 	}
 
 	routerCertPath := masterConfigDir + "/router.pem"

--- a/pkg/oc/clusterup/coreinstall/components/persistent-volumes/setup_persistent_volumes.go
+++ b/pkg/oc/clusterup/coreinstall/components/persistent-volumes/setup_persistent_volumes.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/oc/admin/policy"
-	"github.com/openshift/origin/pkg/oc/clusterup/docker/host"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -125,9 +124,6 @@ func (c *SetupPersistentVolumesOptions) Install(dockerClient dockerhelper.Interf
 		return fmt.Errorf("error retrieving job to setup persistent volumes (%s/%s): %v", pvTargetNamespace, pvSetupJobName, err)
 	}
 	targetDir := path.Join(c.InstallContext.BaseDir(), "openshift.local.pv")
-	if len(os.Getenv("DOCKER_HOST")) > 0 {
-		targetDir = path.Join(host.RemoteHostOriginDir, targetDir)
-	}
 
 	if _, err := os.Stat(path.Join(targetDir, pvIgnoreMarkerFile)); !os.IsNotExist(err) {
 		glog.Infof("Found %q marker file, skipping persistent volume setup", path.Join(targetDir, pvIgnoreMarkerFile))

--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -256,15 +256,9 @@ func (c *ClusterUpConfig) LocalDirFor(componentName string) string {
 }
 
 // RemoteDirFor returns a directory path on remote host
+// DEPRECATED:
 func (c *ClusterUpConfig) RemoteDirFor(componentName string) string {
 	return filepath.Join(host.RemoteHostOriginDir, c.BaseDir, componentName)
-}
-
-func (c *ClusterUpConfig) copyToRemote(source, component string) (string, error) {
-	if err := c.hostHelper.CopyToHost(source, c.RemoteDirFor(component)); err != nil {
-		return "", err
-	}
-	return c.RemoteDirFor(component), nil
 }
 
 func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
@@ -279,16 +273,9 @@ func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 
 	originalMasterConfigDir := configs.masterConfigDir
 	originalNodeConfigDir := configs.nodeConfigDir
-	var err error
 
 	if _, err := os.Stat(configs.masterConfigDir); os.IsNotExist(err) {
 		_, err = c.makeMasterConfig()
-		if err != nil {
-			return nil, err
-		}
-	}
-	if c.isRemoteDocker {
-		configs.masterConfigDir, err = c.copyToRemote(configs.masterConfigDir, kubeapiserver.KubeAPIServerDirName)
 		if err != nil {
 			return nil, err
 		}
@@ -300,21 +287,9 @@ func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 			return nil, err
 		}
 	}
-	if c.isRemoteDocker {
-		configs.openshiftAPIServerConfigDir, err = c.copyToRemote(configs.openshiftAPIServerConfigDir, kubeapiserver.OpenShiftAPIServerDirName)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	if _, err := os.Stat(configs.openshiftControllerConfigDir); os.IsNotExist(err) {
 		_, err = c.makeOpenShiftControllerConfig(originalMasterConfigDir)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if c.isRemoteDocker {
-		configs.openshiftControllerConfigDir, err = c.copyToRemote(configs.openshiftControllerConfigDir, kubeapiserver.OpenShiftControllerManagerDirName)
 		if err != nil {
 			return nil, err
 		}
@@ -326,12 +301,6 @@ func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 			return nil, err
 		}
 	}
-	if c.isRemoteDocker {
-		configs.nodeConfigDir, err = c.copyToRemote(configs.nodeConfigDir, kubelet.NodeConfigDirName)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	if _, err := os.Stat(configs.kubeDNSConfigDir); os.IsNotExist(err) {
 		_, err = c.makeKubeDNSConfig(originalNodeConfigDir)
@@ -339,12 +308,6 @@ func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 			return nil, err
 		}
 
-	}
-	if c.isRemoteDocker {
-		configs.kubeDNSConfigDir, err = c.copyToRemote(configs.kubeDNSConfigDir, kubelet.KubeDNSDirName)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if _, err := os.Stat(configs.podManifestDir); os.IsNotExist(err) {
@@ -379,12 +342,6 @@ func (c *ClusterUpConfig) BuildConfig() (*configDirs, error) {
 		}
 	}
 
-	if c.isRemoteDocker {
-		configs.podManifestDir, err = c.copyToRemote(configs.podManifestDir, kubelet.PodManifestDirName)
-		if err != nil {
-			return nil, err
-		}
-	}
 	glog.V(2).Infof("configLocations = %#v", *configs)
 
 	return configs, nil

--- a/pkg/oc/clusterup/up.go
+++ b/pkg/oc/clusterup/up.go
@@ -327,13 +327,8 @@ func (c *ClusterUpConfig) Complete(cmd *cobra.Command) error {
 	if c.UseNsenterMount {
 		// This is default path when you run cluster up locally, with local docker daemon
 		c.HostVolumesDir = path.Join(c.BaseDir, "openshift.local.volumes")
-		// This is a snowflake when Docker runs on remote host
-		if c.isRemoteDocker {
-			c.HostVolumesDir = c.RemoteDirFor("openshift.local.volumes")
-		} else {
-			if err := os.MkdirAll(c.HostVolumesDir, 0755); err != nil {
-				return err
-			}
+		if err := os.MkdirAll(c.HostVolumesDir, 0755); err != nil {
+			return err
 		}
 	} else {
 		// Snowflake for OSX Docker for Mac
@@ -341,21 +336,13 @@ func (c *ClusterUpConfig) Complete(cmd *cobra.Command) error {
 	}
 
 	c.HostPersistentVolumesDir = path.Join(c.BaseDir, "openshift.local.pv")
-	if c.isRemoteDocker {
-		c.HostPersistentVolumesDir = c.RemoteDirFor("openshift.local.pv")
-	} else {
-		if err := os.MkdirAll(c.HostPersistentVolumesDir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(c.HostPersistentVolumesDir, 0755); err != nil {
+		return err
 	}
 
 	c.HostDataDir = path.Join(c.BaseDir, "etcd")
-	if c.isRemoteDocker {
-		c.HostDataDir = c.RemoteDirFor("etcd")
-	} else {
-		if err := os.MkdirAll(c.HostDataDir, 0755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(c.HostDataDir, 0755); err != nil {
+		return err
 	}
 
 	// Ensure that host directories exist.


### PR DESCRIPTION
This removes support for cluster up running against remote Docker daemon (DOCKER_HOST).

/cc @deads2k 
/cc @soltysh 