### PR TITLE
Bug 1579194 - Fixes handling of multiple provision request

### DIFF
--- a/pkg/templateservicebroker/servicebroker/provision.go
+++ b/pkg/templateservicebroker/servicebroker/provision.go
@@ -268,7 +268,13 @@ func (b *Broker) ensureBrokerTemplateInstance(u user.Info, namespace, instanceID
 		}
 
 		existingBrokerTemplateInstance, err := b.templateclient.BrokerTemplateInstances().Get(brokerTemplateInstance.Name, metav1.GetOptions{})
-		if err == nil && reflect.DeepEqual(brokerTemplateInstance.Spec, existingBrokerTemplateInstance.Spec) {
+		if err == nil &&
+			brokerTemplateInstance.Spec.TemplateInstance.Kind == existingBrokerTemplateInstance.Spec.TemplateInstance.Kind &&
+			brokerTemplateInstance.Spec.TemplateInstance.Namespace == existingBrokerTemplateInstance.Spec.TemplateInstance.Namespace &&
+			brokerTemplateInstance.Spec.TemplateInstance.Name == existingBrokerTemplateInstance.Spec.TemplateInstance.Name &&
+			brokerTemplateInstance.Spec.Secret.Kind == existingBrokerTemplateInstance.Spec.Secret.Kind &&
+			brokerTemplateInstance.Spec.Secret.Namespace == existingBrokerTemplateInstance.Spec.Secret.Namespace &&
+			brokerTemplateInstance.Spec.Secret.Name == existingBrokerTemplateInstance.Spec.Secret.Name {
 			return existingBrokerTemplateInstance, nil
 		}
 

--- a/pkg/templateservicebroker/servicebroker/servicebroker.go
+++ b/pkg/templateservicebroker/servicebroker/servicebroker.go
@@ -39,6 +39,7 @@ type Broker struct {
 
 var _ api.Broker = &Broker{}
 
+// NewBroker - returns a new Broker
 func NewBroker(saKubeClientConfig *restclient.Config, informer templateinformer.TemplateInformer, namespaces []string) (*Broker, error) {
 	templateNamespaces := map[string]struct{}{}
 	for _, namespace := range namespaces {


### PR DESCRIPTION
Bug 1579194
Bug 1584970
This correctly handles the case when multiple provision requests come in for the same Broker Template Instance.

API changes would be a better solution, however went with this approach, since the migration costs to do the API changes would not be practical at this point.