### PR TITLE
Allow egress-router to connect to cluster service network for DNS, etc.

### DIFF
--- a/pkg/network/node/cniserver/cniserver.go
+++ b/pkg/network/node/cniserver/cniserver.go
@@ -51,13 +51,14 @@ const CNIServerRunDir string = "/var/run/openshift-sdn"
 const CNIServerSocketName string = "cni-server.sock"
 const CNIServerSocketPath string = CNIServerRunDir + "/" + CNIServerSocketName
 
-// Config file containing MTU, and default full path
+// Config file contains server to plugin config data
 const CNIServerConfigFileName string = "config.json"
 const CNIServerConfigFilePath string = CNIServerRunDir + "/" + CNIServerConfigFileName
 
 // Server-to-plugin config data
 type Config struct {
-	MTU uint32 `json:"mtu"`
+	MTU                uint32 `json:"mtu"`
+	ServiceNetworkCIDR string `json:"serviceNetworkCIDR"`
 }
 
 // Explicit type for CNI commands the server handles

--- a/pkg/network/node/cniserver/cniserver_test.go
+++ b/pkg/network/node/cniserver/cniserver_test.go
@@ -62,7 +62,7 @@ func TestCNIServer(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	socketPath := filepath.Join(tmpDir, CNIServerSocketName)
 
-	s := NewCNIServer(tmpDir, &Config{MTU: 1500})
+	s := NewCNIServer(tmpDir, &Config{MTU: 1500, ServiceNetworkCIDR: "172.30.0.0/16"})
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -349,7 +349,8 @@ func (node *OsdnNode) Start() error {
 	}
 
 	glog.V(2).Infof("Starting openshift-sdn pod manager")
-	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR, node.networkInfo.ClusterNetworks); err != nil {
+	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR,
+		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String()); err != nil {
 		return err
 	}
 

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -168,7 +168,7 @@ func getIPAMConfig(clusterNetworks []common.ClusterNetwork, localSubnet string) 
 }
 
 // Start the CNI server and start processing requests from it
-func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork) error {
+func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string) error {
 	if m.enableHostports {
 		iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
 		m.hostportSyncer = kubehostport.NewHostportSyncer(iptInterface)
@@ -181,7 +181,7 @@ func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetwork
 
 	go m.processCNIRequests()
 
-	m.cniServer = cniserver.NewCNIServer(rundir, &cniserver.Config{MTU: m.mtu})
+	m.cniServer = cniserver.NewCNIServer(rundir, &cniserver.Config{MTU: m.mtu, ServiceNetworkCIDR: serviceNetworkCIDR})
 	return m.cniServer.Start(m.handleCNIRequest)
 }
 

--- a/pkg/network/node/pod_test.go
+++ b/pkg/network/node/pod_test.go
@@ -318,7 +318,7 @@ func TestPodManager(t *testing.T) {
 		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
 		_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}})
+		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
 		if err != nil {
 			t.Fatalf("could not start PodManager: %v", err)
 		}
@@ -417,7 +417,7 @@ func TestDirectPodUpdate(t *testing.T) {
 	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
 	_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}})
+	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
 	if err != nil {
 		t.Fatalf("could not start PodManager: %v", err)
 	}

--- a/pkg/network/sdn-cni-plugin/openshift-sdn.go
+++ b/pkg/network/sdn-cni-plugin/openshift-sdn.go
@@ -213,10 +213,22 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 					},
 					Gw: defaultGW,
 				}
-				err = netlink.RouteAdd(route)
-				if err != nil {
-					return fmt.Errorf("failed to configure macvlan device: %v", err)
+				if err := netlink.RouteAdd(route); err != nil {
+					return fmt.Errorf("failed to add route to node IP: %v", err)
 				}
+			}
+
+			// Add a route to service network via SDN
+			_, serviceIPNet, err := net.ParseCIDR(config.ServiceNetworkCIDR)
+			if err != nil {
+				return fmt.Errorf("failed to parse ServiceNetworkCIDR: %v", err)
+			}
+			route := &netlink.Route{
+				Dst: serviceIPNet,
+				Gw:  defaultGW,
+			}
+			if err := netlink.RouteAdd(route); err != nil {
+				return fmt.Errorf("failed to add route to service network: %v", err)
 			}
 		}
 

--- a/pkg/network/sdn-cni-plugin/sdn_cni_plugin_test.go
+++ b/pkg/network/sdn-cni-plugin/sdn_cni_plugin_test.go
@@ -83,7 +83,7 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	path := filepath.Join(tmpDir, cniserver.CNIServerSocketName)
-	server := cniserver.NewCNIServer(tmpDir, &cniserver.Config{MTU: 1500})
+	server := cniserver.NewCNIServer(tmpDir, &cniserver.Config{MTU: 1500, ServiceNetworkCIDR: "172.30.0.0/16"})
 	if err := server.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}


### PR DESCRIPTION
https://github.com/openshift/origin/pull/19885 allows egress routers to
connect to the node IP but when openshift node is configured to use
service network IP as DNS IP then egress router pod will not be able
to resolve DNS requests. This change will address this issue.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594958