### PR TITLE
Fix VRRP check script

### DIFF
--- a/images/ipfailover/keepalived/lib/config-generators.sh
+++ b/images/ipfailover/keepalived/lib/config-generators.sh
@@ -64,7 +64,7 @@ function generate_script_config() {
     if [[ "${port}" == "0" ]]; then
       echo "   script \"true\""
     else
-      echo "   script \"</dev/tcp/${serviceip}/${port}\""
+      echo "   script \"/bin/bash -c '</dev/tcp/${serviceip}/${port}'\""
     fi
   fi
 


### PR DESCRIPTION
Internal check script does not work with current
security checks for keepalived, this patch is a
workaround for this problem.

Fixes: rhbz#1576398