### PR TITLE
Use IfNotPresent image pull policy in router tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -6675,6 +6675,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: idling-echo
           command:
             - /usr/bin/socat
@@ -6744,6 +6745,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: idling-tcp-echo
           command:
             - /usr/bin/socat
@@ -6753,6 +6755,7 @@ items:
           - containerPort: 8675
             protocol: TCP
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: idling-udp-echo
           command:
             - /usr/bin/socat
@@ -9401,6 +9404,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: router-http-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/idling-echo-server-rc.yaml
+++ b/test/extended/testdata/idling-echo-server-rc.yaml
@@ -18,6 +18,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: idling-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/idling-echo-server.yaml
+++ b/test/extended/testdata/idling-echo-server.yaml
@@ -21,6 +21,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: idling-tcp-echo
           command:
             - /usr/bin/socat
@@ -30,6 +31,7 @@ items:
           - containerPort: 8675
             protocol: TCP
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: idling-udp-echo
           command:
             - /usr/bin/socat

--- a/test/extended/testdata/router-http-echo-server.yaml
+++ b/test/extended/testdata/router-http-echo-server.yaml
@@ -21,6 +21,7 @@ items:
       spec:
         containers:
         - image: openshift/origin-base
+          imagePullPolicy: IfNotPresent
           name: router-http-echo
           command:
             - /usr/bin/socat

--- a/test/testdata/idling-dc.yaml
+++ b/test/testdata/idling-dc.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
       - image: openshift/origin-base
+        imagePullPolicy: IfNotPresent
         name: idling-tcp-echo
         command:
           - /usr/bin/socat
@@ -26,6 +27,7 @@ spec:
         - containerPort: 8675
           protocol: TCP
       - image: openshift/origin-base
+        imagePullPolicy: IfNotPresent
         name: idling-udp-echo
         command:
           - /usr/bin/socat


### PR DESCRIPTION
CI uses the current branch's tests but was pulling newer images.  In the case of `router-http-echo-server.yaml`, the test data specified the openshift/origin-base image with a command that required Perl, which is missing from newer versions of that image.

This commit changes router test data to specify the IfNotPresent image pull policy so that tests will use locally built images.

This commit fixes openshift/origin#19887.