### PR TITLE
Update egress IPs when node changes IP

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -2,7 +2,10 @@ package common
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	ktypes "k8s.io/apimachinery/pkg/types"
 
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 )
@@ -75,15 +78,31 @@ func setupEgressIPTracker(t *testing.T) (*EgressIPTracker, *testEIPWatcher) {
 	return NewEgressIPTracker(watcher), watcher
 }
 
+func updateHostSubnetEgress(eit *EgressIPTracker, hs *networkapi.HostSubnet) {
+	if hs.Host == "" {
+		hs.Host = "node-" + hs.HostIP[strings.LastIndex(hs.HostIP, ".")+1:]
+	}
+	hs.Name = hs.Host
+	hs.UID = ktypes.UID(hs.Name)
+	eit.UpdateHostSubnetEgress(hs)
+}
+
+func updateNetNamespaceEgress(eit *EgressIPTracker, ns *networkapi.NetNamespace) {
+	if ns.NetName == "" {
+		ns.NetName = fmt.Sprintf("ns-%d", ns.NetID)
+	}
+	ns.Name = ns.NetName
+	ns.UID = ktypes.UID(ns.Name)
+	eit.UpdateNetNamespaceEgress(ns)
+}
+
 func TestEgressIP(t *testing.T) {
 	eit, w := setupEgressIPTracker(t)
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:   "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP: "172.17.0.3",
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:   "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP: "172.17.0.4",
 	})
 	eit.DeleteNetNamespaceEgress(42)
@@ -96,8 +115,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Assign NetNamespace.EgressIP first, then HostSubnet.EgressIP
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -108,8 +126,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"}, // Added .100
 	})
@@ -122,13 +139,11 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Assign HostSubnet.EgressIP first, then NetNamespace.EgressIP
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100", "172.17.0.101"}, // Added .101
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-5",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.5",
 		EgressIPs: []string{"172.17.0.105"},
 	})
@@ -137,8 +152,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-43",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     43,
 		EgressIPs: []string{"172.17.0.105"},
 	})
@@ -151,8 +165,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Change NetNamespace.EgressIP
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-43",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     43,
 		EgressIPs: []string{"172.17.0.101"},
 	})
@@ -166,8 +179,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Assign another EgressIP...
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-44",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     44,
 		EgressIPs: []string{"172.17.0.104"},
 	})
@@ -178,8 +190,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.102", "172.17.0.104"}, // Added .102, .104
 	})
@@ -192,8 +203,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Change Namespace EgressIP
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-44",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     44,
 		EgressIPs: []string{"172.17.0.102"},
 	})
@@ -207,8 +217,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Assign HostSubnet.EgressIP first, then NetNamespace.EgressIP
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.102", "172.17.0.103"}, // Added .103, Dropped .104
 	})
@@ -217,8 +226,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-45",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     45,
 		EgressIPs: []string{"172.17.0.103"},
 	})
@@ -241,8 +249,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Add namespace EgressIP back again after having removed it...
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-44",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     44,
 		EgressIPs: []string{"172.17.0.102"},
 	})
@@ -255,8 +262,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Drop node EgressIPs
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"}, // Dropped .101
 	})
@@ -268,8 +274,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.102"}, // Dropped .103
 	})
@@ -282,8 +287,7 @@ func TestEgressIP(t *testing.T) {
 	}
 
 	// Add them back, swapped
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100", "172.17.0.103"}, // Added .103
 	})
@@ -295,8 +299,7 @@ func TestEgressIP(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.101", "172.17.0.102"}, // Added .101
 	})
@@ -312,13 +315,11 @@ func TestEgressIP(t *testing.T) {
 func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	eit, w := setupEgressIPTracker(t)
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -334,8 +335,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Prepending a second, unavailable, namespace egress IP should have no effect
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.101", "172.17.0.100"},
 	})
@@ -345,8 +345,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Now assigning that IP to a node should switch OVS to use that since it's first in the list
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.101"},
 	})
@@ -359,8 +358,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Swapping the order in the NetNamespace should swap back
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100", "172.17.0.101"},
 	})
@@ -372,8 +370,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Removing the inactive egress IP from its node should have no effect
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.200"},
 	})
@@ -385,8 +382,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Removing the remaining egress IP should now kill the namespace
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{},
 	})
@@ -399,13 +395,11 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Now add the egress IPs back...
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.101"},
 	})
@@ -420,8 +414,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 
 	// Assigning either the used or the unused Egress IP to another namespace should
 	// break this namespace
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-43",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     43,
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -444,8 +437,7 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-44",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     44,
 		EgressIPs: []string{"172.17.0.101"},
 	})
@@ -472,13 +464,11 @@ func TestMultipleNamespaceEgressIPs(t *testing.T) {
 func TestDuplicateNodeEgressIPs(t *testing.T) {
 	eit, w := setupEgressIPTracker(t)
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -496,8 +486,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 	// Adding the Egress IP to another node should not work and should cause the
 	// namespace to start dropping traffic. (And in particular, should not result
 	// in a ClaimEgressIP for the new IP.)
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -510,8 +499,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 	}
 
 	// Removing the duplicate node egressIP should restore traffic to the broken namespace
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{},
 	})
@@ -524,8 +512,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 	}
 
 	// As above, but with a different node IP
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-5",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.5",
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -547,8 +534,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -561,8 +547,7 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 
 	// Removing the original egress node should result in the "duplicate" egress node
 	// now being used.
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{},
 	})
@@ -578,13 +563,11 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 	eit, w := setupEgressIPTracker(t)
 
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -601,8 +584,7 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 
 	// Adding the Egress IP to another namespace should not work and should cause both
 	// namespaces to start dropping traffic.
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-43",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     43,
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -627,8 +609,7 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 	}
 
 	// Add duplicate back, re-breaking it
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-43",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     43,
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -643,8 +624,7 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 
 	// Now remove and re-add the Node EgressIP; the namespace should stay broken
 	// whether the IP is assigned to a node or not.
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{},
 	})
@@ -653,8 +633,7 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"},
 	})
@@ -679,18 +658,15 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 func TestOfflineEgressIPs(t *testing.T) {
 	eit, w := setupEgressIPTracker(t)
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.3",
 		EgressIPs: []string{"172.17.0.100"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
 		EgressIPs: []string{"172.17.0.101"},
 	})
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100", "172.17.0.101"},
 	})
@@ -751,8 +727,7 @@ func updateAllocations(eit *EgressIPTracker, allocation map[string][]string) {
 	for nodeName, egressIPs := range allocation {
 		for _, node := range eit.nodesByNodeIP {
 			if node.nodeName == nodeName {
-				eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-					Host:        nodeName,
+				updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 					HostIP:      node.nodeIP,
 					EgressIPs:   egressIPs,
 					EgressCIDRs: node.requestedCIDRs.List(),
@@ -766,20 +741,17 @@ func updateAllocations(eit *EgressIPTracker, allocation map[string][]string) {
 func TestEgressCIDRAllocation(t *testing.T) {
 	eit, w := setupEgressIPTracker(t)
 
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:        "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:      "172.17.0.3",
 		EgressIPs:   []string{},
 		EgressCIDRs: []string{"172.17.0.100/32", "172.17.0.101/32", "172.17.0.102/32", "172.17.0.103/32", "172.17.1.0/24"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:        "node-4",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:      "172.17.0.4",
 		EgressIPs:   []string{},
 		EgressCIDRs: []string{"172.17.0.0/24"},
 	})
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:        "node-5",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:      "172.17.0.5",
 		EgressIPs:   []string{},
 		EgressCIDRs: []string{},
@@ -794,13 +766,11 @@ func TestEgressCIDRAllocation(t *testing.T) {
 	}
 
 	// Either of these could be assigned to either node, but they should be balanced
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-42",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     42,
 		EgressIPs: []string{"172.17.0.100"},
 	})
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-43",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     43,
 		EgressIPs: []string{"172.17.0.101"},
 	})
@@ -844,13 +814,11 @@ func TestEgressCIDRAllocation(t *testing.T) {
 
 	// First can only be assigned to node3. Second *could* be assigned to either, but
 	// must get assigned to node4 for balance
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-44",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     44,
 		EgressIPs: []string{"172.17.1.1"},
 	})
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-45",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     45,
 		EgressIPs: []string{"172.17.0.102"},
 	})
@@ -879,13 +847,11 @@ func TestEgressCIDRAllocation(t *testing.T) {
 	// Manually assigning egress IPs to the node with no EgressCIDRs should have no
 	// effect on automatic assignments (though it will result in a spurious "update
 	// egress CIDRs" notification).
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:      "node-5",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.5",
 		EgressIPs: []string{"172.17.2.100"},
 	})
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-50",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     50,
 		EgressIPs: []string{"172.17.2.100"},
 	})
@@ -908,18 +874,15 @@ func TestEgressCIDRAllocation(t *testing.T) {
 	}
 
 	// First two can only be assigned to node4. Last must get assigned to node3 for balance
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-46",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     46,
 		EgressIPs: []string{"172.17.0.200"},
 	})
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-47",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     47,
 		EgressIPs: []string{"172.17.0.201"},
 	})
-	eit.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
-		NetName:   "ns-48",
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     48,
 		EgressIPs: []string{"172.17.0.103"},
 	})
@@ -951,8 +914,7 @@ func TestEgressCIDRAllocation(t *testing.T) {
 
 	// Dropping an Egress CIDR will drop the Egress IP(s) that came from that CIDR.
 	// If we then reallocate, the dropped Egress IP(s) might be allocated to new nodes.
-	eit.UpdateHostSubnetEgress(&networkapi.HostSubnet{
-		Host:        "node-3",
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:      "172.17.0.3",
 		EgressIPs:   allocation["node-3"],
 		EgressCIDRs: []string{"172.17.0.100/32", "172.17.0.101/32", "172.17.0.102/32", "172.17.1.0/24"}, // removed "172.17.0.103/32"

--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+
 	networkapi "github.com/openshift/origin/pkg/network/apis/network"
 )
 
@@ -144,14 +147,26 @@ func setupEgressIPWatcher(t *testing.T) (*egressIPWatcher, []string) {
 }
 
 func updateNodeEgress(eip *egressIPWatcher, nodeIP string, egressIPs []string) {
+	name := "node-" + nodeIP[strings.LastIndex(nodeIP, ".")+1:]
 	eip.tracker.UpdateHostSubnetEgress(&networkapi.HostSubnet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  ktypes.UID(name),
+		},
+		Host:      name,
 		HostIP:    nodeIP,
 		EgressIPs: egressIPs,
 	})
 }
 
 func updateNamespaceEgress(eip *egressIPWatcher, vnid uint32, egressIPs []string) {
+	name := fmt.Sprintf("ns-%d", vnid)
 	eip.tracker.UpdateNetNamespaceEgress(&networkapi.NetNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  ktypes.UID(name),
+		},
+		NetName:   name,
 		NetID:     vnid,
 		EgressIPs: egressIPs,
 	})


### PR DESCRIPTION
Pointed out by @pravisankar while reviewing the fully-automatic egress IP stuff. This will probably need to be backported (which will probably involve backporting the `common/egressip.go` PR too).

(There is a similar bug with `NetNamespace.NetID` changing, which will be addressed by a later PR.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1607395 (bug filed just to make sure we get QE tests)