### PR TITLE
Poll metrics for openshift resources

### DIFF
--- a/pkg/util/restoptions/configgetter.go
+++ b/pkg/util/restoptions/configgetter.go
@@ -109,6 +109,7 @@ func (g *configRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) 
 		DeleteCollectionWorkers: g.deleteCollectionWorkers,
 		EnableGarbageCollection: g.enableGarbageCollection,
 		ResourcePrefix:          g.storageFactory.ResourcePrefix(resource),
+		CountMetricPollPeriod:   config.CountMetricPollPeriod,
 	}
 	g.restOptionsMap[resource] = resourceOptions
 


### PR DESCRIPTION
Ensures openshift resources show up in `etcd_object_counts` (they were not before because this defaulted to zero).

@liggitt