### PR TITLE
add debugging to test-cmd

### DIFF
--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -522,15 +522,11 @@ function os::start::internal::openshift_executable() {
 
 		openshift_executable="${sudo} docker run ${docker_options} ${volumes} ${envvars} openshift/origin:${version}"
 	else
-		local envvars=""
-		if [[ -n "${ENV:-}" ]]; then
-			envvars="env "
-			for envvar in "${ENV[@]}"; do
-				envvars+="${envvar} "
-			done
-		fi
-
-		openshift_executable="${sudo} ${envvars} $(which openshift)"
+		if [[ -n "${sudo}" ]]; then
+        	openshift_executable="${sudo} -E $(which openshift)"
+        else
+        	openshift_executable="$(which openshift)"
+        fi
 	fi
 
 	echo "${openshift_executable}"

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -18,7 +18,7 @@ trap os::test::junit::reconcile_output EXIT
   oc delete identities/anypassword:cascaded-user
   oc adm policy reconcile-cluster-roles --confirm --additive-only=false
   oc adm policy reconcile-cluster-role-bindings --confirm --additive-only=false
-) &>/dev/null
+)
 
 project="$( oc project -q )"
 

--- a/test/cmd/annotations.sh
+++ b/test/cmd/annotations.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/annotate"

--- a/test/cmd/authentication.sh
+++ b/test/cmd/authentication.sh
@@ -11,10 +11,10 @@ fi
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete oauthaccesstokens --all
+  oc delete oauthaccesstokens --all --loglevel=8
   oc adm policy remove-cluster-role-from-user cluster-debugger user3
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/authentication"
 

--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -8,9 +8,9 @@ trap os::test::junit::reconcile_output EXIT
   oc delete all,templates,secrets,pods,jobs --all
   oc delete image v1-image
   oc delete group patch-group
-  oc delete project test-project-admin
+  oc delete project test-project-admin --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 function escape_regex() {
   sed 's/[]\.|$(){}?+*^]/\\&/g' <<< "$*"

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 url=":${API_PORT:-8443}"

--- a/test/cmd/config.sh
+++ b/test/cmd/config.sh
@@ -12,9 +12,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates,secrets --all
+  oc delete all,templates,secrets --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 # check to make sure that "get"ting a resource with no config file present
 # still returns error indicating that no config-file is set

--- a/test/cmd/convert.sh
+++ b/test/cmd/convert.sh
@@ -12,9 +12,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all --all
+  oc delete all --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/convert"
 # This test validates the convert command

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/create"

--- a/test/cmd/debug.sh
+++ b/test/cmd/debug.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/debug"
 # This test validates the debug command

--- a/test/cmd/deployments.sh
+++ b/test/cmd/deployments.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/deployments"

--- a/test/cmd/describer.sh
+++ b/test/cmd/describer.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/describe"

--- a/test/cmd/dns.sh
+++ b/test/cmd/dns.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete svc,endpoints --all
+  oc delete svc,endpoints --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/dns"

--- a/test/cmd/edit.sh
+++ b/test/cmd/edit.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/edit"

--- a/test/cmd/explain.sh
+++ b/test/cmd/explain.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/explain"

--- a/test/cmd/export.sh
+++ b/test/cmd/export.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/export"

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/get"

--- a/test/cmd/idle.sh
+++ b/test/cmd/idle.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 project="$(oc project -q)"
 idled_at_annotation='idling.alpha.openshift.io/idled-at'

--- a/test/cmd/image-lookup.sh
+++ b/test/cmd/image-lookup.sh
@@ -5,10 +5,10 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,is,pods --all
+  oc delete all,is,pods --all --loglevel=8
 
   exit 0
-) &> /dev/null
+)
 
 project="$( oc project -q )"
 

--- a/test/cmd/images.sh
+++ b/test/cmd/images.sh
@@ -9,11 +9,11 @@ trap os::test::junit::reconcile_output EXIT
   os::cmd::expect_success 'oc login -u system:admin'
   cluster_admin_context="$( oc config current-context )"
   os::cmd::expect_success "oc config use-context '${original_context}'"
-  oc delete project test-cmd-images-2 merge-tags --context=${cluster_admin_context}
-  oc delete all,templates --all --context=${cluster_admin_context}
+  oc delete project test-cmd-images-2 merge-tags --context=${cluster_admin_context} --loglevel=8
+  oc delete all,templates --all --context=${cluster_admin_context} --loglevel=8
 
   exit 0
-) &> /dev/null
+)
 
 project="$( oc project -q )"
 

--- a/test/cmd/login.sh
+++ b/test/cmd/login.sh
@@ -12,9 +12,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete project project-foo
+  oc delete project project-foo --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/login"
 # This test validates login functionality for the client

--- a/test/cmd/migrate.sh
+++ b/test/cmd/migrate.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all --all
+  oc delete all --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/migrate"
 # This test validates storage migration

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -6,10 +6,10 @@ trap os::test::junit::reconcile_output EXIT
 (
   set +e
 #  oc delete all,templates --all
-  oc delete-project template-substitute
-  oc delete-project prefix-template-substitute
+  oc delete project template-substitute --loglevel=8
+  oc delete project prefix-template-substitute --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::util::environment::setup_time_vars
 

--- a/test/cmd/quota.sh
+++ b/test/cmd/quota.sh
@@ -7,9 +7,9 @@ os::test::junit::declare_suite_start "cmd/quota"
 # Cleanup cluster resources created by this test suite
 (
   set +e
-  oc delete project quota-{foo,bar,asmail,images}
+  oc delete project quota-{foo,bar,asmail,images} --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/quota/clusterquota"
 

--- a/test/cmd/registry.sh
+++ b/test/cmd/registry.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all --all
+  oc delete all --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/registry/login"

--- a/test/cmd/router.sh
+++ b/test/cmd/router.sh
@@ -6,9 +6,9 @@ trap os::test::junit::reconcile_output EXIT
 (
   set +e
   oc adm policy remove-scc-from-user privileged -z router
-  oc delete sa/router -n default
+  oc delete sa/router -n default --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 defaultimage="openshift/origin-\${component}:latest"
 USE_IMAGES=${USE_IMAGES:-$defaultimage}

--- a/test/cmd/routes.sh
+++ b/test/cmd/routes.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete route foo bar testroute test-route new-route
+  oc delete route foo bar testroute test-route new-route --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/routes"

--- a/test/cmd/sdn.sh
+++ b/test/cmd/sdn.sh
@@ -5,12 +5,12 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete namespace sdn-test-1
-  oc delete namespace sdn-test-2
-  oc delete namespace sdn-test-3
-  oc delete egressnetworkpolicy --all
+  oc delete namespace sdn-test-1 --loglevel=8
+  oc delete namespace sdn-test-2 --loglevel=8
+  oc delete namespace sdn-test-3 --loglevel=8
+  oc delete egressnetworkpolicy --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/sdn"
 

--- a/test/cmd/secrets.sh
+++ b/test/cmd/secrets.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates,secrets --all
+  oc delete all,templates,secrets --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/secrets"

--- a/test/cmd/services.sh
+++ b/test/cmd/services.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all --loglevel=8
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/create-service-nodeport"

--- a/test/cmd/set-image.sh
+++ b/test/cmd/set-image.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/oc/set/image"

--- a/test/cmd/set-liveness-probe.sh
+++ b/test/cmd/set-liveness-probe.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/set-probe-liveness"

--- a/test/cmd/setbuildhook.sh
+++ b/test/cmd/setbuildhook.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/builds/setbuildhook"

--- a/test/cmd/setbuildsecret.sh
+++ b/test/cmd/setbuildsecret.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 os::test::junit::declare_suite_start "cmd/builds/setbuildsecret"
 # Validate the set build-secret command

--- a/test/cmd/status.sh
+++ b/test/cmd/status.sh
@@ -12,9 +12,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete project project-bar
+  oc delete project project-bar &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 login_kubeconfig="${ARTIFACT_DIR}/login.kubeconfig"
 cp "${KUBECONFIG}" "${login_kubeconfig}"

--- a/test/cmd/templates.sh
+++ b/test/cmd/templates.sh
@@ -5,12 +5,12 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
-  oc delete template/ruby-helloworld-sample -n openshift
-  oc delete project test-template-project
-  oc delete user someval someval=moreval someval=moreval2 someval=moreval3
+  oc delete all,templates --all &>/dev/null
+  oc delete template/ruby-helloworld-sample -n openshift &>/dev/null
+  oc delete project test-template-project &>/dev/null
+  oc delete user someval someval=moreval someval=moreval2 someval=moreval3 &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/templates"

--- a/test/cmd/timeout.sh
+++ b/test/cmd/timeout.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/request-timeout"

--- a/test/cmd/triggers.sh
+++ b/test/cmd/triggers.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all --all
+  oc delete all --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 url=":${API_PORT:-8443}"

--- a/test/cmd/volumes.sh
+++ b/test/cmd/volumes.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates,pv,pvc --all
+  oc delete all,templates,pv,pvc --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/volumes"

--- a/test/cmd/whoami.sh
+++ b/test/cmd/whoami.sh
@@ -5,9 +5,9 @@ trap os::test::junit::reconcile_output EXIT
 # Cleanup cluster resources created by this test
 (
   set +e
-  oc delete all,templates --all
+  oc delete all,templates --all &>/dev/null
   exit 0
-) &>/dev/null
+)
 
 
 os::test::junit::declare_suite_start "cmd/whoami"


### PR DESCRIPTION
Best guess is that a cleanup function is failing.  Adding logging on the most likely commands, stop piping to dev/null.

@smarterclayton @stevekuznetsov it used to be that I could kick a dozen jenkins jobs directly to watch CI flakes.  How can I do that now?