### PR TITLE
Fix stale references to pkg/oc/admin

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -80,7 +80,7 @@
       "github.com/openshift/origin/pkg/cmd/server/apis/config/validation",
       "github.com/openshift/origin/pkg/cmd/server/handlers",
       "github.com/openshift/origin/pkg/oauth/util",
-      "github.com/openshift/origin/pkg/oc/admin",
+      "github.com/openshift/origin/pkg/oc/cli/admin",
       "github.com/openshift/origin/pkg/oc/cli/admin/createerrortemplate",
       "github.com/openshift/origin/pkg/oc/cli/admin/createlogintemplate",
       "github.com/openshift/origin/pkg/oc/cli/admin/createproviderselectiontemplate",
@@ -398,7 +398,7 @@
       "github.com/openshift/origin/pkg/oc"
     ],
     "ignoredSubTrees": [
-      "github.com/openshift/origin/pkg/oc/admin/groups/examples"
+      "github.com/openshift/origin/pkg/oc/cli/admin/groups/examples"
     ],
     "allowedImportPackageRoots": [
       "vendor/github.com/aws/aws-sdk-go",

--- a/pkg/authorization/apis/authorization/rbacconversion/conversion.go
+++ b/pkg/authorization/apis/authorization/rbacconversion/conversion.go
@@ -20,7 +20,6 @@ var (
 )
 
 // reconcileProtectAnnotation is the name of an annotation which prevents reconciliation if set to "true"
-// can't use this const in pkg/oc/admin/policy because of import cycle
 const reconcileProtectAnnotation = "openshift.io/reconcile-protect"
 
 func addConversionFuncs(scheme *runtime.Scheme) error {

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/README.md
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/README.md
@@ -94,7 +94,7 @@ save may be your own.
 
 A diagnostic is an object that conforms to the Diagnostic interface
 (see pkg/diagnostics/types/diagnostic.go). The diagnostic object should
-be built in one of the builders in the pkg/oc/admin/diagnostics
+be built in one of the builders in the pkg/oc/cli/admin/diagnostics
 package (based on whether it depends on client, cluster-admin, or host
 configuration). When executed, the diagnostic logs its findings into
 a result object. It should be assumed that they may run in parallel.

--- a/tools/testdebug/cmd/load_etcd.go
+++ b/tools/testdebug/cmd/load_etcd.go
@@ -27,7 +27,7 @@ import (
 	kubernetes "github.com/openshift/origin/pkg/cmd/server/kubernetes/master"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	"github.com/openshift/origin/pkg/cmd/server/start"
-	"github.com/openshift/origin/pkg/oc/admin/policy"
+	"github.com/openshift/origin/pkg/oc/cli/admin/policy"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )


### PR DESCRIPTION
#20322 left some stray references to `pkg/oc/admin`. In particular, the import in `tools/testdebug/cmd/load_etcd.go` causes `hack/update-deps.sh` to fail.

I don't know if the changes to `import-restrictions.json` are correct. I deleted the comment in `rbacconversion/conversion.go` because nothing in `pkg/oc` refers to that annotation anyway.