### PR TITLE
Avoid race between inserting secret for internal registry into SA and creation of a Pod in DC tests

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -54,6 +54,10 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			ctx:    ctx,
 			cancel: cancel,
 		}
+
+		// FIXME: remove this when https://github.com/openshift/origin/issues/20225 gets fixed
+		err := exutil.WaitForServiceAccount(oc.KubeClient().CoreV1().ServiceAccounts(oc.Namespace()), "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	// This have to be registered before we create kube framework (NewCLI).


### PR DESCRIPTION
Temporary hack for DC tests to avoid a race (https://github.com/openshift/origin/issues/20225) while it gets fixed.

/assign @mfojtik
/cc @bparees 