### PR TITLE
move controller SA to openshift-system

### DIFF
--- a/install/openshift-controller-manager/install-rbac.yaml
+++ b/install/openshift-controller-manager/install-rbac.yaml
@@ -5,8 +5,8 @@ parameters:
   value: openshift-controller-manager
 - name: KUBE_SYSTEM
   value: kube-system
-- name: OPENSHIFT_INFRA
-  value: openshift-infra
+- name: OPENSHIFT_SYSTEM
+  value: openshift-system
 objects:
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -87,7 +87,7 @@ objects:
   kind: Role
   metadata:
     name: system:openshift:sa-creating-openshift-controller-manager
-    namespace: ${OPENSHIFT_INFRA}
+    namespace: ${OPENSHIFT_SYSTEM}
   rules:
   - apiGroups:
     - ""
@@ -108,7 +108,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    namespace: ${OPENSHIFT_INFRA}
+    namespace: ${OPENSHIFT_SYSTEM}
     name: system:openshift:sa-creating-openshift-controller-manager
   roleRef:
     kind: Role

--- a/pkg/admission/namespaceconditions/decorator.go
+++ b/pkg/admission/namespaceconditions/decorator.go
@@ -10,7 +10,7 @@ import (
 // this is a list of namespaces with special meaning.  The kube ones are here in particular because
 // we don't control their creation or labeling on their creation
 var runLevelZeroNamespaces = sets.NewString("kube-system", "kube-public")
-var runLevelOneNamespaces = sets.NewString("openshift-node", "openshift-infra", "openshift")
+var runLevelOneNamespaces = sets.NewString("openshift-node", "openshift-system", "openshift")
 
 func init() {
 	runLevelOneNamespaces.Insert(runLevelZeroNamespaces.List()...)

--- a/pkg/cmd/openshift-controller-manager/controller_manager.go
+++ b/pkg/cmd/openshift-controller-manager/controller_manager.go
@@ -134,7 +134,7 @@ func newControllerContext(
 				ClientConfig:         rest.AnonymousClientConfig(clientConfig),
 				CoreClient:           kubeExternal.Core(),
 				AuthenticationClient: kubeExternal.Authentication(),
-				Namespace:            bootstrappolicy.DefaultOpenShiftInfraNamespace,
+				Namespace:            bootstrappolicy.DefaultOpenShiftSystemNamespace,
 			},
 		},
 		ExternalKubeInformers:   informers.GetExternalKubeInformers(),

--- a/pkg/cmd/server/bootstrappolicy/constants.go
+++ b/pkg/cmd/server/bootstrappolicy/constants.go
@@ -4,6 +4,7 @@ package bootstrappolicy
 const (
 	DefaultOpenShiftSharedResourcesNamespace = "openshift"
 	DefaultOpenShiftInfraNamespace           = "openshift-infra"
+	DefaultOpenShiftSystemNamespace          = "openshift-system"
 	DefaultOpenShiftNodeNamespace            = "openshift-node"
 )
 

--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -59,7 +59,7 @@ var (
 )
 
 func bindControllerRole(saName string, roleName string) {
-	roleBinding := rbac.NewClusterBinding(roleName).SAs(DefaultOpenShiftInfraNamespace, saName).BindingOrDie()
+	roleBinding := rbac.NewClusterBinding(roleName).SAs(DefaultOpenShiftSystemNamespace, saName).BindingOrDie()
 	addDefaultMetadata(&roleBinding)
 	controllerRoleBindings = append(controllerRoleBindings, roleBinding)
 }
@@ -68,7 +68,7 @@ func addControllerRole(role rbac.ClusterRole) {
 	if !strings.HasPrefix(role.Name, saRolePrefix) {
 		glog.Fatalf(`role %q must start with %q`, role.Name, saRolePrefix)
 	}
-	addControllerRoleToSA(DefaultOpenShiftInfraNamespace, role.Name[len(saRolePrefix):], role)
+	addControllerRoleToSA(DefaultOpenShiftSystemNamespace, role.Name[len(saRolePrefix):], role)
 }
 
 func addControllerRoleToSA(saNamespace, saName string, role rbac.ClusterRole) {
@@ -164,7 +164,7 @@ func init() {
 	})
 
 	// template-instance-controller
-	templateInstanceController := rbac.NewClusterBinding(AdminRoleName).SAs(DefaultOpenShiftInfraNamespace, InfraTemplateInstanceControllerServiceAccountName).BindingOrDie()
+	templateInstanceController := rbac.NewClusterBinding(AdminRoleName).SAs(DefaultOpenShiftSystemNamespace, InfraTemplateInstanceControllerServiceAccountName).BindingOrDie()
 	templateInstanceController.Name = "system:openshift:controller:" + InfraTemplateInstanceControllerServiceAccountName + ":admin"
 	addDefaultMetadata(&templateInstanceController)
 	controllerRoleBindings = append(controllerRoleBindings, templateInstanceController)
@@ -178,7 +178,7 @@ func init() {
 	})
 
 	// template-instance-finalizer-controller
-	templateInstanceFinalizerController := rbac.NewClusterBinding(AdminRoleName).SAs(DefaultOpenShiftInfraNamespace, InfraTemplateInstanceFinalizerControllerServiceAccountName).BindingOrDie()
+	templateInstanceFinalizerController := rbac.NewClusterBinding(AdminRoleName).SAs(DefaultOpenShiftSystemNamespace, InfraTemplateInstanceFinalizerControllerServiceAccountName).BindingOrDie()
 	templateInstanceFinalizerController.Name = "system:openshift:controller:" + InfraTemplateInstanceFinalizerControllerServiceAccountName + ":admin"
 	addDefaultMetadata(&templateInstanceFinalizerController)
 	controllerRoleBindings = append(controllerRoleBindings, templateInstanceFinalizerController)

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -943,9 +943,14 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbac.ClusterRoleBinding {
 		newOriginClusterBinding(BuildStrategyJenkinsPipelineRoleBindingName, BuildStrategyJenkinsPipelineRoleName).
 			Groups(AuthenticatedGroup).
 			BindingOrDie(),
-		// Allow node-bootstrapper SA to bootstrap nodes by default.
+		// Allow node-bootstrapper SA to bootstrap nodes by default.  It sets it up for multiple namespaces.
 		rbac.NewClusterBinding(NodeBootstrapRoleName).
 			SAs(DefaultOpenShiftInfraNamespace, InfraNodeBootstrapServiceAccountName).
+			SAs(DefaultOpenShiftSystemNamespace, InfraNodeBootstrapServiceAccountName).
+			BindingOrDie(),
+		// Allow openshift-pv-recycle SA to do its work.  This matches our default value
+		rbac.NewClusterBinding("system:openshift:controller:pv-recycler-controller").
+			SAs("openshift-pv-recycler", "pv-recycler").
 			BindingOrDie(),
 		// Everyone should be able to add a scope to their impersonation request.  It is purely tightening.
 		// This does not grant access to impersonate in general, only tighten if you already have permission.

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -286,15 +286,15 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 }
 
 // GetBoostrapSCCAccess provides the default set of access that should be passed to GetBootstrapSecurityContextConstraints.
-func GetBoostrapSCCAccess(infraNamespace string) (map[string][]string, map[string][]string) {
+func GetBoostrapSCCAccess() (map[string][]string, map[string][]string) {
 	groups := map[string][]string{
 		SecurityContextConstraintPrivileged: {ClusterAdminGroup, NodesGroup, MastersGroup},
 		SecurityContextConstraintsAnyUID:    {ClusterAdminGroup},
 		SecurityContextConstraintRestricted: {AuthenticatedGroup},
 	}
 
-	buildControllerUsername := serviceaccount.MakeUsername(infraNamespace, InfraBuildControllerServiceAccountName)
-	pvRecyclerControllerUsername := serviceaccount.MakeUsername(infraNamespace, InfraPersistentVolumeRecyclerControllerServiceAccountName)
+	buildControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftSystemNamespace, InfraBuildControllerServiceAccountName)
+	pvRecyclerControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftInfraNamespace, InfraPersistentVolumeRecyclerControllerServiceAccountName)
 	users := map[string][]string{
 		SecurityContextConstraintPrivileged:         {SystemAdminUsername, buildControllerUsername},
 		SecurityContextConstraintHostMountAndAnyUID: {pvRecyclerControllerUsername},

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -26,7 +26,7 @@ func TestBootstrappedConstraints(t *testing.T) {
 	expectedGroups, expectedUsers := getExpectedAccess()
 	expectedVolumes := []securityapi.FSType{securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim}
 
-	groups, users := GetBoostrapSCCAccess(DefaultOpenShiftInfraNamespace)
+	groups, users := GetBoostrapSCCAccess()
 	bootstrappedConstraints := GetBootstrapSecurityContextConstraints(groups, users)
 
 	if len(expectedConstraintNames) != len(bootstrappedConstraints) {
@@ -61,7 +61,7 @@ func TestBootstrappedConstraintsWithAddedUser(t *testing.T) {
 	expectedGroups, expectedUsers := getExpectedAccess()
 
 	// get default access and add our own user to it
-	groups, users := GetBoostrapSCCAccess(DefaultOpenShiftInfraNamespace)
+	groups, users := GetBoostrapSCCAccess()
 	users[SecurityContextConstraintPrivileged] = append(users[SecurityContextConstraintPrivileged], "foo")
 	bootstrappedConstraints := GetBootstrapSecurityContextConstraints(groups, users)
 
@@ -88,7 +88,7 @@ func getExpectedAccess() (map[string][]string, map[string][]string) {
 		SecurityContextConstraintRestricted: {AuthenticatedGroup},
 	}
 
-	buildControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftInfraNamespace, InfraBuildControllerServiceAccountName)
+	buildControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftSystemNamespace, InfraBuildControllerServiceAccountName)
 	pvRecyclerControllerUsername := serviceaccount.MakeUsername(DefaultOpenShiftInfraNamespace, InfraPersistentVolumeRecyclerControllerServiceAccountName)
 	users := map[string][]string{
 		SecurityContextConstraintPrivileged:         {SystemAdminUsername, buildControllerUsername},

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -669,8 +669,7 @@ func (c *completedConfig) startProjectAuthorizationCache(context genericapiserve
 }
 
 func (c *completedConfig) bootstrapSCC(context genericapiserver.PostStartHookContext) error {
-	ns := bootstrappolicy.DefaultOpenShiftInfraNamespace
-	bootstrapSCCGroups, bootstrapSCCUsers := bootstrappolicy.GetBoostrapSCCAccess(ns)
+	bootstrapSCCGroups, bootstrapSCCUsers := bootstrappolicy.GetBoostrapSCCAccess()
 
 	var securityClient securityclient.Interface
 	err := wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {

--- a/pkg/oc/admin/policy/reconcile_sccs.go
+++ b/pkg/oc/admin/policy/reconcile_sccs.go
@@ -182,7 +182,7 @@ func (o *ReconcileSCCOptions) RunReconcileSCCs(cmd *cobra.Command, f *clientcmd.
 func (o *ReconcileSCCOptions) ChangedSCCs() ([]*securityapi.SecurityContextConstraints, error) {
 	changedSCCs := []*securityapi.SecurityContextConstraints{}
 
-	groups, users := bootstrappolicy.GetBoostrapSCCAccess(o.InfraNamespace)
+	groups, users := bootstrappolicy.GetBoostrapSCCAccess()
 	bootstrapSCCs := bootstrappolicy.GetBootstrapSecurityContextConstraints(groups, users)
 
 	for _, expectedSCC := range bootstrapSCCs {

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -17209,8 +17209,8 @@ parameters:
   value: openshift-controller-manager
 - name: KUBE_SYSTEM
   value: kube-system
-- name: OPENSHIFT_INFRA
-  value: openshift-infra
+- name: OPENSHIFT_SYSTEM
+  value: openshift-system
 objects:
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -17291,7 +17291,7 @@ objects:
   kind: Role
   metadata:
     name: system:openshift:sa-creating-openshift-controller-manager
-    namespace: ${OPENSHIFT_INFRA}
+    namespace: ${OPENSHIFT_SYSTEM}
   rules:
   - apiGroups:
     - ""
@@ -17312,7 +17312,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    namespace: ${OPENSHIFT_INFRA}
+    namespace: ${OPENSHIFT_SYSTEM}
     name: system:openshift:sa-creating-openshift-controller-manager
   roleRef:
     kind: Role

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -77,7 +77,7 @@ func TestPodNodeConstraints(t *testing.T) {
 		{
 			config:           testConfig(),
 			resource:         nodeSelectorPod(),
-			userinfo:         serviceaccount.UserInfo("openshift-infra", "daemonset-controller", ""),
+			userinfo:         serviceaccount.UserInfo("openshift-system", "daemonset-controller", ""),
 			reviewResponse:   reviewResponse(true, ""),
 			expectedResource: "pods/binding",
 			expectedErrorMsg: "",
@@ -86,7 +86,7 @@ func TestPodNodeConstraints(t *testing.T) {
 		{
 			config:           testConfig(),
 			resource:         nodeNamePod(),
-			userinfo:         serviceaccount.UserInfo("openshift-infra", "daemonset-controller", ""),
+			userinfo:         serviceaccount.UserInfo("openshift-system", "daemonset-controller", ""),
 			reviewResponse:   reviewResponse(true, ""),
 			expectedResource: "pods/binding",
 			expectedErrorMsg: "",
@@ -464,7 +464,7 @@ func (a *fakeTestAuthorizer) Authorize(attributes authorizer.Attributes) (author
 		return authorizer.DecisionNoOpinion, "", fmt.Errorf("No valid UserInfo for Context")
 	}
 	// User with pods/bindings. permission:
-	if ui.GetName() == "system:serviceaccount:openshift-infra:daemonset-controller" {
+	if ui.GetName() == "system:serviceaccount:openshift-system:daemonset-controller" {
 		return authorizer.DecisionAllow, "", nil
 	}
 	// User without pods/bindings. permission:

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -32193,8 +32193,8 @@ parameters:
   value: openshift-controller-manager
 - name: KUBE_SYSTEM
   value: kube-system
-- name: OPENSHIFT_INFRA
-  value: openshift-infra
+- name: OPENSHIFT_SYSTEM
+  value: openshift-system
 objects:
 
 - apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -32275,7 +32275,7 @@ objects:
   kind: Role
   metadata:
     name: system:openshift:sa-creating-openshift-controller-manager
-    namespace: ${OPENSHIFT_INFRA}
+    namespace: ${OPENSHIFT_SYSTEM}
   rules:
   - apiGroups:
     - ""
@@ -32296,7 +32296,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    namespace: ${OPENSHIFT_INFRA}
+    namespace: ${OPENSHIFT_SYSTEM}
     name: system:openshift:sa-creating-openshift-controller-manager
   roleRef:
     kind: Role

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -374,11 +374,11 @@ var globalDeploymentConfigGetterUsers = sets.NewString(
 	"system:serviceaccount:kube-system:generic-garbage-collector",
 	"system:serviceaccount:kube-system:namespace-controller",
 	"system:serviceaccount:kube-system:clusterrole-aggregation-controller",
-	"system:serviceaccount:openshift-infra:image-trigger-controller",
-	"system:serviceaccount:openshift-infra:deploymentconfig-controller",
-	"system:serviceaccount:openshift-infra:template-instance-controller",
-	"system:serviceaccount:openshift-infra:template-instance-finalizer-controller",
-	"system:serviceaccount:openshift-infra:unidling-controller",
+	"system:serviceaccount:openshift-system:image-trigger-controller",
+	"system:serviceaccount:openshift-system:deploymentconfig-controller",
+	"system:serviceaccount:openshift-system:template-instance-controller",
+	"system:serviceaccount:openshift-system:template-instance-finalizer-controller",
+	"system:serviceaccount:openshift-system:unidling-controller",
 )
 
 type resourceAccessReviewTest struct {
@@ -628,8 +628,8 @@ func TestAuthorizationResourceAccessReview(t *testing.T) {
 		}
 		test.response.Users.Insert(globalClusterReaderUsers.List()...)
 		test.response.Users.Insert(globalDeploymentConfigGetterUsers.List()...)
-		test.response.Users.Delete("system:serviceaccount:openshift-infra:template-instance-controller")
-		test.response.Users.Delete("system:serviceaccount:openshift-infra:template-instance-finalizer-controller")
+		test.response.Users.Delete("system:serviceaccount:openshift-system:template-instance-controller")
+		test.response.Users.Delete("system:serviceaccount:openshift-system:template-instance-finalizer-controller")
 		test.response.Groups.Insert(globalClusterReaderGroups.List()...)
 		test.run(t)
 	}
@@ -1513,7 +1513,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 
 		expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 			Namespace: namespace,
-			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:clusterrole-aggregation-controller", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:openshift-infra:template-instance-controller", "system:serviceaccount:openshift-infra:template-instance-finalizer-controller", "system:serviceaccount:hammer-project:builder", "system:admin", "system:serviceaccount:openshift-infra:default-rolebindings-controller"),
+			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:clusterrole-aggregation-controller", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:openshift-system:template-instance-controller", "system:serviceaccount:openshift-system:template-instance-finalizer-controller", "system:serviceaccount:hammer-project:builder", "system:admin", "system:serviceaccount:openshift-system:default-rolebindings-controller"),
 			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:cluster-readers", "system:serviceaccounts:hammer-project"),
 		}
 		if (actualResponse.Namespace != expectedResponse.Namespace) ||
@@ -1544,7 +1544,7 @@ func TestOldLocalResourceAccessReviewEndpoint(t *testing.T) {
 
 		expectedResponse := &authorizationapi.ResourceAccessReviewResponse{
 			Namespace: namespace,
-			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:clusterrole-aggregation-controller", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:openshift-infra:template-instance-controller", "system:serviceaccount:openshift-infra:template-instance-finalizer-controller", "system:serviceaccount:hammer-project:builder", "system:admin", "system:serviceaccount:openshift-infra:default-rolebindings-controller"),
+			Users:     sets.NewString("harold", "system:serviceaccount:kube-system:clusterrole-aggregation-controller", "system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:openshift-system:template-instance-controller", "system:serviceaccount:openshift-system:template-instance-finalizer-controller", "system:serviceaccount:hammer-project:builder", "system:admin", "system:serviceaccount:openshift-system:default-rolebindings-controller"),
 			Groups:    sets.NewString("system:cluster-admins", "system:masters", "system:cluster-readers", "system:serviceaccounts:hammer-project"),
 		}
 		if (actualResponse.Namespace != expectedResponse.Namespace) ||

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -168,7 +168,7 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (buildtypedc
 				ClientConfig:         restclient.AnonymousClientConfig(clusterAdminClientConfig),
 				CoreClient:           externalKubeClient.Core(),
 				AuthenticationClient: externalKubeClient.Authentication(),
-				Namespace:            bootstrappolicy.DefaultOpenShiftInfraNamespace,
+				Namespace:            bootstrappolicy.DefaultOpenShiftSystemNamespace,
 			},
 		},
 		ExternalKubeInformers: informers.GetExternalKubeInformers(),

--- a/test/integration/front_proxy_test.go
+++ b/test/integration/front_proxy_test.go
@@ -158,6 +158,8 @@ func TestFrontProxy(t *testing.T) {
 				"openshift",
 				"openshift-infra",
 				"openshift-node",
+				"openshift-pv-recycler",
+				"openshift-system",
 			),
 		},
 	} {

--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -30,7 +30,7 @@ func TestNamespaceLifecycleAdmission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, ns := range []string{"default", "openshift", "openshift-infra"} {
+	for _, ns := range []string{"default", "openshift", "openshift-infra", "openshift-system"} {
 		if err := clusterAdminKubeClientset.Core().Namespaces().Delete(ns, nil); err == nil {
 			t.Fatalf("expected error deleting %q namespace, got none", ns)
 		}

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -595,7 +595,7 @@ func TestInvalidRoleRefs(t *testing.T) {
 		for _, project := range projects.Items {
 			projectNames.Insert(project.Name)
 		}
-		if !projectNames.HasAll("foo", "bar", "openshift-infra", "openshift", "default") {
+		if !projectNames.HasAll("foo", "bar", "openshift-infra", "openshift-system", "openshift", "default") {
 			t.Errorf("Expected projects foo and bar, got %v", projectNames.List())
 		}
 	}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -276,6 +276,24 @@ items:
   - kind: ServiceAccount
     name: node-bootstrapper
     namespace: openshift-infra
+  - kind: ServiceAccount
+    name: node-bootstrapper
+    namespace: openshift-system
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: ClusterRoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:pv-recycler-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:openshift:controller:pv-recycler-controller
+  subjects:
+  - kind: ServiceAccount
+    name: pv-recycler
+    namespace: openshift-pv-recycler
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -745,7 +763,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: build-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -760,7 +778,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: build-config-change-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -775,7 +793,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: deployer-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -790,7 +808,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: deploymentconfig-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -805,7 +823,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -820,7 +838,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -835,7 +853,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-finalizer-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -850,7 +868,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-finalizer-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -865,7 +883,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: origin-namespace-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -880,7 +898,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: serviceaccount-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -895,7 +913,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: serviceaccount-pull-secrets-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -910,7 +928,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: image-trigger-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -925,7 +943,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: service-serving-cert-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -940,7 +958,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: image-import-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -955,7 +973,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: sdn-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -970,7 +988,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: cluster-quota-reconciliation-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -985,7 +1003,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: unidling-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1000,7 +1018,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: service-ingress-ip-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1015,7 +1033,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: ingress-to-route-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1030,7 +1048,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: pv-recycler-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1045,7 +1063,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: resourcequota-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1060,7 +1078,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1075,7 +1093,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1090,7 +1108,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-service-broker
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1105,7 +1123,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1120,7 +1138,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1135,7 +1153,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1150,7 +1168,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:
@@ -1165,7 +1183,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: namespace-security-allocation-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -6196,6 +6196,24 @@ items:
   - kind: ServiceAccount
     name: node-bootstrapper
     namespace: openshift-infra
+  - kind: ServiceAccount
+    name: node-bootstrapper
+    namespace: openshift-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:controller:pv-recycler-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:openshift:controller:pv-recycler-controller
+  subjects:
+  - kind: ServiceAccount
+    name: pv-recycler
+    namespace: openshift-pv-recycler
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6665,7 +6683,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: build-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6680,7 +6698,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: build-config-change-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6695,7 +6713,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: deployer-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6710,7 +6728,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: deploymentconfig-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6725,7 +6743,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6740,7 +6758,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6755,7 +6773,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-finalizer-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6770,7 +6788,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-instance-finalizer-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6785,7 +6803,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: origin-namespace-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6800,7 +6818,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: serviceaccount-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6815,7 +6833,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: serviceaccount-pull-secrets-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6830,7 +6848,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: image-trigger-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6845,7 +6863,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: service-serving-cert-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6860,7 +6878,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: image-import-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6875,7 +6893,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: sdn-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6890,7 +6908,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: cluster-quota-reconciliation-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6905,7 +6923,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: unidling-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6920,7 +6938,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: service-ingress-ip-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6935,7 +6953,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: ingress-to-route-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6950,7 +6968,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: pv-recycler-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6965,7 +6983,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: resourcequota-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6980,7 +6998,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -6995,7 +7013,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: horizontal-pod-autoscaler
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -7010,7 +7028,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: template-service-broker
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -7025,7 +7043,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -7040,7 +7058,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -7055,7 +7073,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -7070,7 +7088,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: default-rolebindings-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -7085,7 +7103,7 @@ items:
   subjects:
   - kind: ServiceAccount
     name: namespace-security-allocation-controller
-    namespace: openshift-infra
+    namespace: openshift-system
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -53,7 +53,7 @@ const (
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
-		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic, "openshift", "openshift-infra"))
+		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic, "openshift", "openshift-infra", "openshift-system"))
 	})
 }
 


### PR DESCRIPTION
Let's just see if this works.

@openshift/sig-storage is there good coverage of the recycler?  This is moving it to use a different SA and namespace.  Why do you use SCC, do you really want to?