### PR TITLE
test/extended/deployments: check for deployment completion with deploymentRunTimeout

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -1076,8 +1076,9 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			// Deployment status can't be updated yet but should be right after
 			o.Expect(appsinternalutil.DeploymentStatusFor(rc1)).To(o.Equal(appsapi.DeploymentStatusRunning))
 			// It should finish right after
-			rc1, err = waitForRCModification(oc, namespace, rc1.Name, deploymentChangeTimeout,
+			rc1, err = waitForRCModification(oc, namespace, rc1.Name, deploymentRunTimeout,
 				rc1.GetResourceVersion(), func(rc *kapiv1.ReplicationController) (bool, error) {
+					e2e.Logf("Deployment status for RC: %#v", appsinternalutil.DeploymentStatusFor(rc))
 					return appsinternalutil.DeploymentStatusFor(rc) == appsapi.DeploymentStatusComplete, nil
 				})
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
We're seeing a bunch of flakies on this test (e.g. here https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/20265/pull-ci-origin-e2e-gcp-crio/1/)

Using run timeout here should help here so running a bunch of crio jobs now.

@mrunalp @smarterclayton PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>