### PR TITLE
Bug 1596440 - surface OOMKilled pod to build

### DIFF
--- a/pkg/build/apis/build/types.go
+++ b/pkg/build/apis/build/types.go
@@ -514,6 +514,9 @@ const (
 	// range of build failures.
 	StatusReasonGenericBuildFailed StatusReason = "GenericBuildFailed"
 
+	// StatusReasonOutOfMemoryKilled indicates that the build pod was killed for its memory consumption
+	StatusReasonOutOfMemoryKilled StatusReason = "OutOfMemoryKilled"
+
 	// StatusCannotRetrieveServiceAccount is the reason associated with a failure
 	// to look up the service account associated with the BuildConfig.
 	StatusReasonCannotRetrieveServiceAccount StatusReason = "CannotRetrieveServiceAccount"
@@ -540,6 +543,7 @@ const (
 	StatusMessageNoBuildContainerStatus          = "The pod for this build has no container statuses indicating success or failure."
 	StatusMessageFailedContainer                 = "The pod for this build has at least one container with a non-zero exit status."
 	StatusMessageGenericBuildFailed              = "Generic Build failure - check logs for details."
+	StatusMessageOutOfMemoryKilled               = "The build pod was killed due to an out of memory condition."
 	StatusMessageUnresolvableEnvironmentVariable = "Unable to resolve build environment variable reference."
 	StatusMessageCannotRetrieveServiceAccount    = "Unable to look up the service account secrets for this build."
 )

--- a/pkg/build/registry/build/strategy.go
+++ b/pkg/build/registry/build/strategy.go
@@ -53,7 +53,11 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	// of the reason and message. This is to prevent the build controller from
 	// overwriting the reason and message that was set by the builder pod
 	// when it updated the build's details.
-	if oldBuild.Status.Phase == buildapi.BuildPhaseFailed {
+	// Only allow OOMKilled override because various processes in a container
+	// can get OOMKilled and this confuses builder to prematurely populate
+	// failure reason
+	if oldBuild.Status.Phase == buildapi.BuildPhaseFailed &&
+		newBuild.Status.Reason != buildapi.StatusReasonOutOfMemoryKilled {
 		newBuild.Status.Reason = oldBuild.Status.Reason
 		newBuild.Status.Message = oldBuild.Status.Message
 	}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -46,6 +46,7 @@
 // test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
 // test/extended/testdata/builds/statusfail-fetchsources2i.yaml
 // test/extended/testdata/builds/statusfail-genericreason.yaml
+// test/extended/testdata/builds/statusfail-oomkilled.yaml
 // test/extended/testdata/builds/statusfail-postcommithook.yaml
 // test/extended/testdata/builds/statusfail-pushtoregistry.yaml
 // test/extended/testdata/builds/sti-environment-build-app/.sti/environment
@@ -1969,6 +1970,40 @@ func testExtendedTestdataBuildsStatusfailGenericreasonYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/builds/statusfail-genericreason.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsStatusfailOomkilledYaml = []byte(`kind: BuildConfig
+apiVersion: v1
+metadata:
+  name: statusfail-oomkilled
+spec:
+  resources:
+    limits:
+      memory: 10Mi
+  source:
+    git:
+      uri: "https://github.com/openshift/ruby-hello-world"
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: centos/ruby-23-centos7:latest
+`)
+
+func testExtendedTestdataBuildsStatusfailOomkilledYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsStatusfailOomkilledYaml, nil
+}
+
+func testExtendedTestdataBuildsStatusfailOomkilledYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsStatusfailOomkilledYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/statusfail-oomkilled.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -33607,6 +33642,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml": testExtendedTestdataBuildsStatusfailFetchsourcedockerYaml,
 	"test/extended/testdata/builds/statusfail-fetchsources2i.yaml": testExtendedTestdataBuildsStatusfailFetchsources2iYaml,
 	"test/extended/testdata/builds/statusfail-genericreason.yaml": testExtendedTestdataBuildsStatusfailGenericreasonYaml,
+	"test/extended/testdata/builds/statusfail-oomkilled.yaml": testExtendedTestdataBuildsStatusfailOomkilledYaml,
 	"test/extended/testdata/builds/statusfail-postcommithook.yaml": testExtendedTestdataBuildsStatusfailPostcommithookYaml,
 	"test/extended/testdata/builds/statusfail-pushtoregistry.yaml": testExtendedTestdataBuildsStatusfailPushtoregistryYaml,
 	"test/extended/testdata/builds/sti-environment-build-app/.sti/environment": testExtendedTestdataBuildsStiEnvironmentBuildAppStiEnvironment,
@@ -34076,6 +34112,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"statusfail-fetchsourcedocker.yaml": &bintree{testExtendedTestdataBuildsStatusfailFetchsourcedockerYaml, map[string]*bintree{}},
 					"statusfail-fetchsources2i.yaml": &bintree{testExtendedTestdataBuildsStatusfailFetchsources2iYaml, map[string]*bintree{}},
 					"statusfail-genericreason.yaml": &bintree{testExtendedTestdataBuildsStatusfailGenericreasonYaml, map[string]*bintree{}},
+					"statusfail-oomkilled.yaml": &bintree{testExtendedTestdataBuildsStatusfailOomkilledYaml, map[string]*bintree{}},
 					"statusfail-postcommithook.yaml": &bintree{testExtendedTestdataBuildsStatusfailPostcommithookYaml, map[string]*bintree{}},
 					"statusfail-pushtoregistry.yaml": &bintree{testExtendedTestdataBuildsStatusfailPushtoregistryYaml, map[string]*bintree{}},
 					"sti-environment-build-app": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -1,0 +1,17 @@
+kind: BuildConfig
+apiVersion: v1
+metadata:
+  name: statusfail-oomkilled
+spec:
+  resources:
+    limits:
+      memory: 10Mi
+  source:
+    git:
+      uri: "https://github.com/openshift/ruby-hello-world"
+  strategy:
+    type: Source
+    sourceStrategy:
+      from:
+        kind: DockerImage
+        name: centos/ruby-23-centos7:latest


### PR DESCRIPTION
Init container can be OOMKilled as well, that way the OOMKilled doesn't bubble up to the `pod.status.reason` but remains among `pod.status.initcontainerstatuses`.

Comparing as a string because it looks like kubelet is setting this as a raw string as well, I couldn't find any constants representing OOMKilled reason
https://github.com/openshift/origin/blob/ea877acae817559712c8d42ef2c5caee880d319d/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_container.go#L355-L359

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596440
ptal @openshift/sig-developer-experience 