### PR TITLE
Add http/2 support for haproxy router.

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -219,6 +219,7 @@ frontend fe_sni
     {{- if isTrue (env "ROUTER_STRICT_SNI") }} strict-sni {{ end }}
     {{- ""}} crt {{firstMatch ".+" .DefaultCertificate "/var/lib/haproxy/conf/default_pub_keys.pem"}}
     {{- ""}} crt-list /var/lib/haproxy/conf/cert_config.map accept-proxy
+    {{- if isTrue (env "ROUTER_ENABLE_HTTP2") }} alpn h2,http/1.1{{ end }}
   mode http
 
   # Strip off Proxy headers to prevent HTTpoxy (https://httpoxy.org/)
@@ -357,11 +358,12 @@ backend be_secure:{{$cfgIdx}}
   http-request set-header X-Forwarded-Port %[dst_port]
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
+  http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }
   {{- if matchPattern "(v4)?v6" $router_ip_v4_v6_mode }}
   # See the quoting rules in https://tools.ietf.org/html/rfc7239 for IPv6 addresses (v4 addresses get translated to v6 when in hybrid mode)
-  http-request set-header Forwarded for="[%[src]]";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
+  http-request set-header Forwarded for="[%[src]]";host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)];proto-version=%[req.hdr(X-Forwarded-Proto-Version)]
   {{- else }}
-  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)]
+  http-request set-header Forwarded for=%[src];host=%[req.hdr(host)];proto=%[req.hdr(X-Forwarded-Proto)];proto-version=%[req.hdr(X-Forwarded-Proto-Version)]
   {{- end }}
 
   {{- if not (isTrue (index $cfg.Annotations "haproxy.router.openshift.io/disable_cookies")) }}


### PR DESCRIPTION
Adds http2 support for haproxy.
Ref: https://trello.com/c/qzvlzuyx/27-3-implement-router-http-2-support-terminating-at-the-router-router

To run: 
```
$ oc adm router --latest-images=true
$ oc set env dc/router ROUTER_ENABLE_HTTP2=true
$ #  add edge secured and/or reencrypt routes:
$ #  Example: use routes from https://github.com/ramr/nodejs-header-echo
```

Test: 
```
$ curl -k --http2 -vvv --resolve edge.header.test:443:127.0.0.1 https://edge.header.test/
$ curl -k --http2  -vvv --resolve reencrypt.header.test:443:127.0.0.1 https://reencrypt.header.test/
```

You should see that the protocol negotiation (between haproxy and the client) uses HTTP2 and there's a new header sent to the backend ` x-forwarded-proto-version: h2`.

@ironcladlou @knobunc PTAL thx