### PR TITLE
Fix math division truncation in migrate storage

### DIFF
--- a/pkg/oc/admin/migrate/storage/storage.go
+++ b/pkg/oc/admin/migrate/storage/storage.go
@@ -373,5 +373,5 @@ func (t *tokenLimiter) getDuration(n int) time.Duration {
 // we use a burst value that scales linearly with the number of workers
 func newTokenLimiter(bandwidth, workers int) *tokenLimiter {
 	burst := 100 * kbToBytes * workers // 100 KB of burst per worker
-	return &tokenLimiter{burst: burst, rateLimiter: rate.NewLimiter(rate.Limit(bandwidth*mbToKB*kbToBytes/byteToBits), burst), nowFunc: time.Now}
+	return &tokenLimiter{burst: burst, rateLimiter: rate.NewLimiter(rate.Limit(bandwidth*mbToKB*kbToBytes)/byteToBits, burst), nowFunc: time.Now}
 }


### PR DESCRIPTION
This change correctly casts the dividend to a float before division to prevent integer floor division.  The dividend is too large and the divisor is too small for this to matter in practice.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @simo5