### PR TITLE
Service Catalog patch update to v0.1.9.1

### DIFF
--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation/binding.go
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation/binding.go
@@ -71,7 +71,6 @@ func internalValidateServiceBinding(binding *sc.ServiceBinding, create bool) fie
 		validateServiceBindingName,
 		field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateServiceBindingSpec(&binding.Spec, field.NewPath("spec"), create)...)
-	allErrs = append(allErrs, validateServiceBindingStatus(&binding.Status, field.NewPath("status"), create)...)
 	if create {
 		allErrs = append(allErrs, validateServiceBindingCreate(binding)...)
 	} else {
@@ -237,5 +236,6 @@ func ValidateServiceBindingUpdate(new *sc.ServiceBinding, old *sc.ServiceBinding
 func ValidateServiceBindingStatusUpdate(new *sc.ServiceBinding, old *sc.ServiceBinding) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, internalValidateServiceBinding(new, false)...)
+	allErrs = append(allErrs, validateServiceBindingStatus(&new.Status, field.NewPath("status"), false)...)
 	return allErrs
 }

--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation/binding_test.go
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/validation/binding_test.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog"
 )
@@ -567,6 +568,7 @@ func TestValidateServiceBinding(t *testing.T) {
 
 	for _, tc := range cases {
 		errs := internalValidateServiceBinding(tc.binding, tc.create)
+		errs = append(errs, validateServiceBindingStatus(&tc.binding.Status, field.NewPath("status"), false)...)
 		if len(errs) != 0 && tc.valid {
 			t.Errorf("%v: unexpected error: %v", tc.name, errs)
 			continue

--- a/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/pkg/controller/controller_test.go
+++ b/cmd/service-catalog/go/src/github.com/kubernetes-incubator/service-catalog/pkg/controller/controller_test.go
@@ -1818,15 +1818,15 @@ func testActionFor(t *testing.T, name string, f failfFunc, action clientgotestin
 	return fakeRtObject, true
 }
 
-func assertRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
-	assertRemovedFromBrokerCatalog(t, obj, false)
+func assertClassRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
+	assertClassRemovedFromBrokerCatalog(t, obj, false)
 }
 
-func assertRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
-	assertRemovedFromBrokerCatalog(t, obj, true)
+func assertClassRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
+	assertClassRemovedFromBrokerCatalog(t, obj, true)
 }
 
-func assertRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
+func assertClassRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
 	clusterServiceClass, ok := obj.(*v1beta1.ClusterServiceClass)
 	if !ok {
 		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ClusterServiceClass", obj)
@@ -1834,6 +1834,25 @@ func assertRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition 
 
 	if clusterServiceClass.Status.RemovedFromBrokerCatalog != condition {
 		fatalf(t, "ClusterServiceClass.RemovedFromBrokerCatalog!=%v", condition)
+	}
+}
+
+func assertPlanRemovedFromBrokerCatalogFalse(t *testing.T, obj runtime.Object) {
+	assertPlanRemovedFromBrokerCatalog(t, obj, false)
+}
+
+func assertPlanRemovedFromBrokerCatalogTrue(t *testing.T, obj runtime.Object) {
+	assertPlanRemovedFromBrokerCatalog(t, obj, true)
+}
+
+func assertPlanRemovedFromBrokerCatalog(t *testing.T, obj runtime.Object, condition bool) {
+	clusterServicePlan, ok := obj.(*v1beta1.ClusterServicePlan)
+	if !ok {
+		fatalf(t, "Couldn't convert object %+v into a *v1beta1.ClusterServicePlan", obj)
+	}
+
+	if clusterServicePlan.Status.RemovedFromBrokerCatalog != condition {
+		fatalf(t, "ClusterServicePlan.RemovedFromBrokerCatalog!=%v", condition)
 	}
 }
 


### PR DESCRIPTION
Update service catalog to v0.1.9.1 for https://bugzilla.redhat.com/show_bug.cgi?id=1586135. This should not be merged until both https://github.com/openshift/origin/pull/19918 and https://github.com/openshift/aos-cd-jobs/pull/1434 are merged and the catalog test re-run.

