### PR TITLE
builder test: fix broken import after PR #20205

### DIFF
--- a/pkg/build/builder/docker_test.go
+++ b/pkg/build/builder/docker_test.go
@@ -14,7 +14,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 
 	"github.com/openshift/source-to-image/pkg/tar"
-	s2iutil "github.com/openshift/source-to-image/pkg/util"
+	s2iutil "github.com/openshift/source-to-image/pkg/util/fs"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	"github.com/openshift/origin/pkg/build/util/dockerfile"


### PR DESCRIPTION
I forgot to update the import path in one of the tests in https://github.com/openshift/origin/pull/20205 and found out when comparing changes with https://github.com/openshift/ose/pull/1345