### PR TITLE
Add router ports (80 & 443) to firewall zone instructions.

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -91,6 +91,8 @@ a URL to access the management console for your cluster.
      firewall-cmd --permanent --zone dockerc --add-port 8443/tcp
      firewall-cmd --permanent --zone dockerc --add-port 53/udp
      firewall-cmd --permanent --zone dockerc --add-port 8053/udp
+     firewall-cmd --permanent --zone dockerc --add-port 443/tcp
+     firewall-cmd --permanent --zone dockerc --add-port 80/tcp
      firewall-cmd --reload
      ```
 


### PR DESCRIPTION
I've had to add these in order for exposed Routes to be accessible on the host running `oc cluster up`

(using Fedora 27)

ping @csrwng