### PR TITLE
Must use `make build` in spec file to build ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ build-router-e2e-test:
 	hack/build-go.sh test/end-to-end/end-to-end.test
 .PHONY: build-router-e2e-test
 
+build-docs:
+	hack/generate-docs.sh
+.PHONY: build-docs
+
 # Run core verification and all self contained tests.
 #
 # Example:

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -335,6 +335,9 @@ readonly OS_ALL_IMAGES=(
 # os::build::check_binaries ensures that binary sizes do not grow without approval.
 function os::build::check_binaries() {
   platform=$(os::build::host_platform)
+  if [[ "${platform}" != "linux/amd64" && "${platform}" != "darwin/amd64" ]]; then
+    return 0
+  fi
   # enforce that certain binaries don't accidentally grow too large
   # IMPORTANT: contact Clayton or another master team member before altering this code
   if [[ -f "${OS_OUTPUT_BINPATH}/${platform}/oc" ]]; then

--- a/origin.spec
+++ b/origin.spec
@@ -13,7 +13,7 @@
 # this is the version we obsolete up to. The packaging changed for Origin
 # 1.0.6 and OSE 3.1 such that 'openshift' package names were no longer used.
 %global package_refactor_version 3.0.2.900
-%global golang_version 1.9.1
+%global golang_version 1.10
 # %commit and %os_git_vars are intended to be set by tito custom builders provided
 # in the .tito/lib directory. The values in this spec file will not be kept up to date.
 %{!?commit:
@@ -229,7 +229,7 @@ of docker.  Exclude those versions of docker.
 %if 0%{make_redistributable}
 # Create Binaries for all supported arches
 %{os_git_vars} OS_BUILD_RELEASE_ARCHIVES=n make build-cross
-%{os_git_vars} hack/build-go.sh vendor/github.com/onsi/ginkgo/ginkgo
+%{os_git_vars} OS_BUILD_RELEASE_ARCHIVES=n make build WHAT=vendor/github.com/onsi/ginkgo/ginkgo
 %else
 # Create Binaries only for building arch
 %ifarch x86_64
@@ -248,11 +248,11 @@ of docker.  Exclude those versions of docker.
   BUILD_PLATFORM="linux/s390x"
 %endif
 OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} OS_BUILD_RELEASE_ARCHIVES=n make build-cross
-OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} hack/build-go.sh vendor/github.com/onsi/ginkgo/ginkgo
+OS_ONLY_BUILD_PLATFORMS="${BUILD_PLATFORM}" %{os_git_vars} OS_BUILD_RELEASE_ARCHIVES=n make build WHAT=vendor/github.com/onsi/ginkgo/ginkgo
 %endif
 
 # Generate man pages
-%{os_git_vars} hack/generate-docs.sh
+%{os_git_vars} make build-docs
 %endif
 
 %install


### PR DESCRIPTION
The OS_OUTPUT_GOPATH value is only set by the makefile, and an RPM build
environment won't have it set otherwise. This resulted in the RPM build
failing because the GOPATH didn't match the repo. 

Blocks 3.11 OCP builds @sosiouxme @adammhaile 