### PR TITLE
openshift-kube-apiserver: use in-process loopback client config from Kube

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -43,20 +43,7 @@ func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error
 		return kerrors.NewInvalid(configapi.Kind("MasterConfig"), "master-config.yaml", validationResults.Errors)
 	}
 
-	// informers are shared amongst all the various api components we build
-	// TODO the needs of the apiserver and the controllers are drifting. We should consider two different skins here
-	clientConfig, err := configapi.GetClientConfig(masterConfig.MasterClients.OpenShiftLoopbackKubeConfig, masterConfig.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
-	if err != nil {
-		return err
-	}
-	informers, err := origin.NewInformers(clientConfig)
-	if err != nil {
-		return err
-	}
-	if err := informers.AddUserIndexes(); err != nil {
-		return err
-	}
-
+	informers := origin.InformerAccess(nil) // use real kube-apiserver loopback client with secret token instead of that from masterConfig.MasterClients.OpenShiftLoopbackKubeConfig
 	openshiftConfig, err := origin.BuildMasterConfig(*masterConfig, informers)
 	if err != nil {
 		return err

--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -47,6 +47,7 @@ import (
 	auditlog "k8s.io/apiserver/plugin/pkg/audit/log"
 	auditwebhook "k8s.io/apiserver/plugin/pkg/audit/webhook"
 	pluginwebhook "k8s.io/apiserver/plugin/pkg/audit/webhook"
+	"k8s.io/client-go/rest"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
@@ -370,12 +371,13 @@ func buildPublicAddress(masterConfig configapi.MasterConfig) (net.IP, error) {
 	return publicAddress, nil
 }
 
-func buildKubeApiserverConfig(
-	masterConfig configapi.MasterConfig,
-	admissionControl admission.Interface,
-	originAuthenticator authenticator.Request,
-	kubeAuthorizer authorizer.Authorizer,
-) (*master.Config, error) {
+type incompleteKubeMasterConfig struct {
+	options          *kapiserveroptions.ServerRunOptions
+	incompleteConfig *apiserver.Config
+	masterConfig     configapi.MasterConfig
+}
+
+func BuildKubernetesMasterConfig(masterConfig configapi.MasterConfig) (*incompleteKubeMasterConfig, error) {
 	apiserverOptions, err := BuildKubeAPIserverOptions(masterConfig)
 	if err != nil {
 		return nil, err
@@ -385,6 +387,20 @@ func buildKubeApiserverConfig(
 	if err != nil {
 		return nil, err
 	}
+
+	return &incompleteKubeMasterConfig{apiserverOptions, genericConfig, masterConfig}, nil
+}
+
+func (rc *incompleteKubeMasterConfig) LoopbackConfig() *rest.Config {
+	return rc.incompleteConfig.LoopbackClientConfig
+}
+
+func (rc *incompleteKubeMasterConfig) Complete(
+	admissionControl admission.Interface,
+	originAuthenticator authenticator.Request,
+	kubeAuthorizer authorizer.Authorizer,
+) (*master.Config, error) {
+	genericConfig, apiserverOptions, masterConfig := rc.incompleteConfig, rc.options, rc.masterConfig
 
 	proxyClientCerts, err := buildProxyClientCerts(masterConfig)
 	if err != nil {
@@ -561,33 +577,13 @@ func buildKubeApiserverConfig(
 		)
 	}
 
-	return kubeApiserverConfig, nil
-}
-
-// TODO this function's parameters need to be refactored
-func BuildKubernetesMasterConfig(
-	masterConfig configapi.MasterConfig,
-	admissionControl admission.Interface,
-	originAuthenticator authenticator.Request,
-	kubeAuthorizer authorizer.Authorizer,
-) (*master.Config, error) {
-	apiserverConfig, err := buildKubeApiserverConfig(
-		masterConfig,
-		admissionControl,
-		originAuthenticator,
-		kubeAuthorizer,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	// we do this for integration tests to be able to turn it off for better startup speed
 	// TODO remove the entire option once openapi is faster
 	if masterConfig.DisableOpenAPI {
-		apiserverConfig.GenericConfig.OpenAPIConfig = nil
+		kubeApiserverConfig.GenericConfig.OpenAPIConfig = nil
 	}
 
-	return apiserverConfig, nil
+	return kubeApiserverConfig, nil
 }
 
 func defaultOpenAPIConfig(config configapi.MasterConfig) *openapicommon.Config {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -126,6 +126,24 @@ func BuildMasterConfig(
 	options configapi.MasterConfig,
 	informers InformerAccess,
 ) (*MasterConfig, error) {
+	incompleteKubeAPIServerConfig, err := kubernetes.BuildKubernetesMasterConfig(options)
+	if err != nil {
+		return nil, err
+	}
+	if informers == nil {
+		// use the real Kubernetes loopback client (using a secret token and preferibly localhost networking), not
+		// the one provided by options.MasterClients.OpenShiftLoopbackKubeConfig. The latter is meant for out-of-process
+		// components of the master.
+		realLoopbackInformers, err := NewInformers(incompleteKubeAPIServerConfig.LoopbackConfig())
+		if err != nil {
+			return nil, err
+		}
+		if err := realLoopbackInformers.AddUserIndexes(); err != nil {
+			return nil, err
+		}
+		informers = realLoopbackInformers
+	}
+
 	restOptsGetter, err := originrest.StorageOptions(options)
 	if err != nil {
 		return nil, err
@@ -181,8 +199,7 @@ func BuildMasterConfig(
 		return nil, err
 	}
 
-	kubeAPIServerConfig, err := kubernetes.BuildKubernetesMasterConfig(
-		options,
+	kubeAPIServerConfig, err := incompleteKubeAPIServerConfig.Complete(
 		admission,
 		authenticator,
 		authorizer,


### PR DESCRIPTION
The loopback config from the master config might reference the master service. It is meant to be used by components which run out-of-process. The openshift-kube-apiserver though talks to itself and should use Kube's "magic" loopback client config instead, which also uses its own self-generated CA and cert (without the need to add 127.0.0.1 to the main server cert and without the need to know the master IP in advance).

Fixes https://github.com/openshift/origin/issues/20060