### PR TITLE
Update apiVersion in migrate-network-policy.sh, add comments

### DIFF
--- a/contrib/migration/migrate-network-policy.sh
+++ b/contrib/migration/migrate-network-policy.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Prepares a multitenant cluster for running the networkpolicy plugin by
+#
+#   1) creating NetworkPolicy objects (and Namespace labels) that
+#      implement the same isolation/sharing as had been configured in
+#      the multitenant cluster via "oc adm pod-network".
+#
+#   2) re-isolating all projects that had previously been joined or
+#      made global (since the networkpolicy plugin requires every
+#      project to have a distinct NetID).
+#
+# See the documentation for more information on how to use this script
+# (the section "Migrating from ovs-networkpolicy to ovs-multitenant"
+# in the "Configuring the SDN" document in the "Installation and
+# Configuration" guide).
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -13,7 +28,7 @@ fi
 function default-deny() {
     oc create --namespace "$1" -f - <<EOF
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
 spec:
@@ -24,7 +39,7 @@ EOF
 function allow-from-self() {
     oc create --namespace "$1" -f - <<EOF
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-from-self
 spec:
@@ -38,7 +53,7 @@ EOF
 function allow-from-other() {
     oc create --namespace "$1" -f - <<EOF
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: $2
 spec:

--- a/contrib/migration/unmigrate-network-policy.sh
+++ b/contrib/migration/unmigrate-network-policy.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Undoes the effects of the migrate-network-policy.sh script by
+# re-isolating and re-making-global the previously isolated/global
+# projects.
+#
+# This only undoes the changes originally made by the migration script
+# (or other changes that were intentionally made to look the same as
+# the changes made by the migration script). It does not attempt to
+# convert arbitrary NetworkPolicy objects into multitenant-style
+# isolation.
+
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
Just noticed that the migration script still refers to NetworkPolicy by its old apiVersion.

The current version of the script still works, but we need to update it at some point.

Also added some comments while I was there. (I referred to the docs by titles rather than linking directly to a URL so that it's not linking to any specific product [Origin/OCP/Dedicated] or version.)