### PR TITLE
Bind mount /etc/origin/kubelet-plugins for flex volumes

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -455,6 +455,16 @@
 	    ]
         },
         {
+            "type": "bind",
+            "source": "/etc/origin/kubelet-plugins",
+            "destination": "/etc/origin/kubelet-plugins",
+            "options": [
+                "rbind",
+                "rslave",
+                "ro"
+            ]
+        },
+        {
 	    "type": "bind",
 	    "source": "$ORIGIN_CONFIG_DIR/node",
 	    "destination": "/etc/origin/node",


### PR DESCRIPTION
This goes hand-in-hand with https://github.com/openshift/openshift-ansible/pull/8964 for fixing flex volume plugin when kubelet runs as system container.

We will have to cherry-pick this to 3.10 too.

cc @jsafrane 
/sig storage
