### PR TITLE
UPSTREAM: <drop>: GCE load balancer unit test is flaky

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal_test.go
@@ -80,6 +80,7 @@ func TestEnsureInternalBackendServiceUpdates(t *testing.T) {
 }
 
 func TestEnsureInternalBackendServiceGroups(t *testing.T) {
+	t.Skipf("test is flaky: https://github.com/kubernetes/kubernetes/issues/65883")
 	for desc, tc := range map[string]struct {
 		mockModifier func(*cloud.MockGCE)
 	}{


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/65883