### PR TITLE
new-app: verify if API has required resources enabled

### DIFF
--- a/pkg/oc/lib/newapp/cmd/newapp.go
+++ b/pkg/oc/lib/newapp/cmd/newapp.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -115,10 +116,11 @@ type AppConfig struct {
 	Out    io.Writer
 	ErrOut io.Writer
 
-	KubeClient     kclientset.Interface
-	ImageClient    imageclient.ImageInterface
-	RouteClient    routeclient.RouteInterface
-	TemplateClient templateclient.TemplateInterface
+	KubeClient      kclientset.Interface
+	ImageClient     imageclient.ImageInterface
+	RouteClient     routeclient.RouteInterface
+	TemplateClient  templateclient.TemplateInterface
+	DiscoveryClient discovery.DiscoveryInterface
 
 	Resolvers
 


### PR DESCRIPTION
fixes https://github.com/openshift/origin/issues/20002 by checking the `kind` of each resource

now it fails very early, produces following output if builds are disabled
```
oc new-app https://github.com/wozniakjan/oc_newapp_expose#env_dot_syntax                  
error: Missing required resources: Build, BuildConfig
```

ptal @openshift/sig-developer-experience, @mfojtik 