### PR TITLE
ssc: fix the case when secret is gone and service has signer annotation

### DIFF
--- a/pkg/service/controller/servingcert/secret_creating_controller_test.go
+++ b/pkg/service/controller/servingcert/secret_creating_controller_test.go
@@ -426,8 +426,11 @@ func TestSkipGenerationControllerFlow(t *testing.T) {
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
 	namespace := "ns"
+	secret := &v1.Secret{}
+	secret.Name = expectedSecretName
+	secret.Namespace = namespace
 
-	caName, kubeclient, fakeWatch, _, controller, informerFactory := controllerSetup([]runtime.Object{}, stopChannel, t)
+	caName, kubeclient, fakeWatch, _, controller, informerFactory := controllerSetup([]runtime.Object{secret}, stopChannel, t)
 	kubeclient.PrependReactor("update", "service", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, &v1.Service{}, kapierrors.NewForbidden(v1.Resource("fdsa"), "new-service", fmt.Errorf("any service reason"))
 	})

--- a/pkg/service/controller/servingcert/secret_updating_controller.go
+++ b/pkg/service/controller/servingcert/secret_updating_controller.go
@@ -52,7 +52,7 @@ func NewServiceServingCertUpdateController(services informers.ServiceInformer, s
 	sc := &ServiceServingCertUpdateController{
 		secretClient: secretClient,
 
-		queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "service-serving-cert-update"),
 
 		ca:        ca,
 		dnsSuffix: dnsSuffix,


### PR DESCRIPTION
Fix the case when the service is left with `serving-cert-signed-by` annotation and the secret is removed and never recreated again.
