### PR TITLE
OpenShift Version 3.9 | Docker Version 1.22

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -31,7 +31,7 @@ OpenShift officially supports the following versions of Docker:
 
 | OpenShift Version | Docker Version |
 | ----------------- | -------------- |
-| 3.9 | 1.13 |
+| 3.9 | >=1.22 |
 | 3.6-3.7 | 1.12 |
 | 1.4-1.5 | 1.12 |
 | 1.3 | 1.10 |


### PR DESCRIPTION
### 1) My version of _oc_ and RHEL

$ oc version
oc v3.9.0+191fece

---

Red Hat Enterprise Linux Workstation 7.4
GNOME Version: Version 3.22.2

### 2) Evidence of >= 1.22

$ oc cluster up
WARNING: Docker version is 1.18, it needs to be >= 1.22
error: FAIL

### 3) Example of it failing 

fatal: [localhost]: FAILED! => {"changed": false, "cmd": "oc cluster up --service-catalog=true --host-data-dir=/home/jstaffor/mext/mobile-core/ui/openshift-data --routing-suffix=192.168.3.178.nip.io --public-hostname=192.168.3.178 --version=v3.9.0 --image=openshift/origin", "delta": "0:01:31.000149", "end": "2018-07-19 13:58:12.218949", "msg": "non-zero return code", "rc": 1, "start": "2018-07-19 13:56:41.218800", "stderr": "error: FAIL\n   Error: error pulling Docker image openshift/origin:v3.9.0\n   Caused By:\n     Error: Error: No such image: openshift/origin:v3.9.0", "stderr_lines": ["error: FAIL", "   Error: error pulling Docker image openshift/origin:v3.9.0", "   Caused By:", "     Error: Error: No such image: openshift/origin:v3.9.0"],

***** "stdout": "WARNING: Docker version is 1.18, it needs to be >= 1.22 *****

\nPulling image openshift/origin:v3.9.0\nPulled 3/6 layers, 50% complete\nPulled 3/6 layers, 63% complete\nPulled 3/6 layers, 76% complete\nPulled 4/6 layers, 83% complete\nPulled 5/6 layers, 90% complete", "stdout_lines": ["WARNING: **Docker version is 1.18, it needs to be >= 1.22**", "Pulling image openshift/origin:v3.9.0", "Pulled 3/6 layers, 50% complete", "Pulled 3/6 layers, 63% complete", "Pulled 3/6 layers, 76% complete", "Pulled 4/6 layers, 83% complete", "Pulled 5/6 layers, 90% complete"]}

### 4) Following up on

https://github.com/aerogear/mobile-docs/pull/301/files