### PR TITLE
serviceaccounts: do not manage pull secrets created by third parties

### DIFF
--- a/pkg/serviceaccounts/controllers/docker_registry_service.go
+++ b/pkg/serviceaccounts/controllers/docker_registry_service.go
@@ -287,6 +287,13 @@ func (e *DockerRegistryServiceController) syncRegistryLocationChange() error {
 			if t.Type != v1.SecretTypeDockercfg {
 				continue
 			}
+			if t.Annotations == nil {
+				continue
+			}
+			// Do not manage dockercfg secrets we haven't created (eg. secrets created by user for private repositories).
+			if _, hasTokenSecret := t.Annotations[ServiceAccountTokenSecretNameKey]; !hasTokenSecret {
+				continue
+			}
 		default:
 			utilruntime.HandleError(fmt.Errorf("object passed to %T that is not expected: %T", e, obj))
 			continue


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1591632

@deads2k doing the initial sweep and correction of dockercfg secrets revealed a bug where we accidentally override user-specified secrets as well.

/cherrypick release-3.9