### PR TITLE
UPSTREAM: 64916: improve memory footprint of daemonset simulate

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/daemon/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/controller/daemon/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/controller/daemon/daemon_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/daemon/daemon_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1251,7 +1252,8 @@ func (dsc *DaemonSetsController) simulate(newPod *v1.Pod, node *v1.Node, ds *app
 		}
 		// ignore pods that belong to the daemonset when taking into account whether
 		// a daemonset should bind to a node.
-		if metav1.IsControlledBy(pod, ds) {
+		// TODO: replace this with metav1.IsControlledBy() in 1.12
+		if isControlledByDaemonSet(pod, ds.GetUID()) {
 			continue
 		}
 		pods = append(pods, pod)
@@ -1471,4 +1473,13 @@ func (o podByCreationTimestamp) Less(i, j int) bool {
 		return o[i].Name < o[j].Name
 	}
 	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+func isControlledByDaemonSet(p *v1.Pod, uuid types.UID) bool {
+	for _, ref := range p.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller && ref.UID == uuid {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
picks https://github.com/kubernetes/kubernetes/pull/64916

This should reduce the memory overheat the `metav1.IsControlledBy` is causing on large clusters with multiple daemonsets where each daemonset basically deep copy the ownerreferences for each pod on every resync on every node (as seen in ca-central-1 memory profile).

/cc @smarterclayton 
/cc @sttts 

I think this is safe to pick for 3.10 and keep for 3.11, then drop in 3.12 when @sttts fix obsoletes this.