### PR TITLE
[release-3.6] Bug 1596548 - fix user labels override

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2905,117 +2905,117 @@
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api/describe",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/api/validation",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies/layered",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies/onbuild",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/build/strategies/sti",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/docker",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/errors",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/ignore",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/empty",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/file",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scm/git",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/scripts",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/tar",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/test",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/glog",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/interrupt",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/status",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/openshift/source-to-image/pkg/util/user",
 			"Comment": "v1.1.5-31-g191ae3b",
-			"Rev": "7f58756254b0a65bf59fa87a8ecedad01ce6a85b"
+			"Rev": "a49bab886b5d5c9eaeea698a6a058b0c8bf90076"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",

--- a/pkg/bootstrap/docker/dockerhelper/filetransfer.go
+++ b/pkg/bootstrap/docker/dockerhelper/filetransfer.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/docker/engine-api/types"
 	s2itar "github.com/openshift/source-to-image/pkg/tar"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // removeLeadingDirectoryAdapter wraps a tar.Reader and strips the first leading

--- a/pkg/build/builder/docker.go
+++ b/pkg/build/builder/docker.go
@@ -19,7 +19,7 @@ import (
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"

--- a/pkg/build/builder/source.go
+++ b/pkg/build/builder/source.go
@@ -14,7 +14,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/builder/cmd/dockercfg"

--- a/pkg/cmd/cli/cmd/rsync/copytar.go
+++ b/pkg/cmd/cli/cmd/rsync/copytar.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )

--- a/pkg/cmd/cli/cmd/startbuild.go
+++ b/pkg/cmd/cli/cmd/startbuild.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/source-to-image/pkg/tar"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/diagnostics/network/results.go
+++ b/pkg/diagnostics/network/results.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 
 	"github.com/openshift/source-to-image/pkg/tar"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	kerrs "k8s.io/apimachinery/pkg/util/errors"
 	kapi "k8s.io/kubernetes/pkg/api"

--- a/pkg/generate/app/sourcelookup.go
+++ b/pkg/generate/app/sourcelookup.go
@@ -15,7 +15,7 @@ import (
 
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/validation"

--- a/pkg/generate/git/git.go
+++ b/pkg/generate/git/git.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // ParseRepository parses a string that may be in the Git format (git@) or URL format

--- a/vendor/github.com/openshift/source-to-image/pkg/api/types_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/api/types_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestVolumeListSet(t *testing.T) {
+	table := []struct {
+		Input    string
+		Expected VolumeList
+	}{
+		{"/test:", VolumeList{{Source: "/test", Destination: "."}}},
+		{"/test:/test", VolumeList{{Source: "/test", Destination: "/test"}}},
+		{"/test/foo:/etc/ssl", VolumeList{{Source: "/test/foo", Destination: "/etc/ssl"}}},
+		{":/foo", VolumeList{{Source: ".", Destination: "/foo"}}},
+		{"/foo", VolumeList{{Source: "/foo", Destination: "."}}},
+		{":", VolumeList{{Source: ".", Destination: "."}}},
+		{"/t est/foo:", VolumeList{{Source: "/t est/foo", Destination: "."}}},
+		{`"/test":"/foo"`, VolumeList{{Source: "/test", Destination: "/foo"}}},
+		{`'/test':"/foo"`, VolumeList{{Source: "/test", Destination: "/foo"}}},
+		{`C:\test:/bar`, VolumeList{{Source: `C:\test`, Destination: "/bar"}}},
+		{`C:\test:bar`, VolumeList{{Source: `C:\test`, Destination: "bar"}}},
+		{`"/te"st":"/foo"`, VolumeList{}},
+		{"/test/foo:/ss;ss", VolumeList{}},
+		{"/test;foo:/ssss", VolumeList{}},
+	}
+	for _, test := range table {
+		if len(test.Expected) != 0 {
+			test.Expected[0].Source = filepath.FromSlash(test.Expected[0].Source)
+		}
+		got := VolumeList{}
+		got.Set(test.Input)
+		if !reflect.DeepEqual(got, test.Expected) {
+			t.Errorf("On test %s, got %#v, expected %#v", test.Input, got, test.Expected)
+		}
+	}
+}
+
+func TestEnvironmentSet(t *testing.T) {
+	table := map[string][]EnvironmentSpec{
+		"FOO=bar":  {{Name: "FOO", Value: "bar"}},
+		"FOO=":     {{Name: "FOO", Value: ""}},
+		"FOO":      {},
+		"=":        {},
+		"FOO=bar,": {{Name: "FOO", Value: "bar,"}},
+		// Users should get a deprecation warning in this case
+		// TODO: Create fake glog interface to be able to verify this.
+		"FOO=bar,BAR=foo": {{Name: "FOO", Value: "bar,BAR=foo"}},
+	}
+
+	for v, expected := range table {
+		got := EnvironmentList{}
+		err := got.Set(v)
+		if len(expected) == 0 && err == nil {
+			t.Errorf("Expected error for env %q", v)
+			continue
+		}
+		if len(expected) != len(got) {
+			t.Errorf("got %d items, expected %d items in the list for %q", len(got), len(expected), v)
+			continue
+		}
+		for _, exp := range expected {
+			found := false
+			for _, g := range got {
+				if g.Name == exp.Name && g.Value == exp.Value {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Expected %+v environment found in %#v list", exp, got)
+			}
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/api/validation/validation_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/api/validation/validation_test.go
@@ -1,0 +1,101 @@
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestValidation(t *testing.T) {
+	testCases := []struct {
+		value    *api.Config
+		expected []Error
+	}{
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]Error{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: "foobar",
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]Error{{ErrorInvalidValue, "dockerNetworkMode"}},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: api.NewDockerNetworkModeContainer("8d873e496bc3e80a1cb22e67f7de7be5b0633e27916b1144978d1419c0abfcdb"),
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]Error{},
+		},
+		{
+			&api.Config{
+				Source:            "",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				DockerNetworkMode: api.NewDockerNetworkModeContainer("8d873e496bc3e80a1cb22e67f7de7be5b0633e27916b1144978d1419c0abfcdb"),
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+			},
+			[]Error{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+				Labels:            nil,
+			},
+			[]Error{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+				Labels:            map[string]string{},
+			},
+			[]Error{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+				Labels:            map[string]string{"some": "thing", "other": "value"},
+			},
+			[]Error{},
+		},
+		{
+			&api.Config{
+				Source:            "http://github.com/openshift/source",
+				BuilderImage:      "openshift/builder",
+				DockerConfig:      &api.DockerConfig{Endpoint: "/var/run/docker.socket"},
+				BuilderPullPolicy: api.DefaultBuilderPullPolicy,
+				Labels:            map[string]string{"some": "thing", "": "emptykey"},
+			},
+			[]Error{{ErrorInvalidValue, "labels"}},
+		},
+	}
+	for _, test := range testCases {
+		result := ValidateConfig(test.value)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("got %+v, expected %+v", result, test.expected)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/cleanup.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/cleanup.go
@@ -3,7 +3,7 @@ package build
 import (
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
 
@@ -13,12 +13,12 @@ var glog = utilglog.StderrLog
 // temporary directories created by STI build and it also cleans the temporary
 // Docker images produced by LayeredBuild
 type DefaultCleaner struct {
-	fs     util.FileSystem
+	fs     fs.FileSystem
 	docker docker.Docker
 }
 
 // NewDefaultCleaner creates a new instance of the default Cleaner implementation
-func NewDefaultCleaner(fs util.FileSystem, docker docker.Docker) Cleaner {
+func NewDefaultCleaner(fs fs.FileSystem, docker docker.Docker) Cleaner {
 	return &DefaultCleaner{
 		fs:     fs,
 		docker: docker,

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/layered/layered.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/layered/layered.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/docker"
 	s2ierr "github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/tar"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 	utilstatus "github.com/openshift/source-to-image/pkg/util/status"
 )
@@ -34,14 +34,14 @@ const defaultDestination = "/tmp"
 type Layered struct {
 	config     *api.Config
 	docker     docker.Docker
-	fs         util.FileSystem
+	fs         fs.FileSystem
 	tar        tar.Tar
 	scripts    build.ScriptsHandler
 	hasOnBuild bool
 }
 
 // New creates a Layered builder.
-func New(client docker.Client, config *api.Config, fs util.FileSystem, scripts build.ScriptsHandler, overrides build.Overrides) (*Layered, error) {
+func New(client docker.Client, config *api.Config, fs fs.FileSystem, scripts build.ScriptsHandler, overrides build.Overrides) (*Layered, error) {
 	excludePattern, err := regexp.Compile(config.ExcludeRegExp)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/layered/layered_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/layered/layered_test.go
@@ -1,0 +1,200 @@
+package layered
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"regexp/syntax"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/build"
+	"github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/test"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+)
+
+type FakeExecutor struct{}
+
+func (f *FakeExecutor) Execute(string, string, *api.Config) error {
+	return nil
+}
+
+func newFakeLayered() *Layered {
+	return &Layered{
+		docker:  &docker.FakeDocker{},
+		config:  &api.Config{},
+		fs:      &testfs.FakeFileSystem{},
+		tar:     &test.FakeTar{},
+		scripts: &FakeExecutor{},
+	}
+}
+
+func newFakeLayeredWithScripts(workDir string) *Layered {
+	return &Layered{
+		docker:  &docker.FakeDocker{},
+		config:  &api.Config{WorkingDir: workDir},
+		fs:      &testfs.FakeFileSystem{},
+		tar:     &test.FakeTar{},
+		scripts: &FakeExecutor{},
+	}
+}
+
+func TestBuildOK(t *testing.T) {
+	workDir, _ := ioutil.TempDir("", "sti")
+	scriptDir := filepath.Join(workDir, api.UploadScripts)
+	err := os.MkdirAll(scriptDir, 0700)
+	assemble := filepath.Join(scriptDir, api.Assemble)
+	file, err := os.Create(assemble)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	defer file.Close()
+	defer os.RemoveAll(workDir)
+	l := newFakeLayeredWithScripts(workDir)
+	l.config.BuilderImage = "test/image"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if m, _ := regexp.MatchString(`s2i-layered-temp-image-\d+`, l.config.BuilderImage); !m {
+		t.Errorf("Expected BuilderImage s2i-layered-temp-image-withnumbers, but got %s", l.config.BuilderImage)
+	}
+	// without config.Destination explicitly set, we should get /tmp/scripts for the scripts url
+	// assuming the assemble script we created above is off the working dir
+	if l.config.ScriptsURL != "image:///tmp/scripts" {
+		t.Errorf("Expected ScriptsURL image:///tmp/scripts, but got %s", l.config.ScriptsURL)
+	}
+	if len(l.config.Destination) != 0 {
+		t.Errorf("Unexpected Destination %s", l.config.Destination)
+	}
+}
+
+func TestBuildOKWithImageRef(t *testing.T) {
+	workDir, _ := ioutil.TempDir("", "sti")
+	scriptDir := filepath.Join(workDir, api.UploadScripts)
+	err := os.MkdirAll(scriptDir, 0700)
+	assemble := filepath.Join(scriptDir, api.Assemble)
+	file, err := os.Create(assemble)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	defer file.Close()
+	defer os.RemoveAll(workDir)
+	l := newFakeLayeredWithScripts(workDir)
+	l.config.BuilderImage = "docker.io/uptoknow/ruby-20-centos7@sha256:d6f5718b85126954d98931e654483ee794ac357e0a98f4a680c1e848d78863a1"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if !strings.HasPrefix(l.config.BuilderImage, "s2i-layered-temp-image-") {
+		t.Errorf("Expected BuilderImage to start with s2i-layered-temp-image-, but got %s", l.config.BuilderImage)
+	}
+	l.config.BuilderImage = "uptoknow/ruby-20-centos7@sha256:d6f5718b85126954d98931e654483ee794ac357e0a98f4a680c1e848d78863a1"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if !strings.HasPrefix(l.config.BuilderImage, "s2i-layered-temp-image-") {
+		t.Errorf("Expected BuilderImage to start with s2i-layered-temp-image-, but got %s", l.config.BuilderImage)
+	}
+	l.config.BuilderImage = "ruby-20-centos7@sha256:d6f5718b85126954d98931e654483ee794ac357e0a98f4a680c1e848d78863a1"
+	_, err = l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if !strings.HasPrefix(l.config.BuilderImage, "s2i-layered-temp-image-") {
+		t.Errorf("Expected BuilderImage to start with s2i-layered-temp-image-, but got %s", l.config.BuilderImage)
+	}
+}
+
+func TestBuildNoScriptsProvided(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BuilderImage = "test/image"
+	_, err := l.Build(l.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	if !l.config.LayeredBuild {
+		t.Errorf("Expected LayeredBuild to be true!")
+	}
+	if m, _ := regexp.MatchString(`s2i-layered-temp-image-\d+`, l.config.BuilderImage); !m {
+		t.Errorf("Expected BuilderImage s2i-layered-temp-image-withnumbers, but got %s", l.config.BuilderImage)
+	}
+	if len(l.config.Destination) != 0 {
+		t.Errorf("Unexpected Destination %s", l.config.Destination)
+	}
+}
+
+func TestBuildErrorWriteDockerfile(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BuilderImage = "test/image"
+	l.fs.(*testfs.FakeFileSystem).WriteFileError = errors.New("WriteDockerfileError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "WriteDockerfileError" {
+		t.Errorf("An error was expected for WriteDockerfile, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorCreateTarFile(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BuilderImage = "test/image"
+	l.tar.(*test.FakeTar).CreateTarError = errors.New("CreateTarError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "CreateTarError" {
+		t.Errorf("An error was expected for CreateTar, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorBuildImage(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BuilderImage = "test/image"
+	l.docker.(*docker.FakeDocker).BuildImageError = errors.New("BuildImageError")
+	_, err := l.Build(l.config)
+	if err == nil || err.Error() != "BuildImageError" {
+		t.Errorf("An error was expected for BuildImage, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorBadImageName(t *testing.T) {
+	l := newFakeLayered()
+	_, err := l.Build(l.config)
+	if err == nil || !strings.Contains(err.Error(), "builder image name cannot be empty") {
+		t.Errorf("A builder image name cannot be empty error was expected, but got different: %v", err)
+	}
+}
+
+func TestBuildErrorOnBuildBlocked(t *testing.T) {
+	l := newFakeLayered()
+	l.config.BlockOnBuild = true
+	l.config.HasOnBuild = true
+	_, err := l.Build(l.config)
+	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed") {
+		t.Errorf("expected error from onbuild due to blocked ONBUILD, got: %v", err)
+	}
+}
+
+func TestNewWithInvalidExcludeRegExp(t *testing.T) {
+	_, err := New(nil, &api.Config{
+		DockerConfig:  docker.GetDefaultDockerConfig(),
+		ExcludeRegExp: "[",
+	}, nil, nil, build.Overrides{})
+	if syntaxErr, ok := err.(*syntax.Error); ok && syntaxErr.Code != syntax.ErrMissingBracket {
+		t.Errorf("expected regexp compilation error, got %v", err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/entrypoint.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/entrypoint.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
 
@@ -20,7 +20,7 @@ var validEntrypoints = []*regexp.Regexp{
 
 // GuessEntrypoint tries to guess the valid entrypoint from the source code
 // repository. The valid entrypoints are defined above (run,start,exec,execute)
-func GuessEntrypoint(fs util.FileSystem, sourceDir string) (string, error) {
+func GuessEntrypoint(fs fs.FileSystem, sourceDir string) (string, error) {
 	files, err := fs.ReadDir(sourceDir)
 	if err != nil {
 		return "", err
@@ -40,7 +40,7 @@ func GuessEntrypoint(fs util.FileSystem, sourceDir string) (string, error) {
 // isValidEntrypoint checks if the given file exists and if it is a regular
 // file. Valid ENTRYPOINT must be an executable file, so the executable bit must
 // be set.
-func isValidEntrypoint(fs util.FileSystem, path string) bool {
+func isValidEntrypoint(fs fs.FileSystem, path string) bool {
 	stat, err := fs.Stat(path)
 	if err != nil {
 		return false

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/entrypoint_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/entrypoint_test.go
@@ -1,0 +1,64 @@
+package onbuild
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+func TestGuessEntrypoint(t *testing.T) {
+
+	testMatrix := map[string][]os.FileInfo{
+		"run": {
+			&fs.FileInfo{FileName: "config.ru", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileIsDir: false, FileMode: 0777},
+		},
+		"start.sh": {
+			&fs.FileInfo{FileName: "config.ru", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "start.sh", FileIsDir: false, FileMode: 0777},
+		},
+		"execute": {
+			&fs.FileInfo{FileName: "config.ru", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "execute", FileIsDir: false, FileMode: 0777},
+		},
+		"ERR:run_not_executable": {
+			&fs.FileInfo{FileName: "config.ru", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileIsDir: false, FileMode: 0600},
+		},
+		"ERR:run_is_dir": {
+			&fs.FileInfo{FileName: "config.ru", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileIsDir: true, FileMode: 0777},
+		},
+		"ERR:none": {
+			&fs.FileInfo{FileName: "config.ru", FileIsDir: false, FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileIsDir: false, FileMode: 0600},
+		},
+	}
+
+	for expectedEntrypoint, files := range testMatrix {
+		f := &testfs.FakeFileSystem{Files: files}
+		result, err := GuessEntrypoint(f, "/test")
+
+		if strings.HasPrefix(expectedEntrypoint, "ERR:") {
+			if len(result) > 0 {
+				t.Errorf("Expected error for %s, got %s", expectedEntrypoint, result)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("[%s] %s", expectedEntrypoint, err)
+		}
+		if result != expectedEntrypoint {
+			t.Errorf("Expected '%s' entrypoint, got '%v'", expectedEntrypoint, result)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/scm/git"
 	"github.com/openshift/source-to-image/pkg/scripts"
 	"github.com/openshift/source-to-image/pkg/tar"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilstatus "github.com/openshift/source-to-image/pkg/util/status"
 )
 
@@ -25,7 +25,7 @@ import (
 type OnBuild struct {
 	docker  docker.Docker
 	git     git.Git
-	fs      util.FileSystem
+	fs      fs.FileSystem
 	tar     tar.Tar
 	source  build.SourceHandler
 	garbage build.Cleaner
@@ -38,7 +38,7 @@ type onBuildSourceHandler struct {
 }
 
 // New returns a new instance of OnBuild builder
-func New(client docker.Client, config *api.Config, fs util.FileSystem, overrides build.Overrides) (*OnBuild, error) {
+func New(client docker.Client, config *api.Config, fs fs.FileSystem, overrides build.Overrides) (*OnBuild, error) {
 	dockerHandler := docker.New(client, config.PullAuthentication)
 	builder := &OnBuild{
 		docker: dockerHandler,

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/onbuild/onbuild_test.go
@@ -1,0 +1,158 @@
+package onbuild
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/builder/dockerfile/parser"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/test"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+type fakeSourceHandler struct{}
+
+func (*fakeSourceHandler) Prepare(r *api.Config) error {
+	return nil
+}
+
+func (*fakeSourceHandler) Ignore(r *api.Config) error {
+	return nil
+}
+
+func (*fakeSourceHandler) Download(r *api.Config) (*api.SourceInfo, error) {
+	return &api.SourceInfo{}, nil
+}
+
+type fakeCleaner struct{}
+
+func (*fakeCleaner) Cleanup(*api.Config) {}
+
+func newFakeOnBuild() *OnBuild {
+	return &OnBuild{
+		docker:  &docker.FakeDocker{},
+		git:     &test.FakeGit{},
+		fs:      &testfs.FakeFileSystem{},
+		tar:     &test.FakeTar{},
+		source:  &fakeSourceHandler{},
+		garbage: &fakeCleaner{},
+	}
+}
+
+func checkDockerfile(fs *testfs.FakeFileSystem, t *testing.T) {
+	if fs.WriteFileError != nil {
+		t.Errorf("%v", fs.WriteFileError)
+	}
+	if filepath.ToSlash(fs.WriteFileName) != "upload/src/Dockerfile" {
+		t.Errorf("Expected Dockerfile in 'upload/src/Dockerfile', got %q", fs.WriteFileName)
+	}
+	if !strings.Contains(fs.WriteFileContent, `ENTRYPOINT ["./run"]`) {
+		t.Errorf("The Dockerfile does not set correct entrypoint, file content:\n%s", fs.WriteFileContent)
+	}
+
+	buf := bytes.NewBuffer([]byte(fs.WriteFileContent))
+	if _, err := parser.Parse(buf); err != nil {
+		t.Errorf("cannot parse new Dockerfile: %v", err)
+	}
+
+}
+
+func TestCreateDockerfile(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+		Environment: api.EnvironmentList{
+			{Name: "FOO", Value: "BAR"},
+			{Name: "TEST", Value: "A VALUE"},
+		},
+	}
+	b := newFakeOnBuild()
+	fakeFs := &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&fs.FileInfo{FileName: "config.ru", FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileMode: 0777},
+		},
+	}
+	b.fs = fakeFs
+	err := b.CreateDockerfile(fakeRequest)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	checkDockerfile(fakeFs, t)
+}
+
+func TestCreateDockerfileWithAssemble(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+	}
+	b := newFakeOnBuild()
+	fakeFs := &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&fs.FileInfo{FileName: "config.ru", FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileMode: 0777},
+			&fs.FileInfo{FileName: "assemble", FileMode: 0777},
+		},
+	}
+	b.fs = fakeFs
+	err := b.CreateDockerfile(fakeRequest)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	checkDockerfile(fakeFs, t)
+	if !strings.Contains(fakeFs.WriteFileContent, `RUN sh assemble`) {
+		t.Errorf("The Dockerfile does not run assemble, file content:\n%s", fakeFs.WriteFileContent)
+	}
+}
+
+func TestBuild(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+		Tag:          "fakeapp",
+	}
+	b := newFakeOnBuild()
+	fakeFs := &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&fs.FileInfo{FileName: "config.ru", FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileMode: 0777},
+		},
+	}
+	b.fs = fakeFs
+	result, err := b.Build(fakeRequest)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected successful build, got: %v", result)
+	}
+	checkDockerfile(fakeFs, t)
+	t.Logf("result: %v", result)
+}
+
+func TestBuildOnBuildBlocked(t *testing.T) {
+	fakeRequest := &api.Config{
+		BuilderImage: "fake:onbuild",
+		Tag:          "fakeapp",
+		BlockOnBuild: true,
+	}
+	b := newFakeOnBuild()
+	fakeFs := &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&fs.FileInfo{FileName: "config.ru", FileMode: 0600},
+			&fs.FileInfo{FileName: "app.rb", FileMode: 0600},
+			&fs.FileInfo{FileName: "run", FileMode: 0777},
+		},
+	}
+	b.fs = fakeFs
+	_, err := b.Build(fakeRequest)
+	if err == nil || !strings.Contains(err.Error(), "builder image uses ONBUILD instructions but ONBUILD is not allowed") {
+		t.Errorf("expected error from onbuild due to blocked ONBUILD, got: %v", err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/postexecutorstep.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/postexecutorstep.go
@@ -17,6 +17,7 @@ import (
 	s2ierr "github.com/openshift/source-to-image/pkg/errors"
 	s2itar "github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilstatus "github.com/openshift/source-to-image/pkg/util/status"
 )
 
@@ -107,7 +108,7 @@ type commitImageStep struct {
 	image   string
 	builder *STI
 	docker  dockerpkg.Docker
-	fs      util.FileSystem
+	fs      fs.FileSystem
 	tar     s2itar.Tar
 }
 
@@ -168,7 +169,7 @@ func (step *commitImageStep) execute(ctx *postExecutorStepContext) error {
 type downloadFilesFromBuilderImageStep struct {
 	builder *STI
 	docker  dockerpkg.Docker
-	fs      util.FileSystem
+	fs      fs.FileSystem
 	tar     s2itar.Tar
 }
 
@@ -234,7 +235,7 @@ func (step *downloadFilesFromBuilderImageStep) downloadAndExtractFile(artifactPa
 type startRuntimeImageAndUploadFilesStep struct {
 	builder *STI
 	docker  dockerpkg.Docker
-	fs      util.FileSystem
+	fs      fs.FileSystem
 }
 
 func (step *startRuntimeImageAndUploadFilesStep) execute(ctx *postExecutorStepContext) error {
@@ -429,7 +430,7 @@ func createLabelsForResultingImage(builder *STI, docker dockerpkg.Docker, baseIm
 	configLabels := builder.config.Labels
 	newLabels := builder.newLabels
 
-	return mergeLabels(configLabels, generatedLabels, existingLabels, newLabels)
+	return mergeLabels(existingLabels, generatedLabels, configLabels, newLabels)
 }
 
 func mergeLabels(labels ...map[string]string) map[string]string {

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/postexecutorstep_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/postexecutorstep_test.go
@@ -1,0 +1,236 @@
+package sti
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/docker"
+)
+
+func TestStorePreviousImageStep(t *testing.T) {
+	testCases := []struct {
+		imageIDError             error
+		expectedPreviousImageID  string
+		expectedPreviousImageTag string
+	}{
+		{
+			imageIDError:             nil,
+			expectedPreviousImageID:  "12345",
+			expectedPreviousImageTag: "0.1",
+		},
+		{
+			imageIDError:             fmt.Errorf("fail"),
+			expectedPreviousImageID:  "",
+			expectedPreviousImageTag: "0.1",
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		builder := newFakeBaseSTI()
+		builder.incremental = true
+		builder.config.RemovePreviousImage = true
+		builder.config.Tag = testCase.expectedPreviousImageTag
+
+		docker := builder.docker.(*docker.FakeDocker)
+		docker.GetImageIDResult = testCase.expectedPreviousImageID
+		docker.GetImageIDError = testCase.imageIDError
+
+		step := &storePreviousImageStep{builder: builder, docker: docker}
+
+		ctx := &postExecutorStepContext{}
+
+		if err := step.execute(ctx); err != nil {
+			t.Fatalf("should exit without error, but it returned %v", err)
+		}
+
+		if docker.GetImageIDImage != testCase.expectedPreviousImageTag {
+			t.Errorf("should invoke docker.GetImageID(%q) but invoked with %q", testCase.expectedPreviousImageTag, docker.GetImageIDImage)
+		}
+
+		if ctx.previousImageID != testCase.expectedPreviousImageID {
+			t.Errorf("should set previousImageID field to %q but it's %q", testCase.expectedPreviousImageID, ctx.previousImageID)
+		}
+	}
+}
+
+func TestRemovePreviousImageStep(t *testing.T) {
+	testCases := []struct {
+		removeImageError        error
+		expectedPreviousImageID string
+	}{
+		{
+			removeImageError:        nil,
+			expectedPreviousImageID: "",
+		},
+		{
+			removeImageError:        nil,
+			expectedPreviousImageID: "12345",
+		},
+		{
+			removeImageError:        fmt.Errorf("fail"),
+			expectedPreviousImageID: "12345",
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		builder := newFakeBaseSTI()
+		builder.incremental = true
+		builder.config.RemovePreviousImage = true
+
+		docker := builder.docker.(*docker.FakeDocker)
+		docker.RemoveImageError = testCase.removeImageError
+
+		step := &removePreviousImageStep{builder: builder, docker: docker}
+
+		ctx := &postExecutorStepContext{previousImageID: testCase.expectedPreviousImageID}
+
+		if err := step.execute(ctx); err != nil {
+			t.Fatalf("should exit without error, but it returned %v", err)
+		}
+
+		if docker.RemoveImageName != testCase.expectedPreviousImageID {
+			t.Errorf("should invoke docker.RemoveImage(%q) but invoked with %q", testCase.expectedPreviousImageID, docker.RemoveImageName)
+		}
+	}
+}
+
+func TestCommitImageStep(t *testing.T) {
+
+	testCases := []struct {
+		embeddedScript   bool
+		destination      string
+		expectedImageCmd string
+	}{
+		{
+			embeddedScript:   false,
+			destination:      "/path/to/location",
+			expectedImageCmd: "/path/to/location/scripts/run",
+		},
+		{
+			embeddedScript:   true,
+			destination:      "image:///usr/bin/run.sh",
+			expectedImageCmd: "/usr/bin/run.sh",
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		expectedEnv := []string{"BUILD_LOGLEVEL"}
+		expectedContainerID := "container-yyyy"
+		expectedImageID := "image-xxx"
+		expectedImageTag := "v1"
+		expectedImageUser := "jboss"
+		expectedEntrypoint := []string{"test_entrypoint"}
+
+		displayName := "MyApp"
+		description := "My Application is awesome!"
+
+		baseImageLabels := make(map[string]string)
+		baseImageLabels["vendor"] = "CentOS"
+
+		configLabels := make(map[string]string)
+		configLabels["distribution-scope"] = "private"
+
+		expectedLabels := make(map[string]string)
+		expectedLabels["io.k8s.description"] = description
+		expectedLabels["io.k8s.display-name"] = displayName
+		expectedLabels["vendor"] = "CentOS"
+		expectedLabels["distribution-scope"] = "private"
+
+		builder := newFakeBaseSTI()
+		builder.config.DisplayName = displayName
+		builder.config.Description = description
+		builder.config.Tag = expectedImageTag
+		builder.config.Labels = configLabels
+		builder.env = expectedEnv
+
+		docker := builder.docker.(*docker.FakeDocker)
+		docker.CommitContainerResult = expectedImageID
+		docker.GetImageUserResult = expectedImageUser
+		docker.GetImageEntrypointResult = expectedEntrypoint
+		docker.Labels = baseImageLabels
+
+		ctx := &postExecutorStepContext{
+			containerID: expectedContainerID,
+		}
+
+		if testCase.embeddedScript {
+			builder.scriptsURL = make(map[string]string)
+			builder.scriptsURL["run"] = testCase.destination
+		} else {
+			ctx.destination = testCase.destination
+		}
+
+		step := &commitImageStep{builder: builder, docker: docker}
+
+		if err := step.execute(ctx); err != nil {
+			t.Fatalf("should exit without error, but it returned %v", err)
+		}
+
+		if ctx.imageID != expectedImageID {
+			t.Errorf("should set ImageID field to %q but it's %q", expectedImageID, ctx.imageID)
+		}
+
+		commitOpts := docker.CommitContainerOpts
+
+		if len(commitOpts.Command) != 1 {
+			t.Errorf("should commit container with Command: %q, but committed with %q", testCase.expectedImageCmd, commitOpts.Command)
+
+		} else if commitOpts.Command[0] != testCase.expectedImageCmd {
+			t.Errorf("should commit container with Command: %q, but committed with %q", testCase.expectedImageCmd, commitOpts.Command[0])
+		}
+
+		if !reflect.DeepEqual(commitOpts.Env, expectedEnv) {
+			t.Errorf("should commit container with Env: %v, but committed with %v", expectedEnv, commitOpts.Env)
+		}
+
+		if commitOpts.ContainerID != expectedContainerID {
+			t.Errorf("should commit container with ContainerID: %q, but committed with %q", expectedContainerID, commitOpts.ContainerID)
+		}
+
+		if commitOpts.Repository != expectedImageTag {
+			t.Errorf("should commit container with Repository: %q, but committed with %q", expectedImageTag, commitOpts.Repository)
+		}
+
+		if commitOpts.User != expectedImageUser {
+			t.Errorf("should commit container with User: %q, but committed with %q", expectedImageUser, commitOpts.User)
+		}
+
+		if !reflect.DeepEqual(commitOpts.Entrypoint, expectedEntrypoint) {
+			t.Errorf("should commit container with Entrypoint: %q, but committed with %q", expectedEntrypoint, commitOpts.Entrypoint)
+		}
+
+		if !reflect.DeepEqual(commitOpts.Labels, expectedLabels) {
+			t.Errorf("should commit container with Labels: %v, but committed with %v", expectedLabels, commitOpts.Labels)
+		}
+	}
+}
+
+func TestDownloadFilesFromBuilderImageStep(t *testing.T) {
+	// FIXME
+}
+
+func TestStartRuntimeImageAndUploadFilesStep(t *testing.T) {
+	// FIXME
+}
+
+func TestReportSuccessStep(t *testing.T) {
+	builder := newFakeBaseSTI()
+	step := &reportSuccessStep{builder: builder}
+	ctx := &postExecutorStepContext{imageID: "my-app"}
+
+	if err := step.execute(ctx); err != nil {
+		t.Fatalf("should exit without error, but it returned %v", err)
+	}
+
+	if builder.result.Success != true {
+		t.Errorf("should set Success field to 'true' but it's %v", builder.result.Success)
+	}
+
+	if builder.result.ImageID != ctx.imageID {
+		t.Errorf("should set ImageID field to %q but it's %q", ctx.imageID, builder.result.ImageID)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/scripts"
 	"github.com/openshift/source-to-image/pkg/tar"
 	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 	utilstatus "github.com/openshift/source-to-image/pkg/util/status"
 )
@@ -50,7 +51,7 @@ type STI struct {
 	installer              scripts.Installer
 	runtimeInstaller       scripts.Installer
 	git                    git.Git
-	fs                     util.FileSystem
+	fs                     fs.FileSystem
 	tar                    tar.Tar
 	docker                 dockerpkg.Docker
 	incrementalDocker      dockerpkg.Docker
@@ -87,7 +88,7 @@ type STI struct {
 // If the layeredBuilder parameter is specified, then the builder provided will
 // be used for the case that the base Docker image does not have 'tar' or 'bash'
 // installed.
-func New(client dockerpkg.Client, config *api.Config, fs util.FileSystem, overrides build.Overrides) (*STI, error) {
+func New(client dockerpkg.Client, config *api.Config, fs fs.FileSystem, overrides build.Overrides) (*STI, error) {
 	excludePattern, err := regexp.Compile(config.ExcludeRegExp)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/sti_test.go
@@ -1,0 +1,935 @@
+package sti
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"reflect"
+	"regexp/syntax"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/build"
+	"github.com/openshift/source-to-image/pkg/docker"
+	s2ierr "github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/ignore"
+	"github.com/openshift/source-to-image/pkg/scm/empty"
+	"github.com/openshift/source-to-image/pkg/scm/file"
+	"github.com/openshift/source-to-image/pkg/scm/git"
+	"github.com/openshift/source-to-image/pkg/test"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+type FakeSTI struct {
+	CleanupCalled          bool
+	PrepareCalled          bool
+	SetupRequired          []string
+	SetupOptional          []string
+	SetupError             error
+	ExistsCalled           bool
+	ExistsError            error
+	BuildRequest           *api.Config
+	BuildResult            *api.Result
+	DownloadError          error
+	SaveArtifactsCalled    bool
+	SaveArtifactsError     error
+	FetchSourceCalled      bool
+	FetchSourceError       error
+	ExecuteCommand         string
+	ExecuteUser            string
+	ExecuteError           error
+	ExpectedError          bool
+	LayeredBuildCalled     bool
+	LayeredBuildError      error
+	PostExecuteDestination string
+	PostExecuteContainerID string
+	PostExecuteError       error
+}
+
+func newFakeBaseSTI() *STI {
+	return &STI{
+		config:    &api.Config{},
+		result:    &api.Result{},
+		docker:    &docker.FakeDocker{},
+		installer: &test.FakeInstaller{},
+		git:       &test.FakeGit{},
+		fs:        &testfs.FakeFileSystem{},
+		tar:       &test.FakeTar{},
+	}
+}
+
+func newFakeSTI(f *FakeSTI) *STI {
+	s := &STI{
+		config:        &api.Config{},
+		result:        &api.Result{},
+		docker:        &docker.FakeDocker{},
+		runtimeDocker: &docker.FakeDocker{},
+		installer:     &test.FakeInstaller{},
+		git:           &test.FakeGit{},
+		fs:            &testfs.FakeFileSystem{},
+		tar:           &test.FakeTar{},
+		preparer:      f,
+		ignorer:       &ignore.DockerIgnorer{},
+		artifacts:     f,
+		scripts:       f,
+		garbage:       f,
+		layered:       &FakeDockerBuild{f},
+	}
+	s.source = &git.Clone{Git: s.git, FileSystem: s.fs}
+	return s
+}
+
+func (f *FakeSTI) Cleanup(*api.Config) {
+	f.CleanupCalled = true
+}
+
+func (f *FakeSTI) Prepare(*api.Config) error {
+	f.PrepareCalled = true
+	f.SetupRequired = []string{api.Assemble, api.Run}
+	f.SetupOptional = []string{api.SaveArtifacts}
+	return nil
+}
+
+func (f *FakeSTI) Exists(*api.Config) bool {
+	f.ExistsCalled = true
+	return true
+}
+
+func (f *FakeSTI) Request() *api.Config {
+	return f.BuildRequest
+}
+
+func (f *FakeSTI) Result() *api.Result {
+	return f.BuildResult
+}
+
+func (f *FakeSTI) Save(*api.Config) error {
+	f.SaveArtifactsCalled = true
+	return f.SaveArtifactsError
+}
+
+func (f *FakeSTI) fetchSource() error {
+	return f.FetchSourceError
+}
+
+func (f *FakeSTI) Download(*api.Config) (*api.SourceInfo, error) {
+	return nil, f.DownloadError
+}
+
+func (f *FakeSTI) Execute(command string, user string, r *api.Config) error {
+	f.ExecuteCommand = command
+	f.ExecuteUser = user
+	return f.ExecuteError
+}
+
+func (f *FakeSTI) wasExpectedError(text string) bool {
+	return f.ExpectedError
+}
+
+func (f *FakeSTI) PostExecute(id, destination string) error {
+	f.PostExecuteContainerID = id
+	f.PostExecuteDestination = destination
+	return f.PostExecuteError
+}
+
+type FakeDockerBuild struct {
+	*FakeSTI
+}
+
+func (f *FakeDockerBuild) Build(*api.Config) (*api.Result, error) {
+	f.LayeredBuildCalled = true
+	return &api.Result{}, f.LayeredBuildError
+}
+
+func TestDefaultSource(t *testing.T) {
+	config := &api.Config{
+		Source:       "file://.",
+		DockerConfig: &api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"},
+	}
+	client, err := docker.NewEngineAPIClient(config.DockerConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sti, err := New(client, config, fs.NewFileSystem(), build.Overrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Source == "" {
+		t.Errorf("Config.Source not set: %v", config.Source)
+	}
+	if _, ok := sti.source.(*file.File); !ok || sti.source == nil {
+		t.Errorf("Source interface not set: %#v", sti.source)
+	}
+}
+
+func TestEmptySource(t *testing.T) {
+	config := &api.Config{
+		Source:       "",
+		DockerConfig: &api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"},
+	}
+	client, err := docker.NewEngineAPIClient(config.DockerConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sti, err := New(client, config, fs.NewFileSystem(), build.Overrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Source != "" {
+		t.Errorf("Config.Source unexpectantly changed: %v", config.Source)
+	}
+	if _, ok := sti.source.(*empty.Noop); !ok || sti.source == nil {
+		t.Errorf("Source interface not set: %#v", sti.source)
+	}
+}
+
+func TestOverrides(t *testing.T) {
+	fd := &FakeSTI{}
+	client, err := docker.NewEngineAPIClient(&api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sti, err := New(client,
+		&api.Config{
+			DockerConfig: &api.DockerConfig{Endpoint: "unix:///var/run/docker.sock"},
+		},
+		fs.NewFileSystem(),
+		build.Overrides{
+			Downloader: fd,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sti.source != fd {
+		t.Errorf("Override of downloader not set: %#v", sti)
+	}
+}
+
+func TestBuild(t *testing.T) {
+	incrementalTest := []bool{false, true}
+	for _, incremental := range incrementalTest {
+		fh := &FakeSTI{
+			BuildRequest: &api.Config{Incremental: incremental},
+			BuildResult:  &api.Result{},
+		}
+
+		builder := newFakeSTI(fh)
+		builder.Build(&api.Config{Incremental: incremental})
+
+		// Verify the right scripts were configed
+		if !reflect.DeepEqual(fh.SetupRequired, []string{api.Assemble, api.Run}) {
+			t.Errorf("Unexpected required scripts configed: %#v", fh.SetupRequired)
+		}
+		if !reflect.DeepEqual(fh.SetupOptional, []string{api.SaveArtifacts}) {
+			t.Errorf("Unexpected optional scripts configed: %#v", fh.SetupOptional)
+		}
+
+		// Verify that Exists was called
+		if !fh.ExistsCalled {
+			t.Errorf("Exists was not called.")
+		}
+
+		// Verify that Save was called for an incremental build
+		if incremental && !fh.SaveArtifactsCalled {
+			t.Errorf("Save artifacts was not called for an incremental build")
+		}
+
+		// Verify that Execute was called with the right script
+		if fh.ExecuteCommand != api.Assemble {
+			t.Errorf("Unexpected execute command: %s", fh.ExecuteCommand)
+		}
+	}
+}
+
+func TestLayeredBuild(t *testing.T) {
+	fh := &FakeSTI{
+		BuildRequest: &api.Config{
+			BuilderImage: "testimage",
+		},
+		BuildResult: &api.Result{
+			BuildInfo: api.BuildInfo{
+				Stages: []api.StageInfo{},
+			},
+		},
+		ExecuteError:  errMissingRequirements,
+		ExpectedError: true,
+	}
+	builder := newFakeSTI(fh)
+	builder.Build(&api.Config{BuilderImage: "testimage"})
+	// Verify layered build
+	if !fh.LayeredBuildCalled {
+		t.Errorf("Layered build was not called.")
+	}
+}
+
+func TestBuildErrorExecute(t *testing.T) {
+	fh := &FakeSTI{
+		BuildRequest: &api.Config{
+			BuilderImage: "testimage",
+		},
+		BuildResult:   &api.Result{},
+		ExecuteError:  errors.New("ExecuteError"),
+		ExpectedError: false,
+	}
+	builder := newFakeSTI(fh)
+	_, err := builder.Build(&api.Config{BuilderImage: "testimage"})
+	if err == nil || err.Error() != "ExecuteError" {
+		t.Errorf("An error was expected, but got different %v", err)
+	}
+}
+
+func TestWasExpectedError(t *testing.T) {
+	type expErr struct {
+		text     string
+		expected bool
+	}
+
+	tests := []expErr{
+		{ // 0 - tar error
+			text:     `/bin/sh: tar: not found`,
+			expected: true,
+		},
+		{ // 1 - tar error
+			text:     `/bin/sh: tar: command not found`,
+			expected: true,
+		},
+		{ // 2 - /bin/sh error
+			text:     `exec: "/bin/sh": stat /bin/sh: no such file or directory`,
+			expected: true,
+		},
+		{ // 3 - non container error
+			text:     "other error",
+			expected: false,
+		},
+	}
+
+	for i, ti := range tests {
+		result := isMissingRequirements(ti.text)
+		if result != ti.expected {
+			t.Errorf("(%d) Unexpected result: %v. Expected: %v", i, result, ti.expected)
+		}
+	}
+}
+
+func testBuildHandler() *STI {
+	s := &STI{
+		docker:            &docker.FakeDocker{},
+		incrementalDocker: &docker.FakeDocker{},
+		installer:         &test.FakeInstaller{},
+		git:               &test.FakeGit{},
+		fs:                &testfs.FakeFileSystem{ExistsResult: map[string]bool{filepath.FromSlash("a-repo-source"): true}},
+		tar:               &test.FakeTar{},
+		config:            &api.Config{},
+		result:            &api.Result{},
+		callbackInvoker:   &test.FakeCallbackInvoker{},
+	}
+	s.source = &git.Clone{Git: s.git, FileSystem: s.fs}
+	s.initPostExecutorSteps()
+	return s
+}
+
+func TestPostExecute(t *testing.T) {
+	type postExecuteTest struct {
+		tag              string
+		incremental      bool
+		previousImageID  string
+		scriptsFromImage bool
+	}
+	testCases := []postExecuteTest{
+		// 0: tagged, incremental, without previous image
+		{"test/tag", true, "", true},
+		// 1: tagged, incremental, with previous image
+		{"test/tag", true, "test-image", true},
+		// 2: tagged, no incremental, without previous image
+		{"test/tag", false, "", true},
+		// 3: tagged, no incremental, with previous image
+		{"test/tag", false, "test-image", true},
+
+		// 4: no tag, incremental, without previous image
+		{"", true, "", false},
+		// 5: no tag, incremental, with previous image
+		{"", true, "test-image", false},
+		// 6: no tag, no incremental, without previous image
+		{"", false, "", false},
+		// 7: no tag, no incremental, with previous image
+		{"", false, "test-image", false},
+	}
+
+	for i, tc := range testCases {
+		bh := testBuildHandler()
+		containerID := "test-container-id"
+		bh.result.Messages = []string{"one", "two"}
+		bh.config.Tag = tc.tag
+		bh.config.Incremental = tc.incremental
+		dh := bh.docker.(*docker.FakeDocker)
+		if tc.previousImageID != "" {
+			bh.config.RemovePreviousImage = true
+			bh.incremental = tc.incremental
+			bh.docker.(*docker.FakeDocker).GetImageIDResult = tc.previousImageID
+		}
+		if tc.scriptsFromImage {
+			bh.scriptsURL = map[string]string{api.Run: "image:///usr/libexec/s2i/run"}
+		}
+		err := bh.PostExecute(containerID, "cmd1")
+		if err != nil {
+			t.Errorf("(%d) Unexpected error from postExecute: %v", i, err)
+		}
+		// Ensure CommitContainer was called with the right parameters
+		expectedCmd := []string{"cmd1/scripts/" + api.Run}
+		if tc.scriptsFromImage {
+			expectedCmd = []string{"/usr/libexec/s2i/" + api.Run}
+		}
+		if !reflect.DeepEqual(dh.CommitContainerOpts.Command, expectedCmd) {
+			t.Errorf("(%d) Unexpected commit container command: %#v, expected %q", i, dh.CommitContainerOpts.Command, expectedCmd)
+		}
+		if dh.CommitContainerOpts.Repository != tc.tag {
+			t.Errorf("(%d) Unexpected tag committed, expected %q, got %q", i, tc.tag, dh.CommitContainerOpts.Repository)
+		}
+		// Ensure image removal when incremental and previousImageID present
+		if tc.incremental && tc.previousImageID != "" {
+			if dh.RemoveImageName != "test-image" {
+				t.Errorf("(%d) Previous image was not removed: %q", i, dh.RemoveImageName)
+			}
+		} else {
+			if dh.RemoveImageName != "" {
+				t.Errorf("(%d) Unexpected image removed: %s", i, dh.RemoveImageName)
+			}
+		}
+	}
+}
+
+func TestExists(t *testing.T) {
+	type incrementalTest struct {
+		// incremental flag was passed
+		incremental bool
+		// previous image existence
+		previousImage bool
+		// script installed
+		scriptInstalled bool
+		// expected result
+		expected bool
+	}
+
+	tests := []incrementalTest{
+		// 0-1: incremental, no image, no matter what with scripts
+		{true, false, false, false},
+		{true, false, true, false},
+
+		// 2: incremental, previous image, no scripts
+		{true, true, false, false},
+		// 3: incremental, previous image, scripts installed
+		{true, true, true, true},
+
+		// 4-7: no incremental build - should always return false no matter what other flags are
+		{false, false, false, false},
+		{false, false, true, false},
+		{false, true, false, false},
+		{false, true, true, false},
+	}
+
+	for i, ti := range tests {
+		bh := testBuildHandler()
+		bh.config.WorkingDir = "/working-dir"
+		bh.config.Incremental = ti.incremental
+		bh.config.BuilderPullPolicy = api.PullAlways
+		bh.installedScripts = map[string]bool{api.SaveArtifacts: ti.scriptInstalled}
+		bh.incrementalDocker.(*docker.FakeDocker).PullResult = ti.previousImage
+		bh.config.DockerConfig = &api.DockerConfig{Endpoint: "http://localhost:4243"}
+		incremental := bh.Exists(bh.config)
+		if incremental != ti.expected {
+			t.Errorf("(%d) Unexpected incremental result: %v. Expected: %v",
+				i, incremental, ti.expected)
+		}
+		if ti.incremental && ti.previousImage && ti.scriptInstalled {
+			if len(bh.fs.(*testfs.FakeFileSystem).ExistsFile) == 0 {
+				continue
+			}
+			scriptChecked := bh.fs.(*testfs.FakeFileSystem).ExistsFile[0]
+			expectedScript := "/working-dir/upload/scripts/save-artifacts"
+			if scriptChecked != expectedScript {
+				t.Errorf("(%d) Unexpected script checked. Actual: %s. Expected: %s",
+					i, scriptChecked, expectedScript)
+			}
+		}
+	}
+}
+
+func TestSaveArtifacts(t *testing.T) {
+	bh := testBuildHandler()
+	bh.config.WorkingDir = "/working-dir"
+	bh.config.Tag = "image/tag"
+	fs := bh.fs.(*testfs.FakeFileSystem)
+	fd := bh.docker.(*docker.FakeDocker)
+	th := bh.tar.(*test.FakeTar)
+	err := bh.Save(bh.config)
+	if err != nil {
+		t.Errorf("Unexpected error when saving artifacts: %v", err)
+	}
+	expectedArtifactDir := "/working-dir/upload/artifacts"
+	if filepath.ToSlash(fs.MkdirDir) != expectedArtifactDir {
+		t.Errorf("Mkdir was not called with the expected directory: %s",
+			fs.MkdirDir)
+	}
+	if fd.RunContainerOpts.Image != bh.config.Tag {
+		t.Errorf("Unexpected image sent to RunContainer: %s",
+			fd.RunContainerOpts.Image)
+	}
+	if filepath.ToSlash(th.ExtractTarDir) != expectedArtifactDir || th.ExtractTarReader == nil {
+		t.Errorf("ExtractTar was not called with the expected parameters.")
+	}
+}
+
+func TestSaveArtifactsCustomTag(t *testing.T) {
+	bh := testBuildHandler()
+	bh.config.WorkingDir = "/working-dir"
+	bh.config.IncrementalFromTag = "custom/tag"
+	bh.config.Tag = "image/tag"
+	fs := bh.fs.(*testfs.FakeFileSystem)
+	fd := bh.docker.(*docker.FakeDocker)
+	th := bh.tar.(*test.FakeTar)
+	err := bh.Save(bh.config)
+	if err != nil {
+		t.Errorf("Unexpected error when saving artifacts: %v", err)
+	}
+	expectedArtifactDir := "/working-dir/upload/artifacts"
+	if filepath.ToSlash(fs.MkdirDir) != expectedArtifactDir {
+		t.Errorf("Mkdir was not called with the expected directory: %s",
+			fs.MkdirDir)
+	}
+	if fd.RunContainerOpts.Image != bh.config.IncrementalFromTag {
+		t.Errorf("Unexpected image sent to RunContainer: %s",
+			fd.RunContainerOpts.Image)
+	}
+	if filepath.ToSlash(th.ExtractTarDir) != expectedArtifactDir || th.ExtractTarReader == nil {
+		t.Errorf("ExtractTar was not called with the expected parameters.")
+	}
+}
+
+func TestSaveArtifactsRunError(t *testing.T) {
+	tests := []error{
+		fmt.Errorf("Run error"),
+		s2ierr.NewContainerError("", -1, ""),
+	}
+	expected := []error{
+		tests[0],
+		s2ierr.NewSaveArtifactsError("", "", tests[1]),
+	}
+	// test with tar extract error or not
+	tarError := []bool{true, false}
+	for i := range tests {
+		for _, te := range tarError {
+			bh := testBuildHandler()
+			fd := bh.docker.(*docker.FakeDocker)
+			th := bh.tar.(*test.FakeTar)
+			fd.RunContainerError = tests[i]
+			if te {
+				th.ExtractTarError = fmt.Errorf("tar error")
+			}
+			err := bh.Save(bh.config)
+			if !te && err != expected[i] {
+				t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+			} else if te && err != th.ExtractTarError {
+				t.Errorf("Expected tar error. Got %v", err)
+			}
+		}
+	}
+}
+
+func TestSaveArtifactsErrorBeforeStart(t *testing.T) {
+	bh := testBuildHandler()
+	fd := bh.docker.(*docker.FakeDocker)
+	expected := fmt.Errorf("run error")
+	fd.RunContainerError = expected
+	fd.RunContainerErrorBeforeStart = true
+	err := bh.Save(bh.config)
+	if err != expected {
+		t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+	}
+}
+
+func TestSaveArtifactsExtractError(t *testing.T) {
+	bh := testBuildHandler()
+	th := bh.tar.(*test.FakeTar)
+	expected := fmt.Errorf("extract error")
+	th.ExtractTarError = expected
+	err := bh.Save(bh.config)
+	if err != expected {
+		t.Errorf("Unexpected error returned from saveArtifacts: %v", err)
+	}
+}
+
+func TestFetchSource(t *testing.T) {
+	type fetchTest struct {
+		refSpecified     bool
+		checkoutExpected bool
+	}
+
+	tests := []fetchTest{
+		// 0
+		{
+			refSpecified:     false,
+			checkoutExpected: false,
+		},
+		// 1
+		{
+			refSpecified:     true,
+			checkoutExpected: true,
+		},
+	}
+
+	for testNum, ft := range tests {
+		bh := testBuildHandler()
+		gh := bh.git.(*test.FakeGit)
+
+		bh.config.WorkingDir = "/working-dir"
+		gh.ValidCloneSpecResult = true
+		if ft.refSpecified {
+			bh.config.Ref = "a-branch"
+		}
+		bh.config.Source = "a-repo-source"
+
+		expectedTargetDir := "/working-dir/upload/src"
+		_, e := bh.source.Download(bh.config)
+		if e != nil {
+			t.Errorf("Unexpected error %v [%d]", e, testNum)
+		}
+		if gh.CloneSource != "a-repo-source" {
+			t.Errorf("Clone was not called with the expected source. Got %s, expected %s [%d]", gh.CloneSource, "a-source-repo-source", testNum)
+		}
+		if filepath.ToSlash(gh.CloneTarget) != expectedTargetDir {
+			t.Errorf("Unexpected target directory for clone operation. Got %s, expected %s [%d]", gh.CloneTarget, expectedTargetDir, testNum)
+		}
+		if ft.checkoutExpected {
+			if gh.CheckoutRef != "a-branch" {
+				t.Errorf("Checkout was not called with the expected branch. Got %s, expected %s [%d]", gh.CheckoutRef, "a-branch", testNum)
+			}
+			if filepath.ToSlash(gh.CheckoutRepo) != expectedTargetDir {
+				t.Errorf("Unexpected target repository for checkout operation. Got %s, expected %s [%d]", gh.CheckoutRepo, expectedTargetDir, testNum)
+			}
+		}
+	}
+}
+
+func TestPrepareOK(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.SetScripts([]string{api.Assemble, api.Run}, []string{api.SaveArtifacts})
+	rh.fs.(*testfs.FakeFileSystem).WorkingDirResult = "/working-dir"
+	err := rh.Prepare(rh.config)
+	if err != nil {
+		t.Errorf("An error occurred setting up the config handler: %v", err)
+	}
+	if !rh.fs.(*testfs.FakeFileSystem).WorkingDirCalled {
+		t.Errorf("Working directory was not created.")
+	}
+	var expected []string
+	for _, dir := range workingDirs {
+		expected = append(expected, filepath.FromSlash("/working-dir/"+dir))
+	}
+	mkdirs := rh.fs.(*testfs.FakeFileSystem).MkdirAllDir
+	if !reflect.DeepEqual(mkdirs, expected) {
+		t.Errorf("Unexpected set of MkdirAll calls: %#v", mkdirs)
+	}
+	scripts := rh.installer.(*test.FakeInstaller).Scripts
+	if !reflect.DeepEqual(scripts[0], []string{api.Assemble, api.Run}) {
+		t.Errorf("Unexpected set of required scripts: %#v", scripts[0])
+	}
+	if !reflect.DeepEqual(scripts[1], []string{api.SaveArtifacts}) {
+		t.Errorf("Unexpected set of optional scripts: %#v", scripts[1])
+	}
+}
+
+func TestPrepareErrorCreatingWorkingDir(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.fs.(*testfs.FakeFileSystem).WorkingDirError = errors.New("WorkingDirError")
+	err := rh.Prepare(rh.config)
+	if err == nil || err.Error() != "WorkingDirError" {
+		t.Errorf("An error was expected for WorkingDir, but got different: %v", err)
+	}
+}
+
+func TestPrepareErrorMkdirAll(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.fs.(*testfs.FakeFileSystem).MkdirAllError = errors.New("MkdirAllError")
+	err := rh.Prepare(rh.config)
+	if err == nil || err.Error() != "MkdirAllError" {
+		t.Errorf("An error was expected for MkdirAll, but got different: %v", err)
+	}
+}
+
+func TestPrepareErrorRequiredDownloadAndInstall(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.SetScripts([]string{api.Assemble, api.Run}, []string{api.SaveArtifacts})
+	rh.installer.(*test.FakeInstaller).Error = fmt.Errorf("%v", api.Assemble)
+	err := rh.Prepare(rh.config)
+	if err == nil || err.Error() != api.Assemble {
+		t.Errorf("An error was expected for required DownloadAndInstall, but got different: %v", err)
+	}
+}
+
+func TestPrepareErrorOptionalDownloadAndInstall(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.SetScripts([]string{api.Assemble, api.Run}, []string{api.SaveArtifacts})
+	err := rh.Prepare(rh.config)
+	if err != nil {
+		t.Errorf("Unexpected error when downloading optional scripts: %v", err)
+	}
+}
+
+func TestPrepareUseCustomRuntimeArtifacts(t *testing.T) {
+	expectedMapping := filepath.FromSlash("/src") + ":dst"
+
+	builder := newFakeSTI(&FakeSTI{})
+
+	config := builder.config
+	config.RuntimeImage = "my-app"
+	config.RuntimeArtifacts.Set(expectedMapping)
+
+	if err := builder.Prepare(config); err != nil {
+		t.Fatalf("Prepare() unexpectedly failed with error: %v", err)
+	}
+
+	if actualMapping := config.RuntimeArtifacts.String(); actualMapping != expectedMapping {
+		t.Errorf("Prepare() shouldn't change mapping, but it was modified from %v to %v", expectedMapping, actualMapping)
+	}
+}
+
+func TestPrepareFailForEmptyRuntimeArtifacts(t *testing.T) {
+	builder := newFakeSTI(&FakeSTI{})
+
+	docker := builder.docker.(*docker.FakeDocker)
+	docker.AssembleInputFilesResult = ""
+
+	config := builder.config
+	config.RuntimeImage = "my-app"
+
+	if len(config.RuntimeArtifacts) > 0 {
+		t.Fatalf("RuntimeArtifacts must be empty by default")
+	}
+
+	err := builder.Prepare(config)
+	if err == nil {
+		t.Errorf("Prepare() should fail but it didn't")
+
+	} else if expectedError := "no runtime artifacts to copy"; !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Prepare() should fail with error that contains text %q but failed with error: %q", expectedError, err)
+	}
+}
+
+func TestPrepareRuntimeArtifactsValidation(t *testing.T) {
+	testCases := []struct {
+		mapping       string
+		expectedError string
+	}{
+		{
+			mapping:       "src:dst",
+			expectedError: "source must be an absolute path",
+		},
+		{
+			mapping:       "/src:/dst",
+			expectedError: "destination must be a relative path",
+		},
+		{
+			mapping:       "/src:../dst",
+			expectedError: "destination cannot start with '..'",
+		},
+	}
+
+	for _, testCase := range testCases {
+		for _, mappingFromUser := range []bool{true, false} {
+			builder := newFakeSTI(&FakeSTI{})
+
+			config := builder.config
+			config.RuntimeImage = "my-app"
+
+			if mappingFromUser {
+				config.RuntimeArtifacts.Set(testCase.mapping)
+			} else {
+				docker := builder.docker.(*docker.FakeDocker)
+				docker.AssembleInputFilesResult = testCase.mapping
+			}
+
+			err := builder.Prepare(config)
+			if err == nil {
+				t.Errorf("Prepare() should fail but it didn't")
+
+			} else if !strings.Contains(err.Error(), testCase.expectedError) {
+				t.Errorf("Prepare() should fail to validate mapping %q with error that contains text %q but failed with error: %q", testCase.mapping, testCase.expectedError, err)
+			}
+		}
+	}
+}
+
+func TestPrepareSetRuntimeArtifacts(t *testing.T) {
+	for _, mapping := range []string{filepath.FromSlash("/src") + ":dst", filepath.FromSlash("/src1") + ":dst1;" + filepath.FromSlash("/src1") + ":dst1"} {
+		expectedMapping := strings.Replace(mapping, ";", ",", -1)
+
+		builder := newFakeSTI(&FakeSTI{})
+
+		docker := builder.docker.(*docker.FakeDocker)
+		docker.AssembleInputFilesResult = mapping
+
+		config := builder.config
+		config.RuntimeImage = "my-app"
+
+		if len(config.RuntimeArtifacts) > 0 {
+			t.Fatalf("RuntimeArtifacts must be empty by default")
+		}
+
+		if err := builder.Prepare(config); err != nil {
+			t.Fatalf("Prepare() unexpectedly failed with error: %v", err)
+		}
+
+		if actualMapping := config.RuntimeArtifacts.String(); actualMapping != expectedMapping {
+			t.Errorf("Prepare() shouldn't change mapping, but it was modified from %v to %v", expectedMapping, actualMapping)
+		}
+	}
+}
+
+func TestPrepareDownloadAssembleRuntime(t *testing.T) {
+	installer := &test.FakeInstaller{}
+
+	builder := newFakeSTI(&FakeSTI{})
+	builder.runtimeInstaller = installer
+	builder.optionalRuntimeScripts = []string{api.AssembleRuntime}
+
+	config := builder.config
+	config.RuntimeImage = "my-app"
+	config.RuntimeArtifacts.Set("/src:dst")
+
+	if err := builder.Prepare(config); err != nil {
+		t.Fatalf("Prepare() unexpectedly failed with error: %v", err)
+	}
+
+	if len(installer.Scripts) != 1 || installer.Scripts[0][0] != api.AssembleRuntime {
+		t.Errorf("Prepare() should download %q script but it downloaded %v", api.AssembleRuntime, installer.Scripts)
+	}
+}
+
+func TestExecuteOK(t *testing.T) {
+	rh := newFakeBaseSTI()
+	pe := &FakeSTI{}
+	rh.postExecutor = pe
+	rh.config.WorkingDir = "/working-dir"
+	rh.config.BuilderImage = "test/image"
+	rh.config.BuilderPullPolicy = api.PullAlways
+	rh.config.Environment = api.EnvironmentList{
+		api.EnvironmentSpec{
+			Name:  "Key1",
+			Value: "Value1",
+		},
+		api.EnvironmentSpec{
+			Name:  "Key2",
+			Value: "Value2",
+		},
+	}
+	expectedEnv := []string{"Key1=Value1", "Key2=Value2"}
+	th := rh.tar.(*test.FakeTar)
+	th.CreateTarResult = "/working-dir/test.tar"
+	fd := rh.docker.(*docker.FakeDocker)
+	fd.RunContainerContainerID = "1234"
+	fd.RunContainerCmd = []string{"one", "two"}
+
+	err := rh.Execute("test-command", "foo", rh.config)
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+	th = rh.tar.(*test.FakeTar).Copy()
+	if th.CreateTarBase != "" {
+		t.Errorf("Unexpected tar base directory: %s", th.CreateTarBase)
+	}
+	if filepath.ToSlash(th.CreateTarDir) != "/working-dir/upload" {
+		t.Errorf("Unexpected tar directory: %s", th.CreateTarDir)
+	}
+	fh, ok := rh.fs.(*testfs.FakeFileSystem)
+	if !ok {
+		t.Fatalf("Unable to convert %v to FakeFilesystem", rh.fs)
+	}
+	if fh.OpenFile != "" {
+		t.Fatalf("Unexpected file opened: %s", fh.OpenFile)
+	}
+	if fh.OpenFileResult != nil {
+		t.Errorf("Tar file was opened.")
+	}
+	ro := fd.RunContainerOpts
+
+	if ro.User != "foo" {
+		t.Errorf("Expected user to be foo, got %q", ro.User)
+	}
+
+	if ro.Image != rh.config.BuilderImage {
+		t.Errorf("Unexpected Image passed to RunContainer")
+	}
+	if _, ok := ro.Stdin.(*io.PipeReader); !ok {
+		t.Errorf("Unexpected input stream: %#v", ro.Stdin)
+	}
+	if ro.PullImage {
+		t.Errorf("PullImage is true for RunContainer, should be false")
+	}
+	if ro.Command != "test-command" {
+		t.Errorf("Unexpected command passed to RunContainer: %s",
+			ro.Command)
+	}
+	if pe.PostExecuteContainerID != "1234" {
+		t.Errorf("PostExecutor not called with expected ID: %s",
+			pe.PostExecuteContainerID)
+	}
+	if !reflect.DeepEqual(ro.Env, expectedEnv) {
+		t.Errorf("Unexpected container environment passed to RunContainer: %v, should be %v", ro.Env, expectedEnv)
+	}
+	if !reflect.DeepEqual(pe.PostExecuteDestination, "test-command") {
+		t.Errorf("PostExecutor not called with expected command: %s", pe.PostExecuteDestination)
+	}
+}
+
+func TestExecuteRunContainerError(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	fd := rh.docker.(*docker.FakeDocker)
+	runContainerError := fmt.Errorf("an error")
+	fd.RunContainerError = runContainerError
+	err := rh.Execute("test-command", "", rh.config)
+	if err != runContainerError {
+		t.Errorf("Did not get expected error, got %v", err)
+	}
+}
+
+func TestExecuteErrorCreateTarFile(t *testing.T) {
+	rh := newFakeSTI(&FakeSTI{})
+	rh.tar.(*test.FakeTar).CreateTarError = errors.New("CreateTarError")
+	err := rh.Execute("test-command", "", rh.config)
+	if err == nil || err.Error() != "CreateTarError" {
+		t.Errorf("An error was expected for CreateTarFile, but got different: %#v", err)
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	rh := newFakeBaseSTI()
+
+	rh.config.WorkingDir = "/working-dir"
+	preserve := []bool{false, true}
+	for _, p := range preserve {
+		rh.config.PreserveWorkingDir = p
+		rh.fs = &testfs.FakeFileSystem{}
+		rh.garbage = build.NewDefaultCleaner(rh.fs, rh.docker)
+		rh.garbage.Cleanup(rh.config)
+		removedDir := rh.fs.(*testfs.FakeFileSystem).RemoveDirName
+		if p && removedDir != "" {
+			t.Errorf("Expected working directory to be preserved, but it was removed.")
+		} else if !p && removedDir == "" {
+			t.Errorf("Expected working directory to be removed, but it was preserved.")
+		}
+	}
+}
+
+func TestNewWithInvalidExcludeRegExp(t *testing.T) {
+	_, err := New(nil, &api.Config{
+		DockerConfig:  docker.GetDefaultDockerConfig(),
+		ExcludeRegExp: "(",
+	}, nil, build.Overrides{})
+	if syntaxErr, ok := err.(*syntax.Error); ok && syntaxErr.Code != syntax.ErrMissingParen {
+		t.Errorf("expected regexp compilation error, got %v", err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/usage.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/usage.go
@@ -4,7 +4,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/build"
 	"github.com/openshift/source-to-image/pkg/docker"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // UsageHandler handles a config to display usage
@@ -23,7 +23,7 @@ type Usage struct {
 
 // NewUsage creates a new instance of the default Usage implementation
 func NewUsage(client docker.Client, config *api.Config) (*Usage, error) {
-	b, err := New(client, config, util.NewFileSystem(), build.Overrides{})
+	b, err := New(client, config, fs.NewFileSystem(), build.Overrides{})
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/usage_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/sti/usage_test.go
@@ -1,0 +1,100 @@
+package sti
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+type FakeUsageHandler struct {
+	cleanupCalled  bool
+	setupRequired  []string
+	setupOptional  []string
+	setupError     error
+	executeCommand string
+	executeUser    string
+	executeError   error
+}
+
+type FakeCleaner struct {
+	cleanupCalled bool
+}
+
+func (f *FakeCleaner) Cleanup(*api.Config) {
+	f.cleanupCalled = true
+}
+
+func (f *FakeUsageHandler) Prepare(*api.Config) error {
+	return f.setupError
+}
+
+func (f *FakeUsageHandler) SetScripts(r, o []string) {
+	f.setupRequired = r
+	f.setupOptional = o
+}
+
+func (f *FakeUsageHandler) Execute(command string, user string, r *api.Config) error {
+	f.executeCommand = command
+	f.executeUser = user
+	return f.executeError
+}
+
+func (f *FakeUsageHandler) Download(*api.Config) error {
+	return nil
+}
+
+func newTestUsage() *Usage {
+	return &Usage{
+		handler: &FakeUsageHandler{},
+	}
+}
+
+func TestUsage(t *testing.T) {
+	u := newTestUsage()
+	g := &FakeCleaner{}
+	u.garbage = g
+	fh := u.handler.(*FakeUsageHandler)
+	err := u.Show()
+	if err != nil {
+		t.Errorf("Unexpected error returned from Usage: %v", err)
+	}
+	if !reflect.DeepEqual(fh.setupOptional, []string{}) {
+		t.Errorf("setup called with unexpected optional scripts: %#v", fh.setupOptional)
+	}
+	if !reflect.DeepEqual(fh.setupRequired, []string{api.Usage}) {
+		t.Errorf("setup called with unexpected required scripts: %#v", fh.setupRequired)
+	}
+	if fh.executeCommand != "usage" {
+		t.Errorf("execute called with unexpected command: %#v", fh.executeCommand)
+	}
+	if !g.cleanupCalled {
+		t.Errorf("cleanup was not called from usage.")
+	}
+}
+
+func TestUsageSetupError(t *testing.T) {
+	u := newTestUsage()
+	u.garbage = &FakeCleaner{}
+	fh := u.handler.(*FakeUsageHandler)
+	fh.setupError = fmt.Errorf("setup error")
+	err := u.Show()
+	if err != fh.setupError {
+		t.Errorf("Unexpected error returned from Usage: %v", err)
+	}
+	if fh.executeCommand != "" {
+		t.Errorf("Execute called when there was a setup error.")
+	}
+}
+
+func TestUsageExecuteError(t *testing.T) {
+	u := newTestUsage()
+	u.garbage = &FakeCleaner{}
+	fh := u.handler.(*FakeUsageHandler)
+	fh.executeError = fmt.Errorf("execute error")
+	err := u.Show()
+	if err != fh.executeError {
+		t.Errorf("Unexpected error returned from Usage: %v", err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/build/strategies/strategies.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/build/strategies/strategies.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/build/strategies/onbuild"
 	"github.com/openshift/source-to-image/pkg/build/strategies/sti"
 	"github.com/openshift/source-to-image/pkg/docker"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilstatus "github.com/openshift/source-to-image/pkg/util/status"
 )
 
@@ -24,7 +24,7 @@ func Strategy(client docker.Client, config *api.Config, overrides build.Override
 	var builder build.Builder
 	var buildInfo api.BuildInfo
 
-	fs := util.NewFileSystem()
+	fs := fs.NewFileSystem()
 
 	startTime := time.Now()
 	image, err := docker.GetBuilderImage(client, config)

--- a/vendor/github.com/openshift/source-to-image/pkg/cmd/util.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/cmd/util.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+// AddCommonFlags adds the common flags for usage, build and rebuild commands
+func AddCommonFlags(c *cobra.Command, cfg *api.Config) {
+	c.Flags().BoolVarP(&(cfg.Quiet), "quiet", "q", false,
+		"Operate quietly. Suppress all non-error output.")
+	c.Flags().BoolVar(&(cfg.Incremental), "incremental", false,
+		"Perform an incremental build")
+	c.Flags().BoolVar(&(cfg.RemovePreviousImage), "rm", false,
+		"Remove the previous image during incremental builds")
+	c.Flags().StringVar(&(cfg.CallbackURL), "callback-url", "",
+		"Specify a URL to invoke via HTTP POST upon build completion")
+	c.Flags().VarP(&(cfg.BuilderPullPolicy), "pull-policy", "p",
+		"Specify when to pull the builder image (always, never or if-not-present)")
+	c.Flags().Var(&(cfg.PreviousImagePullPolicy), "incremental-pull-policy",
+		"Specify when to pull the previous image for incremental builds (always, never or if-not-present)")
+	c.Flags().Var(&(cfg.RuntimeImagePullPolicy), "runtime-pull-policy",
+		"Specify when to pull the runtime image (always, never or if-not-present)")
+	c.Flags().BoolVar(&(cfg.PreserveWorkingDir), "save-temp-dir", false,
+		"Save the temporary directory used by S2I instead of deleting it")
+	c.Flags().StringVarP(&(cfg.DockerCfgPath), "dockercfg-path", "", filepath.Join(os.Getenv("HOME"), ".docker/config.json"),
+		"Specify the path to the Docker configuration file")
+	c.Flags().StringVarP(&(cfg.Destination), "destination", "d", "",
+		"Specify a destination location for untar operation")
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/config/config.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/config/config.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"io/ioutil"
+
+	"encoding/json"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var glog = utilglog.StderrLog
+
+// DefaultConfigPath specifies the default location of the S2I config file
+const DefaultConfigPath = ".s2ifile"
+
+// Config represents a basic serialization for the S2I build options.
+type Config struct {
+	Source       string            `json:"source" yaml:"source"`
+	BuilderImage string            `json:"builderImage" yaml:"builderImage"`
+	Tag          string            `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Flags        map[string]string `json:"flags,omitempty" yaml:"flags,omitempty"`
+}
+
+// Save persists the S2I command line arguments into disk.
+func Save(config *api.Config, cmd *cobra.Command) {
+	c := Config{
+		BuilderImage: config.BuilderImage,
+		Source:       config.Source,
+		Tag:          config.Tag,
+		Flags:        make(map[string]string),
+	}
+	// Store only flags that have changed
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		c.Flags[f.Name] = f.Value.String()
+	})
+	data, err := json.Marshal(c)
+	if err != nil {
+		glog.V(1).Infof("Unable to serialize to %s: %v", DefaultConfigPath, err)
+		return
+	}
+	if err := ioutil.WriteFile(DefaultConfigPath, data, 0644); err != nil {
+		glog.V(1).Infof("Unable to save %s: %v", DefaultConfigPath, err)
+	}
+	return
+}
+
+// Restore loads the arguments from disk and prefills the Request
+func Restore(config *api.Config, cmd *cobra.Command) {
+	data, err := ioutil.ReadFile(DefaultConfigPath)
+	if err != nil {
+		data, err = ioutil.ReadFile(".stifile")
+		if err != nil {
+			glog.V(1).Infof("Unable to restore %s: %v", DefaultConfigPath, err)
+			return
+		}
+		glog.Infof("DEPRECATED: Use %s instead of .stifile", DefaultConfigPath)
+	}
+	c := Config{}
+	if err := json.Unmarshal(data, &c); err != nil {
+		glog.V(1).Infof("Unable to parse %s: %v", DefaultConfigPath, err)
+		return
+	}
+	config.BuilderImage = c.BuilderImage
+	config.Source = c.Source
+	config.Tag = c.Tag
+	for name, value := range c.Flags {
+		// Do not change flags that user sets. Allow overriding of stored flags.
+		if cmd.Flag(name).Changed {
+			continue
+		}
+		cmd.Flags().Set(name, value)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/create/create.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/create/create.go
@@ -1,0 +1,71 @@
+package create
+
+import (
+	"os"
+	"text/template"
+
+	"github.com/openshift/source-to-image/pkg/create/templates"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
+)
+
+var glog = utilglog.StderrLog
+
+// Bootstrap defines parameters for the template processing
+type Bootstrap struct {
+	DestinationDir string
+	ImageName      string
+}
+
+// New returns a new bootstrap for given image name and destination directory
+func New(name, dst string) *Bootstrap {
+	return &Bootstrap{ImageName: name, DestinationDir: dst}
+}
+
+// AddSTIScripts creates the STI scripts directory structure and process
+// templates for STI scripts
+func (b *Bootstrap) AddSTIScripts() {
+	os.MkdirAll(b.DestinationDir+"/"+"s2i/bin", 0700)
+	b.process(templates.AssembleScript, "s2i/bin/assemble", 0755)
+	b.process(templates.RunScript, "s2i/bin/run", 0755)
+	b.process(templates.UsageScript, "s2i/bin/usage", 0755)
+	b.process(templates.SaveArtifactsScript, "s2i/bin/save-artifacts", 0755)
+}
+
+// AddDockerfile creates an example Dockerfile
+func (b *Bootstrap) AddDockerfile() {
+	b.process(templates.Dockerfile, "Dockerfile", 0600)
+}
+
+// AddReadme creates a README.md
+func (b *Bootstrap) AddReadme() {
+	b.process(templates.Readme, "README.md", 0700)
+}
+
+// AddTests creates an example test for the STI image and the Makefile
+func (b *Bootstrap) AddTests() {
+	os.MkdirAll(b.DestinationDir+"/"+"test/test-app", 0700)
+	b.process(templates.Index, "test/test-app/index.html", 0700)
+	b.process(templates.TestRunScript, "test/run", 0700)
+	b.process(templates.Makefile, "Makefile", 0600)
+}
+
+func (b *Bootstrap) process(t string, dst string, perm os.FileMode) {
+	tpl := template.Must(template.New("").Parse(t))
+	if _, err := os.Stat(b.DestinationDir + "/" + dst); err == nil {
+		glog.Errorf("File already exists: %s, skipping", dst)
+		return
+	}
+	f, err := os.Create(b.DestinationDir + "/" + dst)
+	if err != nil {
+		glog.Errorf("Unable to create %s file, skipping: %v", dst, err)
+		return
+	}
+	if err := os.Chmod(b.DestinationDir+"/"+dst, perm); err != nil {
+		glog.Errorf("Unable to chmod %s file to %v, skipping: %v", dst, perm, err)
+		return
+	}
+	defer f.Close()
+	if err := tpl.Execute(f, b); err != nil {
+		glog.Errorf("Error processing %s template: %v", dst, err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/create/templates/docker.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/create/templates/docker.go
@@ -1,0 +1,43 @@
+package templates
+
+// Dockerfile is a default Dockerfile laid down by s2i create
+const Dockerfile = `
+# {{.ImageName}}
+FROM openshift/base-centos7
+
+# TODO: Put the maintainer name in the image metadata
+# MAINTAINER Your Name <your@email.com>
+
+# TODO: Rename the builder environment variable to inform users about application you provide them
+# ENV BUILDER_VERSION 1.0
+
+# TODO: Set labels used in OpenShift to describe the builder image
+#LABEL io.k8s.description="Platform for building xyz" \
+#      io.k8s.display-name="builder x.y.z" \
+#      io.openshift.expose-services="8080:http" \
+#      io.openshift.tags="builder,x.y.z,etc."
+
+# TODO: Install required packages here:
+# RUN yum install -y ... && yum clean all -y
+RUN yum install -y rubygems && yum clean all -y
+RUN gem install asdf
+
+# TODO (optional): Copy the builder files into /opt/app-root
+# COPY ./<builder_folder>/ /opt/app-root/
+
+# TODO: Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image
+# sets io.openshift.s2i.scripts-url label that way, or update that label
+COPY ./s2i/bin/ /usr/libexec/s2i
+
+# TODO: Drop the root user and make the content of /opt/app-root owned by user 1001
+# RUN chown -R 1001:1001 /opt/app-root
+
+# This default user is created in the openshift/base-centos7 image
+USER 1001
+
+# TODO: Set the default port for applications built using this image
+# EXPOSE 8080
+
+# TODO: Set the default CMD for the image
+# CMD ["/usr/libexec/s2i/usage"]
+`

--- a/vendor/github.com/openshift/source-to-image/pkg/create/templates/readme.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/create/templates/readme.go
@@ -1,0 +1,91 @@
+package templates
+
+// Readme is a default README laid down by s2i create
+const Readme = `
+# Creating a basic S2I builder image  
+
+## Getting started  
+
+### Files and Directories  
+| File                   | Required? | Description                                                  |
+|------------------------|-----------|--------------------------------------------------------------|
+| Dockerfile             | Yes       | Defines the base builder image                               |
+| s2i/bin/assemble       | Yes       | Script that builds the application                           |
+| s2i/bin/usage          | No        | Script that prints the usage of the builder                  |
+| s2i/bin/run            | Yes       | Script that runs the application                             |
+| s2i/bin/save-artifacts | No        | Script for incremental builds that saves the built artifacts |
+| test/run               | No        | Test script for the builder image                            |
+| test/test-app          | Yes       | Test application source code                                 |
+
+#### Dockerfile
+Create a *Dockerfile* that installs all of the necessary tools and libraries that are needed to build and run our application.  This file will also handle copying the s2i scripts into the created image.
+
+#### S2I scripts
+
+##### assemble
+Create an *assemble* script that will build our application, e.g.:
+- build python modules
+- bundle install ruby gems
+- setup application specific configuration
+
+The script can also specify a way to restore any saved artifacts from the previous image.   
+
+##### run
+Create a *run* script that will start the application. 
+
+##### save-artifacts (optional)
+Create a *save-artifacts* script which allows a new build to reuse content from a previous version of the application image.
+
+##### usage (optional) 
+Create a *usage* script that will print out instructions on how to use the image.
+
+##### Make the scripts executable 
+Make sure that all of the scripts are executable by running *chmod +x s2i/bin/**
+
+#### Create the builder image
+The following command will create a builder image named {{.ImageName}} based on the Dockerfile that was created previously.
+` +
+	"```\n" +
+	"docker build -t {{.ImageName}} .\n" +
+	"```\n" +
+	`The builder image can also be created by using the *make* command since a *Makefile* is included.
+
+Once the image has finished building, the command *s2i usage {{.ImageName}}* will print out the help info that was defined in the *usage* script.
+
+#### Testing the builder image
+The builder image can be tested using the following commands:
+` +
+	"```\n" +
+	"docker build -t {{.ImageName}}-candidate .\n" +
+	"IMAGE_NAME={{.ImageName}}-candidate test/run\n" +
+	"```\n" +
+	`The builder image can also be tested by using the *make test* command since a *Makefile* is included.
+
+#### Creating the application image
+The application image combines the builder image with your applications source code, which is served using whatever application is installed via the *Dockerfile*, compiled using the *assemble* script, and run using the *run* script.
+The following command will create the application image:
+` +
+	"```\n" +
+	"s2i build test/test-app {{.ImageName}} {{.ImageName}}-app\n" +
+	"---> Building and installing application from source...\n" +
+	"```\n" +
+	`Using the logic defined in the *assemble* script, s2i will now create an application image using the builder image as a base and including the source code from the test/test-app directory. 
+
+#### Running the application image
+Running the application image is as simple as invoking the docker run command:
+` +
+	"```\n" +
+	"docker run -d -p 8080:8080 {{.ImageName}}-app\n" +
+	"```\n" +
+	`The application, which consists of a simple static web page, should now be accessible at  [http://localhost:8080](http://localhost:8080).
+
+#### Using the saved artifacts script
+Rebuilding the application using the saved artifacts can be accomplished using the following command:
+` +
+	"```\n" +
+	"s2i build --incremental=true test/test-app nginx-centos7 nginx-app\n" +
+	"---> Restoring build artifacts...\n" +
+	"---> Building and installing application from source...\n" +
+	"```\n" +
+	`This will run the *save-artifacts* script which includes the custom code to backup the currently running application source, rebuild the application image, and then re-deploy the previously saved source using the *assemble* script.
+`

--- a/vendor/github.com/openshift/source-to-image/pkg/create/templates/scripts.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/create/templates/scripts.go
@@ -1,0 +1,72 @@
+package templates
+
+// AssembleScript is a default assemble script laid down by s2i create
+const AssembleScript = `#!/bin/bash -e
+#
+# S2I assemble script for the '{{.ImageName}}' image.
+# The 'assemble' script builds your application source so that it is ready to run.
+#
+# For more information refer to the documentation:
+#	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+
+# If the '{{.ImageName}}' assemble script is executed with the '-h' flag, print the usage.
+if [[ "$1" == "-h" ]]; then
+	exec /usr/libexec/s2i/usage
+fi
+
+# Restore artifacts from the previous build (if they exist).
+#
+if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
+  echo "---> Restoring build artifacts..."
+  mv /tmp/artifacts/. ./
+fi
+
+echo "---> Installing application source..."
+cp -Rf /tmp/src/. ./
+
+echo "---> Building application from source..."
+# TODO: Add build steps for your application, eg npm install, bundle install, pip install, etc.
+`
+
+// RunScript is a default run script laid down by s2i create
+const RunScript = `#!/bin/bash -e
+#
+# S2I run script for the '{{.ImageName}}' image.
+# The run script executes the server that runs your application.
+#
+# For more information see the documentation:
+#	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+
+exec asdf -p 8080
+`
+
+// UsageScript is a default usage script laid down by s2i create
+const UsageScript = `#!/bin/bash -e
+cat <<EOF
+This is the {{.ImageName}} S2I image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build <source code path/URL> {{.ImageName}} <application image>
+
+You can then run the resulting image via:
+docker run <application image>
+EOF
+`
+
+// SaveArtifactsScript is a default save artifacts script laid down by s2i
+// create
+const SaveArtifactsScript = `#!/bin/sh -e
+#
+# S2I save-artifacts script for the '{{.ImageName}}' image.
+# The save-artifacts script streams a tar archive to standard output.
+# The archive contains the files and folders you want to re-use in the next build.
+#
+# For more information see the documentation:
+#	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+# tar cf - <list of files and folders>
+`

--- a/vendor/github.com/openshift/source-to-image/pkg/create/templates/test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/create/templates/test.go
@@ -1,0 +1,190 @@
+package templates
+
+// TestRunScript is a simple test script that verifies the S2I image.
+const TestRunScript = `#!/bin/bash
+#
+# The 'run' performs a simple test that verifies the S2I image.
+# The main focus here is to exercise the S2I scripts.
+#
+# For more information see the documentation:
+# https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+IMAGE_NAME=${IMAGE_NAME-{{.ImageName}}-candidate}
+
+# Determining system utility executables (darwin compatibility check)
+READLINK_EXEC="readlink"
+MKTEMP_EXEC="mktemp"
+if [[ "$OSTYPE" =~ 'darwin' ]]; then
+  ! type -a "greadlink" &>"/dev/null" || READLINK_EXEC="greadlink"
+  ! type -a "gmktemp" &>"/dev/null" || MKTEMP_EXEC="gmktemp"
+fi
+
+test_dir="$($READLINK_EXEC -zf $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$($READLINK_EXEC -zf ${test_dir}/..)
+cid_file=$($MKTEMP_EXEC -u --suffix=.cid)
+
+# Since we built the candidate image locally, we don't want S2I to attempt to pull
+# it from Docker hub
+s2i_args="--pull-policy=never --loglevel=2"
+
+# Port the image exposes service to be tested
+test_port=8080
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+container_exists() {
+  image_exists $(cat $cid_file)
+}
+
+container_ip() {
+  if [ ! -z "$DOCKER_HOST" ] && [[ "$OSTYPE" =~ 'darwin' ]]; then
+    docker-machine ip
+  else
+    docker inspect --format="{{"{{"}} .NetworkSettings.IPAddress {{"}}"}}" $(cat $cid_file)
+  fi
+}
+
+container_port() {
+  if [ ! -z "$DOCKER_HOST" ] && [[ "$OSTYPE" =~ 'darwin' ]]; then
+    docker inspect --format="{{"{{"}}(index .NetworkSettings.Ports \"$test_port/tcp\" 0).HostPort{{"}}"}}" "$(cat "${cid_file}")"
+  else
+    echo $test_port
+  fi
+}
+
+run_s2i_build() {
+  s2i build --incremental=true ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+}
+
+prepare() {
+  if ! image_exists ${IMAGE_NAME}; then
+    echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
+    exit 1
+  fi
+  # s2i build requires the application is a valid 'Git' repository
+  pushd ${test_dir}/test-app >/dev/null
+  git init
+  git config user.email "build@localhost" && git config user.name "builder"
+  git add -A && git commit -m "Sample commit"
+  popd >/dev/null
+  run_s2i_build
+}
+
+run_test_application() {
+  docker run --rm --cidfile=${cid_file} -p ${test_port} ${IMAGE_NAME}-testapp
+}
+
+cleanup() {
+  if [ -f $cid_file ]; then
+    if container_exists; then
+      docker stop $(cat $cid_file)
+    fi
+  fi
+  if image_exists ${IMAGE_NAME}-testapp; then
+    docker rmi ${IMAGE_NAME}-testapp
+  fi
+}
+
+check_result() {
+  local result="$1"
+  if [[ "$result" != "0" ]]; then
+    echo "S2I image '${IMAGE_NAME}' test FAILED (exit code: ${result})"
+    cleanup
+    exit $result
+  fi
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && break
+    echo "Waiting for container to start..."
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+test_usage() {
+  echo "Testing 's2i usage'..."
+  s2i usage ${s2i_args} ${IMAGE_NAME} &>/dev/null
+}
+
+test_connection() {
+  echo "Testing HTTP connection (http://$(container_ip):$(container_port))"
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  while [ $attempt -le $max_attempts ]; do
+    echo "Sending GET request to http://$(container_ip):$(container_port)/"
+    response_code=$(curl -s -w %{http_code} -o /dev/null http://$(container_ip):$(container_port)/)
+    status=$?
+    if [ $status -eq 0 ]; then
+      if [ $response_code -eq 200 ]; then
+        result=0
+      fi
+      break
+    fi
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+  return $result
+}
+
+# Build the application image twice to ensure the 'save-artifacts' and
+# 'restore-artifacts' scripts are working properly
+prepare
+run_s2i_build
+check_result $?
+
+# Verify the 'usage' script is working properly
+test_usage
+check_result $?
+
+# Verify that the HTTP connection can be established to test application container
+run_test_application &
+
+# Wait for the container to write its CID file
+wait_for_cid
+
+test_connection
+check_result $?
+
+cleanup
+
+`
+
+// Makefile contains a sample Makefile which can build and test a container.
+const Makefile = `
+IMAGE_NAME = {{.ImageName}}
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE_NAME) .
+
+.PHONY: test
+test:
+	docker build -t $(IMAGE_NAME)-candidate .
+	IMAGE_NAME=$(IMAGE_NAME)-candidate test/run
+`
+
+// Index contains a sample index.html file.
+const Index = `
+<!doctype html>
+<html>
+	<head>
+		<title>Hello World!</title>
+	</head>
+	<body>
+		<h1>Hello World!</h1>
+	</body>
+</html>
+ `

--- a/vendor/github.com/openshift/source-to-image/pkg/docker/docker_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/docker/docker_test.go
@@ -1,0 +1,588 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	dockertest "github.com/openshift/source-to-image/pkg/docker/test"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+
+	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
+	dockerstrslice "github.com/docker/engine-api/types/strslice"
+)
+
+func TestContainerName(t *testing.T) {
+	rand.Seed(0)
+	got := containerName("sub.domain.com:5000/repo:tag@sha256:ffffff")
+	want := "s2i_sub_domain_com_5000_repo_tag_sha256_ffffff_f1f85ff5"
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func getDocker(client Client) *stiDocker {
+	return &stiDocker{
+		client:   client,
+		pullAuth: dockertypes.AuthConfig{},
+	}
+}
+
+func TestRemoveContainer(t *testing.T) {
+	fakeDocker := dockertest.NewFakeDockerClient()
+	dh := getDocker(fakeDocker)
+	containerID := "testContainerId"
+	fakeDocker.Containers[containerID] = dockercontainer.Config{}
+	err := dh.RemoveContainer(containerID)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+	expectedCalls := []string{"remove"}
+	if !reflect.DeepEqual(fakeDocker.Calls, expectedCalls) {
+		t.Errorf("Expected fakeDocker.Calls %v, got %v", expectedCalls, fakeDocker.Calls)
+	}
+}
+
+func TestCommitContainer(t *testing.T) {
+	type commitTest struct {
+		containerID     string
+		containerTag    string
+		expectedImageID string
+		expectedError   error
+	}
+
+	tests := map[string]commitTest{
+		"valid": {
+			containerID:     "test-container-id",
+			containerTag:    "test-container-tag",
+			expectedImageID: "test-container-tag",
+		},
+		"error": {
+			containerID:     "test-container-id",
+			containerTag:    "test-container-tag",
+			expectedImageID: "test-container-tag",
+			expectedError:   fmt.Errorf("Test error"),
+		},
+	}
+
+	for desc, tst := range tests {
+		opt := CommitContainerOptions{
+			ContainerID: tst.containerID,
+			Repository:  tst.containerTag,
+		}
+		param := dockertypes.ContainerCommitOptions{
+			Reference: tst.containerTag,
+		}
+		resp := dockertypes.ContainerCommitResponse{
+			ID: tst.expectedImageID,
+		}
+		fakeDocker := &dockertest.FakeDockerClient{
+			ContainerCommitResponse: resp,
+			ContainerCommitErr:      tst.expectedError,
+		}
+		dh := getDocker(fakeDocker)
+
+		imageID, err := dh.CommitContainer(opt)
+		if err != tst.expectedError {
+			t.Errorf("test case %s: Unexpected error returned: %v", desc, err)
+		}
+		if tst.containerID != fakeDocker.ContainerCommitID {
+			t.Errorf("test case %s: Commit container called with unexpected container id: %s and %+v", desc, tst.containerID, fakeDocker.ContainerCommitID)
+		}
+		if !reflect.DeepEqual(param, fakeDocker.ContainerCommitOptions) {
+			t.Errorf("test case %s: Commit container called with unexpected parameters: %+v and %+v", desc, param, fakeDocker.ContainerCommitOptions)
+		}
+		if tst.expectedError == nil && imageID != tst.expectedImageID {
+			t.Errorf("test case %s: Did not return the correct image id: %s", desc, imageID)
+		}
+	}
+}
+
+func TestCopyToContainer(t *testing.T) {
+	type copyToTest struct {
+		containerID string
+		src         string
+		destPath    string
+	}
+
+	tests := map[string]copyToTest{
+		"valid": {
+			containerID: "test-container-id",
+			src:         "foo",
+		},
+		"error": {
+			containerID: "test-container-id",
+			src:         "badsource",
+		},
+	}
+
+	for desc, tst := range tests {
+		var tempDir, fileName string
+		var err error
+		var file *os.File
+		if len(tst.src) > 0 {
+			tempDir, err = ioutil.TempDir("", tst.src)
+			defer os.RemoveAll(tempDir)
+			fileName = filepath.Join(tempDir, "bar")
+			if err = os.MkdirAll(filepath.Dir(fileName), 0700); err == nil {
+				file, err = os.Create(fileName)
+				if err == nil {
+					defer file.Close()
+					file.WriteString("asdf")
+				}
+			}
+		}
+		if err != nil {
+			t.Fatalf("Error creating src test files: %v", err)
+		}
+		fakeDocker := &dockertest.FakeDockerClient{
+			CopyToContainerContent: file,
+		}
+		dh := getDocker(fakeDocker)
+
+		err = dh.UploadToContainer(&testfs.FakeFileSystem{}, fileName, fileName, tst.containerID)
+		// the error we are inducing will prevent call into engine-api
+		if len(tst.src) > 0 {
+			if err != nil {
+				t.Errorf("test case %s: Unexpected error returned: %v", desc, err)
+			}
+			if tst.containerID != fakeDocker.CopyToContainerID {
+				t.Errorf("test case %s: copy to container called with unexpected id: %s and %s", desc, tst.containerID, fakeDocker.CopyToContainerID)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("test case %s: Unexpected error returned: %v", desc, err)
+			}
+			if len(fakeDocker.CopyToContainerID) > 0 {
+				t.Errorf("test case %s: copy to container called with unexpected id: %s and %s", desc, tst.containerID, fakeDocker.CopyToContainerID)
+			}
+		}
+		// the directory of our file gets passed down to the engine-api method
+		if tempDir != fakeDocker.CopyToContainerPath {
+			t.Errorf("test case %s: copy to container called with unexpected path: %s and %s", desc, tempDir, fakeDocker.CopyToContainerPath)
+		}
+		// reflect.DeepEqual does not help here cause the reader is transformed prior to calling the engine-api stack, so just make sure it is no nil
+		if file != nil && fakeDocker.CopyToContainerContent == nil {
+			t.Errorf("test case %s: copy to container content was not passed through", desc)
+		}
+	}
+}
+
+func TestCopyFromContainer(t *testing.T) {
+	type copyFromTest struct {
+		containerID   string
+		srcPath       string
+		expectedError error
+	}
+
+	tests := map[string]copyFromTest{
+		"valid": {
+			containerID: "test-container-id",
+			srcPath:     "/foo/bar",
+		},
+		"error": {
+			containerID:   "test-container-id",
+			srcPath:       "/foo/bar",
+			expectedError: fmt.Errorf("Test error"),
+		},
+	}
+
+	for desc, tst := range tests {
+		buffer := bytes.NewBuffer([]byte(""))
+		fakeDocker := &dockertest.FakeDockerClient{
+			CopyFromContainerErr: tst.expectedError,
+		}
+		dh := getDocker(fakeDocker)
+
+		err := dh.DownloadFromContainer(tst.srcPath, buffer, tst.containerID)
+		if err != tst.expectedError {
+			t.Errorf("test case %s: Unexpected error returned: %v", desc, err)
+		}
+		if fakeDocker.CopyFromContainerID != tst.containerID {
+			t.Errorf("test case %s: Unexpected container id: %s and %s", desc, tst.containerID, fakeDocker.CopyFromContainerID)
+		}
+		if fakeDocker.CopyFromContainerPath != tst.srcPath {
+			t.Errorf("test case %s: Unexpected container id: %s and %s", desc, tst.srcPath, fakeDocker.CopyFromContainerPath)
+		}
+	}
+}
+
+func TestImageBuild(t *testing.T) {
+	type waitTest struct {
+		imageID       string
+		expectedError error
+	}
+
+	tests := map[string]waitTest{
+		"valid": {
+			imageID: "test-container-id",
+		},
+		"error": {
+			imageID:       "test-container-id",
+			expectedError: fmt.Errorf("Test error"),
+		},
+	}
+
+	for desc, tst := range tests {
+		fakeDocker := &dockertest.FakeDockerClient{
+			BuildImageErr: tst.expectedError,
+		}
+		dh := getDocker(fakeDocker)
+		opts := BuildImageOptions{
+			Name: tst.imageID,
+		}
+
+		err := dh.BuildImage(opts)
+		if err != tst.expectedError {
+			t.Errorf("test case %s: Unexpected error returned: %v", desc, err)
+		}
+		if len(fakeDocker.BuildImageOpts.Tags) != 1 || fakeDocker.BuildImageOpts.Tags[0] != tst.imageID {
+			t.Errorf("test case %s: Unexpected container id: %s and %+v", desc, tst.imageID, fakeDocker.BuildImageOpts.Tags)
+		}
+	}
+}
+
+func TestGetScriptsURL(t *testing.T) {
+	type urltest struct {
+		image      dockertypes.ImageInspect
+		result     string
+		calls      []string
+		inspectErr error
+	}
+	tests := map[string]urltest{
+		"not present": {
+			calls: []string{"inspect_image"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{
+					Env:    []string{"Env1=value1"},
+					Labels: map[string]string{},
+				},
+				Config: &dockercontainer.Config{
+					Env:    []string{"Env2=value2"},
+					Labels: map[string]string{},
+				},
+			},
+			result: "",
+		},
+
+		"env in containerConfig": {
+			calls: []string{"inspect_image"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{
+					Env: []string{"Env1=value1", ScriptsURLEnvironment + "=test_url_value"},
+				},
+				Config: &dockercontainer.Config{},
+			},
+			result: "",
+		},
+
+		"env in image config": {
+			calls: []string{"inspect_image"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Env: []string{
+						"Env1=value1",
+						ScriptsURLEnvironment + "=test_url_value_2",
+						"Env2=value2",
+					},
+				},
+			},
+			result: "test_url_value_2",
+		},
+
+		"label in containerConfig": {
+			calls: []string{"inspect_image"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{
+					Labels: map[string]string{ScriptsURLLabel: "test_url_value"},
+				},
+				Config: &dockercontainer.Config{},
+			},
+			result: "",
+		},
+
+		"label in image config": {
+			calls: []string{"inspect_image"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Labels: map[string]string{ScriptsURLLabel: "test_url_value_2"},
+				},
+			},
+			result: "test_url_value_2",
+		},
+
+		"inspect error": {
+			calls:      []string{"inspect_image", "pull"},
+			image:      dockertypes.ImageInspect{},
+			inspectErr: fmt.Errorf("Inspect error"),
+		},
+	}
+	for desc, tst := range tests {
+		fakeDocker := dockertest.NewFakeDockerClient()
+		dh := getDocker(fakeDocker)
+		tst.image.ID = "test/image:latest"
+		if tst.inspectErr != nil {
+			fakeDocker.PullFail = tst.inspectErr
+		} else {
+			fakeDocker.Images = map[string]dockertypes.ImageInspect{tst.image.ID: tst.image}
+		}
+		url, err := dh.GetScriptsURL(tst.image.ID)
+
+		if !reflect.DeepEqual(fakeDocker.Calls, tst.calls) {
+			t.Errorf("%s: Expected fakeDocker.Calls %v, got %v", desc, tst.calls, fakeDocker.Calls)
+		}
+		if err != nil && tst.inspectErr == nil {
+			t.Errorf("%s: Unexpected error returned: %v", desc, err)
+		}
+		if tst.inspectErr == nil && url != tst.result {
+			//t.Errorf("%s: Unexpected result. Expected: %s Actual: %s",
+			//	desc, tst.result, url)
+		}
+	}
+}
+
+func TestRunContainer(t *testing.T) {
+	type runtest struct {
+		calls            []string
+		image            dockertypes.ImageInspect
+		cmd              string
+		externalScripts  bool
+		paramScriptsURL  string
+		paramDestination string
+		cmdExpected      []string
+	}
+
+	tests := map[string]runtest{
+		"default": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config:          &dockercontainer.Config{},
+			},
+			cmd:             api.Assemble,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /tmp/scripts/%s", api.Assemble)},
+		},
+		"paramDestination": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config:          &dockercontainer.Config{},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  true,
+			paramDestination: "/opt/test",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/test -xf - && /opt/test/scripts/%s", api.Assemble)},
+		},
+		"paramDestination&paramScripts": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config:          &dockercontainer.Config{},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  true,
+			paramDestination: "/opt/test",
+			paramScriptsURL:  "http://my.test.url/test?param=one",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/test -xf - && /opt/test/scripts/%s", api.Assemble)},
+		},
+		"scriptsInsideImageEnvironment": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Env: []string{ScriptsURLEnvironment + "=image:///opt/bin/"},
+				},
+			},
+			cmd:             api.Assemble,
+			externalScripts: false,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"scriptsInsideImageLabel": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Labels: map[string]string{ScriptsURLLabel: "image:///opt/bin/"},
+				},
+			},
+			cmd:             api.Assemble,
+			externalScripts: false,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"scriptsInsideImageEnvironmentWithParamDestination": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Env: []string{ScriptsURLEnvironment + "=image:///opt/bin"},
+				},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  false,
+			paramDestination: "/opt/sti",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/sti -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"scriptsInsideImageLabelWithParamDestination": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Labels: map[string]string{ScriptsURLLabel: "image:///opt/bin"},
+				},
+			},
+			cmd:              api.Assemble,
+			externalScripts:  false,
+			paramDestination: "/opt/sti",
+			cmdExpected:      []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt/sti -xf - && /opt/bin/%s", api.Assemble)},
+		},
+		"paramDestinationFromImageEnvironment": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Env: []string{LocationEnvironment + "=/opt", ScriptsURLEnvironment + "=http://my.test.url/test?param=one"},
+				},
+			},
+			cmd:             api.Assemble,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt -xf - && /opt/scripts/%s", api.Assemble)},
+		},
+		"paramDestinationFromImageLabel": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config: &dockercontainer.Config{
+					Labels: map[string]string{DestinationLabel: "/opt", ScriptsURLLabel: "http://my.test.url/test?param=one"},
+				},
+			},
+			cmd:             api.Assemble,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /opt -xf - && /opt/scripts/%s", api.Assemble)},
+		},
+		"usageCommand": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config:          &dockercontainer.Config{},
+			},
+			cmd:             api.Usage,
+			externalScripts: true,
+			cmdExpected:     []string{"/bin/sh", "-c", fmt.Sprintf("tar -C /tmp -xf - && /tmp/scripts/%s", api.Usage)},
+		},
+		"otherCommand": {
+			calls: []string{"inspect_image", "inspect_image", "inspect_image", "create", "attach", "start", "remove"},
+			image: dockertypes.ImageInspect{
+				ContainerConfig: &dockercontainer.Config{},
+				Config:          &dockercontainer.Config{},
+			},
+			cmd:             api.Run,
+			externalScripts: true,
+			cmdExpected:     []string{fmt.Sprintf("/tmp/scripts/%s", api.Run)},
+		},
+	}
+
+	for desc, tst := range tests {
+		fakeDocker := dockertest.NewFakeDockerClient()
+		dh := getDocker(fakeDocker)
+		tst.image.ID = "test/image:latest"
+		fakeDocker.Images = map[string]dockertypes.ImageInspect{tst.image.ID: tst.image}
+		if len(fakeDocker.Containers) > 0 {
+			t.Errorf("newly created fake client should have empty container map: %+v", fakeDocker.Containers)
+		}
+
+		err := dh.RunContainer(RunContainerOptions{
+			Image:           "test/image",
+			PullImage:       true,
+			ExternalScripts: tst.externalScripts,
+			ScriptsURL:      tst.paramScriptsURL,
+			Destination:     tst.paramDestination,
+			Command:         tst.cmd,
+			Env:             []string{"Key1=Value1", "Key2=Value2"},
+			Stdin:           ioutil.NopCloser(os.Stdin),
+		})
+		if err != nil {
+			t.Errorf("%s: Unexpected error: %v", desc, err)
+		}
+
+		// container ID will be random, so don't look up directly ... just get the 1 entry which should be there
+		if len(fakeDocker.Containers) != 1 {
+			t.Errorf("fake container map should only have 1 entry: %+v", fakeDocker.Containers)
+		}
+
+		for _, container := range fakeDocker.Containers {
+			// Validate the Container parameters
+			if container.Image != "test/image:latest" {
+				t.Errorf("%s: Unexpected create config image: %s", desc, container.Image)
+			}
+			if !reflect.DeepEqual(container.Cmd, dockerstrslice.StrSlice(tst.cmdExpected)) {
+				t.Errorf("%s: Unexpected create config command: %#v instead of %q", desc, container.Cmd, strings.Join(tst.cmdExpected, " "))
+			}
+			if !reflect.DeepEqual(container.Env, []string{"Key1=Value1", "Key2=Value2"}) {
+				t.Errorf("%s: Unexpected create config env: %#v", desc, container.Env)
+			}
+			if !reflect.DeepEqual(fakeDocker.Calls, tst.calls) {
+				t.Errorf("%s: Expected fakeDocker.Calls %v, got %v", desc, tst.calls, fakeDocker.Calls)
+			}
+		}
+	}
+}
+
+func TestGetImageID(t *testing.T) {
+	fakeDocker := dockertest.NewFakeDockerClient()
+	dh := getDocker(fakeDocker)
+	image := dockertypes.ImageInspect{ID: "test-abcd:latest"}
+	fakeDocker.Images = map[string]dockertypes.ImageInspect{image.ID: image}
+	id, err := dh.GetImageID("test-abcd")
+	expectedCalls := []string{"inspect_image"}
+	if !reflect.DeepEqual(fakeDocker.Calls, expectedCalls) {
+		t.Errorf("Expected fakeDocker.Calls %v, got %v", expectedCalls, fakeDocker.Calls)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	} else if id != image.ID {
+		t.Errorf("Unexpected image id returned: %s", id)
+	}
+}
+
+func TestRemoveImage(t *testing.T) {
+	fakeDocker := dockertest.NewFakeDockerClient()
+	dh := getDocker(fakeDocker)
+	image := dockertypes.ImageInspect{ID: "test-abcd"}
+	fakeDocker.Images = map[string]dockertypes.ImageInspect{image.ID: image}
+	err := dh.RemoveImage("test-abcd")
+	if err != nil {
+		t.Errorf("Unexpected error removing image: %s", err)
+	}
+}
+
+func TestGetImageName(t *testing.T) {
+	type runtest struct {
+		name     string
+		expected string
+	}
+	tests := []runtest{
+		{"test/image", "test/image:latest"},
+		{"test/image:latest", "test/image:latest"},
+		{"test/image:tag", "test/image:tag"},
+		{"repository/test/image", "repository/test/image:latest"},
+		{"repository/test/image:latest", "repository/test/image:latest"},
+		{"repository/test/image:tag", "repository/test/image:tag"},
+	}
+
+	for _, tc := range tests {
+		if e, a := tc.expected, getImageName(tc.name); e != a {
+			t.Errorf("Expected image name %s, but got %s!", e, a)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/docker/fake_docker.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/docker/fake_docker.go
@@ -8,7 +8,7 @@ import (
 	dockertypes "github.com/docker/engine-api/types"
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/tar"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // FakeDocker provides a fake docker interface
@@ -134,12 +134,12 @@ func (f *FakeDocker) RunContainer(opts RunContainerOptions) error {
 }
 
 // UploadToContainer uploads artifacts to the container.
-func (f *FakeDocker) UploadToContainer(fs util.FileSystem, srcPath, destPath, container string) error {
+func (f *FakeDocker) UploadToContainer(fs fs.FileSystem, srcPath, destPath, container string) error {
 	return nil
 }
 
 // UploadToContainerWithTarWriter uploads artifacts to the container.
-func (f *FakeDocker) UploadToContainerWithTarWriter(fs util.FileSystem, srcPath, destPath, container string, makeTarWriter func(io.Writer) tar.Writer) error {
+func (f *FakeDocker) UploadToContainerWithTarWriter(fs fs.FileSystem, srcPath, destPath, container string, makeTarWriter func(io.Writer) tar.Writer) error {
 	return errors.New("not implemented")
 }
 

--- a/vendor/github.com/openshift/source-to-image/pkg/docker/test/client.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/docker/test/client.go
@@ -1,0 +1,218 @@
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"time"
+
+	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
+	dockernetwork "github.com/docker/engine-api/types/network"
+	"golang.org/x/net/context"
+)
+
+// FakeConn fakes a net.Conn
+type FakeConn struct {
+}
+
+// Read reads bytes
+func (c FakeConn) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+// Write writes bytes
+func (c FakeConn) Write(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+// Close closes the connection
+func (c FakeConn) Close() error {
+	return nil
+}
+
+// LocalAddr returns the local address
+func (c FakeConn) LocalAddr() net.Addr {
+	ip, _ := net.ResolveIPAddr("ip4", "127.0.0.1")
+	return ip
+}
+
+// RemoteAddr returns the remote address
+func (c FakeConn) RemoteAddr() net.Addr {
+	ip, _ := net.ResolveIPAddr("ip4", "127.0.0.1")
+	return ip
+}
+
+// SetDeadline sets the deadline
+func (c FakeConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+// SetReadDeadline sets the read deadline
+func (c FakeConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+// SetWriteDeadline sets the write deadline
+func (c FakeConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// FakeDockerClient provides a Fake client for Docker testing
+type FakeDockerClient struct {
+	CopyToContainerID      string
+	CopyToContainerPath    string
+	CopyToContainerContent io.Reader
+
+	CopyFromContainerID   string
+	CopyFromContainerPath string
+	CopyFromContainerErr  error
+
+	WaitContainerID     string
+	WaitContainerResult int
+	WaitContainerErr    error
+
+	ContainerCommitID       string
+	ContainerCommitOptions  dockertypes.ContainerCommitOptions
+	ContainerCommitResponse dockertypes.ContainerCommitResponse
+	ContainerCommitErr      error
+
+	BuildImageOpts dockertypes.ImageBuildOptions
+	BuildImageErr  error
+	Images         map[string]dockertypes.ImageInspect
+
+	Containers map[string]dockercontainer.Config
+
+	PullFail error
+
+	Calls []string
+}
+
+// NewFakeDockerClient returns a new FakeDockerClient
+func NewFakeDockerClient() *FakeDockerClient {
+	return &FakeDockerClient{
+		Images:     make(map[string]dockertypes.ImageInspect),
+		Containers: make(map[string]dockercontainer.Config),
+		Calls:      make([]string, 0),
+	}
+}
+
+// ImageInspectWithRaw returns the image information and its raw representation.
+func (d *FakeDockerClient) ImageInspectWithRaw(ctx context.Context, imageID string, getSize bool) (dockertypes.ImageInspect, []byte, error) {
+	d.Calls = append(d.Calls, "inspect_image")
+
+	if _, exists := d.Images[imageID]; exists {
+		return d.Images[imageID], nil, nil
+	}
+	return dockertypes.ImageInspect{}, nil, fmt.Errorf("No such image: %q", imageID)
+}
+
+// CopyToContainer copies content into the container filesystem.
+func (d *FakeDockerClient) CopyToContainer(ctx context.Context, container, path string, content io.Reader, opts dockertypes.CopyToContainerOptions) error {
+	d.CopyToContainerID = container
+	d.CopyToContainerPath = path
+	d.CopyToContainerContent = content
+	return nil
+}
+
+// CopyFromContainer gets the content from the container and returns it as a Reader
+// to manipulate it in the host. It's up to the caller to close the reader.
+func (d *FakeDockerClient) CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, dockertypes.ContainerPathStat, error) {
+	d.CopyFromContainerID = container
+	d.CopyFromContainerPath = srcPath
+	return ioutil.NopCloser(bytes.NewReader([]byte(""))), dockertypes.ContainerPathStat{}, d.CopyFromContainerErr
+}
+
+// ContainerWait pauses execution until a container exits.
+func (d *FakeDockerClient) ContainerWait(ctx context.Context, containerID string) (int, error) {
+	d.WaitContainerID = containerID
+	return d.WaitContainerResult, d.WaitContainerErr
+}
+
+// ContainerCommit applies changes into a container and creates a new tagged image.
+func (d *FakeDockerClient) ContainerCommit(ctx context.Context, container string, options dockertypes.ContainerCommitOptions) (dockertypes.ContainerCommitResponse, error) {
+	d.ContainerCommitID = container
+	d.ContainerCommitOptions = options
+	return d.ContainerCommitResponse, d.ContainerCommitErr
+}
+
+// ContainerAttach attaches a connection to a container in the server.
+func (d *FakeDockerClient) ContainerAttach(ctx context.Context, container string, options dockertypes.ContainerAttachOptions) (dockertypes.HijackedResponse, error) {
+	d.Calls = append(d.Calls, "attach")
+	return dockertypes.HijackedResponse{Conn: FakeConn{}, Reader: bufio.NewReader(&bytes.Buffer{})}, nil
+}
+
+// ImageBuild sends request to the daemon to build images.
+func (d *FakeDockerClient) ImageBuild(ctx context.Context, buildContext io.Reader, options dockertypes.ImageBuildOptions) (dockertypes.ImageBuildResponse, error) {
+	d.BuildImageOpts = options
+	return dockertypes.ImageBuildResponse{
+		Body: ioutil.NopCloser(bytes.NewReader([]byte(""))),
+	}, d.BuildImageErr
+}
+
+// ContainerCreate creates a new container based in the given configuration.
+func (d *FakeDockerClient) ContainerCreate(ctx context.Context, config *dockercontainer.Config, hostConfig *dockercontainer.HostConfig, networkingConfig *dockernetwork.NetworkingConfig, containerName string) (dockertypes.ContainerCreateResponse, error) {
+	d.Calls = append(d.Calls, "create")
+
+	d.Containers[containerName] = *config
+	return dockertypes.ContainerCreateResponse{}, nil
+}
+
+// ContainerInspect returns the container information.
+func (d *FakeDockerClient) ContainerInspect(ctx context.Context, containerID string) (dockertypes.ContainerJSON, error) {
+	d.Calls = append(d.Calls, "inspect_container")
+	return dockertypes.ContainerJSON{}, nil
+}
+
+// ContainerRemove kills and removes a container from the docker host.
+func (d *FakeDockerClient) ContainerRemove(ctx context.Context, containerID string, options dockertypes.ContainerRemoveOptions) error {
+	d.Calls = append(d.Calls, "remove")
+
+	if _, exists := d.Containers[containerID]; exists {
+		delete(d.Containers, containerID)
+		return nil
+	}
+	return errors.New("container does not exist")
+}
+
+// ContainerKill terminates the container process but does not remove the container from the docker host.
+func (d *FakeDockerClient) ContainerKill(ctx context.Context, containerID, signal string) error {
+	return nil
+}
+
+// ContainerStart sends a request to the docker daemon to start a container.
+func (d *FakeDockerClient) ContainerStart(ctx context.Context, containerID string) error {
+	d.Calls = append(d.Calls, "start")
+	return nil
+}
+
+// ImagePull requests the docker host to pull an image from a remote registry.
+func (d *FakeDockerClient) ImagePull(ctx context.Context, ref string, options dockertypes.ImagePullOptions) (io.ReadCloser, error) {
+	d.Calls = append(d.Calls, "pull")
+
+	if d.PullFail != nil {
+		return nil, d.PullFail
+	}
+
+	return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+}
+
+// ImageRemove removes an image from the docker host.
+func (d *FakeDockerClient) ImageRemove(ctx context.Context, imageID string, options dockertypes.ImageRemoveOptions) ([]dockertypes.ImageDelete, error) {
+	d.Calls = append(d.Calls, "remove_image")
+
+	if _, exists := d.Images[imageID]; exists {
+		delete(d.Images, imageID)
+		return []dockertypes.ImageDelete{}, nil
+	}
+	return []dockertypes.ImageDelete{}, errors.New("image does not exist")
+}
+
+// ServerVersion returns information of the docker client and server host.
+func (d *FakeDockerClient) ServerVersion(ctx context.Context) (dockertypes.Version, error) {
+	return dockertypes.Version{}, nil
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/docker/util_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/docker/util_test.go
@@ -1,0 +1,135 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/util/user"
+)
+
+func rangeList(str string) *user.RangeList {
+	l, err := user.ParseRangeList(str)
+	if err != nil {
+		panic(err)
+	}
+	return l
+}
+
+func TestCheckAllowedUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowedUIDs *user.RangeList
+		user        string
+		onbuild     []string
+		expectErr   bool
+	}{
+		{
+			name:        "AllowedUIDs is not set",
+			allowedUIDs: rangeList(""),
+			user:        "root",
+			onbuild:     []string{},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, non-numeric user",
+			allowedUIDs: rangeList("0"),
+			user:        "default",
+			onbuild:     []string{},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, user 0",
+			allowedUIDs: rangeList("1-"),
+			user:        "0",
+			onbuild:     []string{},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, non-numeric onbuild",
+			allowedUIDs: rangeList("1-10,30-"),
+			user:        "100",
+			onbuild:     []string{"COPY test test", "USER default"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, no onbuild user directive",
+			allowedUIDs: rangeList("1-10,30-"),
+			user:        "200",
+			onbuild:     []string{"VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild numeric user directive",
+			allowedUIDs: rangeList("200,500-"),
+			user:        "200",
+			onbuild:     []string{"USER 500", "VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild user 0",
+			allowedUIDs: rangeList("1-"),
+			user:        "200",
+			onbuild:     []string{"RUN echo \"hello world\"", "USER 0"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild numeric user directive, upper bound range",
+			allowedUIDs: rangeList("-1000"),
+			user:        "80",
+			onbuild:     []string{"USER 501", "VOLUME /data"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user with group",
+			allowedUIDs: rangeList("1-"),
+			user:        "5:5000",
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user with named group",
+			allowedUIDs: rangeList("1-"),
+			user:        "5:group",
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, named user with group",
+			allowedUIDs: rangeList("1-"),
+			user:        "root:wheel",
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild user with group",
+			allowedUIDs: rangeList("1-"),
+			user:        "200",
+			onbuild:     []string{"RUN echo \"hello world\"", "USER 10:100"},
+			expectErr:   false,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild named user with group",
+			allowedUIDs: rangeList("1-"),
+			user:        "200",
+			onbuild:     []string{"RUN echo \"hello world\"", "USER root:wheel"},
+			expectErr:   true,
+		},
+		{
+			name:        "AllowedUIDs is set, numeric user, onbuild user with named group",
+			allowedUIDs: rangeList("1-"),
+			user:        "200",
+			onbuild:     []string{"RUN echo \"hello world\"", "USER 10:wheel"},
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		docker := &FakeDocker{
+			GetImageUserResult: tc.user,
+			OnBuildResult:      tc.onbuild,
+		}
+		err := CheckAllowedUser(docker, "", *tc.allowedUIDs, len(tc.onbuild) > 0)
+		if err != nil && !tc.expectErr {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		}
+		if err == nil && tc.expectErr {
+			t.Errorf("%s: expected error, but did not get any", tc.name)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/ignore/ignore_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/ignore/ignore_test.go
@@ -1,0 +1,203 @@
+package ignore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+func baseTest(t *testing.T, patterns []string, filesToDel []string, filesToKeep []string) {
+	// create working dir
+	workingDir, werr := fs.NewFileSystem().CreateWorkingDirectory()
+	if werr != nil {
+		t.Errorf("problem allocating working dir: %v", werr)
+	} else {
+		t.Logf("working directory is %q", workingDir)
+	}
+	defer func() {
+		// clean up test
+		cleanerr := os.RemoveAll(workingDir)
+		if cleanerr != nil {
+			t.Errorf("problem cleaning up: %v", cleanerr)
+		}
+	}()
+
+	c := &api.Config{WorkingDir: workingDir}
+
+	// create source repo dir for .s2iignore that matches where ignore.go looks
+	dpath := filepath.Join(c.WorkingDir, "upload", "src")
+	derr := os.MkdirAll(dpath, 0777)
+	if derr != nil {
+		t.Errorf("Problem creating source repo dir %q: %v", dpath, derr)
+	}
+
+	c.WorkingSourceDir = dpath
+	t.Logf("working source dir %q", dpath)
+
+	// create s2iignore file
+	ipath := filepath.Join(dpath, api.IgnoreFile)
+	ifile, ierr := os.Create(ipath)
+	defer ifile.Close()
+	if ierr != nil {
+		t.Errorf("Problem creating .s2iignore in %q: %v", ipath, ierr)
+	}
+
+	// write patterns to remove into s2ignore, but save ! exclusions
+	filesToIgnore := make(map[string]string)
+	for _, pattern := range patterns {
+		t.Logf("storing pattern %q", pattern)
+		_, serr := ifile.WriteString(pattern)
+
+		if serr != nil {
+			t.Errorf("Problem setting .s2iignore: %v", serr)
+		}
+		if strings.HasPrefix(pattern, "!") {
+			pattern = strings.Replace(pattern, "!", "", 1)
+			t.Logf("Noting ignore pattern %q", pattern)
+			filesToIgnore[pattern] = pattern
+		}
+	}
+
+	// create slices the store files to create, maps for files which should be deleted, files which should be kept
+	filesToCreate := []string{}
+	filesToDelCheck := make(map[string]string)
+	for _, fileToDel := range filesToDel {
+		filesToDelCheck[fileToDel] = fileToDel
+		filesToCreate = append(filesToCreate, fileToDel)
+	}
+	filesToKeepCheck := make(map[string]string)
+	for _, fileToKeep := range filesToKeep {
+		filesToKeepCheck[fileToKeep] = fileToKeep
+		filesToCreate = append(filesToCreate, fileToKeep)
+	}
+
+	// create files for test
+	for _, fileToCreate := range filesToCreate {
+		fbpath := filepath.Join(dpath, fileToCreate)
+
+		// ensure any subdirs off working dir exist
+		dirpath := filepath.Dir(fbpath)
+		derr := os.MkdirAll(dirpath, 0777)
+		if derr != nil && !os.IsExist(derr) {
+			t.Errorf("Problem creating subdirs %q: %v", dirpath, derr)
+		}
+		t.Logf("Going to create file %q", fbpath)
+		fbfile, fberr := os.Create(fbpath)
+		if fberr != nil {
+			t.Errorf("Problem creating test file: %v", fberr)
+		}
+		fbfile.Close()
+	}
+
+	// run ignorer algorithm
+	ignorer := &DockerIgnorer{}
+	ignorer.Ignore(c)
+
+	// check if filesToDel, minus ignores, are gone, and filesToKeep are still there
+	for _, fileToCheck := range filesToCreate {
+		fbpath := filepath.Join(dpath, fileToCheck)
+		t.Logf("Evaluating file %q from dir %q and file to check %q", fbpath, dpath, fileToCheck)
+
+		// see if file still exists or not
+		ofile, oerr := os.Open(fbpath)
+		defer ofile.Close()
+		var fileExists bool
+		if oerr == nil {
+			fileExists = true
+			t.Logf("The file %q exists after Ignore was run", fbpath)
+		} else {
+			if os.IsNotExist(oerr) {
+				t.Logf("The file %q does not exist after Ignore was run", fbpath)
+				fileExists = false
+			} else {
+				t.Errorf("Could not verify existence of %q: %v", fbpath, oerr)
+			}
+		}
+
+		_, iok := filesToIgnore[fileToCheck]
+		_, kok := filesToKeepCheck[fileToCheck]
+		_, dok := filesToDelCheck[fileToCheck]
+
+		// if file present, verify it is in ignore or keep list, and not in del list
+		if fileExists {
+			if iok {
+				t.Logf("validated ignored file is still present: %q", fileToCheck)
+				continue
+			}
+			if kok {
+				t.Logf("validated file to keep is still present: %q", fileToCheck)
+				continue
+			}
+			if dok {
+				t.Errorf("file which was cited to be deleted by caller to runTest exists: %q", fileToCheck)
+				continue
+			}
+			// if here, something unexpected
+			t.Errorf("file %q not in ignore / keep / del list !?!?!?!?", fileToCheck)
+		} else {
+			if dok {
+				t.Logf("file which should have been deleted is in fact gone: %q", fileToCheck)
+				continue
+			}
+			if iok {
+				t.Errorf("file put into ignore list does not exist: %q", fileToCheck)
+				continue
+			}
+			if kok {
+				t.Errorf("file passed in with keep list does not exist: %q", fileToCheck)
+				continue
+			}
+			// if here, then something unexpected happened
+			t.Errorf("file %q not in ignore / keep / del list !?!?!?!?", fileToCheck)
+		}
+	}
+}
+
+func TestBlankLine(t *testing.T) {
+	baseTest(t, []string{"foo.bar\n", "\n", "bar.baz\n"}, []string{"foo.bar", "bar.baz"}, []string{"foo.baz"})
+}
+
+func TestSingleIgnore(t *testing.T) {
+	baseTest(t, []string{"foo.bar\n"}, []string{"foo.bar"}, []string{})
+}
+
+func TestWildcardIgnore(t *testing.T) {
+	baseTest(t, []string{"foo.*\n"}, []string{"foo.a", "foo.b"}, []string{})
+}
+
+func TestExclusion(t *testing.T) {
+	baseTest(t, []string{"foo.*\n", "!foo.a"}, []string{"foo.b"}, []string{"foo.a"})
+}
+
+func TestSubDirs(t *testing.T) {
+	baseTest(t, []string{"*/foo.a\n"}, []string{"asdf/foo.a"}, []string{"foo.a"})
+}
+
+func TestBasicDelKeepMix(t *testing.T) {
+	baseTest(t, []string{"foo.bar\n"}, []string{"foo.bar"}, []string{"bar.foo"})
+}
+
+/*
+Per the docker user guide, with a docker ignore list of:
+
+    LICENSE.*
+    !LICENSE.md
+    *.md
+
+LICENSE.MD will NOT be kept, as *.md overrides !LICENSE.md
+*/
+func TestExcludeOverride(t *testing.T) {
+	baseTest(t, []string{"LICENSE.*\n", "!LICENSE.md\n", "*.md"}, []string{"LICENSE.foo", "LICENSE.md"}, []string{"foo.bar"})
+}
+
+func TestExclusionWithWildcard(t *testing.T) {
+	baseTest(t, []string{"*.bar\n", "!foo.*"}, []string{"boo.bar", "bar.bar"}, []string{"foo.bar"})
+}
+
+func TestHopelessExclusion(t *testing.T) {
+	baseTest(t, []string{"!LICENSE.md\n", "LICENSE.*"}, []string{"LICENSE.md"}, []string{})
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/run/run.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/run/run.go
@@ -1,0 +1,60 @@
+// Package run supports running images produced by S2I. It is used by the
+// --run=true command line option.
+package run
+
+import (
+	"io"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/docker"
+	s2ierr "github.com/openshift/source-to-image/pkg/errors"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
+)
+
+var (
+	glog = utilglog.StderrLog
+)
+
+// A DockerRunner allows running a Docker image as a new container, streaming
+// stdout and stderr with glog.
+type DockerRunner struct {
+	ContainerClient docker.Docker
+}
+
+// New creates a DockerRunner for executing the methods associated with running
+// the produced image in a docker container for verification purposes.
+func New(client docker.Client, config *api.Config) *DockerRunner {
+	d := docker.New(client, config.PullAuthentication)
+	return &DockerRunner{d}
+}
+
+// Run invokes the Docker API to run the image defined in config as a new
+// container. The container's stdout and stderr will be logged with glog.
+func (b *DockerRunner) Run(config *api.Config) error {
+	glog.V(4).Infof("Attempting to run image %s \n", config.Tag)
+
+	outReader, outWriter := io.Pipe()
+	errReader, errWriter := io.Pipe()
+
+	opts := docker.RunContainerOptions{
+		Image:        config.Tag,
+		Stdout:       outWriter,
+		Stderr:       errWriter,
+		TargetImage:  true,
+		CGroupLimits: config.CGroupLimits,
+		CapDrop:      config.DropCapabilities,
+	}
+
+	docker.StreamContainerIO(errReader, nil, func(s string) { glog.Error(s) })
+	docker.StreamContainerIO(outReader, nil, func(s string) { glog.Info(s) })
+
+	err := b.ContainerClient.RunContainer(opts)
+	// If we get a ContainerError, the original message reports the
+	// container name. The container is temporary and its name is
+	// meaningless, therefore we make the error message more helpful by
+	// replacing the container name with the image tag.
+	if e, ok := err.(s2ierr.ContainerError); ok {
+		return s2ierr.NewContainerError(config.Tag, e.ErrorCode, e.Output)
+	}
+	return err
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/file/download.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/file/download.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
 
@@ -14,7 +14,7 @@ var glog = utilglog.StderrLog
 // File represents a simplest possible Downloader implementation where the
 // sources are just copied from local directory.
 type File struct {
-	util.FileSystem
+	fs.FileSystem
 }
 
 // Download copies sources from a local directory into the working directory

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/file/download_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/file/download_test.go
@@ -1,0 +1,48 @@
+package file
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+)
+
+func TestDownload(t *testing.T) {
+	fs := &testfs.FakeFileSystem{}
+	f := &File{fs}
+
+	config := &api.Config{
+		Source: "file:///foo",
+	}
+	info, err := f.Download(config)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if fs.CopySource != "/foo" {
+		t.Errorf("Unexpected fs.CopySource %s", fs.CopySource)
+	}
+	if info.Location != config.Source[7:] || info.ContextDir != config.ContextDir {
+		t.Errorf("Unexpected info")
+	}
+}
+
+func TestDownloadWithContext(t *testing.T) {
+	fs := &testfs.FakeFileSystem{}
+	f := &File{fs}
+
+	config := &api.Config{
+		Source:     "file:///foo",
+		ContextDir: "bar",
+	}
+	info, err := f.Download(config)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if filepath.ToSlash(fs.CopySource) != "/foo/bar" {
+		t.Errorf("Unexpected fs.CopySource %s", fs.CopySource)
+	}
+	if info.Location != config.Source[7:] || info.ContextDir != config.ContextDir {
+		t.Errorf("Unexpected info")
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/git/clone.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/git/clone.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 
 	"github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/cygpath"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // Clone knows how to clone a Git repository.
 type Clone struct {
 	Git
-	util.FileSystem
+	fs.FileSystem
 }
 
 // Download downloads the application source code from the Git repository
@@ -40,9 +41,9 @@ func (c *Clone) Download(config *api.Config) (*api.SourceInfo, error) {
 	if strings.HasPrefix(config.Source, "file://") {
 		s := strings.TrimPrefix(config.Source, "file://")
 
-		if util.UsingCygwinGit {
+		if cygpath.UsingCygwinGit {
 			var err error
-			s, err = util.ToSlashCygwin(s)
+			s, err = cygpath.ToSlashCygwin(s)
 			if err != nil {
 				glog.V(0).Infof("error: Cygwin path conversion failed: %v", err)
 				return nil, err

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/git/clone_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/git/clone_test.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	testcmd "github.com/openshift/source-to-image/pkg/test/cmd"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+)
+
+func TestCloneWithContext(t *testing.T) {
+	fs := &testfs.FakeFileSystem{}
+	gh := New(fs).(*stiGit)
+	cr := &testcmd.FakeCmdRunner{}
+	gh.CommandRunner = cr
+	c := &Clone{gh, fs}
+
+	fakeConfig := &api.Config{
+		Source:           "https://foo/bar.git",
+		ContextDir:       "subdir",
+		Ref:              "ref1",
+		IgnoreSubmodules: true,
+	}
+	info, err := c.Download(fakeConfig)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if info == nil {
+		t.Fatalf("Expected info to be not nil")
+	}
+	if filepath.ToSlash(fs.CopySource) != "upload/tmp/subdir" {
+		t.Errorf("The source directory should be 'upload/tmp/subdir', it is %v", fs.CopySource)
+	}
+	if filepath.ToSlash(fs.CopyDest) != "upload/src" {
+		t.Errorf("The target directory should be 'upload/src', it is %v", fs.CopyDest)
+	}
+	if filepath.ToSlash(fs.RemoveDirName) != "upload/tmp" {
+		t.Errorf("Expected to remove the upload/tmp directory")
+	}
+	if !reflect.DeepEqual(cr.Args, []string{"checkout", "ref1"}) {
+		t.Errorf("Unexpected command arguments: %#v", cr.Args)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/git/git.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/git/git.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/openshift/source-to-image/pkg/api"
 	s2ierr "github.com/openshift/source-to-image/pkg/errors"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/cmd"
+	"github.com/openshift/source-to-image/pkg/util/cygpath"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
 
@@ -35,16 +37,16 @@ type Git interface {
 }
 
 // New returns a new instance of the default implementation of the Git interface
-func New(fs util.FileSystem) Git {
+func New(fs fs.FileSystem) Git {
 	return &stiGit{
 		FileSystem:    fs,
-		CommandRunner: util.NewCommandRunner(),
+		CommandRunner: cmd.NewCommandRunner(),
 	}
 }
 
 type stiGit struct {
-	util.FileSystem
-	util.CommandRunner
+	fs.FileSystem
+	cmd.CommandRunner
 }
 
 // URLMods encapsulates potential changes to similarly named fields in the URL struct defined in golang
@@ -227,7 +229,7 @@ func makePathAbsolute(source string) string {
 // expect git clone spec syntax; it also provides details if the file://
 // proto was explicitly specified, if we should use OS copy vs. the git
 // binary, and if a frag/ref has a bad format
-func ParseFile(fs util.FileSystem, source string) (*FileProtoDetails, *URLMods, error) {
+func ParseFile(fs fs.FileSystem, source string) (*FileProtoDetails, *URLMods, error) {
 	// Checking to see if the user included a "file://" in the call
 	protoSpecified := false
 	if strings.HasPrefix(source, "file://") && len(source) > 7 {
@@ -376,7 +378,7 @@ func ParseSSH(source string) (*URLMods, error) {
 // it the gitdir value, which is supposed to indicate the location of the
 // corresponding .git /directory/.  Note: the gitdir value should point directly
 // to the corresponding .git directory even in the case of nested submodules.
-func followGitSubmodule(fs util.FileSystem, gitPath string) (string, error) {
+func followGitSubmodule(fs fs.FileSystem, gitPath string) (string, error) {
 	f, err := os.Open(gitPath)
 	if err != nil {
 		return "", err
@@ -410,7 +412,7 @@ func followGitSubmodule(fs util.FileSystem, gitPath string) (string, error) {
 
 // isValidGitRepository checks to see if there is a git repository in the
 // directory and if the repository is valid -- i.e. it has remotes or commits
-func isValidGitRepository(fs util.FileSystem, dir string) (bool, error) {
+func isValidGitRepository(fs fs.FileSystem, dir string) (bool, error) {
 	gitPath := filepath.Join(strings.TrimPrefix(dir, "file://"), ".git")
 
 	fi, err := fs.Stat(gitPath)
@@ -474,9 +476,9 @@ func hasGitBinary() bool {
 
 // Clone clones a git repository to a specific target directory
 func (h *stiGit) Clone(source, target string, c api.CloneConfig) error {
-	if util.UsingCygwinGit {
+	if cygpath.UsingCygwinGit {
 		var err error
-		target, err = util.ToSlashCygwin(target)
+		target, err = cygpath.ToSlashCygwin(target)
 		if err != nil {
 			return err
 		}
@@ -495,7 +497,7 @@ func (h *stiGit) Clone(source, target string, c api.CloneConfig) error {
 	cloneArgs := append([]string{"clone"}, cloneConfigToArgs(c)...)
 	cloneArgs = append(cloneArgs, []string{source, target}...)
 	errReader, errWriter, _ := os.Pipe()
-	opts := util.CommandOpts{Stderr: errWriter}
+	opts := cmd.CommandOpts{Stderr: errWriter}
 	err := h.RunWithOptions(opts, "git", cloneArgs...)
 	errWriter.Close()
 	if err != nil {
@@ -511,7 +513,7 @@ func (h *stiGit) Clone(source, target string, c api.CloneConfig) error {
 
 // Checkout checks out a specific branch reference of a given git repository
 func (h *stiGit) Checkout(repo, ref string) error {
-	opts := util.CommandOpts{
+	opts := cmd.CommandOpts{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Dir:    repo,
@@ -521,7 +523,7 @@ func (h *stiGit) Checkout(repo, ref string) error {
 
 // SubmoduleInit initializes/clones submodules
 func (h *stiGit) SubmoduleInit(repo string) error {
-	opts := util.CommandOpts{
+	opts := cmd.CommandOpts{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Dir:    repo,
@@ -540,7 +542,7 @@ func (h *stiGit) SubmoduleUpdate(repo string, init, recursive bool) error {
 		updateArgs = append(updateArgs, "--recursive")
 	}
 
-	opts := util.CommandOpts{
+	opts := cmd.CommandOpts{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Dir:    repo,
@@ -557,7 +559,7 @@ func (h *stiGit) LsTree(repo, ref string, recursive bool) ([]os.FileInfo, error)
 		args = append(args, "-r")
 	}
 
-	opts := util.CommandOpts{
+	opts := cmd.CommandOpts{
 		Dir: repo,
 	}
 
@@ -581,7 +583,7 @@ func (h *stiGit) LsTree(repo, ref string, recursive bool) ([]os.FileInfo, error)
 			submodules = append(submodules, filepath.Join(repo, path))
 			continue
 		}
-		rv = append(rv, &util.FileInfo{FileMode: os.FileMode(mode), FileName: path})
+		rv = append(rv, &fs.FileInfo{FileMode: os.FileMode(mode), FileName: path})
 	}
 	err = scanner.Err()
 	if err != nil {

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/git/git_munge_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/git/git_munge_test.go
@@ -1,0 +1,153 @@
+// +build !windows
+
+package git
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/test"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+// NB: MungeNoProtocolURL is only called by OpenShift, running on a Linux
+// system.  It is unclear what its behaviour should be running on Windows / when
+// passed Windows-style paths, therefore for now this test does not run on
+// Windows builds.
+// TODO: fix this.
+func TestMungeNoProtocolURL(t *testing.T) {
+	gitLocalDir := test.CreateLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+
+	tests := map[string]url.URL{
+		"git@github.com:user/repo.git": {
+			Scheme: "ssh",
+			Host:   "github.com",
+			User:   url.User("git"),
+			Path:   "user/repo.git",
+		},
+		"git://github.com/user/repo.git": {
+			Scheme: "git",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"git://github.com/user/repo": {
+			Scheme: "git",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"http://github.com/user/repo.git": {
+			Scheme: "http",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"http://github.com/user/repo": {
+			Scheme: "http",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"https://github.com/user/repo.git": {
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   "/user/repo.git",
+		},
+		"https://github.com/user/repo": {
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   "/user/repo",
+		},
+		"file://" + gitLocalDir: {
+			Scheme: "file",
+			Path:   gitLocalDir,
+		},
+		gitLocalDir: {
+			Scheme: "file",
+			Path:   gitLocalDir,
+		},
+		"git@192.168.122.1:repositories/authooks": {
+			Scheme: "ssh",
+			Host:   "192.168.122.1",
+			User:   url.User("git"),
+			Path:   "repositories/authooks",
+		},
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git": {
+			Scheme: "ssh",
+			Host:   "build.ulx.hu",
+			User:   url.User("mbalazs"),
+			Path:   "/var/git/eap-ulx.git",
+		},
+		"ssh://git@[2001:db8::1]/repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "/repository.git",
+		},
+		"ssh://git@mydomain.com:8080/foo/bar": {
+			Scheme: "ssh",
+			Host:   "mydomain.com:8080",
+			User:   url.User("git"),
+			Path:   "/foo/bar",
+		},
+		"git@[2001:db8::1]:repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "repository.git",
+		},
+		"git@[2001:db8::1]:/repository.git": {
+			Scheme: "ssh",
+			Host:   "[2001:db8::1]",
+			User:   url.User("git"),
+			Path:   "/repository.git",
+		},
+	}
+
+	gh := New(fs.NewFileSystem())
+
+	for scenario, test := range tests {
+		uri, err := url.Parse(scenario)
+		if err != nil {
+			t.Errorf("Could not parse url %q", scenario)
+			continue
+		}
+
+		err = gh.MungeNoProtocolURL(scenario, uri)
+		if err != nil {
+			t.Errorf("MungeNoProtocolURL returned err: %v", err)
+			continue
+		}
+
+		// reflect.DeepEqual was not dealing with url.URL correctly, have to check each field individually
+		// First, the easy string compares
+		equal := uri.Scheme == test.Scheme && uri.Opaque == test.Opaque && uri.Host == test.Host && uri.Path == test.Path && uri.RawQuery == test.RawQuery && uri.Fragment == test.Fragment
+		if equal {
+			// now deal with User, a Userinfo struct ptr
+			if uri.User == nil && test.User != nil {
+				equal = false
+			} else if uri.User != nil && test.User == nil {
+				equal = false
+			} else if uri.User != nil && test.User != nil {
+				equal = uri.User.String() == test.User.String()
+			}
+		}
+		if !equal {
+			t.Errorf(`URL string %q, field by field check:
+- Scheme: got %v, ok? %v
+- Opaque: got %v, ok? %v
+- Host: got %v, ok? %v
+- Path: got %v, ok? %v
+- RawQuery: got %v, ok? %v
+- Fragment: got %v, ok? %v
+- User: got %v`,
+				scenario,
+				uri.Scheme, uri.Scheme == test.Scheme,
+				uri.Opaque, uri.Opaque == test.Opaque,
+				uri.Host, uri.Host == test.Host,
+				uri.Path, uri.Path == test.Path,
+				uri.RawQuery, uri.RawQuery == test.RawQuery,
+				uri.Fragment, uri.Fragment == test.Fragment,
+				uri.User)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/git/git_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/git/git_test.go
@@ -1,0 +1,216 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	s2ierr "github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/test"
+	testcmd "github.com/openshift/source-to-image/pkg/test/cmd"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+func TestIsValidGitRepository(t *testing.T) {
+	fs := fs.NewFileSystem()
+
+	d := test.CreateLocalGitDirectory(t)
+	defer os.RemoveAll(d)
+
+	// We have a .git that is populated
+	// Should return true with no error
+	ok, err := isValidGitRepository(fs, d)
+	if !ok {
+		t.Errorf("The %q directory is git repository", d)
+	}
+
+	if err != nil {
+		t.Errorf("isValidGitRepository returned an unexpected error: %q", err.Error())
+	}
+
+	d = test.CreateEmptyLocalGitDirectory(t)
+	defer os.RemoveAll(d)
+
+	// There are no tracking objects in the .git repository
+	// Should return true with an EmptyGitRepositoryError
+	ok, err = isValidGitRepository(fs, d)
+	if !ok {
+		t.Errorf("The %q directory is a git repository, but is empty", d)
+	}
+
+	if err != nil {
+		var e s2ierr.Error
+		if e, ok = err.(s2ierr.Error); !ok || e.ErrorCode != s2ierr.EmptyGitRepositoryError {
+			t.Errorf("isValidGitRepository returned an unexpected error: %q, expecting EmptyGitRepositoryError", err.Error())
+		}
+	} else {
+		t.Errorf("isValidGitRepository returned no error, expecting EmptyGitRepositoryError")
+	}
+
+	d = filepath.Join(d, ".git")
+
+	// There is no .git in the provided directory
+	// Should return false with no error
+	if ok, err = isValidGitRepository(fs, d); ok {
+		t.Errorf("The %q directory is not git repository", d)
+	}
+
+	if err != nil {
+		t.Errorf("isValidGitRepository returned an unexpected error: %q", err.Error())
+	}
+
+	d = test.CreateLocalGitDirectoryWithSubmodule(t)
+	defer os.RemoveAll(d)
+
+	ok, err = isValidGitRepository(fs, filepath.Join(d, "submodule"))
+	if !ok || err != nil {
+		t.Errorf("Expected isValidGitRepository to return true, nil on submodule; got %v, %v", ok, err)
+	}
+}
+
+func TestValidCloneSpec(t *testing.T) {
+	gitLocalDir := test.CreateLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+
+	valid := []string{"git@github.com:user/repo.git",
+		"git://github.com/user/repo.git",
+		"git://github.com/user/repo",
+		"http://github.com/user/repo.git",
+		"http://github.com/user/repo",
+		"https://github.com/user/repo.git",
+		"https://github.com/user/repo",
+		"file://" + gitLocalDir,
+		"file://" + gitLocalDir + "#master",
+		gitLocalDir,
+		gitLocalDir + "#master",
+		"git@192.168.122.1:repositories/authooks",
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git",
+		"ssh://git@[2001:db8::1]/repository.git",
+		"ssh://git@mydomain.com:8080/foo/bar",
+		"git@[2001:db8::1]:repository.git",
+		"git@[2001:db8::1]:/repository.git",
+		"g_m@foo.bar:foo/bar",
+		"g-m@foo.bar:foo/bar",
+		"g.m@foo.bar:foo/bar",
+		"github.com:openshift/origin.git",
+		"http://github.com/user/repo#1234",
+	}
+	invalid := []string{"g&m@foo.bar:foo.bar",
+		"~git@test.server/repo.git",
+		"some/lo:cal/path", // a local path that does not exist, but "some/lo" is not a valid host name
+		"http://github.com/user/repo#%%%%",
+	}
+
+	gh := New(fs.NewFileSystem())
+
+	for _, scenario := range valid {
+		result, _ := gh.ValidCloneSpec(scenario)
+		if result == false {
+			t.Error(scenario)
+		}
+	}
+	for _, scenario := range invalid {
+		result, _ := gh.ValidCloneSpec(scenario)
+		if result {
+			t.Error(scenario)
+		}
+	}
+}
+
+func TestValidCloneSpecRemoteOnly(t *testing.T) {
+	valid := []string{"git://github.com/user/repo.git",
+		"git://github.com/user/repo",
+		"http://github.com/user/repo.git",
+		"http://github.com/user/repo",
+		"https://github.com/user/repo.git",
+		"https://github.com/user/repo",
+		"ssh://git@[2001:db8::1]/repository.git",
+		"ssh://git@mydomain.com:8080/foo/bar",
+		"git@github.com:user/repo.git",
+		"git@192.168.122.1:repositories/authooks",
+		"mbalazs@build.ulx.hu:/var/git/eap-ulx.git",
+		"git@[2001:db8::1]:repository.git",
+		"git@[2001:db8::1]:/repository.git",
+	}
+	invalid := []string{"file:///home/user/code/repo.git",
+		"/home/user/code/repo.git",
+	}
+
+	gh := New(fs.NewFileSystem())
+
+	for _, scenario := range valid {
+		result := gh.ValidCloneSpecRemoteOnly(scenario)
+		if result == false {
+			t.Error(scenario)
+		}
+	}
+	for _, scenario := range invalid {
+		result := gh.ValidCloneSpecRemoteOnly(scenario)
+		if result {
+			t.Error(scenario)
+		}
+	}
+}
+
+func getGit() (*stiGit, *testcmd.FakeCmdRunner) {
+	gh := New(&testfs.FakeFileSystem{}).(*stiGit)
+	cr := &testcmd.FakeCmdRunner{}
+	gh.CommandRunner = cr
+
+	return gh, cr
+}
+
+func TestGitClone(t *testing.T) {
+	gh, ch := getGit()
+	err := gh.Clone("source1", "target1", api.CloneConfig{Quiet: true, Recursive: true})
+	if err != nil {
+		t.Errorf("Unexpected error returned from clone: %v", err)
+	}
+	if ch.Name != "git" {
+		t.Errorf("Unexpected command name: %q", ch.Name)
+	}
+	if !reflect.DeepEqual(ch.Args, []string{"clone", "--quiet", "--recursive", "source1", "target1"}) {
+		t.Errorf("Unexpected command arguments: %#v", ch.Args)
+	}
+}
+
+func TestGitCloneError(t *testing.T) {
+	gh, ch := getGit()
+	runErr := fmt.Errorf("Run Error")
+	ch.Err = runErr
+	err := gh.Clone("source1", "target1", api.CloneConfig{})
+	if err != runErr {
+		t.Errorf("Unexpected error returned from clone: %v", err)
+	}
+}
+
+func TestGitCheckout(t *testing.T) {
+	gh, ch := getGit()
+	err := gh.Checkout("repo1", "ref1")
+	if err != nil {
+		t.Errorf("Unexpected error returned from checkout: %v", err)
+	}
+	if ch.Name != "git" {
+		t.Errorf("Unexpected command name: %q", ch.Name)
+	}
+	if !reflect.DeepEqual(ch.Args, []string{"checkout", "ref1"}) {
+		t.Errorf("Unexpected command arguments: %#v", ch.Args)
+	}
+	if ch.Opts.Dir != "repo1" {
+		t.Errorf("Unexpected value in exec directory: %q", ch.Opts.Dir)
+	}
+}
+
+func TestGitCheckoutError(t *testing.T) {
+	gh, ch := getGit()
+	runErr := fmt.Errorf("Run Error")
+	ch.Err = runErr
+	err := gh.Checkout("repo1", "ref1")
+	if err != runErr {
+		t.Errorf("Unexpected error returned from checkout: %v", err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/scm.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/scm.go
@@ -3,21 +3,20 @@ package scm
 import (
 	"fmt"
 
-	s2ierr "github.com/openshift/source-to-image/pkg/errors"
-	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
-
 	"github.com/openshift/source-to-image/pkg/build"
+	s2ierr "github.com/openshift/source-to-image/pkg/errors"
 	"github.com/openshift/source-to-image/pkg/scm/empty"
 	"github.com/openshift/source-to-image/pkg/scm/file"
 	"github.com/openshift/source-to-image/pkg/scm/git"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
 
 var glog = utilglog.StderrLog
 
 // DownloaderForSource determines what SCM plugin should be used for downloading
 // the sources from the repository.
-func DownloaderForSource(fs util.FileSystem, s string, forceCopy bool) (build.Downloader, string, error) {
+func DownloaderForSource(fs fs.FileSystem, s string, forceCopy bool) (build.Downloader, string, error) {
 	glog.V(4).Infof("DownloadForSource %s", s)
 
 	if len(s) == 0 {

--- a/vendor/github.com/openshift/source-to-image/pkg/scm/scm_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scm/scm_test.go
@@ -1,0 +1,93 @@
+package scm
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/test"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+func TestDownloaderForSource(t *testing.T) {
+	gitLocalDir := test.CreateLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	localDir, _ := ioutil.TempDir(os.TempDir(), "localdir-s2i-test")
+	defer os.RemoveAll(localDir)
+
+	tc := map[string]string{
+		// Valid Git clone specs
+		"git://github.com/bar":       "git.Clone",
+		"https://github.com/bar":     "git.Clone",
+		"git@github.com:foo/bar.git": "git.Clone",
+		// Non-existing local path (it is not git repository, so it is file
+		// download)
+		"file://foo/bar": "error",
+		"/foo/bar":       "error",
+		// Local directory with valid Git repository
+		gitLocalDir:             "git.Clone",
+		"file://" + gitLocalDir: "git.Clone",
+		// Local directory that exists but it is not Git repository
+		localDir:               "file.File",
+		"file://" + localDir:   "file.File",
+		"foo://github.com/bar": "error",
+		"./foo":                "error",
+		// Empty source string
+		"": "empty.Noop",
+	}
+
+	for s, expected := range tc {
+		r, filePathUpdate, err := DownloaderForSource(fs.NewFileSystem(), s, false)
+		if err != nil {
+			if expected != "error" {
+				t.Errorf("Unexpected error %q for %q, expected %q", err, s, expected)
+			}
+			continue
+		}
+
+		if s == gitLocalDir || s == localDir {
+			if !strings.HasPrefix(filePathUpdate, "file://") {
+				t.Errorf("input %s should have produced a file path update starting with file:// but produced:  %s", s, filePathUpdate)
+			}
+		}
+
+		expected = "*" + expected
+		if reflect.TypeOf(r).String() != expected {
+			t.Errorf("Expected %q for %q, got %q", expected, s, reflect.TypeOf(r).String())
+		}
+	}
+}
+
+func TestDownloaderForSourceOnRelativeGit(t *testing.T) {
+	gitLocalDir := test.CreateLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	os.Chdir(gitLocalDir)
+	r, s, err := DownloaderForSource(fs.NewFileSystem(), ".", false)
+	if err != nil {
+		t.Errorf("Unexpected error %q for %q, expected %q", err, ".", "git.Clone")
+	}
+	if !strings.HasPrefix(s, "file://") {
+		t.Errorf("Expected source to have 'file://' prefix, it is %q", s)
+	}
+	if reflect.TypeOf(r).String() != "*git.Clone" {
+		t.Errorf("Expected %q for %q, got %q", "*git.Clone", ".", reflect.TypeOf(r).String())
+	}
+}
+
+func TestDownloaderForceCopy(t *testing.T) {
+	gitLocalDir := test.CreateLocalGitDirectory(t)
+	defer os.RemoveAll(gitLocalDir)
+	os.Chdir(gitLocalDir)
+	r, s, err := DownloaderForSource(fs.NewFileSystem(), ".", true)
+	if err != nil {
+		t.Errorf("Unexpected error %q for %q, expected %q", err, ".", "*file.File")
+	}
+	if !strings.HasPrefix(s, "file://") {
+		t.Errorf("Expected source to have 'file://' prefix, it is %q", s)
+	}
+	if reflect.TypeOf(r).String() != "*file.File" {
+		t.Errorf("Expected %q for %q, got %q", "*file.File", ".", reflect.TypeOf(r).String())
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scripts/download_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scripts/download_test.go
@@ -1,0 +1,146 @@
+package scripts
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	s2ierr "github.com/openshift/source-to-image/pkg/errors"
+)
+
+type FakeHTTPGet struct {
+	url        string
+	content    string
+	err        error
+	body       io.ReadCloser
+	statusCode int
+}
+
+func (f *FakeHTTPGet) get(url string) (*http.Response, error) {
+	f.url = url
+	f.body = ioutil.NopCloser(strings.NewReader(f.content))
+	return &http.Response{
+		Body:       f.body,
+		StatusCode: f.statusCode,
+	}, f.err
+}
+
+func getHTTPReader() (*HTTPURLReader, *FakeHTTPGet) {
+	sr := &HTTPURLReader{}
+	g := &FakeHTTPGet{content: "test content", statusCode: 200}
+	sr.Get = g.get
+	return sr, g
+}
+
+func TestHTTPRead(t *testing.T) {
+	u, _ := url.Parse("http://test.url/test")
+	sr, fg := getHTTPReader()
+	rc, err := sr.Read(u)
+	if rc != fg.body {
+		t.Errorf("Unexpected readcloser returned: %#v", rc)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error returned: %v", err)
+	}
+}
+
+func TestHTTPReadGetError(t *testing.T) {
+	u, _ := url.Parse("http://test.url/test")
+	sr, fg := getHTTPReader()
+	fg.err = fmt.Errorf("URL Error")
+	rc, err := sr.Read(u)
+	if rc != nil {
+		t.Errorf("Unexpected stream returned: %#v", rc)
+	}
+	if err != fg.err {
+		t.Errorf("Unexpected error returned: %#v", err)
+	}
+}
+
+func TestHTTPReadErrorCode(t *testing.T) {
+	u, _ := url.Parse("http://test.url/test")
+	sr, fg := getHTTPReader()
+	fg.statusCode = 500
+	rc, err := sr.Read(u)
+	if rc != nil {
+		t.Errorf("Unexpected stream returned: %#v", rc)
+	}
+	if err == nil {
+		t.Errorf("Error expeccted and not returned")
+	}
+}
+
+type FakeSchemeReader struct {
+	content string
+	err     error
+}
+
+func (f *FakeSchemeReader) Read(url *url.URL) (io.ReadCloser, error) {
+	return ioutil.NopCloser(strings.NewReader(f.content)), f.err
+}
+
+func getDownloader() (Downloader, *FakeSchemeReader) {
+	fakeReader := &FakeSchemeReader{}
+	return &downloader{
+		schemeReaders: map[string]schemeReader{
+			"http":  fakeReader,
+			"https": fakeReader,
+			"file":  fakeReader,
+		},
+	}, fakeReader
+}
+
+func TestDownload(t *testing.T) {
+	dl, fr := getDownloader()
+	fr.content = "test file content"
+	temp, err := ioutil.TempFile("", "testdownload")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	defer os.Remove(temp.Name())
+	u, _ := url.Parse("http://www.test.url/a/file")
+	temp.Close()
+	info, err := dl.Download(u, temp.Name())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(info.Location) == 0 {
+		t.Errorf("Expected info.Location to be set, got %v", info)
+	}
+	content, _ := ioutil.ReadFile(temp.Name())
+	if string(content) != fr.content {
+		t.Errorf("Unexpected file content: %s", string(content))
+	}
+}
+
+func TestNoDownload(t *testing.T) {
+	dl := &downloader{
+		schemeReaders: map[string]schemeReader{
+			"image": &ImageReader{},
+		},
+	}
+	u, _ := url.Parse("image:///tmp/testfile")
+	_, err := dl.Download(u, "")
+	if err == nil {
+		t.Error("Expected error with information about scripts inside the image!")
+	}
+	if e, ok := err.(s2ierr.Error); !ok || e.ErrorCode != s2ierr.ScriptsInsideImageError {
+		t.Errorf("Unexpected error %v", err)
+	}
+}
+
+func TestNoDownloader(t *testing.T) {
+	dl := &downloader{
+		schemeReaders: map[string]schemeReader{},
+	}
+	u, _ := url.Parse("http://www.test.url/a/file")
+	_, err := dl.Download(u, "")
+	if err == nil {
+		t.Errorf("Expected error, got nil!")
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scripts/environment_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scripts/environment_test.go
@@ -1,0 +1,42 @@
+package scripts
+
+import (
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestConvertEnvironmentList(t *testing.T) {
+	testEnv := api.EnvironmentList{
+		{Name: "Key1", Value: "Value1"},
+		{Name: "Key2", Value: "Value2"},
+		{Name: "Key3", Value: "Value3"},
+		{Name: "Key4", Value: "Value=4"},
+		{Name: "Key5", Value: "Value,5"},
+	}
+	result := ConvertEnvironmentList(testEnv)
+	expected := []string{"Key1=Value1", "Key2=Value2", "Key3=Value3", "Key4=Value=4", "Key5=Value,5"}
+	if !equalArrayContents(result, expected) {
+		t.Errorf("Unexpected result. Expected: %#v. Actual: %#v",
+			expected, result)
+	}
+}
+
+func equalArrayContents(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, e := range a {
+		found := false
+		for _, f := range b {
+			if f == e {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/scripts/install.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scripts/install.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/api"
 	"github.com/openshift/source-to-image/pkg/docker"
 	s2ierr "github.com/openshift/source-to-image/pkg/errors"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // Installer interface is responsible for installing scripts needed to run the
@@ -32,7 +32,7 @@ type URLScriptHandler struct {
 	URL            string
 	DestinationDir string
 	download       Downloader
-	fs             util.FileSystem
+	fs             fs.FileSystem
 	name           string
 }
 
@@ -104,7 +104,7 @@ func (s *URLScriptHandler) Install(r *api.InstallResult) error {
 // source code directory.
 type SourceScriptHandler struct {
 	DestinationDir string
-	fs             util.FileSystem
+	fs             fs.FileSystem
 }
 
 // Get verifies if the script is present in the source directory and get the
@@ -170,7 +170,7 @@ type DefaultScriptSourceManager struct {
 	docker     docker.Docker
 	dockerAuth api.AuthConfig
 	sources    []ScriptHandler
-	fs         util.FileSystem
+	fs         fs.FileSystem
 }
 
 // Add registers a new script source handler.
@@ -182,7 +182,7 @@ func (m *DefaultScriptSourceManager) Add(s ScriptHandler) {
 }
 
 // NewInstaller returns a new instance of the default Installer implementation
-func NewInstaller(image string, scriptsURL string, proxyConfig *api.ProxyConfig, docker docker.Docker, auth api.AuthConfig, fs util.FileSystem) Installer {
+func NewInstaller(image string, scriptsURL string, proxyConfig *api.ProxyConfig, docker docker.Docker, auth api.AuthConfig, fs fs.FileSystem) Installer {
 	m := DefaultScriptSourceManager{
 		Image:      image,
 		ScriptsURL: scriptsURL,

--- a/vendor/github.com/openshift/source-to-image/pkg/scripts/install_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/scripts/install_test.go
@@ -1,0 +1,327 @@
+package scripts
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	dockerpkg "github.com/openshift/source-to-image/pkg/docker"
+	"github.com/openshift/source-to-image/pkg/test"
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+type fakeScriptManagerConfig struct {
+	download Downloader
+	docker   dockerpkg.Docker
+	fs       fs.FileSystem
+	url      string
+}
+
+func newFakeConfig() *fakeScriptManagerConfig {
+	return &fakeScriptManagerConfig{
+		docker:   &dockerpkg.FakeDocker{},
+		download: &test.FakeDownloader{},
+		fs:       &testfs.FakeFileSystem{},
+		url:      "http://the.scripts.url/s2i/bin",
+	}
+}
+
+func newFakeInstaller(config *fakeScriptManagerConfig) Installer {
+	m := DefaultScriptSourceManager{
+		Image:      "test-image",
+		ScriptsURL: config.url,
+		docker:     config.docker,
+		fs:         config.fs,
+		download:   config.download,
+	}
+	m.Add(&URLScriptHandler{URL: m.ScriptsURL, download: m.download, fs: m.fs, name: ScriptURLHandler})
+	m.Add(&SourceScriptHandler{fs: m.fs})
+	defaultURL, err := m.docker.GetScriptsURL(m.Image)
+	if err == nil && defaultURL != "" {
+		m.Add(&URLScriptHandler{URL: defaultURL, download: m.download, fs: m.fs, name: ImageURLHandler})
+	}
+	return &m
+}
+
+func isValidInstallResult(result api.InstallResult, t *testing.T) {
+	if len(result.Script) == 0 {
+		t.Errorf("expected the Script not be empty")
+	}
+	if result.Error != nil {
+		t.Errorf("unexpected the error %v for the %q script in install result", result.Error, result.Script)
+	}
+	if !result.Downloaded {
+		t.Errorf("expected the %q script install result to be downloaded", result.Script)
+	}
+	if !result.Installed {
+		t.Errorf("expected the %q script install result to be installed", result.Script)
+	}
+	if len(result.URL) == 0 {
+		t.Errorf("expected the %q script install result to have valid URL", result.Script)
+	}
+}
+
+func TestInstallOptionalFromURL(t *testing.T) {
+	config := newFakeConfig()
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	results := inst.InstallOptional(scripts, "/output")
+	for _, r := range results {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		downloaded := false
+		targets := config.download.(*test.FakeDownloader).Target
+		for _, t := range targets {
+			if filepath.ToSlash(t) == "/output/upload/scripts/"+s {
+				downloaded = true
+			}
+		}
+		if !downloaded {
+			t.Errorf("the script %q was not downloaded properly (%#v)", s, targets)
+		}
+		validURL := false
+		urls := config.download.(*test.FakeDownloader).URL
+		for _, u := range urls {
+			if u.String() == config.url+"/"+s {
+				validURL = true
+			}
+		}
+		if !validURL {
+			t.Errorf("the script %q was downloaded from invalid URL (%+v)", s, urls)
+		}
+	}
+}
+
+func TestInstallRequiredFromURL(t *testing.T) {
+	config := newFakeConfig()
+	config.download.(*test.FakeDownloader).Err = map[string]error{
+		config.url + "/" + api.Assemble: fmt.Errorf("download error"),
+	}
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	_, err := inst.InstallRequired(scripts, "/output")
+	if err == nil {
+		t.Errorf("expected assemble to fail install")
+	}
+}
+
+func TestInstallRequiredFromDocker(t *testing.T) {
+	config := newFakeConfig()
+	// We fail the download for assemble, which means the Docker image default URL
+	// should be used instead.
+	config.download.(*test.FakeDownloader).Err = map[string]error{
+		config.url + "/" + api.Assemble: fmt.Errorf("not available"),
+	}
+	defaultDockerURL := "image:///usr/libexec/s2i/bin"
+	config.docker.(*dockerpkg.FakeDocker).DefaultURLResult = defaultDockerURL
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	results, err := inst.InstallRequired(scripts, "/output")
+	if err != nil {
+		t.Errorf("unexpected error, assemble should be installed from docker image url")
+	}
+	for _, r := range results {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		validURL := false
+		urls := config.download.(*test.FakeDownloader).URL
+		for _, u := range urls {
+			url := config.url
+			// The assemble script should be downloaded from image default URL
+			if s == api.Assemble {
+				url = defaultDockerURL
+			}
+			if u.String() == url+"/"+s {
+				validURL = true
+			}
+		}
+		if !validURL {
+			t.Errorf("the script %q was downloaded from invalid URL (%+v)", s, urls)
+		}
+	}
+}
+
+func TestInstallRequiredFromSource(t *testing.T) {
+	config := newFakeConfig()
+	// There is no other script source than the source code
+	config.url = ""
+	deprecatedSourceScripts := strings.Replace(api.SourceScripts, ".s2i", ".sti", -1)
+	config.fs.(*testfs.FakeFileSystem).ExistsResult = map[string]bool{
+		filepath.Join("/workdir", api.SourceScripts, api.Assemble):  true,
+		filepath.Join("/workdir", deprecatedSourceScripts, api.Run): true,
+	}
+	inst := newFakeInstaller(config)
+	scripts := []string{api.Assemble, api.Run}
+	result, err := inst.InstallRequired(scripts, "/workdir")
+	if err != nil {
+		t.Errorf("unexpected error, assemble should be installed from docker image url: %v", err)
+	}
+	for _, r := range result {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		validResultURL := false
+		for _, r := range result {
+			// The api.Run use deprecated path, but it should still work.
+			if s == api.Run && r.URL == filepath.FromSlash(sourcesRootAbbrev+"/.sti/bin/"+s) {
+				validResultURL = true
+			}
+			if r.URL == filepath.FromSlash(sourcesRootAbbrev+"/.s2i/bin/"+s) {
+				validResultURL = true
+			}
+		}
+		if !validResultURL {
+			t.Errorf("expected %q has result URL %s, got %#v", s, filepath.FromSlash(sourcesRootAbbrev+"/.s2i/bin/"+s), result)
+		}
+		chmodCalled := false
+		fs := config.fs.(*testfs.FakeFileSystem)
+		for _, f := range fs.ChmodFile {
+			if filepath.ToSlash(f) == "/workdir/upload/scripts/"+s {
+				chmodCalled = true
+			}
+		}
+		if !chmodCalled {
+			t.Errorf("expected chmod called on /workdir/upload/scripts/%s", s)
+		}
+	}
+}
+
+// TestInstallRequiredOrder tests the proper order for retrieving the source
+// scripts.
+// The scenario here is that the assemble script does not exists in provided
+// scripts url, but it exists in source code directory. The save-artifacts does
+// not exists at provided url nor in source code, so the docker image default
+// URL should be used.
+func TestInstallRequiredOrder(t *testing.T) {
+	config := newFakeConfig()
+	config.download.(*test.FakeDownloader).Err = map[string]error{
+		config.url + "/" + api.Assemble:      fmt.Errorf("not available"),
+		config.url + "/" + api.SaveArtifacts: fmt.Errorf("not available"),
+	}
+	config.fs.(*testfs.FakeFileSystem).ExistsResult = map[string]bool{
+		filepath.Join("/workdir", api.SourceScripts, api.Assemble):      true,
+		filepath.Join("/workdir", api.SourceScripts, api.Run):           false,
+		filepath.Join("/workdir", api.SourceScripts, api.SaveArtifacts): false,
+	}
+	defaultDockerURL := "http://the.docker.url/s2i"
+	config.docker.(*dockerpkg.FakeDocker).DefaultURLResult = defaultDockerURL
+	scripts := []string{api.Assemble, api.Run, api.SaveArtifacts}
+	inst := newFakeInstaller(config)
+	result, err := inst.InstallRequired(scripts, "/workdir")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	for _, r := range result {
+		isValidInstallResult(r, t)
+	}
+	for _, s := range scripts {
+		found := false
+		for _, r := range result {
+			if r.Script == s && r.Script == api.Assemble && r.URL == filepath.FromSlash(sourcesRootAbbrev+"/.s2i/bin/assemble") {
+				found = true
+				break
+			}
+			if r.Script == s && r.Script == api.Run && r.URL == config.url+"/"+api.Run {
+				found = true
+				break
+			}
+			if r.Script == s && r.Script == api.SaveArtifacts && r.URL == defaultDockerURL+"/"+api.SaveArtifacts {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("the %q script installed in wrong order: %+v", s, result)
+		}
+	}
+}
+
+func TestInstallRequiredError(t *testing.T) {
+	config := newFakeConfig()
+	config.url = ""
+	scripts := []string{api.Assemble, api.Run}
+	inst := newFakeInstaller(config)
+	result, err := inst.InstallRequired(scripts, "/output")
+	if err == nil {
+		t.Errorf("expected error, got %+v", result)
+	}
+}
+
+func TestInstallRequiredFromInvalidURL(t *testing.T) {
+	config := newFakeConfig()
+	config.url = "../invalid-url"
+	scripts := []string{api.Assemble}
+	inst := newFakeInstaller(config)
+	result, err := inst.InstallRequired(scripts, "/output")
+	if err == nil {
+		t.Errorf("expected error, got %+v", result)
+	}
+}
+
+func TestNewInstaller(t *testing.T) {
+	docker := &dockerpkg.FakeDocker{DefaultURLResult: "image://docker"}
+	inst := NewInstaller("test-image", "http://foo.bar", nil, docker, api.AuthConfig{}, &testfs.FakeFileSystem{})
+	sources := inst.(*DefaultScriptSourceManager).sources
+	firstHandler, ok := sources[0].(*URLScriptHandler)
+	if !ok {
+		t.Errorf("expected first handler to be script url handler, got %#v", inst.(*DefaultScriptSourceManager).sources)
+	}
+	if firstHandler.URL != "http://foo.bar" {
+		t.Errorf("expected first handler to handle the script url, got %+v", firstHandler)
+	}
+	lastHandler, ok := sources[len(sources)-1].(*URLScriptHandler)
+	if !ok {
+		t.Errorf("expected last handler to be docker url handler, got %#v", inst.(*DefaultScriptSourceManager).sources)
+	}
+	if lastHandler.URL != "image://docker" {
+		t.Errorf("expected last handler to handle the docker default url, got %+v", lastHandler)
+	}
+}
+
+type fakeSource struct {
+	name   string
+	failOn map[string]struct{}
+}
+
+func (f *fakeSource) Get(script string) *api.InstallResult {
+	return &api.InstallResult{Script: script}
+}
+
+func (f *fakeSource) Install(r *api.InstallResult) error {
+	if _, fail := f.failOn[r.Script]; fail {
+		return fmt.Errorf("error")
+	}
+	return nil
+}
+
+func (f *fakeSource) SetDestinationDir(string) {}
+
+func (f *fakeSource) String() string {
+	return f.name
+}
+
+func TestInstallOptionalFailedSources(t *testing.T) {
+
+	m := DefaultScriptSourceManager{}
+	m.Add(&fakeSource{name: "failing1", failOn: map[string]struct{}{"one": {}, "two": {}, "three": {}}})
+	m.Add(&fakeSource{name: "failing2", failOn: map[string]struct{}{"one": {}, "two": {}, "three": {}}})
+	m.Add(&fakeSource{name: "almostpassing", failOn: map[string]struct{}{"three": {}}})
+
+	expect := map[string][]string{
+		"one":   {"failing1", "failing2"},
+		"two":   {"failing1", "failing2"},
+		"three": {"failing1", "failing2", "almostpassing"},
+	}
+	results := m.InstallOptional([]string{"one", "two", "three"}, "foo")
+	for _, result := range results {
+		if !reflect.DeepEqual(result.FailedSources, expect[result.Script]) {
+			t.Errorf("Did not get expected failed sources: %#v", result)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/tar/tar.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/tar/tar.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/source-to-image/pkg/util/fs"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	s2ierr "github.com/openshift/source-to-image/pkg/errors"
@@ -132,7 +133,7 @@ func (a RenameAdapter) WriteHeader(hdr *tar.Header) error {
 }
 
 // New creates a new Tar
-func New(fs util.FileSystem) Tar {
+func New(fs fs.FileSystem) Tar {
 	return &stiTar{
 		FileSystem: fs,
 		exclude:    DefaultExclusionPattern,
@@ -142,7 +143,7 @@ func New(fs util.FileSystem) Tar {
 
 // stiTar is an implementation of the Tar interface
 type stiTar struct {
-	util.FileSystem
+	fs.FileSystem
 	timeout          time.Duration
 	exclude          *regexp.Regexp
 	includeDirInPath bool
@@ -337,6 +338,7 @@ func (t *stiTar) ExtractTarStreamFromTarReader(dir string, tarReader Reader, log
 					glog.Errorf("Error creating dir %q: %v", dirPath, err)
 					return err
 				}
+				t.Chmod(dirPath, header.FileInfo().Mode())
 			} else {
 				fileDir := filepath.Dir(header.Name)
 				dirPath := filepath.Join(dir, fileDir)

--- a/vendor/github.com/openshift/source-to-image/pkg/tar/tar_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/tar/tar_test.go
@@ -1,0 +1,531 @@
+package tar
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+	"time"
+
+	s2ierr "github.com/openshift/source-to-image/pkg/errors"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+type dirDesc struct {
+	name         string
+	modifiedDate time.Time
+	mode         os.FileMode
+}
+
+type fileDesc struct {
+	name         string
+	modifiedDate time.Time
+	mode         os.FileMode
+	content      string
+	shouldSkip   bool
+	target       string
+}
+
+type linkDesc struct {
+	linkName string
+	fileName string
+}
+
+func createTestFiles(baseDir string, dirs []dirDesc, files []fileDesc, links []linkDesc) error {
+	for _, dd := range dirs {
+		fileName := filepath.Join(baseDir, dd.name)
+		err := os.Mkdir(fileName, dd.mode)
+		if err != nil {
+			return err
+		}
+		os.Chmod(fileName, dd.mode) // umask
+	}
+	for _, fd := range files {
+		fileName := filepath.Join(baseDir, fd.name)
+		err := ioutil.WriteFile(fileName, []byte(fd.content), fd.mode)
+		if err != nil {
+			return err
+		}
+		os.Chmod(fileName, fd.mode)
+		os.Chtimes(fileName, fd.modifiedDate, fd.modifiedDate)
+	}
+	for _, ld := range links {
+		linkName := filepath.Join(baseDir, ld.linkName)
+		if err := os.MkdirAll(filepath.Dir(linkName), 0700); err != nil {
+			return err
+		}
+		if err := os.Symlink(ld.fileName, linkName); err != nil {
+			return err
+		}
+	}
+	for _, dd := range dirs {
+		fileName := filepath.Join(baseDir, dd.name)
+		os.Chtimes(fileName, dd.modifiedDate, dd.modifiedDate)
+	}
+	return nil
+}
+
+func verifyTarFile(t *testing.T, filename string, dirs []dirDesc, files []fileDesc, links []linkDesc) {
+	if runtime.GOOS == "windows" {
+		for i := range files {
+			if files[i].mode&0700 == 0400 {
+				files[i].mode = 0444
+			} else {
+				files[i].mode = 0666
+			}
+		}
+		for i := range dirs {
+			if dirs[i].mode&0700 == 0500 {
+				dirs[i].mode = 0555
+			} else {
+				dirs[i].mode = 0777
+			}
+		}
+	}
+	dirsToVerify := make(map[string]dirDesc)
+	for _, dd := range dirs {
+		dirsToVerify[dd.name] = dd
+	}
+	filesToVerify := make(map[string]fileDesc)
+	for _, fd := range files {
+		if !fd.shouldSkip {
+			filesToVerify[fd.name] = fd
+		}
+	}
+	linksToVerify := make(map[string]linkDesc)
+	for _, ld := range links {
+		linksToVerify[ld.linkName] = ld
+	}
+
+	file, err := os.Open(filename)
+	defer file.Close()
+	if err != nil {
+		t.Fatalf("Cannot open tar file %q: %v", filename, err)
+	}
+	tr := tar.NewReader(file)
+	for {
+		hdr, err := tr.Next()
+		if hdr == nil {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Error reading tar %q: %v", filename, err)
+		}
+		finfo := hdr.FileInfo()
+		if dd, ok := dirsToVerify[hdr.Name]; ok {
+			delete(dirsToVerify, hdr.Name)
+			if finfo.Mode()&os.ModeDir == 0 {
+				t.Errorf("Incorrect dir %q", finfo.Name())
+			}
+			if finfo.Mode().Perm() != dd.mode {
+				t.Errorf("Dir %q from tar %q does not match expected mode. Expected: %v, actual: %v",
+					hdr.Name, filename, dd.mode, finfo.Mode().Perm())
+			}
+			if !dd.modifiedDate.IsZero() && finfo.ModTime().UTC() != dd.modifiedDate {
+				t.Errorf("Dir %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
+					hdr.Name, filename, dd.modifiedDate, finfo.ModTime().UTC())
+			}
+		} else if fd, ok := filesToVerify[hdr.Name]; ok {
+			delete(filesToVerify, hdr.Name)
+			if finfo.Mode().Perm() != fd.mode {
+				t.Errorf("File %q from tar %q does not match expected mode. Expected: %v, actual: %v",
+					hdr.Name, filename, fd.mode, finfo.Mode().Perm())
+			}
+			if !fd.modifiedDate.IsZero() && finfo.ModTime().UTC() != fd.modifiedDate {
+				t.Errorf("File %q from tar %q does not match expected modified date. Expected: %v, actual: %v",
+					hdr.Name, filename, fd.modifiedDate, finfo.ModTime().UTC())
+			}
+			fileBytes, err := ioutil.ReadAll(tr)
+			if err != nil {
+				t.Fatalf("Error reading tar %q: %v", filename, err)
+			}
+			fileContent := string(fileBytes)
+			if fileContent != fd.content {
+				t.Errorf("Content for file %q in tar %q doesn't match expected value. Expected: %q, Actual: %q",
+					finfo.Name(), filename, fd.content, fileContent)
+			}
+		} else if ld, ok := linksToVerify[hdr.Name]; ok {
+			delete(linksToVerify, hdr.Name)
+			if finfo.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("Incorrect link %q", finfo.Name())
+			}
+			if hdr.Linkname != ld.fileName {
+				t.Errorf("Incorrect link location. Expected: %q, Actual %q", ld.fileName, hdr.Linkname)
+			}
+		} else {
+			t.Errorf("Cannot find file %q from tar in files to verify.", hdr.Name)
+		}
+	}
+
+	if len(filesToVerify) > 0 || len(linksToVerify) > 0 {
+		t.Errorf("Did not find all expected files in tar: fileToVerify %v, linksToVerify %v", filesToVerify, linksToVerify)
+	}
+}
+
+func TestCreateTarStreamIncludeParentDir(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, []linkDesc{}); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+	th := New(fs.NewFileSystem())
+	tarFile, err := ioutil.TempFile("", "testtarout")
+	if err != nil {
+		t.Fatalf("Unable to create temporary file %v", err)
+	}
+	defer os.Remove(tarFile.Name())
+	err = th.CreateTarStream(tempDir, true, tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create tar file %v", err)
+	}
+	tarFile.Close()
+	for i := range testDirs {
+		testDirs[i].name = filepath.ToSlash(filepath.Join(filepath.Base(tempDir), testDirs[i].name))
+	}
+	for i := range testFiles {
+		testFiles[i].name = filepath.ToSlash(filepath.Join(filepath.Base(tempDir), testFiles[i].name))
+	}
+	verifyTarFile(t, tarFile.Name(), testDirs, testFiles, []linkDesc{})
+}
+
+func TestCreateTar(t *testing.T) {
+	th := New(fs.NewFileSystem())
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Ignore file content", true, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/errdirlink", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testDirs, testFiles, testLinks)
+}
+
+func TestCreateTarIncludeDotGit(t *testing.T) {
+	th := New(fs.NewFileSystem())
+	th.SetExclusionPattern(regexp.MustCompile("test3.txt"))
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", true, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Allow .git content", false, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/okdirlink2", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testDirs, testFiles, testLinks)
+}
+
+func TestCreateTarEmptyRegexp(t *testing.T) {
+	th := New(fs.NewFileSystem())
+	th.SetExclusionPattern(regexp.MustCompile(""))
+	tempDir, err := ioutil.TempDir("", "testtar")
+	defer os.RemoveAll(tempDir)
+	if err != nil {
+		t.Fatalf("Cannot create temp directory for test: %v", err)
+	}
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testDirs := []dirDesc{
+		{"dir01", modificationDate, 0700},
+		{"dir01/.git", modificationDate, 0755},
+		{"dir01/dir02", modificationDate, 0755},
+		{"dir01/dir03", modificationDate, 0775},
+		{"link", modificationDate, 0775},
+	}
+	testFiles := []fileDesc{
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/.git/hello.txt", modificationDate, 0600, "Allow .git content", false, ""},
+	}
+	testLinks := []linkDesc{
+		{"link/okfilelink", "../dir01/dir02/test1.txt"},
+		{"link/errfilelink", "../dir01/missing.target"},
+		{"link/okdirlink", "../dir01/dir02"},
+		{"link/okdirlink2", "../dir01/.git"},
+	}
+	if err = createTestFiles(tempDir, testDirs, testFiles, testLinks); err != nil {
+		t.Fatalf("Cannot create test files: %v", err)
+	}
+
+	tarFile, err := th.CreateTarFile("", tempDir)
+	defer os.Remove(tarFile)
+	if err != nil {
+		t.Fatalf("Unable to create new tar upload file: %v", err)
+	}
+	verifyTarFile(t, tarFile, testDirs, testFiles, testLinks)
+}
+
+func createTestTar(files []fileDesc, writer io.Writer) error {
+	tw := tar.NewWriter(writer)
+	defer tw.Close()
+	for _, fd := range files {
+		if isSymLink(fd.mode) {
+			if err := addSymLink(tw, &fd); err != nil {
+				msg := "unable to add symbolic link %q (points to %q) to archive: %v"
+				return fmt.Errorf(msg, fd.name, fd.target, err)
+			}
+			continue
+		}
+		if fd.mode.IsDir() {
+			if err := addDir(tw, &fd); err != nil {
+				msg := "unable to add dir %q to archive: %v"
+				return fmt.Errorf(msg, fd.name, err)
+			}
+			continue
+		}
+		if err := addRegularFile(tw, &fd); err != nil {
+			return fmt.Errorf("unable to add file %q to archive: %v", fd.name, err)
+		}
+	}
+	return nil
+}
+
+func addRegularFile(tw *tar.Writer, fd *fileDesc) error {
+	contentBytes := []byte(fd.content)
+	hdr := &tar.Header{
+		Name:       fd.name,
+		Mode:       int64(fd.mode),
+		Size:       int64(len(contentBytes)),
+		Typeflag:   tar.TypeReg,
+		AccessTime: time.Now(),
+		ModTime:    fd.modifiedDate,
+		ChangeTime: fd.modifiedDate,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	_, err := tw.Write(contentBytes)
+	return err
+}
+
+func addDir(tw *tar.Writer, fd *fileDesc) error {
+	hdr := &tar.Header{
+		Name:       fd.name,
+		Mode:       int64(fd.mode & 0777),
+		Typeflag:   tar.TypeDir,
+		AccessTime: time.Now(),
+		ModTime:    fd.modifiedDate,
+		ChangeTime: fd.modifiedDate,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addSymLink(tw *tar.Writer, fd *fileDesc) error {
+	if len(fd.target) == 0 {
+		return fmt.Errorf("link %q must point to somewhere, but target wasn't defined", fd.name)
+	}
+
+	hdr := &tar.Header{
+		Name:     fd.name,
+		Linkname: fd.target,
+		Mode:     int64(fd.mode & os.ModePerm),
+		Typeflag: tar.TypeSymlink,
+		ModTime:  fd.modifiedDate,
+	}
+
+	return tw.WriteHeader(hdr)
+}
+
+func isSymLink(mode os.FileMode) bool {
+	return mode&os.ModeSymlink == os.ModeSymlink
+}
+
+func verifyDirectory(t *testing.T, dir string, files []fileDesc) {
+	if runtime.GOOS == "windows" {
+		for i := range files {
+			files[i].name = filepath.FromSlash(files[i].name)
+			if files[i].mode&0200 == 0200 {
+				// if the file is user writable make it writable for everyone
+				files[i].mode |= 0666
+			} else {
+				// if the file is only readable, make it readable for everyone
+				// first clear the r/w permission bits
+				files[i].mode &^= 0666
+				// then set r permission for all
+				files[i].mode |= 0444
+			}
+			if files[i].mode.IsDir() {
+				// if the file is a directory, make it executable for everyone
+				files[i].mode |= 0111
+			} else {
+				// if it's not a directory, clear the executable bits as they are
+				// irrelevant on windows.
+				files[i].mode &^= 0111
+			}
+			files[i].target = filepath.FromSlash(files[i].target)
+		}
+	}
+	pathsToVerify := make(map[string]fileDesc)
+	for _, fd := range files {
+		pathsToVerify[fd.name] = fd
+	}
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if path == dir {
+			return nil
+		}
+		relpath := path[len(dir)+1:]
+		if fd, ok := pathsToVerify[relpath]; ok {
+			if info.Mode() != fd.mode {
+				t.Errorf("File mode is not equal for %q. Expected: %v, Actual: %v",
+					relpath, fd.mode, info.Mode())
+			}
+			// TODO: check modification time for symlinks when extractLink() will support it
+			if info.ModTime().UTC() != fd.modifiedDate && !isSymLink(fd.mode) && !fd.mode.IsDir() {
+				t.Errorf("File modified date is not equal for %q. Expected: %v, Actual: %v",
+					relpath, fd.modifiedDate, info.ModTime())
+			}
+			if !info.IsDir() {
+				contentBytes, err := ioutil.ReadFile(path)
+				if err != nil {
+					t.Errorf("Error reading file %q: %v", path, err)
+					return err
+				}
+				content := string(contentBytes)
+				if content != fd.content {
+					t.Errorf("File content is not equal for %q. Expected: %q, Actual: %q",
+						relpath, fd.content, content)
+				}
+			}
+			if isSymLink(fd.mode) {
+				target, err := os.Readlink(path)
+				if err != nil {
+					t.Errorf("Error reading symlink %q: %v", path, err)
+					return err
+				}
+				if target != fd.target {
+					msg := "Symbolic link %q points to wrong path. Expected: %q, Actual: %q"
+					t.Errorf(msg, fd.name, fd.target, target)
+				}
+			}
+		} else {
+			t.Errorf("Unexpected file found: %q", relpath)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Error walking directory %q: %v", dir, err)
+	}
+}
+
+func TestExtractTarStream(t *testing.T) {
+	modificationDate := time.Date(2011, time.March, 5, 23, 30, 1, 0, time.UTC)
+	testFiles := []fileDesc{
+		{"dir01", modificationDate, 0700 | os.ModeDir, "", false, ""},
+		{"dir01/.git", modificationDate, 0755 | os.ModeDir, "", false, ""},
+		{"dir01/dir02", modificationDate, 0755 | os.ModeDir, "", false, ""},
+		{"dir01/dir03", modificationDate, 0775 | os.ModeDir, "", false, ""},
+		{"dir01/dir02/test1.txt", modificationDate, 0700, "Test1 file content", false, ""},
+		{"dir01/test2.git", modificationDate, 0660, "Test2 file content", false, ""},
+		{"dir01/dir03/test3.txt", modificationDate, 0444, "Test3 file content", false, ""},
+		{"dir01/symlink", modificationDate, os.ModeSymlink | 0777, "Test3 file content", false, "../dir01/dir03/test3.txt"},
+	}
+	reader, writer := io.Pipe()
+	destDir, err := ioutil.TempDir("", "testExtract")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory: %v", err)
+	}
+	defer os.RemoveAll(destDir)
+	th := New(fs.NewFileSystem())
+
+	go func() {
+		err := createTestTar(testFiles, writer)
+		if err != nil {
+			t.Fatalf("Error creating tar stream: %v", err)
+		}
+		writer.CloseWithError(err)
+	}()
+	th.ExtractTarStream(destDir, reader)
+	verifyDirectory(t, destDir, testFiles)
+}
+
+func TestExtractTarStreamTimeout(t *testing.T) {
+	reader, writer := io.Pipe()
+	destDir, err := ioutil.TempDir("", "testExtract")
+	if err != nil {
+		t.Fatalf("Cannot create temp directory: %v", err)
+	}
+	defer os.RemoveAll(destDir)
+	th := New(fs.NewFileSystem())
+	th.(*stiTar).timeout = 10 * time.Millisecond
+	time.AfterFunc(20*time.Millisecond, func() { writer.Close() })
+	err = th.ExtractTarStream(destDir, reader)
+	if e, ok := err.(s2ierr.Error); err == nil || (ok && e.ErrorCode != s2ierr.TarTimeoutError) {
+		t.Errorf("Did not get the expected timeout error. err = %v", err)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/test/cmd/cmd.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/test/cmd/cmd.go
@@ -1,23 +1,23 @@
-package test
+package cmd
 
 import (
 	"bytes"
 	"io"
 	"io/ioutil"
 
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/cmd"
 )
 
 // FakeCmdRunner provider the fake command runner
 type FakeCmdRunner struct {
 	Name string
 	Args []string
-	Opts util.CommandOpts
+	Opts cmd.CommandOpts
 	Err  error
 }
 
 // RunWithOptions runs the command runner with extra options
-func (f *FakeCmdRunner) RunWithOptions(opts util.CommandOpts, name string, args ...string) error {
+func (f *FakeCmdRunner) RunWithOptions(opts cmd.CommandOpts, name string, args ...string) error {
 	f.Name = name
 	f.Args = args
 	f.Opts = opts
@@ -26,12 +26,12 @@ func (f *FakeCmdRunner) RunWithOptions(opts util.CommandOpts, name string, args 
 
 // Run runs the fake command runner
 func (f *FakeCmdRunner) Run(name string, args ...string) error {
-	return f.RunWithOptions(util.CommandOpts{}, name, args...)
+	return f.RunWithOptions(cmd.CommandOpts{}, name, args...)
 }
 
 // StartWithStdoutPipe executes a command returning a ReadCloser connected to
 // the command's stdout.
-func (f *FakeCmdRunner) StartWithStdoutPipe(opts util.CommandOpts, name string, arg ...string) (io.ReadCloser, error) {
+func (f *FakeCmdRunner) StartWithStdoutPipe(opts cmd.CommandOpts, name string, arg ...string) (io.ReadCloser, error) {
 	return ioutil.NopCloser(&bytes.Buffer{}), f.Err
 }
 

--- a/vendor/github.com/openshift/source-to-image/pkg/test/git.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/test/git.go
@@ -8,7 +8,8 @@ import (
 	"testing"
 
 	"github.com/openshift/source-to-image/pkg/api"
-	"github.com/openshift/source-to-image/pkg/util"
+	"github.com/openshift/source-to-image/pkg/util/cmd"
+	"github.com/openshift/source-to-image/pkg/util/cygpath"
 )
 
 // FakeGit provides a fake Git
@@ -97,18 +98,18 @@ func (f *FakeGit) GetInfo(repo string) *api.SourceInfo {
 
 // CreateLocalGitDirectory creates a git directory with a commit
 func CreateLocalGitDirectory(t *testing.T) string {
-	cr := util.NewCommandRunner()
+	cr := cmd.NewCommandRunner()
 	dir := CreateEmptyLocalGitDirectory(t)
 	f, err := os.Create(filepath.Join(dir, "testfile"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	f.Close()
-	err = cr.RunWithOptions(util.CommandOpts{Dir: dir}, "git", "add", ".")
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "add", ".")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cr.RunWithOptions(util.CommandOpts{Dir: dir, EnvAppend: []string{"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test"}}, "git", "commit", "-m", "testcommit")
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir, EnvAppend: []string{"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test"}}, "git", "commit", "-m", "testcommit")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,13 +119,13 @@ func CreateLocalGitDirectory(t *testing.T) string {
 
 // CreateEmptyLocalGitDirectory creates a git directory with no checkin yet
 func CreateEmptyLocalGitDirectory(t *testing.T) string {
-	cr := util.NewCommandRunner()
+	cr := cmd.NewCommandRunner()
 
 	dir, err := ioutil.TempDir(os.TempDir(), "gitdir-s2i-test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = cr.RunWithOptions(util.CommandOpts{Dir: dir}, "git", "init")
+	err = cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "init")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,21 +135,21 @@ func CreateEmptyLocalGitDirectory(t *testing.T) string {
 
 // CreateLocalGitDirectoryWithSubmodule creates a git directory with a submodule
 func CreateLocalGitDirectoryWithSubmodule(t *testing.T) string {
-	cr := util.NewCommandRunner()
+	cr := cmd.NewCommandRunner()
 
 	submodule := CreateLocalGitDirectory(t)
 	defer os.RemoveAll(submodule)
 
-	if util.UsingCygwinGit {
+	if cygpath.UsingCygwinGit {
 		var err error
-		submodule, err = util.ToSlashCygwin(submodule)
+		submodule, err = cygpath.ToSlashCygwin(submodule)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	dir := CreateEmptyLocalGitDirectory(t)
-	err := cr.RunWithOptions(util.CommandOpts{Dir: dir}, "git", "submodule", "add", submodule, "submodule")
+	err := cr.RunWithOptions(cmd.CommandOpts{Dir: dir}, "git", "submodule", "add", submodule, "submodule")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/callback_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/callback_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+type FakePost struct {
+	err      error
+	response http.Response
+	body     []byte
+	url      string
+}
+
+func (f *FakePost) post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	f.url = url
+	f.body, _ = ioutil.ReadAll(body)
+	return &f.response, f.err
+}
+
+func TestExecuteCallback(t *testing.T) {
+	fp := FakePost{}
+	cb := callbackInvoker{
+		postFunc: fp.post,
+	}
+
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	cb.ExecuteCallback("http://the.callback.url/test", true, labels, []string{"msg1", "msg2"})
+
+	type postBody struct {
+		Labels  map[string]string
+		Payload string
+		Success bool
+	}
+	var pb postBody
+	json.Unmarshal(fp.body, &pb)
+	if pb.Payload != "msg1\nmsg2\n" {
+		t.Errorf("Unexpected payload: %s", pb.Payload)
+	}
+	if len(pb.Labels) == 0 {
+		t.Errorf("Expected labels to be present in payload")
+	}
+	if pb.Labels["foo"] != "bar" {
+		t.Errorf("Expected 'foo' to be 'bar', got %q", pb.Labels["foo"])
+	}
+	if pb.Success != true {
+		t.Errorf("Unexpected success flag: %v", pb.Success)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/cmd/cmd.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/cmd/cmd.go
@@ -1,4 +1,4 @@
-package util
+package cmd
 
 import (
 	"io"

--- a/vendor/github.com/openshift/source-to-image/pkg/util/cygpath/cygpath.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/cygpath/cygpath.go
@@ -1,4 +1,4 @@
-package util
+package cygpath
 
 import (
 	"os/exec"

--- a/vendor/github.com/openshift/source-to-image/pkg/util/env_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/env_test.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestStripProxyCredentials(t *testing.T) {
+
+	inputs := []string{
+		// values w/o protocols are untouched
+		"http_proxy=user:password@hostname.com",
+		"https_proxy=user:password@hostname.com",
+		"HTTP_PROXY=user:password@hostname.com",
+		"HTTPS_PROXY=user:password@hostname.com",
+		// values with protocol are properly stripped
+		"http_proxy=http://user:password@hostname.com",
+		"https_proxy=https://user:password@hostname.com",
+		"HTTP_PROXY=http://user:password@hostname.com",
+		"HTTPS_PROXY=https://user:password@hostname.com",
+		"http_proxy=http://user:password@hostname.com:80",
+		"https_proxy=https://user:password@hostname.com:443",
+		"HTTP_PROXY=http://user:password@hostname.com:8080",
+		"HTTPS_PROXY=https://user:password@hostname.com:8443",
+		// values with no user info are untouched
+		"http_proxy=http://hostname.com",
+		"https_proxy=https://hostname.com",
+		"HTTP_PROXY=http://hostname.com",
+		"HTTPS_PROXY=https://hostname.com",
+		// keys that don't contain "proxy" are untouched
+		"othervalue=http://user:password@hostname.com",
+		"othervalue=user:password@hostname.com",
+		// unparseable url
+		"proxy=https://user:password@foo%$ @bar@blah.com",
+	}
+
+	expected := []string{
+		"http_proxy=user:password@hostname.com",
+		"https_proxy=user:password@hostname.com",
+		"HTTP_PROXY=user:password@hostname.com",
+		"HTTPS_PROXY=user:password@hostname.com",
+		"http_proxy=http://redacted@hostname.com",
+		"https_proxy=https://redacted@hostname.com",
+		"HTTP_PROXY=http://redacted@hostname.com",
+		"HTTPS_PROXY=https://redacted@hostname.com",
+		"http_proxy=http://redacted@hostname.com:80",
+		"https_proxy=https://redacted@hostname.com:443",
+		"HTTP_PROXY=http://redacted@hostname.com:8080",
+		"HTTPS_PROXY=https://redacted@hostname.com:8443",
+		"http_proxy=http://redacted@hostname.com",
+		"https_proxy=https://redacted@hostname.com",
+		"HTTP_PROXY=http://redacted@hostname.com",
+		"HTTPS_PROXY=https://redacted@hostname.com",
+		"othervalue=http://user:password@hostname.com",
+		"othervalue=user:password@hostname.com",
+		"proxy=https://user:password@foo%$ @bar@blah.com",
+	}
+	result := SafeForLoggingEnv(inputs)
+	for i := range result {
+		if result[i] != expected[i] {
+			t.Errorf("expected %s to be stripped to %s, but got %s", inputs[i], expected[i], result[i])
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/fs/fs.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/fs/fs.go
@@ -1,4 +1,4 @@
-package util
+package fs
 
 import (
 	"fmt"
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openshift/source-to-image/pkg/util/cmd"
 	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 
 	s2ierr "github.com/openshift/source-to-image/pkg/errors"
@@ -33,23 +34,27 @@ type FileSystem interface {
 	RemoveDirectory(dir string) error
 	CreateWorkingDirectory() (string, error)
 	Open(file string) (io.ReadCloser, error)
+	Create(file string) (io.WriteCloser, error)
 	WriteFile(file string, data []byte) error
 	ReadDir(string) ([]os.FileInfo, error)
 	Stat(string) (os.FileInfo, error)
+	Lstat(string) (os.FileInfo, error)
 	Walk(string, filepath.WalkFunc) error
+	Readlink(string) (string, error)
+	Symlink(string, string) error
 }
 
 // NewFileSystem creates a new instance of the default FileSystem
 // implementation
 func NewFileSystem() FileSystem {
 	return &fs{
-		runner:    NewCommandRunner(),
+		runner:    cmd.NewCommandRunner(),
 		fileModes: make(map[string]os.FileMode),
 	}
 }
 
 type fs struct {
-	runner CommandRunner
+	runner cmd.CommandRunner
 
 	// on Windows, fileModes is used to track the UNIX file mode of every file we
 	// work with; m is used to synchronize access to fileModes.
@@ -118,6 +123,15 @@ func (h *fs) Stat(path string) (os.FileInfo, error) {
 	return fi, err
 }
 
+// Lstat returns a FileInfo describing the named file (not following symlinks).
+func (h *fs) Lstat(path string) (os.FileInfo, error) {
+	fi, err := os.Lstat(path)
+	if runtime.GOOS == "windows" && err == nil {
+		fi = h.enrichFileInfo(path, fi)
+	}
+	return fi, err
+}
+
 // ReadDir reads the directory named by dirname and returns a list of directory
 // entries sorted by filename.
 func (h *fs) ReadDir(path string) ([]os.FileInfo, error) {
@@ -173,7 +187,29 @@ func (h *fs) Exists(file string) bool {
 // we copy the content of the source directory to destination directory
 // recursively.
 func (h *fs) Copy(source string, dest string) (err error) {
-	sourcefile, err := os.Open(source)
+	return doCopy(h, source, dest)
+}
+
+func doCopy(h FileSystem, source, dest string) error {
+	// Our current symlink behaviour is broken.  We follow symlinks and copy the
+	// referenced file, and fail when a symlink is broken.  In all cases we
+	// should actually copy the symlink as is.  For now, at least catch the
+	// broken symlink case and copy the symlink rather than failing.
+	lstatinfo, lstaterr := h.Lstat(source)
+	_, staterr := h.Stat(source)
+	if lstaterr == nil &&
+		lstatinfo.Mode()&os.ModeSymlink != 0 &&
+		os.IsNotExist(staterr) {
+		glog.V(5).Infof("(broken) L %q -> %q", source, dest)
+		linkdest, err := h.Readlink(source)
+		if err != nil {
+			return err
+		}
+
+		return h.Symlink(linkdest, dest)
+	}
+
+	sourcefile, err := h.Open(source)
 	if err != nil {
 		return err
 	}
@@ -192,7 +228,7 @@ func (h *fs) Copy(source string, dest string) (err error) {
 	if destinfo != nil && destinfo.IsDir() {
 		return fmt.Errorf("destination must be full path to a file, not directory")
 	}
-	destfile, err := os.Create(dest)
+	destfile, err := h.Create(dest)
 	if err != nil {
 		return err
 	}
@@ -276,6 +312,11 @@ func (h *fs) Open(filename string) (io.ReadCloser, error) {
 	return os.Open(filename)
 }
 
+// Create creates a file and returns a WriteCloser interface to that file
+func (h *fs) Create(filename string) (io.WriteCloser, error) {
+	return os.Create(filename)
+}
+
 // WriteFile opens a file and writes data to it, returning error if such
 // occurred
 func (h *fs) WriteFile(filename string, data []byte) error {
@@ -319,4 +360,14 @@ func (h *fs) enrichFileInfos(root string, fis []os.FileInfo) {
 		}
 	}
 	h.m.Unlock()
+}
+
+// Readlink reads the destination of a symlink
+func (h *fs) Readlink(name string) (string, error) {
+	return os.Readlink(name)
+}
+
+// Symlink creates a symlink at newname, pointing to oldname
+func (h *fs) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
 }

--- a/vendor/github.com/openshift/source-to-image/pkg/util/fs/fs_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/fs/fs_test.go
@@ -1,0 +1,79 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	testfs "github.com/openshift/source-to-image/pkg/test/fs"
+)
+
+func TestCopy(t *testing.T) {
+	sep := string(filepath.Separator)
+
+	// test plain file copy
+	fake := &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&FileInfo{FileName: "file", FileMode: 0600},
+		},
+		OpenContent: "test",
+	}
+	err := doCopy(fake, sep+"file", sep+"dest")
+	if err != nil {
+		t.Error(err)
+	}
+	if fake.CreateFile != sep+"dest" {
+		t.Error(fake.CreateFile)
+	}
+	if fake.CreateContent.String() != "test" {
+		t.Error(fake.CreateContent.String())
+	}
+	if !reflect.DeepEqual(fake.ChmodFile, []string{sep + "dest"}) {
+		t.Error(fake.ChmodFile)
+	}
+	if fake.ChmodMode != 0600 {
+		t.Error(fake.ChmodMode)
+	}
+
+	// test broken symlink copy
+	fake = &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&FileInfo{FileName: "link", FileMode: os.ModeSymlink},
+		},
+		ReadlinkName: sep + "linkdest",
+	}
+	err = doCopy(fake, sep+"link", sep+"dest")
+	if err != nil {
+		t.Error(err)
+	}
+	if fake.SymlinkNewname != sep+"dest" {
+		t.Error(fake.SymlinkNewname)
+	}
+	if fake.SymlinkOldname != sep+"linkdest" {
+		t.Error(fake.SymlinkOldname)
+	}
+
+	// test non-broken symlink copy
+	fake = &testfs.FakeFileSystem{
+		Files: []os.FileInfo{
+			&FileInfo{FileName: "file", FileMode: 0600},
+			&FileInfo{FileName: "link", FileMode: os.ModeSymlink},
+		},
+		OpenContent:  "test",
+		ReadlinkName: sep + "file",
+	}
+	err = doCopy(fake, sep+"link", sep+"dest")
+	if fake.CreateFile != sep+"dest" {
+		t.Error(fake.CreateFile)
+	}
+	if fake.CreateContent.String() != "test" {
+		t.Error(fake.CreateContent.String())
+	}
+	if !reflect.DeepEqual(fake.ChmodFile, []string{sep + "dest"}) {
+		t.Error(fake.ChmodFile)
+	}
+	if fake.ChmodMode != 0600 {
+		t.Error(fake.ChmodMode)
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/injection.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/injection.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/util/fs"
 )
 
 // FixInjectionsWithRelativePath fixes the injections that does not specify the
@@ -38,7 +39,7 @@ func FixInjectionsWithRelativePath(workdir string, injections api.VolumeList) ap
 
 // ExpandInjectedFiles returns a flat list of all files that are injected into a
 // container. All files from nested directories are returned in the list.
-func ExpandInjectedFiles(fs FileSystem, injections api.VolumeList) ([]string, error) {
+func ExpandInjectedFiles(fs fs.FileSystem, injections api.VolumeList) ([]string, error) {
 	result := []string{}
 	for _, s := range injections {
 		if _, err := os.Stat(s.Source); err != nil {

--- a/vendor/github.com/openshift/source-to-image/pkg/util/injection_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/injection_test.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openshift/source-to-image/pkg/api"
+	"github.com/openshift/source-to-image/pkg/util/fs"
+)
+
+func TestCreateInjectedFilesRemovalScript(t *testing.T) {
+	files := []string{
+		"/foo",
+		"/bar/bar",
+	}
+	name, err := CreateInjectedFilesRemovalScript(files, "/tmp/rm-foo")
+	defer os.Remove(name)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", name)
+	}
+	_, err = os.Stat(name)
+	if err != nil {
+		t.Errorf("Expected file %q to exists, got: %v", name, err)
+	}
+	data, err := ioutil.ReadFile(name)
+	if err != nil {
+		t.Errorf("Unable to read %q: %v", name, err)
+	}
+	if !strings.Contains(string(data), fmt.Sprintf("truncate -s0 %q", "/foo")) {
+		t.Errorf("Expected script to contain truncate -s0 \"/foo\", got: %q", string(data))
+	}
+	if !strings.Contains(string(data), fmt.Sprintf("truncate -s0 %q", "/tmp/rm-foo")) {
+		t.Errorf("Expected script to truncate itself, got: %q", string(data))
+	}
+}
+
+func TestExpandInjectedFiles(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "s2i-test-")
+	tmpNested, err := ioutil.TempDir(tmp, "nested")
+	if err != nil {
+		t.Errorf("Unable to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	list := api.VolumeList{{Source: tmp, Destination: "/foo"}}
+	f1, _ := ioutil.TempFile(tmp, "foo")
+	f2, _ := ioutil.TempFile(tmpNested, "bar")
+	files, err := ExpandInjectedFiles(fs.NewFileSystem(), list)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	expected := []string{"/foo/" + filepath.Base(f1.Name()), "/foo/" + filepath.Base(tmpNested) + "/" + filepath.Base(f2.Name())}
+	for _, exp := range expected {
+		found := false
+		for _, f := range files {
+			if f == exp {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected %q in resulting file list, got %+v", exp, files)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/status/build_status_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/status/build_status_test.go
@@ -1,0 +1,77 @@
+package status
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/source-to-image/pkg/api"
+)
+
+func TestNewFailureReason(t *testing.T) {
+	failureReason := NewFailureReason(ReasonAssembleFailed, ReasonMessageAssembleFailed)
+
+	if failureReason.Reason != ReasonAssembleFailed {
+		t.Errorf("Expected reason to be: %s, got %s", ReasonAssembleFailed, failureReason.Reason)
+	}
+
+	if failureReason.Message != ReasonMessageAssembleFailed {
+		t.Errorf("Expected message reason to be: %s, got %s", ReasonMessageAssembleFailed, failureReason.Message)
+	}
+}
+
+func TestAddNewStage(t *testing.T) {
+	buildInfo := new(api.BuildInfo)
+
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullPreviousImage, time.Now(), time.Now())
+
+	if len(buildInfo.Stages) != 1 {
+		t.Errorf("Stage not added wanted 1, got %#v", len(buildInfo.Stages))
+	}
+}
+
+func TestAddNewStages(t *testing.T) {
+	buildInfo := new(api.BuildInfo)
+
+	if len(buildInfo.Stages) > 0 {
+		t.Errorf("Stages should be 0 but was %v instead.", len(buildInfo.Stages))
+	}
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullBuilderImage, time.Now(), time.Now())
+
+	if len(buildInfo.Stages) != 1 {
+		t.Errorf("Stages should be 1 but was %v instead.", len(buildInfo.Stages))
+	}
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StageBuild, api.StepBuildDockerImage, time.Now(), time.Now())
+	if len(buildInfo.Stages) != 2 {
+		t.Errorf("Stages should be 2 but was %v instead.", len(buildInfo.Stages))
+	}
+}
+
+func TestAddNewStepToStage(t *testing.T) {
+	buildInfo := new(api.BuildInfo)
+
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullPreviousImage, time.Now(), time.Now())
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullBuilderImage, time.Now(), time.Now())
+
+	if len(buildInfo.Stages[0].Steps) != 2 {
+		t.Errorf("Step not added in Stage, wanted 2, got %#v", len(buildInfo.Stages[0].Steps))
+	}
+}
+
+func TestUpdateStageDuration(t *testing.T) {
+	buildInfo := new(api.BuildInfo)
+
+	startTime := time.Now()
+
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullPreviousImage, startTime, time.Now())
+
+	addDuration, _ := time.ParseDuration("5m")
+
+	endTime := time.Now().Add(addDuration)
+
+	buildInfo.Stages = api.RecordStageAndStepInfo(buildInfo.Stages, api.StagePullImages, api.StepPullBuilderImage, time.Now(), endTime)
+
+	if buildInfo.Stages[0].DurationMilliseconds != (endTime.Sub(startTime).Nanoseconds() / int64(time.Millisecond)) {
+		t.Errorf("Stage Duration was not updated, expected %#v, got %#v", (endTime.Sub(startTime).Nanoseconds() / int64(time.Millisecond)), buildInfo.Stages[0].DurationMilliseconds)
+	}
+
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/timeout_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/timeout_test.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestTimeoutAfter(t *testing.T) {
+	type testCase struct {
+		fn      func(*time.Timer) error
+		msg     string
+		timeout time.Duration
+		expect  interface{}
+	}
+	table := []testCase{
+		{
+			fn:      func(timer *time.Timer) error { time.Sleep(1 * time.Second); return nil },
+			timeout: 50 * time.Millisecond,
+			expect:  &TimeoutError{after: 50 * time.Millisecond},
+		},
+		{
+			fn:      func(timer *time.Timer) error { return fmt.Errorf("foo") },
+			timeout: 50 * time.Millisecond,
+			expect:  fmt.Errorf("foo"),
+		},
+		{
+			fn:      func(timer *time.Timer) error { time.Sleep(1 * time.Second); return fmt.Errorf("foo") },
+			msg:     "bar",
+			timeout: 50 * time.Millisecond,
+			expect:  fmt.Errorf("bar timed out after 50ms"),
+		},
+		{
+			fn:      func(timer *time.Timer) error { return nil },
+			timeout: 50 * time.Millisecond,
+			expect:  nil,
+		},
+	}
+	for _, item := range table {
+		got := TimeoutAfter(item.timeout, item.msg, item.fn)
+		if len(item.msg) > 0 {
+			expect, ok := item.expect.(error)
+			if !ok {
+				t.Errorf("expect must be an error, got %+v", item.expect)
+			}
+			if expect.Error() != got.Error() {
+				t.Errorf("expected message %q, got %q", item.msg, got.Error())
+			}
+			continue
+		}
+		if !reflect.DeepEqual(item.expect, got) {
+			t.Errorf("expected %+v, got %+v", item.expect, got)
+		}
+		if _, ok := item.expect.(*TimeoutError); ok {
+			if !IsTimeoutError(got) {
+				t.Errorf("expected %+v to be timeout error", got)
+			}
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/user/range_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/user/range_test.go
@@ -1,0 +1,113 @@
+package user
+
+import (
+	"testing"
+)
+
+func validRange(r *Range, err error) *Range {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func TestParseRange(t *testing.T) {
+	tests := []struct {
+		str         string
+		expected    *Range
+		errExpected bool
+	}{
+		{
+			str:      "1-5",
+			expected: validRange(NewRange(1, 5)),
+		},
+		{
+			str:      "7",
+			expected: validRange(NewRange(7, 7)),
+		},
+		{
+			str:      "1-",
+			expected: validRange(NewRangeFrom(1)),
+		},
+		{
+			str:      "-1000",
+			expected: validRange(NewRangeTo(1000)),
+		},
+		{
+			str:      "",
+			expected: &Range{},
+		},
+		{
+			str:         "--",
+			errExpected: true,
+		},
+		{
+			str:         "4-5-1",
+			errExpected: true,
+		},
+		{
+			str:         "-1-5",
+			errExpected: true,
+		},
+		{
+			str:         "abc",
+			errExpected: true,
+		},
+	}
+	for _, tc := range tests {
+		actual, err := ParseRange(tc.str)
+		if err != nil {
+			if !tc.errExpected {
+				t.Errorf("Unexpected error for input %s: %v", tc.str, err)
+			}
+			continue
+		}
+		if tc.errExpected {
+			t.Errorf("Did not get expected error for input %s", tc.str)
+			continue
+		}
+		if actual.String() != tc.expected.String() {
+			t.Errorf("Did not get expected range for input %s. Expected: %v. Got: %v", tc.str, tc.expected, actual)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		uid      int
+		r        *Range
+		expected bool
+	}{
+		{
+			uid:      0,
+			r:        validRange(NewRange(0, 4)),
+			expected: true,
+		},
+		{
+			uid:      0,
+			r:        validRange(NewRangeFrom(1)),
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        validRange(NewRangeTo(5001)),
+			expected: true,
+		},
+		{
+			uid:      5000,
+			r:        validRange(NewRangeTo(4999)),
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        &Range{},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		actual := tc.r.Contains(tc.uid)
+		if actual != tc.expected {
+			t.Errorf("Unexpected contains result. Input: %d, Range: %v. Expected: %v, Got: %v.", tc.uid, tc.r, tc.expected, actual)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/user/rangelist_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/user/rangelist_test.go
@@ -1,0 +1,123 @@
+package user
+
+import (
+	"testing"
+)
+
+func TestParseRangeList(t *testing.T) {
+	tests := []struct {
+		str         string
+		expected    *RangeList
+		errExpected bool
+	}{
+		{
+			str: "1-5,5,2-",
+			expected: &RangeList{
+				validRange(NewRange(1, 5)),
+				validRange(NewRange(5, 5)),
+				validRange(NewRangeFrom(2)),
+			},
+		},
+		{
+			str: ",4-5,0-",
+			expected: &RangeList{
+				&Range{},
+				validRange(NewRange(4, 5)),
+				validRange(NewRangeFrom(0)),
+			},
+		},
+		{
+			str: "5",
+			expected: &RangeList{
+				validRange(NewRange(5, 5)),
+			},
+		},
+		{
+			str: "1-",
+			expected: &RangeList{
+				validRange(NewRangeFrom(1)),
+			},
+		},
+		{
+			str: "-5",
+			expected: &RangeList{
+				validRange(NewRangeTo(5)),
+			},
+		},
+		{
+			str:         "abc",
+			errExpected: true,
+		},
+		{
+			str:         "{1-5}",
+			errExpected: true,
+		},
+		{
+			str:         "1-5-,2-",
+			errExpected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		actual, err := ParseRangeList(tc.str)
+		if err != nil {
+			if !tc.errExpected {
+				t.Errorf("Unexpected error for input %s: %v", tc.str, err)
+			}
+			continue
+		}
+		if tc.errExpected {
+			t.Errorf("Expected error but did not get one for input %s", tc.str)
+			continue
+		}
+		if actual.String() != tc.expected.String() {
+			t.Errorf("Did not get expected range list for input %s. Expected: %v, Got: %v",
+				tc.str, tc.expected, actual)
+		}
+	}
+}
+
+func TestRangeListContains(t *testing.T) {
+	tests := []struct {
+		uid      int
+		r        *RangeList
+		expected bool
+	}{
+		{
+			uid: 10,
+			r: &RangeList{
+				validRange(NewRange(0, 9)),
+				validRange(NewRange(10, 10)),
+				validRange(NewRange(20, 30)),
+			},
+			expected: true,
+		},
+		{
+			uid: 5,
+			r: &RangeList{
+				validRange(NewRange(3, 4)),
+				validRange(NewRange(6, 7)),
+			},
+			expected: false,
+		},
+		{
+			uid: 10,
+			r: &RangeList{
+				validRange(NewRangeFrom(11)),
+				validRange(NewRangeFrom(20)),
+			},
+			expected: false,
+		},
+		{
+			uid:      5000,
+			r:        &RangeList{},
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		actual := tc.r.Contains(tc.uid)
+		if actual != tc.expected {
+			t.Errorf("Unexpected contains result. Input: %d, Range: %v. Expected: %v, Got: %v.", tc.uid, tc.r, tc.expected, actual)
+		}
+	}
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/util/util.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/util.go
@@ -2,7 +2,11 @@ package util
 
 import (
 	"github.com/docker/engine-api/types/container"
+
+	utilglog "github.com/openshift/source-to-image/pkg/util/glog"
 )
+
+var glog = utilglog.StderrLog
 
 // SafeForLoggingContainerConfig returns a copy of the container.Config object
 // with sensitive information (proxy environment variables containing credentials)

--- a/vendor/github.com/openshift/source-to-image/pkg/util/util_test.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/util/util_test.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/docker/engine-api/types/container"
+)
+
+func TestSafeForLoggingContainerConfig(t *testing.T) {
+	c := &container.Config{
+		Env: []string{
+			"http_proxy=http://user:password@hostname.com",
+			"https_proxy=https://user:password@hostname.com",
+			"HTTP_PROXY=HTTP://user:password@hostname.com",
+			"HTTPS_PROXY=HTTPS://user:password@hostname.com",
+		},
+	}
+	orig := fmt.Sprintf("%+v", *c)
+
+	s := fmt.Sprintf("%+v", *SafeForLoggingContainerConfig(c))
+	if strings.Contains(s, "user:password") {
+		t.Errorf("expected %s to not contain credentials", s)
+	}
+
+	if !strings.Contains(s, "redacted") {
+		t.Errorf("expected %s to be redacted", s)
+	}
+
+	// make sure the original object was not changed
+	s = fmt.Sprintf("%+v", *c)
+	if !(s == orig) {
+		t.Errorf("expected original %s to be unchanged, got %s", orig, s)
+	}
+
+}

--- a/vendor/github.com/openshift/source-to-image/pkg/version/doc.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/version/doc.go
@@ -1,0 +1,2 @@
+// Package version supplies version information for S2I collected at build time.
+package version

--- a/vendor/github.com/openshift/source-to-image/pkg/version/version.go
+++ b/vendor/github.com/openshift/source-to-image/pkg/version/version.go
@@ -1,0 +1,42 @@
+package version
+
+var (
+	// commitFromGit is a constant representing the source version that
+	// generated this build. It should be set during build via -ldflags.
+	commitFromGit string
+	// versionFromGit is a constant representing the version tag that
+	// generated this build. It should be set during build via -ldflags.
+	versionFromGit string
+	// major version
+	majorFromGit string
+	// minor version
+	minorFromGit string
+)
+
+// Info contains versioning information.
+type Info struct {
+	Major      string `json:"major"`
+	Minor      string `json:"minor"`
+	GitCommit  string `json:"gitCommit"`
+	GitVersion string `json:"gitVersion"`
+}
+
+// Get returns the overall codebase version. It's for detecting what code a
+// binary was built from.
+func Get() Info {
+	return Info{
+		Major:      majorFromGit,
+		Minor:      minorFromGit,
+		GitCommit:  commitFromGit,
+		GitVersion: versionFromGit,
+	}
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	version := info.GitVersion
+	if version == "" {
+		version = "unknown"
+	}
+	return version
+}


### PR DESCRIPTION
bump(github.com/openshift/source-to-image): a49bab886b5d5c9eaeea698a6a058b0c8bf90076

The vendored `source-to-image` referenced older commit than `openshift-3.6.0` branch. Backport https://github.com/openshift/source-to-image/pull/900 was applied on top of `openshift-3.6.0` and brings few more changes with it.

Also, `godep restore` fails with `Godeps.json` referencing non-reachable commits in a few dependencies. Per @dmage recommendation, I ended up manually editing `Godeps.json` and copying over vendored `source-to-image/pkg`