### PR TITLE
upstream machinery picks

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config_test.go
+++ b/pkg/cmd/server/kubernetes/master/master_config_test.go
@@ -321,17 +321,7 @@ func TestCMServerDefaults(t *testing.T) {
 			ConcurrentGCSyncs:      20,
 			EnableGarbageCollector: true,
 			GCIgnoredResources: []componentconfig.GroupResource{
-				{Group: "extensions", Resource: "replicationcontrollers"},
-				{Group: "", Resource: "bindings"},
-				{Group: "", Resource: "componentstatuses"},
 				{Group: "", Resource: "events"},
-				{Group: "authentication.k8s.io", Resource: "tokenreviews"},
-				{Group: "authorization.k8s.io", Resource: "subjectaccessreviews"},
-				{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"},
-				{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"},
-				{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"},
-				{Group: "apiregistration.k8s.io", Resource: "apiservices"},
-				{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 			},
 		},
 		HPAController: &cmoptions.HPAControllerOptions{

--- a/test/integration/oauth_serviceaccount_client_events_test.go
+++ b/test/integration/oauth_serviceaccount_client_events_test.go
@@ -87,7 +87,7 @@ func TestOAuthServiceAccountClientEvent(t *testing.T) {
 			annotationPrefix:    saoauth.OAuthRedirectModelAnnotationReferencePrefix + "1",
 			annotation:          `{"kind":"foo","apiVersion":"oauth.openshift.io/v1","metadata":{"creationTimestamp":null},"reference":{"group":"foo","kind":"Route","name":"route1"}}`,
 			expectedEventReason: "NoSAOAuthRedirectURIs",
-			expectedEventMsg:    `[no kind "foo" is registered for version "oauth.openshift.io/v1", system:serviceaccount:` + projectName + ":" + saName + " has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]",
+			expectedEventMsg:    `[no kind "foo" is registered for version "oauth.openshift.io/v1" in scheme "github.com/openshift/origin/pkg/serviceaccounts/oauthclient/oauthclientregistry.go:54", system:serviceaccount:` + projectName + ":" + saName + " has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]",
 			numEvents:           1,
 			expectBadRequest:    true,
 		},

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options_test.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options_test.go
@@ -176,17 +176,7 @@ func TestAddFlags(t *testing.T) {
 		GarbageCollectorController: &cmoptions.GarbageCollectorControllerOptions{
 			ConcurrentGCSyncs: 30,
 			GCIgnoredResources: []componentconfig.GroupResource{
-				{Group: "extensions", Resource: "replicationcontrollers"},
-				{Group: "", Resource: "bindings"},
-				{Group: "", Resource: "componentstatuses"},
 				{Group: "", Resource: "events"},
-				{Group: "authentication.k8s.io", Resource: "tokenreviews"},
-				{Group: "authorization.k8s.io", Resource: "subjectaccessreviews"},
-				{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"},
-				{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"},
-				{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"},
-				{Group: "apiregistration.k8s.io", Resource: "apiservices"},
-				{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 			},
 			EnableGarbageCollector: false,
 		},

--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/graph_builder.go
@@ -337,17 +337,7 @@ func (gb *GraphBuilder) Run(stopCh <-chan struct{}) {
 }
 
 var ignoredResources = map[schema.GroupResource]struct{}{
-	{Group: "extensions", Resource: "replicationcontrollers"}:              {},
-	{Group: "", Resource: "bindings"}:                                      {},
-	{Group: "", Resource: "componentstatuses"}:                             {},
-	{Group: "", Resource: "events"}:                                        {},
-	{Group: "authentication.k8s.io", Resource: "tokenreviews"}:             {},
-	{Group: "authorization.k8s.io", Resource: "subjectaccessreviews"}:      {},
-	{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"}:  {},
-	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}: {},
-	{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"}:   {},
-	{Group: "apiregistration.k8s.io", Resource: "apiservices"}:             {},
-	{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}: {},
+	{Group: "", Resource: "events"}: {},
 }
 
 // DefaultIgnoredResources returns the default set of resources that the garbage collector controller

--- a/vendor/k8s.io/kubernetes/pkg/quota/install/registry.go
+++ b/vendor/k8s.io/kubernetes/pkg/quota/install/registry.go
@@ -37,29 +37,7 @@ func NewQuotaConfigurationForControllers(f quota.ListerForResourceFunc) quota.Co
 
 // ignoredResources are ignored by quota by default
 var ignoredResources = map[schema.GroupResource]struct{}{
-	{Group: "extensions", Resource: "replicationcontrollers"}:                     {},
-	{Group: "extensions", Resource: "networkpolicies"}:                            {},
-	{Group: "", Resource: "bindings"}:                                             {},
-	{Group: "", Resource: "componentstatuses"}:                                    {},
-	{Group: "", Resource: "events"}:                                               {},
-	{Group: "authentication.k8s.io", Resource: "tokenreviews"}:                    {},
-	{Group: "authorization.k8s.io", Resource: "subjectaccessreviews"}:             {},
-	{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"}:         {},
-	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}:        {},
-	{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"}:          {},
-	{Group: "authorization.openshift.io", Resource: "selfsubjectaccessreviews"}:   {},
-	{Group: "authorization.openshift.io", Resource: "subjectaccessreviews"}:       {},
-	{Group: "authorization.openshift.io", Resource: "localsubjectaccessreviews"}:  {},
-	{Group: "authorization.openshift.io", Resource: "resourceaccessreviews"}:      {},
-	{Group: "authorization.openshift.io", Resource: "localresourceaccessreviews"}: {},
-	{Group: "authorization.openshift.io", Resource: "selfsubjectrulesreviews"}:    {},
-	{Group: "authorization.openshift.io", Resource: "subjectrulesreviews"}:        {},
-	{Group: "authorization.openshift.io", Resource: "roles"}:                      {},
-	{Group: "authorization.openshift.io", Resource: "rolebindings"}:               {},
-	{Group: "authorization.openshift.io", Resource: "clusterroles"}:               {},
-	{Group: "authorization.openshift.io", Resource: "clusterrolebindings"}:        {},
-	{Group: "apiregistration.k8s.io", Resource: "apiservices"}:                    {},
-	{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}:        {},
+	{Group: "", Resource: "events"}: {},
 }
 
 // DefaultIgnoredResources returns the default set of resources that quota system

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/BUILD
@@ -47,6 +47,7 @@ filegroup(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/establish:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status:all-srcs",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/crdserverscheme:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/features:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition:all-srcs",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1083,6 +1083,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -52,7 +52,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/scale/scheme/autoscalingv1"
 	"k8s.io/client-go/tools/cache"
@@ -64,6 +63,7 @@ import (
 	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion"
 	"k8s.io/apiextensions-apiserver/pkg/controller/establish"
 	"k8s.io/apiextensions-apiserver/pkg/controller/finalizer"
+	"k8s.io/apiextensions-apiserver/pkg/crdserverscheme"
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
@@ -606,7 +606,7 @@ func (s unstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.Serial
 }
 
 func (s unstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
-	return versioning.NewCodec(encoder, nil, s.converter, Scheme, Scheme, Scheme, gv, nil)
+	return versioning.NewCodec(encoder, nil, s.converter, Scheme, Scheme, Scheme, gv, nil, "crdNegotiatedSerializer")
 }
 
 func (s unstructuredNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
@@ -622,7 +622,7 @@ type UnstructuredObjectTyper struct {
 func newUnstructuredObjectTyper(Delegate runtime.ObjectTyper) UnstructuredObjectTyper {
 	return UnstructuredObjectTyper{
 		Delegate:          Delegate,
-		UnstructuredTyper: discovery.NewUnstructuredObjectTyper(),
+		UnstructuredTyper: crdserverscheme.NewUnstructuredObjectTyper(),
 	}
 }
 
@@ -710,7 +710,17 @@ func (t crdConversionRESTOptionsGetter) GetRESTOptions(resource schema.GroupReso
 			dropInvalidMetadata: true,
 		}}
 		c := schemaCoercingConverter{delegate: t.converter, validator: unstructuredSchemaCoercer{}}
-		ret.StorageConfig.Codec = versioning.NewCodec(ret.StorageConfig.Codec, d, c, &unstructuredCreator{}, discovery.NewUnstructuredObjectTyper(), &unstructuredDefaulter{delegate: Scheme}, t.encoderVersion, t.decoderVersion)
+		ret.StorageConfig.Codec = versioning.NewCodec(
+			ret.StorageConfig.Codec,
+			d,
+			c,
+			&unstructuredCreator{},
+			crdserverscheme.NewUnstructuredObjectTyper(),
+			&unstructuredDefaulter{delegate: Scheme},
+			t.encoderVersion,
+			t.decoderVersion,
+			"crdRESTOptions",
+		)
 	}
 	return ret, err
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/crdserverscheme/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/crdserverscheme/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["unstructured.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/crdserverscheme",
+    importpath = "k8s.io/apiextensions-apiserver/pkg/crdserverscheme",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/crdserverscheme/unstructured.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/crdserverscheme/unstructured.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package discovery
+package crdserverscheme
 
 import (
 	"reflect"
@@ -26,7 +26,6 @@ import (
 // UnstructuredObjectTyper provides a runtime.ObjectTyper implementation for
 // runtime.Unstructured object based on discovery information.
 type UnstructuredObjectTyper struct {
-	typers []runtime.ObjectTyper
 }
 
 // NewUnstructuredObjectTyper returns a runtime.ObjectTyper for
@@ -34,10 +33,8 @@ type UnstructuredObjectTyper struct {
 // for handling objects that are not runtime.Unstructured. It does not delegate the Recognizes
 // check, only ObjectKinds.
 // TODO this only works for the apiextensions server and doesn't recognize any types.  Move to point of use.
-func NewUnstructuredObjectTyper(typers ...runtime.ObjectTyper) *UnstructuredObjectTyper {
-	dot := &UnstructuredObjectTyper{
-		typers: typers,
-	}
+func NewUnstructuredObjectTyper() *UnstructuredObjectTyper {
+	dot := &UnstructuredObjectTyper{}
 	return dot
 }
 
@@ -57,19 +54,8 @@ func (d *UnstructuredObjectTyper) ObjectKinds(obj runtime.Object) (gvks []schema
 		}
 		return []schema.GroupVersionKind{gvk}, false, nil
 	}
-	var lastErr error
-	for _, typer := range d.typers {
-		gvks, unversioned, err := typer.ObjectKinds(obj)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		return gvks, unversioned, nil
-	}
-	if lastErr == nil {
-		lastErr = runtime.NewNotRegisteredErrForType(reflect.TypeOf(obj))
-	}
-	return nil, false, lastErr
+
+	return nil, false, runtime.NewNotRegisteredErrForType("crdserverscheme.UnstructuredObjectTyper", reflect.TypeOf(obj))
 }
 
 // Recognizes returns true if the provided group,version,kind was in the

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd_test.go
@@ -38,10 +38,10 @@ import (
 	registrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/client-go/discovery"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver"
+	"k8s.io/apiextensions-apiserver/pkg/crdserverscheme"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
 )
@@ -61,7 +61,7 @@ func newStorage(t *testing.T) (customresource.CustomResourceStorage, *etcdtestin
 
 	typer := apiserver.UnstructuredObjectTyper{
 		Delegate:          parameterScheme,
-		UnstructuredTyper: discovery.NewUnstructuredObjectTyper(),
+		UnstructuredTyper: crdserverscheme.NewUnstructuredObjectTyper(),
 	}
 
 	kind := schema.GroupVersionKind{Group: "mygroup.example.com", Version: "v1beta1", Kind: "Noxu"}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
@@ -24,46 +24,47 @@ import (
 )
 
 type notRegisteredErr struct {
-	gvk    schema.GroupVersionKind
-	target GroupVersioner
-	t      reflect.Type
+	schemeName string
+	gvk        schema.GroupVersionKind
+	target     GroupVersioner
+	t          reflect.Type
 }
 
-func NewNotRegisteredErrForKind(gvk schema.GroupVersionKind) error {
-	return &notRegisteredErr{gvk: gvk}
+func NewNotRegisteredErrForKind(schemeName string, gvk schema.GroupVersionKind) error {
+	return &notRegisteredErr{schemeName: schemeName, gvk: gvk}
 }
 
-func NewNotRegisteredErrForType(t reflect.Type) error {
-	return &notRegisteredErr{t: t}
+func NewNotRegisteredErrForType(schemeName string, t reflect.Type) error {
+	return &notRegisteredErr{schemeName: schemeName, t: t}
 }
 
-func NewNotRegisteredErrForTarget(t reflect.Type, target GroupVersioner) error {
-	return &notRegisteredErr{t: t, target: target}
+func NewNotRegisteredErrForTarget(schemeName string, t reflect.Type, target GroupVersioner) error {
+	return &notRegisteredErr{schemeName: schemeName, t: t, target: target}
 }
 
-func NewNotRegisteredGVKErrForTarget(gvk schema.GroupVersionKind, target GroupVersioner) error {
-	return &notRegisteredErr{gvk: gvk, target: target}
+func NewNotRegisteredGVKErrForTarget(schemeName string, gvk schema.GroupVersionKind, target GroupVersioner) error {
+	return &notRegisteredErr{schemeName: schemeName, gvk: gvk, target: target}
 }
 
 func (k *notRegisteredErr) Error() string {
 	if k.t != nil && k.target != nil {
-		return fmt.Sprintf("%v is not suitable for converting to %q", k.t, k.target)
+		return fmt.Sprintf("%v is not suitable for converting to %q in scheme %q", k.t, k.target, k.schemeName)
 	}
 	nullGVK := schema.GroupVersionKind{}
 	if k.gvk != nullGVK && k.target != nil {
-		return fmt.Sprintf("%q is not suitable for converting to %q", k.gvk.GroupVersion(), k.target)
+		return fmt.Sprintf("%q is not suitable for converting to %q in scheme %q", k.gvk.GroupVersion(), k.target, k.schemeName)
 	}
 	if k.t != nil {
-		return fmt.Sprintf("no kind is registered for the type %v", k.t)
+		return fmt.Sprintf("no kind is registered for the type %v in scheme %q", k.t, k.schemeName)
 	}
 	if len(k.gvk.Kind) == 0 {
-		return fmt.Sprintf("no version %q has been registered", k.gvk.GroupVersion())
+		return fmt.Sprintf("no version %q has been registered in scheme %q", k.gvk.GroupVersion(), k.schemeName)
 	}
 	if k.gvk.Version == APIVersionInternal {
-		return fmt.Sprintf("no kind %q is registered for the internal version of group %q", k.gvk.Kind, k.gvk.Group)
+		return fmt.Sprintf("no kind %q is registered for the internal version of group %q in scheme %q", k.gvk.Kind, k.gvk.Group, k.schemeName)
 	}
 
-	return fmt.Sprintf("no kind %q is registered for version %q", k.gvk.Kind, k.gvk.GroupVersion())
+	return fmt.Sprintf("no kind %q is registered for version %q in scheme %q", k.gvk.Kind, k.gvk.GroupVersion(), k.schemeName)
 }
 
 // IsNotRegisteredError returns true if the error indicates the provided

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-
 	"strings"
 
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/naming"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -78,6 +78,10 @@ type Scheme struct {
 
 	// observedVersions keeps track of the order we've seen versions during type registration
 	observedVersions []schema.GroupVersion
+
+	// schemeName is the name of this scheme.  If you don't specify a name, the stack of the NewScheme caller will be used.
+	// This is useful for error reporting to indicate the origin of the scheme.
+	schemeName string
 }
 
 // Function to convert a field selector to internal representation.
@@ -93,6 +97,7 @@ func NewScheme() *Scheme {
 		fieldLabelConversionFuncs: map[string]map[string]FieldLabelConversionFunc{},
 		defaulterFuncs:            map[reflect.Type]func(interface{}){},
 		versionPriority:           map[string][]string{},
+		schemeName:                naming.GetNameFromCallsite(internalPackages...),
 	}
 	s.converter = conversion.NewConverter(s.nameFunc)
 
@@ -255,7 +260,7 @@ func (s *Scheme) ObjectKinds(obj Object) ([]schema.GroupVersionKind, bool, error
 
 	gvks, ok := s.typeToGVK[t]
 	if !ok {
-		return nil, false, NewNotRegisteredErrForType(t)
+		return nil, false, NewNotRegisteredErrForType(s.schemeName, t)
 	}
 	_, unversionedType := s.unversionedTypes[t]
 
@@ -293,7 +298,7 @@ func (s *Scheme) New(kind schema.GroupVersionKind) (Object, error) {
 	if t, exists := s.unversionedKinds[kind.Kind]; exists {
 		return reflect.New(t).Interface().(Object), nil
 	}
-	return nil, NewNotRegisteredErrForKind(kind)
+	return nil, NewNotRegisteredErrForKind(s.schemeName, kind)
 }
 
 // AddGenericConversionFunc adds a function that accepts the ConversionFunc call pattern
@@ -541,7 +546,7 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 
 	kinds, ok := s.typeToGVK[t]
 	if !ok || len(kinds) == 0 {
-		return nil, NewNotRegisteredErrForType(t)
+		return nil, NewNotRegisteredErrForType(s.schemeName, t)
 	}
 
 	gvk, ok := target.KindForGroupVersionKinds(kinds)
@@ -554,7 +559,7 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 			}
 			return copyAndSetTargetKind(copy, in, unversionedKind)
 		}
-		return nil, NewNotRegisteredErrForTarget(t, target)
+		return nil, NewNotRegisteredErrForTarget(s.schemeName, t, target)
 	}
 
 	// target wants to use the existing type, set kind and return (no conversion necessary)
@@ -764,3 +769,11 @@ func (s *Scheme) addObservedVersion(version schema.GroupVersion) {
 
 	s.observedVersions = append(s.observedVersions, version)
 }
+
+func (s *Scheme) Name() string {
+	return s.schemeName
+}
+
+// internalPackages are packages that ignored when creating a default reflector name. These packages are in the common
+// call chains to NewReflector, so they'd be low entropy names for reflectors
+var internalPackages = []string{"k8s.io/apimachinery/pkg/runtime/scheme.go"}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -179,7 +179,7 @@ func TestDecode(t *testing.T) {
 		{
 			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","value":1,"Other":"test"}`),
 			into:        &testDecodable{},
-			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind(schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
 			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
 			expectedObject: &testDecodable{
 				Other: "test",
@@ -247,7 +247,7 @@ func TestDecode(t *testing.T) {
 			// "VaLue" should have been "value"
 			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","VaLue":1,"Other":"test"}`),
 			into:        &testDecodable{},
-			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind(schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
 			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
 			expectedObject: &testDecodable{
 				Other: "test",
@@ -258,7 +258,7 @@ func TestDecode(t *testing.T) {
 			// "b" should have been "B", "I" should have been "i"
 			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","spec": {"A": 1, "b": 2, "h": 3, "I": 4}}`),
 			into:        &testDecodable{},
-			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind(schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind("mock", schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
 			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
 			expectedObject: &testDecodable{
 				Spec: DecodableSpec{A: 1, H: 3},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -72,7 +72,7 @@ func (d *testNestedDecodable) DecodeNestedObjects(_ runtime.Decoder) error {
 func TestNestedDecode(t *testing.T) {
 	n := &testNestedDecodable{nestedErr: fmt.Errorf("unable to decode")}
 	decoder := &mockSerializer{obj: n}
-	codec := NewCodec(nil, decoder, nil, nil, nil, nil, nil, nil)
+	codec := NewCodec(nil, decoder, nil, nil, nil, nil, nil, nil, "TestNestedDecode")
 	if _, _, err := codec.Decode([]byte(`{}`), nil, n); err != n.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -92,6 +92,7 @@ func TestNestedEncode(t *testing.T) {
 		&mockTyper{gvks: []schema.GroupVersionKind{{Kind: "test"}}},
 		nil,
 		schema.GroupVersion{Group: "other"}, nil,
+		"TestNestedEncode",
 	)
 	if err := codec.Encode(n, ioutil.Discard); err != n2.nestedErr {
 		t.Errorf("unexpected error: %v", err)
@@ -231,7 +232,7 @@ func TestDecode(t *testing.T) {
 
 	for i, test := range testCases {
 		t.Logf("%d", i)
-		s := NewCodec(test.serializer, test.serializer, test.convertor, test.creater, test.typer, test.defaulter, test.encodes, test.decodes)
+		s := NewCodec(test.serializer, test.serializer, test.convertor, test.creater, test.typer, test.defaulter, test.encodes, test.decodes, fmt.Sprintf("mock-%d", i))
 		obj, gvk, err := s.Decode([]byte(`{}`), test.defaultGVK, test.into)
 
 		if !reflect.DeepEqual(test.expectedGVK, gvk) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/naming/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/naming/BUILD
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["from_stack.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/naming",
+    importpath = "k8s.io/apimachinery/pkg/util/naming",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["from_stack_test.go"],
+    embed = [":go_default_library"],
+)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package naming
+
+import (
+	"fmt"
+	"regexp"
+	goruntime "runtime"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// GetNameFromCallsite walks back through the call stack until we find a caller from outside of the ignoredPackages
+// it returns back a shortpath/filename:line to aid in identification of this reflector when it starts logging
+func GetNameFromCallsite(ignoredPackages ...string) string {
+	name := "????"
+	const maxStack = 10
+	for i := 1; i < maxStack; i++ {
+		_, file, line, ok := goruntime.Caller(i)
+		if !ok {
+			file, line, ok = extractStackCreator()
+			if !ok {
+				break
+			}
+			i += maxStack
+		}
+		if hasPackage(file, append(ignoredPackages, "/runtime/asm_")) {
+			continue
+		}
+
+		file = trimPackagePrefix(file)
+		name = fmt.Sprintf("%s:%d", file, line)
+		break
+	}
+	return name
+}
+
+// hasPackage returns true if the file is in one of the ignored packages.
+func hasPackage(file string, ignoredPackages []string) bool {
+	for _, ignoredPackage := range ignoredPackages {
+		if strings.Contains(file, ignoredPackage) {
+			return true
+		}
+	}
+	return false
+}
+
+// trimPackagePrefix reduces duplicate values off the front of a package name.
+func trimPackagePrefix(file string) string {
+	if l := strings.LastIndex(file, "/vendor/"); l >= 0 {
+		return file[l+len("/vendor/"):]
+	}
+	if l := strings.LastIndex(file, "/src/"); l >= 0 {
+		return file[l+5:]
+	}
+	if l := strings.LastIndex(file, "/pkg/"); l >= 0 {
+		return file[l+1:]
+	}
+	return file
+}
+
+var stackCreator = regexp.MustCompile(`(?m)^created by (.*)\n\s+(.*):(\d+) \+0x[[:xdigit:]]+$`)
+
+// extractStackCreator retrieves the goroutine file and line that launched this stack. Returns false
+// if the creator cannot be located.
+// TODO: Go does not expose this via runtime https://github.com/golang/go/issues/11440
+func extractStackCreator() (string, int, bool) {
+	stack := debug.Stack()
+	matches := stackCreator.FindStringSubmatch(string(stack))
+	if matches == nil || len(matches) != 4 {
+		return "", 0, false
+	}
+	line, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return "", 0, false
+	}
+	return matches[2], line, true
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/naming/from_stack_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package naming
+
+import "testing"
+
+func TestGetNameFromCallsite(t *testing.T) {
+	tests := []struct {
+		name            string
+		ignoredPackages []string
+		expected        string
+	}{
+		{
+			name:     "simple",
+			expected: "k8s.io/apimachinery/pkg/util/naming/from_stack_test.go:50",
+		},
+		{
+			name:            "ignore-package",
+			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming"},
+			expected:        "testing/testing.go:777",
+		},
+		{
+			name:            "ignore-file",
+			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming/from_stack_test.go"},
+			expected:        "testing/testing.go:777",
+		},
+		{
+			name:            "ignore-multiple",
+			ignoredPackages: []string{"k8s.io/apimachinery/pkg/util/naming/from_stack_test.go", "testing/testing.go"},
+			expected:        "????",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := GetNameFromCallsite(tc.ignoredPackages...)
+			if tc.expected != actual {
+				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1099,6 +1099,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/patch.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/patch.go
@@ -1,0 +1,7 @@
+package lifecycle
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+func AccessReviewResources() map[schema.GroupResource]bool {
+	return accessReviewResources
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -531,6 +531,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/BUILD
@@ -13,7 +13,6 @@ go_library(
         "discovery_client.go",
         "helper.go",
         "round_tripper.go",
-        "unstructured.go",
     ],
     importpath = "k8s.io/client-go/discovery",
     deps = [

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -24,9 +24,6 @@ import (
 	"net"
 	"net/url"
 	"reflect"
-	"regexp"
-	goruntime "runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -40,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/naming"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -96,7 +94,7 @@ func NewNamespaceKeyedIndexerAndReflector(lw ListerWatcher, expectedType interfa
 // resyncPeriod, so that you can use reflectors to periodically process everything as
 // well as incrementally processing the things that change.
 func NewReflector(lw ListerWatcher, expectedType interface{}, store Store, resyncPeriod time.Duration) *Reflector {
-	return NewNamedReflector(getDefaultReflectorName(internalPackages...), lw, expectedType, store, resyncPeriod)
+	return NewNamedReflector(naming.GetNameFromCallsite(internalPackages...), lw, expectedType, store, resyncPeriod)
 }
 
 // reflectorDisambiguator is used to disambiguate started reflectors.
@@ -127,74 +125,7 @@ func makeValidPrometheusMetricLabel(in string) string {
 
 // internalPackages are packages that ignored when creating a default reflector name. These packages are in the common
 // call chains to NewReflector, so they'd be low entropy names for reflectors
-var internalPackages = []string{"client-go/tools/cache/", "/runtime/asm_"}
-
-// getDefaultReflectorName walks back through the call stack until we find a caller from outside of the ignoredPackages
-// it returns back a shortpath/filename:line to aid in identification of this reflector when it starts logging
-func getDefaultReflectorName(ignoredPackages ...string) string {
-	name := "????"
-	const maxStack = 10
-	for i := 1; i < maxStack; i++ {
-		_, file, line, ok := goruntime.Caller(i)
-		if !ok {
-			file, line, ok = extractStackCreator()
-			if !ok {
-				break
-			}
-			i += maxStack
-		}
-		if hasPackage(file, ignoredPackages) {
-			continue
-		}
-
-		file = trimPackagePrefix(file)
-		name = fmt.Sprintf("%s:%d", file, line)
-		break
-	}
-	return name
-}
-
-// hasPackage returns true if the file is in one of the ignored packages.
-func hasPackage(file string, ignoredPackages []string) bool {
-	for _, ignoredPackage := range ignoredPackages {
-		if strings.Contains(file, ignoredPackage) {
-			return true
-		}
-	}
-	return false
-}
-
-// trimPackagePrefix reduces duplicate values off the front of a package name.
-func trimPackagePrefix(file string) string {
-	if l := strings.LastIndex(file, "k8s.io/client-go/pkg/"); l >= 0 {
-		return file[l+len("k8s.io/client-go/"):]
-	}
-	if l := strings.LastIndex(file, "/src/"); l >= 0 {
-		return file[l+5:]
-	}
-	if l := strings.LastIndex(file, "/pkg/"); l >= 0 {
-		return file[l+1:]
-	}
-	return file
-}
-
-var stackCreator = regexp.MustCompile(`(?m)^created by (.*)\n\s+(.*):(\d+) \+0x[[:xdigit:]]+$`)
-
-// extractStackCreator retrieves the goroutine file and line that launched this stack. Returns false
-// if the creator cannot be located.
-// TODO: Go does not expose this via runtime https://github.com/golang/go/issues/11440
-func extractStackCreator() (string, int, bool) {
-	stack := debug.Stack()
-	matches := stackCreator.FindStringSubmatch(string(stack))
-	if matches == nil || len(matches) != 4 {
-		return "", 0, false
-	}
-	line, err := strconv.Atoi(matches[3])
-	if err != nil {
-		return "", 0, false
-	}
-	return matches[2], line, true
-}
+var internalPackages = []string{"client-go/tools/cache/"}
 
 // Run starts a watch and handles watch events. Will restart the watch if it is closed.
 // Run will exit when stopCh is closed.

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -755,6 +755,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/metrics/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/metrics/Godeps/Godeps.json
@@ -371,6 +371,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -735,6 +735,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/sample-controller/Godeps/Godeps.json
@@ -403,6 +403,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/naming",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/vendor/k8s.io/kubernetes/test/integration/framework/serializer.go
+++ b/vendor/k8s.io/kubernetes/test/integration/framework/serializer.go
@@ -45,9 +45,9 @@ func (s *wrappedSerializer) UniversalDeserializer() runtime.Decoder {
 }
 
 func (s *wrappedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
-	return versioning.NewCodec(encoder, nil, s.scheme, s.scheme, s.scheme, s.scheme, gv, nil)
+	return versioning.NewCodec(encoder, nil, s.scheme, s.scheme, s.scheme, s.scheme, gv, nil, s.scheme.Name())
 }
 
 func (s *wrappedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
-	return versioning.NewCodec(nil, decoder, s.scheme, s.scheme, s.scheme, s.scheme, nil, gv)
+	return versioning.NewCodec(nil, decoder, s.scheme, s.scheme, s.scheme, s.scheme, nil, gv, s.scheme.Name())
 }


### PR DESCRIPTION
1. track schemes by name so we know which scheme is failing
2. only ignore events for GC and quota

both are lgtm'd upstream