### PR TITLE
Apply defaults to bootstrap SCCs before reconciliation

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -40,11 +40,17 @@ func TestBootstrappedConstraints(t *testing.T) {
 			t.Errorf("unexpected contraint no. %d (by priority).  Found %v, wanted %v", i, constraint.Name, expectedConstraintNames[i])
 		}
 		g := expectedGroups[constraint.Name]
+		if g == nil {
+			g = []string{}
+		}
 		if !reflect.DeepEqual(g, constraint.Groups) {
 			t.Errorf("unexpected group access for %s.  Found %v, wanted %v", constraint.Name, constraint.Groups, g)
 		}
 
 		u := expectedUsers[constraint.Name]
+		if u == nil {
+			u = []string{}
+		}
 		if !reflect.DeepEqual(u, constraint.Users) {
 			t.Errorf("unexpected user access for %s.  Found %v, wanted %v", constraint.Name, constraint.Users, u)
 		}
@@ -70,11 +76,17 @@ func TestBootstrappedConstraintsWithAddedUser(t *testing.T) {
 
 	for _, constraint := range bootstrappedConstraints {
 		g := expectedGroups[constraint.Name]
+		if g == nil {
+			g = []string{}
+		}
 		if !reflect.DeepEqual(g, constraint.Groups) {
 			t.Errorf("unexpected group access for %s.  Found %v, wanted %v", constraint.Name, constraint.Groups, g)
 		}
 
 		u := expectedUsers[constraint.Name]
+		if u == nil {
+			u = []string{}
+		}
 		if !reflect.DeepEqual(u, constraint.Users) {
 			t.Errorf("unexpected user access for %s.  Found %v, wanted %v", constraint.Name, constraint.Users, u)
 		}


### PR DESCRIPTION
https://github.com/openshift/origin/pull/20152 added a new field to SCC objects, which defaults to `true` if unspecified. The in-memory bootstrap SCC objects weren't updated to populate this field, which meant that when they were compared to objects from the server, it appeared there were differences that required them to be updated.

This round-trips the bootstrap SCC objects to make sure all the same defaults are applied to them.

Fixes spurious `reconcile-scc` output for defaulted fields

/assign @simo5
/cc @sdodson @michaelgugino