### PR TITLE
UPSTREAM: 64573: remove extra "../" when copying from pod to local

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
@@ -235,7 +235,20 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 	}()
 	prefix := getPrefix(src.File)
 	prefix = path.Clean(prefix)
+	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
+	// and attempted to navigate beyond "/" in a remote filesystem
+	prefix = stripPathShortcuts(prefix)
 	return untarAll(reader, dest.File, prefix)
+}
+
+// stripPathShortcuts removes any leading or trailing "../" from a given path
+func stripPathShortcuts(p string) string {
+	newPath := path.Clean(p)
+	if len(newPath) > 0 && string(newPath[0]) == "/" {
+		return newPath[1:]
+	}
+
+	return newPath
 }
 
 func makeTar(srcPath, destPath string, writer io.Writer) error {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1584555

Copying via `kubectl cp` from a pod to local will no longer panic if any received tar headers contain an extra "../". This can happen when specifying a remote location beyond "/" - for example:

```
# I am attempting to go backwards beyond "/"
$ kubectl cp mypod:/one/two/../../../etc/hosts ./
```

The above command results in a tar header containing an extra "../" in its name (../etc/hosts), causing a panic [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/cp.go#L388).

cc @soltysh 