### PR TITLE
 use new authorization install pattern to have reliable self-SAR resolution

### DIFF
--- a/pkg/api/legacy/authorization.go
+++ b/pkg/api/legacy/authorization.go
@@ -1,0 +1,98 @@
+package legacy
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+
+	authorizationv1 "github.com/openshift/api/authorization/v1"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization"
+	authorizationv1helpers "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
+)
+
+// InstallLegacyAuthorization this looks like a lot of duplication, but the code in the individual versions is living and may
+// change. The code here should never change and needs to allow the other code to move independently.
+func InstallLegacyAuthorization(scheme *runtime.Scheme) {
+	InstallExternalLegacyAuthorization(scheme)
+
+	schemeBuilder := runtime.NewSchemeBuilder(
+		addUngroupifiedInternalAuthorizationTypes,
+		core.AddToScheme,
+		rbac.AddToScheme,
+
+		authorizationv1helpers.AddConversionFuncs,
+		authorizationv1helpers.AddFieldSelectorKeyConversions,
+		authorizationv1helpers.RegisterDefaults,
+		authorizationv1helpers.RegisterConversions,
+	)
+	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
+}
+
+func InstallExternalLegacyAuthorization(scheme *runtime.Scheme) {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		addUngroupifiedAuthorizationTypes,
+		corev1.AddToScheme,
+		rbacv1.AddToScheme,
+	)
+	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
+}
+
+func addUngroupifiedAuthorizationTypes(scheme *runtime.Scheme) error {
+	types := []runtime.Object{
+		&authorizationv1.Role{},
+		&authorizationv1.RoleBinding{},
+		&authorizationv1.RoleBindingList{},
+		&authorizationv1.RoleList{},
+
+		&authorizationv1.SelfSubjectRulesReview{},
+		&authorizationv1.SubjectRulesReview{},
+		&authorizationv1.ResourceAccessReview{},
+		&authorizationv1.SubjectAccessReview{},
+		&authorizationv1.LocalResourceAccessReview{},
+		&authorizationv1.LocalSubjectAccessReview{},
+		&authorizationv1.ResourceAccessReviewResponse{},
+		&authorizationv1.SubjectAccessReviewResponse{},
+		&authorizationv1.IsPersonalSubjectAccessReview{},
+
+		&authorizationv1.ClusterRole{},
+		&authorizationv1.ClusterRoleBinding{},
+		&authorizationv1.ClusterRoleBindingList{},
+		&authorizationv1.ClusterRoleList{},
+
+		&authorizationv1.RoleBindingRestriction{},
+		&authorizationv1.RoleBindingRestrictionList{},
+	}
+	scheme.AddKnownTypes(GroupVersion, types...)
+	return nil
+}
+
+func addUngroupifiedInternalAuthorizationTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(internalGroupVersion,
+		&authorization.Role{},
+		&authorization.RoleBinding{},
+		&authorization.RoleBindingList{},
+		&authorization.RoleList{},
+
+		&authorization.SelfSubjectRulesReview{},
+		&authorization.SubjectRulesReview{},
+		&authorization.ResourceAccessReview{},
+		&authorization.SubjectAccessReview{},
+		&authorization.LocalResourceAccessReview{},
+		&authorization.LocalSubjectAccessReview{},
+		&authorization.ResourceAccessReviewResponse{},
+		&authorization.SubjectAccessReviewResponse{},
+		&authorization.IsPersonalSubjectAccessReview{},
+
+		&authorization.ClusterRole{},
+		&authorization.ClusterRoleBinding{},
+		&authorization.ClusterRoleBindingList{},
+		&authorization.ClusterRoleList{},
+
+		&authorization.RoleBindingRestriction{},
+		&authorization.RoleBindingRestrictionList{},
+	)
+	return nil
+}

--- a/pkg/api/legacy/doc.go
+++ b/pkg/api/legacy/doc.go
@@ -1,0 +1,4 @@
+// legacy is a deprecated package that exists to install types into an ungroupified scheme for use reading old files
+// by the CLI and the old oapi API server.  Generally, if you're depending on this package, you're trying to manage
+// a case that you shouldn't tolerate.
+package legacy

--- a/pkg/api/legacy/install.go
+++ b/pkg/api/legacy/install.go
@@ -7,8 +7,6 @@ import (
 
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsapiv1 "github.com/openshift/origin/pkg/apps/apis/apps/v1"
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildapiv1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -32,18 +30,19 @@ import (
 )
 
 var (
-	GroupName    = ""
-	GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
+	GroupName            = ""
+	GroupVersion         = schema.GroupVersion{Group: GroupName, Version: "v1"}
+	internalGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
 )
+
+// DEPRECATED
+func Kind(kind string) schema.GroupKind {
+	return schema.GroupKind{Group: GroupName, Kind: kind}
+}
 
 func InstallLegacyApps(scheme *runtime.Scheme) {
 	utilruntime.Must(appsapi.AddToSchemeInCoreGroup(scheme))
 	utilruntime.Must(appsapiv1.AddToSchemeInCoreGroup(scheme))
-}
-
-func InstallLegacyAuthorization(scheme *runtime.Scheme) {
-	utilruntime.Must(authorizationapi.AddToSchemeInCoreGroup(scheme))
-	utilruntime.Must(authorizationapiv1.AddToSchemeInCoreGroup(scheme))
 }
 
 func InstallLegacyBuild(scheme *runtime.Scheme) {

--- a/pkg/authorization/apis/authorization/install/install.go
+++ b/pkg/authorization/apis/authorization/install/install.go
@@ -5,6 +5,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
+	authorizationv1 "github.com/openshift/api/authorization/v1"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 	authorizationapiv1 "github.com/openshift/origin/pkg/authorization/apis/authorization/v1"
@@ -16,8 +17,8 @@ func init() {
 
 // Install registers the API group and adds types to a scheme
 func Install(scheme *runtime.Scheme) {
-	utilruntime.Must(authorizationapi.AddToScheme(scheme))
+	utilruntime.Must(authorizationapi.Install(scheme))
 	utilruntime.Must(rbacconversion.AddToScheme(scheme))
-	utilruntime.Must(authorizationapiv1.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(authorizationapiv1.SchemeGroupVersion))
+	utilruntime.Must(authorizationapiv1.Install(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(authorizationv1.GroupVersion))
 }

--- a/pkg/authorization/apis/authorization/register.go
+++ b/pkg/authorization/apis/authorization/register.go
@@ -3,43 +3,32 @@ package authorization
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/rbac"
 )
 
 const (
-	LegacyGroupName = ""
-	GroupName       = "authorization.openshift.io"
+	GroupName = "authorization.openshift.io"
 )
 
 var (
-	SchemeGroupVersion       = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
-	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: runtime.APIVersionInternal}
+	schemeBuilder = runtime.NewSchemeBuilder(
+		addKnownTypes,
+		core.AddToScheme,
+		rbac.AddToScheme,
+	)
+	Install = schemeBuilder.AddToScheme
 
-	LegacySchemeBuilder    = runtime.NewSchemeBuilder(addLegacyKnownTypes)
-	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
-
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// DEPRECATED kept for generated code
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+	// DEPRECATED kept for generated code
+	AddToScheme = schemeBuilder.AddToScheme
 )
 
-// Kind takes an unqualified kind and returns back a Group qualified GroupKind
-func Kind(kind string) schema.GroupKind {
-	return SchemeGroupVersion.WithKind(kind).GroupKind()
-}
-
-// LegacyKind takes an unqualified kind and returns back a Group qualified GroupKind
-func LegacyKind(kind string) schema.GroupKind {
-	return LegacySchemeGroupVersion.WithKind(kind).GroupKind()
-}
-
-// Resource takes an unqualified resource and returns back a Group qualified GroupResource
+// Resource kept for generated code
+// DEPRECATED
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
-}
-
-// LegacyResource takes an unqualified resource and returns back a Group qualified
-// GroupResource using legacy API
-func LegacyResource(resource string) schema.GroupResource {
-	return LegacySchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
 // Adds the list of known types to api.Scheme.
@@ -68,34 +57,5 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&RoleBindingRestriction{},
 		&RoleBindingRestrictionList{},
 	)
-	return nil
-}
-
-func addLegacyKnownTypes(scheme *runtime.Scheme) error {
-	types := []runtime.Object{
-		&Role{},
-		&RoleBinding{},
-		&RoleBindingList{},
-		&RoleList{},
-
-		&SelfSubjectRulesReview{},
-		&SubjectRulesReview{},
-		&ResourceAccessReview{},
-		&SubjectAccessReview{},
-		&LocalResourceAccessReview{},
-		&LocalSubjectAccessReview{},
-		&ResourceAccessReviewResponse{},
-		&SubjectAccessReviewResponse{},
-		&IsPersonalSubjectAccessReview{},
-
-		&ClusterRole{},
-		&ClusterRoleBinding{},
-		&ClusterRoleBindingList{},
-		&ClusterRoleList{},
-
-		&RoleBindingRestriction{},
-		&RoleBindingRestrictionList{},
-	}
-	scheme.AddKnownTypes(LegacySchemeGroupVersion, types...)
 	return nil
 }

--- a/pkg/authorization/apis/authorization/v1/conversion.go
+++ b/pkg/authorization/apis/authorization/v1/conversion.go
@@ -180,7 +180,7 @@ func Convert_authorization_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *newer
 	return nil
 }
 
-func addConversionFuncs(scheme *runtime.Scheme) error {
+func AddConversionFuncs(scheme *runtime.Scheme) error {
 	err := scheme.AddConversionFuncs(
 		Convert_v1_SubjectAccessReview_To_authorization_SubjectAccessReview,
 		Convert_authorization_SubjectAccessReview_To_v1_SubjectAccessReview,
@@ -207,6 +207,6 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	return nil
 }
 
-func addFieldSelectorKeyConversions(scheme *runtime.Scheme) error {
+func AddFieldSelectorKeyConversions(scheme *runtime.Scheme) error {
 	return nil
 }

--- a/pkg/authorization/apis/authorization/v1/defaults_test.go
+++ b/pkg/authorization/apis/authorization/v1/defaults_test.go
@@ -13,10 +13,8 @@ import (
 var scheme = runtime.NewScheme()
 
 func init() {
-	LegacySchemeBuilder.AddToScheme(scheme)
-	authorizationapi.LegacySchemeBuilder.AddToScheme(scheme)
-	SchemeBuilder.AddToScheme(scheme)
-	authorizationapi.SchemeBuilder.AddToScheme(scheme)
+	Install(scheme)
+	authorizationapi.Install(scheme)
 }
 
 func TestDefaults(t *testing.T) {

--- a/pkg/authorization/apis/authorization/v1/register.go
+++ b/pkg/authorization/apis/authorization/v1/register.go
@@ -1,29 +1,19 @@
 package v1
 
 import (
-	"github.com/openshift/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
 
-const (
-	GroupName       = "authorization.openshift.io"
-	LegacyGroupName = ""
+	"github.com/openshift/api/authorization/v1"
+	"github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
 
 var (
-	SchemeGroupVersion       = schema.GroupVersion{Group: GroupName, Version: "v1"}
-	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: "v1"}
-
-	LegacySchemeBuilder    = runtime.NewSchemeBuilder(v1.DeprecatedInstallWithoutGroup, addConversionFuncs, RegisterDefaults, RegisterConversions)
-	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
-
-	SchemeBuilder = runtime.NewSchemeBuilder(v1.Install, addConversionFuncs, addFieldSelectorKeyConversions, RegisterDefaults)
-	AddToScheme   = SchemeBuilder.AddToScheme
-
-	localSchemeBuilder = &SchemeBuilder
+	localSchemeBuilder = runtime.NewSchemeBuilder(
+		authorization.Install,
+		v1.Install,
+		AddConversionFuncs,
+		AddFieldSelectorKeyConversions,
+		RegisterDefaults,
+	)
+	Install = localSchemeBuilder.AddToScheme
 )
-
-func Resource(resource string) schema.GroupResource {
-	return SchemeGroupVersion.WithResource(resource).GroupResource()
-}

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -210,7 +210,7 @@ func (userEvaluator) ResolveRules(scope, namespace string, _ rbaclisters.Cluster
 				Resources("selfsubjectaccessreviews").
 				RuleOrDie(),
 			rbacv1helpers.NewRule("create").
-				Groups(authorizationapi.GroupName, authorizationapi.LegacyGroupName).
+				Groups(authorizationapi.GroupName, legacy.GroupName).
 				Resources("selfsubjectrulesreviews").
 				RuleOrDie(),
 		}, nil
@@ -270,16 +270,16 @@ var escalatingScopeResources = []schema.GroupResource{
 	{Group: legacy.GroupName, Resource: "oauthaccesstokens"},
 
 	{Group: authorizationapi.GroupName, Resource: "roles"},
-	{Group: authorizationapi.LegacyGroupName, Resource: "roles"},
+	{Group: legacy.GroupName, Resource: "roles"},
 
 	{Group: authorizationapi.GroupName, Resource: "rolebindings"},
-	{Group: authorizationapi.LegacyGroupName, Resource: "rolebindings"},
+	{Group: legacy.GroupName, Resource: "rolebindings"},
 
 	{Group: authorizationapi.GroupName, Resource: "clusterroles"},
-	{Group: authorizationapi.LegacyGroupName, Resource: "clusterroles"},
+	{Group: legacy.GroupName, Resource: "clusterroles"},
 
 	{Group: authorizationapi.GroupName, Resource: "clusterrolebindings"},
-	{Group: authorizationapi.LegacyGroupName, Resource: "clusterrolebindings"},
+	{Group: legacy.GroupName, Resource: "clusterrolebindings"},
 }
 
 // role:<clusterrole name>:<namespace to allow the cluster role, * means all>

--- a/pkg/authorization/registry/localresourceaccessreview/rest.go
+++ b/pkg/authorization/registry/localresourceaccessreview/rest.go
@@ -10,6 +10,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authorization "github.com/openshift/api/authorization"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
 	"github.com/openshift/origin/pkg/authorization/registry/resourceaccessreview"
@@ -43,7 +44,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a localResourceAccessReview: %#v", obj))
 	}
 	if errs := authorizationvalidation.ValidateLocalResourceAccessReview(localRAR); len(errs) > 0 {
-		return nil, kapierrors.NewInvalid(authorizationapi.Kind(localRAR.Kind), "", errs)
+		return nil, kapierrors.NewInvalid(authorization.Kind(localRAR.Kind), "", errs)
 	}
 	if namespace := apirequest.NamespaceValue(ctx); len(namespace) == 0 {
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("namespace is required on this type: %v", namespace))

--- a/pkg/authorization/registry/localsubjectaccessreview/rest.go
+++ b/pkg/authorization/registry/localsubjectaccessreview/rest.go
@@ -10,6 +10,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authorization "github.com/openshift/api/authorization"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
 	"github.com/openshift/origin/pkg/authorization/registry/subjectaccessreview"
@@ -43,7 +44,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a localSubjectAccessReview: %#v", obj))
 	}
 	if errs := authorizationvalidation.ValidateLocalSubjectAccessReview(localSAR); len(errs) > 0 {
-		return nil, kapierrors.NewInvalid(authorizationapi.Kind(localSAR.Kind), "", errs)
+		return nil, kapierrors.NewInvalid(authorization.Kind(localSAR.Kind), "", errs)
 	}
 	if namespace := apirequest.NamespaceValue(ctx); len(namespace) == 0 {
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("namespace is required on this type: %v", namespace))

--- a/pkg/authorization/registry/resourceaccessreview/rest.go
+++ b/pkg/authorization/registry/resourceaccessreview/rest.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
+	authorization "github.com/openshift/api/authorization"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
 	"github.com/openshift/origin/pkg/authorization/registry/util"
@@ -50,7 +51,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a resourceAccessReview: %#v", obj))
 	}
 	if errs := authorizationvalidation.ValidateResourceAccessReview(resourceAccessReview); len(errs) > 0 {
-		return nil, kapierrors.NewInvalid(authorizationapi.Kind(resourceAccessReview.Kind), "", errs)
+		return nil, kapierrors.NewInvalid(authorization.Kind(resourceAccessReview.Kind), "", errs)
 	}
 
 	user, ok := apirequest.UserFrom(ctx)
@@ -98,10 +99,10 @@ func (r *REST) isAllowed(user user.Info, rar *authorizationapi.ResourceAccessRev
 	authorized, reason, err := r.authorizer.Authorize(localRARAttributes)
 
 	if err != nil {
-		return kapierrors.NewForbidden(authorizationapi.Resource(localRARAttributes.GetResource()), localRARAttributes.GetName(), err)
+		return kapierrors.NewForbidden(authorization.Resource(localRARAttributes.GetResource()), localRARAttributes.GetName(), err)
 	}
 	if authorized != kauthorizer.DecisionAllow {
-		forbiddenError := kapierrors.NewForbidden(authorizationapi.Resource(localRARAttributes.GetResource()), localRARAttributes.GetName(), errors.New("") /*discarded*/)
+		forbiddenError := kapierrors.NewForbidden(authorization.Resource(localRARAttributes.GetResource()), localRARAttributes.GetName(), errors.New("") /*discarded*/)
 		forbiddenError.ErrStatus.Message = reason
 		return forbiddenError
 	}

--- a/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
+++ b/pkg/authorization/registry/rolebindingrestriction/etcd/etcd.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	authorization "github.com/openshift/api/authorization"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/registry/rolebindingrestriction"
 	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
@@ -25,7 +26,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 	store := &registry.Store{
 		NewFunc:                  func() runtime.Object { return &authorizationapi.RoleBindingRestriction{} },
 		NewListFunc:              func() runtime.Object { return &authorizationapi.RoleBindingRestrictionList{} },
-		DefaultQualifiedResource: authorizationapi.Resource("rolebindingrestrictions"),
+		DefaultQualifiedResource: authorization.Resource("rolebindingrestrictions"),
 
 		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 

--- a/pkg/authorization/registry/subjectaccessreview/rest.go
+++ b/pkg/authorization/registry/subjectaccessreview/rest.go
@@ -12,6 +12,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authorization "github.com/openshift/api/authorization"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationvalidation "github.com/openshift/origin/pkg/authorization/apis/authorization/validation"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
@@ -47,7 +48,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, kapierrors.NewBadRequest(fmt.Sprintf("not a subjectAccessReview: %#v", obj))
 	}
 	if errs := authorizationvalidation.ValidateSubjectAccessReview(subjectAccessReview); len(errs) > 0 {
-		return nil, kapierrors.NewInvalid(authorizationapi.Kind(subjectAccessReview.Kind), "", errs)
+		return nil, kapierrors.NewInvalid(authorization.Kind(subjectAccessReview.Kind), "", errs)
 	}
 
 	requestingUser, ok := apirequest.UserFrom(ctx)
@@ -153,10 +154,10 @@ func (r *REST) isAllowed(user user.Info, sar *authorizationapi.SubjectAccessRevi
 	authorized, reason, err := r.authorizer.Authorize(localSARAttributes)
 
 	if err != nil {
-		return kapierrors.NewForbidden(authorizationapi.Resource(localSARAttributes.GetResource()), localSARAttributes.GetName(), err)
+		return kapierrors.NewForbidden(authorization.Resource(localSARAttributes.GetResource()), localSARAttributes.GetName(), err)
 	}
 	if authorized != kauthorizer.DecisionAllow {
-		forbiddenError := kapierrors.NewForbidden(authorizationapi.Resource(localSARAttributes.GetResource()), localSARAttributes.GetName(), errors.New("") /*discarded*/)
+		forbiddenError := kapierrors.NewForbidden(authorization.Resource(localSARAttributes.GetResource()), localSARAttributes.GetName(), errors.New("") /*discarded*/)
 		forbiddenError.ErrStatus.Message = reason
 		return forbiddenError
 	}

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 
 	oapi "github.com/openshift/origin/pkg/api"
+	"github.com/openshift/origin/pkg/api/legacy"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
@@ -71,7 +72,7 @@ var (
 	authzGroup          = authorizationapi.GroupName
 	kAuthzGroup         = kauthorizationapi.GroupName
 	kAuthnGroup         = kauthenticationapi.GroupName
-	legacyAuthzGroup    = authorizationapi.LegacyGroupName
+	legacyAuthzGroup    = legacy.GroupName
 	buildGroup          = buildapi.GroupName
 	legacyBuildGroup    = buildapi.LegacyGroupName
 	deployGroup         = appsapi.GroupName

--- a/pkg/oc/admin/policy/reconcile_clusterrolebindings.go
+++ b/pkg/oc/admin/policy/reconcile_clusterrolebindings.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	authorization "github.com/openshift/api/authorization"
 	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -137,11 +137,11 @@ func (o *ReconcileClusterRoleBindingsOptions) Complete(cmd *cobra.Command, f kcm
 		return err
 	}
 	for _, resourceString := range args {
-		resource, name, err := cmdutil.ResolveResource(authorizationapi.Resource("clusterroles"), resourceString, mapper)
+		resource, name, err := cmdutil.ResolveResource(authorization.Resource("clusterroles"), resourceString, mapper)
 		if err != nil {
 			return err
 		}
-		if resource != authorizationapi.Resource("clusterroles") {
+		if resource != authorization.Resource("clusterroles") {
 			return fmt.Errorf("%v is not a valid resource type for this command", resource)
 		}
 		if len(name) == 0 {

--- a/pkg/oc/admin/policy/reconcile_clusterroles.go
+++ b/pkg/oc/admin/policy/reconcile_clusterroles.go
@@ -18,7 +18,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	authorization "github.com/openshift/api/authorization"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	osutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/print"
@@ -125,11 +125,11 @@ func (o *ReconcileClusterRolesOptions) Complete(cmd *cobra.Command, f kcmdutil.F
 		return err
 	}
 	for _, resourceString := range args {
-		resource, name, err := osutil.ResolveResource(authorizationapi.Resource("clusterroles"), resourceString, mapper)
+		resource, name, err := osutil.ResolveResource(authorization.Resource("clusterroles"), resourceString, mapper)
 		if err != nil {
 			return err
 		}
-		if authorizationapi.Resource("clusterroles") != resource {
+		if authorization.Resource("clusterroles") != resource {
 			return fmt.Errorf("%v is not a valid resource type for this command", resource)
 		}
 		if len(name) == 0 {

--- a/pkg/oc/cli/describe/describer.go
+++ b/pkg/oc/cli/describe/describer.go
@@ -26,6 +26,7 @@ import (
 	kprinters "k8s.io/kubernetes/pkg/printers"
 	kinternalprinters "k8s.io/kubernetes/pkg/printers/internalversion"
 
+	authorization "github.com/openshift/api/authorization"
 	oapi "github.com/openshift/origin/pkg/api"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
@@ -106,34 +107,34 @@ func describerMap(clientConfig *rest.Config, kclient kclientset.Interface, host 
 	}
 
 	m := map[schema.GroupKind]kprinters.Describer{
-		buildapi.Kind("Build"):                          &BuildDescriber{buildClient, kclient},
-		buildapi.Kind("BuildConfig"):                    &BuildConfigDescriber{buildClient, kclient, host},
-		appsapi.Kind("DeploymentConfig"):                &DeploymentConfigDescriber{appsClient, kclient, nil},
-		imageapi.Kind("Image"):                          &ImageDescriber{imageClient},
-		imageapi.Kind("ImageStream"):                    &ImageStreamDescriber{imageClient},
-		imageapi.Kind("ImageStreamTag"):                 &ImageStreamTagDescriber{imageClient},
-		imageapi.Kind("ImageStreamImage"):               &ImageStreamImageDescriber{imageClient},
-		routeapi.Kind("Route"):                          &RouteDescriber{routeClient, kclient},
-		projectapi.Kind("Project"):                      &ProjectDescriber{projectClient, kclient},
-		templateapi.Kind("Template"):                    &TemplateDescriber{templateClient, meta.NewAccessor(), legacyscheme.Scheme, nil},
-		templateapi.Kind("TemplateInstance"):            &TemplateInstanceDescriber{kclient, templateClient, nil},
-		authorizationapi.Kind("RoleBinding"):            &RoleBindingDescriber{oauthorizationClient},
-		authorizationapi.Kind("Role"):                   &RoleDescriber{oauthorizationClient},
-		authorizationapi.Kind("ClusterRoleBinding"):     &ClusterRoleBindingDescriber{oauthorizationClient},
-		authorizationapi.Kind("ClusterRole"):            &ClusterRoleDescriber{oauthorizationClient},
-		authorizationapi.Kind("RoleBindingRestriction"): &RoleBindingRestrictionDescriber{oauthorizationClient},
-		oauthapi.Kind("OAuthAccessToken"):               &OAuthAccessTokenDescriber{oauthClient},
-		userapi.Kind("Identity"):                        &IdentityDescriber{userClient},
-		userapi.Kind("User"):                            &UserDescriber{userClient},
-		userapi.Kind("Group"):                           &GroupDescriber{userClient},
-		userapi.Kind("UserIdentityMapping"):             &UserIdentityMappingDescriber{userClient},
-		quotaapi.Kind("ClusterResourceQuota"):           &ClusterQuotaDescriber{quotaClient},
-		quotaapi.Kind("AppliedClusterResourceQuota"):    &AppliedClusterQuotaDescriber{quotaClient},
-		networkapi.Kind("ClusterNetwork"):               &ClusterNetworkDescriber{onetworkClient},
-		networkapi.Kind("HostSubnet"):                   &HostSubnetDescriber{onetworkClient},
-		networkapi.Kind("NetNamespace"):                 &NetNamespaceDescriber{onetworkClient},
-		networkapi.Kind("EgressNetworkPolicy"):          &EgressNetworkPolicyDescriber{onetworkClient},
-		securityapi.Kind("SecurityContextConstraints"):  &SecurityContextConstraintsDescriber{securityClient},
+		buildapi.Kind("Build"):                         &BuildDescriber{buildClient, kclient},
+		buildapi.Kind("BuildConfig"):                   &BuildConfigDescriber{buildClient, kclient, host},
+		appsapi.Kind("DeploymentConfig"):               &DeploymentConfigDescriber{appsClient, kclient, nil},
+		imageapi.Kind("Image"):                         &ImageDescriber{imageClient},
+		imageapi.Kind("ImageStream"):                   &ImageStreamDescriber{imageClient},
+		imageapi.Kind("ImageStreamTag"):                &ImageStreamTagDescriber{imageClient},
+		imageapi.Kind("ImageStreamImage"):              &ImageStreamImageDescriber{imageClient},
+		routeapi.Kind("Route"):                         &RouteDescriber{routeClient, kclient},
+		projectapi.Kind("Project"):                     &ProjectDescriber{projectClient, kclient},
+		templateapi.Kind("Template"):                   &TemplateDescriber{templateClient, meta.NewAccessor(), legacyscheme.Scheme, nil},
+		templateapi.Kind("TemplateInstance"):           &TemplateInstanceDescriber{kclient, templateClient, nil},
+		authorization.Kind("RoleBinding"):              &RoleBindingDescriber{oauthorizationClient},
+		authorization.Kind("Role"):                     &RoleDescriber{oauthorizationClient},
+		authorization.Kind("ClusterRoleBinding"):       &ClusterRoleBindingDescriber{oauthorizationClient},
+		authorization.Kind("ClusterRole"):              &ClusterRoleDescriber{oauthorizationClient},
+		authorization.Kind("RoleBindingRestriction"):   &RoleBindingRestrictionDescriber{oauthorizationClient},
+		oauthapi.Kind("OAuthAccessToken"):              &OAuthAccessTokenDescriber{oauthClient},
+		userapi.Kind("Identity"):                       &IdentityDescriber{userClient},
+		userapi.Kind("User"):                           &UserDescriber{userClient},
+		userapi.Kind("Group"):                          &GroupDescriber{userClient},
+		userapi.Kind("UserIdentityMapping"):            &UserIdentityMappingDescriber{userClient},
+		quotaapi.Kind("ClusterResourceQuota"):          &ClusterQuotaDescriber{quotaClient},
+		quotaapi.Kind("AppliedClusterResourceQuota"):   &AppliedClusterQuotaDescriber{quotaClient},
+		networkapi.Kind("ClusterNetwork"):              &ClusterNetworkDescriber{onetworkClient},
+		networkapi.Kind("HostSubnet"):                  &HostSubnetDescriber{onetworkClient},
+		networkapi.Kind("NetNamespace"):                &NetNamespaceDescriber{onetworkClient},
+		networkapi.Kind("EgressNetworkPolicy"):         &EgressNetworkPolicyDescriber{onetworkClient},
+		securityapi.Kind("SecurityContextConstraints"): &SecurityContextConstraintsDescriber{securityClient},
 	}
 
 	// Register the legacy ("core") API group for all kinds as well.

--- a/pkg/project/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/registry/projectrequest/delegated/delegated.go
@@ -29,6 +29,7 @@ import (
 	rbaclisters "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion"
 
 	projectapiv1 "github.com/openshift/api/project/v1"
+	"github.com/openshift/origin/pkg/api/legacy"
 	osauthorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -98,7 +99,7 @@ var (
 	ForbiddenPrefixes = []string{"openshift-", "kubernetes-", "kube-"}
 
 	defaultRoleBindingNames = bootstrappolicy.GetBootstrapServiceAccountProjectRoleBindingNames()
-	roleBindingGroups       = sets.NewString(osauthorizationapi.LegacyGroupName, osauthorizationapi.GroupName, rbac.GroupName)
+	roleBindingGroups       = sets.NewString(legacy.GroupName, osauthorizationapi.GroupName, rbac.GroupName)
 	roleBindingKind         = "RoleBinding"
 )
 

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -24,7 +24,9 @@ import (
 	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/test/e2e/framework"
 
+	authorization "github.com/openshift/api/authorization"
 	templateapiv1 "github.com/openshift/api/template/v1"
+	"github.com/openshift/origin/pkg/api/legacy"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -309,8 +311,8 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker end-to-end te
 					kapi.Kind("Secret"),
 					kapi.Kind("RoleBinding"),
 					rbacapi.Kind("RoleBinding"),
-					authorizationapi.LegacyKind("RoleBinding"),
-					authorizationapi.Kind("RoleBinding"),
+					legacy.Kind("RoleBinding"),
+					authorization.Kind("RoleBinding"),
 					schema.GroupKind{Group: "events.k8s.io", Kind: "Event"}:
 					continue
 				}


### PR DESCRIPTION
builds on https://github.com/openshift/origin/pull/20200

@gabemontero I think this solves your problem.  I'll test it on Monday.  The problem was that the kube-apiserver didn't have the ungroupified objects registered in the scheme for interpreting requests and our SAR is special.