### PR TITLE
extended tests: use leaner repo for contextdir test

### DIFF
--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -98,14 +98,20 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 
 		g.Describe("docker context directory build", func() {
 			g.It(fmt.Sprintf("should docker build an application using a context directory"), func() {
+				g.By("initializing local repo")
+				repo, err := exutil.NewGitRepo("contextdir")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				defer repo.Remove()
+				err = repo.AddAndCommit("2.3/Dockerfile", "FROM busybox")
+				o.Expect(err).NotTo(o.HaveOccurred())
 
 				exutil.CheckOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc create -f %q", appFixture))
-				err := oc.Run("create").Args("-f", appFixture).Execute()
+				err = oc.Run("create").Args("-f", appFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("starting a build")
-				err = oc.Run("start-build").Args(dockerBuildConfigName).Execute()
+				err = oc.Run("start-build").Args(dockerBuildConfigName, "--from-repo", repo.RepoPath).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				// build will fail if we don't use the right context dir because there won't be a dockerfile present.

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -3071,10 +3071,8 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
       "spec": {
         "triggers": [],
         "source": {
-          "type": "Git",
-          "git": {
-            "uri":"https://github.com/sclorg/s2i-ruby-container"
-          },
+          "type": "binary",
+          "binary": {},
           "contextDir": "2.3"
         },
         "strategy": {
@@ -3211,7 +3209,8 @@ var _testExtendedTestdataBuildsTestContextBuildJson = []byte(`{
       }
     }
   ]
-}`)
+}
+`)
 
 func testExtendedTestdataBuildsTestContextBuildJsonBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsTestContextBuildJson, nil

--- a/test/extended/testdata/builds/test-context-build.json
+++ b/test/extended/testdata/builds/test-context-build.json
@@ -12,10 +12,8 @@
       "spec": {
         "triggers": [],
         "source": {
-          "type": "Git",
-          "git": {
-            "uri":"https://github.com/sclorg/s2i-ruby-container"
-          },
+          "type": "binary",
+          "binary": {},
           "contextDir": "2.3"
         },
         "strategy": {

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1327,6 +1327,10 @@ type GitRepo struct {
 
 // AddAndCommit commits a file with its content to local repo
 func (r GitRepo) AddAndCommit(file, content string) error {
+	dir := filepath.Dir(file)
+	if err := os.MkdirAll(filepath.Join(r.RepoPath, dir), 0777); err != nil {
+		return err
+	}
 	if err := ioutil.WriteFile(filepath.Join(r.RepoPath, file), []byte(content), 0666); err != nil {
 		return err
 	}


### PR DESCRIPTION
speed up from 166s to 17s

```
old using s2i ruby based docker image
STEP: starting a build
Jun 12 11:54:45.365: INFO: Running 'oc start-build --config=/tmp/configfile443130924 --namespace=e2e-test-contextdir-ntbrt dockercontext'
build "dockercontext-1" started
STEP: waiting for build to finish
[AfterEach]
  /tmp/openshift/build-rpms/rpm/BUILD/origin-3.10.0/_output/local/go/src/github.com/openshift/origin/test/extended/builds/contextdir.go:38
[AfterEach] [Feature:Builds][Slow] builds with a context directory
  /tmp/openshift/build-rpms/rpm/BUILD/origin-3.10.0/_output/local/go/src/github.com/openshift/origin/test/extended/util/cli.go:72
STEP: Deleting namespaces
Jun 12 11:57:21.689: INFO: namespace : e2e-test-contextdir-ntbrt api call to delete is complet
```

```
new using busybox
STEP: starting a build
Jun 15 13:41:24.455: INFO: Running 'oc start-build --config=/tmp/configfile409710299 --namespace=e2e-test-contextdir-nfbw4 dockercontext --from-repo /tmp/openshift/core/contextdir796719742/contextdir'
Uploading "/tmp/openshift/core/contextdir796719742/contextdir" at commit "HEAD" as binary input for the build ... 
WARNING: the provided file may not be an archive (tar, tar.gz, or zip), use --from-file to prevent extraction
build "dockercontext-1" started
STEP: waiting for build to finish
[AfterEach] 
  /go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/builds/contextdir.go:38
[AfterEach] [Feature:Builds][Slow] builds with a context directory
  /go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/cli.go:72
STEP: Deleting namespaces
Jun 15 13:41:34.470: INFO: namespace : e2e-test-contextdir-nfbw4 api call to delete is complete 
```

ptal @openshift/sig-developer-experience , I would like to note that it issues a warning with `--from-repo`, is that expected warning? Using `--from-file` feels misleading given we would like to pass a repo
```
WARNING: the provided file may not be an archive (tar, tar.gz, or zip), use --from-file to prevent extraction
```