### PR TITLE
Correct the typo in the command examples comments.

### DIFF
--- a/pkg/oc/cli/cli.go
+++ b/pkg/oc/cli/cli.go
@@ -249,7 +249,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	templates.ActsAsRootCommand(cmds, filters, groups...).
 		ExposeFlags(loginCmd, "certificate-authority", "insecure-skip-tls-verify", "token")
 
-	cmds.AddCommand(newExperimentalCommand("ex", name+"ex", f, ioStreams))
+	cmds.AddCommand(newExperimentalCommand("ex", name+" ex", f, ioStreams))
 
 	cmds.AddCommand(kubectlwrappers.NewCmdPlugin(fullName, f, ioStreams))
 	if name == fullName {


### PR DESCRIPTION
Adding the one blank between cli name and ex option.

- before

```
Examples:
  # Perform garbage collection with the default settings
  ocex dockergc
```

-  after

```
Examples:
  # Perform garbage collection with the default settings
  oc ex dockergc
```
