### PR TITLE
make build timing test more tolerant of fast builds

### DIFF
--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -62,7 +62,7 @@ var _ = g.Describe("[Feature:Builds][timing] capture build stages and durations"
 			expectedBuildStages["CommitContainer"] = []string{"10ms", "1000s"}
 			expectedBuildStages["Assemble"] = []string{"10ms", "1000s"}
 			expectedBuildStages["PostCommit"] = []string{"", "1000s"}
-			expectedBuildStages["PushImage"] = []string{"1s", "1000s"}
+			expectedBuildStages["PushImage"] = []string{"500ms", "1000s"}
 
 			g.By("creating test image stream")
 			err := oc.Run("create").Args("-f", isFixture).Execute()
@@ -87,7 +87,7 @@ var _ = g.Describe("[Feature:Builds][timing] capture build stages and durations"
 			expectedBuildStages["PullImages"] = []string{"", "1000s"}
 			expectedBuildStages["Build"] = []string{"10ms", "1000s"}
 			expectedBuildStages["PostCommit"] = []string{"", "1000s"}
-			expectedBuildStages["PushImage"] = []string{"1s", "1000s"}
+			expectedBuildStages["PushImage"] = []string{"500ms", "1000s"}
 
 			g.By("creating test image stream")
 			err := oc.Run("create").Args("-f", isFixture).Execute()


### PR DESCRIPTION
fix for https://ci.openshift.redhat.com/jenkins/job/test_branch_origin_extended_builds/517/testReport/junit/(root)/Extended/_Feature_Builds__timing__capture_build_stages_and_durations__should_record_build_stages_and_durations_for_docker__Suite_openshift_conformance_parallel_/
