### PR TITLE
apps: use external config when decoding from rc annotation

### DIFF
--- a/api/docs/api/v1.ReplicationController.adoc
+++ b/api/docs/api/v1.ReplicationController.adoc
@@ -1766,7 +1766,7 @@ Content-Type: application/json'
 
 {
   "kind": "Scale",
-  "apiVersion": "v1",
+  "apiVersion": "apps.openshift.io/v1",
   ...
 }
 
@@ -1783,7 +1783,7 @@ $ curl -k \
     https://$ENDPOINT/apis/extensions/v1beta1/namespaces/$NAMESPACE/replicationcontrollers/$NAME/scale <<'EOF'
 {
   "kind": "Scale",
-  "apiVersion": "v1",
+  "apiVersion": "apps.openshift.io/v1",
   ...
 }
 EOF

--- a/api/docs/oapi/v1.DeploymentConfig.adoc
+++ b/api/docs/oapi/v1.DeploymentConfig.adoc
@@ -2128,7 +2128,7 @@ Content-Type: application/json'
 
 {
   "kind": "Scale",
-  "apiVersion": "v1",
+  "apiVersion": "apps.openshift.io/v1",
   ...
 }
 
@@ -2145,7 +2145,7 @@ $ curl -k \
     https://$ENDPOINT/oapi/v1/namespaces/$NAMESPACE/deploymentconfigs/$NAME/scale <<'EOF'
 {
   "kind": "Scale",
-  "apiVersion": "v1",
+  "apiVersion": "apps.openshift.io/v1",
   ...
 }
 EOF

--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -114,6 +114,8 @@
     "allowedImportPackages": [
       "vendor/k8s.io/kubernetes/pkg/apis/core",
       "vendor/k8s.io/kubernetes/pkg/apis/core/v1",
+      "vendor/k8s.io/kubernetes/pkg/apis/extensions",
+      "vendor/k8s.io/kubernetes/pkg/apis/extensions/v1beta1",
       "github.com/openshift/origin/pkg/image/apis/image"
     ]
   },
@@ -133,6 +135,7 @@
       "vendor/k8s.io/kubernetes/pkg/apis/core",
       "vendor/k8s.io/kubernetes/pkg/apis/core/v1",
       "vendor/k8s.io/kubernetes/pkg/apis/rbac",
+      "vendor/k8s.io/kubernetes/pkg/apis/rbac/v1",
       "vendor/k8s.io/kubernetes/pkg/api/legacyscheme",
       "github.com/openshift/origin/pkg/authorization/apis/authorization/internal/serviceaccount"
     ]

--- a/pkg/api/legacy/apps.go
+++ b/pkg/api/legacy/apps.go
@@ -1,0 +1,65 @@
+package legacy
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/openshift/origin/pkg/apps/apis/apps"
+	appsv1helpers "github.com/openshift/origin/pkg/apps/apis/apps/v1"
+)
+
+// InstallLegacyApps this looks like a lot of duplication, but the code in the individual versions is living and may
+// change. The code here should never change and needs to allow the other code to move independently.
+func InstallLegacyApps(scheme *runtime.Scheme) {
+	InstallExternalLegacyApps(scheme)
+
+	schemeBuilder := runtime.NewSchemeBuilder(
+		addUngroupifiedInternalAppsTypes,
+		core.AddToScheme,
+		extensions.AddToScheme,
+
+		appsv1helpers.AddConversionFuncs,
+		appsv1helpers.RegisterDefaults,
+		appsv1helpers.RegisterConversions,
+	)
+	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
+}
+
+func InstallExternalLegacyApps(scheme *runtime.Scheme) {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		addUngroupifiedAppsTypes,
+		corev1.AddToScheme,
+		rbacv1.AddToScheme,
+	)
+	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
+}
+
+func addUngroupifiedAppsTypes(scheme *runtime.Scheme) error {
+	types := []runtime.Object{
+		&appsv1.DeploymentConfig{},
+		&appsv1.DeploymentConfigList{},
+		&appsv1.DeploymentConfigRollback{},
+		&appsv1.DeploymentRequest{},
+		&appsv1.DeploymentLog{},
+		&appsv1.DeploymentLogOptions{},
+	}
+	scheme.AddKnownTypes(GroupVersion, types...)
+	return nil
+}
+
+func addUngroupifiedInternalAppsTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(internalGroupVersion,
+		&apps.DeploymentConfig{},
+		&apps.DeploymentConfigList{},
+		&apps.DeploymentConfigRollback{},
+		&apps.DeploymentRequest{},
+		&apps.DeploymentLog{},
+		&apps.DeploymentLogOptions{},
+	)
+	return nil
+}

--- a/pkg/api/legacy/install.go
+++ b/pkg/api/legacy/install.go
@@ -5,8 +5,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
-	appsapiv1 "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildapiv1 "github.com/openshift/origin/pkg/build/apis/build/v1"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -40,9 +38,9 @@ func Kind(kind string) schema.GroupKind {
 	return schema.GroupKind{Group: GroupName, Kind: kind}
 }
 
-func InstallLegacyApps(scheme *runtime.Scheme) {
-	utilruntime.Must(appsapi.AddToSchemeInCoreGroup(scheme))
-	utilruntime.Must(appsapiv1.AddToSchemeInCoreGroup(scheme))
+// DEPRECATED
+func Resource(resource string) schema.GroupResource {
+	return schema.GroupResource{Group: GroupName, Resource: resource}
 }
 
 func InstallLegacyBuild(scheme *runtime.Scheme) {

--- a/pkg/api/meta/pods.go
+++ b/pkg/api/meta/pods.go
@@ -17,6 +17,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
+	oapps "github.com/openshift/api/apps"
 	appsapiv1 "github.com/openshift/api/apps/v1"
 	securityapiv1 "github.com/openshift/api/security/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
@@ -66,7 +67,7 @@ var resourcesToCheck = map[schema.GroupResource]schema.GroupKind{
 	{Group: "", Resource: "podsecuritypolicyselfsubjectreviews"}: {Group: "", Kind: "PodSecurityPolicySelfSubjectReview"},
 	{Group: "", Resource: "podsecuritypolicyreviews"}:            {Group: "", Kind: "PodSecurityPolicyReview"},
 
-	appsapi.Resource("deploymentconfigs"):                       appsapi.Kind("DeploymentConfig"),
+	oapps.Resource("deploymentconfigs"):                         oapps.Kind("DeploymentConfig"),
 	securityapi.Resource("podsecuritypolicysubjectreviews"):     securityapi.Kind("PodSecurityPolicySubjectReview"),
 	securityapi.Resource("podsecuritypolicyselfsubjectreviews"): securityapi.Kind("PodSecurityPolicySelfSubjectReview"),
 	securityapi.Resource("podsecuritypolicyreviews"):            securityapi.Kind("PodSecurityPolicyReview"),

--- a/pkg/apps/apis/apps/install/install.go
+++ b/pkg/apps/apis/apps/install/install.go
@@ -5,6 +5,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsapiv1 "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 )
@@ -16,6 +17,6 @@ func init() {
 // Install registers the API group and adds types to a scheme
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(appsapi.AddToScheme(scheme))
-	utilruntime.Must(appsapiv1.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(appsapiv1.SchemeGroupVersion))
+	utilruntime.Must(appsapiv1.Install(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(appsv1.GroupVersion))
 }

--- a/pkg/apps/apis/apps/register.go
+++ b/pkg/apps/apis/apps/register.go
@@ -3,52 +3,32 @@ package apps
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 const (
-	LegacyGroupName = ""
-	GroupName       = "apps.openshift.io"
+	GroupName = "apps.openshift.io"
 )
 
 var (
-	SchemeGroupVersion       = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
-	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: runtime.APIVersionInternal}
+	schemeBuilder = runtime.NewSchemeBuilder(
+		addKnownTypes,
+		core.AddToScheme,
+		extensions.AddToScheme,
+	)
+	Install = schemeBuilder.AddToScheme
 
-	LegacySchemeBuilder    = runtime.NewSchemeBuilder(addLegacyKnownTypes)
-	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
-
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// DEPRECATED kept for generated code
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+	// DEPRECATED kept for generated code
+	AddToScheme = schemeBuilder.AddToScheme
 )
 
-// Kind takes an unqualified kind and returns back a Group qualified GroupKind
-func Kind(kind string) schema.GroupKind {
-	return SchemeGroupVersion.WithKind(kind).GroupKind()
-}
-
-// Resource takes an unqualified resource and returns back a Group qualified GroupResource
+// Resource kept for generated code
+// DEPRECATED
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
-}
-
-// LegacyResource takes an unqualified resource and returns back a Group qualified
-// GroupResource using legacy API
-func LegacyResource(resource string) schema.GroupResource {
-	return LegacySchemeGroupVersion.WithResource(resource).GroupResource()
-}
-
-// Adds the list of known types to api.Scheme.
-func addLegacyKnownTypes(scheme *runtime.Scheme) error {
-	types := []runtime.Object{
-		&DeploymentConfig{},
-		&DeploymentConfigList{},
-		&DeploymentConfigRollback{},
-		&DeploymentRequest{},
-		&DeploymentLog{},
-		&DeploymentLogOptions{},
-	}
-	scheme.AddKnownTypes(LegacySchemeGroupVersion, types...)
-	return nil
 }
 
 // Adds the list of known types to api.Scheme.

--- a/pkg/apps/apis/apps/v1/conversion.go
+++ b/pkg/apps/apis/apps/v1/conversion.go
@@ -107,7 +107,7 @@ func Convert_apps_RollingDeploymentStrategyParams_To_v1_RollingDeploymentStrateg
 	return nil
 }
 
-func addConversionFuncs(scheme *runtime.Scheme) error {
+func AddConversionFuncs(scheme *runtime.Scheme) error {
 	return scheme.AddConversionFuncs(
 		Convert_v1_DeploymentTriggerImageChangeParams_To_apps_DeploymentTriggerImageChangeParams,
 		Convert_apps_DeploymentTriggerImageChangeParams_To_v1_DeploymentTriggerImageChangeParams,

--- a/pkg/apps/apis/apps/v1/conversion_test.go
+++ b/pkg/apps/apis/apps/v1/conversion_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/openshift/api/apps/v1"
 	newer "github.com/openshift/origin/pkg/apps/apis/apps"
@@ -19,12 +19,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 func init() {
-	kapi.AddToScheme(scheme)
-	kapiv1.AddToScheme(scheme)
-	LegacySchemeBuilder.AddToScheme(scheme)
-	newer.LegacySchemeBuilder.AddToScheme(scheme)
-	SchemeBuilder.AddToScheme(scheme)
-	newer.SchemeBuilder.AddToScheme(scheme)
+	utilruntime.Must(Install(scheme))
 }
 
 func TestTriggerRoundTrip(t *testing.T) {

--- a/pkg/apps/apis/apps/v1/defaults_test.go
+++ b/pkg/apps/apis/apps/v1/defaults_test.go
@@ -560,7 +560,7 @@ func TestDefaults(t *testing.T) {
 }
 
 func roundTrip(t *testing.T, obj runtime.Object) runtime.Object {
-	data, err := runtime.Encode(codecs.LegacyCodec(LegacySchemeGroupVersion), obj)
+	data, err := runtime.Encode(codecs.LegacyCodec(v1.GroupVersion), obj)
 	if err != nil {
 		t.Errorf("%v\n %#v", err, obj)
 		return nil

--- a/pkg/apps/apis/apps/v1/register.go
+++ b/pkg/apps/apis/apps/v1/register.go
@@ -1,29 +1,22 @@
 package v1
 
 import (
-	"github.com/openshift/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+	corev1conversions "k8s.io/kubernetes/pkg/apis/core/v1"
+	extensionsv1beta1conversions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 
-const (
-	LegacyGroupName = ""
-	GroupName       = "apps.openshift.io"
+	"github.com/openshift/api/apps/v1"
+	"github.com/openshift/origin/pkg/apps/apis/apps"
 )
 
 var (
-	SchemeGroupVersion       = schema.GroupVersion{Group: GroupName, Version: "v1"}
-	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: "v1"}
-
-	LegacySchemeBuilder    = runtime.NewSchemeBuilder(v1.DeprecatedInstallWithoutGroup, addConversionFuncs, RegisterDefaults, RegisterConversions)
-	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
-
-	SchemeBuilder = runtime.NewSchemeBuilder(v1.Install, addConversionFuncs, RegisterDefaults)
-	AddToScheme   = SchemeBuilder.AddToScheme
-
-	localSchemeBuilder = &SchemeBuilder
+	localSchemeBuilder = runtime.NewSchemeBuilder(
+		apps.Install,
+		v1.Install,
+		corev1conversions.AddToScheme,
+		extensionsv1beta1conversions.AddToScheme,
+		AddConversionFuncs,
+		RegisterDefaults,
+	)
+	Install = localSchemeBuilder.AddToScheme
 )
-
-func Resource(resource string) schema.GroupResource {
-	return SchemeGroupVersion.WithResource(resource).GroupResource()
-}

--- a/pkg/apps/controller/util/scheme.go
+++ b/pkg/apps/controller/util/scheme.go
@@ -4,9 +4,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	coreapi "k8s.io/kubernetes/pkg/apis/core"
 
 	appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/openshift/origin/pkg/api/legacy"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsv1helpers "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 )
@@ -22,22 +22,14 @@ var (
 )
 
 func init() {
-	utilruntime.Must(appsv1.Install(annotationDecodingScheme))
-	utilruntime.Must(appsv1.DeprecatedInstallWithoutGroup(annotationDecodingScheme))
+	legacy.InstallLegacyApps(annotationDecodingScheme)
 	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
-	utilruntime.Must(appsv1helpers.AddToScheme(annotationDecodingScheme))
-	utilruntime.Must(appsv1helpers.AddToSchemeInCoreGroup(annotationDecodingScheme))
-	utilruntime.Must(coreapi.AddToScheme(annotationDecodingScheme))
-	utilruntime.Must(appsapi.AddToScheme(annotationDecodingScheme))
-	utilruntime.Must(appsapi.AddToSchemeInCoreGroup(annotationDecodingScheme))
+	utilruntime.Must(appsv1helpers.Install(annotationDecodingScheme))
 	annotationDecoderCodecFactory := serializer.NewCodecFactory(annotationDecodingScheme)
 	annotationDecoder = annotationDecoderCodecFactory.UniversalDecoder(appsapi.SchemeGroupVersion)
 
-	utilruntime.Must(appsv1.Install(annotationEncodingScheme))
 	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
-	utilruntime.Must(appsv1helpers.AddToScheme(annotationEncodingScheme))
-	utilruntime.Must(coreapi.AddToScheme(annotationEncodingScheme))
-	utilruntime.Must(appsapi.AddToScheme(annotationEncodingScheme))
+	utilruntime.Must(appsv1helpers.Install(annotationEncodingScheme))
 	annotationEncoderCodecFactory := serializer.NewCodecFactory(annotationEncodingScheme)
-	annotationEncoder = annotationEncoderCodecFactory.LegacyCodec(appsv1.SchemeGroupVersion)
+	annotationEncoder = annotationEncoderCodecFactory.LegacyCodec(appsv1.GroupVersion)
 }

--- a/pkg/apps/registry/deployconfig/etcd/etcd.go
+++ b/pkg/apps/registry/deployconfig/etcd/etcd.go
@@ -20,6 +20,7 @@ import (
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/labels"
 
+	"github.com/openshift/api/apps"
 	appsapiv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/origin/pkg/api/legacy"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
@@ -54,7 +55,7 @@ func NewREST(optsGetter restoptions.Getter) (*REST, *StatusREST, *ScaleREST, err
 	store := &registry.Store{
 		NewFunc:                  func() runtime.Object { return &appsapi.DeploymentConfig{} },
 		NewListFunc:              func() runtime.Object { return &appsapi.DeploymentConfigList{} },
-		DefaultQualifiedResource: appsapi.Resource("deploymentconfigs"),
+		DefaultQualifiedResource: apps.Resource("deploymentconfigs"),
 
 		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 

--- a/pkg/apps/registry/deploylog/rest.go
+++ b/pkg/apps/registry/deploylog/rest.go
@@ -25,6 +25,7 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/controller"
 
+	"github.com/openshift/api/apps"
 	apiserverrest "github.com/openshift/origin/pkg/apiserver/rest"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	"github.com/openshift/origin/pkg/apps/apis/apps/validation"
@@ -96,14 +97,14 @@ func (r *REST) Get(ctx context.Context, name string, opts runtime.Object) (runti
 		return nil, apierrors.NewBadRequest("did not get an expected options.")
 	}
 	if errs := validation.ValidateDeploymentLogOptions(deployLogOpts); len(errs) > 0 {
-		return nil, apierrors.NewInvalid(appsapi.Kind("DeploymentLogOptions"), "", errs)
+		return nil, apierrors.NewInvalid(apps.Kind("DeploymentLogOptions"), "", errs)
 	}
 
 	// Fetch deploymentConfig and check latest version; if 0, there are no deployments
 	// for this config
 	config, err := r.dcClient.DeploymentConfigs(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return nil, apierrors.NewNotFound(appsapi.Resource("deploymentconfig"), name)
+		return nil, apierrors.NewNotFound(apps.Resource("deploymentconfig"), name)
 	}
 	desiredVersion := config.Status.LatestVersion
 	if desiredVersion == 0 {

--- a/pkg/apps/registry/instantiate/rest.go
+++ b/pkg/apps/registry/instantiate/rest.go
@@ -21,6 +21,7 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
+	"github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	"github.com/openshift/origin/pkg/apps/apis/apps/validation"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
@@ -65,7 +66,7 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		old := config
 
 		if errs := validation.ValidateRequestForDeploymentConfig(req, config); len(errs) > 0 {
-			return errors.NewInvalid(appsapi.Kind("DeploymentRequest"), req.Name, errs)
+			return errors.NewInvalid(apps.Kind("DeploymentRequest"), req.Name, errs)
 		}
 
 		// We need to process the deployment config before we can determine if it is possible to trigger
@@ -103,7 +104,7 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		config.Status.LatestVersion++
 
 		userInfo, _ := apirequest.UserFrom(ctx)
-		attrs := admission.NewAttributesRecord(config, old, appsapi.Kind("DeploymentConfig").WithVersion(""), config.Namespace, config.Name, appsapi.Resource("DeploymentConfig").WithVersion(""), "", admission.Update, userInfo)
+		attrs := admission.NewAttributesRecord(config, old, apps.Kind("DeploymentConfig").WithVersion(""), config.Namespace, config.Name, apps.Resource("DeploymentConfig").WithVersion(""), "", admission.Update, userInfo)
 		if err := s.admit.(admission.MutationInterface).Admit(attrs); err != nil {
 			return err
 		}

--- a/pkg/apps/registry/rollback/rest.go
+++ b/pkg/apps/registry/rollback/rest.go
@@ -13,17 +13,18 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
+	"github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	"github.com/openshift/origin/pkg/apps/apis/apps/validation"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
 	appsclientinternal "github.com/openshift/origin/pkg/apps/generated/internalclientset"
-	apps "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
+	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
 )
 
 // REST provides a rollback generation endpoint. Only the Create method is implemented.
 type REST struct {
 	generator RollbackGenerator
-	dn        apps.DeploymentConfigsGetter
+	dn        appsclient.DeploymentConfigsGetter
 	rn        kcoreclient.ReplicationControllersGetter
 }
 
@@ -55,7 +56,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	}
 
 	if errs := validation.ValidateDeploymentConfigRollback(rollback); len(errs) > 0 {
-		return nil, kerrors.NewInvalid(appsapi.Kind("DeploymentConfigRollback"), rollback.Name, errs)
+		return nil, kerrors.NewInvalid(apps.Kind("DeploymentConfigRollback"), rollback.Name, errs)
 	}
 	if err := createValidation(obj); err != nil {
 		return nil, err
@@ -104,5 +105,5 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 
 func newInvalidError(rollback *appsapi.DeploymentConfigRollback, reason string) error {
 	err := field.Invalid(field.NewPath("name"), rollback.Name, reason)
-	return kerrors.NewInvalid(appsapi.Kind("DeploymentConfigRollback"), rollback.Name, field.ErrorList{err})
+	return kerrors.NewInvalid(apps.Kind("DeploymentConfigRollback"), rollback.Name, field.ErrorList{err})
 }

--- a/pkg/apps/registry/rollback/rest_test.go
+++ b/pkg/apps/registry/rollback/rest_test.go
@@ -13,6 +13,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
+	"github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	_ "github.com/openshift/origin/pkg/apps/apis/apps/install"
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
@@ -195,7 +196,7 @@ func TestCreateMissingDeploymentConfig(t *testing.T) {
 	oc := &appsfake.Clientset{}
 	oc.AddReactor("get", "deploymentconfigs", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
 		dc := appstest.OkDeploymentConfig(2)
-		return true, nil, kerrors.NewNotFound(appsapi.Resource("deploymentConfig"), dc.Name)
+		return true, nil, kerrors.NewNotFound(apps.Resource("deploymentConfig"), dc.Name)
 	})
 	kc := &fake.Clientset{}
 	kc.AddReactor("get", "replicationcontrollers", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {

--- a/pkg/apps/strategy/recreate/recreate.go
+++ b/pkg/apps/strategy/recreate/recreate.go
@@ -22,8 +22,6 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	imageclienttyped "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	appsinternal "github.com/openshift/origin/pkg/apps/apis/apps"
-	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
 	strat "github.com/openshift/origin/pkg/apps/strategy"
 	stratsupport "github.com/openshift/origin/pkg/apps/strategy/support"
 	stratutil "github.com/openshift/origin/pkg/apps/strategy/util"
@@ -101,13 +99,12 @@ func (s *RecreateDeploymentStrategy) Deploy(from *corev1.ReplicationController, 
 // for initial deployments.
 func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *corev1.ReplicationController, to *corev1.ReplicationController, desiredReplicas int,
 	updateAcceptor strat.UpdateAcceptor) error {
-	// TODO: This should move to external version once we are sure there are no replication controller with internal DeploymentConfig serialized.
-	config, err := appsinternalutil.DecodeDeploymentConfig(to)
+	config, err := appsutil.DecodeDeploymentConfig(to)
 	if err != nil {
 		return fmt.Errorf("couldn't decode config from deployment %s: %v", to.Name, err)
 	}
 
-	recreateTimeout := time.Duration(appsinternal.DefaultRecreateTimeoutSeconds) * time.Second
+	recreateTimeout := time.Duration(appsutil.DefaultRecreateTimeoutSeconds) * time.Second
 	params := config.Spec.Strategy.RecreateParams
 	rollingParams := config.Spec.Strategy.RollingParams
 
@@ -127,7 +124,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *corev1.Replication
 
 	// Execute any pre-hook.
 	if params != nil && params.Pre != nil {
-		if err := s.hookExecutor.Execute(params.Pre, to, appsinternal.PreHookPodSuffix, "pre"); err != nil {
+		if err := s.hookExecutor.Execute(params.Pre, to, appsutil.PreHookPodSuffix, "pre"); err != nil {
 			return fmt.Errorf("pre hook failed: %s", err)
 		}
 	}
@@ -156,7 +153,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *corev1.Replication
 	}
 
 	if params != nil && params.Mid != nil {
-		if err := s.hookExecutor.Execute(params.Mid, to, appsinternal.MidHookPodSuffix, "mid"); err != nil {
+		if err := s.hookExecutor.Execute(params.Mid, to, appsutil.MidHookPodSuffix, "mid"); err != nil {
 			return fmt.Errorf("mid hook failed: %s", err)
 		}
 	}
@@ -212,7 +209,7 @@ func (s *RecreateDeploymentStrategy) DeployWithAcceptor(from *corev1.Replication
 
 	// Execute any post-hook.
 	if params != nil && params.Post != nil {
-		if err := s.hookExecutor.Execute(params.Post, to, appsinternal.PostHookPodSuffix, "post"); err != nil {
+		if err := s.hookExecutor.Execute(params.Post, to, appsutil.PostHookPodSuffix, "post"); err != nil {
 			return fmt.Errorf("post hook failed: %s", err)
 		}
 	}

--- a/pkg/apps/strategy/recreate/recreate_test.go
+++ b/pkg/apps/strategy/recreate/recreate_test.go
@@ -14,6 +14,7 @@ import (
 	scalefake "k8s.io/client-go/scale/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
@@ -122,10 +123,10 @@ func (c *fakePodClient) Pods(ns string) kcoreclient.PodInterface {
 }
 
 type hookExecutorImpl struct {
-	executeFunc func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error
+	executeFunc func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error
 }
 
-func (h *hookExecutorImpl) Execute(hook *appsapi.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
+func (h *hookExecutorImpl) Execute(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
 	return h.executeFunc(hook, rc, suffix, label)
 }
 
@@ -172,7 +173,7 @@ func TestRecreate_deploymentPreHookSuccess(t *testing.T) {
 		rcClient:          controllerClient,
 		scaleClient:       controllerClient.fakeScaleClient(),
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				hookExecuted = true
 				return nil
 			},
@@ -203,7 +204,7 @@ func TestRecreate_deploymentPreHookFail(t *testing.T) {
 		rcClient:          controllerClient,
 		scaleClient:       controllerClient.fakeScaleClient(),
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				return fmt.Errorf("hook execution failure")
 			},
 		},
@@ -234,7 +235,7 @@ func TestRecreate_deploymentMidHookSuccess(t *testing.T) {
 		eventClient:       fake.NewSimpleClientset().Core(),
 		getUpdateAcceptor: getUpdateAcceptor,
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				return fmt.Errorf("hook execution failure")
 			},
 		},
@@ -266,7 +267,7 @@ func TestRecreate_deploymentPostHookSuccess(t *testing.T) {
 		eventClient:       fake.NewSimpleClientset().Core(),
 		getUpdateAcceptor: getUpdateAcceptor,
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				hookExecuted = true
 				return nil
 			},
@@ -298,7 +299,7 @@ func TestRecreate_deploymentPostHookFail(t *testing.T) {
 		eventClient:       fake.NewSimpleClientset().Core(),
 		getUpdateAcceptor: getUpdateAcceptor,
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				hookExecuted = true
 				return fmt.Errorf("post hook failure")
 			},

--- a/pkg/apps/strategy/rolling/rolling_test.go
+++ b/pkg/apps/strategy/rolling/rolling_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
@@ -144,10 +145,10 @@ func TestRolling_deployRolling(t *testing.T) {
 }
 
 type hookExecutorImpl struct {
-	executeFunc func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error
+	executeFunc func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error
 }
 
-func (h *hookExecutorImpl) Execute(hook *appsapi.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
+func (h *hookExecutorImpl) Execute(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
 	return h.executeFunc(hook, rc, suffix, label)
 }
 
@@ -183,7 +184,7 @@ func TestRolling_deployRollingHooks(t *testing.T) {
 			return nil
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				return hookError
 			},
 		},
@@ -244,7 +245,7 @@ func TestRolling_deployInitialHooks(t *testing.T) {
 			return nil
 		},
 		hookExecutor: &hookExecutorImpl{
-			executeFunc: func(hook *appsapi.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
+			executeFunc: func(hook *appsv1.LifecycleHook, deployment *corev1.ReplicationController, suffix, label string) error {
 				return hookError
 			},
 		},

--- a/pkg/apps/strategy/util/events.go
+++ b/pkg/apps/strategy/util/events.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
-	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
 )
 
@@ -24,7 +23,7 @@ func RecordConfigEvent(client corev1client.EventsGetter, deployment *corev1.Repl
 	msg string) {
 	t := metav1.Time{Time: time.Now()}
 	var obj runtime.Object = deployment
-	if config, err := appsinternalutil.DecodeDeploymentConfig(deployment); err == nil {
+	if config, err := appsutil.DecodeDeploymentConfig(deployment); err == nil {
 		obj = config
 	} else {
 		glog.Errorf("Unable to decode deployment config from %s/%s: %v", deployment.Namespace, deployment.Name, err)

--- a/pkg/apps/util/const.go
+++ b/pkg/apps/util/const.go
@@ -1,0 +1,39 @@
+package util
+
+const (
+	// DeploymentStatusAnnotation is an annotation name used to retrieve the DeploymentPhase of
+	// a deployment.
+	// Used by CLI and utils:
+	// TODO: Should move to library-go?
+	DeploymentStatusAnnotation = "openshift.io/deployment.phase"
+
+	// DeployerPodForDeploymentLabel is a label which groups pods related to a
+	// Used by utils and lifecycle hooks:
+	DeployerPodForDeploymentLabel = "openshift.io/deployer-pod-for.name"
+
+	// MaxDeploymentDurationSeconds represents the maximum duration that a deployment is allowed to run.
+	// This is set as the default value for ActiveDeadlineSeconds for the deployer pod.
+	// Currently set to 6 hours.
+	MaxDeploymentDurationSeconds int64 = 21600
+
+	// DefaultRecreateTimeoutSeconds is the default TimeoutSeconds for RecreateDeploymentStrategyParams.
+	// Used by strategies:
+	DefaultRecreateTimeoutSeconds int64 = 10 * 60
+
+	// PreHookPodSuffix is the suffix added to all pre hook pods
+	PreHookPodSuffix = "hook-pre"
+	// MidHookPodSuffix is the suffix added to all mid hook pods
+	MidHookPodSuffix = "hook-mid"
+	// PostHookPodSuffix is the suffix added to all post hook pods
+	PostHookPodSuffix = "hook-post"
+
+	// Used only internally by utils:
+	deploymentEncodedConfigAnnotation = "openshift.io/encoded-deployment-config"
+	deploymentPodAnnotation           = "openshift.io/deployer-pod.name"
+	desiredReplicasAnnotation         = "kubectl.kubernetes.io/desired-replicas"
+	deploymentConfigAnnotation        = "openshift.io/deployment-config.name"
+	deploymentVersionAnnotation       = "openshift.io/deployment-config.latest-version"
+)
+
+// DeploymentStatus describes the possible states a deployment can be in.
+type DeploymentStatus string

--- a/pkg/apps/util/scheme.go
+++ b/pkg/apps/util/scheme.go
@@ -4,31 +4,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	coreapi "k8s.io/kubernetes/pkg/apis/core"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	appsv1helpers "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 )
 
 var (
-	// for decoding, we want to be tolerant of groupified and non-groupified
-	annotationDecodingScheme = runtime.NewScheme()
-	annotationDecoder        runtime.Decoder
-
 	// for encoding, we want to be strict on groupified
 	annotationEncodingScheme = runtime.NewScheme()
 	annotationEncoder        runtime.Encoder
 )
 
 func init() {
-	utilruntime.Must(appsv1.Install(annotationDecodingScheme))
-	utilruntime.Must(appsv1.DeprecatedInstallWithoutGroup(annotationDecodingScheme))
-	utilruntime.Must(appsv1helpers.AddToScheme(annotationDecodingScheme))
-	utilruntime.Must(appsv1helpers.AddToSchemeInCoreGroup(annotationDecodingScheme))
-	utilruntime.Must(coreapi.AddToScheme(annotationDecodingScheme))
-	utilruntime.Must(appsv1.Install(annotationEncodingScheme))
-	utilruntime.Must(appsv1helpers.AddToScheme(annotationEncodingScheme))
-	utilruntime.Must(coreapi.AddToScheme(annotationEncodingScheme))
+	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
+	utilruntime.Must(appsv1helpers.Install(annotationEncodingScheme))
 	annotationEncoderCodecFactory := serializer.NewCodecFactory(annotationEncodingScheme)
-	annotationEncoder = annotationEncoderCodecFactory.LegacyCodec(appsv1.SchemeGroupVersion)
+	annotationEncoder = annotationEncoderCodecFactory.LegacyCodec(appsv1.GroupVersion)
 }

--- a/pkg/apps/util/scheme.go
+++ b/pkg/apps/util/scheme.go
@@ -6,16 +6,28 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/openshift/origin/pkg/api/legacy"
+	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsv1helpers "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 )
 
 var (
+	// for decoding, we want to be tolerant of groupified and non-groupified
+	annotationDecodingScheme = runtime.NewScheme()
+	annotationDecoder        runtime.Decoder
+
 	// for encoding, we want to be strict on groupified
 	annotationEncodingScheme = runtime.NewScheme()
 	annotationEncoder        runtime.Encoder
 )
 
 func init() {
+	legacy.InstallLegacyApps(annotationDecodingScheme)
+	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
+	utilruntime.Must(appsv1helpers.Install(annotationDecodingScheme))
+	annotationDecoderCodecFactory := serializer.NewCodecFactory(annotationDecodingScheme)
+	annotationDecoder = annotationDecoderCodecFactory.UniversalDecoder(appsapi.SchemeGroupVersion)
+
 	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
 	utilruntime.Must(appsv1helpers.Install(annotationEncodingScheme))
 	annotationEncoderCodecFactory := serializer.NewCodecFactory(annotationEncodingScheme)

--- a/pkg/apps/util/scheme.go
+++ b/pkg/apps/util/scheme.go
@@ -7,7 +7,6 @@ import (
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/origin/pkg/api/legacy"
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsv1helpers "github.com/openshift/origin/pkg/apps/apis/apps/v1"
 )
 
@@ -23,12 +22,10 @@ var (
 
 func init() {
 	legacy.InstallLegacyApps(annotationDecodingScheme)
-	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
 	utilruntime.Must(appsv1helpers.Install(annotationDecodingScheme))
 	annotationDecoderCodecFactory := serializer.NewCodecFactory(annotationDecodingScheme)
-	annotationDecoder = annotationDecoderCodecFactory.UniversalDecoder(appsapi.SchemeGroupVersion)
+	annotationDecoder = annotationDecoderCodecFactory.UniversalDecoder(appsv1.GroupVersion)
 
-	// TODO eventually we shouldn't deal in internal versions, but for now decode into one.
 	utilruntime.Must(appsv1helpers.Install(annotationEncodingScheme))
 	annotationEncoderCodecFactory := serializer.NewCodecFactory(annotationEncodingScheme)
 	annotationEncoder = annotationEncoderCodecFactory.LegacyCodec(appsv1.GroupVersion)

--- a/pkg/apps/util/scheme_test.go
+++ b/pkg/apps/util/scheme_test.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/davecgh/go-spew/spew"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+const legacyDC = `{
+  "apiVersion": "v1",
+  "kind": "DeploymentConfig",
+  "metadata": {
+    "name": "sinatra-app-example-a"
+  }
+}
+`
+
+func TestLegacyDecoding(t *testing.T) {
+	result, err := runtime.Decode(annotationDecoder, []byte(legacyDC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.(*appsv1.DeploymentConfig).Name != "sinatra-app-example-a" {
+		t.Fatal(spew.Sdump(result))
+	}
+
+	groupfiedBytes, err := runtime.Encode(annotationEncoder, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(groupfiedBytes), "apps.openshift.io/v1") {
+		t.Fatal(string(groupfiedBytes))
+	}
+
+	result2, err := runtime.Decode(annotationDecoder, groupfiedBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result2.(*appsv1.DeploymentConfig).Name != "sinatra-app-example-a" {
+		t.Fatal(spew.Sdump(result2))
+	}
+}

--- a/pkg/apps/util/util_test.go
+++ b/pkg/apps/util/util_test.go
@@ -67,7 +67,7 @@ func TestMakeDeploymentOk(t *testing.T) {
 		t.Fatalf("expected deployment with DeploymentEncodedConfigAnnotation annotation")
 	}
 
-	if decodedConfig, err := appsinternalutil.DecodeDeploymentConfig(deployment); err != nil {
+	if decodedConfig, err := DecodeDeploymentConfig(deployment); err != nil {
 		t.Fatalf("invalid encoded config on deployment: %v", err)
 	} else {
 		if e, a := config.Name, decodedConfig.Name; e != a {

--- a/pkg/authorization/apis/authorization/v1/register.go
+++ b/pkg/authorization/apis/authorization/v1/register.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	corev1conversions "k8s.io/kubernetes/pkg/apis/core/v1"
+	rbacv1conversions "k8s.io/kubernetes/pkg/apis/rbac/v1"
 
 	"github.com/openshift/api/authorization/v1"
 	"github.com/openshift/origin/pkg/authorization/apis/authorization"
@@ -11,6 +13,8 @@ var (
 	localSchemeBuilder = runtime.NewSchemeBuilder(
 		authorization.Install,
 		v1.Install,
+		rbacv1conversions.AddToScheme,
+		corev1conversions.AddToScheme,
 		AddConversionFuncs,
 		AddFieldSelectorKeyConversions,
 		RegisterDefaults,

--- a/pkg/cmd/infra/deployer/deployer_test.go
+++ b/pkg/cmd/infra/deployer/deployer_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/kubectl"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
@@ -20,7 +21,7 @@ import (
 
 func TestDeployer_getDeploymentFail(t *testing.T) {
 	deployer := &Deployer{
-		strategyFor: func(config *appsapi.DeploymentConfig) (strategy.DeploymentStrategy, error) {
+		strategyFor: func(config *appsv1.DeploymentConfig) (strategy.DeploymentStrategy, error) {
 			t.Fatal("unexpected call")
 			return nil, nil
 		},
@@ -150,7 +151,7 @@ func TestDeployer_deployScenarios(t *testing.T) {
 		deployer := &Deployer{
 			out:    &bytes.Buffer{},
 			errOut: &bytes.Buffer{},
-			strategyFor: func(config *appsapi.DeploymentConfig) (strategy.DeploymentStrategy, error) {
+			strategyFor: func(config *appsv1.DeploymentConfig) (strategy.DeploymentStrategy, error) {
 				return &testStrategy{
 					deployFunc: func(from *corev1.ReplicationController, to *corev1.ReplicationController, desiredReplicas int) error {
 						actualFrom = from

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -74,25 +74,25 @@ var (
 	kAuthnGroup         = kauthenticationapi.GroupName
 	legacyAuthzGroup    = legacy.GroupName
 	buildGroup          = buildapi.GroupName
-	legacyBuildGroup    = buildapi.LegacyGroupName
+	legacyBuildGroup    = legacy.GroupName
 	deployGroup         = appsapi.GroupName
-	legacyDeployGroup   = appsapi.LegacyGroupName
+	legacyDeployGroup   = legacy.GroupName
 	imageGroup          = imageapi.GroupName
-	legacyImageGroup    = imageapi.LegacyGroupName
+	legacyImageGroup    = legacy.GroupName
 	projectGroup        = projectapi.GroupName
-	legacyProjectGroup  = projectapi.LegacyGroupName
+	legacyProjectGroup  = legacy.GroupName
 	quotaGroup          = quotaapi.GroupName
-	legacyQuotaGroup    = quotaapi.LegacyGroupName
+	legacyQuotaGroup    = legacy.GroupName
 	routeGroup          = routeapi.GroupName
-	legacyRouteGroup    = routeapi.LegacyGroupName
+	legacyRouteGroup    = legacy.GroupName
 	templateGroup       = templateapi.GroupName
-	legacyTemplateGroup = templateapi.LegacyGroupName
+	legacyTemplateGroup = legacy.GroupName
 	userGroup           = userapi.GroupName
-	legacyUserGroup     = userapi.LegacyGroupName
+	legacyUserGroup     = legacy.GroupName
 	oauthGroup          = oauthapi.GroupName
-	legacyOauthGroup    = oauthapi.LegacyGroupName
+	legacyOauthGroup    = legacy.GroupName
 	networkGroup        = networkapi.GroupName
-	legacyNetworkGroup  = networkapi.LegacyGroupName
+	legacyNetworkGroup  = legacy.GroupName
 )
 
 func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {

--- a/pkg/oc/cli/logs/logs.go
+++ b/pkg/oc/cli/logs/logs.go
@@ -14,6 +14,7 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 
+	"github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildclientinternal "github.com/openshift/origin/pkg/build/generated/internalclientset"
@@ -171,8 +172,7 @@ func (o *LogsOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []st
 		}
 		o.Options = bopts
 
-	case appsapi.Resource("deploymentconfig"),
-		appsapi.Resource("deploymentconfigs"):
+	case apps.Resource("deploymentconfigs"):
 		dopts := &appsapi.DeploymentLogOptions{
 			Container:    podLogOptions.Container,
 			Follow:       podLogOptions.Follow,

--- a/pkg/oc/cli/rsh/rsh.go
+++ b/pkg/oc/cli/rsh/rsh.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	oapps "github.com/openshift/api/apps"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
 	appsclientinternal "github.com/openshift/origin/pkg/apps/generated/internalclientset"
 	"github.com/openshift/origin/pkg/cmd/util"
@@ -224,7 +224,7 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 			return "", err
 		}
 		return pod.Name, nil
-	case appsapi.Resource("deploymentconfigs"):
+	case oapps.Resource("deploymentconfigs"):
 		appsClient, err := appsclientinternal.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err

--- a/pkg/oc/lib/describe/deployments.go
+++ b/pkg/oc/lib/describe/deployments.go
@@ -19,6 +19,8 @@ import (
 	kprinters "k8s.io/kubernetes/pkg/printers"
 	kinternalprinters "k8s.io/kubernetes/pkg/printers/internalversion"
 
+	"github.com/openshift/api/apps"
+	"github.com/openshift/origin/pkg/api/legacy"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
 	appsinternalversion "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
@@ -295,9 +297,9 @@ func printDeploymentConfigSpec(kc kclientset.Interface, dc appsapi.DeploymentCon
 	// FIXME: The CrossVersionObjectReference should specify the Group
 	printAutoscalingInfo(
 		[]schema.GroupResource{
-			appsapi.Resource("DeploymentConfig"),
+			apps.Resource("DeploymentConfig"),
 			// this needs to remain as long as HPA supports putting in the "wrong" DC scheme
-			appsapi.LegacyResource("DeploymentConfig"),
+			legacy.Resource("DeploymentConfig"),
 		},
 		dc.Namespace, dc.Name, kc, w)
 

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -26,9 +26,9 @@ import (
 	kprinters "k8s.io/kubernetes/pkg/printers"
 	kinternalprinters "k8s.io/kubernetes/pkg/printers/internalversion"
 
+	oapps "github.com/openshift/api/apps"
 	authorization "github.com/openshift/api/authorization"
 	oapi "github.com/openshift/origin/pkg/api"
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	oauthorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"
@@ -109,7 +109,7 @@ func describerMap(clientConfig *rest.Config, kclient kclientset.Interface, host 
 	m := map[schema.GroupKind]kprinters.Describer{
 		buildapi.Kind("Build"):                         &BuildDescriber{buildClient, kclient},
 		buildapi.Kind("BuildConfig"):                   &BuildConfigDescriber{buildClient, kclient, host},
-		appsapi.Kind("DeploymentConfig"):               &DeploymentConfigDescriber{appsClient, kclient, nil},
+		oapps.Kind("DeploymentConfig"):                 &DeploymentConfigDescriber{appsClient, kclient, nil},
 		imageapi.Kind("Image"):                         &ImageDescriber{imageClient},
 		imageapi.Kind("ImageStream"):                   &ImageStreamDescriber{imageClient},
 		imageapi.Kind("ImageStreamTag"):                &ImageStreamTagDescriber{imageClient},

--- a/pkg/oc/lib/graph/kubegraph/edges.go
+++ b/pkg/oc/lib/graph/kubegraph/edges.go
@@ -14,6 +14,8 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
+	oapps "github.com/openshift/api/apps"
+	"github.com/openshift/origin/pkg/api/legacy"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	triggerapi "github.com/openshift/origin/pkg/image/apis/image/v1/trigger"
@@ -255,9 +257,9 @@ func AddHPAScaleRefEdges(g osgraph.Graph, restMapper meta.RESTMapper) {
 		switch r {
 		case kapi.Resource("replicationcontrollers"):
 			syntheticNode = kubegraph.FindOrCreateSyntheticReplicationControllerNode(g, &kapi.ReplicationController{ObjectMeta: syntheticMeta})
-		case appsapi.Resource("deploymentconfigs"),
+		case oapps.Resource("deploymentconfigs"),
 			// we need the legacy resource until we stop supporting HPA having old refs
-			appsapi.LegacyResource("deploymentconfigs"):
+			legacy.Resource("deploymentconfigs"):
 			syntheticNode = appsgraph.FindOrCreateSyntheticDeploymentConfigNode(g, &appsapi.DeploymentConfig{ObjectMeta: syntheticMeta})
 		case extensions.Resource("deployments"):
 			syntheticNode = kubegraph.FindOrCreateSyntheticDeploymentNode(g, &extensions.Deployment{ObjectMeta: syntheticMeta})

--- a/pkg/oc/originpolymorphichelpers/canbeautoscaled.go
+++ b/pkg/oc/originpolymorphichelpers/canbeautoscaled.go
@@ -1,15 +1,14 @@
 package originpolymorphichelpers
 
 import (
+	oapps "github.com/openshift/api/apps"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
-
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 )
 
 func NewCanBeAutoscaledFn(delegate polymorphichelpers.CanBeAutoscaledFunc) polymorphichelpers.CanBeAutoscaledFunc {
 	return func(kind schema.GroupKind) error {
-		if appsapi.Kind("DeploymentConfig") == kind {
+		if oapps.Kind("DeploymentConfig") == kind {
 			return nil
 		}
 		return delegate(kind)

--- a/pkg/oc/originpolymorphichelpers/canbeexposed.go
+++ b/pkg/oc/originpolymorphichelpers/canbeexposed.go
@@ -1,15 +1,14 @@
 package originpolymorphichelpers
 
 import (
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
-
+	oapps "github.com/openshift/api/apps"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 )
 
 func NewCanBeExposedFn(delegate polymorphichelpers.CanBeExposedFunc) polymorphichelpers.CanBeExposedFunc {
 	return func(kind schema.GroupKind) error {
-		if appsapi.Kind("DeploymentConfig") == kind {
+		if oapps.Kind("DeploymentConfig") == kind {
 			return nil
 		}
 		return delegate(kind)

--- a/pkg/oc/originpolymorphichelpers/historyviewer.go
+++ b/pkg/oc/originpolymorphichelpers/historyviewer.go
@@ -7,13 +7,13 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	oapps "github.com/openshift/api/apps"
 	deploymentcmd "github.com/openshift/origin/pkg/oc/originpolymorphichelpers/deploymentconfigs"
 )
 
 func NewHistoryViewerFn(delegate polymorphichelpers.HistoryViewerFunc) polymorphichelpers.HistoryViewerFunc {
 	return func(restClientGetter genericclioptions.RESTClientGetter, mapping *meta.RESTMapping) (kubectl.HistoryViewer, error) {
-		if appsapi.Kind("DeploymentConfig") == mapping.GroupVersionKind.GroupKind() {
+		if oapps.Kind("DeploymentConfig") == mapping.GroupVersionKind.GroupKind() {
 			config, err := restClientGetter.ToRESTConfig()
 			if err != nil {
 				return nil, err

--- a/pkg/oc/originpolymorphichelpers/rollbacker.go
+++ b/pkg/oc/originpolymorphichelpers/rollbacker.go
@@ -6,14 +6,14 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	oapps "github.com/openshift/api/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset"
 	deploymentcmd "github.com/openshift/origin/pkg/oc/originpolymorphichelpers/deploymentconfigs"
 )
 
 func NewRollbackerFn(delegate polymorphichelpers.RollbackerFunc) polymorphichelpers.RollbackerFunc {
 	return func(restClientGetter genericclioptions.RESTClientGetter, mapping *meta.RESTMapping) (kubectl.Rollbacker, error) {
-		if appsapi.Kind("DeploymentConfig") == mapping.GroupVersionKind.GroupKind() {
+		if oapps.Kind("DeploymentConfig") == mapping.GroupVersionKind.GroupKind() {
 			config, err := restClientGetter.ToRESTConfig()
 			if err != nil {
 				return nil, err

--- a/pkg/oc/originpolymorphichelpers/statusviewer.go
+++ b/pkg/oc/originpolymorphichelpers/statusviewer.go
@@ -6,14 +6,14 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
+	oapps "github.com/openshift/api/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset"
 	deploymentcmd "github.com/openshift/origin/pkg/oc/originpolymorphichelpers/deploymentconfigs"
 )
 
 func NewStatusViewerFn(delegate polymorphichelpers.StatusViewerFunc) polymorphichelpers.StatusViewerFunc {
 	return func(restClientGetter genericclioptions.RESTClientGetter, mapping *meta.RESTMapping) (kubectl.StatusViewer, error) {
-		if appsapi.Kind("DeploymentConfig") == mapping.GroupVersionKind.GroupKind() {
+		if oapps.Kind("DeploymentConfig") == mapping.GroupVersionKind.GroupKind() {
 			config, err := restClientGetter.ToRESTConfig()
 			if err != nil {
 				return nil, err

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 
+	oapps "github.com/openshift/api/apps"
 	_ "github.com/openshift/origin/pkg/api/install"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
@@ -225,8 +226,8 @@ func TestPodNodeConstraintsResources(t *testing.T) {
 		},
 		{
 			resource:      deploymentConfig,
-			kind:          appsapi.Kind("DeploymentConfig"),
-			groupresource: appsapi.Resource("deploymentconfigs"),
+			kind:          oapps.Kind("DeploymentConfig"),
+			groupresource: oapps.Resource("deploymentconfigs"),
 			prefix:        "DeploymentConfig",
 		},
 		{

--- a/pkg/template/controller/readiness.go
+++ b/pkg/template/controller/readiness.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 
+	oapps "github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
@@ -151,7 +152,7 @@ var readinessCheckers = map[schema.GroupKind]func(runtime.Object) (bool, bool, e
 	buildapi.Kind("Build"):                checkBuildReadiness,
 	apps.Kind("Deployment"):               checkDeploymentReadiness,
 	extensions.Kind("Deployment"):         checkDeploymentReadiness,
-	appsapi.Kind("DeploymentConfig"):      checkDeploymentConfigReadiness,
+	oapps.Kind("DeploymentConfig"):        checkDeploymentConfigReadiness,
 	batch.Kind("Job"):                     checkJobReadiness,
 	apps.Kind("StatefulSet"):              checkStatefulSetReadiness,
 	routeapi.Kind("Route"):                checkRouteReadiness,

--- a/pkg/template/controller/readiness_test.go
+++ b/pkg/template/controller/readiness_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 
+	oapps "github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	fakebuild "github.com/openshift/origin/pkg/build/generated/internalclientset/fake"
@@ -153,11 +154,11 @@ func TestCheckReadiness(t *testing.T) {
 
 		// DeploymentConfig
 		{
-			groupKind: appsapi.Kind("DeploymentConfig"),
+			groupKind: oapps.Kind("DeploymentConfig"),
 			object:    &appsapi.DeploymentConfig{},
 		},
 		{
-			groupKind: appsapi.Kind("DeploymentConfig"),
+			groupKind: oapps.Kind("DeploymentConfig"),
 			object: &appsapi.DeploymentConfig{
 				Status: appsapi.DeploymentConfigStatus{
 					Conditions: []appsapi.DeploymentCondition{
@@ -176,7 +177,7 @@ func TestCheckReadiness(t *testing.T) {
 			expectedReady: true,
 		},
 		{
-			groupKind: appsapi.Kind("DeploymentConfig"),
+			groupKind: oapps.Kind("DeploymentConfig"),
 			object: &appsapi.DeploymentConfig{
 				Status: appsapi.DeploymentConfigStatus{
 					Conditions: []appsapi.DeploymentCondition{

--- a/pkg/unidling/util/scale.go
+++ b/pkg/unidling/util/scale.go
@@ -14,6 +14,7 @@ import (
 	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	appsapiv1 "github.com/openshift/api/apps/v1"
+	"github.com/openshift/origin/pkg/api/legacy"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset/typed/apps/internalversion"
 	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
@@ -124,7 +125,7 @@ func (c *ScaleAnnotater) GetObjectWithScale(namespace string, ref unidlingapi.Cr
 	var scale *kextapi.Scale
 
 	switch {
-	case ref.Kind == "DeploymentConfig" && (ref.Group == appsapi.GroupName || ref.Group == appsapi.LegacyGroupName):
+	case ref.Kind == "DeploymentConfig" && (ref.Group == appsapi.GroupName || ref.Group == legacy.GroupName):
 		var dc *appsapi.DeploymentConfig
 		dc, err = c.dcs.DeploymentConfigs(namespace).Get(ref.Name, metav1.GetOptions{})
 		if err != nil {

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 	rbacclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 
+	oapps "github.com/openshift/api/apps"
 	"github.com/openshift/origin/pkg/api/legacy"
-	oappsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appsclient "github.com/openshift/origin/pkg/apps/generated/internalclientset"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
@@ -177,10 +177,10 @@ func TestClusterReaderCoverage(t *testing.T) {
 		buildapi.Resource("buildconfigs/instantiatebinary"),
 		buildapi.Resource("buildconfigs/instantiate"),
 		buildapi.Resource("builds/clone"),
-		oappsapi.Resource("deploymentconfigrollbacks"),
-		oappsapi.Resource("generatedeploymentconfigs"),
-		oappsapi.Resource("deploymentconfigs/rollback"),
-		oappsapi.Resource("deploymentconfigs/instantiate"),
+		oapps.Resource("deploymentconfigrollbacks"),
+		oapps.Resource("generatedeploymentconfigs"),
+		oapps.Resource("deploymentconfigs/rollback"),
+		oapps.Resource("deploymentconfigs/instantiate"),
 		imageapi.Resource("imagestreamimports"),
 		imageapi.Resource("imagestreammappings"),
 		extensionsapi.Resource("deployments/rollback"),

--- a/test/integration/deploy_scale_test.go
+++ b/test/integration/deploy_scale_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 
+	"github.com/openshift/api/apps"
 	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	appstest "github.com/openshift/origin/pkg/apps/apis/apps/test"
 	appsinternalutil "github.com/openshift/origin/pkg/apps/controller/util"
@@ -119,7 +120,7 @@ func TestDeployScale(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scale, err := scaleClient.Scales(namespace).Get(appsapi.Resource("deploymentconfigs"), config.Name)
+	scale, err := scaleClient.Scales(namespace).Get(apps.Resource("deploymentconfigs"), config.Name)
 	if err != nil {
 		t.Fatalf("Couldn't get DeploymentConfig scale: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestDeployScale(t *testing.T) {
 
 	scaleUpdate := scale.DeepCopy()
 	scaleUpdate.Spec.Replicas = 3
-	updatedScale, err := scaleClient.Scales(namespace).Update(appsapi.Resource("deploymentconfigs"), scaleUpdate)
+	updatedScale, err := scaleClient.Scales(namespace).Update(apps.Resource("deploymentconfigs"), scaleUpdate)
 	if err != nil {
 		// If this complains about "Scale" not being registered in "v1", check the kind overrides in the API registration in SubresourceGroupVersionKind
 		t.Fatalf("Couldn't update DeploymentConfig scale to %#v: %v", scaleUpdate, err)
@@ -138,7 +139,7 @@ func TestDeployScale(t *testing.T) {
 		t.Fatalf("Expected scale.spec.replicas=3, got %#v", scale)
 	}
 
-	persistedScale, err := scaleClient.Scales(namespace).Get(appsapi.Resource("deploymentconfigs"), config.Name)
+	persistedScale, err := scaleClient.Scales(namespace).Get(apps.Resource("deploymentconfigs"), config.Name)
 	if err != nil {
 		t.Fatalf("Couldn't get DeploymentConfig scale: %v", err)
 	}

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -864,7 +864,6 @@ var ephemeralWhiteList = createEphemeralWhiteList(
 	gvr("", "v1", "deploymentconfigrollbacks"),                  // triggers rolleback dc, not stored in etcd
 	gvr("apps.openshift.io", "v1", "deploymentconfigrollbacks"), // triggers rolleback dc, not stored in etcd
 
-	gvr("", "v1", "scales"),                  // not stored in etcd, part of kapiv1.ReplicationController
 	gvr("apps.openshift.io", "v1", "scales"), // not stored in etcd, part of kapiv1.ReplicationController
 	// --
 

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	imageclientv1 "github.com/openshift/client-go/image/clientset/versioned"
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
 	stratsupport "github.com/openshift/origin/pkg/apps/strategy/support"
 	imagetest "github.com/openshift/origin/pkg/image/admission/testutil"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
@@ -418,11 +418,11 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	// can tag to a stream that exists
 	exec := stratsupport.NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
 	err = exec.Execute(
-		&appsapi.LifecycleHook{
-			TagImages: []appsapi.TagImageHook{
+		&appsv1.LifecycleHook{
+			TagImages: []appsv1.TagImageHook{
 				{
 					ContainerName: "test",
-					To:            kapi.ObjectReference{Kind: "ImageStreamTag", Name: stream.Name + ":test"},
+					To:            corev1.ObjectReference{Kind: "ImageStreamTag", Name: stream.Name + ":test"},
 				},
 			},
 		},
@@ -456,11 +456,11 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	// can execute a second time the same tag and it should work
 	exec = stratsupport.NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
 	err = exec.Execute(
-		&appsapi.LifecycleHook{
-			TagImages: []appsapi.TagImageHook{
+		&appsv1.LifecycleHook{
+			TagImages: []appsv1.TagImageHook{
 				{
 					ContainerName: "test",
-					To:            kapi.ObjectReference{Kind: "ImageStreamTag", Name: stream.Name + ":test"},
+					To:            corev1.ObjectReference{Kind: "ImageStreamTag", Name: stream.Name + ":test"},
 				},
 			},
 		},
@@ -488,11 +488,11 @@ func TestImageStreamTagLifecycleHook(t *testing.T) {
 	// can lifecycle tag a new image stream
 	exec = stratsupport.NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
 	err = exec.Execute(
-		&appsapi.LifecycleHook{
-			TagImages: []appsapi.TagImageHook{
+		&appsv1.LifecycleHook{
+			TagImages: []appsv1.TagImageHook{
 				{
 					ContainerName: "test",
-					To:            kapi.ObjectReference{Kind: "ImageStreamTag", Name: "test2:test"},
+					To:            corev1.ObjectReference{Kind: "ImageStreamTag", Name: "test2:test"},
 				},
 			},
 		},


### PR DESCRIPTION
This move strategies, hooks and deployer to use external deployment config when decoding it from the replication controller annotation. That means the `pkg/apps/strategy` and the deployer command are now using the external api exclusively.

The last users of internal DC is storage (REST) and controllers which should be refactored as follow up.

/cc @tnozicka 
/cc @deads2k 