### PR TITLE
set image pull policy to not pull

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4985,7 +4985,7 @@ spec:
       containers:
       - image: "openshift/origin-base:latest"
         command: [ "/bin/bash", "-c", "sleep infinity" ]
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         name: myapp
 `)
 
@@ -6675,6 +6675,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: idling-echo
           command:
             - /usr/bin/socat
@@ -6744,6 +6745,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: idling-tcp-echo
           command:
             - /usr/bin/socat
@@ -6753,6 +6755,7 @@ items:
           - containerPort: 8675
             protocol: TCP
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: idling-udp-echo
           command:
             - /usr/bin/socat
@@ -9401,6 +9404,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: router-http-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/deployments/deployment-with-ref-env.yaml
+++ b/test/extended/testdata/deployments/deployment-with-ref-env.yaml
@@ -29,5 +29,5 @@ spec:
       containers:
       - image: "openshift/origin-base:latest"
         command: [ "/bin/bash", "-c", "sleep infinity" ]
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Never
         name: myapp

--- a/test/extended/testdata/idling-echo-server-rc.yaml
+++ b/test/extended/testdata/idling-echo-server-rc.yaml
@@ -18,6 +18,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: idling-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/idling-echo-server.yaml
+++ b/test/extended/testdata/idling-echo-server.yaml
@@ -21,6 +21,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: idling-tcp-echo
           command:
             - /usr/bin/socat
@@ -30,6 +31,7 @@ items:
           - containerPort: 8675
             protocol: TCP
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: idling-udp-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/router-http-echo-server.yaml
+++ b/test/extended/testdata/router-http-echo-server.yaml
@@ -21,6 +21,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: Never
           name: router-http-echo
           command:
             - /usr/bin/socat

--- a/test/testdata/idling-dc.yaml
+++ b/test/testdata/idling-dc.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
       - image: openshift/origin-base
+        imagePullPolicy: Never
         name: idling-tcp-echo
         command:
           - /usr/bin/socat
@@ -26,6 +27,7 @@ spec:
         - containerPort: 8675
           protocol: TCP
       - image: openshift/origin-base
+        imagePullPolicy: Never
         name: idling-udp-echo
         command:
           - /usr/bin/socat


### PR DESCRIPTION
Since :latest implies always pull, the correct image is not being used. This is an attempt to fix #19887.