### PR TITLE
[release-3.9] Replace Perl with Bash in router echo test server

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -9405,7 +9405,7 @@ items:
           command:
             - /usr/bin/socat
             - TCP4-LISTEN:8676,reuseaddr,fork
-            - EXEC:'perl -e \"print qq(HTTP/1.0 200 OK\r\n\r\n); while (<>) { print; last if /^\r/}\"'
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
           ports:
           - containerPort: 8676
             protocol: TCP

--- a/test/extended/testdata/router-http-echo-server.yaml
+++ b/test/extended/testdata/router-http-echo-server.yaml
@@ -25,7 +25,7 @@ items:
           command:
             - /usr/bin/socat
             - TCP4-LISTEN:8676,reuseaddr,fork
-            - EXEC:'perl -e \"print qq(HTTP/1.0 200 OK\r\n\r\n); while (<>) { print; last if /^\r/}\"'
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
           ports:
           - containerPort: 8676
             protocol: TCP


### PR DESCRIPTION
The router tests use an echo test server based on socat and Perl.  This test server runs in a container launched using the openshift/origin-base image.  However, commit 4333db3960e1f134bbf606bd5a8ea7f4fd062c93 removed Perl from openshift/origin-base, which breaks this test server.

This commit replaces Perl with Bash, printf, and sed.

This commit fixes openshift/origin#19887.