### PR TITLE
Update tag, registry-info, registry-login, version, startbuild cmds

### DIFF
--- a/pkg/oc/admin/admin.go
+++ b/pkg/oc/admin/admin.go
@@ -144,7 +144,7 @@ func NewCommandAdmin(name, fullName string, f kcmdutil.Factory, streams genericc
 	)
 
 	if name == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, streams, cmd.VersionOptions{}))
+		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, cmd.NewVersionOptions(false, streams)))
 	}
 
 	return cmds

--- a/pkg/oc/cli/cli.go
+++ b/pkg/oc/cli/cli.go
@@ -227,7 +227,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 
 	cmds.AddCommand(cmd.NewCmdPlugin(fullName, f, ioStreams))
 	if name == fullName {
-		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, ioStreams, cmd.VersionOptions{PrintClientFeatures: true}))
+		cmds.AddCommand(cmd.NewCmdVersion(fullName, f, cmd.NewVersionOptions(true, ioStreams)))
 	}
 	cmds.AddCommand(cmd.NewCmdOptions(ioStreams))
 	cmds.AddCommand(cmd.NewCmdDeploy(fullName, f, ioStreams))

--- a/pkg/oc/cli/cmd/registry/info/info.go
+++ b/pkg/oc/cli/cmd/registry/info/info.go
@@ -2,7 +2,6 @@ package info
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -16,6 +15,7 @@ import (
 	imageclient "github.com/openshift/client-go/image/clientset/versioned"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/registryclient"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 var (
@@ -44,16 +44,18 @@ type Options struct {
 	Namespaces []string
 	Client     imageclient.Interface
 
-	Out    io.Writer
-	ErrOut io.Writer
+	genericclioptions.IOStreams
+}
+
+func NewRegistryInfoOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: streams,
+	}
 }
 
 // New creates a command that displays info about the registry.
-func New(name string, f kcmdutil.Factory, out, errOut io.Writer) *cobra.Command {
-	o := &Options{
-		Out:    out,
-		ErrOut: errOut,
-	}
+func NewRegistryInfoCmd(name string, f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRegistryInfoOptions(streams)
 
 	cmd := &cobra.Command{
 		Use:     "info ",

--- a/pkg/oc/cli/cmd/registry/login/login.go
+++ b/pkg/oc/cli/cmd/registry/login/login.go
@@ -27,6 +27,7 @@ import (
 	imageclient "github.com/openshift/client-go/image/clientset/versioned"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/registryclient"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 )
 
 var (
@@ -86,18 +87,20 @@ type LoginOptions struct {
 	Insecure        bool
 	CreateDirectory bool
 
-	Out    io.Writer
-	ErrOut io.Writer
-
 	ServiceAccount string
+
+	genericclioptions.IOStreams
+}
+
+func NewRegistryLoginOptions(streams genericclioptions.IOStreams) *LoginOptions {
+	return &LoginOptions{
+		IOStreams: streams,
+	}
 }
 
 // New logs you in to a docker registry locally.
-func New(name string, f kcmdutil.Factory, out, errOut io.Writer) *cobra.Command {
-	o := &LoginOptions{
-		Out:    out,
-		ErrOut: errOut,
-	}
+func NewRegistryLoginCmd(name string, f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRegistryLoginOptions(streams)
 
 	cmd := &cobra.Command{
 		Use:     "login ",

--- a/pkg/oc/cli/cmd/registry/registry.go
+++ b/pkg/oc/cli/cmd/registry/registry.go
@@ -35,8 +35,8 @@ func NewCmd(fullName string, f kcmdutil.Factory, streams genericclioptions.IOStr
 		{
 			Message: "Advanced commands:",
 			Commands: []*cobra.Command{
-				info.New(name, f, streams.Out, streams.ErrOut),
-				login.New(name, f, streams.Out, streams.ErrOut),
+				info.NewRegistryInfoCmd(name, f, streams),
+				login.NewRegistryLoginCmd(name, f, streams),
 			},
 		},
 	}

--- a/pkg/oc/cli/cmd/startbuild.go
+++ b/pkg/oc/cli/cmd/startbuild.go
@@ -86,13 +86,57 @@ var (
 	  %[1]s start-build hello-world --wait`)
 )
 
+type StartBuildOptions struct {
+	Git git.Repository
+
+	FromBuild    string
+	FromWebhook  string
+	ListWebhooks string
+
+	Commit      string
+	FromFile    string
+	FromDir     string
+	FromRepo    string
+	FromArchive string
+
+	Env  []string
+	Args []string
+
+	Follow              bool
+	WaitForComplete     bool
+	IncrementalOverride bool
+	Incremental         bool
+	NoCacheOverride     bool
+	NoCache             bool
+	LogLevel            string
+
+	GitRepository  string
+	GitPostReceive string
+
+	Mapper         meta.RESTMapper
+	BuildClient    buildclient.BuildInterface
+	BuildLogClient buildclientinternalmanual.BuildLogInterface
+	ClientConfig   *restclient.Config
+
+	AsBinary    bool
+	ShortOutput bool
+	EnvVar      []kapi.EnvVar
+	BuildArgs   []kapi.EnvVar
+	Name        string
+	Namespace   string
+
+	genericclioptions.IOStreams
+}
+
+func NewStartBuildOptions(streams genericclioptions.IOStreams) *StartBuildOptions {
+	return &StartBuildOptions{
+		IOStreams: streams,
+	}
+}
+
 // NewCmdStartBuild implements the OpenShift cli start-build command
 func NewCmdStartBuild(fullName string, f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	o := &StartBuildOptions{
-		In:     streams.In,
-		Out:    streams.Out,
-		ErrOut: streams.ErrOut,
-	}
+	o := NewStartBuildOptions(streams)
 
 	cmd := &cobra.Command{
 		Use:        "start-build (BUILDCONFIG | --from-build=BUILD)",
@@ -130,48 +174,6 @@ func NewCmdStartBuild(fullName string, f kcmdutil.Factory, streams genericcliopt
 
 	kcmdutil.AddOutputFlagsForMutation(cmd)
 	return cmd
-}
-
-type StartBuildOptions struct {
-	In          io.Reader
-	Out, ErrOut io.Writer
-	Git         git.Repository
-
-	FromBuild    string
-	FromWebhook  string
-	ListWebhooks string
-
-	Commit      string
-	FromFile    string
-	FromDir     string
-	FromRepo    string
-	FromArchive string
-
-	Env  []string
-	Args []string
-
-	Follow              bool
-	WaitForComplete     bool
-	IncrementalOverride bool
-	Incremental         bool
-	NoCacheOverride     bool
-	NoCache             bool
-	LogLevel            string
-
-	GitRepository  string
-	GitPostReceive string
-
-	Mapper         meta.RESTMapper
-	BuildClient    buildclient.BuildInterface
-	BuildLogClient buildclientinternalmanual.BuildLogInterface
-	ClientConfig   *restclient.Config
-
-	AsBinary    bool
-	ShortOutput bool
-	EnvVar      []kapi.EnvVar
-	BuildArgs   []kapi.EnvVar
-	Name        string
-	Namespace   string
 }
 
 func (o *StartBuildOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, cmdFullName string, args []string) error {

--- a/pkg/oc/cli/cmd/startbuild_test.go
+++ b/pkg/oc/cli/cmd/startbuild_test.go
@@ -22,6 +22,7 @@ import (
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildclient "github.com/openshift/origin/pkg/build/client/internalversion"
@@ -64,9 +65,8 @@ func TestStartBuildWebHook(t *testing.T) {
 	defer server.Close()
 
 	cfg := &FakeClientConfig{}
-	buf := &bytes.Buffer{}
 	o := &StartBuildOptions{
-		Out:          buf,
+		IOStreams:    genericclioptions.NewTestIOStreamsDiscard(),
 		ClientConfig: cfg.Client,
 		FromWebhook:  server.URL + "/webhook",
 		Mapper:       testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme),
@@ -77,7 +77,7 @@ func TestStartBuildWebHook(t *testing.T) {
 	<-invoked
 
 	o = &StartBuildOptions{
-		Out:            buf,
+		IOStreams:      genericclioptions.NewTestIOStreamsDiscard(),
 		FromWebhook:    server.URL + "/webhook",
 		GitPostReceive: "unknownpath",
 	}
@@ -109,9 +109,8 @@ func TestStartBuildHookPostReceive(t *testing.T) {
 	cfg := &FakeClientConfig{
 		Err: testErr,
 	}
-	buf := &bytes.Buffer{}
 	o := &StartBuildOptions{
-		Out:            buf,
+		IOStreams:      genericclioptions.NewTestIOStreamsDiscard(),
 		ClientConfig:   cfg.Client,
 		FromWebhook:    server.URL + "/webhook",
 		GitPostReceive: f.Name(),
@@ -360,9 +359,10 @@ func TestStreamBuildLogs(t *testing.T) {
 			}),
 		}
 
+		ioStreams, _, out, _ := genericclioptions.NewTestIOStreams()
+
 		o := &StartBuildOptions{
-			Out:            out,
-			ErrOut:         out,
+			IOStreams:      ioStreams,
 			BuildLogClient: buildclient.NewBuildLogClient(fakeREST, build.Namespace),
 		}
 

--- a/pkg/oc/cli/cmd/tag_test.go
+++ b/pkg/oc/cli/cmd/tag_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagefake "github.com/openshift/origin/pkg/image/generated/internalclientset/fake"
@@ -172,7 +173,7 @@ func TestTag(t *testing.T) {
 			return true, nil, kapierrors.NewMethodNotSupported(imageapi.Resource("imagestreamtags"), "update")
 		})
 
-		test.opts.out = os.Stdout
+		test.opts.IOStreams = genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr}
 		test.opts.isGetter = client.Image()
 		test.opts.isTagGetter = client.Image()
 
@@ -221,7 +222,7 @@ func TestRunTag_DeleteOld(t *testing.T) {
 		expectedErr     error
 	}{
 		opts: &TagOptions{
-			out:            os.Stdout,
+			IOStreams:      genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
 			isGetter:       client.Image(),
 			isTagGetter:    client.Image(),
 			deleteTag:      true,
@@ -265,7 +266,7 @@ func TestRunTag_AddNew(t *testing.T) {
 		expectedErr     error
 	}{
 		opts: &TagOptions{
-			out:         os.Stdout,
+			IOStreams:   genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
 			isGetter:    client.Image(),
 			isTagGetter: client.Image(),
 			ref: imageapi.DockerImageReference{
@@ -314,7 +315,7 @@ func TestRunTag_AddRestricted(t *testing.T) {
 		expectedErr     error
 	}{
 		opts: &TagOptions{
-			out:         os.Stdout,
+			IOStreams:   genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
 			isGetter:    client.Image(),
 			isTagGetter: client.Image(),
 			ref: imageapi.DockerImageReference{
@@ -361,7 +362,7 @@ func TestRunTag_DeleteNew(t *testing.T) {
 		expectedErr     error
 	}{
 		opts: &TagOptions{
-			out:            os.Stdout,
+			IOStreams:      genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
 			isGetter:       client.Image(),
 			isTagGetter:    client.Image(),
 			deleteTag:      true,

--- a/pkg/oc/cli/cmd/version.go
+++ b/pkg/oc/cli/cmd/version.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -31,7 +30,6 @@ var (
 
 type VersionOptions struct {
 	BaseName string
-	Out      io.Writer
 
 	ClientConfig *rest.Config
 	Clients      func() (kclientset.Interface, error)
@@ -41,10 +39,19 @@ type VersionOptions struct {
 	IsServer            bool
 	PrintEtcdVersion    bool
 	PrintClientFeatures bool
+
+	genericclioptions.IOStreams
+}
+
+func NewVersionOptions(printClientFeatures bool, streams genericclioptions.IOStreams) *VersionOptions {
+	return &VersionOptions{
+		IOStreams:           streams,
+		PrintClientFeatures: printClientFeatures,
+	}
 }
 
 // NewCmdVersion creates a command for displaying the version of this binary
-func NewCmdVersion(fullName string, f kcmdutil.Factory, streams genericclioptions.IOStreams, options VersionOptions) *cobra.Command {
+func NewCmdVersion(fullName string, f kcmdutil.Factory, options *VersionOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display client and server versions",
@@ -52,7 +59,7 @@ func NewCmdVersion(fullName string, f kcmdutil.Factory, streams genericclioption
 		Run: func(cmd *cobra.Command, args []string) {
 			options.BaseName = fullName
 
-			if err := options.Complete(cmd, f, streams.Out); err != nil {
+			if err := options.Complete(cmd, f); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageErrorf(cmd, err.Error()))
 			}
 
@@ -65,9 +72,7 @@ func NewCmdVersion(fullName string, f kcmdutil.Factory, streams genericclioption
 	return cmd
 }
 
-func (o *VersionOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, out io.Writer) error {
-	o.Out = out
-
+func (o *VersionOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory) error {
 	if f == nil {
 		return nil
 	}


### PR DESCRIPTION
Updates `tag`, `registry/info`, `registry/login`, `version`, `startbuild` commands with upstream patterns.

cc @deads2k 