### PR TITLE
UPSTREAM: 65189: revert: fix paths w shortcuts when copying from pods"

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
@@ -244,7 +244,6 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 // stripPathShortcuts removes any leading or trailing "../" from a given path
 func stripPathShortcuts(p string) string {
 	newPath := path.Clean(p)
-	newPath = strings.TrimLeft(p, "../")
 	if len(newPath) > 0 && string(newPath[0]) == "/" {
 		return newPath[1:]
 	}
@@ -399,24 +398,8 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 }
 
 func getPrefix(file string) string {
-	segs := strings.Split(file, "/")
-	prefix := file
-
-	lastIdx := -1
-	for i := len(segs) - 1; i > 0; i-- {
-		if len(segs[i]) == 0 {
-			continue
-		}
-		lastIdx = i
-		break
-	}
-
-	if lastIdx >= 0 {
-		prefix = strings.Join(segs[:lastIdx], "/")
-	}
-
 	// tar strips the leading '/' if it's there, so we will too
-	return strings.TrimLeft(prefix, "/")
+	return strings.TrimLeft(file, "/")
 }
 
 func execute(f cmdutil.Factory, cmd *cobra.Command, options *ExecOptions) error {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp_test.go
@@ -93,49 +93,15 @@ func TestGetPrefix(t *testing.T) {
 	}{
 		{
 			input:    "/foo/bar",
-			expected: "foo",
+			expected: "foo/bar",
 		},
 		{
 			input:    "foo/bar",
-			expected: "foo",
-		},
-		{
-			input: "foo/bar/baz/",
 			expected: "foo/bar",
 		},
 	}
 	for _, test := range tests {
 		out := getPrefix(test.input)
-		if out != test.expected {
-			t.Errorf("expected: %s, saw: %s", test.expected, out)
-		}
-	}
-}
-
-func TestStripPathShortcuts(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "test single path shortcut prefix",
-			input:    "../foo/bar",
-			expected: "foo/bar",
-		},
-		{
-			name:     "test multiple path shortcuts",
-			input:    "../../foo/bar",
-			expected: "foo/bar",
-		},
-		{
-			name:     "test path shortcuts in middle of path are preserved",
-			input:    "../foo/../foo/bar/baz/",
-			expected: "foo/../foo/bar/baz/",
-		},
-	}
-	for _, test := range tests {
-		out := stripPathShortcuts(test.input)
 		if out != test.expected {
 			t.Errorf("expected: %s, saw: %s", test.expected, out)
 		}
@@ -353,7 +319,10 @@ func TestCopyToLocalFileOrDir(t *testing.T) {
 				t.FailNow()
 			}
 
-			actualDestFilePath := filepath.Join(destPath, filepath.Base(srcFilePath))
+			actualDestFilePath := destPath
+			if file.destDirExists {
+				actualDestFilePath = filepath.Join(destPath, filepath.Base(srcFilePath))
+			}
 			_, err = os.Stat(actualDestFilePath)
 			if err != nil && os.IsNotExist(err) {
 				t.Errorf("expecting %s exists, but actually it's missing", actualDestFilePath)


### PR DESCRIPTION
This reverts commit 6359a955909ce54b1d00a54757f68bffc6a81e71.

The upstream master PR did not merge because of some issues found, and the 1.11 PR was reverted. We don't want this to go into 3.10 as is