### PR TITLE
Bindmount /var/lib/iscsi rw for iscsi attach

### DIFF
--- a/images/node/system-container/config.json.template
+++ b/images/node/system-container/config.json.template
@@ -465,6 +465,16 @@
             ]
         },
         {
+            "type": "bind",
+            "source": "/var/lib/iscsi",
+            "destination": "/var/lib/iscsi",
+            "options": [
+                "bind",
+                "rw",
+                "mode=755"
+            ]
+        },
+        {
 	    "type": "bind",
 	    "source": "$ORIGIN_CONFIG_DIR/node",
 	    "destination": "/etc/origin/node",


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1598271

iscsiadm tries to write /var/lib/iscsi/send_targets/ (and later /var/lib/iscsi/nodes) when trying to attach an iscsi volume to the host but it fails because the filesystem in the kubelet system container (at /var/lib/iscsi) is read only. I think we should be writing this information to the host. Fix is similar to the fix for flex plugins.

I've confirmed iscsi attachment succeeds with this change.

@openshift/storage 