### PR TITLE
make kubelet client preferred address types configurable

### DIFF
--- a/pkg/cmd/server/apis/config/serialization_test.go
+++ b/pkg/cmd/server/apis/config/serialization_test.go
@@ -79,6 +79,9 @@ func fuzzInternalObject(t *testing.T, forVersion schema.GroupVersion, item runti
 			if len(obj.MasterClients.OpenShiftLoopbackClientConnectionOverrides.ContentType) == 0 {
 				obj.MasterClients.OpenShiftLoopbackClientConnectionOverrides.ContentType = "test/fifth"
 			}
+			if len(obj.KubeletClientInfo.PreferredAddressTypes) == 0 {
+				obj.KubeletClientInfo.PreferredAddressTypes = []string{"Hostname", "InternalIP", "ExternalIP"}
+			}
 
 			// Populate the new NetworkConfig.ServiceNetworkCIDR field from the KubernetesMasterConfig.ServicesSubnet field if needed
 			if len(obj.NetworkConfig.ServiceNetworkCIDR) == 0 {

--- a/pkg/cmd/server/apis/config/types.go
+++ b/pkg/cmd/server/apis/config/types.go
@@ -672,6 +672,8 @@ type KubeletConnectionInfo struct {
 	CA string
 	// CertInfo is the TLS client cert information for securing communication to kubelets
 	ClientCert CertInfo
+	// PreferredAddressTypes is the order of node address types used to connect to the kubelet
+	PreferredAddressTypes []string
 }
 
 type EtcdConnectionInfo struct {

--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -252,6 +252,11 @@ func SetDefaults_GrantConfig(obj *GrantConfig) {
 		obj.ServiceAccountMethod = "prompt"
 	}
 }
+func SetDefaults_KubeletConnectionInfo(obj *KubeletConnectionInfo) {
+	if len(obj.PreferredAddressTypes) == 0 {
+		obj.PreferredAddressTypes = []string{"Hostname", "InternalIP", "ExternalIP"}
+	}
+}
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
 	return scheme.AddConversionFuncs(
@@ -348,6 +353,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 			out.CA = in.CA
 			out.ClientCert.CertFile = in.CertFile
 			out.ClientCert.KeyFile = in.KeyFile
+			out.PreferredAddressTypes = in.PreferredAddressTypes
 			return nil
 		},
 		func(in *internal.KubeletConnectionInfo, out *KubeletConnectionInfo, s conversion.Scope) error {
@@ -355,6 +361,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 			out.CA = in.CA
 			out.CertFile = in.ClientCert.CertFile
 			out.KeyFile = in.ClientCert.KeyFile
+			out.PreferredAddressTypes = in.PreferredAddressTypes
 			return nil
 		},
 		func(in *MasterVolumeConfig, out *internal.MasterVolumeConfig, s conversion.Scope) error {

--- a/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
+++ b/pkg/cmd/server/apis/config/v1/testdata/master-config.yaml
@@ -90,6 +90,10 @@ kubeletClientInfo:
   certFile: ""
   keyFile: ""
   port: 0
+  preferredAddressTypes:
+  - Hostname
+  - InternalIP
+  - ExternalIP
 kubernetesMasterConfig:
   apiLevels: null
   apiServerArguments: null

--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -580,6 +580,8 @@ type KubeletConnectionInfo struct {
 	// CertInfo is the TLS client cert information for securing communication to kubelets
 	// this is anonymous so that we can inline it for serialization
 	CertInfo `json:",inline"`
+	// PreferredAddressTypes is the order of node address types used to connect to the kubelet
+	PreferredAddressTypes []string `json:"preferredAddressTypes"`
 }
 
 // EtcdConnectionInfo holds information necessary for connecting to an etcd server

--- a/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.deepcopy.go
@@ -790,6 +790,11 @@ func (in *KeystonePasswordIdentityProvider) DeepCopyObject() runtime.Object {
 func (in *KubeletConnectionInfo) DeepCopyInto(out *KubeletConnectionInfo) {
 	*out = *in
 	out.CertInfo = in.CertInfo
+	if in.PreferredAddressTypes != nil {
+		in, out := &in.PreferredAddressTypes, &out.PreferredAddressTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1113,7 +1118,7 @@ func (in *MasterConfig) DeepCopyInto(out *MasterConfig) {
 	in.ControllerConfig.DeepCopyInto(&out.ControllerConfig)
 	out.EtcdStorageConfig = in.EtcdStorageConfig
 	in.EtcdClientInfo.DeepCopyInto(&out.EtcdClientInfo)
-	out.KubeletClientInfo = in.KubeletClientInfo
+	in.KubeletClientInfo.DeepCopyInto(&out.KubeletClientInfo)
 	in.KubernetesMasterConfig.DeepCopyInto(&out.KubernetesMasterConfig)
 	if in.EtcdConfig != nil {
 		in, out := &in.EtcdConfig, &out.EtcdConfig

--- a/pkg/cmd/server/apis/config/v1/zz_generated.defaults.go
+++ b/pkg/cmd/server/apis/config/v1/zz_generated.defaults.go
@@ -21,6 +21,7 @@ func SetObjectDefaults_MasterConfig(in *MasterConfig) {
 	SetDefaults_MasterConfig(in)
 	SetDefaults_ServingInfo(&in.ServingInfo.ServingInfo)
 	SetDefaults_EtcdStorageConfig(&in.EtcdStorageConfig)
+	SetDefaults_KubeletConnectionInfo(&in.KubeletClientInfo)
 	SetDefaults_KubernetesMasterConfig(&in.KubernetesMasterConfig)
 	if in.EtcdConfig != nil {
 		SetDefaults_ServingInfo(&in.EtcdConfig.ServingInfo)

--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -474,6 +474,16 @@ func ValidateKubeletConnectionInfo(config configapi.KubeletConnectionInfo, fldPa
 	}
 	allErrs = append(allErrs, ValidateCertInfo(config.ClientCert, false, fldPath)...)
 
+	if len(config.PreferredAddressTypes) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("preferredAddressTypes"), ""))
+	}
+	validAddressTypes := sets.NewString("Hostname", "InternalIP", "ExternalIP", "InternalDNS", "ExternalDNS")
+	for _, preferredAddressType := range config.PreferredAddressTypes {
+		if !validAddressTypes.Has(preferredAddressType) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("preferredAddressTypes"), preferredAddressType, "not one of "+strings.Join(validAddressTypes.List(), ", ")))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
+++ b/pkg/cmd/server/apis/config/zz_generated.deepcopy.go
@@ -900,6 +900,11 @@ func (in *KeystonePasswordIdentityProvider) DeepCopyObject() runtime.Object {
 func (in *KubeletConnectionInfo) DeepCopyInto(out *KubeletConnectionInfo) {
 	*out = *in
 	out.ClientCert = in.ClientCert
+	if in.PreferredAddressTypes != nil {
+		in, out := &in.PreferredAddressTypes, &out.PreferredAddressTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1237,7 +1242,7 @@ func (in *MasterConfig) DeepCopyInto(out *MasterConfig) {
 	in.ControllerConfig.DeepCopyInto(&out.ControllerConfig)
 	out.EtcdStorageConfig = in.EtcdStorageConfig
 	in.EtcdClientInfo.DeepCopyInto(&out.EtcdClientInfo)
-	out.KubeletClientInfo = in.KubeletClientInfo
+	in.KubeletClientInfo.DeepCopyInto(&out.KubeletClientInfo)
 	in.KubernetesMasterConfig.DeepCopyInto(&out.KubernetesMasterConfig)
 	if in.EtcdConfig != nil {
 		in, out := &in.EtcdConfig, &out.EtcdConfig

--- a/pkg/cmd/server/kubernetes/node/client/client.go
+++ b/pkg/cmd/server/kubernetes/node/client/client.go
@@ -9,11 +9,7 @@ import (
 func GetKubeletClientConfig(options configapi.MasterConfig) *kubeletclient.KubeletClientConfig {
 	config := &kubeletclient.KubeletClientConfig{
 		Port: options.KubeletClientInfo.Port,
-		PreferredAddressTypes: []string{
-			string("Hostname"),
-			string("InternalIP"),
-			string("ExternalIP"),
-		},
+		PreferredAddressTypes: options.KubeletClientInfo.PreferredAddressTypes,
 	}
 
 	if len(options.KubeletClientInfo.CA) > 0 {


### PR DESCRIPTION
OpenShift on Azure deployments need to be able to connect to kubelets via IP, not Hostname, hence adding the preferred address types configurable.  This matches existing Kubernetes behaviour.