### PR TITLE
Remove the node from dnsmasq config when shutting down

### DIFF
--- a/pkg/cmd/server/kubernetes/network/network.go
+++ b/pkg/cmd/server/kubernetes/network/network.go
@@ -48,10 +48,10 @@ func (c *NetworkConfig) RunSDN() {
 }
 
 // RunDNS starts the DNS server as soon as services are loaded.
-func (c *NetworkConfig) RunDNS() {
+func (c *NetworkConfig) RunDNS(stopCh <-chan struct{}) {
 	go func() {
 		glog.Infof("Starting DNS on %s", c.DNSServer.Config.DnsAddr)
-		err := c.DNSServer.ListenAndServe()
+		err := c.DNSServer.ListenAndServe(stopCh)
 		glog.Fatalf("DNS server failed to start: %v", err)
 	}()
 }

--- a/pkg/cmd/server/kubernetes/network/options/options.go
+++ b/pkg/cmd/server/kubernetes/network/options/options.go
@@ -39,9 +39,10 @@ func Build(options configapi.NodeConfig) (*kubeproxyconfig.KubeProxyConfiguratio
 		return nil, fmt.Errorf("The provided value to bind to must be an ip:port: %q", addr)
 	}
 	proxyconfig.BindAddress = ip.String()
-	// MetricsBindAddress - disable by default but allow enablement until we switch to
-	// reading proxy config directly
-	proxyconfig.MetricsBindAddress = ""
+	// MetricsBindAddress - enable as a separate port in the 11xxx range for now, but only
+	// on localhost. Metrics contains no tenant information.
+	// TODO: move this to a secured port that we can query from prometheus.
+	proxyconfig.MetricsBindAddress = "localhost:11256"
 	if arg := options.ProxyArguments["metrics-bind-address"]; len(arg) > 0 {
 		proxyconfig.MetricsBindAddress = arg[0]
 	}

--- a/pkg/cmd/server/origin/dns_server.go
+++ b/pkg/cmd/server/origin/dns_server.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/dns"
 )
@@ -52,7 +54,7 @@ func (c *MasterConfig) RunDNSServer() {
 
 	go func() {
 		s := dns.NewServer(config, services, endpoints, "apiserver")
-		err := s.ListenAndServe()
+		err := s.ListenAndServe(wait.NeverStop)
 		glog.Fatalf("Could not start DNS: %v", err)
 	}()
 

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -26,7 +27,6 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	tsbcmd "github.com/openshift/origin/pkg/templateservicebroker/cmd/server"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type AllInOneOptions struct {
@@ -310,7 +310,7 @@ func (o AllInOneOptions) StartAllInOne() error {
 		ConfigFile: o.NodeConfigFile,
 		Output:     o.MasterOptions.Output,
 	}
-	if err := nodeOptions.RunNode(); err != nil {
+	if err := nodeOptions.RunNode(wait.NeverStop); err != nil {
 		return err
 	}
 

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -420,7 +420,7 @@ func StartConfiguredNode(nodeConfig *configapi.NodeConfig, components *utilflags
 		return err
 	}
 
-	if err := start.StartNode(*nodeConfig, components); err != nil {
+	if err := start.StartNode(*nodeConfig, components, wait.NeverStop); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Prevents dnsmasq from pending a dead server when the network pod dies or is interrupted. Also prevents us serving DNS before our caches fill.

https://bugzilla.redhat.com/show_bug.cgi?id=1584995