### PR TITLE
Disable progress bar in curl

### DIFF
--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -204,7 +204,7 @@ func getRegistrySchema(pod *testPod, host string) (schema string, err error) {
 }
 
 func runHTTPRequest(pod *testPod, URL string, headers map[string]string) (string, error) {
-	command := []string{"curl", "-v", "-k", "-L", "-o", "/dev/null"}
+	command := []string{"curl", "-s", "-v", "-k", "-L", "-o", "/dev/null"}
 	for k, v := range headers {
 		command = append(command, "-H", fmt.Sprintf("%s", k+":"+v))
 	}


### PR DESCRIPTION
Sometimes progress bar could overlap with output of headers:
```
> GET /v2/e2e-test-image-mirror-6kfk4/mirror-8411f276df6b9760ff42e9f92503a1bf6236d47d/manifests/sha256:6a7d45238874e24bf677f3724ece6f8a3fccc9deae5b80be3cfe18a2f4bfc0b2 HTTP/1.1
      > User-Agent: curl/7.29.0
      > Host: 172.30.215.36:5000
      > Accept: */*
      > Authorization:bearer P7ZQZkM4TNCSbAKPnhHHSAAAAAAAAAAA
      > 
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0< HTTP/1.1 200 OK
      < Content-Length: 1148
      < Content-Type: application/vnd.docker.distribution.manifest.v2+json
```
This causes an error because the string `< HTTP/1.1 200 OK` is not at the beginning of the line. In this case, it will be correct to remove the unnecessary progress bar.

