### PR TITLE
remove something that breaks server launch

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -522,15 +522,11 @@ function os::start::internal::openshift_executable() {
 
 		openshift_executable="${sudo} docker run ${docker_options} ${volumes} ${envvars} openshift/origin:${version}"
 	else
-		local envvars=""
-		if [[ -n "${ENV:-}" ]]; then
-			envvars="env "
-			for envvar in "${ENV[@]}"; do
-				envvars+="${envvar} "
-			done
-		fi
-
-		openshift_executable="${sudo} ${envvars} $(which openshift)"
+		if [[ -n "${sudo}" ]]; then
+		    openshift_executable="${sudo} -E $(which openshift)"
+        else
+		    openshift_executable="$(which openshift)"
+        fi
 	fi
 
 	echo "${openshift_executable}"


### PR DESCRIPTION
These lines seem produce a command which doesn't run on fedora 28.

```
[deads@deads-02 origin]$ hack/update-generated-swagger-spec.sh 
[INFO] [CLEANUP] Cleaning up temporary directories
Generated new key pair as /tmp/openshift/update-generated-swagger-spec/openshift.local.config/master/serviceaccounts.public.key and /tmp/openshift/update-generated-swagger-spec/openshift.local.config/master/serviceaccounts.private.key
Generating node credentials ...
Created node config for 10.192.216.32 in /tmp/openshift/update-generated-swagger-spec/openshift.local.config/node-10.192.216.32
env: ‘/usr/share/Modules/init/profile.sh’: Permission denied
[ERROR] PID 18880: hack/lib/start.sh:132: `${openshift_executable} start --create-certs=false --images="${USE_IMAGES}" --master="${MASTER_ADDR}" --dns="tcp://${API_HOST}:53" --hostname="${KUBELET_HOST}" --volume-dir="${VOLUME_DIR}" --etcd-dir="${ETCD_DATA_DIR}" --network-plugin="${NETWORK_PLUGIN:-}" --write-config="${SERVER_CONFIG_DIR}" --listen="${API_SCHEME}://${API_BIND_HOST}:${API_PORT}" --public-master="${API_SCHEME}://${PUBLIC_MASTER_HOST}:${API_PORT}"` exited with status 126.
```

Removing this env bit (which should be automatic, right?  Seems to work.

/assign @stevekuznetsov 
@soltysh did you have trouble with this?