### PR TITLE
 use release-3.10 for deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e6bc2aa3a92ae1c76ecc6478c9246eccf1dc123587b350b111dca8593b5cc078
-updated: 2018-06-07T15:41:54.543777833-05:00
+hash: ce2c9c5c1323a030dfa6afeaba2801780a27b7c1b38b1ee1de2b00baf254377d
+updated: 2018-06-13T11:06:49.527989847-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -305,7 +305,7 @@ imports:
 - name: github.com/dgrijalva/jwt-go
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/distribution
-  version: 114d1c11fb9258426f7197995cf4a3dfe46ef472
+  version: 9e3018b6ff58e5b86c76b5f9b8826494caca28ea
   repo: https://github.com/openshift/docker-distribution.git
   subpackages:
   - context
@@ -446,7 +446,7 @@ imports:
   - sortkeys
   - types
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
@@ -603,7 +603,7 @@ imports:
 - name: github.com/gorilla/mux
   version: 8096f47503459bcc74d1f4c487b7e6e42e5746b5
 - name: github.com/gorilla/securecookie
-  version: b009e17e9cb1a3b7b447cf9dc0110fcaebcc1b6b
+  version: 78f3d318a8bf316cda921f25e96fd0b441c5173d
 - name: github.com/gorilla/sessions
   version: a3acf13e802c358d65f249324d14ed24aac11370
 - name: github.com/gorilla/websocket
@@ -839,7 +839,7 @@ imports:
   - user/v1
   - webconsole/v1
 - name: github.com/openshift/client-go
-  version: 0d482887777e2d8bc9aeaade933c2a7f5180bb6d
+  version: 6a9817e0a0720dd8e837d1d18cd2938342ef6e54
   subpackages:
   - apps/clientset/versioned
   - apps/clientset/versioned/scheme
@@ -946,14 +946,14 @@ imports:
   - user/informers/externalversions/user/v1
   - user/listers/user/v1
 - name: github.com/openshift/imagebuilder
-  version: 11c1f088aac583ad8aee6c6eb6b8491becf26c25
+  version: 38229f93eea5ad4527ec60be7dd81267b80bb4ff
   subpackages:
   - dockerclient
   - imageprogress
   - signal
   - strslice
 - name: github.com/openshift/library-go
-  version: 3601ae4dd46a04c1b8a81b789de67f58f48895b2
+  version: 753950908a10d3f3d58fd93082a50f63ce6bae26
   subpackages:
   - pkg/config/client
   - pkg/config/leaderelection
@@ -965,7 +965,7 @@ imports:
   - pkg/operator/resource/resourcemerge
   - pkg/serviceability
 - name: github.com/openshift/service-serving-cert-signer
-  version: ff33759721d44aab5426ff6071391b4545da8b4b
+  version: 7418cff96fcaf79a52e04890ed6433cd08c79a79
   subpackages:
   - pkg/controller/servingcert
   - pkg/controller/servingcert/cryptoextensions
@@ -1471,7 +1471,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: 1a2137df01330dc1246703a473bde39642240207
+  version: 4c6cc85b0f68eaf541653156bad79866a46d5102
   repo: https://github.com/openshift/kubernetes-apiserver.git
   subpackages:
   - pkg/admission
@@ -1814,7 +1814,7 @@ imports:
   - pkg/util/proto
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: 3ded9a6dc915fef5b6b27dade59668870da01010
+  version: 8afc46914f13dc03452e1d2df354a01ab738e2f0
   repo: https://github.com/openshift/kubernetes.git
   subpackages:
   - cmd/controller-manager/app

--- a/glide.yaml
+++ b/glide.yaml
@@ -38,13 +38,13 @@ import:
 
 # openshift second
 - package: github.com/openshift/api
-  version: master
+  version: release-3.10
 - package: github.com/openshift/client-go
-  version: master
+  version: release-3.10
 - package: github.com/openshift/imagebuilder
   version: master
 - package: github.com/openshift/library-go
-  version: master
+  version: release-3.10
 # master already branched for 3.11
 - package: github.com/openshift/service-serving-cert-signer
   version: release-3.10
@@ -106,6 +106,9 @@ import:
   version: v1.3.0
 - package: github.com/coreos/bbolt
   version: 32c383e75ce054674c53b5a07e55de85332aee14
+# master: don't print ugly
+- package: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 # cli
 - package: github.com/gonum/blas
   version: 37e82626499e1df7c54aeaba0959fd6e7e8dc1e4

--- a/vendor/github.com/golang/glog/README
+++ b/vendor/github.com/golang/glog/README
@@ -5,7 +5,7 @@ Leveled execution logs for Go.
 
 This is an efficient pure Go implementation of leveled logs in the
 manner of the open source C++ package
-	https://github.com/google/glog
+	http://code.google.com/p/google-glog
 
 By binding methods to booleans it is possible to use the log package
 without paying the expense of evaluating the arguments to the log.

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -676,10 +676,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	data := buf.Bytes()
-	if !flag.Parsed() {
-		os.Stderr.Write([]byte("ERROR: logging before flag.Parse: "))
-		os.Stderr.Write(data)
-	} else if l.toStderr {
+	if l.toStderr {
 		os.Stderr.Write(data)
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {

--- a/vendor/github.com/gorilla/securecookie/AUTHORS
+++ b/vendor/github.com/gorilla/securecookie/AUTHORS
@@ -1,0 +1,19 @@
+# This is the official list of gorilla/securecookie authors for copyright purposes.
+# Please keep the list sorted.
+
+0x434D53 <christoph.seufert@gmail.com>
+Abdülhamit Yilmaz <mr.yilmaz@gmx.de>
+Annonomus-Penguin <Annonomus-Penguin@users.noreply.github.com>
+Craig Peterson <cpeterson@stackoverflow.com>
+Cyril David <cyx@cyx.is>
+Dmitry Chestnykh <dmitry@codingrobots.com>
+Dominik Honnef <dominikh@fork-bomb.org>
+Google LLC (https://opensource.google.com/)
+John Downey <john@jtdowney.com>
+Kamil Kisiel <kamil@kamilkisiel.net>
+Keunwoo Lee <keunwoo@flux.io>
+Mahmud Ridwan <m@hjr265.me>
+Matt Silverlock <matt@eatsleeprepeat.net>
+rodrigo moraes <rodrigo.moraes@gmail.com>
+s7v7nislands <s7v7nislands@gmail.com>
+Wesley Bitter <github@wessie.info>

--- a/vendor/github.com/gorilla/securecookie/LICENSE
+++ b/vendor/github.com/gorilla/securecookie/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012 Rodrigo Moraes. All rights reserved.
+Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/vendor/github.com/openshift/client-go/glide.lock
+++ b/vendor/github.com/openshift/client-go/glide.lock
@@ -1,5 +1,5 @@
-hash: 4fdf7505a3c35be1f1c503f8bc5c0fdfb23ca5ce4f00152d3dde79ca0e441c1b
-updated: 2018-05-23T11:13:09.115553549-04:00
+hash: 6117e8c021d028cdf0da606479635438ec604db12fb7e7a087e6290c53081ecd
+updated: 2018-06-13T10:25:52.727017566-04:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
@@ -13,7 +13,7 @@ imports:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
   version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
@@ -41,7 +41,7 @@ imports:
 - name: github.com/json-iterator/go
   version: 13f86432b882000a51c6e610c620974462691a97
 - name: github.com/openshift/api
-  version: 1adcd4e8b64faf3eaa8166a62e92f95cc7ee1d60
+  version: 6ef6704e604af539af656171d5c0bde774923a43
   subpackages:
   - apps/v1
   - authorization/v1

--- a/vendor/github.com/openshift/client-go/glide.yaml
+++ b/vendor/github.com/openshift/client-go/glide.yaml
@@ -13,7 +13,7 @@ import:
 - package: k8s.io/client-go
   version: kubernetes-1.10.2
 - package: github.com/openshift/api
-  version: master
+  version: release-3.10
 - package: github.com/golang/glog
 - package: github.com/spf13/pflag
 # for gengo

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
@@ -704,7 +704,8 @@ func (e *ClientExecutor) Run(run imagebuilder.Run, config docker.Config) error {
 		return err
 	}
 	if status.ExitCode != 0 {
-		return fmt.Errorf("running '%s' failed with exit code %d", strings.Join(args, " "), status.ExitCode)
+		glog.V(4).Infof("Failed command (code %d): %v", status.ExitCode, args)
+		return fmt.Errorf("running '%s' failed with exit code %d", strings.Join(run.Args, " "), status.ExitCode)
 	}
 
 	if err := e.Volumes.Restore(e.Container.ID, e.Client); err != nil {

--- a/vendor/github.com/openshift/library-go/glide.lock
+++ b/vendor/github.com/openshift/library-go/glide.lock
@@ -1,5 +1,5 @@
-hash: 9326118fde05a9e8947a7335cf93b62e0892d7f5d300543f648646a96eb3c069
-updated: 2018-05-25T14:18:12.564619838-04:00
+hash: d915b042f3861d7eb106e802b551e32b7476a9f77358ac2b8084b204ee7a3455
+updated: 2018-06-13T10:38:18.855094478-04:00
 imports:
 - name: github.com/blang/semver
   version: b38d23b8782a487059e8fc8773e9a5b228a77cb6
@@ -49,7 +49,7 @@ imports:
 - name: github.com/json-iterator/go
   version: 13f86432b882000a51c6e610c620974462691a97
 - name: github.com/openshift/api
-  version: 1adcd4e8b64faf3eaa8166a62e92f95cc7ee1d60
+  version: 6ef6704e604af539af656171d5c0bde774923a43
   subpackages:
   - config/v1
   - operator/v1alpha1

--- a/vendor/github.com/openshift/library-go/glide.yaml
+++ b/vendor/github.com/openshift/library-go/glide.yaml
@@ -11,7 +11,7 @@ import:
 - package: k8s.io/client-go
   version: kubernetes-1.10.2
 - package: github.com/openshift/api
-  version: master
+  version: release-3.10
 
 # sig-master
 - package: github.com/getsentry/raven-go

--- a/vendor/github.com/openshift/service-serving-cert-signer/glide.lock
+++ b/vendor/github.com/openshift/service-serving-cert-signer/glide.lock
@@ -1,5 +1,5 @@
-hash: 6386d29ae8efa779aaa0b0858459b792a25c4fe2548a3d0ec82df995f5d6b40f
-updated: 2018-05-11T11:59:28.155323789-04:00
+hash: 945a6330d17e125fed35133fdfe685f02c8f65f07df36bd0e10588be01d0eb86
+updated: 2018-06-13T10:45:48.824606944-04:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
@@ -37,7 +37,7 @@ imports:
 - name: github.com/json-iterator/go
   version: 13f86432b882000a51c6e610c620974462691a97
 - name: github.com/openshift/library-go
-  version: 20e418d78cdab88870e7d100c906e5101c272c56
+  version: 753950908a10d3f3d58fd93082a50f63ce6bae26
   subpackages:
   - pkg/controller
   - pkg/crypto

--- a/vendor/github.com/openshift/service-serving-cert-signer/glide.yaml
+++ b/vendor/github.com/openshift/service-serving-cert-signer/glide.yaml
@@ -9,4 +9,4 @@ import:
 - package: k8s.io/client-go
   version: kubernetes-1.10.2
 - package: github.com/openshift/library-go
-  version: master
+  version: release-3.10


### PR DESCRIPTION
Update glide.yaml to point to release branches for dependencies so we can start moving the prereq repos forward.

I also pinned glog.

/assign @liggitt 