### PR TITLE
Fix to pass quoted unsafe strings (with characters like *,<,%) correctly to kubelet

### DIFF
--- a/images/node/scripts/openshift-node
+++ b/images/node/scripts/openshift-node
@@ -15,4 +15,4 @@ if [[ -f /etc/origin/node/node-config.yaml ]]; then
   config=/etc/origin/node/node-config.yaml
 fi
 flags=$( /usr/bin/openshift-node-config "--config=${config}" )
-exec /usr/bin/hyperkube kubelet --v=${DEBUG_LOGLEVEL:-2} ${flags}
+eval "exec /usr/bin/hyperkube kubelet --v=${DEBUG_LOGLEVEL:-2} ${flags}"


### PR DESCRIPTION
Fix rhbz https://bugzilla.redhat.com/show_bug.cgi?id=1587824. With experimental-allowed-unsafe-sysctls,
"*" is a valid character now as part of kubelet arguments. For example:

```
kubeletArguments:
  experimental-allowed-unsafe-sysctls:
  - 'kernel.shm*,kernel.msg*,kernel.sem,fs.mqueue.*,net.*'
```

@sjenning @smarterclayton 

Related PR to openshift-ansible: https://github.com/openshift/openshift-ansible/pull/8772