### PR TITLE
Add Sprintf directive for --vmodule in execKubelet

### DIFF
--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -419,7 +419,7 @@ func execKubelet(kubeletArgs []string) error {
 	for i, s := range os.Args {
 		if s == "--vmodule" {
 			if i+1 < len(os.Args) {
-				args = append(args, fmt.Sprintf("--vmodule=", os.Args[i+1]))
+				args = append(args, fmt.Sprintf("--vmodule=%s", os.Args[i+1]))
 				break
 			}
 		}


### PR DESCRIPTION
The change originally came from https://github.com/openshift/origin/pull/16270. I'm assuming adding silent support still mandates an argument for `--vmodule`, if present.