### PR TITLE
UPSTREAM: <carry>: gracefully handle empty volume-config file

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kubelet/app/patch_volumequota.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubelet/app/patch_volumequota.go
@@ -55,7 +55,11 @@ func PatchVolumePluginsForLocalQuota(rootdir string, plugins *[]volume.VolumePlu
 	// node and volume config files out of the same configmap
 	volumeConfigFilePath := "/etc/origin/node/volume-config.yaml"
 
-	if _, err := os.Stat(volumeConfigFilePath); os.IsNotExist(err) {
+	stat, err := os.Stat(volumeConfigFilePath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if stat.Size() == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Follow-on carry to https://github.com/openshift/origin/pull/19533

Gracefully handle an empty `volume-config.yaml` file.
 
xref https://bugzilla.redhat.com/show_bug.cgi?id=1596439

@derekwaynecarr @jupierce 