### PR TITLE
3.10: imagebuilder: Some `COPY --from` statements would fail

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 1511c1c08d724d5b2f6c586490bfa154f305c5b0038fb2a4bf3c0404aabc72a6
-updated: 2018-06-22T15:14:13.366539768-04:00
+updated: 2018-06-24T03:58:28.501190286-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -947,7 +947,7 @@ imports:
   - user/informers/externalversions/user/v1
   - user/listers/user/v1
 - name: github.com/openshift/imagebuilder
-  version: cef62bca5ea70ac8aa7c86b63e28e888c152ad0e
+  version: 937f2b31b364190f90c4bc51a1ae8b80125b374b
   subpackages:
   - dockerclient
   - imageprogress

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/client.go
@@ -730,7 +730,7 @@ func (e *ClientExecutor) CopyContainer(container *docker.Container, excludes []s
 	for _, c := range copies {
 		// TODO: reuse source
 		for _, src := range c.Src {
-			glog.V(4).Infof("Archiving %s download=%t fromFS=%t", src, c.Download, c.FromFS)
+			glog.V(4).Infof("Archiving %s download=%t fromFS=%t from=%s", src, c.Download, c.FromFS, c.From)
 			var r io.Reader
 			var closer io.Closer
 			var err error
@@ -780,6 +780,7 @@ func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.
 		if other.Container == nil {
 			return nil, nil, fmt.Errorf("the stage %q has not been built yet", from)
 		}
+		glog.V(5).Infof("Using container %s as input for archive request", other.Container.ID)
 		containerID = other.Container.ID
 	} else {
 		glog.V(5).Infof("Creating a container temporarily for image input from %q in %s", from, src)
@@ -800,19 +801,20 @@ func (e *ClientExecutor) archiveFromContainer(from string, src, dst string) (io.
 	}
 
 	pr, pw := io.Pipe()
-	ar, arclose, err := archiveFromContainer(pr, src, dst, nil)
+	ar, archiveRoot, err := archiveFromContainer(pr, src, dst, nil)
 	if err != nil {
 		pr.Close()
 		return nil, nil, err
 	}
 	go func() {
+		glog.V(6).Infof("Download from container %s at path %s", containerID, archiveRoot)
 		err := e.Client.DownloadFromContainer(containerID, docker.DownloadFromContainerOptions{
 			OutputStream: pw,
-			Path:         src,
+			Path:         archiveRoot,
 		})
 		pw.CloseWithError(err)
 	}()
-	return ar, closers{pr.Close, arclose.Close}, nil
+	return ar, pr, nil
 }
 
 // TODO: this does not support decompressing nested archives for ADD (when the source is a compressed file)

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_1
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_1
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /a /b
+FROM busybox
+COPY --from=base /a /
+RUN ls -al /a

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_10
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_10
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+FROM busybox
+COPY --from=base /a/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_2
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_2
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /a
+FROM busybox
+COPY --from=base /a /a
+RUN ls -al /a

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_3
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_3
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN touch /a
+FROM busybox
+WORKDIR /b
+COPY --from=base /a .
+RUN ls -al /b/a

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_4
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_4
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+FROM busybox
+COPY --from=base /a/b/ /b/
+RUN ls -al /b/1 /b/2 /b && ! ls -al /a

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_5
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_5
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+FROM busybox
+COPY --from=base /a/b/* /b/
+RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_6
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_6
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a/b && touch /a/b/1 /a/b/2
+FROM busybox
+COPY --from=base /a/b/. /b/
+RUN ls -al /b/1 /b/2 /b && ! ls -al /a /b/a /b/b

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_7
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_7
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN touch /b
+FROM busybox
+COPY --from=base /b /a
+RUN ls -al /a && ! ls -al /b

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_8
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_8
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/b
+FROM busybox
+COPY --from=base /a/b /a
+RUN ls -al /a && ! ls -al /b

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_9
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_9
@@ -1,0 +1,5 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+FROM busybox
+COPY --from=base /a/1 /a/b/c/
+RUN ls -al /a/b/c/1 && ! ls -al /a/b/1

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/copyfrom/Dockerfile
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/copyfrom/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:7 as base
+RUN mkdir -p /a/blah && touch /a/blah/1 /a/blah/2
+FROM centos:7
+COPY --from=base /a/blah/* /blah/


### PR DESCRIPTION
A dockerfile with

```
FROM a AS a
RUN mkdir -p /a/b && touch /a/b/1
FROM b
COPY --from=a /a/b/* /a
```

would fail with an lstat error because we were not properly handling
wildcards on archives. Added more tests and verified the included
scenarios were correct.

@liggitt one more, found this while testing copying an entire directory over.

openshift/imagebuilder#81