### PR TITLE
UPSTREAM: docker/distribution: <carry>: disable addition of docker.io to unqualified image references

### DIFF
--- a/vendor/github.com/docker/distribution/reference/normalize.go
+++ b/vendor/github.com/docker/distribution/reference/normalize.go
@@ -45,7 +45,15 @@ func ParseNormalizedNamed(s string) (Named, error) {
 		return nil, errors.New("invalid reference format: repository name must be lowercase")
 	}
 
-	ref, err := Parse(domain + "/" + remainder)
+	image := domain + "/" + remainder
+	if !hasDomain(s) {
+		// If the original request did not have a domain
+		// component then continue parsing with that rather
+		// than defaulting to whatever splitDockerDomain()
+		// would add (e.g., "docker.io").
+		image = s
+	}
+	ref, err := Parse(image)
 	if err != nil {
 		return nil, err
 	}
@@ -155,4 +163,12 @@ func ParseAnyReferenceWithSet(ref string, ds *digestset.Set) (Reference, error) 
 	}
 
 	return ParseNormalizedNamed(ref)
+}
+
+func hasDomain(name string) bool {
+	i := strings.IndexRune(name, '/')
+	if i == -1 || (!strings.ContainsAny(name[:i], ".:") && name[:i] != "localhost") {
+		return false
+	}
+	return true
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/parsers/parsers_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/parsers/parsers_test.go
@@ -29,12 +29,12 @@ func TestParseImageName(t *testing.T) {
 		Tag    string
 		Digest string
 	}{
-		{Input: "root", Repo: "docker.io/library/root", Tag: "latest"},
-		{Input: "root:tag", Repo: "docker.io/library/root", Tag: "tag"},
-		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Repo: "docker.io/library/root", Digest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
-		{Input: "user/repo", Repo: "docker.io/user/repo", Tag: "latest"},
-		{Input: "user/repo:tag", Repo: "docker.io/user/repo", Tag: "tag"},
-		{Input: "user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Repo: "docker.io/user/repo", Digest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "root", Repo: "root", Tag: "latest"},
+		{Input: "root:tag", Repo: "root", Tag: "tag"},
+		{Input: "root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Repo: "root", Digest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{Input: "user/repo", Repo: "user/repo", Tag: "latest"},
+		{Input: "user/repo:tag", Repo: "user/repo", Tag: "tag"},
+		{Input: "user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Repo: "user/repo", Digest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
 		{Input: "url:5000/repo", Repo: "url:5000/repo", Tag: "latest"},
 		{Input: "url:5000/repo:tag", Repo: "url:5000/repo", Tag: "tag"},
 		{Input: "url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Repo: "url:5000/repo", Digest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},


### PR DESCRIPTION
This change explicitly prevents `ParseNormalizedName()` from adding "docker.io" if the image reference is unqualified. The intent is to cut off this behaviour at the source (i.e., automatically qualifying image names) rather than chasing down all the callers of this function.

Note: the unit tests in the `docker/distribution/reference` package have not been updated to reflect this change.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1583500