### PR TITLE
Allow egress-router to connect to its own node IP, for DNS, etc

### DIFF
--- a/images/egress/router/egress-router.sh
+++ b/images/egress/router/egress-router.sh
@@ -106,7 +106,7 @@ function gen_iptables_rules() {
             fi
         fi
     done <<< "${EGRESS_DESTINATION}"
-    echo -A POSTROUTING -j SNAT --to-source "${EGRESS_SOURCE}"
+    echo -A POSTROUTING -o macvlan0 -j SNAT --to-source "${EGRESS_SOURCE}"
 }
 
 function setup_iptables() {

--- a/images/egress/router/egress_router_test.go
+++ b/images/egress/router/egress_router_test.go
@@ -20,7 +20,7 @@ func TestEgressRouter(t *testing.T) {
 			dest:    "10.1.2.3",
 			output: `
 -A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -29,7 +29,7 @@ func TestEgressRouter(t *testing.T) {
 			dest:    "10.1.2.3",
 			output: `
 -A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -38,7 +38,7 @@ func TestEgressRouter(t *testing.T) {
 			dest:    "10.1.2.3",
 			output: `
 -A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -47,7 +47,7 @@ func TestEgressRouter(t *testing.T) {
 			dest:    "10.1.2.3\n",
 			output: `
 -A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -56,7 +56,7 @@ func TestEgressRouter(t *testing.T) {
 			dest:    "80 tcp 10.4.5.6",
 			output: `
 -A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -65,7 +65,7 @@ func TestEgressRouter(t *testing.T) {
 			dest:    "8080 tcp 10.7.8.9 80",
 			output: `
 -A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -75,7 +75,7 @@ func TestEgressRouter(t *testing.T) {
 			output: `
 -A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
 -A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -86,7 +86,7 @@ func TestEgressRouter(t *testing.T) {
 -A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
 -A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
 -A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 		{
@@ -115,7 +115,7 @@ func TestEgressRouter(t *testing.T) {
 -A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.4.5.6
 -A PREROUTING -i eth0 -p tcp --dport 8080 -j DNAT --to-destination 10.7.8.9:80
 -A PREROUTING -i eth0 -j DNAT --to-destination 10.1.2.3
--A POSTROUTING -j SNAT --to-source 1.2.3.4
+-A POSTROUTING -o macvlan0 -j SNAT --to-source 1.2.3.4
 `,
 		},
 	}


### PR DESCRIPTION
Egress routers can't currently connect to their own node, because they try to do it via the macvlan, and macvlans are never able to reach their parent interface, regardless of configuration options. This fixes it so that egress-router-to-node-IP traffic gets routed via the SDN instead. This also requires a fix to the egress-router iptables NAT rules, which were being overzealous before.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552738