### PR TITLE
WaitForBuilder was too fast, not too slow

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -721,7 +721,7 @@ func WaitForBuilderAccount(c kcoreclient.ServiceAccountInterface) error {
 		if err != nil {
 			// If we can't access the service accounts, let's wait till the controller
 			// create it.
-			if errors.IsForbidden(err) {
+			if errors.IsNotFound(err) || errors.IsForbidden(err) {
 				return false, nil
 			}
 			return false, err


### PR DESCRIPTION
We are getting a NotFound error the first time we try to find the
service account, not timing out.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/20217/pull-ci-origin-e2e-gcp/517/