### PR TITLE
Make ReconcileSCCOptions.ChangedSCCs return separate constraints slices

### DIFF
--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/scc.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/scc.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	kerrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/authorization"
 	authorizationtypedclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
@@ -59,36 +57,35 @@ func (d *SCC) Check() types.DiagnosticResult {
 		InfraNamespace: bootstrappolicy.DefaultOpenShiftInfraNamespace,
 	}
 
-	changedSCCs, err := reconcileOptions.ChangedSCCs()
+	newSCCs, changedSCCs, err := reconcileOptions.ChangedSCCs()
 	if err != nil {
 		r.Error("CSD1000", err, fmt.Sprintf("Error inspecting SCCs: %v", err))
 		return r
 	}
+	for _, newSCC := range newSCCs {
+		r.Error("CSD1001", nil, fmt.Sprintf("scc/%s is missing.\n\nUse the `oc adm policy reconcile-sccs` command to recreate sccs.", newSCC.Name))
+	}
 	changedSCCNames := map[string]bool{}
 	for _, changedSCC := range changedSCCs {
-		_, err := d.SCCClient.Get(changedSCC.Name, metav1.GetOptions{})
-		if kerrs.IsNotFound(err) {
-			r.Error("CSD1001", nil, fmt.Sprintf("scc/%s is missing.\n\nUse the `oc adm policy reconcile-sccs` command to recreate sccs.", changedSCC.Name))
-			continue
-		}
-		if err != nil {
-			r.Error("CSD1002", err, fmt.Sprintf("Unable to get scc/%s: %v", changedSCC.Name, err))
-			continue
-		}
 		r.Warn("CSD1003", nil, fmt.Sprintf("scc/%s will be reconciled. Use the `oc adm policy reconcile-sccs` command to check sccs.", changedSCC.Name))
 		changedSCCNames[changedSCC.Name] = true
 	}
 
 	// Including non-additive SCCs, but output messages with debug level.
 	reconcileOptions.Union = false
-	changedSCCs, err = reconcileOptions.ChangedSCCs()
+	newSCCsUnion, changedSCCsUnion, err := reconcileOptions.ChangedSCCs()
 	if err != nil {
 		r.Error("CSD1000", err, fmt.Sprintf("Error inspecting SCCs: %v", err))
 		return r
 	}
-	for _, changedSCC := range changedSCCs {
+
+	defaultsErrMsgFmt := "scc/%s does not match defaults. Use the `oc adm policy reconcile-sccs --additive-only=false` command to check sccs."
+	for _, newSCC := range newSCCsUnion {
+		r.Debug("CSD1004", fmt.Sprintf(defaultsErrMsgFmt, newSCC.Name))
+	}
+	for _, changedSCC := range changedSCCsUnion {
 		if !changedSCCNames[changedSCC.Name] {
-			r.Debug("CSD1004", fmt.Sprintf("scc/%s does not match defaults. Use the `oc adm policy reconcile-sccs --additive-only=false` command to check sccs.", changedSCC.Name))
+			r.Debug("CSD1004", fmt.Sprintf(defaultsErrMsgFmt, changedSCC.Name))
 		}
 	}
 	return r

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/scc.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/scc.go
@@ -73,19 +73,15 @@ func (d *SCC) Check() types.DiagnosticResult {
 
 	// Including non-additive SCCs, but output messages with debug level.
 	reconcileOptions.Union = false
-	newSCCsUnion, changedSCCsUnion, err := reconcileOptions.ChangedSCCs()
+	_, changedSCCsUnion, err := reconcileOptions.ChangedSCCs()
 	if err != nil {
 		r.Error("CSD1000", err, fmt.Sprintf("Error inspecting SCCs: %v", err))
 		return r
 	}
 
-	defaultsErrMsgFmt := "scc/%s does not match defaults. Use the `oc adm policy reconcile-sccs --additive-only=false` command to check sccs."
-	for _, newSCC := range newSCCsUnion {
-		r.Debug("CSD1004", fmt.Sprintf(defaultsErrMsgFmt, newSCC.Name))
-	}
 	for _, changedSCC := range changedSCCsUnion {
 		if !changedSCCNames[changedSCC.Name] {
-			r.Debug("CSD1004", fmt.Sprintf(defaultsErrMsgFmt, changedSCC.Name))
+			r.Debug("CSD1004", fmt.Sprintf("scc/%s does not match defaults. Use the `oc adm policy reconcile-sccs --additive-only=false` command to check sccs.", changedSCC.Name))
 		}
 	}
 	return r


### PR DESCRIPTION
Refactored `ReconcileSCCOptions.ChangedSCCs` to return two separate
`SecurityContextConstraints` arrays, one representing the SCCs
that need to be created, one that need to be updated to match
the recommended bootstrap SCCs.

The refactoring makes the code avoid unnecessary prodding of the server
for the existence of an SCC.

-----
Rebased on top of https://github.com/openshift/origin/pull/19610, requested in https://github.com/openshift/origin/pull/19610#discussion_r195723544