### PR TITLE
[oc cluster up] node config needs right IPs

### DIFF
--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -372,7 +372,7 @@ func (c *ClusterUpConfig) makeMasterConfig() (string, error) {
 
 // makeNodeConfig returns the directory where a generated nodeconfig lives
 func (c *ClusterUpConfig) makeNodeConfig(masterConfigDir string) (string, error) {
-	defaultNodeName := "localhost"
+	defaultNodeName := c.GetPublicHostName()
 
 	container := kubelet.NewNodeStartConfig()
 	container.ContainerBinds = append(container.ContainerBinds, masterConfigDir+":/var/lib/origin/openshift.local.masterconfig:z")
@@ -382,7 +382,9 @@ func (c *ClusterUpConfig) makeNodeConfig(masterConfigDir string) (string, error)
 		fmt.Sprintf("--certificate-authority=%s", "/var/lib/origin/openshift.local.masterconfig/ca.crt"),
 		fmt.Sprintf("--dns-bind-address=0.0.0.0:%d", c.DNSPort),
 		fmt.Sprintf("--hostnames=%s", defaultNodeName),
+		fmt.Sprintf("--hostnames=%s", "localhost"),
 		fmt.Sprintf("--hostnames=%s", "127.0.0.1"),
+		fmt.Sprintf("--hostnames=%s", c.ServerIP),
 		fmt.Sprintf("--images=%s", c.imageFormat()),
 		fmt.Sprintf("--node=%s", defaultNodeName),
 		fmt.Sprintf("--node-client-certificate-authority=%s", "/var/lib/origin/openshift.local.masterconfig/ca.crt"),


### PR DESCRIPTION
Previously, when `oc cluster up` generated the node config, it hardcoded
the node name as localhost, and hostnames as localhost and 127.0.0.1.
This causes issues when things try to connect to the node (e.g. for
metrics), since the certs are signed for 127.0.0.1, but applications
connect to the node with non-loopback addresses (e.g. the node IP, or
public hostname).

This changes `oc cluster up` to generate certs for the server IP and
public hostname.