### PR TITLE
Revert "Make NewCommandStartNode() handle SIGTERM and SIGINT"

### DIFF
--- a/cmd/openshift/openshift.go
+++ b/cmd/openshift/openshift.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"time"
 
-	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
 
 	"github.com/openshift/library-go/pkg/serviceability"
@@ -34,7 +33,7 @@ func main() {
 	}
 
 	basename := filepath.Base(os.Args[0])
-	command := openshift.CommandFor(basename, server.SetupSignalHandler())
+	command := openshift.CommandFor(basename)
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/cmd/openshift/openshift.go
+++ b/pkg/cmd/openshift/openshift.go
@@ -39,7 +39,7 @@ var (
 
 // CommandFor returns the appropriate command for this base name,
 // or the global OpenShift command
-func CommandFor(basename string, stopCh <-chan struct{}) *cobra.Command {
+func CommandFor(basename string) *cobra.Command {
 	var cmd *cobra.Command
 
 	out := os.Stdout
@@ -70,9 +70,9 @@ func CommandFor(basename string, stopCh <-chan struct{}) *cobra.Command {
 	case "openshift-extract-image-content":
 		cmd = builder.NewCommandExtractImageContent(basename)
 	case "origin":
-		cmd = NewCommandOpenShift(basename, stopCh)
+		cmd = NewCommandOpenShift(basename)
 	default:
-		cmd = NewCommandOpenShift("openshift", stopCh)
+		cmd = NewCommandOpenShift("openshift")
 	}
 
 	if cmd.UsageFunc() == nil {
@@ -84,7 +84,7 @@ func CommandFor(basename string, stopCh <-chan struct{}) *cobra.Command {
 }
 
 // NewCommandOpenShift creates the standard OpenShift command
-func NewCommandOpenShift(name string, stopCh <-chan struct{}) *cobra.Command {
+func NewCommandOpenShift(name string) *cobra.Command {
 	out, errout := os.Stdout, os.Stderr
 
 	root := &cobra.Command{
@@ -94,7 +94,7 @@ func NewCommandOpenShift(name string, stopCh <-chan struct{}) *cobra.Command {
 		Run:   kcmdutil.DefaultSubCommandRun(out),
 	}
 
-	startAllInOne, _ := start.NewCommandStartAllInOne(name, out, errout, stopCh)
+	startAllInOne, _ := start.NewCommandStartAllInOne(name, out, errout)
 	root.AddCommand(startAllInOne)
 	root.AddCommand(newCompletionCommand("completion", name+" completion"))
 	root.AddCommand(cmdversion.NewCmdVersion(name, osversion.Get(), os.Stdout))

--- a/pkg/cmd/openshift/openshift_test.go
+++ b/pkg/cmd/openshift/openshift_test.go
@@ -2,17 +2,15 @@ package openshift
 
 import (
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestCommandFor(t *testing.T) {
-	cmd := CommandFor("openshift-router", wait.NeverStop)
+	cmd := CommandFor("openshift-router")
 	if cmd.Use != "openshift-router" {
 		t.Errorf("expected command to start with prefix: %#v", cmd)
 	}
 
-	cmd = CommandFor("unknown", wait.NeverStop)
+	cmd = CommandFor("unknown")
 	if cmd.Use != "openshift" {
 		t.Errorf("expected command to be openshift: %#v", cmd)
 	}

--- a/pkg/cmd/server/start/command_test.go
+++ b/pkg/cmd/server/start/command_test.go
@@ -19,7 +19,6 @@ import (
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
-	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 )
 
@@ -228,7 +227,7 @@ func executeAllInOneCommandWithConfigs(args []string) (*MasterArgs, *configapi.M
 		},
 	}
 
-	openshiftStartCommand, cfg := NewCommandStartAllInOne("openshift start", os.Stdout, os.Stderr, wait.NeverStop)
+	openshiftStartCommand, cfg := NewCommandStartAllInOne("openshift start", os.Stdout, os.Stderr)
 	root.AddCommand(openshiftStartCommand)
 	root.SetArgs(argsToUse)
 	root.Execute()

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -63,7 +63,7 @@ var allInOneLong = templates.LongDesc(`
 	You may also pass --etcd=<address> to connect to an external etcd server.`)
 
 // NewCommandStartAllInOne provides a CLI handler for 'start' command
-func NewCommandStartAllInOne(basename string, out, errout io.Writer, stopCh <-chan struct{}) (*cobra.Command, *AllInOneOptions) {
+func NewCommandStartAllInOne(basename string, out, errout io.Writer) (*cobra.Command, *AllInOneOptions) {
 	options := &AllInOneOptions{
 		MasterOptions: &MasterOptions{
 			Output: out,
@@ -120,7 +120,7 @@ func NewCommandStartAllInOne(basename string, out, errout io.Writer, stopCh <-ch
 	BindImageFormatArgs(imageFormatArgs, flags, "")
 
 	startMaster, _ := NewCommandStartMaster(basename, out, errout)
-	startNode, _ := NewCommandStartNode(basename, out, errout, stopCh)
+	startNode, _ := NewCommandStartNode(basename, out, errout)
 	startNodeNetwork, _ := NewCommandStartNetwork(basename, out, errout)
 	startEtcdServer, _ := NewCommandStartEtcdServer(RecommendedStartEtcdServerName, basename, out, errout)
 	startTSBServer := tsbcmd.NewCommandStartTemplateServiceBrokerServer(out, errout, wait.NeverStop)

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -19,6 +19,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	kubeletapp "k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -69,7 +70,7 @@ var nodeLong = templates.LongDesc(`
 	`)
 
 // NewCommandStartNode provides a CLI handler for 'start node' command
-func NewCommandStartNode(basename string, out, errout io.Writer, stopCh <-chan struct{}) (*cobra.Command, *NodeOptions) {
+func NewCommandStartNode(basename string, out, errout io.Writer) (*cobra.Command, *NodeOptions) {
 	options := &NodeOptions{
 		ExpireDays: crypto.DefaultCertificateLifetimeInDays,
 		Output:     out,
@@ -80,7 +81,7 @@ func NewCommandStartNode(basename string, out, errout io.Writer, stopCh <-chan s
 		Short: "Launch a node",
 		Long:  fmt.Sprintf(nodeLong, basename),
 		Run: func(c *cobra.Command, args []string) {
-			options.Run(c, errout, args, stopCh)
+			options.Run(c, errout, args, wait.NeverStop)
 		},
 	}
 
@@ -231,8 +232,7 @@ func (o NodeOptions) StartNode(stopCh <-chan struct{}) error {
 	}
 
 	go daemon.SdNotify(false, "READY=1")
-	<-stopCh
-	return nil
+	select {}
 }
 
 // RunNode takes the options and:

--- a/tools/clicheck/check_cli_conventions.go
+++ b/tools/clicheck/check_cli_conventions.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift/origin/pkg/cmd/openshift"
 	cmdsanity "github.com/openshift/origin/tools/clicheck/sanity"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
@@ -23,7 +22,7 @@ var (
 func main() {
 	errors := []error{}
 
-	oc := openshift.NewCommandOpenShift("openshift", wait.NeverStop)
+	oc := openshift.NewCommandOpenShift("openshift")
 	result := cmdsanity.CheckCmdTree(oc, cmdsanity.AllCmdChecks, skip)
 	errors = append(errors, result...)
 

--- a/tools/genman/gen_man.go
+++ b/tools/genman/gen_man.go
@@ -12,7 +12,6 @@ import (
 	mangen "github.com/openshift/origin/tools/genman/md2man"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/cmd/genutils"
 )
 
@@ -25,7 +24,7 @@ func main() {
 	if strings.HasSuffix(os.Args[2], "oc") {
 		genCmdMan("oc", cli.NewCommandCLI("oc", "oc", &bytes.Buffer{}, os.Stdout, ioutil.Discard))
 	} else if strings.HasSuffix(os.Args[2], "openshift") {
-		genCmdMan("openshift", openshift.NewCommandOpenShift("openshift", wait.NeverStop))
+		genCmdMan("openshift", openshift.NewCommandOpenShift("openshift"))
 	} else {
 		fmt.Fprintf(os.Stderr, "Root command not specified (oc | openshift).")
 		os.Exit(1)


### PR DESCRIPTION
This reverts commit 8377bcdebcd69e96dec9b6545fa4829a1661487c.

This change needs to be layered on top of kubernetes/kubernetes#63859
to avoid duplicate signal handler registrations.