### PR TITLE
Egress DNS: Get lowest TTL from the dns resolution chain

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -142,7 +142,7 @@ func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
 			dialServer = net.JoinHostPort(server, d.port)
 		}
 		c := new(dns.Client)
-		c.Timeout = 2 * time.Second
+		c.Timeout = 5 * time.Second
 		in, _, err := c.Exchange(msg, dialServer)
 		if err != nil {
 			return nil, defaultTTL, err

--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -153,20 +153,20 @@ func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
 
 		if in != nil && len(in.Answer) > 0 {
 			for _, a := range in.Answer {
+				if !ttlSet || a.Header().Ttl < minTTL {
+					minTTL = a.Header().Ttl
+					ttlSet = true
+				}
+
 				switch t := a.(type) {
 				case *dns.A:
 					ips = append(ips, t.A)
-
-					if !ttlSet || t.Hdr.Ttl < minTTL {
-						minTTL = t.Hdr.Ttl
-						ttlSet = true
-					}
 				}
 			}
 		}
 	}
 
-	if !ttlSet {
+	if !ttlSet || (len(ips) == 0) {
 		return nil, defaultTTL, fmt.Errorf("IPv4 addr not found for domain: %q, nameservers: %v", domain, d.nameservers)
 	}
 

--- a/pkg/network/common/dns_test.go
+++ b/pkg/network/common/dns_test.go
@@ -50,7 +50,7 @@ func TestAddDNS(t *testing.T) {
 			domainName:        "example.com",
 			dnsResolverOutput: "example.com. 200 IN CNAME foo.example.com.\nfoo.example.com. 600 IN A 10.11.12.13",
 			ips:               []net.IP{ip},
-			ttl:               600,
+			ttl:               200,
 			expectFailure:     false,
 		},
 		{


### PR DESCRIPTION
- Currently, we consider minTTL as lowest TTL among all available dns
'A' records and TTL for CNAME recs are ignored. This change will get
lowest TTL for the entire chain irrespective of the dns record type.

Related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1575583