### PR TITLE
test/extended/networking: wait for NetNamespace to appear before running multicast tests

### DIFF
--- a/test/extended/networking/multicast.go
+++ b/test/extended/networking/multicast.go
@@ -28,6 +28,10 @@ var _ = Describe("[Area:Networking] multicast", func() {
 			oc := testexutil.NewCLI("multicast", testexutil.KubeConfigPath())
 			f := oc.KubeFramework()
 
+			BeforeEach(func() {
+				waitForNetNamespace(f.Namespace.Name)
+			})
+
 			It("should block multicast traffic", func() {
 				Expect(testMulticast(f, oc)).NotTo(Succeed())
 			})
@@ -38,6 +42,10 @@ var _ = Describe("[Area:Networking] multicast", func() {
 		func() {
 			oc := testexutil.NewCLI("multicast", testexutil.KubeConfigPath())
 			f := oc.KubeFramework()
+
+			BeforeEach(func() {
+				waitForNetNamespace(f.Namespace.Name)
+			})
 
 			It("should block multicast traffic in namespaces where it is disabled", func() {
 				Expect(testMulticast(f, oc)).NotTo(Succeed())

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -120,6 +120,22 @@ func waitForEndpoint(c kclientset.Interface, ns, name string) error {
 	return fmt.Errorf("Failed to get endpoints for %s/%s", ns, name)
 }
 
+func waitForNetNamespace(nsName string) error {
+	clientConfig, err := testutil.GetClusterAdminClientConfig(testexutil.KubeConfigPath())
+	networkClient := networkclient.NewForConfigOrDie(clientConfig)
+	expectNoError(err)
+
+	for t := time.Now(); time.Since(t) < 3*time.Minute; time.Sleep(poll) {
+		_, err := networkClient.Network().NetNamespaces().Get(nsName, metav1.GetOptions{})
+		if err == nil {
+			// success
+			return nil
+		}
+		e2e.Logf("NetNamespace %s is not ready yet", nsName)
+	}
+	return fmt.Errorf("Failed to get NetNamespace %s", nsName)
+}
+
 func launchWebserverService(f *e2e.Framework, serviceName string, nodeName string) (serviceAddr string) {
 	e2e.LaunchWebserverPod(f, serviceName, nodeName)
 


### PR DESCRIPTION
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/20179/pull-ci-origin-e2e-gcp/345/

Untested, but may fix the issue?

@smarterclayton @knobunc 