### PR TITLE
HAProxy config template: Fix weight logic for A/B testing

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -377,7 +377,7 @@ backend be_secure:{{$cfgIdx}}
   {{- end }}{{/* is "edge" or "reencrypt" */}}
 
   {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
-    {{- if ne $weight 0 }}
+    {{- if ge $weight 0 }}{{/* weight=0 is reasonable to keep existing connections to backends with cookies as we can see the HTTP headers */}}
       {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
         {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} cookie {{$endpoint.IdHash}} weight {{$weight}}
@@ -446,7 +446,7 @@ backend be_tcp:{{$cfgIdx}}
   hash-type consistent
   timeout check 5000ms
     {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
-      {{- if ne $weight 0 }}
+      {{- if ne $weight 0 }}}{{/* drop connections where weight=0 as we can't use cookies, leaving only r-r and src-ip as dispatch methods and weight make no sense there */}}
         {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
           {{- range $idx, $endpoint := processEndpointsForAlias $cfg $serviceUnit (env "ROUTER_BACKEND_PROCESS_ENDPOINTS" "") }}
   server {{$endpoint.ID}} {{$endpoint.IP}}:{{$endpoint.Port}} weight {{$weight}}


### PR DESCRIPTION
Using an OpenShift route with several services setup for A/B testing,
and the "oc set route-backends", setting a zero weigth to a service
removes the endpoints from the haproxy backend.
This results in a loss of all existing connections, and a loss of
associated end-users sessions.

Changing:
      {{ if ne $weight 0 }}
to
      {{ if ge $weight 0 }}
fixes the issue.
Removing older services is then done whith the  "set route-backend" command.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1584701