### PR TITLE
Add server-side column printer support for openshift objects

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -499,6 +499,7 @@
       "github.com/openshift/origin/pkg/oauth/urls",
       "github.com/openshift/origin/pkg/oauth/util",
       "github.com/openshift/origin/pkg/pod/envresolve",
+      "github.com/openshift/origin/pkg/printers/internalversion",
       "github.com/openshift/origin/pkg/project/apis/project",
       "github.com/openshift/origin/pkg/project/apis/project/helpers",
       "github.com/openshift/origin/pkg/project/registry/projectrequest/delegated",

--- a/pkg/apps/registry/deployconfig/etcd/etcd.go
+++ b/pkg/apps/registry/deployconfig/etcd/etcd.go
@@ -16,11 +16,14 @@ import (
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	autoscalingvalidation "k8s.io/kubernetes/pkg/apis/autoscaling/validation"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/labels"
 
 	appsapiv1 "github.com/openshift/api/apps/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	"github.com/openshift/origin/pkg/apps/registry/deployconfig"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -51,6 +54,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, *ScaleREST, err
 		NewFunc:                  func() runtime.Object { return &appsapi.DeploymentConfig{} },
 		NewListFunc:              func() runtime.Object { return &appsapi.DeploymentConfigList{} },
 		DefaultQualifiedResource: appsapi.Resource("deploymentconfigs"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: deployconfig.GroupStrategy,
 		UpdateStrategy: deployconfig.GroupStrategy,

--- a/pkg/authorization/registry/clusterrole/proxy.go
+++ b/pkg/authorization/registry/clusterrole/proxy.go
@@ -8,15 +8,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
 	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
 	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 
 type REST struct {
 	privilegedClient restclient.Interface
+	rest.TableConvertor
 }
 
 var _ rest.Lister = &REST{}
@@ -25,7 +29,10 @@ var _ rest.CreaterUpdater = &REST{}
 var _ rest.GracefulDeleter = &REST{}
 
 func NewREST(client restclient.Interface) utilregistry.NoWatchStorage {
-	return utilregistry.WrapNoWatchStorageError(&REST{privilegedClient: client})
+	return utilregistry.WrapNoWatchStorageError(&REST{
+		privilegedClient: client,
+		TableConvertor:   printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+	})
 }
 
 func (s *REST) New() runtime.Object {

--- a/pkg/authorization/registry/clusterrolebinding/proxy.go
+++ b/pkg/authorization/registry/clusterrolebinding/proxy.go
@@ -8,15 +8,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
 	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
 	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 
 type REST struct {
 	privilegedClient restclient.Interface
+	rest.TableConvertor
 }
 
 var _ rest.Lister = &REST{}
@@ -25,7 +29,10 @@ var _ rest.CreaterUpdater = &REST{}
 var _ rest.GracefulDeleter = &REST{}
 
 func NewREST(client restclient.Interface) utilregistry.NoWatchStorage {
-	return utilregistry.WrapNoWatchStorageError(&REST{privilegedClient: client})
+	return utilregistry.WrapNoWatchStorageError(&REST{
+		privilegedClient: client,
+		TableConvertor:   printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+	})
 }
 
 func (s *REST) New() runtime.Object {

--- a/pkg/authorization/registry/role/proxy.go
+++ b/pkg/authorization/registry/role/proxy.go
@@ -9,15 +9,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
 	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
 	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 
 type REST struct {
 	privilegedClient restclient.Interface
+	rest.TableConvertor
 }
 
 var _ rest.Lister = &REST{}
@@ -26,7 +30,10 @@ var _ rest.CreaterUpdater = &REST{}
 var _ rest.GracefulDeleter = &REST{}
 
 func NewREST(client restclient.Interface) utilregistry.NoWatchStorage {
-	return utilregistry.WrapNoWatchStorageError(&REST{privilegedClient: client})
+	return utilregistry.WrapNoWatchStorageError(&REST{
+		privilegedClient: client,
+		TableConvertor:   printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+	})
 }
 
 func (s *REST) New() runtime.Object {

--- a/pkg/authorization/registry/rolebinding/proxy.go
+++ b/pkg/authorization/registry/rolebinding/proxy.go
@@ -9,15 +9,19 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
 	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
 	authclient "github.com/openshift/origin/pkg/client/impersonatingclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	utilregistry "github.com/openshift/origin/pkg/util/registry"
 )
 
 type REST struct {
 	privilegedClient restclient.Interface
+	rest.TableConvertor
 }
 
 var _ rest.Lister = &REST{}
@@ -26,7 +30,10 @@ var _ rest.CreaterUpdater = &REST{}
 var _ rest.GracefulDeleter = &REST{}
 
 func NewREST(client restclient.Interface) utilregistry.NoWatchStorage {
-	return utilregistry.WrapNoWatchStorageError(&REST{privilegedClient: client})
+	return utilregistry.WrapNoWatchStorageError(&REST{
+		privilegedClient: client,
+		TableConvertor:   printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+	})
 }
 
 func (s *REST) New() runtime.Object {

--- a/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
+++ b/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/rolebindingrestriction"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -23,6 +26,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &authorizationapi.RoleBindingRestriction{} },
 		NewListFunc:              func() runtime.Object { return &authorizationapi.RoleBindingRestrictionList{} },
 		DefaultQualifiedResource: authorizationapi.Resource("rolebindingrestrictions"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: rolebindingrestriction.Strategy,
 		UpdateStrategy: rolebindingrestriction.Strategy,

--- a/pkg/build/registry/build/etcd/etcd.go
+++ b/pkg/build/registry/build/etcd/etcd.go
@@ -7,9 +7,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/registry/build"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -31,6 +34,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, *DetailsREST, error) {
 		NewFunc:                  func() runtime.Object { return &buildapi.Build{} },
 		NewListFunc:              func() runtime.Object { return &buildapi.BuildList{} },
 		DefaultQualifiedResource: buildapi.Resource("builds"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: build.Strategy,
 		UpdateStrategy: build.Strategy,

--- a/pkg/build/registry/buildconfig/etcd/etcd.go
+++ b/pkg/build/registry/buildconfig/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/registry/buildconfig"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -35,6 +38,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &buildapi.BuildConfig{} },
 		NewListFunc:              func() runtime.Object { return &buildapi.BuildConfigList{} },
 		DefaultQualifiedResource: buildapi.Resource("buildconfigs"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: buildconfig.GroupStrategy,
 		UpdateStrategy: buildconfig.GroupStrategy,

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -41,6 +41,7 @@ import (
 	imageinformer "github.com/openshift/origin/pkg/image/generated/informers/internalversion"
 	networkinformer "github.com/openshift/origin/pkg/network/generated/informers/internalversion"
 	oauthinformer "github.com/openshift/origin/pkg/oauth/generated/informers/internalversion"
+	_ "github.com/openshift/origin/pkg/printers/internalversion"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"

--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/registry/image"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &imageapi.Image{} },
 		NewListFunc:              func() runtime.Object { return &imageapi.ImageList{} },
 		DefaultQualifiedResource: imageapi.Resource("images"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: image.Strategy,
 		UpdateStrategy: image.Strategy,

--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -9,11 +9,14 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	imageadmission "github.com/openshift/origin/pkg/image/admission"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -48,6 +51,8 @@ func NewREST(
 		NewFunc:                  func() runtime.Object { return &imageapi.ImageStream{} },
 		NewListFunc:              func() runtime.Object { return &imageapi.ImageStreamList{} },
 		DefaultQualifiedResource: imageapi.Resource("imagestreams"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 	}
 
 	rest := &REST{

--- a/pkg/image/registry/imagestreamimage/rest.go
+++ b/pkg/image/registry/imagestreamimage/rest.go
@@ -6,11 +6,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
 	"github.com/openshift/origin/pkg/image/util"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 )
 
 // REST implements the RESTStorage interface in terms of an image registry and
@@ -20,6 +23,7 @@ import (
 type REST struct {
 	imageRegistry       image.Registry
 	imageStreamRegistry imagestream.Registry
+	rest.TableConvertor
 }
 
 var _ rest.Getter = &REST{}
@@ -32,7 +36,11 @@ func (r *REST) ShortNames() []string {
 
 // NewREST returns a new REST.
 func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry) *REST {
-	return &REST{imageRegistry, imageStreamRegistry}
+	return &REST{
+		imageRegistry,
+		imageStreamRegistry,
+		printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+	}
 }
 
 // New is only implemented to make REST implement RESTStorage

--- a/pkg/image/registry/imagestreamtag/rest.go
+++ b/pkg/image/registry/imagestreamtag/rest.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -16,6 +18,7 @@ import (
 	"github.com/openshift/origin/pkg/image/registry/image"
 	"github.com/openshift/origin/pkg/image/registry/imagestream"
 	"github.com/openshift/origin/pkg/image/util"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 )
 
 // REST implements the RESTStorage interface for ImageStreamTag
@@ -24,6 +27,7 @@ type REST struct {
 	imageRegistry       image.Registry
 	imageStreamRegistry imagestream.Registry
 	strategy            Strategy
+	rest.TableConvertor
 }
 
 // NewREST returns a new REST.
@@ -32,6 +36,7 @@ func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Regis
 		imageRegistry:       imageRegistry,
 		imageStreamRegistry: imageStreamRegistry,
 		strategy:            NewStrategy(registryWhitelister),
+		TableConvertor:      printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 	}
 }
 

--- a/pkg/network/registry/clusternetwork/etcd/etcd.go
+++ b/pkg/network/registry/clusternetwork/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/registry/clusternetwork"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &networkapi.ClusterNetwork{} },
 		NewListFunc:              func() runtime.Object { return &networkapi.ClusterNetworkList{} },
 		DefaultQualifiedResource: networkapi.Resource("clusternetworks"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: clusternetwork.Strategy,
 		UpdateStrategy: clusternetwork.Strategy,

--- a/pkg/network/registry/egressnetworkpolicy/etcd/etcd.go
+++ b/pkg/network/registry/egressnetworkpolicy/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/registry/egressnetworkpolicy"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &networkapi.EgressNetworkPolicy{} },
 		NewListFunc:              func() runtime.Object { return &networkapi.EgressNetworkPolicyList{} },
 		DefaultQualifiedResource: networkapi.Resource("egressnetworkpolicies"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: egressnetworkpolicy.Strategy,
 		UpdateStrategy: egressnetworkpolicy.Strategy,

--- a/pkg/network/registry/hostsubnet/etcd/etcd.go
+++ b/pkg/network/registry/hostsubnet/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/registry/hostsubnet"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &networkapi.HostSubnet{} },
 		NewListFunc:              func() runtime.Object { return &networkapi.HostSubnetList{} },
 		DefaultQualifiedResource: networkapi.Resource("hostsubnets"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: hostsubnet.Strategy,
 		UpdateStrategy: hostsubnet.Strategy,

--- a/pkg/network/registry/netnamespace/etcd/etcd.go
+++ b/pkg/network/registry/netnamespace/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/registry/netnamespace"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &networkapi.NetNamespace{} },
 		NewListFunc:              func() runtime.Object { return &networkapi.NetNamespaceList{} },
 		DefaultQualifiedResource: networkapi.Resource("netnamespaces"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: netnamespace.Strategy,
 		UpdateStrategy: netnamespace.Strategy,

--- a/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthaccesstoken/etcd/etcd.go
@@ -6,10 +6,13 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthaccesstoken"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -27,6 +30,8 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthAccessToken{} },
 		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthAccessTokenList{} },
 		DefaultQualifiedResource: oauthapi.Resource("oauthaccesstokens"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		TTLFunc: func(obj runtime.Object, existing uint64, update bool) (uint64, error) {
 			token := obj.(*oauthapi.OAuthAccessToken)

--- a/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthauthorizetoken/etcd/etcd.go
@@ -6,10 +6,13 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthauthorizetoken"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -27,6 +30,8 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthAuthorizeToken{} },
 		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthAuthorizeTokenList{} },
 		DefaultQualifiedResource: oauthapi.Resource("oauthauthorizetokens"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		TTLFunc: func(obj runtime.Object, existing uint64, update bool) (uint64, error) {
 			token := obj.(*oauthapi.OAuthAuthorizeToken)

--- a/pkg/oauth/registry/oauthclient/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclient/etcd/etcd.go
@@ -5,9 +5,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthClient{} },
 		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthClientList{} },
 		DefaultQualifiedResource: oauthapi.Resource("oauthclients"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: oauthclient.Strategy,
 		UpdateStrategy: oauthclient.Strategy,

--- a/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
+++ b/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go
@@ -6,10 +6,13 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -28,6 +31,8 @@ func NewREST(optsGetter restoptions.Getter, clientGetter oauthclient.Getter) (*R
 		NewFunc:                  func() runtime.Object { return &oauthapi.OAuthClientAuthorization{} },
 		NewListFunc:              func() runtime.Object { return &oauthapi.OAuthClientAuthorizationList{} },
 		DefaultQualifiedResource: oauthapi.Resource("oauthclientauthorizations"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/oc/cli/describe/helpers.go
+++ b/pkg/oc/cli/describe/helpers.go
@@ -3,6 +3,7 @@ package describe
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/url"
 	"regexp"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildinternalclient "github.com/openshift/origin/pkg/build/client/internalversion"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
 
 const emptyString = "<none>"
@@ -448,4 +450,23 @@ func roleBindingRestrictionType(rbr *authorizationapi.RoleBindingRestriction) st
 		return "ServiceAccount"
 	}
 	return ""
+}
+
+// PrintTemplateParameters the Template parameters with their default values
+func PrintTemplateParameters(params []templateapi.Parameter, output io.Writer) error {
+	w := tabwriter.NewWriter(output, 20, 5, 3, ' ', 0)
+	defer w.Flush()
+	parameterColumns := []string{"NAME", "DESCRIPTION", "GENERATOR", "VALUE"}
+	fmt.Fprintf(w, "%s\n", strings.Join(parameterColumns, "\t"))
+	for _, p := range params {
+		value := p.Value
+		if len(p.Generate) != 0 {
+			value = p.From
+		}
+		_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, p.Description, p.Generate, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/oc/cli/describe/imports.go
+++ b/pkg/oc/cli/describe/imports.go
@@ -1,0 +1,5 @@
+package describe
+
+import (
+	_ "github.com/openshift/origin/pkg/printers/internalversion"
+)

--- a/pkg/printers/internalversion/helpers.go
+++ b/pkg/printers/internalversion/helpers.go
@@ -1,0 +1,30 @@
+package internalversion
+
+import (
+	"time"
+
+	units "github.com/docker/go-units"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+)
+
+func formatRelativeTime(t time.Time) string {
+	return units.HumanDuration(timeNowFn().Sub(t))
+}
+
+var timeNowFn = func() time.Time {
+	return time.Now()
+}
+
+// roleBindingRestrictionType returns a string that indicates the type of the
+// given RoleBindingRestriction.
+func roleBindingRestrictionType(rbr *authorizationapi.RoleBindingRestriction) string {
+	switch {
+	case rbr.Spec.UserRestriction != nil:
+		return "User"
+	case rbr.Spec.GroupRestriction != nil:
+		return "Group"
+	case rbr.Spec.ServiceAccountRestriction != nil:
+		return "ServiceAccount"
+	}
+	return ""
+}

--- a/pkg/printers/internalversion/printer.go
+++ b/pkg/printers/internalversion/printer.go
@@ -1,4 +1,4 @@
-package describe
+package internalversion
 
 import (
 	"fmt"

--- a/pkg/printers/internalversion/printer.go
+++ b/pkg/printers/internalversion/printer.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kprinters "k8s.io/kubernetes/pkg/printers"
-	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+	kprintersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
@@ -81,12 +81,14 @@ var (
 
 func init() {
 	// TODO this should be eliminated
-	printersinternal.AddHandlers = addPrintHandlers
+	kprintersinternal.AddHandlers = func(p kprinters.PrintHandler) {
+		kprintersinternal.AddKubeHandlers(p)
+		AddHandlers(p)
+	}
 }
 
-func addPrintHandlers(p kprinters.PrintHandler) {
-	printersinternal.AddKubeHandlers(p)
-
+// AddHandlers adds print handlers for internal openshift API objects
+func AddHandlers(p kprinters.PrintHandler) {
 	p.Handler(buildColumns, nil, printBuild)
 	p.Handler(buildColumns, nil, printBuildList)
 	p.Handler(buildConfigColumns, nil, printBuildConfig)

--- a/pkg/printers/internalversion/printer_test.go
+++ b/pkg/printers/internalversion/printer_test.go
@@ -69,7 +69,7 @@ var MissingPrinterCoverageExceptions = []reflect.Type{
 
 func TestPrinterCoverage(t *testing.T) {
 	printer := kprinters.NewHumanReadablePrinter(nil, nil, kprinters.PrintOptions{})
-	addPrintHandlers(printer)
+	AddHandlers(printer)
 
 main:
 	for _, apiType := range legacyscheme.Scheme.KnownTypes(api.SchemeGroupVersion) {

--- a/pkg/printers/internalversion/printer_test.go
+++ b/pkg/printers/internalversion/printer_test.go
@@ -1,4 +1,4 @@
-package describe
+package internalversion
 
 import (
 	"bytes"

--- a/pkg/project/registry/project/proxy/proxy.go
+++ b/pkg/project/registry/project/proxy/proxy.go
@@ -14,11 +14,14 @@ import (
 	kstorage "k8s.io/apiserver/pkg/storage"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	nsregistry "k8s.io/kubernetes/pkg/registry/core/namespace"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectauth "github.com/openshift/origin/pkg/project/auth"
 	projectcache "github.com/openshift/origin/pkg/project/cache"
@@ -38,6 +41,8 @@ type REST struct {
 
 	authCache    *projectauth.AuthorizationCache
 	projectCache *projectcache.ProjectCache
+
+	rest.TableConvertor
 }
 
 var _ rest.Lister = &REST{}
@@ -55,6 +60,8 @@ func NewREST(client kcoreclient.NamespaceInterface, lister projectauth.Lister, a
 
 		authCache:    authCache,
 		projectCache: projectCache,
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 	}
 }
 

--- a/pkg/quota/registry/appliedclusterresourcequota/filter.go
+++ b/pkg/quota/registry/appliedclusterresourcequota/filter.go
@@ -12,8 +12,11 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	oapi "github.com/openshift/origin/pkg/api"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotalister "github.com/openshift/origin/pkg/quota/generated/listers/quota/internalversion"
@@ -23,6 +26,7 @@ type AppliedClusterResourceQuotaREST struct {
 	quotaMapper     clusterquotamapping.ClusterQuotaMapper
 	quotaLister     quotalister.ClusterResourceQuotaLister
 	namespaceLister kcorelisters.NamespaceLister
+	rest.TableConvertor
 }
 
 func NewREST(quotaMapper clusterquotamapping.ClusterQuotaMapper, quotaLister quotalister.ClusterResourceQuotaLister, namespaceLister kcorelisters.NamespaceLister) *AppliedClusterResourceQuotaREST {
@@ -30,6 +34,7 @@ func NewREST(quotaMapper clusterquotamapping.ClusterQuotaMapper, quotaLister quo
 		quotaMapper:     quotaMapper,
 		quotaLister:     quotaLister,
 		namespaceLister: namespaceLister,
+		TableConvertor:  printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 	}
 }
 

--- a/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
+++ b/pkg/quota/registry/clusterresourcequota/etcd/etcd.go
@@ -7,7 +7,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
 	"github.com/openshift/origin/pkg/quota/registry/clusterresourcequota"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -31,6 +34,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, error) {
 		NewFunc:                  func() runtime.Object { return &quotaapi.ClusterResourceQuota{} },
 		NewListFunc:              func() runtime.Object { return &quotaapi.ClusterResourceQuotaList{} },
 		DefaultQualifiedResource: quotaapi.Resource("clusterresourcequotas"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: clusterresourcequota.Strategy,
 		UpdateStrategy: clusterresourcequota.Strategy,

--- a/pkg/route/registry/route/etcd/etcd.go
+++ b/pkg/route/registry/route/etcd/etcd.go
@@ -9,7 +9,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	kapirest "k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/route"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	routeregistry "github.com/openshift/origin/pkg/route/registry/route"
@@ -36,6 +39,8 @@ func NewREST(optsGetter restoptions.Getter, allocator route.RouteAllocator, sarC
 		NewFunc:                  func() runtime.Object { return &routeapi.Route{} },
 		NewListFunc:              func() runtime.Object { return &routeapi.RouteList{} },
 		DefaultQualifiedResource: routeapi.Resource("routes"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/security/registry/rangeallocations/etcd.go
+++ b/pkg/security/registry/rangeallocations/etcd.go
@@ -5,7 +5,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 )
 
@@ -20,6 +23,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &securityapi.RangeAllocation{} },
 		NewListFunc:              func() runtime.Object { return &securityapi.RangeAllocationList{} },
 		DefaultQualifiedResource: securityapi.Resource("rangeallocations"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: strategyInstance,
 		UpdateStrategy: strategyInstance,

--- a/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
+++ b/pkg/security/registry/securitycontextconstraints/etcd/etcd.go
@@ -5,7 +5,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 	"github.com/openshift/origin/pkg/security/registry/securitycontextconstraints"
 )
@@ -33,6 +36,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		},
 		PredicateFunc:            securitycontextconstraints.Matcher,
 		DefaultQualifiedResource: securityapi.Resource("securitycontextconstraints"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy:      securitycontextconstraints.Strategy,
 		UpdateStrategy:      securitycontextconstraints.Strategy,

--- a/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
+++ b/pkg/template/registry/brokertemplateinstance/etcd/etcd.go
@@ -5,7 +5,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	"github.com/openshift/origin/pkg/template/registry/brokertemplateinstance"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &templateapi.BrokerTemplateInstance{} },
 		NewListFunc:              func() runtime.Object { return &templateapi.BrokerTemplateInstanceList{} },
 		DefaultQualifiedResource: templateapi.Resource("brokertemplateinstances"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: brokertemplateinstance.Strategy,
 		UpdateStrategy: brokertemplateinstance.Strategy,

--- a/pkg/template/registry/template/etcd/etcd.go
+++ b/pkg/template/registry/template/etcd/etcd.go
@@ -5,7 +5,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	"github.com/openshift/origin/pkg/template/registry/template"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -24,6 +27,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &templateapi.Template{} },
 		NewListFunc:              func() runtime.Object { return &templateapi.TemplateList{} },
 		DefaultQualifiedResource: templateapi.Resource("templates"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: template.Strategy,
 		UpdateStrategy: template.Strategy,

--- a/pkg/template/registry/templateinstance/etcd/etcd.go
+++ b/pkg/template/registry/templateinstance/etcd/etcd.go
@@ -8,7 +8,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	authorizationinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	"github.com/openshift/origin/pkg/template/registry/templateinstance"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -29,6 +32,8 @@ func NewREST(optsGetter restoptions.Getter, authorizationClient authorizationint
 		NewFunc:                  func() runtime.Object { return &templateapi.TemplateInstance{} },
 		NewListFunc:              func() runtime.Object { return &templateapi.TemplateInstanceList{} },
 		DefaultQualifiedResource: templateapi.Resource("templateinstances"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/pkg/user/registry/group/etcd/etcd.go
+++ b/pkg/user/registry/group/etcd/etcd.go
@@ -4,7 +4,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	"github.com/openshift/origin/pkg/user/registry/group"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -21,6 +24,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &userapi.Group{} },
 		NewListFunc:              func() runtime.Object { return &userapi.GroupList{} },
 		DefaultQualifiedResource: userapi.Resource("groups"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: group.Strategy,
 		UpdateStrategy: group.Strategy,

--- a/pkg/user/registry/identity/etcd/etcd.go
+++ b/pkg/user/registry/identity/etcd/etcd.go
@@ -6,7 +6,10 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	"github.com/openshift/origin/pkg/user/registry/identity"
 	"github.com/openshift/origin/pkg/util/restoptions"
@@ -25,6 +28,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &userapi.Identity{} },
 		NewListFunc:              func() runtime.Object { return &userapi.IdentityList{} },
 		DefaultQualifiedResource: userapi.Resource("identities"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: identity.Strategy,
 		UpdateStrategy: identity.Strategy,

--- a/pkg/user/registry/user/etcd/etcd.go
+++ b/pkg/user/registry/user/etcd/etcd.go
@@ -14,8 +14,11 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	"github.com/openshift/origin/pkg/user/apis/user/validation"
 	"github.com/openshift/origin/pkg/user/registry/user"
@@ -35,6 +38,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		NewFunc:                  func() runtime.Object { return &userapi.User{} },
 		NewListFunc:              func() runtime.Object { return &userapi.UserList{} },
 		DefaultQualifiedResource: userapi.Resource("users"),
+
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 
 		CreateStrategy: user.Strategy,
 		UpdateStrategy: user.Strategy,

--- a/pkg/util/registry/wrapper.go
+++ b/pkg/util/registry/wrapper.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -13,6 +14,7 @@ import (
 type NoWatchStorage interface {
 	rest.Getter
 	rest.Lister
+	rest.TableConvertor
 	rest.CreaterUpdater
 	rest.GracefulDeleter
 }
@@ -37,6 +39,10 @@ func (s *noWatchStorageErrWrapper) Get(ctx request.Context, name string, options
 func (s *noWatchStorageErrWrapper) List(ctx request.Context, options *internalversion.ListOptions) (runtime.Object, error) {
 	obj, err := s.delegate.List(ctx, options)
 	return obj, errors.SyncStatusError(ctx, err)
+}
+
+func (s *noWatchStorageErrWrapper) ConvertToTable(ctx request.Context, object runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+	return s.delegate.ConvertToTable(ctx, object, tableOptions)
 }
 
 func (s *noWatchStorageErrWrapper) Create(ctx request.Context, in runtime.Object, createValidation rest.ValidateObjectFunc, includeUninitialized bool) (runtime.Object, error) {

--- a/vendor/k8s.io/kubernetes/pkg/printers/humanreadable.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/humanreadable.go
@@ -114,17 +114,25 @@ func (h *HumanReadablePrinter) EnsurePrintHeaders() {
 // See ValidatePrintHandlerFunc for required method signature.
 func (h *HumanReadablePrinter) Handler(columns, columnsWithWide []string, printFunc interface{}) error {
 	var columnDefinitions []metav1beta1.TableColumnDefinition
-	for _, column := range columns {
+	for i, column := range columns {
+		format := ""
+		if i == 0 && strings.EqualFold(column, "name") {
+			format = "name"
+		}
+
 		columnDefinitions = append(columnDefinitions, metav1beta1.TableColumnDefinition{
-			Name: column,
-			Type: "string",
+			Name:        column,
+			Description: column,
+			Type:        "string",
+			Format:      format,
 		})
 	}
 	for _, column := range columnsWithWide {
 		columnDefinitions = append(columnDefinitions, metav1beta1.TableColumnDefinition{
-			Name:     column,
-			Type:     "string",
-			Priority: 1,
+			Name:        column,
+			Description: column,
+			Type:        "string",
+			Priority:    1,
 		})
 	}
 
@@ -635,6 +643,13 @@ func (h *HumanReadablePrinter) legacyPrinterToTable(obj runtime.Object, handler 
 	args := []reflect.Value{reflect.ValueOf(obj), reflect.ValueOf(buf), reflect.ValueOf(options)}
 
 	if meta.IsListType(obj) {
+		listInterface, ok := obj.(metav1.ListInterface)
+		if ok {
+			table.ListMeta.SelfLink = listInterface.GetSelfLink()
+			table.ListMeta.ResourceVersion = listInterface.GetResourceVersion()
+			table.ListMeta.Continue = listInterface.GetContinue()
+		}
+
 		// TODO: this uses more memory than it has to, as we refactor printers we should remove the need
 		// for this.
 		args[0] = reflect.ValueOf(obj)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -1311,7 +1311,7 @@ func (t *Tester) testListTableConversion(obj runtime.Object, assignFn AssignFunc
 	if len(columns) == 0 {
 		t.Errorf("unexpected number of columns: %v", len(columns))
 	}
-	if columns[0].Name != "Name" || columns[0].Type != "string" || columns[0].Format != "name" {
+	if !strings.EqualFold(columns[0].Name, "Name") || columns[0].Type != "string" || columns[0].Format != "name" {
 		t.Errorf("expect column 0 to be the name column: %#v", columns[0])
 	}
 	for j, column := range columns {


### PR DESCRIPTION
We never hooked up openshift storage to act as table printers to support server-side printing in 3.10

If we want to drop client-side printing in 3.11, this is required.
