### PR TITLE
Fix pluginwatcher flake

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/plugin_watcher_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/plugin_watcher_test.go
@@ -212,6 +212,7 @@ func TestExamplePlugin(t *testing.T) {
 func waitForPluginRegistrationStatus(t *testing.T, statusCh chan registerapi.RegistrationStatus) bool {
 	select {
 	case status := <-statusCh:
+		time.Sleep(time.Second)
 		return status.PluginRegistered
 	case <-time.After(10 * time.Second):
 		t.Fatalf("Timed out while waiting for registration status")


### PR DESCRIPTION
This is a stopgap(temporary) fix for the flake, https://github.com/openshift/origin/issues/20136
This part has got changed recently, and this issue is not there at upstream kube. This PR,https://github.com/kubernetes/kubernetes/pull/65662, is cherry-picking the changed part to kube 1.11.

Meanwhile this fix will help avoiding this flake.

Implementation of `NotifyRegistrationStatus` RPC at example plugin is writing registration status to a channel that unit test is listening on. Unit test after receving data on this channel, stops the example plugin server. Here is a race. Sometimes plugin server gets closed before `NotifyRegistrationStatus` could return and thus showing error on client (plugin watcher), which if being verified in the unit test.

Fix: With this 1 ms delay, plugin server is not getting closed before RPC return. 

WIthout this fix, issue is happening at my local machine with this cmd:
> go test -race  -count 10 k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher -run TestExamplePlugin

After this fix, following is also working:
> go test -race  -count 500 k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher -run TestExamplePlugin


UPDATE: Increased sleep time to 1 sec 


/cc @sjenning @liggitt 
