### PR TITLE
switch imagestream refs to pull from new registry

### DIFF
--- a/examples/image-streams/image-streams-rhel7.json
+++ b/examples/image-streams/image-streams-rhel7.json
@@ -45,7 +45,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/httpd-24-rhel7"
+              "name": "registry.redhat.io/rhscl/httpd-24-rhel7"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -94,7 +94,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-1-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/jenkins-1-rhel7:latest"
             },
             "name": "1",
             "referencePolicy": {
@@ -112,7 +112,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.11"
+              "name": "registry.redhat.io/openshift3/jenkins-2-rhel7:v3.11"
             },
             "name": "2",
             "referencePolicy": {
@@ -161,7 +161,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mariadb-101-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mariadb-101-rhel7:latest"
             },
             "name": "10.1",
             "referencePolicy": {
@@ -179,7 +179,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mariadb-102-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
             },
             "name": "10.2",
             "referencePolicy": {
@@ -228,7 +228,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/mongodb-24-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/mongodb-24-rhel7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -246,7 +246,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-26-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-26-rhel7:latest"
             },
             "name": "2.6",
             "referencePolicy": {
@@ -264,7 +264,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-32-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-32-rhel7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -282,7 +282,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-34-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-34-rhel7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -300,7 +300,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-36-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-36-rhel7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -349,7 +349,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/mysql-55-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/mysql-55-rhel7:latest"
             },
             "name": "5.5",
             "referencePolicy": {
@@ -367,7 +367,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mysql-56-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mysql-56-rhel7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -385,7 +385,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mysql-57-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mysql-57-rhel7:latest"
             },
             "name": "5.7",
             "referencePolicy": {
@@ -419,7 +419,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-18-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-18-rhel7:latest"
             },
             "name": "1.8",
             "referencePolicy": {
@@ -439,7 +439,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-110-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-110-rhel7:latest"
             },
             "name": "1.10",
             "referencePolicy": {
@@ -459,7 +459,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-112-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-112-rhel7:latest"
             },
             "name": "1.12",
             "referencePolicy": {
@@ -531,7 +531,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/nodejs-010-rhel7:latest"
             },
             "name": "0.10",
             "referencePolicy": {
@@ -551,7 +551,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-4-rhel7:latest"
             },
             "name": "4",
             "referencePolicy": {
@@ -571,7 +571,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-6-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-6-rhel7:latest"
             },
             "name": "6",
             "referencePolicy": {
@@ -590,7 +590,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-8-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-8-rhel7:latest"
             },
             "name": "8",
             "referencePolicy": {
@@ -609,7 +609,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-8"
+              "name": "registry.redhat.io/rhoar-nodejs/nodejs-8"
             },
             "name": "8-RHOAR",
             "referencePolicy": {
@@ -628,7 +628,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-10"
+              "name": "registry.redhat.io/rhoar-nodejs/nodejs-10"
             },
             "name": "10",
             "referencePolicy": {
@@ -681,7 +681,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/perl-516-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/perl-516-rhel7:latest"
             },
             "name": "5.16",
             "referencePolicy": {
@@ -701,7 +701,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-520-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-520-rhel7:latest"
             },
             "name": "5.20",
             "referencePolicy": {
@@ -721,7 +721,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-524-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-524-rhel7:latest"
             },
             "name": "5.24",
             "referencePolicy": {
@@ -741,7 +741,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-526-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-526-rhel7:latest"
             },
             "name": "5.26",
             "referencePolicy": {
@@ -794,7 +794,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/php-55-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/php-55-rhel7:latest"
             },
             "name": "5.5",
             "referencePolicy": {
@@ -814,7 +814,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-56-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-56-rhel7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -834,7 +834,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-70-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-70-rhel7:latest"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -854,7 +854,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-71-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-71-rhel7:latest"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -903,7 +903,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/postgresql-92-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/postgresql-92-rhel7:latest"
             },
             "name": "9.2",
             "referencePolicy": {
@@ -921,7 +921,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-94-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-94-rhel7:latest"
             },
             "name": "9.4",
             "referencePolicy": {
@@ -939,7 +939,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-95-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-95-rhel7:latest"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -957,7 +957,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-96-rhel7:latest"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -975,7 +975,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-10-rhel7:latest"
             },
             "name": "10",
             "referencePolicy": {
@@ -1028,7 +1028,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/python-33-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/python-33-rhel7:latest"
             },
             "name": "3.3",
             "referencePolicy": {
@@ -1048,7 +1048,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-27-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-27-rhel7:latest"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -1068,7 +1068,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-34-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-34-rhel7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -1088,7 +1088,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-35-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-35-rhel7:latest"
             },
             "name": "3.5",
             "referencePolicy": {
@@ -1108,7 +1108,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-36-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-36-rhel7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -1157,7 +1157,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/redis-32-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/redis-32-rhel7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -1210,7 +1210,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/ruby-20-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/ruby-20-rhel7:latest"
             },
             "name": "2.0",
             "referencePolicy": {
@@ -1230,7 +1230,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-22-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-22-rhel7:latest"
             },
             "name": "2.2",
             "referencePolicy": {
@@ -1250,7 +1250,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-23-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-23-rhel7:latest"
             },
             "name": "2.3",
             "referencePolicy": {
@@ -1270,7 +1270,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-24-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-24-rhel7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -1290,7 +1290,7 @@
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-25-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "name": "2.5",
             "referencePolicy": {

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -1691,7 +1691,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/httpd-24-rhel7"
+              "name": "registry.redhat.io/rhscl/httpd-24-rhel7"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -1740,7 +1740,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-1-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/jenkins-1-rhel7:latest"
             },
             "name": "1",
             "referencePolicy": {
@@ -1758,7 +1758,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.11"
+              "name": "registry.redhat.io/openshift3/jenkins-2-rhel7:v3.11"
             },
             "name": "2",
             "referencePolicy": {
@@ -1807,7 +1807,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mariadb-101-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mariadb-101-rhel7:latest"
             },
             "name": "10.1",
             "referencePolicy": {
@@ -1825,7 +1825,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mariadb-102-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
             },
             "name": "10.2",
             "referencePolicy": {
@@ -1874,7 +1874,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/mongodb-24-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/mongodb-24-rhel7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -1892,7 +1892,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-26-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-26-rhel7:latest"
             },
             "name": "2.6",
             "referencePolicy": {
@@ -1910,7 +1910,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-32-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-32-rhel7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -1928,7 +1928,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-34-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-34-rhel7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -1946,7 +1946,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-36-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-36-rhel7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -1995,7 +1995,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/mysql-55-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/mysql-55-rhel7:latest"
             },
             "name": "5.5",
             "referencePolicy": {
@@ -2013,7 +2013,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mysql-56-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mysql-56-rhel7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -2031,7 +2031,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mysql-57-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mysql-57-rhel7:latest"
             },
             "name": "5.7",
             "referencePolicy": {
@@ -2065,7 +2065,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-18-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-18-rhel7:latest"
             },
             "name": "1.8",
             "referencePolicy": {
@@ -2085,7 +2085,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-110-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-110-rhel7:latest"
             },
             "name": "1.10",
             "referencePolicy": {
@@ -2105,7 +2105,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-112-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-112-rhel7:latest"
             },
             "name": "1.12",
             "referencePolicy": {
@@ -2177,7 +2177,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/nodejs-010-rhel7:latest"
             },
             "name": "0.10",
             "referencePolicy": {
@@ -2197,7 +2197,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-4-rhel7:latest"
             },
             "name": "4",
             "referencePolicy": {
@@ -2217,7 +2217,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-6-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-6-rhel7:latest"
             },
             "name": "6",
             "referencePolicy": {
@@ -2236,7 +2236,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-8-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-8-rhel7:latest"
             },
             "name": "8",
             "referencePolicy": {
@@ -2255,7 +2255,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-8"
+              "name": "registry.redhat.io/rhoar-nodejs/nodejs-8"
             },
             "name": "8-RHOAR",
             "referencePolicy": {
@@ -2274,7 +2274,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-10"
+              "name": "registry.redhat.io/rhoar-nodejs/nodejs-10"
             },
             "name": "10",
             "referencePolicy": {
@@ -2327,7 +2327,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/perl-516-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/perl-516-rhel7:latest"
             },
             "name": "5.16",
             "referencePolicy": {
@@ -2347,7 +2347,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-520-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-520-rhel7:latest"
             },
             "name": "5.20",
             "referencePolicy": {
@@ -2367,7 +2367,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-524-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-524-rhel7:latest"
             },
             "name": "5.24",
             "referencePolicy": {
@@ -2387,7 +2387,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-526-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-526-rhel7:latest"
             },
             "name": "5.26",
             "referencePolicy": {
@@ -2440,7 +2440,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/php-55-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/php-55-rhel7:latest"
             },
             "name": "5.5",
             "referencePolicy": {
@@ -2460,7 +2460,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-56-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-56-rhel7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -2480,7 +2480,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-70-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-70-rhel7:latest"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -2500,7 +2500,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-71-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-71-rhel7:latest"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -2549,7 +2549,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/postgresql-92-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/postgresql-92-rhel7:latest"
             },
             "name": "9.2",
             "referencePolicy": {
@@ -2567,7 +2567,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-94-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-94-rhel7:latest"
             },
             "name": "9.4",
             "referencePolicy": {
@@ -2585,7 +2585,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-95-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-95-rhel7:latest"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -2603,7 +2603,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-96-rhel7:latest"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -2621,7 +2621,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-10-rhel7:latest"
             },
             "name": "10",
             "referencePolicy": {
@@ -2674,7 +2674,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/python-33-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/python-33-rhel7:latest"
             },
             "name": "3.3",
             "referencePolicy": {
@@ -2694,7 +2694,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-27-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-27-rhel7:latest"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -2714,7 +2714,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-34-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-34-rhel7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -2734,7 +2734,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-35-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-35-rhel7:latest"
             },
             "name": "3.5",
             "referencePolicy": {
@@ -2754,7 +2754,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-36-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-36-rhel7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -2803,7 +2803,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/redis-32-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/redis-32-rhel7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -2856,7 +2856,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/ruby-20-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/ruby-20-rhel7:latest"
             },
             "name": "2.0",
             "referencePolicy": {
@@ -2876,7 +2876,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-22-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-22-rhel7:latest"
             },
             "name": "2.2",
             "referencePolicy": {
@@ -2896,7 +2896,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-23-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-23-rhel7:latest"
             },
             "name": "2.3",
             "referencePolicy": {
@@ -2916,7 +2916,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-24-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-24-rhel7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -2936,7 +2936,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-25-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "name": "2.5",
             "referencePolicy": {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17177,7 +17177,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/httpd-24-rhel7"
+              "name": "registry.redhat.io/rhscl/httpd-24-rhel7"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -17226,7 +17226,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-1-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/jenkins-1-rhel7:latest"
             },
             "name": "1",
             "referencePolicy": {
@@ -17244,7 +17244,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.11"
+              "name": "registry.redhat.io/openshift3/jenkins-2-rhel7:v3.11"
             },
             "name": "2",
             "referencePolicy": {
@@ -17293,7 +17293,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mariadb-101-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mariadb-101-rhel7:latest"
             },
             "name": "10.1",
             "referencePolicy": {
@@ -17311,7 +17311,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mariadb-102-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mariadb-102-rhel7:latest"
             },
             "name": "10.2",
             "referencePolicy": {
@@ -17360,7 +17360,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/mongodb-24-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/mongodb-24-rhel7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -17378,7 +17378,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-26-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-26-rhel7:latest"
             },
             "name": "2.6",
             "referencePolicy": {
@@ -17396,7 +17396,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-32-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-32-rhel7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -17414,7 +17414,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-34-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-34-rhel7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -17432,7 +17432,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mongodb-36-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mongodb-36-rhel7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -17481,7 +17481,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/mysql-55-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/mysql-55-rhel7:latest"
             },
             "name": "5.5",
             "referencePolicy": {
@@ -17499,7 +17499,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mysql-56-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mysql-56-rhel7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -17517,7 +17517,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/mysql-57-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/mysql-57-rhel7:latest"
             },
             "name": "5.7",
             "referencePolicy": {
@@ -17551,7 +17551,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-18-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-18-rhel7:latest"
             },
             "name": "1.8",
             "referencePolicy": {
@@ -17571,7 +17571,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-110-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-110-rhel7:latest"
             },
             "name": "1.10",
             "referencePolicy": {
@@ -17591,7 +17591,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nginx-112-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nginx-112-rhel7:latest"
             },
             "name": "1.12",
             "referencePolicy": {
@@ -17663,7 +17663,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/nodejs-010-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/nodejs-010-rhel7:latest"
             },
             "name": "0.10",
             "referencePolicy": {
@@ -17683,7 +17683,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-4-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-4-rhel7:latest"
             },
             "name": "4",
             "referencePolicy": {
@@ -17703,7 +17703,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-6-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-6-rhel7:latest"
             },
             "name": "6",
             "referencePolicy": {
@@ -17722,7 +17722,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-8-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/nodejs-8-rhel7:latest"
             },
             "name": "8",
             "referencePolicy": {
@@ -17741,7 +17741,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-8"
+              "name": "registry.redhat.io/rhoar-nodejs/nodejs-8"
             },
             "name": "8-RHOAR",
             "referencePolicy": {
@@ -17760,7 +17760,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhoar-nodejs/nodejs-10"
+              "name": "registry.redhat.io/rhoar-nodejs/nodejs-10"
             },
             "name": "10",
             "referencePolicy": {
@@ -17813,7 +17813,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/perl-516-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/perl-516-rhel7:latest"
             },
             "name": "5.16",
             "referencePolicy": {
@@ -17833,7 +17833,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-520-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-520-rhel7:latest"
             },
             "name": "5.20",
             "referencePolicy": {
@@ -17853,7 +17853,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-524-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-524-rhel7:latest"
             },
             "name": "5.24",
             "referencePolicy": {
@@ -17873,7 +17873,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/perl-526-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/perl-526-rhel7:latest"
             },
             "name": "5.26",
             "referencePolicy": {
@@ -17926,7 +17926,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/php-55-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/php-55-rhel7:latest"
             },
             "name": "5.5",
             "referencePolicy": {
@@ -17946,7 +17946,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-56-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-56-rhel7:latest"
             },
             "name": "5.6",
             "referencePolicy": {
@@ -17966,7 +17966,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-70-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-70-rhel7:latest"
             },
             "name": "7.0",
             "referencePolicy": {
@@ -17986,7 +17986,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/php-71-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/php-71-rhel7:latest"
             },
             "name": "7.1",
             "referencePolicy": {
@@ -18035,7 +18035,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/postgresql-92-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/postgresql-92-rhel7:latest"
             },
             "name": "9.2",
             "referencePolicy": {
@@ -18053,7 +18053,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-94-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-94-rhel7:latest"
             },
             "name": "9.4",
             "referencePolicy": {
@@ -18071,7 +18071,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-95-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-95-rhel7:latest"
             },
             "name": "9.5",
             "referencePolicy": {
@@ -18089,7 +18089,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-96-rhel7:latest"
             },
             "name": "9.6",
             "referencePolicy": {
@@ -18107,7 +18107,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/postgresql-10-rhel7:latest"
             },
             "name": "10",
             "referencePolicy": {
@@ -18160,7 +18160,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/python-33-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/python-33-rhel7:latest"
             },
             "name": "3.3",
             "referencePolicy": {
@@ -18180,7 +18180,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-27-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-27-rhel7:latest"
             },
             "name": "2.7",
             "referencePolicy": {
@@ -18200,7 +18200,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-34-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-34-rhel7:latest"
             },
             "name": "3.4",
             "referencePolicy": {
@@ -18220,7 +18220,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-35-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-35-rhel7:latest"
             },
             "name": "3.5",
             "referencePolicy": {
@@ -18240,7 +18240,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/python-36-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/python-36-rhel7:latest"
             },
             "name": "3.6",
             "referencePolicy": {
@@ -18289,7 +18289,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/redis-32-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/redis-32-rhel7:latest"
             },
             "name": "3.2",
             "referencePolicy": {
@@ -18342,7 +18342,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/openshift3/ruby-20-rhel7:latest"
+              "name": "registry.redhat.io/openshift3/ruby-20-rhel7:latest"
             },
             "name": "2.0",
             "referencePolicy": {
@@ -18362,7 +18362,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-22-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-22-rhel7:latest"
             },
             "name": "2.2",
             "referencePolicy": {
@@ -18382,7 +18382,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-23-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-23-rhel7:latest"
             },
             "name": "2.3",
             "referencePolicy": {
@@ -18402,7 +18402,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-24-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-24-rhel7:latest"
             },
             "name": "2.4",
             "referencePolicy": {
@@ -18422,7 +18422,7 @@ var _examplesImageStreamsImageStreamsRhel7Json = []byte(`{
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/ruby-25-rhel7:latest"
+              "name": "registry.redhat.io/rhscl/ruby-25-rhel7:latest"
             },
             "name": "2.5",
             "referencePolicy": {


### PR DESCRIPTION
ansible is being updated here: https://github.com/openshift/openshift-ansible/pull/9200

note that the upstream repos are not updated, so running hack/update-external-examples will revert this change.  please don't commit these files if you run that script.
