### PR TITLE
oc start-build: provide progress on file upload

### DIFF
--- a/pkg/oc/cli/startbuild/startbuild.go
+++ b/pkg/oc/cli/startbuild/startbuild.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -707,7 +708,31 @@ func streamPathToBuild(repo git.Repository, in io.Reader, out io.Writer, client 
 		}
 	}
 
+	stopProgress := progress(out)
+	defer stopProgress()
 	return client.InstantiateBinary(options.Name, options, r)
+}
+
+func progress(out io.Writer) func() {
+	stop := make(chan bool)
+	done := make(chan bool)
+	go func() {
+		tick := time.Tick(5 * time.Second)
+		for {
+			select {
+			case <-tick:
+				fmt.Fprintf(out, ".")
+			case <-stop:
+				fmt.Fprintf(out, "\nUploading finished\n")
+				done <- true
+				return
+			}
+		}
+	}()
+	return func() {
+		stop <- true
+		<-done
+	}
 }
 
 func isArchive(r *bufio.Reader) bool {


### PR DESCRIPTION
The bottleneck appears to be a POST HTTP request and I am not sure there is a way to provide proper progress bar in k8 go-client REST calls
https://github.com/openshift/origin/blob/bb11f51660b665259cebcb626b2d7097bdd7af86/pkg/build/client/internalversion/buildinstantiatebinary.go#L25-L37

Making very simple "progress" measurement that tells the user every 5s that the POST is still executing

sample output:
```
Uploading directory "nodejs-ex" as binary input for the build ...
....
Uploading finished
build.build.openshift.io "bc1-12" started
```

this is a followup to https://github.com/openshift/origin/pull/19121

\cc @apupier. @openshift/sig-developer-experience 