### PR TITLE
Hide deprecated commands

### DIFF
--- a/pkg/oc/cli/cmd/buildlogs.go
+++ b/pkg/oc/cli/cmd/buildlogs.go
@@ -41,7 +41,8 @@ func NewCmdBuildLogs(fullName string, f *clientcmd.Factory, out io.Writer) *cobr
 		Short:      "Show logs from a build",
 		Long:       buildLogsLong,
 		Example:    fmt.Sprintf(buildLogsExample, fullName),
-		Deprecated: fmt.Sprintf("use \"oc %v build/<build-name>\" instead.", LogsRecommendedCommandName),
+		Deprecated: fmt.Sprintf("use oc %v build/<build-name>", LogsRecommendedCommandName),
+		Hidden:     true,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunBuildLogs(fullName, f, out, cmd, opts, args)
 

--- a/pkg/oc/cli/cmd/deploy.go
+++ b/pkg/oc/cli/cmd/deploy.go
@@ -108,6 +108,8 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 		Long:       fmt.Sprintf(deployLong, fullName),
 		Example:    fmt.Sprintf(deployExample, fullName),
 		SuggestFor: []string{"deployment"},
+		Deprecated: "use the oc rollout latest and oc rollout status",
+		Hidden:     true,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, args, out); err != nil {
 				kcmdutil.CheckErr(err)
@@ -122,7 +124,6 @@ func NewCmdDeploy(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.C
 			}
 		},
 	}
-	cmd.Deprecated = "Use the `rollout latest` and `rollout cancel` commands instead."
 
 	cmd.Flags().BoolVar(&options.deployLatest, "latest", false, "If true, start a new deployment now.")
 	cmd.Flags().MarkDeprecated("latest", fmt.Sprintf("use '%s rollout latest' instead", fullName))

--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -54,10 +54,12 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 	exporter := &DefaultExporter{}
 	var filenames []string
 	cmd := &cobra.Command{
-		Use:     "export RESOURCE/NAME ... [flags]",
-		Short:   "Export resources so they can be used elsewhere",
-		Long:    exportLong,
-		Example: fmt.Sprintf(exportExample, fullName),
+		Use:        "export RESOURCE/NAME ... [flags]",
+		Short:      "Export resources so they can be used elsewhere",
+		Long:       exportLong,
+		Example:    fmt.Sprintf(exportExample, fullName),
+		Deprecated: "use the oc get --export",
+		Hidden:     true,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunExport(f, exporter, in, out, cmd, args, filenames)
 			if err == kcmdutil.ErrExit {
@@ -66,7 +68,6 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 			kcmdutil.CheckErr(err)
 		},
 	}
-	cmd.Deprecated = "Use the `get --export` command instead."
 
 	cmd.Flags().String("as-template", "", "Output a Template object with specified name instead of a List or single object.")
 	cmd.Flags().Bool("exact", false, "If true, preserve fields that may be cluster specific, such as service clusterIPs or generated names")

--- a/pkg/oc/cli/secrets/basicauth.go
+++ b/pkg/oc/cli/secrets/basicauth.go
@@ -70,6 +70,7 @@ func NewCmdCreateBasicAuthSecret(name, fullName string, f kcmdutil.Factory, read
 		Long:       createBasicAuthSecretLong,
 		Example:    fmt.Sprintf(createBasicAuthSecretExample, fullName, newSecretFullName, ocEditFullName),
 		Deprecated: "use oc create secret",
+		Hidden:     true,
 		Run: func(c *cobra.Command, args []string) {
 			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(c, err.Error()))

--- a/pkg/oc/cli/secrets/dockercfg.go
+++ b/pkg/oc/cli/secrets/dockercfg.go
@@ -70,6 +70,7 @@ func NewCmdCreateDockerConfigSecret(name, fullName string, f kcmdutil.Factory, o
 		Long:       createDockercfgLong,
 		Example:    fmt.Sprintf(createDockercfgExample, fullName, newSecretFullName, ocEditFullName),
 		Deprecated: "use oc create secret",
+		Hidden:     true,
 		Run: func(c *cobra.Command, args []string) {
 			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(c, err.Error()))

--- a/pkg/oc/cli/secrets/new.go
+++ b/pkg/oc/cli/secrets/new.go
@@ -81,6 +81,7 @@ func NewCmdCreateSecret(name, fullName string, f *clientcmd.Factory, out io.Writ
 		Long:       newLong,
 		Example:    fmt.Sprintf(newExample, fullName),
 		Deprecated: "use oc create secret",
+		Hidden:     true,
 		Run: func(c *cobra.Command, args []string) {
 			if err := options.Complete(args, f); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(c, err.Error()))

--- a/pkg/oc/cli/secrets/sshauth.go
+++ b/pkg/oc/cli/secrets/sshauth.go
@@ -64,6 +64,7 @@ func NewCmdCreateSSHAuthSecret(name, fullName string, f kcmdutil.Factory, out io
 		Long:       createSSHAuthSecretLong,
 		Example:    fmt.Sprintf(createSSHAuthSecretExample, fullName, newSecretFullName, ocEditFullName),
 		Deprecated: "use oc create secret",
+		Hidden:     true,
 		Run: func(c *cobra.Command, args []string) {
 			if err := o.Complete(f, args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(c, err.Error()))


### PR DESCRIPTION
This will hide all the deprecated commands from help and everywhere else. 

/assign @mfojtik 
