### PR TITLE
[WIP] UPSTREAM: docker/client: <carry>: disable image ref normalisation

### DIFF
--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/image_ecosystem"
 	_ "github.com/openshift/origin/test/extended/imageapis"
 	_ "github.com/openshift/origin/test/extended/images"
+	_ "github.com/openshift/origin/test/extended/images/pull"
 	_ "github.com/openshift/origin/test/extended/images/trigger"
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"

--- a/test/extended/images/pull/pull.go
+++ b/test/extended/images/pull/pull.go
@@ -1,0 +1,94 @@
+package pull
+
+import (
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	provenanceTestPod = "provenance"
+)
+
+var _ = g.Describe("[Feature:ImagePull] Image Pull", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLI("image-provenance", exutil.KubeConfigPath())
+		f  = oc.KubeFramework()
+	)
+
+	// This test will pull an unqualified image reference
+	// "openshift3/image-provenance" and verify that the output
+	// from the running pod does not contain the string
+	// 'docker.io'.
+	//
+	// To make this work the same image-by-name is pushed to two
+	// registries.
+	//
+	// The image pushed to the docker.io registry should contain:
+	//
+	//  FROM busybox
+	//  CMD exec /bin/sh -c 'trap : TERM INT; echo "This image came from docker.io"; tail -f /dev/null & wait'
+	//
+	// and the image pushed to "registry.access.redhat.com" should contain:
+	//
+	//  FROM busybox
+	//  CMD exec /bin/sh -c 'trap : TERM INT; echo "This image came from openshift.io"; tail -f /dev/null & wait'
+	//
+	// When we pull the unqualified image reference
+	// "openshift3/image-provenance" in this test we should get
+	// "This image came from OpenShift.io" as the ImagePull logic
+	// no longer uses the result of calling through
+	// ParseNormalizedNamed(); calls to that function add
+	// "docker.io" which we don't want to happen as we rely on the
+	// registry search order in the docker daemon to find and pull
+	// the image based on its --add-registry search configuration.
+
+	g.Describe("[Conformance] Validate pull image provenance of unqualified image references", func() {
+		g.It("It should not pull an image from docker.io", func() {
+			g.By("creating a pod from an unqualified image reference")
+			image := "frobware/image-provenance" // add :good to make test pass
+			pod := testPOD(image, provenanceTestPod)
+			_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			defer f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(pod.Name, nil)
+
+			g.By("waiting for the pod to become running")
+			err = f.WaitForPodRunning(pod.Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("inspecting pod output")
+			podOutput, logErr := oc.Run("logs").Args(provenanceTestPod).Output()
+			o.Expect(logErr).NotTo(o.HaveOccurred())
+			if strings.Contains(podOutput, "docker.io") {
+				e2e.Failf("Pod image was pulled from docker.io; %q\n", strings.Trim(podOutput, "\n"))
+			}
+		})
+	})
+})
+
+func testPOD(image, name string) *kapiv1.Pod {
+	return &kapiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kapiv1.PodSpec{
+			Containers: []kapiv1.Container{
+				{
+					Name:            name,
+					Image:           image,
+					ImagePullPolicy: kapiv1.PullAlways,
+				},
+			},
+		},
+	}
+}

--- a/vendor/github.com/docker/docker/client/image_pull.go
+++ b/vendor/github.com/docker/docker/client/image_pull.go
@@ -26,7 +26,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options types.I
 	}
 
 	query := url.Values{}
-	query.Set("fromImage", reference.FamiliarName(ref))
+	query.Set("fromImage", refStr)
 	if !options.All {
 		query.Set("tag", getAPITagFromNamedRef(ref))
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/helpers.go
@@ -322,13 +322,12 @@ func ensureSandboxImageExists(client libdocker.Interface, image string) error {
 		return fmt.Errorf("failed to inspect sandbox image %q: %v", image, err)
 	}
 
-	repoToPull, _, _, err := parsers.ParseImageName(image)
-	if err != nil {
+	if _, _, _, err := parsers.ParseImageName(image); err != nil {
 		return err
 	}
 
 	keyring := credentialprovider.NewDockerKeyring()
-	creds, withCredentials := keyring.Lookup(repoToPull)
+	creds, withCredentials := keyring.Lookup(image)
 	if !withCredentials {
 		glog.V(3).Infof("Pulling image %q without credentials", image)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -31,8 +31,7 @@ import (
 // secrets if necessary.
 func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pullSecrets []v1.Secret) (string, error) {
 	img := image.Image
-	repoToPull, _, _, err := parsers.ParseImageName(img)
-	if err != nil {
+	if _, _, _, err := parsers.ParseImageName(img); err != nil {
 		return "", err
 	}
 
@@ -42,7 +41,7 @@ func (m *kubeGenericRuntimeManager) PullImage(image kubecontainer.ImageSpec, pul
 	}
 
 	imgSpec := &runtimeapi.ImageSpec{Image: img}
-	creds, withCredentials := keyring.Lookup(repoToPull)
+	creds, withCredentials := keyring.Lookup(imgSpec.Image)
 	if !withCredentials {
 		glog.V(3).Infof("Pulling image %q without credentials", img)
 


### PR DESCRIPTION
Remove normalisation of image refs in calls to ImagePull.

Calls to k8s.io/kubernetes/pkg/util/parsers.ParseImage() or
docker/reference.ParseNormalizedNamed() will automatically qualify
unqualified image references with "docker.io". This commit continues
to use ParseNormalizedNamed() but only for a validity check. If the
image reference is valid it will use the original unqualified name
when making queries against the docker client API ensuring that calls
like:

  $ oc run test --image=openshift3/metrics-heapster

don't automatically turn into:

  $ oc run test --image=docker.io/openshift3/metrics-heapster

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1583500