### PR TITLE
UPSTREAM: <drop>: Fix pluginwatcher flake

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/example_plugin.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/example_plugin.go
@@ -143,7 +143,7 @@ func (e *examplePlugin) Stop() error {
 	select {
 	case <-c:
 		return nil
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		glog.Errorf("Timed out on waiting for stop completion")
 		return fmt.Errorf("Timed out on waiting for stop completion")
 	}


### PR DESCRIPTION
Missed to notice that timeout duration for plugin stop is also 1 sec and therefore it started flaking, which is obvious.

Related: https://github.com/openshift/origin/pull/20212#issuecomment-402805692
/cc @sjenning @smarterclayton @liggitt 