### PR TITLE
UPSTREAM 65593 and carry to expand critical pods to openshift namespaces

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/priority/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/priority/admission.go
@@ -19,6 +19,7 @@ package priority
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,7 +143,7 @@ func priorityClassPermittedInNamespace(priorityClassName string, namespace strin
 	// usage of these priorities. Pods created at these priorities could preempt system critical
 	// components.
 	for _, spc := range scheduling.SystemPriorityClasses() {
-		if spc.Name == priorityClassName && namespace != metav1.NamespaceSystem {
+		if spc.Name == priorityClassName && namespace != metav1.NamespaceSystem && !strings.HasPrefix(namespace, "openshift-") {
 			return false
 		}
 	}

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/priority/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/priority/admission.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -134,6 +135,20 @@ func (p *priorityPlugin) Validate(a admission.Attributes) error {
 	}
 }
 
+// priorityClassPermittedInNamespace returns true if we allow the given priority class name in the
+// given namespace. It currently checks that system priorities are created only in the system namespace.
+func priorityClassPermittedInNamespace(priorityClassName string, namespace string) bool {
+	// Only allow system priorities in the system namespace. This is to prevent abuse or incorrect
+	// usage of these priorities. Pods created at these priorities could preempt system critical
+	// components.
+	for _, spc := range scheduling.SystemPriorityClasses() {
+		if spc.Name == priorityClassName && namespace != metav1.NamespaceSystem {
+			return false
+		}
+	}
+	return true
+}
+
 // admitPod makes sure a new pod does not set spec.Priority field. It also makes sure that the PriorityClassName exists if it is provided and resolves the pod priority from the PriorityClassName.
 func (p *priorityPlugin) admitPod(a admission.Attributes) error {
 	operation := a.GetOperation()
@@ -162,6 +177,10 @@ func (p *priorityPlugin) admitPod(a admission.Attributes) error {
 				return fmt.Errorf("failed to get default priority class: %v", err)
 			}
 		} else {
+			pcName := pod.Spec.PriorityClassName
+			if !priorityClassPermittedInNamespace(pcName, a.GetNamespace()) {
+				return admission.NewForbidden(a, fmt.Errorf("pods with %v priorityClass is not permitted in %v namespace", pcName, a.GetNamespace()))
+			}
 			// Try resolving the priority class name.
 			pc, err := p.lister.Get(pod.Spec.PriorityClassName)
 			if err != nil {

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/priority/admission_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/priority/admission_test.go
@@ -389,6 +389,21 @@ func TestPodAdmission(t *testing.T) {
 				PriorityClassName: scheduling.SystemClusterCritical,
 			},
 		},
+		// pod[9]: Pod with a system priority class name in openshift namespace
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-w-system-priority-in-openshift-namespace",
+				Namespace: "openshift-logging",
+			},
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{
+						Name: containerName,
+					},
+				},
+				PriorityClassName: scheduling.SystemClusterCritical,
+			},
+		},
 	}
 	// Enable PodPriority feature gate.
 	utilfeature.DefaultFeatureGate.Set(fmt.Sprintf("%s=true", features.PodPriority))
@@ -480,6 +495,13 @@ func TestPodAdmission(t *testing.T) {
 			*pods[8],
 			scheduling.SystemCriticalPriority,
 			true,
+		},
+		{
+			"pod with system critical priority in openshift namespace",
+			[]*scheduling.PriorityClass{systemClusterCritical},
+			*pods[9],
+			scheduling.SystemCriticalPriority,
+			false,
 		},
 	}
 

--- a/vendor/k8s.io/kubernetes/test/e2e/scheduling/predicates.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/scheduling/predicates.go
@@ -47,6 +47,7 @@ var masterNodes sets.String
 
 type pausePodConfig struct {
 	Name                              string
+	Namespace                         string
 	Affinity                          *v1.Affinity
 	Annotations, Labels, NodeSelector map[string]string
 	Resources                         *v1.ResourceRequirements
@@ -622,9 +623,11 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 })
 
 func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
+	var gracePeriod = int64(1)
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            conf.Name,
+			Namespace:       conf.Namespace,
 			Labels:          conf.Labels,
 			Annotations:     conf.Annotations,
 			OwnerReferences: conf.OwnerReferences,
@@ -639,9 +642,10 @@ func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 					Ports: conf.Ports,
 				},
 			},
-			Tolerations:       conf.Tolerations,
-			NodeName:          conf.NodeName,
-			PriorityClassName: conf.PriorityClassName,
+			Tolerations:                   conf.Tolerations,
+			NodeName:                      conf.NodeName,
+			PriorityClassName:             conf.PriorityClassName,
+			TerminationGracePeriodSeconds: &gracePeriod,
 		},
 	}
 	if conf.Resources != nil {
@@ -651,6 +655,10 @@ func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 }
 
 func createPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
+	namespace := conf.Namespace
+	if len(namespace) == 0 {
+		namespace = f.Namespace.Name
+	}
 	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(initPausePod(f, conf))
 	framework.ExpectNoError(err)
 	return pod
@@ -659,7 +667,7 @@ func createPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 func runPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 	pod := createPausePod(f, conf)
 	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.ClientSet, pod))
-	pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(conf.Name, metav1.GetOptions{})
+	pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(conf.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	return pod
 }

--- a/vendor/k8s.io/kubernetes/test/kubemark/resources/kube_dns_template.yaml
+++ b/vendor/k8s.io/kubernetes/test/kubemark/resources/kube_dns_template.yaml
@@ -60,7 +60,6 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: system-cluster-critical
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"


### PR DESCRIPTION
This has 2 commits.

206101a - This the upstream pick for limiting critical priority classes to kube-system namespace
8ddf9ae - This the carry for expanding critical pods to openshift namespace.

/cc @sjenning @aveshagarwal @derekwaynecarr @liggitt 
