### PR TITLE
Changed to pidof to find the haproxy pids

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -66,7 +66,7 @@ function haproxyHealthCheck() {
 }
 
 
-old_pids=$(ps -A -opid,args | grep haproxy | egrep -v -e 'grep|reload-haproxy' | awk '{print $1}' | tr '\n' ' ')
+old_pids=$(pidof haproxy)
 
 reload_status=0
 if [ -n "$old_pids" ]; then


### PR DESCRIPTION
Before we were using a bunch of piped commands to pull the PID for the running haproxy processes.  It is simpler to just call pidof.

Thanks https://github.com/openshift/origin/issues/18892 for the suggestion