### PR TITLE
UPSTREAM: 63926: Avoid unnecessary calls to the cloud provider

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/service/service_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/service/service_controller.go
@@ -283,6 +283,11 @@ func (s *ServiceController) createLoadBalancerIfNeeded(key string, service *v1.S
 	var err error
 
 	if !wantsLoadBalancer(service) {
+		if v1helper.LoadBalancerStatusEqual(previousState, &v1.LoadBalancerStatus{}) {
+			return nil, notRetryable
+		}
+
+		glog.V(3).Infof("Getting load balancer for service %s", key)
 		_, exists, err := s.balancer.GetLoadBalancer(s.clusterName, service)
 		if err != nil {
 			return fmt.Errorf("error getting LB for service %s: %v", key, err), retryable


### PR DESCRIPTION
If the service controller is processing a service that does not have type
LoadBalancer and does not have any external load balancer recorded in its
status, do not call the cloud provider to check for an associated load
balancer.
    
This commit fixes bug 1571940
https://bugzilla.redhat.com/show_bug.cgi?id=1571940
and 1583718 for OCP 3.9:
https://bugzilla.redhat.com/show_bug.cgi?id=1583718

(cherry picked from commit aaf46c42283d2cd2611474ad72a76c196f09d0d1)
Author:    Miciah Masters <miciah.masters@gmail.com>
Date:      Wed May 16 11:52:25 2018 -0400