### PR TITLE
Fix a crash on a certain type of unsupported NetworkPolicy

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -342,15 +342,18 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 				return nil, fmt.Errorf("policy specifies unrecognized protocol %q", *port.Protocol)
 			}
 			var portNum int
-			if port.Port.Type == intstr.Int {
+			if port.Port == nil {
+				// FIXME: implement this?
+				return nil, fmt.Errorf("port fields with no port value are not implemented")
+			} else if port.Port.Type != intstr.Int {
+				// FIXME: implement this?
+				return nil, fmt.Errorf("named port values (%q) are not implemented", port.Port.StrVal)
+			} else {
 				portNum = int(port.Port.IntVal)
 				if portNum < 0 || portNum > 0xFFFF {
 					// FIXME: validation should catch this
 					return nil, fmt.Errorf("port value out of bounds %q", port.Port.IntVal)
 				}
-			} else {
-				// FIXME: implement this
-				return nil, fmt.Errorf("named port values (%q) are not yet implemented", port.Port.StrVal)
 			}
 			portFlows = append(portFlows, fmt.Sprintf("%s, tp_dst=%d, ", protocol, portNum))
 		}


### PR DESCRIPTION
Similar to #19869 but different, and not caused by "new features" in this case. In theory, NetworkPolicy allows you to say:

    kind: NetworkPolicy
    spec:
      podSelector:
      ingress:
      - ports
        - protocol: TCP

meaning "allow all TCP ports but no UDP ports". This is a dumb feature, and we don't bother to implement it, but we were accidentally crashing if we saw a NetworkPolicy like that. (Which only happened because someone created a NetworkPolicy with broken indentation that caused parts of it to be parsed as the wrong subfield.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1591584