### PR TITLE
dind: Added support for local registry to push and pull images

### DIFF
--- a/hack/build-local-images.py
+++ b/hack/build-local-images.py
@@ -122,16 +122,6 @@ image_config = {
         },
         "files": {}
     },
-    "nginx-router": {
-        "tag": "latest",
-        "directory": "router/nginx",
-        "binaries": {
-            "openshift": "/usr/bin/openshift"
-        },
-        "files": {
-            ".": "/var/lib/nginx"
-        }
-    },
     "haproxy-router": {
         "tag": "latest",
         "directory": "router/haproxy",

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -70,7 +70,9 @@ function start() {
   local container_runtime=$7
   local wait_for_cluster=$8
   local node_count=$9
-  local additional_args=${10}
+  local local_registry=${10}
+  local local_registry_images=${11}
+  local additional_args=${12}
 
   # docker-in-docker's use of volumes is not compatible with SELinux
   check-selinux
@@ -117,6 +119,12 @@ function start() {
   fi
   echo "OPENSHIFT_OVN_KUBERNETES=${ovn_kubernetes}" >> "${config_root}/dind-env"
 
+  local registry_ip=
+  if [[ -n "${local_registry}" ]]; then
+    registry_ip=$(get-registry-ip)
+    enable-local-registry "${origin_root}" "${config_root}" "${registry_ip}" "${local_registry_images[@]}"
+  fi
+
   # Create containers
   start-container "${config_root}" "${deployed_config_root}" "${MASTER_IMAGE}" "${MASTER_NAME}"
   for name in "${NODE_NAMES[@]}"; do
@@ -125,8 +133,15 @@ function start() {
 
   if [[ -n "${ADDITIONAL_NETWORK_INTERFACE}" ]]; then
     add-network-interface-to-nodes "${config_root}"
-    update-master-config
-    update-node-config
+  fi
+
+  if [[ -n "${local_registry}" ]]; then
+    add-registry-to-runtime "${registry_ip}:${REGISTRY_PORT}" "${container_runtime}"
+  fi
+
+  if [[ -n "${ADDITIONAL_NETWORK_INTERFACE}" || -n "${local_registry}" ]]; then
+    update-master-config "${deployed_config_root}"
+    update-node-config "${deployed_config_root}"
   fi
 
   local rc_file="dind-${cluster_id}.rc"
@@ -168,6 +183,88 @@ cluster's rc file to configure the bash environment:
   $ oc get nodes
 "
   fi
+}
+
+function get-registry-ip() {
+  local default_iface=$(route | grep default | awk '{print $8}')
+  echo $(ip addr show ${default_iface} | grep -Po 'inet \K[\d.]+')
+}
+
+function add-registry-to-runtime() {
+  local registry=$1
+  local runtime=$2
+
+  for cid in $( ${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}|${NODE_PREFIX}" ); do
+    if [[ "${runtime}" = "dockershim" ]]; then
+      ${DOCKER_CMD} exec -t ${cid} sh -c "sed -i '/^\[registries.search\]$/{\$!{N;s/^\[registries.search\]\nregistries .*/\[registries.search\]\nregistries = \[\"${registry}\", \"docker.io\", \"registry.fedoraproject.org\", \"registry.access.redhat.com\"\]/g;ty;P;D;:y}}' /etc/containers/registries.conf"
+      ${DOCKER_CMD} exec -t ${cid} sh -c "sed -i '/^\[registries.insecure\]$/{\$!{N;s/^\[registries.insecure\]\nregistries .*/\[registries.insecure\]\nregistries = \[\"${registry}\"\]/g;ty;P;D;:y}}' /etc/containers/registries.conf"
+      ${DOCKER_CMD} exec -t ${cid} sh -c "systemctl restart docker"
+    else
+      ${DOCKER_CMD} exec -t ${cid} sh -c "sed -i 's/^registries .*/registries = [\n\t\"${registry}\",/g' /etc/crio/crio.conf"
+      ${DOCKER_CMD} exec -t ${cid} sh -c "sed -i 's/^insecure_registries .*/insecure_registries = [\n\t\"${registry}\",/g' /etc/crio/crio.conf"
+      ${DOCKER_CMD} exec -t ${cid} sh -c "systemctl restart crio"
+    fi
+  done
+}
+
+function enable-local-registry() {
+  local origin_root=$1
+  local config_root=$2
+  local ip=$3
+  local images=($4)
+  local tag=$(pushd "${origin_root}" >/dev/null ; git describe --abbrev=0 ; popd > /dev/null)
+
+  # Start local registry
+  ${DOCKER_CMD} run -d -p ${REGISTRY_PORT}:5000 --restart=always --name ${REGISTRY_NAME} registry:2 > /dev/null
+  echo "Created local registry '${REGISTRY_NAME}' at ${ip}:${REGISTRY_PORT}"
+
+  # Build, tag and push local images
+  for image in "${images[@]}"; do
+    ${BUILD_LOCAL_IMAGES_CMD} ${image}
+
+    ${DOCKER_CMD} tag ${image} ${ip}:${REGISTRY_PORT}/${image}:latest
+    ${DOCKER_CMD} tag ${image} ${ip}:${REGISTRY_PORT}/${image}:${tag}
+
+    ${DOCKER_CMD} push ${ip}:${REGISTRY_PORT}/${image}:latest
+    ${DOCKER_CMD} push ${ip}:${REGISTRY_PORT}/${image}:${tag}
+  done
+
+  local image_prefix=$(echo ${images[0]} | cut -d'-' -f1)
+  echo "OPENSHIFT_IMAGE_FORMAT=${ip}:${REGISTRY_PORT}/${image_prefix}-\\\${component}:\\\${version}" >> "${config_root}/dind-env"
+}
+
+function get-local-images() {
+  local user_requested_images=$1
+  local local_image_list=$(${BUILD_LOCAL_IMAGES_CMD} get-list | grep -v ERROR | xargs)
+  local supported_images=(${local_image_list})
+  local -a images=()
+
+  if [[ -n "${user_requested_images}" ]]; then
+    images=($(echo ${user_requested_images} | tr "," " "))
+
+    # Validate user provided images
+    for image in "${images[@]}"; do
+      local found=0
+      for sup_image in "${supported_images[@]}"; do
+        if [[ "${image}" = "${sup_image}" ]]; then
+          found=1
+          break
+        fi
+      done
+
+      if [ "${found}" -ne "1" ]; then
+        echo "Local image '${image}' not supported by command '${BUILD_LOCAL_IMAGES_CMD}'"
+        echo "Supported local images:"
+        echo "${supported_images[@]}"
+        return 1
+      fi
+    done
+  else
+    images=${supported_images[@]}
+  fi
+
+  echo ${images[@]}
+  return 0
 }
 
 # This is embedded in the rc file we generate
@@ -229,34 +326,39 @@ function add-network-interface-to-nodes () {
 }
 
 function update-master-config() {
-  local config_path="/data/openshift.local.config"
-  local master_config_path="${config_path}/master"
-  local master_config_file="${master_config_path}/master-config.yaml"
+  local deployed_config_root=$1
 
   # Remove master config file to trigger master config regeneration
   #
   # openshift-generate-master-config.sh script repopulates master config
-  # with certs for both eth0 and eth1 IP addrs.
+  # Depending on the dind config, it may:
+  # - add certs for both eth0 and eth1 IP addrs.
+  # - change imageFormat to use local registry
   #
   # openshift-master service executes openshift-generate-master-config.sh
   # as pre start hook.
-  rm -f "${master_config_file}"
+  for cid in $( ${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}" ); do
+    ${DOCKER_CMD} exec -t ${cid} sh -c "rm -f ${deployed_config_root}/openshift.local.config/master/master-config.yaml"
+    ${DOCKER_CMD} exec -t ${cid} sh -c "systemctl restart openshift-master"
+  done
 }
 
 function update-node-config() {
-  local config_path="/data/openshift.local.config"
-  local host="$(hostname)"
-  local node_config_path="${config_path}/node-${host}"
-  local node_config_file="${node_config_path}/node-config.yaml"
+  local deployed_config_root=$1
 
   # Remove node config file to trigger node config regeneration
   #
   # openshift-generate-node-config.sh script repopulates node config
-  # with certs for both eth0 and eth1 IP addrs.
+  # Depending on the dind config, it may:
+  # - add certs for both eth0 and eth1 IP addrs.
+  # - change imageFormat to use local registry
   #
   # openshift-node service executes openshift-generate-node-config.sh
   # as pre start hook.
-  rm -f "${node_config_file}"
+  for cid in $( ${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}|${NODE_PREFIX}" ); do
+    ${DOCKER_CMD} exec -t ${cid} sh -c "rm -f ${deployed_config_root}/openshift.local.config/node-*/node-config.yaml"
+    ${DOCKER_CMD} exec -t ${cid} sh -c "systemctl restart openshift-node"
+  done
 }
 
 function add-node () {
@@ -344,7 +446,7 @@ function stop() {
   fi
 
   # Delete the containers
-  for cid in $( ${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}|${NODE_PREFIX}" ); do
+  for cid in $( ${DOCKER_CMD} ps -qa --filter "name=${MASTER_NAME}|${NODE_PREFIX}|${REGISTRY_NAME}" ); do
     ${DOCKER_CMD} rm -f "${cid}" > /dev/null
   done
 
@@ -692,8 +794,10 @@ function os::build::get-bin-output-path() {
 ## Start of the main program
 
 DEFAULT_DOCKER_CMD="sudo docker"
+DEFAULT_BUILD_LOCAL_IMAGES_CMD="sudo ${OS_ROOT}/hack/build-local-images.py"
 if [[ -w "/var/run/docker.sock" ]]; then
   DEFAULT_DOCKER_CMD="docker"
+  DEFAULT_BUILD_LOCAL_IMAGES_CMD="${OS_ROOT}/hack/build-local-images.py"
 
   # Since docker is a shell script we do not want to pass our restrictions to it
   # This would be stripped by sudo, but we have to do it manually otherwise
@@ -703,6 +807,7 @@ else
   sudo echo -n
 fi
 DOCKER_CMD="${DOCKER_CMD:-$DEFAULT_DOCKER_CMD}"
+BUILD_LOCAL_IMAGES_CMD="${BUILD_LOCAL_IMAGES_CMD:-$DEFAULT_BUILD_LOCAL_IMAGES_CMD}"
 
 CLUSTER_ID="${OPENSHIFT_CLUSTER_ID:-openshift}"
 
@@ -715,6 +820,9 @@ MASTER_NAME="${CLUSTER_ID}-master"
 NODE_PREFIX="${CLUSTER_ID}-node-"
 NODE_COUNT=2
 NODE_NAMES=()
+
+REGISTRY_NAME="${CLUSTER_ID}-local-registry"
+REGISTRY_PORT="${REGISTRY_PORT:-5000}"
 
 ADDITIONAL_BRIDGE_NAME="${ADDITIONAL_BRIDGE_NAME:-os-addbr-1}"
 ADDITIONAL_NETWORK_NUM=18
@@ -736,8 +844,10 @@ case "${1:-""}" in
     NETWORK_PLUGIN=
     REMOVE_EXISTING_CLUSTER=
     ADDITIONAL_NETWORK_INTERFACE=
+    ENABLE_LOCAL_REGISTRY=
+    LOCAL_REGISTRY_IMAGES=
     OPTIND=2
-    while getopts ":abc:in:rsN:" opt; do
+    while getopts ":abc:in:rsN:lm:" opt; do
       case $opt in
         b)
           BUILD=1
@@ -762,6 +872,12 @@ case "${1:-""}" in
           ;;
         a)
           ADDITIONAL_NETWORK_INTERFACE=1
+          ;;
+        l)
+          ENABLE_LOCAL_REGISTRY=1
+          ;;
+        m)
+          LOCAL_REGISTRY_IMAGES="${OPTARG}"
           ;;
         \?)
           echo "Invalid option: -${OPTARG}" >&2
@@ -810,9 +926,20 @@ case "${1:-""}" in
       OVN_ROOT=
     fi
 
+    declare -a images=("")
+    if [[ -n "${ENABLE_LOCAL_REGISTRY}" ]]; then
+      error=0
+      images=$(get-local-images "${LOCAL_REGISTRY_IMAGES}") || error=1
+      if [[ "${error}" -eq "1" ]]; then
+        echo "${images}"
+        exit 1
+      fi
+    fi
+
     start "${OS_ROOT}" "${OVN_ROOT}" "${CONFIG_ROOT}" "${DEPLOYED_CONFIG_ROOT}" \
           "${CLUSTER_ID}" "${NETWORK_PLUGIN}" "${CONTAINER_RUNTIME}" \
-          "${WAIT_FOR_CLUSTER}" "${NODE_COUNT}" "${ADDITIONAL_ARGS}"
+          "${WAIT_FOR_CLUSTER}" "${NODE_COUNT}" "${ENABLE_LOCAL_REGISTRY}" \
+          "${images[@]}" "${ADDITIONAL_ARGS}"
     ;;
   add-node)
     WAIT_FOR_CLUSTER=1
@@ -945,6 +1072,9 @@ start accepts the following options:
  -i                build container images before starting the cluster
  -r                remove an existing cluster
  -a                add additional network interface to all nodes in the cluster
+ -l                setup registry to push and pull local images
+ -m                filtered local images for registry (comma separated list)
+                   default: all images supported by ${OS_ROOT}/hack/build-local-images.py
  -s                skip waiting for nodes to become ready
 
 Any of the arguments that would be used in creating openshift master can be passed
@@ -962,6 +1092,7 @@ add-node and resume accept the following option:
 
 The following environment variables are honored:
  - DOCKER_CMD: The docker command used.  Default: 'sudo docker'
+ - BUILD_LOCAL_IMAGES_CMD: The command used for building local images.  Default: 'sudo ${OS_ROOT}/hack/build-local-images.py'
  - OPENSHIFT_CLUSTER_ID: The name of the cluster (so multiple can be run). Default: 'openshift'
  - OPENSHIFT_CONFIG_BASE: Where the cluster configs are written, move somewhere persistent if you
       want to pause and resume across reboots.  Default: '${TMPDIR}/openshift-dind-cluster'

--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -36,6 +36,12 @@ function ensure-master-config() {
     serving_ip_addr="${ip_addr1}"
   fi
 
+  local image_format=${OPENSHIFT_IMAGE_FORMAT:-}
+  local image_format_str=""
+  if [[ -n "${image_format}" ]]; then
+    image_format_str="--images=${image_format}"
+  fi
+
   mkdir -p "${config_path}"
   (flock 200;
    /usr/local/bin/oc adm ca create-master-certs \
@@ -46,6 +52,7 @@ function ensure-master-config() {
 
    /usr/local/bin/openshift start master --write-config="${master_path}" \
      --master="https://${serving_ip_addr}:8443" \
+     ${image_format_str} \
      --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
      ${OPENSHIFT_ADDITIONAL_ARGS}
   ) 200>"${config_path}"/.openshift-ca.lock

--- a/images/dind/node/openshift-generate-node-config.sh
+++ b/images/dind/node/openshift-generate-node-config.sh
@@ -51,6 +51,12 @@ function ensure-node-config() {
       ip_addrs="${ip_addr1}"
     fi
 
+    local image_format=${OPENSHIFT_IMAGE_FORMAT:-}
+    local image_format_str=""
+    if [[ -n "${image_format}" ]]; then
+      image_format_str="--images=${image_format}"
+    fi
+
     # Hold a lock on the shared volume to ensure cert generation is
     # performed serially.  Cert generation is not compatible with
     # concurrent execution since the file passed to --signer-serial
@@ -61,6 +67,7 @@ function ensure-node-config() {
        --node="${host}" \
        --master="${master_host}" \
        --dns-ip="172.30.0.1" \
+       ${image_format_str} \
        --hostnames="${host},${ip_addrs}" \
        --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
        --node-client-certificate-authority="${master_config_path}/ca.crt" \


### PR DESCRIPTION
- This will be useful for dev testing router, egress router features.
- This will also help if we plan to switch dind to use newer openshift
deployment(kubelet with openshift flags, sdn/ovs/config daemonsets)