### PR TITLE
Support both v4 and v3 GitLab User APIs

### DIFF
--- a/pkg/oauthserver/oauth/external/gitlab/gitlab_test.go
+++ b/pkg/oauthserver/oauth/external/gitlab/gitlab_test.go
@@ -18,7 +18,8 @@ func TestGitLab(t *testing.T) {
 		providerName: "gitlab",
 		authorizeURL: "https://gitlab.com/oauth/authorize",
 		tokenURL:     "https://gitlab.com/oauth/token",
-		userAPIURL:   "https://gitlab.com/api/v3/user",
+		userAPIURLV3: "https://gitlab.com/api/v3/user",
+		userAPIURLV4: "https://gitlab.com/api/v4/user",
 		clientID:     "clientid",
 		clientSecret: "clientsecret",
 	}


### PR DESCRIPTION
This change adds logic that attempts to use the v4 GitLab User API.  If that fails, it falls back to the legacy v3 API.  This will allow OpenShift's GitLab integration to work with newer versions of GitLab while still supporting older versions.

Signed-off-by: Monis Khan <mkhan@redhat.com>

Fixes #19937

/kind bug

Per https://gitlab.com/gitlab-org/gitlab-ce/issues/47565#note_80751232, this legacy v3 User API will not be removed.

/assign @liggitt @simo5
@openshift/sig-security
cc @alikhajeh1