### PR TITLE
Set etcd DialTimeout, fix etcd start order in all-in-one

### DIFF
--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -425,6 +425,17 @@ func (m *Master) Start() error {
 	}
 
 	if m.api {
+		// start etcd if configured to run in process
+		if m.config.EtcdConfig != nil {
+			etcdserver.RunEtcd(m.config.EtcdConfig)
+		}
+
+		// ensure connectivity to etcd before calling BuildMasterConfig,
+		// which constructs storage whose etcd clients require connectivity to etcd at construction time
+		if err := testEtcdConnectivity(m.config.EtcdClientInfo); err != nil {
+			return err
+		}
+
 		// informers are shared amongst all the various api components we build
 		// TODO the needs of the apiserver and the controllers are drifting. We should consider two different skins here
 		clientConfig, err := configapi.GetClientConfig(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
@@ -461,20 +472,9 @@ func (m *Master) Start() error {
 
 // StartAPI starts the components of the master that are considered part of the API - the Kubernetes
 // API and core controllers, the Origin API, the group, policy, project, and authorization caches,
-// etcd, the asset server (for the UI), the OAuth server endpoints, and the DNS server.
+// the asset server (for the UI), the OAuth server endpoints, and the DNS server.
 // TODO: allow to be more granularly targeted
 func StartAPI(oc *origin.MasterConfig) error {
-	// start etcd
-	if oc.Options.EtcdConfig != nil {
-		etcdserver.RunEtcd(oc.Options.EtcdConfig)
-	}
-
-	// verify we can connect to etcd with the provided config
-	// TODO remove when this becomes a health check in 3.8
-	if err := testEtcdConnectivity(oc.Options.EtcdClientInfo); err != nil {
-		return err
-	}
-
 	// start DNS before the informers are started because it adds a ClusterIP index.
 	if oc.Options.DNSConfig != nil {
 		oc.RunDNSServer()
@@ -493,6 +493,7 @@ func testEtcdConnectivity(etcdClientInfo configapi.EtcdConnectionInfo) error {
 	if err != nil {
 		return err
 	}
+	defer etcdClient3.Close()
 	if err := etcd.TestEtcdClientV3(etcdClient3); err != nil {
 		return err
 	}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -29,11 +29,13 @@ import (
 	"k8s.io/apiserver/pkg/storage/value"
 )
 
-// The short keepalive timeout and interval have been chosen to aggressively
-// detect a failed etcd server without introducing much overhead.
 var (
+	// The short keepalive timeout and interval have been chosen to aggressively
+	// detect a failed etcd server without introducing much overhead.
 	keepaliveTime    = 30 * time.Second
 	keepaliveTimeout = 10 * time.Second
+	// dialTimeout is the timeout for failing to establish a connection.
+	dialTimeout = 10 * time.Second
 )
 
 func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
@@ -52,6 +54,7 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 		tlsConfig = nil
 	}
 	cfg := clientv3.Config{
+		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,
 		Endpoints:            c.ServerList,


### PR DESCRIPTION
DialTimeout addresses apiserver memory issues when trying to reach a dead etcd server

Etcd ordering issues fix deadlock in all-in-one, since setting DialTimeout makes etcd client construction blocking