### PR TITLE
Verify that someone isn't accidentally importing staging

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -551,5 +551,15 @@
       "vendor/k8s.io/kubernetes/pkg/registry/rbac/reconciliation",
       "vendor/k8s.io/kubernetes/pkg/registry/rbac/validation"
     ]
+  },
+
+  {
+  "checkedPackageRoots": [
+    "github.com/openshift/origin"
+  ],
+  "forbiddenImportPackageRoots": [
+    "k8s.io/kubernetes/staging"
+  ]
   }
+
 ]


### PR DESCRIPTION
Some IDEs, when not set properly, automatically add imports and include references to staging, which should never be imported directly, only through the vendor symlinks.

/cc @mfojtik 