### PR TITLE
stop using legacyscheme in builds

### DIFF
--- a/pkg/build/admission/buildpodutil.go
+++ b/pkg/build/admission/buildpodutil.go
@@ -4,10 +4,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/origin/pkg/build/buildscheme"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
@@ -25,7 +24,7 @@ func GetBuildFromPod(pod *v1.Pod) (*buildapi.Build, error) {
 		return nil, errors.New("unable to get build from pod: BUILD environment variable is empty")
 	}
 
-	obj, _, err := legacyscheme.Codecs.UniversalDecoder().Decode([]byte(buildEnvVar), nil, nil)
+	obj, err := runtime.Decode(buildscheme.Decoder, []byte(buildEnvVar))
 	if err != nil {
 		return nil, fmt.Errorf("unable to get build from pod: %v", err)
 	}
@@ -38,7 +37,7 @@ func GetBuildFromPod(pod *v1.Pod) (*buildapi.Build, error) {
 
 // SetBuildInPod encodes a build object and sets it in a pod's BUILD environment variable
 func SetBuildInPod(pod *v1.Pod, build *buildapi.Build) error {
-	encodedBuild, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(schema.GroupVersion{Group: "build.openshift.io", Version: "v1"}), build)
+	encodedBuild, err := runtime.Encode(buildscheme.Encoder, build)
 	if err != nil {
 		return fmt.Errorf("unable to set build in pod: %v", err)
 	}

--- a/pkg/build/admission/strategyrestrictions/admission.go
+++ b/pkg/build/admission/strategyrestrictions/admission.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"strings"
 
+	"github.com/openshift/origin/pkg/build/buildscheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
@@ -185,24 +185,24 @@ func (a *buildByStrategy) checkBuildRequestAuthorization(req *buildapi.BuildRequ
 	switch gr {
 	case buildapi.Resource("builds"),
 		buildapi.LegacyResource("builds"):
-		build, err := a.buildClient.Build().Builds(attr.GetNamespace()).Get(req.Name, metav1.GetOptions{})
+		build, err := a.buildClient.BuildV1().Builds(attr.GetNamespace()).Get(req.Name, metav1.GetOptions{})
 		if err != nil {
 			return admission.NewForbidden(attr, err)
 		}
 		internalBuild := &buildapi.Build{}
-		if err := legacyscheme.Scheme.Convert(build, internalBuild, nil); err != nil {
+		if err := buildscheme.InternalExternalScheme.Convert(build, internalBuild, nil); err != nil {
 			return admission.NewForbidden(attr, err)
 		}
 		return a.checkBuildAuthorization(internalBuild, attr)
 
 	case buildapi.Resource("buildconfigs"),
 		buildapi.LegacyResource("buildconfigs"):
-		buildConfig, err := a.buildClient.Build().BuildConfigs(attr.GetNamespace()).Get(req.Name, metav1.GetOptions{})
+		buildConfig, err := a.buildClient.BuildV1().BuildConfigs(attr.GetNamespace()).Get(req.Name, metav1.GetOptions{})
 		if err != nil {
 			return admission.NewForbidden(attr, err)
 		}
 		internalBuildConfig := &buildapi.BuildConfig{}
-		if err := legacyscheme.Scheme.Convert(buildConfig, internalBuildConfig, nil); err != nil {
+		if err := buildscheme.InternalExternalScheme.Convert(buildConfig, internalBuildConfig, nil); err != nil {
 			return admission.NewForbidden(attr, err)
 		}
 		return a.checkBuildConfigAuthorization(internalBuildConfig, attr)

--- a/pkg/build/admission/testutil/pod.go
+++ b/pkg/build/admission/testutil/pod.go
@@ -3,11 +3,10 @@ package test
 import (
 	"testing"
 
+	"github.com/openshift/origin/pkg/build/buildscheme"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
@@ -40,7 +39,7 @@ func (p *TestPod) WithEnvVar(name, value string) *TestPod {
 }
 
 func (p *TestPod) WithBuild(t *testing.T, build *buildapi.Build) *TestPod {
-	encodedBuild, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(schema.GroupVersion{Group: "build.openshift.io", Version: "v1"}), build)
+	encodedBuild, err := runtime.Encode(buildscheme.Encoder, build)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -72,7 +71,7 @@ func (p *TestPod) EnvValue(name string) string {
 }
 
 func (p *TestPod) GetBuild(t *testing.T) *buildapi.Build {
-	obj, err := runtime.Decode(legacyscheme.Codecs.UniversalDecoder(), []byte(p.EnvValue("BUILD")))
+	obj, err := runtime.Decode(buildscheme.Decoder, []byte(p.EnvValue("BUILD")))
 	if err != nil {
 		t.Fatalf("Could not decode build: %v", err)
 	}

--- a/pkg/build/buildscheme/scheme.go
+++ b/pkg/build/buildscheme/scheme.go
@@ -1,0 +1,51 @@
+package buildscheme
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	buildv1 "github.com/openshift/api/build/v1"
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+	buildv1helpers "github.com/openshift/origin/pkg/build/apis/build/v1"
+)
+
+var (
+	// Decoder understands groupified and non-groupfied.  It deals in internals for now, but will be updated later
+	Decoder runtime.Decoder
+
+	// EncoderScheme can identify types for serialization. We use this for the event recorder and other things that need to
+	// identify external kinds.
+	EncoderScheme = runtime.NewScheme()
+	// Encoder always encodes to groupfied.
+	Encoder runtime.Encoder
+
+	// provides a way to convert between internal and external.  Please don't used this to serialize and deserialize
+	// Use this for places where you have to convert to some kind of a helper.  It happens in apiserver flows where you have
+	// internal objects available
+	InternalExternalScheme = runtime.NewScheme()
+)
+
+func init() {
+	annotationDecodingScheme := runtime.NewScheme()
+	utilruntime.Must(buildv1.AddToScheme(annotationDecodingScheme))
+	utilruntime.Must(buildv1helpers.AddToScheme(annotationDecodingScheme))
+	utilruntime.Must(buildv1.AddToSchemeInCoreGroup(annotationDecodingScheme))
+	utilruntime.Must(buildv1helpers.AddToSchemeInCoreGroup(annotationDecodingScheme))
+	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
+	utilruntime.Must(buildapi.AddToScheme(annotationDecodingScheme))
+	utilruntime.Must(buildapi.AddToSchemeInCoreGroup(annotationDecodingScheme))
+	annotationDecoderCodecFactory := serializer.NewCodecFactory(annotationDecodingScheme)
+	Decoder = annotationDecoderCodecFactory.UniversalDecoder(buildapi.SchemeGroupVersion)
+
+	utilruntime.Must(buildv1.AddToScheme(EncoderScheme))
+	// TODO eventually we shouldn't deal in internal versions, but for now encode from one.
+	utilruntime.Must(buildv1helpers.AddToScheme(EncoderScheme))
+	utilruntime.Must(buildapi.AddToScheme(EncoderScheme))
+	annotationEncoderCodecFactory := serializer.NewCodecFactory(EncoderScheme)
+	Encoder = annotationEncoderCodecFactory.LegacyCodec(buildv1.SchemeGroupVersion)
+
+	utilruntime.Must(buildv1.AddToScheme(InternalExternalScheme))
+	utilruntime.Must(buildv1helpers.AddToScheme(InternalExternalScheme))
+	utilruntime.Must(buildapi.AddToScheme(InternalExternalScheme))
+}

--- a/pkg/build/buildscheme/scheme_test.go
+++ b/pkg/build/buildscheme/scheme_test.go
@@ -1,0 +1,47 @@
+package buildscheme
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+)
+
+const legacyBC = `{
+  "apiVersion": "v1",
+  "kind": "BuildConfig",
+  "metadata": {
+    "name": "sinatra-app-example-a"
+  }
+}
+`
+
+func TestLegacyDecoding(t *testing.T) {
+	result, err := runtime.Decode(Decoder, []byte(legacyBC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.(*buildapi.BuildConfig).Name != "sinatra-app-example-a" {
+		t.Fatal(spew.Sdump(result))
+	}
+
+	groupfiedBytes, err := runtime.Encode(Encoder, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(groupfiedBytes), "build.openshift.io/v1") {
+		t.Fatal(string(groupfiedBytes))
+	}
+
+	result2, err := runtime.Decode(Decoder, groupfiedBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result2.(*buildapi.BuildConfig).Name != "sinatra-app-example-a" {
+		t.Fatal(spew.Sdump(result2))
+	}
+}

--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -23,13 +23,13 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	"github.com/openshift/origin/pkg/api/meta"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/apis/build/validation"
+	"github.com/openshift/origin/pkg/build/buildscheme"
 	buildclient "github.com/openshift/origin/pkg/build/client"
 	builddefaults "github.com/openshift/origin/pkg/build/controller/build/defaults"
 	buildoverrides "github.com/openshift/origin/pkg/build/controller/build/overrides"
@@ -202,7 +202,7 @@ func NewBuildController(params *BuildControllerParams) *BuildController {
 		imageStreamQueue: newResourceTriggerQueue(),
 		buildConfigQueue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 
-		recorder:    eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "build-controller"}),
+		recorder:    eventBroadcaster.NewRecorder(buildscheme.EncoderScheme, v1.EventSource{Component: "build-controller"}),
 		runPolicies: policy.GetAllRunPolicies(buildLister, buildClient),
 	}
 

--- a/pkg/build/controller/buildconfig/buildconfig_controller.go
+++ b/pkg/build/controller/buildconfig/buildconfig_controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/build/buildscheme"
 	clientv1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kcontroller "k8s.io/kubernetes/pkg/controller"
 
@@ -84,7 +84,7 @@ func NewBuildConfigController(buildInternalClient buildinternalclient.Interface,
 		buildConfigInformer: buildConfigInformer.Informer(),
 
 		queue:    workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		recorder: eventBroadcaster.NewRecorder(legacyscheme.Scheme, clientv1.EventSource{Component: "buildconfig-controller"}),
+		recorder: eventBroadcaster.NewRecorder(buildscheme.EncoderScheme, clientv1.EventSource{Component: "buildconfig-controller"}),
 	}
 
 	c.buildConfigInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
 
@@ -128,7 +128,7 @@ func TestEmptySource(t *testing.T) {
 func TestCustomCreateBuildPodWithCustomCodec(t *testing.T) {
 	strategy := CustomBuildStrategy{}
 
-	for _, version := range legacyscheme.Scheme.PrioritizedVersionsForGroup(buildapi.LegacyGroupName) {
+	for _, version := range []schema.GroupVersion{{Group: "", Version: "v1"}, {Group: "build.openshift.io", Version: "v1"}} {
 		// Create new Build specification and modify Spec API version
 		build := mockCustomBuild(false, false)
 		build.Spec.Strategy.CustomStrategy.BuildAPIVersion = fmt.Sprintf("%s/%s", version.Group, version.Version)


### PR DESCRIPTION
The legacy scheme is unreliable, side-effect prone.  Switching to specific encoder and decoders will ensure consistent behavior pre and post rebase.  I started this in case it had a problem like the deployer.  Doesn't look like it.

/assign @bparees 