### PR TITLE
fix the go 1.10 unit test failures

### DIFF
--- a/pkg/cmd/server/apis/config/v1/types.go
+++ b/pkg/cmd/server/apis/config/v1/types.go
@@ -506,7 +506,7 @@ type UserAgentMatchRule struct {
 
 // UserAgentDenyRule adds a rejection message that can be used to help a user figure out how to get an approved client
 type UserAgentDenyRule struct {
-	UserAgentMatchRule `json:", inline"`
+	UserAgentMatchRule `json:",inline"`
 
 	// RejectionMessage is the message shown when rejecting a client.  If it is not a set, the default message is used.
 	RejectionMessage string `json:"rejectionMessage"`

--- a/pkg/cmd/server/start/start_node.go
+++ b/pkg/cmd/server/start/start_node.go
@@ -419,7 +419,7 @@ func execKubelet(kubeletArgs []string) error {
 	for i, s := range os.Args {
 		if s == "--vmodule" {
 			if i+1 < len(os.Args) {
-				args = append(args, fmt.Sprintf("--vmodule=", os.Args[i+1]))
+				args = append(args, fmt.Sprintf("--vmodule=%q", os.Args[i+1]))
 				break
 			}
 		}

--- a/pkg/oauthserver/osinserver/osinserver_test.go
+++ b/pkg/oauthserver/osinserver/osinserver_test.go
@@ -127,9 +127,9 @@ func TestAuthorizeStartFlow(t *testing.T) {
 	}
 	url := config.AuthCodeURL("")
 	client := http.Client{ /*CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		t.Logf("redirect (%d): to %s, %#v", len(via), req.URL, req)
-		return nil
-	}*/}
+			t.Logf("redirect (%d): to %s, %#v", len(via), req.URL, req)
+			return nil
+		}*/}
 	if _, err := client.Get(url); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/oc/cli/describe/describer.go
+++ b/pkg/oc/cli/describe/describer.go
@@ -1873,7 +1873,7 @@ func describeSecurityContextConstraints(scc *securityapi.SecurityContextConstrai
 
 		fmt.Fprintf(out, "Settings:\t\n")
 		fmt.Fprintf(out, "  Allow Privileged:\t%t\n", scc.AllowPrivilegedContainer)
-		fmt.Fprintf(out, "  Allow Privilege Escalation:\t%t\n", scc.AllowPrivilegeEscalation)
+		fmt.Fprintf(out, "  Allow Privilege Escalation:\t%v\n", scc.AllowPrivilegeEscalation)
 		fmt.Fprintf(out, "  Default Add Capabilities:\t%s\n", capsToString(scc.DefaultAddCapabilities))
 		fmt.Fprintf(out, "  Required Drop Capabilities:\t%s\n", capsToString(scc.RequiredDropCapabilities))
 		fmt.Fprintf(out, "  Allowed Capabilities:\t%s\n", capsToString(scc.AllowedCapabilities))

--- a/pkg/security/securitycontextconstraints/provider_test.go
+++ b/pkg/security/securitycontextconstraints/provider_test.go
@@ -836,7 +836,7 @@ func defaultPod() *api.Pod {
 		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
 		Spec: api.PodSpec{
 			SecurityContext: &api.PodSecurityContext{
-			// fill in for test cases
+				// fill in for test cases
 			},
 			Containers: []api.Container{
 				{

--- a/test/integration/dockerregistryclient_test.go
+++ b/test/integration/dockerregistryclient_test.go
@@ -123,7 +123,7 @@ func TestRegistryClientConnectPulpRegistry(t *testing.T) {
 	}, imageNotFoundErrorPatterns...)
 	if err != nil {
 		if strings.Contains(err.Error(), "x509: certificate has expired or is not yet valid") {
-			t.Skip("SKIPPING: due to expired certificate of %s: %v", pulpRegistryName, err)
+			t.Skipf("SKIPPING: due to expired certificate of %s: %v", pulpRegistryName, err)
 		}
 		t.Skip("pulp is failing")
 		//t.Fatal(err)
@@ -257,6 +257,6 @@ func TestRegistryClientQuayIOImage(t *testing.T) {
 		return err
 	}, imageNotFoundErrorPatterns...)
 	if err != nil {
-		t.Skip("SKIPPING: unexpected error from quay.io: %v", err)
+		t.Skipf("SKIPPING: unexpected error from quay.io: %v", err)
 	}
 }

--- a/test/integration/imageimporter_test.go
+++ b/test/integration/imageimporter_test.go
@@ -1001,7 +1001,7 @@ func TestImageStreamImportRedHatRegistry(t *testing.T) {
 	}, imageNotFoundErrorPatterns...)
 	if err != nil {
 		if strings.Contains(err.Error(), "x509: certificate has expired or is not yet valid") {
-			t.Skip("SKIPPING: due to expired certificate of %s: %v", pulpRegistryName, err)
+			t.Skipf("SKIPPING: due to expired certificate of %s: %v", pulpRegistryName, err)
 		}
 		t.Fatal(err.Error())
 	}

--- a/test/integration/oauth_cert_fallback_test.go
+++ b/test/integration/oauth_cert_fallback_test.go
@@ -25,9 +25,9 @@ func TestOAuthCertFallback(t *testing.T) {
 		noToken      = ""
 
 		invalidCert = restclient.TLSClientConfig{
-		// We have to generate this dynamically in order to have an invalid cert signed by a signer with the same name as the valid CA
-		// CertData: ...,
-		// KeyData:  ...,
+			// We have to generate this dynamically in order to have an invalid cert signed by a signer with the same name as the valid CA
+			// CertData: ...,
+			// KeyData:  ...,
 		}
 		noCert = restclient.TLSClientConfig{}
 

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -152,9 +152,9 @@ func TestOAuthStorage(t *testing.T) {
 	}
 	url := config.AuthCodeURL("")
 	client := http.Client{ /*CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		t.Logf("redirect (%d): to %s, %#v", len(via), req.URL, req)
-		return nil
-	}*/}
+			t.Logf("redirect (%d): to %s, %#v", len(via), req.URL, req)
+			return nil
+		}*/}
 
 	resp, err := client.Get(url)
 	if err != nil {

--- a/tools/rebasehelpers/godepchecker/godepchecker.go
+++ b/tools/rebasehelpers/godepchecker/godepchecker.go
@@ -25,8 +25,7 @@ func main() {
   Assumes the following:
   - $GOPATH is set to a single directory (not the godepsified path)
   - "godeps save ./..." has not yet been run on origin
-  - The desired level of kubernetes is checked out
-`)
+  - The desired level of kubernetes is checked out`)
 	var self, other string
 	var checkoutNewer, examineForks bool
 	flag.StringVar(&self, "self", filepath.Join(gopath, "src/github.com/openshift/origin/Godeps/Godeps.json"), "The first file to compare")


### PR DESCRIPTION
@smarterclayton the unit weren't flakes.  They were failing one these directives https://unsid.com/openshift/pull-ci-origin-unit/690/ which set non-zero return values.