### PR TITLE
diagnostics: replace usage of brctl with /sbin/ip

### DIFF
--- a/pkg/oc/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
+++ b/pkg/oc/admin/diagnostics/diagnostics/cluster/network/in_pod/util/log.go
@@ -23,7 +23,6 @@ func (l *LogInterface) LogNode(kubeClient kclientset.Interface) {
 	l.LogSystem()
 	l.LogServices()
 
-	l.Run("brctl show", "bridges")
 	l.Run("docker ps -a", "docker-ps")
 	l.Run("ovs-ofctl -O OpenFlow13 dump-flows br0", "flows")
 	l.Run("ovs-ofctl -O OpenFlow13 show br0", "ovs-show")


### PR DESCRIPTION
brctl (and its bridge-utils package) has been unmaintained
for years and it's functionality replaced by the 'ip' tool
from the iproute project. brctl may not be available on
systems so just use 'ip link' instead.

@knobunc @openshift/networking @pravisankar 