### PR TITLE
disable all the problematic db replica tests

### DIFF
--- a/test/extended/image_ecosystem/mongodb_replica_statefulset.go
+++ b/test/extended/image_ecosystem/mongodb_replica_statefulset.go
@@ -5,14 +5,15 @@ import (
 	"time"
 
 	g "github.com/onsi/ginkgo"
-	o "github.com/onsi/gomega"
+	//	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	dbutil "github.com/openshift/origin/test/extended/util/db"
-	kapiv1 "k8s.io/api/core/v1"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
+	//	kapiv1 "k8s.io/api/core/v1"
+	//	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
+/*
 var _ = g.Describe("[Conformance][image_ecosystem][mongodb][Slow] openshift mongodb replication (with statefulset)", func() {
 	defer g.GinkgoRecover()
 
@@ -158,6 +159,7 @@ var _ = g.Describe("[Conformance][image_ecosystem][mongodb][Slow] openshift mong
 		})
 	})
 })
+*/
 
 func readRecordFromPod(oc *exutil.CLI, podName string) error {
 	// don't include _id field to output because it changes every time

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/db"
 	testutil "github.com/openshift/origin/test/util"
 
-	kapiv1 "k8s.io/api/core/v1"
+	//	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -193,8 +193,10 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase, cleanup func()) func() 
 	}
 }
 
+/*
 var _ = g.Describe("[image_ecosystem][mysql][Slow] openshift mysql replication", func() {
 	defer g.GinkgoRecover()
+	g.Skip("db replica tests are currently flaky and disabled")
 
 	var oc = exutil.NewCLI("mysql-replication", exutil.KubeConfigPath())
 	var pvs = []*kapiv1.PersistentVolume{}
@@ -240,3 +242,4 @@ var _ = g.Describe("[image_ecosystem][mysql][Slow] openshift mysql replication",
 		}
 	})
 })
+*/

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/db"
 	testutil "github.com/openshift/origin/test/util"
 
-	kapiv1 "k8s.io/api/core/v1"
+	//	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -27,8 +27,10 @@ var (
 	}
 )
 
+/*
 var _ = g.Describe("[image_ecosystem][postgresql][Slow][local] openshift postgresql replication", func() {
 	defer g.GinkgoRecover()
+	g.Skip("db replica tests are currently flaky and disabled")
 
 	var oc = exutil.NewCLI("postgresql-replication", exutil.KubeConfigPath())
 	var pvs = []*kapiv1.PersistentVolume{}
@@ -81,6 +83,7 @@ var _ = g.Describe("[image_ecosystem][postgresql][Slow][local] openshift postgre
 		}
 	})
 })
+*/
 
 // CreatePostgreSQLReplicationHelpers creates a set of PostgreSQL helpers for master,
 // slave an en extra helper that is used for remote login test.


### PR DESCRIPTION
these tests are unacceptably flaky and we've burned too many engineering resources on them already.  supporting db replica functionality on the SCL images is not part of our mission at this point, so i am dumping these tests.
