### PR TITLE
really fix the cluster up race

### DIFF
--- a/pkg/oc/clusteradd/components/web-console-operator/web_console_operator.go
+++ b/pkg/oc/clusteradd/components/web-console-operator/web_console_operator.go
@@ -93,25 +93,25 @@ func (c *WebConsoleOperatorComponentOptions) Install(dockerClient dockerhelper.I
 	if err != nil {
 		return err
 	}
-	operatorConfig, err := operatorClient.WebconsoleV1alpha1().OpenShiftWebConsoleConfigs().Get("instance", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	masterPublicHostPort, err := getMasterPublicHostPort(c.InstallContext.BaseDir())
-	if err != nil {
-		return err
-	}
-	operatorConfig.Spec.WebConsoleConfig.ClusterInfo.ConsolePublicURL = "https://" + masterPublicHostPort + "/console/"
-	operatorConfig.Spec.WebConsoleConfig.ClusterInfo.MasterPublicURL, err = getMasterPublicURL(c.InstallContext.BaseDir())
-	if err != nil {
-		return err
-	}
 	// we can race a controller.  It's not a big deal if we're a little late, so retry on conflict. It's easier than a patch.
 	backoff := retry.DefaultBackoff
 	backoff.Steps = 6
 	err = retry.RetryOnConflict(backoff, func() error {
-		_, err := operatorClient.WebconsoleV1alpha1().OpenShiftWebConsoleConfigs().Update(operatorConfig)
+		operatorConfig, err := operatorClient.WebconsoleV1alpha1().OpenShiftWebConsoleConfigs().Get("instance", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		masterPublicHostPort, err := getMasterPublicHostPort(c.InstallContext.BaseDir())
+		if err != nil {
+			return err
+		}
+		operatorConfig.Spec.WebConsoleConfig.ClusterInfo.ConsolePublicURL = "https://" + masterPublicHostPort + "/console/"
+		operatorConfig.Spec.WebConsoleConfig.ClusterInfo.MasterPublicURL, err = getMasterPublicURL(c.InstallContext.BaseDir())
+		if err != nil {
+			return err
+		}
+		_, err = operatorClient.WebconsoleV1alpha1().OpenShiftWebConsoleConfigs().Update(operatorConfig)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
@mfojtik @smarterclayton when I made the "retry on conflict" pull, I forgot to re-get the thing I was updating.  That means it just fails six times.

Here's the fix with the re-get.