### PR TITLE
Prevent a router panic when ROUTER_BIND_PORTS_AFTER_SYNC is set

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -314,7 +314,10 @@ func (o *TemplateRouterOptions) Run() error {
 		if isTrue(util.Env("ROUTER_USE_PROXY_PROTOCOL", "")) {
 			checkBackend = metrics.ProxyProtocolHTTPBackendAvailable(u)
 		}
-		checkSync := metrics.HasSynced(&ptrTemplatePlugin)
+		checkSync, err := metrics.HasSynced(&ptrTemplatePlugin)
+		if err != nil {
+			return err
+		}
 		checkController := metrics.ControllerLive()
 		liveChecks := []healthz.HealthzChecker{checkController}
 		if !(isTrue(util.Env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {


### PR DESCRIPTION
The function that was checking whether the router had synced needed to check the nilness of the target of a pointer, not the pointer itself.

I also corrected the logic so that when the routerPtr target was not defined, it says the router has not synced.

Fixes bug 1589740 (https://bugzilla.redhat.com/show_bug.cgi?id=1589740)