### PR TITLE
Switch origin to use gotest2junit

### DIFF
--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -110,8 +110,6 @@ function os::build::environment::cleanup() {
   local container=$1
   local volume=$2
   local tmp_volume=$3
-  os::log::debug "Recording container information to ${LOG_DIR}/${container}.json"
-  docker inspect "${container}" > "${LOG_DIR}/${container}.json"
   os::log::debug "Stopping container ${container}"
   docker stop --time=0 "${container}" > /dev/null || true
   if [[ -z "${OS_BUILD_ENV_LEAVE_CONTAINER:-}" ]]; then

--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -157,7 +157,7 @@ readonly -f os::cmd::try_until_text
 
 # In order to harvest stderr and stdout at the same time into different buckets, we need to stick them into files
 # in an intermediate step
-os_cmd_internal_tmpdir="${TMPDIR:-"/tmp"}/openshift"
+os_cmd_internal_tmpdir="${TMPDIR:-"/tmp"}/cmd"
 os_cmd_internal_tmpout="${os_cmd_internal_tmpdir}/tmp_stdout.log"
 os_cmd_internal_tmperr="${os_cmd_internal_tmpdir}/tmp_stderr.log"
 

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -51,14 +51,10 @@ os::log::stacktrace::install
 os::util::environment::update_path_var
 
 if [[ -z "${OS_TMP_ENV_SET-}" ]]; then
-	if [[ "${0}" =~ .*\.sh ]]; then
-		os::util::environment::setup_tmpdir_vars "$( basename "${0}" ".sh" )"
-	else
-		os::util::environment::setup_tmpdir_vars "shell"
-	fi
+	os::util::environment::setup_tmpdir_vars "$( basename "$0" ".sh" )"
 fi
 
 # Allow setting $JUNIT_REPORT to toggle output behavior
 if [[ -n "${JUNIT_REPORT:-}" ]]; then
-	export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
+  export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 fi

--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -8,7 +8,7 @@
 # Arguments:
 #  - all: message to write
 function os::log::info() {
-	local message; message="$( os::log::internal::prefix_lines "[INFO] [$( date +%H:%M:%S%z )]" "$*" )"
+	local message; message="$( os::log::internal::prefix_lines "[INFO]" "$*" )"
 	os::log::internal::to_logfile "${message}"
 	echo "${message}"
 }
@@ -21,7 +21,7 @@ readonly -f os::log::info
 # Arguments:
 #  - all: message to write
 function os::log::warning() {
-	local message; message="$( os::log::internal::prefix_lines "[WARNING] [$( date +%H:%M:%S%z )]" "$*" )"
+	local message; message="$( os::log::internal::prefix_lines "[WARNING]" "$*" )"
 	os::log::internal::to_logfile "${message}"
 	os::text::print_yellow "${message}" 1>&2
 }
@@ -34,7 +34,7 @@ readonly -f os::log::warning
 # Arguments:
 #  - all: message to write
 function os::log::error() {
-	local message; message="$( os::log::internal::prefix_lines "[ERROR] [$( date +%H:%M:%S%z )]" "$*" )"
+	local message; message="$( os::log::internal::prefix_lines "[ERROR]" "$*" )"
 	os::log::internal::to_logfile "${message}"
 	os::text::print_red "${message}" 1>&2
 }
@@ -48,7 +48,7 @@ readonly -f os::log::error
 # Arguments:
 #  - all: message to write
 function os::log::fatal() {
-	local message; message="$( os::log::internal::prefix_lines "[FATAL] [$( date +%H:%M:%S%z )]" "$*" )"
+	local message; message="$( os::log::internal::prefix_lines "[FATAL]" "$*" )"
 	os::log::internal::to_logfile "${message}"
 	os::text::print_red "${message}" 1>&2
 	exit 1
@@ -63,7 +63,7 @@ readonly -f os::log::fatal
 # Arguments:
 #  - all: message to write
 function os::log::debug() {
-	local message; message="$( os::log::internal::prefix_lines "[DEBUG] [$( date +%H:%M:%S%z )]" "$*" )"
+	local message; message="$( os::log::internal::prefix_lines "[DEBUG]" "$*" )"
 	os::log::internal::to_logfile "${message}"
 	if [[ -n "${OS_DEBUG:-}" ]]; then
 		os::text::print_blue "${message}" 1>&2

--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -165,8 +165,6 @@ function os::test::junit::generate_report() {
         os::test::junit::reconcile_output
         os::test::junit::check_test_counters
         os::test::junit::internal::generate_report "oscmd"
-    else
-        os::test::junit::internal::generate_report "gotest"
     fi
 }
 

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -70,11 +70,6 @@ if [[ "${OS_PUSH_BASE_REGISTRY-}" != "" || "${tag}" != "" ]]; then
       docker tag "openshift/${image}:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}${image}${tag}"
     done
   done
-  # TODO: remove in 3.11
-  for tag in "${tags[@]}"; do
-    docker tag "openshift/origin-control-plane:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}origin${tag}"
-    docker tag "openshift/origin-node:${source_tag}" "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}node${tag}"
-  done
 fi
 
 for image in "${images[@]}"; do
@@ -82,15 +77,6 @@ for image in "${images[@]}"; do
     os::log::info "Pushing ${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}${image}${tag}..."
     docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}${image}${tag}"
   done
-done
-# TODO: remove in 3.11
-for tag in "${tags[@]}"; do
-  os::log::info "Pushing ${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}origin${tag}..."
-  docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}origin${tag}"
-done
-for tag in "${tags[@]}"; do
-  os::log::info "Pushing ${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}node${tag}..."
-  docker push ${PUSH_OPTS} "${OS_PUSH_BASE_REGISTRY-}${OS_PUSH_BASE_REPO}node${tag}"
 done
 
 ret=$?; ENDTIME=$(date +%s); echo "$0 took $(($ENDTIME - $STARTTIME)) seconds"; exit "$ret"

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -22,14 +22,6 @@
 function cleanup() {
     return_code=$?
 
-    os::test::junit::generate_report
-    if [[ "${JUNIT_REPORT_NUM_FAILED:-}" == "0 failed" ]]; then
-        if [[ "${return_code}" -ne "0" ]]; then
-            os::log::warning "While the jUnit report found no failed tests, the \`go test\` process failed."
-            os::log::warning "This usually means that the unit test suite failed to compile."
-        fi
-    fi
-
     os::util::describe_return_code "${return_code}"
     exit "${return_code}"
 }
@@ -136,8 +128,10 @@ if [[ -n "${junit_report}" ]]; then
     # we don't care if the `go test` fails in this pipe, as we want to generate the report and summarize the output anyway
     set +o pipefail
 
-    go test -i ${gotest_flags} ${test_packages}
-    go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" | tee "${JUNIT_REPORT_OUTPUT}"
+    os::util::ensure::built_binary_exists 'gotest2junit'
+    report_file="$( mktemp "${ARTIFACT_DIR}/unit_report_XXXXX" ).xml"
+
+    go test -json ${gotest_flags} ${test_packages} 2>"${test_error_file}" | tee "${JUNIT_REPORT_OUTPUT}" | gotest2junit > "${report_file}"
 
     test_return_code="${PIPESTATUS[0]}"
 
@@ -163,7 +157,6 @@ $( cat "${test_error_file}") "
 
 elif [[ -n "${coverage_output_dir}" ]]; then
     # we need to generate coverage reports
-    go test -i ${gotest_flags} ${test_packages}
     for test_package in ${test_packages}; do
         mkdir -p "${coverage_output_dir}/${test_package}"
         local_gotest_flags="${gotest_flags} -coverprofile=${coverage_output_dir}/${test_package}/profile.out"
@@ -188,6 +181,5 @@ elif [[ -n "${dlv_debug}" ]]; then
     dlv test ${test_packages}
 else
     # we need to generate neither jUnit XML nor coverage reports
-    go test -i ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages}
 fi

--- a/tools/gotest2junit/gotest2junit.go
+++ b/tools/gotest2junit/gotest2junit.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/tools/gotest2junit/pkg/api"
+)
+
+type Record struct {
+	Package string
+	Test    string
+
+	Time    time.Time
+	Action  string
+	Output  string
+	Elapsed float64
+}
+
+type testSuite struct {
+	suite *api.TestSuite
+	tests map[string]*api.TestCase
+}
+
+func main() {
+	summarize := false
+	verbose := false
+	flag.BoolVar(&summarize, "summary", true, "display a summary as items are processed")
+	flag.BoolVar(&verbose, "v", false, "display passing results")
+	flag.Parse()
+
+	if err := process(os.Stdin, summarize, verbose); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func process(r io.Reader, summarize, verbose bool) error {
+	suites, err := stream(r, summarize, verbose)
+	if err != nil {
+		return err
+	}
+	obj := newTestSuites(suites)
+	out, err := xml.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", string(out))
+	return nil
+}
+
+func newTestSuites(suites map[string]*testSuite) *api.TestSuites {
+	all := &api.TestSuites{}
+	for _, suite := range suites {
+		for _, test := range suite.suite.TestCases {
+			suite.suite.NumTests++
+			if test.SkipMessage != nil {
+				suite.suite.NumSkipped++
+				continue
+			}
+			if test.FailureOutput != nil {
+				suite.suite.NumFailed++
+				continue
+			}
+		}
+		// suites with no tests are usually empty packages, ignore them
+		if suite.suite.NumTests == 0 {
+			continue
+		}
+		// always return the test cases in consistent order
+		sort.Slice(suite.suite.TestCases, func(i, j int) bool {
+			return suite.suite.TestCases[i].Name < suite.suite.TestCases[j].Name
+		})
+		all.Suites = append(all.Suites, suite.suite)
+	}
+	// always return the test suites in consistent order
+	sort.Slice(all.Suites, func(i, j int) bool {
+		return all.Suites[i].Name < all.Suites[j].Name
+	})
+	return all
+}
+
+func stream(r io.Reader, summarize, verbose bool) (map[string]*testSuite, error) {
+	suites := make(map[string]*testSuite)
+	defaultTest := &api.TestCase{
+		Name: "build and execution",
+	}
+	defaultSuite := &testSuite{
+		suite: &api.TestSuite{Name: "go test", TestCases: []*api.TestCase{defaultTest}},
+	}
+	suites[""] = defaultSuite
+
+	rdr := bufio.NewReader(r)
+	for {
+		// some output from go test -json is not valid JSON - read the line to see whether it
+		// starts with { - if not, just mirror it to stderr and continue.
+		line, err := rdr.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				return suites, err
+			}
+			break
+		}
+		if len(line) == 0 || line[0] != '{' {
+			defaultTest.SystemOut += line
+			if strings.HasPrefix(line, "FAIL") {
+				defaultTest.FailureOutput = &api.FailureOutput{}
+			}
+			fmt.Fprint(os.Stderr, line)
+			continue
+		}
+		var r Record
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			if err == io.EOF {
+				return suites, nil
+			}
+			fmt.Fprintf(os.Stderr, "error: Unable to parse remainder of output %v\n", err)
+			return suites, nil
+		}
+
+		suite, ok := suites[r.Package]
+		if !ok {
+			suite = &testSuite{
+				suite: &api.TestSuite{
+					Name: r.Package,
+				},
+				tests: make(map[string]*api.TestCase),
+			}
+			suites[r.Package] = suite
+		}
+
+		// if this is package level output, we only care about pass/fail duration
+		if len(r.Test) == 0 {
+			switch r.Action {
+			case "pass", "fail":
+				suite.suite.Duration = r.Elapsed
+			}
+			continue
+		}
+
+		test, ok := suite.tests[r.Test]
+		if !ok {
+			test = &api.TestCase{
+				Name: r.Test,
+			}
+			suite.suite.TestCases = append(suite.suite.TestCases, test)
+			suite.tests[r.Test] = test
+		}
+
+		switch r.Action {
+		case "run":
+		case "pause":
+		case "cont":
+		case "bench":
+		case "skip":
+			if summarize {
+				fmt.Fprintf(os.Stderr, "SKIP: %s %s\n", r.Package, r.Test)
+			}
+			test.SkipMessage = &api.SkipMessage{
+				Message: r.Output,
+			}
+		case "pass":
+			if summarize && verbose {
+				fmt.Fprintf(os.Stderr, "PASS: %s %s %s\n", r.Package, r.Test, time.Duration(r.Elapsed*float64(time.Second)))
+			}
+			test.SystemOut = ""
+			test.Duration = r.Elapsed
+		case "fail":
+			if summarize {
+				fmt.Fprintf(os.Stderr, "FAIL: %s %s %s\n", r.Package, r.Test, time.Duration(r.Elapsed*float64(time.Second)))
+			}
+			test.Duration = r.Elapsed
+			if len(r.Output) == 0 {
+				r.Output = test.SystemOut
+				if len(r.Output) > 50 {
+					r.Output = r.Output[:50] + " ..."
+				}
+			}
+			test.FailureOutput = &api.FailureOutput{
+				Message: r.Output,
+				Output:  r.Output,
+			}
+		case "output":
+			test.SystemOut += r.Output
+		default:
+			// usually a bug in go test -json
+			out := fmt.Sprintf("error: Unrecognized go test action %s: %#v\n", r.Action, r)
+			defaultTest.SystemOut += line
+			defaultTest.SystemOut += out
+			defaultTest.FailureOutput = &api.FailureOutput{}
+			fmt.Fprintf(os.Stderr, out)
+		}
+	}
+
+	// if we recorded any failure output
+	if defaultTest.FailureOutput != nil {
+		defaultTest.FailureOutput.Message = "Some packages failed during test execution"
+		defaultTest.FailureOutput.Output = defaultTest.SystemOut
+		defaultTest.SystemOut = ""
+	}
+
+	return suites, nil
+}

--- a/tools/gotest2junit/pkg/api/junit.xsd
+++ b/tools/gotest2junit/pkg/api/junit.xsd
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+   <xs:annotation>
+      <xs:documentation xml:lang="en">JUnit test result schema for the Apache Ant JUnit and JUnitReport tasks
+Copyright © 2011, Windy Road Technology Pty. Limited
+The Apache Ant JUnit XML Schema is distributed under the terms of the GNU Lesser General Public License (LGPL) http://www.gnu.org/licenses/lgpl.html
+Permission to waive conditions of this license may be requested from Windy Road Support (http://windyroad.org/support).</xs:documentation>
+   </xs:annotation>
+   <xs:element name="testsuite" type="testsuite" />
+   <xs:simpleType name="ISO8601_DATETIME_PATTERN">
+      <xs:restriction base="xs:dateTime">
+         <xs:pattern value="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}" />
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:element name="testsuites">
+      <xs:annotation>
+         <xs:documentation xml:lang="en">Contains an aggregation of testsuite results</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="testsuite" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:complexContent>
+                     <xs:extension base="testsuite">
+                        <xs:attribute name="package" type="xs:token" use="required">
+                           <xs:annotation>
+                              <xs:documentation xml:lang="en">Derived from testsuite/@name in the non-aggregated documents</xs:documentation>
+                           </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="id" type="xs:int" use="required">
+                           <xs:annotation>
+                              <xs:documentation xml:lang="en">Starts at '0' for the first testsuite and is incremented by 1 for each following testsuite</xs:documentation>
+                           </xs:annotation>
+                        </xs:attribute>
+                     </xs:extension>
+                  </xs:complexContent>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:complexType name="testsuite">
+      <xs:annotation>
+         <xs:documentation xml:lang="en">Contains the results of exexuting a testsuite</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="properties">
+            <xs:annotation>
+               <xs:documentation xml:lang="en">Properties (e.g., environment settings) set during test execution</xs:documentation>
+            </xs:annotation>
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:attribute name="name" use="required">
+                           <xs:simpleType>
+                              <xs:restriction base="xs:token">
+                                 <xs:minLength value="1" />
+                              </xs:restriction>
+                           </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="value" type="xs:string" use="required" />
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:choice minOccurs="0">
+                  <xs:element name="error">
+                     <xs:annotation>
+                        <xs:documentation xml:lang="en">Indicates that the test errored.  An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test. Contains as a text node relevant data for the error, e.g., a stack trace</xs:documentation>
+                     </xs:annotation>
+                     <xs:complexType>
+                        <xs:simpleContent>
+                           <xs:extension base="pre-string">
+                              <xs:attribute name="message" type="xs:string">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The error message. e.g., if a java exception is thrown, the return value of getMessage()</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                              <xs:attribute name="type" type="xs:string" use="required">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The type of error that occured. e.g., if a java execption is thrown the full class name of the exception.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                           </xs:extension>
+                        </xs:simpleContent>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="failure">
+                     <xs:annotation>
+                        <xs:documentation xml:lang="en">Indicates that the test failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals. Contains as a text node relevant data for the failure, e.g., a stack trace</xs:documentation>
+                     </xs:annotation>
+                     <xs:complexType>
+                        <xs:simpleContent>
+                           <xs:extension base="pre-string">
+                              <xs:attribute name="message" type="xs:string">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The message specified in the assert</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                              <xs:attribute name="type" type="xs:string" use="required">
+                                 <xs:annotation>
+                                    <xs:documentation xml:lang="en">The type of the assert.</xs:documentation>
+                                 </xs:annotation>
+                              </xs:attribute>
+                           </xs:extension>
+                        </xs:simpleContent>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:choice>
+               <xs:attribute name="name" type="xs:token" use="required">
+                  <xs:annotation>
+                     <xs:documentation xml:lang="en">Name of the test method</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+               <xs:attribute name="classname" type="xs:token" use="required">
+                  <xs:annotation>
+                     <xs:documentation xml:lang="en">Full class name for the class the test method is in.</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+               <xs:attribute name="time" type="xs:decimal" use="required">
+                  <xs:annotation>
+                     <xs:documentation xml:lang="en">Time taken (in seconds) to execute the test</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="system-out">
+            <xs:annotation>
+               <xs:documentation xml:lang="en">Data that was written to standard out while the test was executed</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="pre-string">
+                  <xs:whiteSpace value="preserve" />
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="system-err">
+            <xs:annotation>
+               <xs:documentation xml:lang="en">Data that was written to standard error while the test was executed</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="pre-string">
+                  <xs:whiteSpace value="preserve" />
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="name" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">Full class name of the test for non-aggregated testsuite documents. Class name without the package for aggregated testsuites documents</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:minLength value="1" />
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="timestamp" type="ISO8601_DATETIME_PATTERN" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">when the test was executed. Timezone may not be specified.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="hostname" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">Host on which the tests were executed. 'localhost' should be used if the hostname cannot be determined.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:minLength value="1" />
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="tests" type="xs:int" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">The total number of tests in the suite</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="failures" type="xs:int" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">The total number of tests in the suite that failed. A failure is a test which the code has explicitly failed by using the mechanisms for that purpose. e.g., via an assertEquals</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="errors" type="xs:int" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">The total number of tests in the suite that errorrd. An errored test is one that had an unanticipated problem. e.g., an unchecked throwable; or a problem with the implementation of the test.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="time" type="xs:decimal" use="required">
+         <xs:annotation>
+            <xs:documentation xml:lang="en">Time taken (in seconds) to execute the tests in the suite</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:simpleType name="pre-string">
+      <xs:restriction base="xs:string">
+         <xs:whiteSpace value="preserve" />
+      </xs:restriction>
+   </xs:simpleType>
+</xs:schema>

--- a/tools/gotest2junit/pkg/api/string.go
+++ b/tools/gotest2junit/pkg/api/string.go
@@ -1,0 +1,37 @@
+package api
+
+import "fmt"
+
+// This file implements Stringer for the API types for ease of debugging
+
+func (t *TestSuites) String() string {
+	return fmt.Sprintf("Test Suites with suites: %s.", t.Suites)
+}
+
+func (t *TestSuite) String() string {
+	childDescriptions := []string{}
+	for _, child := range t.Children {
+		childDescriptions = append(childDescriptions, child.String())
+	}
+	return fmt.Sprintf("Test Suite %q with properties: %s, %d test cases, of which %d failed and %d were skipped: %s, and children: %s.", t.Name, t.Properties, t.NumTests, t.NumFailed, t.NumSkipped, t.TestCases, childDescriptions)
+}
+
+func (t *TestCase) String() string {
+	var result, message, output string
+	result = "passed"
+	if t.SkipMessage != nil {
+		result = "skipped"
+		message = t.SkipMessage.Message
+	}
+	if t.FailureOutput != nil {
+		result = "failed"
+		message = t.FailureOutput.Message
+		output = t.FailureOutput.Output
+	}
+
+	return fmt.Sprintf("Test Case %q %s after %f seconds with message %q and output %q.", t.Name, result, t.Duration, message, output)
+}
+
+func (p *TestSuiteProperty) String() string {
+	return fmt.Sprintf("%q=%q", p.Name, p.Value)
+}

--- a/tools/gotest2junit/pkg/api/test_case.go
+++ b/tools/gotest2junit/pkg/api/test_case.go
@@ -1,0 +1,30 @@
+package api
+
+import "time"
+
+// SetDuration sets the runtime duration of the test case
+func (t *TestCase) SetDuration(duration string) error {
+	parsedDuration, err := time.ParseDuration(duration)
+	if err != nil {
+		return err
+	}
+
+	// we round to the millisecond on duration
+	t.Duration = float64(int(parsedDuration.Seconds()*1000)) / 1000
+	return nil
+}
+
+// MarkSkipped marks the test as skipped with the given message
+func (t *TestCase) MarkSkipped(message string) {
+	t.SkipMessage = &SkipMessage{
+		Message: message,
+	}
+}
+
+// MarkFailed marks the test as failed with the given message and output
+func (t *TestCase) MarkFailed(message, output string) {
+	t.FailureOutput = &FailureOutput{
+		Message: message,
+		Output:  output,
+	}
+}

--- a/tools/gotest2junit/pkg/api/test_suite.go
+++ b/tools/gotest2junit/pkg/api/test_suite.go
@@ -1,0 +1,67 @@
+package api
+
+import "time"
+
+// AddProperty adds a property to the test suite, deduplicating multiple additions of the same property
+// by overwriting the previous record to reflect the new values
+func (t *TestSuite) AddProperty(name, value string) {
+	for _, property := range t.Properties {
+		if property.Name == name {
+			property.Value = value
+			return
+		}
+	}
+
+	t.Properties = append(t.Properties, &TestSuiteProperty{Name: name, Value: value})
+}
+
+// AddTestCase adds a test case to the test suite and updates test suite metrics as necessary
+func (t *TestSuite) AddTestCase(testCase *TestCase) {
+	t.NumTests += 1
+
+	switch {
+	case testCase.SkipMessage != nil:
+		t.NumSkipped += 1
+	case testCase.FailureOutput != nil:
+		t.NumFailed += 1
+	default:
+		// we do not preserve output on tests that are not failures or skips
+		testCase.SystemOut = ""
+		testCase.SystemErr = ""
+	}
+
+	t.Duration += testCase.Duration
+	// we round to the millisecond on duration
+	t.Duration = float64(int(t.Duration*1000)) / 1000
+
+	t.TestCases = append(t.TestCases, testCase)
+}
+
+// SetDuration sets the duration of the test suite if this value is not calculated by aggregating the durations
+// of all of the substituent test cases. This should *not* be used if the total duration of the test suite is
+// calculated as that sum, as AddTestCase will handle that case.
+func (t *TestSuite) SetDuration(duration string) error {
+	parsedDuration, err := time.ParseDuration(duration)
+	if err != nil {
+		return err
+	}
+
+	// we round to the millisecond on duration
+	t.Duration = float64(int(parsedDuration.Seconds()*1000)) / 1000
+	return nil
+}
+
+// ByName implements sort.Interface for []*TestSuite based on the Name field
+type ByName []*TestSuite
+
+func (n ByName) Len() int {
+	return len(n)
+}
+
+func (n ByName) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}
+
+func (n ByName) Less(i, j int) bool {
+	return n[i].Name < n[j].Name
+}

--- a/tools/gotest2junit/pkg/api/types.go
+++ b/tools/gotest2junit/pkg/api/types.go
@@ -1,0 +1,108 @@
+package api
+
+import "encoding/xml"
+
+// The below types are directly marshalled into XML. The types correspond to jUnit
+// XML schema, but do not contain all valid fields. For instance, the class name
+// field for test cases is omitted, as this concept does not directly apply to Go.
+// For XML specifications see http://help.catchsoftware.com/display/ET/JUnit+Format
+// or view the XSD included in this package as 'junit.xsd'
+
+// TestSuites represents a flat collection of jUnit test suites.
+type TestSuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	// Suites are the jUnit test suites held in this collection
+	Suites []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuite represents a single jUnit test suite, potentially holding child suites.
+type TestSuite struct {
+	XMLName xml.Name `xml:"testsuite"`
+
+	// Name is the name of the test suite
+	Name string `xml:"name,attr"`
+
+	// NumTests records the number of tests in the TestSuite
+	NumTests uint `xml:"tests,attr"`
+
+	// NumSkipped records the number of skipped tests in the suite
+	NumSkipped uint `xml:"skipped,attr"`
+
+	// NumFailed records the number of failed tests in the suite
+	NumFailed uint `xml:"failures,attr"`
+
+	// Duration is the time taken in seconds to run all tests in the suite
+	Duration float64 `xml:"time,attr"`
+
+	// Properties holds other properties of the test suite as a mapping of name to value
+	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+
+	// TestCases are the test cases contained in the test suite
+	TestCases []*TestCase `xml:"testcase"`
+
+	// Children holds nested test suites
+	Children []*TestSuite `xml:"testsuite"`
+}
+
+// TestSuiteProperty contains a mapping of a property name to a value
+type TestSuiteProperty struct {
+	XMLName xml.Name `xml:"property"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// TestCase represents a jUnit test case
+type TestCase struct {
+	XMLName xml.Name `xml:"testcase"`
+
+	// Name is the name of the test case
+	Name string `xml:"name,attr"`
+
+	// Classname is an attribute set by the package type and is required
+	Classname string `xml:"classname,attr,omitempty"`
+
+	// Duration is the time taken in seconds to run the test
+	Duration float64 `xml:"time,attr"`
+
+	// SkipMessage holds the reason why the test was skipped
+	SkipMessage *SkipMessage `xml:"skipped"`
+
+	// FailureOutput holds the output from a failing test
+	FailureOutput *FailureOutput `xml:"failure"`
+
+	// SystemOut is output written to stdout during the execution of this test case
+	SystemOut string `xml:"system-out,omitempty"`
+
+	// SystemErr is output written to stderr during the execution of this test case
+	SystemErr string `xml:"system-err,omitempty"`
+}
+
+// SkipMessage holds a message explaining why a test was skipped
+type SkipMessage struct {
+	XMLName xml.Name `xml:"skipped"`
+
+	// Message explains why the test was skipped
+	Message string `xml:"message,attr,omitempty"`
+}
+
+// FailureOutput holds the output from a failing test
+type FailureOutput struct {
+	XMLName xml.Name `xml:"failure"`
+
+	// Message holds the failure message from the test
+	Message string `xml:"message,attr"`
+
+	// Output holds verbose failure output from the test
+	Output string `xml:",chardata"`
+}
+
+// TestResult is the result of a test case
+type TestResult string
+
+const (
+	TestResultPass TestResult = "pass"
+	TestResultSkip TestResult = "skip"
+	TestResultFail TestResult = "fail"
+)

--- a/tools/gotest2junit/test/test_test.go
+++ b/tools/gotest2junit/test/test_test.go
@@ -1,0 +1,18 @@
+// +build output
+
+package test
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	t.Run("panic", func(t *testing.T) {
+		panic("here")
+	})
+	t.Run("pass", func(t *testing.T) {
+	})
+	t.Run("skip", func(t *testing.T) {
+		t.Skip("skipped")
+	})
+}

--- a/tools/import-verifier/import-verifier.go
+++ b/tools/import-verifier/import-verifier.go
@@ -215,14 +215,14 @@ func main() {
 
 		// make sure that all the allowed imports are used
 		if unused := unusedPackageImports(restriction.AllowedImportPackages, packages); len(unused) > 0 {
-			log.Printf("-- found unused allowed package imports(remove them)\n")
+			log.Printf("-- found unused package imports\n")
 			for _, unusedPackage := range unused {
 				log.Printf("\t%s\n", unusedPackage)
 			}
 			failedRestrictionCheck = true
 		}
 		if unused := unusedPackageImportRoots(restriction.AllowedImportPackageRoots, packages); len(unused) > 0 {
-			log.Printf("-- found unused allowed package import roots(remove them)\n")
+			log.Printf("-- found unused package import roots\n")
 			for _, unusedPackage := range unused {
 				log.Printf("\t%s\n", unusedPackage)
 			}

--- a/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
+++ b/tools/junitreport/pkg/parser/gotest/parser_nested_test.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/diff"
-
 	"github.com/openshift/origin/tools/junitreport/pkg/api"
 	"github.com/openshift/origin/tools/junitreport/pkg/builder/nested"
 )
@@ -532,7 +530,7 @@ func TestNestedParse(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(testSuites, testCase.expectedSuites) {
-				t.Errorf("did not produce the correct test suites from file:\n %s", diff.ObjectReflectDiff(testCase.expectedSuites, testSuites))
+				t.Errorf("did not produce the correct test suites from file:\n%#v\n%#v", testCase.expectedSuites, testSuites)
 			}
 		})
 	}


### PR DESCRIPTION
Update a few other small changes that were made to the common scripts,
and remove special cased output from 3.10 for pushing releases
alongside.