### PR TITLE
Migrate egress IP tracking code to pkg/network/common

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -1,0 +1,404 @@
+package common
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+
+	networkapi "github.com/openshift/origin/pkg/network/apis/network"
+	networkinformers "github.com/openshift/origin/pkg/network/generated/informers/internalversion/network/internalversion"
+	"github.com/openshift/origin/pkg/util/netutils"
+)
+
+type nodeEgress struct {
+	nodeIP       string
+	sdnIP        string
+	requestedIPs sets.String
+	offline      bool
+}
+
+type namespaceEgress struct {
+	vnid         uint32
+	requestedIPs []string
+
+	activeEgressIP string
+}
+
+type egressIPInfo struct {
+	ip string
+
+	nodes      []*nodeEgress
+	namespaces []*namespaceEgress
+
+	assignedNodeIP string
+	assignedVNID   uint32
+}
+
+type EgressIPWatcher interface {
+	ClaimEgressIP(vnid uint32, egressIP, nodeIP string)
+	ReleaseEgressIP(egressIP, nodeIP string)
+
+	SetNamespaceEgressNormal(vnid uint32)
+	SetNamespaceEgressDropped(vnid uint32)
+	SetNamespaceEgressViaEgressIP(vnid uint32, egressIP, nodeIP string)
+}
+
+type EgressIPTracker struct {
+	sync.Mutex
+
+	watcher EgressIPWatcher
+
+	nodesByNodeIP    map[string]*nodeEgress
+	namespacesByVNID map[uint32]*namespaceEgress
+	egressIPs        map[string]*egressIPInfo
+
+	changedEgressIPs  map[*egressIPInfo]bool
+	changedNamespaces map[*namespaceEgress]bool
+}
+
+func NewEgressIPTracker(watcher EgressIPWatcher) *EgressIPTracker {
+	return &EgressIPTracker{
+		watcher: watcher,
+
+		nodesByNodeIP:    make(map[string]*nodeEgress),
+		namespacesByVNID: make(map[uint32]*namespaceEgress),
+		egressIPs:        make(map[string]*egressIPInfo),
+
+		changedEgressIPs:  make(map[*egressIPInfo]bool),
+		changedNamespaces: make(map[*namespaceEgress]bool),
+	}
+}
+
+func (eit *EgressIPTracker) Start(hostSubnetInformer networkinformers.HostSubnetInformer, netNamespaceInformer networkinformers.NetNamespaceInformer) {
+	eit.watchHostSubnets(hostSubnetInformer)
+	eit.watchNetNamespaces(netNamespaceInformer)
+}
+
+func (eit *EgressIPTracker) ensureEgressIPInfo(egressIP string) *egressIPInfo {
+	eg := eit.egressIPs[egressIP]
+	if eg == nil {
+		eg = &egressIPInfo{ip: egressIP}
+		eit.egressIPs[egressIP] = eg
+	}
+	return eg
+}
+
+func (eit *EgressIPTracker) egressIPChanged(eg *egressIPInfo) {
+	eit.changedEgressIPs[eg] = true
+	for _, ns := range eg.namespaces {
+		eit.changedNamespaces[ns] = true
+	}
+}
+
+func (eit *EgressIPTracker) addNodeEgressIP(node *nodeEgress, egressIP string) {
+	eg := eit.ensureEgressIPInfo(egressIP)
+	eg.nodes = append(eg.nodes, node)
+
+	eit.egressIPChanged(eg)
+}
+
+func (eit *EgressIPTracker) deleteNodeEgressIP(node *nodeEgress, egressIP string) {
+	eg := eit.egressIPs[egressIP]
+	if eg == nil {
+		return
+	}
+
+	for i := range eg.nodes {
+		if eg.nodes[i] == node {
+			eit.egressIPChanged(eg)
+			eg.nodes = append(eg.nodes[:i], eg.nodes[i+1:]...)
+			return
+		}
+	}
+}
+
+func (eit *EgressIPTracker) addNamespaceEgressIP(ns *namespaceEgress, egressIP string) {
+	eg := eit.ensureEgressIPInfo(egressIP)
+	eg.namespaces = append(eg.namespaces, ns)
+
+	eit.egressIPChanged(eg)
+}
+
+func (eit *EgressIPTracker) deleteNamespaceEgressIP(ns *namespaceEgress, egressIP string) {
+	eg := eit.egressIPs[egressIP]
+	if eg == nil {
+		return
+	}
+
+	for i := range eg.namespaces {
+		if eg.namespaces[i] == ns {
+			eit.egressIPChanged(eg)
+			eg.namespaces = append(eg.namespaces[:i], eg.namespaces[i+1:]...)
+			return
+		}
+	}
+}
+
+func (eit *EgressIPTracker) watchHostSubnets(hostSubnetInformer networkinformers.HostSubnetInformer) {
+	funcs := InformerFuncs(&networkapi.HostSubnet{}, eit.handleAddOrUpdateHostSubnet, eit.handleDeleteHostSubnet)
+	hostSubnetInformer.Informer().AddEventHandler(funcs)
+}
+
+func (eit *EgressIPTracker) handleAddOrUpdateHostSubnet(obj, _ interface{}, eventType watch.EventType) {
+	hs := obj.(*networkapi.HostSubnet)
+	glog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
+
+	eit.UpdateHostSubnetEgress(hs)
+}
+
+func (eit *EgressIPTracker) handleDeleteHostSubnet(obj interface{}) {
+	hs := obj.(*networkapi.HostSubnet)
+	glog.V(5).Infof("Watch %s event for HostSubnet %q", watch.Deleted, hs.Name)
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		HostIP: hs.HostIP,
+	})
+}
+
+func (eit *EgressIPTracker) UpdateHostSubnetEgress(hs *networkapi.HostSubnet) {
+	eit.Lock()
+	defer eit.Unlock()
+
+	sdnIP := ""
+	if hs.Subnet != "" {
+		_, cidr, err := net.ParseCIDR(hs.Subnet)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("could not parse HostSubnet %q CIDR: %v", hs.Name, err))
+		}
+		sdnIP = netutils.GenerateDefaultGateway(cidr).String()
+	}
+
+	node := eit.nodesByNodeIP[hs.HostIP]
+	if node == nil {
+		if len(hs.EgressIPs) == 0 {
+			return
+		}
+		node = &nodeEgress{
+			nodeIP:       hs.HostIP,
+			sdnIP:        sdnIP,
+			requestedIPs: sets.NewString(),
+		}
+		eit.nodesByNodeIP[hs.HostIP] = node
+	} else if len(hs.EgressIPs) == 0 {
+		delete(eit.nodesByNodeIP, hs.HostIP)
+	}
+	oldRequestedIPs := node.requestedIPs
+	node.requestedIPs = sets.NewString(hs.EgressIPs...)
+
+	// Process new and removed EgressIPs
+	for _, ip := range node.requestedIPs.Difference(oldRequestedIPs).UnsortedList() {
+		eit.addNodeEgressIP(node, ip)
+	}
+	for _, ip := range oldRequestedIPs.Difference(node.requestedIPs).UnsortedList() {
+		eit.deleteNodeEgressIP(node, ip)
+	}
+
+	eit.syncEgressIPs()
+}
+
+func (eit *EgressIPTracker) watchNetNamespaces(netNamespaceInformer networkinformers.NetNamespaceInformer) {
+	funcs := InformerFuncs(&networkapi.NetNamespace{}, eit.handleAddOrUpdateNetNamespace, eit.handleDeleteNetNamespace)
+	netNamespaceInformer.Informer().AddEventHandler(funcs)
+}
+
+func (eit *EgressIPTracker) handleAddOrUpdateNetNamespace(obj, _ interface{}, eventType watch.EventType) {
+	netns := obj.(*networkapi.NetNamespace)
+	glog.V(5).Infof("Watch %s event for NetNamespace %q", eventType, netns.Name)
+
+	eit.UpdateNetNamespaceEgress(netns)
+}
+
+func (eit *EgressIPTracker) handleDeleteNetNamespace(obj interface{}) {
+	netns := obj.(*networkapi.NetNamespace)
+	glog.V(5).Infof("Watch %s event for NetNamespace %q", watch.Deleted, netns.Name)
+
+	eit.DeleteNetNamespaceEgress(netns.NetID)
+}
+
+func (eit *EgressIPTracker) UpdateNetNamespaceEgress(netns *networkapi.NetNamespace) {
+	eit.Lock()
+	defer eit.Unlock()
+
+	ns := eit.namespacesByVNID[netns.NetID]
+	if ns == nil {
+		if len(netns.EgressIPs) == 0 {
+			return
+		}
+		ns = &namespaceEgress{vnid: netns.NetID}
+		eit.namespacesByVNID[netns.NetID] = ns
+	} else if len(netns.EgressIPs) == 0 {
+		delete(eit.namespacesByVNID, netns.NetID)
+	}
+
+	oldRequestedIPs := sets.NewString(ns.requestedIPs...)
+	newRequestedIPs := sets.NewString(netns.EgressIPs...)
+	ns.requestedIPs = netns.EgressIPs
+
+	// Process new and removed EgressIPs
+	for _, ip := range newRequestedIPs.Difference(oldRequestedIPs).UnsortedList() {
+		eit.addNamespaceEgressIP(ns, ip)
+	}
+	for _, ip := range oldRequestedIPs.Difference(newRequestedIPs).UnsortedList() {
+		eit.deleteNamespaceEgressIP(ns, ip)
+	}
+
+	// Even IPs that weren't added/removed need to be considered "changed", to
+	// ensure we correctly process reorderings, duplicates added/removed, etc.
+	for _, ip := range newRequestedIPs.Intersection(oldRequestedIPs).UnsortedList() {
+		eit.egressIPChanged(eit.egressIPs[ip])
+	}
+
+	eit.syncEgressIPs()
+}
+
+func (eit *EgressIPTracker) DeleteNetNamespaceEgress(vnid uint32) {
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetID: vnid,
+	})
+}
+
+func (eit *EgressIPTracker) egressIPActive(eg *egressIPInfo) (bool, error) {
+	if len(eg.nodes) == 0 || len(eg.namespaces) == 0 {
+		return false, nil
+	}
+	if len(eg.nodes) > 1 {
+		return false, fmt.Errorf("Multiple nodes (%s, %s) claiming EgressIP %s", eg.nodes[0].nodeIP, eg.nodes[1].nodeIP, eg.ip)
+	}
+	if len(eg.namespaces) > 1 {
+		return false, fmt.Errorf("Multiple namespaces (%d, %d) claiming EgressIP %s", eg.namespaces[0].vnid, eg.namespaces[1].vnid, eg.ip)
+	}
+	for _, ip := range eg.namespaces[0].requestedIPs {
+		eg2 := eit.egressIPs[ip]
+		if eg2 != eg && len(eg2.nodes) == 1 && eg2.nodes[0] == eg.nodes[0] {
+			return false, fmt.Errorf("Multiple EgressIPs (%s, %s) for VNID %d on node %s", eg.ip, eg2.ip, eg.namespaces[0].vnid, eg.nodes[0].nodeIP)
+		}
+	}
+	return true, nil
+}
+
+func (eit *EgressIPTracker) syncEgressIPs() {
+	changedEgressIPs := eit.changedEgressIPs
+	eit.changedEgressIPs = make(map[*egressIPInfo]bool)
+
+	changedNamespaces := eit.changedNamespaces
+	eit.changedNamespaces = make(map[*namespaceEgress]bool)
+
+	for eg := range changedEgressIPs {
+		active, err := eit.egressIPActive(eg)
+		if err != nil {
+			utilruntime.HandleError(err)
+		}
+		eit.syncEgressNodeState(eg, active)
+	}
+
+	for ns := range changedNamespaces {
+		eit.syncEgressNamespaceState(ns)
+	}
+}
+
+func (eit *EgressIPTracker) syncEgressNodeState(eg *egressIPInfo, active bool) {
+	if active && eg.assignedNodeIP != eg.nodes[0].nodeIP {
+		glog.V(4).Infof("Assigning egress IP %s to node %s", eg.ip, eg.nodes[0].nodeIP)
+		eg.assignedNodeIP = eg.nodes[0].nodeIP
+		eit.watcher.ClaimEgressIP(eg.namespaces[0].vnid, eg.ip, eg.assignedNodeIP)
+	} else if !active && eg.assignedNodeIP != "" {
+		glog.V(4).Infof("Removing egress IP %s from node %s", eg.ip, eg.assignedNodeIP)
+		eit.watcher.ReleaseEgressIP(eg.ip, eg.assignedNodeIP)
+		eg.assignedNodeIP = ""
+	}
+}
+
+func (eit *EgressIPTracker) syncEgressNamespaceState(ns *namespaceEgress) {
+	if len(ns.requestedIPs) == 0 {
+		if ns.activeEgressIP != "" {
+			ns.activeEgressIP = ""
+			eit.watcher.SetNamespaceEgressNormal(ns.vnid)
+		}
+		return
+	}
+
+	var active *egressIPInfo
+	for _, ip := range ns.requestedIPs {
+		eg := eit.egressIPs[ip]
+		if eg == nil {
+			continue
+		}
+		if len(eg.namespaces) > 1 {
+			active = nil
+			glog.V(4).Infof("VNID %d gets no egress due to multiply-assigned egress IP %s", ns.vnid, eg.ip)
+			break
+		}
+		if active == nil {
+			if eg.assignedNodeIP == "" {
+				glog.V(4).Infof("VNID %d cannot use unassigned egress IP %s", ns.vnid, eg.ip)
+			} else if len(ns.requestedIPs) > 1 && eg.nodes[0].offline {
+				glog.V(4).Infof("VNID %d cannot use egress IP %s on offline node %s", ns.vnid, eg.ip, eg.assignedNodeIP)
+			} else {
+				active = eg
+			}
+		}
+	}
+
+	if active != nil {
+		if ns.activeEgressIP != active.ip {
+			ns.activeEgressIP = active.ip
+			eit.watcher.SetNamespaceEgressViaEgressIP(ns.vnid, active.ip, active.assignedNodeIP)
+		}
+	} else {
+		if ns.activeEgressIP != "dropped" {
+			ns.activeEgressIP = "dropped"
+			eit.watcher.SetNamespaceEgressDropped(ns.vnid)
+		}
+	}
+}
+
+func (eit *EgressIPTracker) SetNodeOffline(nodeIP string, offline bool) {
+	eit.Lock()
+	defer eit.Unlock()
+
+	node := eit.nodesByNodeIP[nodeIP]
+	if node == nil {
+		return
+	}
+
+	node.offline = offline
+	for _, ip := range node.requestedIPs.UnsortedList() {
+		eg := eit.egressIPs[ip]
+		if eg != nil {
+			eit.egressIPChanged(eg)
+		}
+	}
+	eit.syncEgressIPs()
+}
+
+// Ping a node and return whether or not it is online. We do this by trying to open a TCP
+// connection to the "discard" service (port 9); if the node is offline, the attempt will
+// time out with no response (and we will return false). If the node is online then we
+// presumably will get a "connection refused" error; the code below assumes that anything
+// other than timing out indicates that the node is online.
+func (eit *EgressIPTracker) Ping(ip string, timeout time.Duration) bool {
+	eit.Lock()
+	defer eit.Unlock()
+
+	// If the caller used a public node IP, replace it with the SDN IP
+	if node := eit.nodesByNodeIP[ip]; node != nil {
+		ip = node.sdnIP
+	}
+
+	conn, err := net.DialTimeout("tcp", ip+":9", timeout)
+	if conn != nil {
+		conn.Close()
+	}
+	if opErr, ok := err.(*net.OpError); ok && opErr.Timeout() {
+		return false
+	} else {
+		return true
+	}
+}

--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -1,0 +1,744 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	networkapi "github.com/openshift/origin/pkg/network/apis/network"
+)
+
+type testEIPWatcher struct {
+	changes []string
+}
+
+func (w *testEIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) {
+	w.changes = append(w.changes, fmt.Sprintf("claim %s on %s for namespace %d", egressIP, nodeIP, vnid))
+}
+
+func (w *testEIPWatcher) ReleaseEgressIP(egressIP, nodeIP string) {
+	w.changes = append(w.changes, fmt.Sprintf("release %s on %s", egressIP, nodeIP))
+}
+
+func (w *testEIPWatcher) SetNamespaceEgressNormal(vnid uint32) {
+	w.changes = append(w.changes, fmt.Sprintf("namespace %d normal", int(vnid)))
+}
+
+func (w *testEIPWatcher) SetNamespaceEgressDropped(vnid uint32) {
+	w.changes = append(w.changes, fmt.Sprintf("namespace %d dropped", int(vnid)))
+}
+
+func (w *testEIPWatcher) SetNamespaceEgressViaEgressIP(vnid uint32, egressIP, nodeIP string) {
+	w.changes = append(w.changes, fmt.Sprintf("namespace %d via %s on %s", int(vnid), egressIP, nodeIP))
+}
+
+func (w *testEIPWatcher) assertChanges(expected ...string) error {
+	changed := w.changes
+	w.changes = []string{}
+	missing := []string{}
+
+	for len(expected) > 0 {
+		exp := expected[0]
+		expected = expected[1:]
+		for i, ch := range changed {
+			if ch == exp {
+				changed = append(changed[:i], changed[i+1:]...)
+				exp = ""
+				break
+			}
+		}
+		if exp != "" {
+			missing = append(missing, exp)
+		}
+	}
+
+	if len(changed) > 0 && len(missing) > 0 {
+		return fmt.Errorf("unexpected changes %#v, missing changes %#v", changed, missing)
+	} else if len(changed) > 0 {
+		return fmt.Errorf("unexpected changes %#v", changed)
+	} else if len(missing) > 0 {
+		return fmt.Errorf("missing changes %#v", missing)
+	} else {
+		return nil
+	}
+}
+
+func (w *testEIPWatcher) assertNoChanges() error {
+	return w.assertChanges()
+}
+
+func setupEgressIPTracker(t *testing.T) (*EgressIPTracker, *testEIPWatcher) {
+	watcher := &testEIPWatcher{}
+	return NewEgressIPTracker(watcher), watcher
+}
+
+func TestEgressIP(t *testing.T) {
+	eit, w := setupEgressIPTracker(t)
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:   "node-3",
+		HostIP: "172.17.0.3",
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:   "node-4",
+		HostIP: "172.17.0.4",
+	})
+	eit.DeleteNetNamespaceEgress(42)
+	eit.DeleteNetNamespaceEgress(43)
+
+	// No namespaces use egress yet, so should be no changes
+	err := w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assign NetNamespace.EgressIP first, then HostSubnet.EgressIP
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"namespace 42 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"}, // Added .100
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assign HostSubnet.EgressIP first, then NetNamespace.EgressIP
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100", "172.17.0.101"}, // Added .101
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-5",
+		HostIP:    "172.17.0.5",
+		EgressIPs: []string{"172.17.0.105"},
+	})
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-43",
+		NetID:     43,
+		EgressIPs: []string{"172.17.0.105"},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.105 on 172.17.0.5 for namespace 43",
+		"namespace 43 via 172.17.0.105 on 172.17.0.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Change NetNamespace.EgressIP
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-43",
+		NetID:     43,
+		EgressIPs: []string{"172.17.0.101"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.105 on 172.17.0.5",
+		"claim 172.17.0.101 on 172.17.0.3 for namespace 43",
+		"namespace 43 via 172.17.0.101 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assign another EgressIP...
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-44",
+		NetID:     44,
+		EgressIPs: []string{"172.17.0.104"},
+	})
+	err = w.assertChanges(
+		"namespace 44 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.102", "172.17.0.104"}, // Added .102, .104
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.104 on 172.17.0.4 for namespace 44",
+		"namespace 44 via 172.17.0.104 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Change Namespace EgressIP
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-44",
+		NetID:     44,
+		EgressIPs: []string{"172.17.0.102"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.104 on 172.17.0.4",
+		"claim 172.17.0.102 on 172.17.0.4 for namespace 44",
+		"namespace 44 via 172.17.0.102 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assign HostSubnet.EgressIP first, then NetNamespace.EgressIP
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.102", "172.17.0.103"}, // Added .103, Dropped .104
+	})
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-45",
+		NetID:     45,
+		EgressIPs: []string{"172.17.0.103"},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.103 on 172.17.0.4 for namespace 45",
+		"namespace 45 via 172.17.0.103 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Drop namespace EgressIP
+	eit.DeleteNetNamespaceEgress(44)
+	err = w.assertChanges(
+		"release 172.17.0.102 on 172.17.0.4",
+		"namespace 44 normal",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Add namespace EgressIP back again after having removed it...
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-44",
+		NetID:     44,
+		EgressIPs: []string{"172.17.0.102"},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.102 on 172.17.0.4 for namespace 44",
+		"namespace 44 via 172.17.0.102 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Drop node EgressIPs
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"}, // Dropped .101
+	})
+	err = w.assertChanges(
+		"release 172.17.0.101 on 172.17.0.3",
+		"namespace 43 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.102"}, // Dropped .103
+	})
+	err = w.assertChanges(
+		"release 172.17.0.103 on 172.17.0.4",
+		"namespace 45 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Add them back, swapped
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100", "172.17.0.103"}, // Added .103
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.103 on 172.17.0.3 for namespace 45",
+		"namespace 45 via 172.17.0.103 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.101", "172.17.0.102"}, // Added .101
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.101 on 172.17.0.4 for namespace 43",
+		"namespace 43 via 172.17.0.101 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestMultipleNamespaceEgressIPs(t *testing.T) {
+	eit, w := setupEgressIPTracker(t)
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err := w.assertChanges(
+		// after UpdateNamespaceEgress()
+		"namespace 42 dropped",
+		// after UpdateHostSubnetEgress()
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Prepending a second, unavailable, namespace egress IP should have no effect
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.101", "172.17.0.100"},
+	})
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now assigning that IP to a node should switch OVS to use that since it's first in the list
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.101"},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.101 on 172.17.0.4 for namespace 42",
+		"namespace 42 via 172.17.0.101 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Swapping the order in the NetNamespace should swap back
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100", "172.17.0.101"},
+	})
+	err = w.assertChanges(
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the inactive egress IP from its node should have no effect
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.200"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.101 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the remaining egress IP should now kill the namespace
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.100 on 172.17.0.3",
+		"namespace 42 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now add the egress IPs back...
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.101"},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"claim 172.17.0.101 on 172.17.0.4 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Assigning either the used or the unused Egress IP to another namespace should
+	// break this namespace
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-43",
+		NetID:     43,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.100 on 172.17.0.3",
+		"namespace 42 dropped",
+		"namespace 43 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.DeleteNetNamespaceEgress(43)
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+		"namespace 43 normal",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-44",
+		NetID:     44,
+		EgressIPs: []string{"172.17.0.101"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.101 on 172.17.0.4",
+		"namespace 42 dropped",
+		"namespace 44 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.DeleteNetNamespaceEgress(44)
+	err = w.assertChanges(
+		"claim 172.17.0.101 on 172.17.0.4 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+		"namespace 44 normal",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestDuplicateNodeEgressIPs(t *testing.T) {
+	eit, w := setupEgressIPTracker(t)
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err := w.assertChanges(
+		// after UpdateNamespaceEgress()
+		"namespace 42 dropped",
+		// after UpdateHostSubnetEgress()
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Adding the Egress IP to another node should not work and should cause the
+	// namespace to start dropping traffic. (And in particular, should not result
+	// in a ClaimEgressIP for the new IP.)
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.100 on 172.17.0.3",
+		"namespace 42 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the duplicate node egressIP should restore traffic to the broken namespace
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// As above, but with a different node IP
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-5",
+		HostIP:    "172.17.0.5",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.100 on 172.17.0.3",
+		"namespace 42 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the egress IP from the namespace and then adding it back should result
+	// in it still being broken.
+	eit.DeleteNetNamespaceEgress(42)
+	err = w.assertChanges(
+		"namespace 42 normal",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"namespace 42 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the original egress node should result in the "duplicate" egress node
+	// now being used.
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{},
+	})
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.5 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestDuplicateNamespaceEgressIPs(t *testing.T) {
+	eit, w := setupEgressIPTracker(t)
+
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err := w.assertChanges(
+		// after UpdateNamespaceEgress()
+		"namespace 42 dropped",
+		// after UpdateHostSubnetEgress()
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Adding the Egress IP to another namespace should not work and should cause both
+	// namespaces to start dropping traffic.
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-43",
+		NetID:     43,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.100 on 172.17.0.3",
+		"namespace 42 dropped",
+		"namespace 43 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the duplicate should cause the original to start working again
+	eit.DeleteNetNamespaceEgress(43)
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+		"namespace 43 normal",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Add duplicate back, re-breaking it
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-43",
+		NetID:     43,
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertChanges(
+		"release 172.17.0.100 on 172.17.0.3",
+		"namespace 42 dropped",
+		"namespace 43 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now remove and re-add the Node EgressIP; the namespace should stay broken
+	// whether the IP is assigned to a node or not.
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{},
+	})
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Removing the egress IP from the original namespace should result in it being
+	// given to the "duplicate" namespace
+	eit.DeleteNetNamespaceEgress(42)
+	err = w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 43",
+		"namespace 42 normal",
+		"namespace 43 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestOfflineEgressIPs(t *testing.T) {
+	eit, w := setupEgressIPTracker(t)
+
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-3",
+		HostIP:    "172.17.0.3",
+		EgressIPs: []string{"172.17.0.100"},
+	})
+	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		Host:      "node-4",
+		HostIP:    "172.17.0.4",
+		EgressIPs: []string{"172.17.0.101"},
+	})
+	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		NetName:   "ns-42",
+		NetID:     42,
+		EgressIPs: []string{"172.17.0.100", "172.17.0.101"},
+	})
+	err := w.assertChanges(
+		"claim 172.17.0.100 on 172.17.0.3 for namespace 42",
+		"claim 172.17.0.101 on 172.17.0.4 for namespace 42",
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// If the primary goes offline, fall back to the secondary
+	eit.SetNodeOffline("172.17.0.3", true)
+	err = w.assertChanges(
+		"namespace 42 via 172.17.0.101 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// If the secondary also goes offline, then we lose
+	eit.SetNodeOffline("172.17.0.4", true)
+	err = w.assertChanges(
+		"namespace 42 dropped",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// If the secondary comes back, use it
+	eit.SetNodeOffline("172.17.0.4", false)
+	err = w.assertChanges(
+		"namespace 42 via 172.17.0.101 on 172.17.0.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// If the primary comes back, use it in preference to the secondary
+	eit.SetNodeOffline("172.17.0.3", false)
+	err = w.assertChanges(
+		"namespace 42 via 172.17.0.100 on 172.17.0.3",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// If the secondary goes offline now, we don't care
+	eit.SetNodeOffline("172.17.0.4", true)
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -9,56 +9,25 @@ import (
 	"github.com/golang/glog"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/watch"
 
-	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 	"github.com/openshift/origin/pkg/network/common"
 	networkinformers "github.com/openshift/origin/pkg/network/generated/informers/internalversion"
-	"github.com/openshift/origin/pkg/util/netutils"
-
 	"github.com/vishvananda/netlink"
 )
 
-type nodeEgress struct {
-	nodeIP       string
-	sdnIP        string
-	requestedIPs sets.String
-	offline      bool
-}
-
-type namespaceEgress struct {
-	vnid         uint32
-	requestedIPs []string
-}
-
-type egressIPInfo struct {
-	ip string
-
-	nodes      []*nodeEgress
-	namespaces []*namespaceEgress
-
-	assignedNodeIP       string
-	assignedIPTablesMark string
-}
-
 type egressIPWatcher struct {
 	sync.Mutex
+
+	tracker *common.EgressIPTracker
 
 	oc            *ovsController
 	localIP       string
 	masqueradeBit uint32
 
-	networkInformers networkinformers.SharedInformerFactory
-	iptables         *NodeIPTables
-	vxlanMonitor     *egressVXLANMonitor
+	iptables     *NodeIPTables
+	iptablesMark map[string]string
 
-	nodesByNodeIP    map[string]*nodeEgress
-	namespacesByVNID map[uint32]*namespaceEgress
-	egressIPs        map[string]*egressIPInfo
-
-	changedEgressIPs  map[*egressIPInfo]bool
-	changedNamespaces map[*namespaceEgress]bool
+	vxlanMonitor *egressVXLANMonitor
 
 	localEgressLink netlink.Link
 	localEgressNet  *net.IPNet
@@ -71,16 +40,13 @@ func newEgressIPWatcher(oc *ovsController, localIP string, masqueradeBit *int32)
 		oc:      oc,
 		localIP: localIP,
 
-		nodesByNodeIP:    make(map[string]*nodeEgress),
-		namespacesByVNID: make(map[uint32]*namespaceEgress),
-		egressIPs:        make(map[string]*egressIPInfo),
-
-		changedEgressIPs:  make(map[*egressIPInfo]bool),
-		changedNamespaces: make(map[*namespaceEgress]bool),
+		iptablesMark: make(map[string]string),
 	}
 	if masqueradeBit != nil {
 		eip.masqueradeBit = 1 << uint32(*masqueradeBit)
 	}
+
+	eip.tracker = common.NewEgressIPTracker(eip)
 	return eip
 }
 
@@ -91,15 +57,13 @@ func (eip *egressIPWatcher) Start(networkInformers networkinformers.SharedInform
 		return nil
 	}
 
-	eip.networkInformers = networkInformers
 	eip.iptables = iptables
 
 	updates := make(chan *egressVXLANNode)
-	eip.vxlanMonitor = newEgressVXLANMonitor(eip.oc.ovs, updates)
+	eip.vxlanMonitor = newEgressVXLANMonitor(eip.oc.ovs, eip.tracker, updates)
 	go eip.watchVXLAN(updates)
 
-	eip.watchHostSubnets()
-	eip.watchNetNamespaces()
+	eip.tracker.Start(networkInformers.Network().InternalVersion().HostSubnets(), networkInformers.Network().InternalVersion().NetNamespaces())
 	return nil
 }
 
@@ -115,278 +79,46 @@ func getMarkForVNID(vnid, masqueradeBit uint32) string {
 	return fmt.Sprintf("0x%08x", vnid)
 }
 
-func (eip *egressIPWatcher) ensureEgressIPInfo(egressIP string) *egressIPInfo {
-	eg := eip.egressIPs[egressIP]
-	if eg == nil {
-		eg = &egressIPInfo{ip: egressIP}
-		eip.egressIPs[egressIP] = eg
-	}
-	return eg
-}
-
-func (eip *egressIPWatcher) egressIPChanged(eg *egressIPInfo) {
-	eip.changedEgressIPs[eg] = true
-	for _, ns := range eg.namespaces {
-		eip.changedNamespaces[ns] = true
-	}
-}
-
-func (eip *egressIPWatcher) addNode(egressIP string, node *nodeEgress) {
-	eg := eip.ensureEgressIPInfo(egressIP)
-	eg.nodes = append(eg.nodes, node)
-	eip.egressIPChanged(eg)
-}
-
-func (eip *egressIPWatcher) deleteNode(egressIP string, node *nodeEgress) {
-	eg := eip.egressIPs[egressIP]
-	if eg == nil {
-		return
-	}
-
-	for i := range eg.nodes {
-		if eg.nodes[i] == node {
-			eip.egressIPChanged(eg)
-			eg.nodes = append(eg.nodes[:i], eg.nodes[i+1:]...)
-			return
+func (eip *egressIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) {
+	if nodeIP == eip.localIP {
+		mark := getMarkForVNID(vnid, eip.masqueradeBit)
+		eip.iptablesMark[egressIP] = mark
+		if err := eip.assignEgressIP(egressIP, mark); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error assigning Egress IP %q: %v", egressIP, err))
 		}
+	} else if eip.vxlanMonitor != nil {
+		eip.vxlanMonitor.AddNode(nodeIP)
 	}
 }
 
-func (eip *egressIPWatcher) addNamespace(egressIP string, ns *namespaceEgress) {
-	eg := eip.ensureEgressIPInfo(egressIP)
-	eg.namespaces = append(eg.namespaces, ns)
-	eip.egressIPChanged(eg)
-}
-
-func (eip *egressIPWatcher) deleteNamespace(egressIP string, ns *namespaceEgress) {
-	eg := eip.egressIPs[egressIP]
-	if eg == nil {
-		return
-	}
-
-	for i := range eg.namespaces {
-		if eg.namespaces[i] == ns {
-			eip.egressIPChanged(eg)
-			eg.namespaces = append(eg.namespaces[:i], eg.namespaces[i+1:]...)
-			return
+func (eip *egressIPWatcher) ReleaseEgressIP(egressIP, nodeIP string) {
+	if nodeIP == eip.localIP {
+		mark := eip.iptablesMark[egressIP]
+		delete(eip.iptablesMark, egressIP)
+		if err := eip.releaseEgressIP(egressIP, mark); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error releasing Egress IP %q: %v", egressIP, err))
 		}
+	} else if eip.vxlanMonitor != nil {
+		eip.vxlanMonitor.RemoveNode(nodeIP)
 	}
 }
 
-func (eip *egressIPWatcher) watchHostSubnets() {
-	funcs := common.InformerFuncs(&networkapi.HostSubnet{}, eip.handleAddOrUpdateHostSubnet, eip.handleDeleteHostSubnet)
-	eip.networkInformers.Network().InternalVersion().HostSubnets().Informer().AddEventHandler(funcs)
-}
-
-func (eip *egressIPWatcher) handleAddOrUpdateHostSubnet(obj, _ interface{}, eventType watch.EventType) {
-	hs := obj.(*networkapi.HostSubnet)
-	glog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
-
-	_, cidr, err := net.ParseCIDR(hs.Subnet)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("could not parse HostSubnet %q CIDR: %v", hs.Name, err))
-	}
-	sdnIP := netutils.GenerateDefaultGateway(cidr).String()
-
-	eip.updateNodeEgress(hs.HostIP, sdnIP, hs.EgressIPs)
-}
-
-func (eip *egressIPWatcher) handleDeleteHostSubnet(obj interface{}) {
-	hs := obj.(*networkapi.HostSubnet)
-	glog.V(5).Infof("Watch %s event for HostSubnet %q", watch.Deleted, hs.Name)
-
-	eip.updateNodeEgress(hs.HostIP, "", nil)
-}
-
-func (eip *egressIPWatcher) updateNodeEgress(nodeIP, sdnIP string, nodeEgressIPs []string) {
-	eip.Lock()
-	defer eip.Unlock()
-
-	node := eip.nodesByNodeIP[nodeIP]
-	if node == nil {
-		if len(nodeEgressIPs) == 0 {
-			return
-		}
-		node = &nodeEgress{
-			nodeIP:       nodeIP,
-			sdnIP:        sdnIP,
-			requestedIPs: sets.NewString(),
-		}
-		eip.nodesByNodeIP[nodeIP] = node
-		if eip.vxlanMonitor != nil && node.nodeIP != eip.localIP {
-			eip.vxlanMonitor.AddNode(node.nodeIP, node.sdnIP)
-		}
-	} else if len(nodeEgressIPs) == 0 {
-		delete(eip.nodesByNodeIP, nodeIP)
-		if eip.vxlanMonitor != nil {
-			eip.vxlanMonitor.RemoveNode(node.nodeIP)
-		}
-	}
-	oldRequestedIPs := node.requestedIPs
-	node.requestedIPs = sets.NewString(nodeEgressIPs...)
-
-	// Process new and removed EgressIPs
-	for _, ip := range node.requestedIPs.Difference(oldRequestedIPs).UnsortedList() {
-		eip.addNode(ip, node)
-	}
-	for _, ip := range oldRequestedIPs.Difference(node.requestedIPs).UnsortedList() {
-		eip.deleteNode(ip, node)
-	}
-
-	eip.syncEgressIPs()
-}
-
-func (eip *egressIPWatcher) watchNetNamespaces() {
-	funcs := common.InformerFuncs(&networkapi.NetNamespace{}, eip.handleAddOrUpdateNetNamespace, eip.handleDeleteNetNamespace)
-	eip.networkInformers.Network().InternalVersion().NetNamespaces().Informer().AddEventHandler(funcs)
-}
-
-func (eip *egressIPWatcher) handleAddOrUpdateNetNamespace(obj, _ interface{}, eventType watch.EventType) {
-	netns := obj.(*networkapi.NetNamespace)
-	glog.V(5).Infof("Watch %s event for NetNamespace %q", eventType, netns.Name)
-
-	eip.updateNamespaceEgress(netns.NetID, netns.EgressIPs)
-}
-
-func (eip *egressIPWatcher) handleDeleteNetNamespace(obj interface{}) {
-	netns := obj.(*networkapi.NetNamespace)
-	glog.V(5).Infof("Watch %s event for NetNamespace %q", watch.Deleted, netns.Name)
-
-	eip.deleteNamespaceEgress(netns.NetID)
-}
-
-func (eip *egressIPWatcher) updateNamespaceEgress(vnid uint32, egressIPs []string) {
-	eip.Lock()
-	defer eip.Unlock()
-
-	ns := eip.namespacesByVNID[vnid]
-	if ns == nil {
-		if len(egressIPs) == 0 {
-			return
-		}
-		ns = &namespaceEgress{vnid: vnid}
-		eip.namespacesByVNID[vnid] = ns
-	} else if len(egressIPs) == 0 {
-		delete(eip.namespacesByVNID, vnid)
-	}
-
-	oldRequestedIPs := sets.NewString(ns.requestedIPs...)
-	newRequestedIPs := sets.NewString(egressIPs...)
-	ns.requestedIPs = egressIPs
-
-	// Process new and removed EgressIPs
-	for _, ip := range newRequestedIPs.Difference(oldRequestedIPs).UnsortedList() {
-		eip.addNamespace(ip, ns)
-	}
-	for _, ip := range oldRequestedIPs.Difference(newRequestedIPs).UnsortedList() {
-		eip.deleteNamespace(ip, ns)
-	}
-
-	// Even IPs that weren't added/removed need to be considered "changed", to
-	// ensure we correctly process reorderings, duplicates added/removed, etc.
-	for _, ip := range newRequestedIPs.Intersection(oldRequestedIPs).UnsortedList() {
-		eip.egressIPChanged(eip.egressIPs[ip])
-	}
-
-	eip.syncEgressIPs()
-}
-
-func (eip *egressIPWatcher) deleteNamespaceEgress(vnid uint32) {
-	eip.updateNamespaceEgress(vnid, nil)
-}
-
-func (eip *egressIPWatcher) egressIPActive(eg *egressIPInfo) (bool, error) {
-	if len(eg.nodes) == 0 || len(eg.namespaces) == 0 {
-		return false, nil
-	}
-	if len(eg.nodes) > 1 {
-		return false, fmt.Errorf("Multiple nodes (%s, %s) claiming EgressIP %s", eg.nodes[0].nodeIP, eg.nodes[1].nodeIP, eg.ip)
-	}
-	if len(eg.namespaces) > 1 {
-		return false, fmt.Errorf("Multiple namespaces (%d, %d) claiming EgressIP %s", eg.namespaces[0].vnid, eg.namespaces[1].vnid, eg.ip)
-	}
-	for _, ip := range eg.namespaces[0].requestedIPs {
-		eg2 := eip.egressIPs[ip]
-		if eg2 != eg && len(eg2.nodes) == 1 && eg2.nodes[0] == eg.nodes[0] {
-			return false, fmt.Errorf("Multiple EgressIPs (%s, %s) for VNID %d on node %s", eg.ip, eg2.ip, eg.namespaces[0].vnid, eg.nodes[0].nodeIP)
-		}
-	}
-	return true, nil
-}
-
-func (eip *egressIPWatcher) syncEgressIPs() {
-	for eg := range eip.changedEgressIPs {
-		active, err := eip.egressIPActive(eg)
-		if err != nil {
-			utilruntime.HandleError(err)
-		}
-		eip.syncEgressNodeState(eg, active)
-	}
-	eip.changedEgressIPs = make(map[*egressIPInfo]bool)
-
-	for ns := range eip.changedNamespaces {
-		err := eip.syncEgressNamespaceState(ns)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules for VNID %d: %v", ns.vnid, err))
-		}
-	}
-	eip.changedNamespaces = make(map[*namespaceEgress]bool)
-}
-
-func (eip *egressIPWatcher) syncEgressNodeState(eg *egressIPInfo, active bool) {
-	if active && eg.assignedNodeIP != eg.nodes[0].nodeIP {
-		glog.V(4).Infof("Assigning egress IP %s to node %s", eg.ip, eg.nodes[0].nodeIP)
-		eg.assignedNodeIP = eg.nodes[0].nodeIP
-		eg.assignedIPTablesMark = getMarkForVNID(eg.namespaces[0].vnid, eip.masqueradeBit)
-		if eg.assignedNodeIP == eip.localIP {
-			if err := eip.assignEgressIP(eg.ip, eg.assignedIPTablesMark); err != nil {
-				utilruntime.HandleError(fmt.Errorf("Error assigning Egress IP %q: %v", eg.ip, err))
-				eg.assignedNodeIP = ""
-			}
-		}
-	} else if !active && eg.assignedNodeIP != "" {
-		glog.V(4).Infof("Removing egress IP %s from node %s", eg.ip, eg.assignedNodeIP)
-		if eg.assignedNodeIP == eip.localIP {
-			if err := eip.releaseEgressIP(eg.ip, eg.assignedIPTablesMark); err != nil {
-				utilruntime.HandleError(fmt.Errorf("Error releasing Egress IP %q: %v", eg.ip, err))
-			}
-		}
-		eg.assignedNodeIP = ""
-		eg.assignedIPTablesMark = ""
+func (eip *egressIPWatcher) SetNamespaceEgressNormal(vnid uint32) {
+	if err := eip.oc.SetNamespaceEgressNormal(vnid); err != nil {
+		utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules for VNID %d: %v", vnid, err))
 	}
 }
 
-func (eip *egressIPWatcher) syncEgressNamespaceState(ns *namespaceEgress) error {
-	if len(ns.requestedIPs) == 0 {
-		return eip.oc.SetNamespaceEgressNormal(ns.vnid)
+func (eip *egressIPWatcher) SetNamespaceEgressDropped(vnid uint32) {
+	if err := eip.oc.SetNamespaceEgressDropped(vnid); err != nil {
+		utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules for VNID %d: %v", vnid, err))
 	}
+}
 
-	var active *egressIPInfo
-	for _, ip := range ns.requestedIPs {
-		eg := eip.egressIPs[ip]
-		if eg == nil {
-			continue
-		}
-		if len(eg.namespaces) > 1 {
-			active = nil
-			glog.V(4).Infof("VNID %d gets no egress due to multiply-assigned egress IP %s", ns.vnid, eg.ip)
-			break
-		}
-		if active == nil {
-			if eg.assignedNodeIP == "" {
-				glog.V(4).Infof("VNID %d cannot use unassigned egress IP %s", ns.vnid, eg.ip)
-			} else if len(ns.requestedIPs) > 1 && eg.nodes[0].offline {
-				glog.V(4).Infof("VNID %d cannot use egress IP %s on offline node %s", ns.vnid, eg.ip, eg.assignedNodeIP)
-			} else {
-				active = eg
-			}
-		}
-	}
-
-	if active != nil {
-		return eip.oc.SetNamespaceEgressViaEgressIP(ns.vnid, active.assignedNodeIP, active.assignedIPTablesMark)
-	} else {
-		return eip.oc.SetNamespaceEgressDropped(ns.vnid)
+func (eip *egressIPWatcher) SetNamespaceEgressViaEgressIP(vnid uint32, egressIP, nodeIP string) {
+	mark := eip.iptablesMark[egressIP]
+	if err := eip.oc.SetNamespaceEgressViaEgressIP(vnid, nodeIP, mark); err != nil {
+		utilruntime.HandleError(fmt.Errorf("Error updating Namespace egress rules for VNID %d: %v", vnid, err))
 	}
 }
 
@@ -459,26 +191,6 @@ func (eip *egressIPWatcher) releaseEgressIP(egressIP, mark string) error {
 
 func (eip *egressIPWatcher) watchVXLAN(updates chan *egressVXLANNode) {
 	for node := range updates {
-		eip.updateNode(node.nodeIP, node.offline)
+		eip.tracker.SetNodeOffline(node.nodeIP, node.offline)
 	}
-}
-
-func (eip *egressIPWatcher) updateNode(nodeIP string, offline bool) {
-	eip.Lock()
-	defer eip.Unlock()
-
-	node := eip.nodesByNodeIP[nodeIP]
-	if node == nil {
-		eip.vxlanMonitor.RemoveNode(nodeIP)
-		return
-	}
-
-	node.offline = offline
-	for _, ip := range node.requestedIPs.UnsortedList() {
-		eg := eip.egressIPs[ip]
-		if eg != nil {
-			eip.egressIPChanged(eg)
-		}
-	}
-	eip.syncEgressIPs()
 }

--- a/pkg/network/node/vxlan_monitor.go
+++ b/pkg/network/node/vxlan_monitor.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +12,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/openshift/origin/pkg/network/common"
 	"github.com/openshift/origin/pkg/util/ovs"
 )
 
@@ -42,6 +42,7 @@ type egressVXLANMonitor struct {
 	sync.Mutex
 
 	ovsif        ovs.Interface
+	tracker      *common.EgressIPTracker
 	updates      chan<- *egressVXLANNode
 	pollInterval time.Duration
 
@@ -51,7 +52,6 @@ type egressVXLANMonitor struct {
 
 type egressVXLANNode struct {
 	nodeIP  string
-	sdnIP   string
 	offline bool
 
 	in  uint64
@@ -67,28 +67,26 @@ const (
 	maxRetries          = 2
 )
 
-func newEgressVXLANMonitor(ovsif ovs.Interface, updates chan<- *egressVXLANNode) *egressVXLANMonitor {
+func newEgressVXLANMonitor(ovsif ovs.Interface, tracker *common.EgressIPTracker, updates chan<- *egressVXLANNode) *egressVXLANMonitor {
 	return &egressVXLANMonitor{
 		ovsif:        ovsif,
+		tracker:      tracker,
 		updates:      updates,
 		pollInterval: defaultPollInterval,
 		monitorNodes: make(map[string]*egressVXLANNode),
 	}
 }
 
-func (evm *egressVXLANMonitor) AddNode(nodeIP, sdnIP string) {
+func (evm *egressVXLANMonitor) AddNode(nodeIP string) {
 	evm.Lock()
 	defer evm.Unlock()
 
 	if evm.monitorNodes[nodeIP] != nil {
 		return
 	}
-	glog.V(4).Infof("Monitoring node %s (SDN IP %s)", nodeIP, sdnIP)
+	glog.V(4).Infof("Monitoring node %s", nodeIP)
 
-	evm.monitorNodes[nodeIP] = &egressVXLANNode{
-		nodeIP: nodeIP,
-		sdnIP:  sdnIP,
-	}
+	evm.monitorNodes[nodeIP] = &egressVXLANNode{nodeIP: nodeIP}
 	if len(evm.monitorNodes) == 1 && evm.pollInterval != 0 {
 		evm.stop = make(chan struct{})
 		go utilwait.PollUntil(evm.pollInterval, evm.poll, evm.stop)
@@ -213,8 +211,11 @@ func (evm *egressVXLANMonitor) check(retryOnly bool) bool {
 				glog.Infof("Node %s is back online", node.nodeIP)
 				node.offline = false
 				evm.updates <- node
-			} else if node.sdnIP != "" {
-				go ping(node.sdnIP)
+			} else if evm.tracker != nil {
+				// We can ignore the return value because if the node responds
+				// (with either success or "connection refused") we'll see it
+				// in the OVS packet counts.
+				go evm.tracker.Ping(node.nodeIP, defaultPollInterval)
 			}
 		} else {
 			if out > node.out && in == node.in {
@@ -249,17 +250,4 @@ func (evm *egressVXLANMonitor) poll() (bool, error) {
 		retry = evm.check(true)
 	}
 	return false, nil
-}
-
-// ping a node by trying to open a TCP connection to the "discard" service (port 9). If
-// the node is still offline, the attempt will time out with no response. But if the node
-// has come back then we'll get a TCP RST (indicating that the node is not listening on
-// that port), or possibly an ACK (if for some strange reason it *was* listening); either
-// way, the input n_packets counter will increase by 1, causing the next poll to mark the
-// node as being back online.
-func ping(ip string) {
-	conn, _ := net.DialTimeout("tcp", ip+":9", defaultPollInterval)
-	if conn != nil {
-		conn.Close()
-	}
 }

--- a/pkg/network/node/vxlan_monitor_test.go
+++ b/pkg/network/node/vxlan_monitor_test.go
@@ -41,12 +41,12 @@ func TestEgressVXLANMonitor(t *testing.T) {
 	setPacketCounts(ovsif, "192.168.1.5", 0, 0)
 
 	updates := make(chan *egressVXLANNode, 10)
-	evm := newEgressVXLANMonitor(ovsif, updates)
+	evm := newEgressVXLANMonitor(ovsif, nil, updates)
 	evm.pollInterval = 0
 
-	evm.AddNode("192.168.1.1", "")
-	evm.AddNode("192.168.1.3", "")
-	evm.AddNode("192.168.1.5", "")
+	evm.AddNode("192.168.1.1")
+	evm.AddNode("192.168.1.3")
+	evm.AddNode("192.168.1.5")
 
 	// Everything should be fine at startup
 	retry := evm.check(false)


### PR DESCRIPTION
Prelude to master-side egress IP tracking; the master will need to be doing the same egressIP-tracking that  the node does, so move the code to pkg/network/common so they can share it.

pkg/network/common/egressip_test.go is mostly just a copy of pkg/network/node/egressip_test.go, with the "netlink" and "OVS" changes squished together into a single change stream, and the comments changed in a few places to reflect the fact that "local node" vs "remote node" doesn't matter to the common code.

The changes at the end of pkg/network/node/egressip_test.go are because if egressIPWatcher deletes OVS flows and then recreates them, the testing code requires that we call `assertOVSChanges` rather than `assertNoOVSChanges` even if the new flows are identical to the old ones. The new code doesn't delete and recreate flows when nothing changed, so we don't need to do that now.