### PR TITLE
test/extended/deployments: do not check logs if deployment still running

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -326,13 +326,14 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 
 			out, err := oc.Run("logs").Args("-f", "dc/deployment-test").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("verifying the deployment is marked complete and scaled to zero")
+			o.Expect(waitForLatestCondition(oc, "deployment-test", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
+
 			g.By(fmt.Sprintf("checking the logs for substrings\n%s", out))
 			o.Expect(out).To(o.ContainSubstring("deployment-test-1 to 2"))
 			o.Expect(out).To(o.ContainSubstring("--> pre: Success"))
 			o.Expect(out).To(o.ContainSubstring("--> Success"))
-
-			g.By("verifying the deployment is marked complete and scaled to zero")
-			o.Expect(waitForLatestCondition(oc, "deployment-test", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 
 			g.By("verifying that scaling does not result in new pods")
 			out, err = oc.Run("scale").Args("dc/deployment-test", "--replicas=1").Output()

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -5653,7 +5653,7 @@ spec:
           command:
           - /bin/bash
           - -c
-          - "echo 'test pre hook executed' && sleep 5"
+          - "echo 'test pre hook executed' && sleep 15"
   template:
     metadata:
       labels:

--- a/test/extended/testdata/deployments/test-deployment-test.yaml
+++ b/test/extended/testdata/deployments/test-deployment-test.yaml
@@ -16,7 +16,7 @@ spec:
           command:
           - /bin/bash
           - -c
-          - "echo 'test pre hook executed' && sleep 5"
+          - "echo 'test pre hook executed' && sleep 15"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Checking logs of a deployment while still running is inherently racy as
we are seeing with CRI-O over Docker. Instead, wait for the deployment
to finish to check from logs that everything went ok.

This contains the same fix as #19763 to fix #19681.
The fix was originally for Docker but CRI-O runs certain operations
much faster than docker and likely the sleep 5 isn't sufficient, so,
increating it here to 15 and see.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>