### PR TITLE
Use arping when claiming egress IPs

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -5,8 +5,10 @@ package node
 import (
 	"fmt"
 	"net"
+	"os/exec"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -151,6 +153,17 @@ func (eip *egressIPWatcher) assignEgressIP(egressIP, mark string) error {
 			return fmt.Errorf("could not add egress IP %q to %s: %v", egressIPNet, eip.localEgressLink.Attrs().Name, err)
 		}
 	}
+	// Use arping to try to update other hosts ARP caches, in case this IP was
+	// previously active on another node. (Based on code from "ifup".)
+	go func() {
+		out, err := exec.Command("/sbin/arping", "-q", "-A", "-c", "1", "-I", eip.localEgressLink.Attrs().Name, egressIP).CombinedOutput()
+		if err != nil {
+			glog.Warning("Failed to send ARP claim for egress IP %q: %v (%s)", egressIP, err, string(out))
+			return
+		}
+		time.Sleep(2 * time.Second)
+		_ = exec.Command("/sbin/arping", "-q", "-U", "-c", "1", "-I", eip.localEgressLink.Attrs().Name, egressIP).Run()
+	}()
 
 	if err := eip.iptables.AddEgressIPRules(egressIP, mark); err != nil {
 		return fmt.Errorf("could not add egress IP iptables rule: %v", err)


### PR DESCRIPTION
When ifup brings up an interface, it calls /sbin/arping to send some unsolicited ARP messages to get other hosts on the subnet to update their ARP caches to reflect the new IP assignment. (This is particularly important when the IP in question was previously on a different host.)

We were copying this behavior in the egress-router, but not when adding egress IPs. This fixes that. (The fact that we weren't doing this in earlier releases isn't a huge deal since egress IPs weren't normally moved between hosts, but with #20258 this is more important.)

It seems like there should be a cleaner/more automatic way to do this, but AFAICT there isn't.