### PR TITLE
etcd should not log at debug unless at v(4)

### DIFF
--- a/pkg/cmd/server/etcd/etcdserver/run.go
+++ b/pkg/cmd/server/etcd/etcdserver/run.go
@@ -19,7 +19,7 @@ const defaultName = "openshift.local"
 // RunEtcd starts an etcd server and runs it forever
 func RunEtcd(etcdServerConfig *configapi.EtcdConfig) {
 	cfg := embed.NewConfig()
-	cfg.Debug = true
+	cfg.Debug = bool(glog.V(4))
 	cfg.Name = defaultName
 	cfg.Dir = etcdServerConfig.StorageDir
 


### PR DESCRIPTION
openshift start master was spewing etcd gRPC client logs due to us
setting the debug flag. Make it more properly associated with a debug
loglevel.

Removes the ccBalancer crap at startup.

@liggitt