### PR TITLE
Fix the oc adm message when the permissions are missing

### DIFF
--- a/pkg/oc/admin/router/router.go
+++ b/pkg/oc/admin/router/router.go
@@ -906,11 +906,11 @@ func validateServiceAccount(client securityclientinternal.Interface, ns string, 
 	}
 
 	if hostNetwork {
-		errMsg := "service account %q is not allowed to access the host network on nodes, grant access with oc adm policy add-scc-to-user %s -z %s"
+		errMsg := "service account %q is not allowed to access the host network on nodes, grant access with: oc adm policy add-scc-to-user %s -z %s"
 		return fmt.Errorf(errMsg, serviceAccount, bootstrappolicy.SecurityContextConstraintsHostNetwork, serviceAccount)
 	}
 	if hostPorts {
-		errMsg := "service account %q is not allowed to access host ports on nodes, grant access with oc adm policy add-scc-to-user %s -z %s"
+		errMsg := "service account %q is not allowed to access host ports on nodes, grant access with: oc adm policy add-scc-to-user %s -z %s"
 		return fmt.Errorf(errMsg, serviceAccount, bootstrappolicy.SecurityContextConstraintsHostNetwork, serviceAccount)
 	}
 	return nil

--- a/pkg/oc/experimental/ipfailover/ipfailover.go
+++ b/pkg/oc/experimental/ipfailover/ipfailover.go
@@ -232,6 +232,6 @@ func validateServiceAccount(client securityclientinternal.Interface, ns string, 
 			}
 		}
 	}
-	errMsg := "service account %q does not have sufficient privileges, grant access with oc adm policy add-scc-to-user %s -z %s"
+	errMsg := "service account %q does not have sufficient privileges, grant access with: oc adm policy add-scc-to-user %s -z %s"
 	return fmt.Errorf(errMsg, serviceAccount, bootstrappolicy.SecurityContextConstraintPrivileged, serviceAccount)
 }


### PR DESCRIPTION
Added a colon to the error message to separate the command to run from the error message.

Before:
  error: router could not be created; service account "router" is not allowed to access the host network on nodes, grant access with oc adm policy add-scc-to-user hostnetwork -z router

After:
  error: router could not be created; service account "router" is not allowed to access the host network on nodes, grant access with: oc adm policy add-scc-to-user hostnetwork -z router

(note the : after with)