### PR TITLE
Scheduler as a static pod

### DIFF
--- a/cmd/openshift-master-config/openshift-master-config.go
+++ b/cmd/openshift-master-config/openshift-master-config.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apiserver/pkg/util/logs"
+
+	"github.com/openshift/origin/pkg/cmd/flagtypes"
+	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
+	configapiv1 "github.com/openshift/origin/pkg/cmd/server/apis/config/v1"
+	"github.com/openshift/origin/pkg/cmd/server/start"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// safeArgRegexp matches only characters that are known safe. DO NOT add to this list
+// without fully considering whether that new character can be used to break shell escaping
+// rules.
+var safeArgRegexp = regexp.MustCompile(`^[\da-zA-Z\-=_\.,/\:]+$`)
+
+// shellEscapeArg quotes an argument if it contains characters that my cause a shell
+// interpreter to split the single argument into multiple.
+func shellEscapeArg(s string) string {
+	if safeArgRegexp.MatchString(s) {
+		return s
+	}
+	return strconv.Quote(s)
+}
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	var configFile string
+	// As of now, they are mutually exclusive as I don't see any reason for having all of them.
+	var getschedulerArgs, controllerArgs, apiServerArgs bool
+
+	cmd := &cobra.Command{
+		Use: "openshift-master-config",
+		Long: heredoc.Doc(`
+			Generate master configuration from master-config.yaml
+
+			This command converts an existing OpenShift master configuration into the appropriate component specific
+			command-line flags.
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configapi.AddToScheme(configapi.Scheme)
+			configapiv1.AddToScheme(configapi.Scheme)
+
+			if len(configFile) == 0 {
+				return fmt.Errorf("you must specify a --config file to read")
+			}
+			masterConfig, err := configapilatest.ReadAndResolveMasterConfig(configFile)
+			if err != nil {
+				return fmt.Errorf("unable to read master config: %v", err)
+			}
+
+			if glog.V(2) {
+				out, _ := yaml.Marshal(masterConfig)
+				glog.V(2).Infof("Master config:\n%s", out)
+			}
+			if getschedulerArgs {
+				return writeSchedulerArgs(*masterConfig)
+			}
+			// Return controllers and api-server arguments.
+			return fmt.Errorf("Expected one of scheduler, api-server or controllers flags to be set.")
+		},
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringVar(&configFile, "config", "", "The config file to convert to master arguments.")
+	cmd.Flags().BoolVar(&getschedulerArgs, "scheduler", false, "Gets the scheduler arguments")
+	cmd.Flags().BoolVar(&controllerArgs, "controllers", false, "Gets the controller arguments")
+	cmd.Flags().BoolVar(&apiServerArgs, "api-server", false, "Gets the api-server arguments")
+	flagtypes.GLog(cmd.PersistentFlags())
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// writeSchedulerArgs returns scheduler arguments to be written.
+func writeSchedulerArgs(masterConfig configapi.MasterConfig) error {
+	privilegedLoopbackConfig, err := configapi.GetClientConfig(masterConfig.MasterClients.OpenShiftLoopbackKubeConfig, masterConfig.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+	if err != nil {
+		return err
+	}
+	// Build scheduler args.
+	schedulerArgs := start.ComputeSchedulerArgs(masterConfig.MasterClients.OpenShiftLoopbackKubeConfig,
+		masterConfig.KubernetesMasterConfig.SchedulerConfigFile, privilegedLoopbackConfig.QPS,
+		privilegedLoopbackConfig.Burst,
+		masterConfig.KubernetesMasterConfig.SchedulerArguments)
+	var outputArgs []string
+	for _, s := range schedulerArgs {
+		outputArgs = append(outputArgs, shellEscapeArg(s))
+	}
+	fmt.Println(strings.Join(outputArgs, " "))
+	return nil
+}

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -47,6 +47,7 @@ readonly OS_CROSS_COMPILE_TARGETS=(
   cmd/oadm
   cmd/template-service-broker
   cmd/openshift-node-config
+  cmd/openshift-master-config
   vendor/k8s.io/kubernetes/cmd/hyperkube
 )
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")

--- a/images/hyperkube/Dockerfile
+++ b/images/hyperkube/Dockerfile
@@ -6,6 +6,8 @@
 #
 FROM openshift/origin-base
 
+COPY scripts/* /usr/local/bin/
+
 RUN INSTALL_PKGS="origin-hyperkube" && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/images/hyperkube/scripts/openshift-master-scheduler
+++ b/images/hyperkube/scripts/openshift-master-scheduler
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# This launches the scheduler by converting the master configuration into scheduler flags.
+
+set -euo pipefail
+
+if [[ -f /etc/origin/node/master-config.yaml ]]; then
+  config=/etc/origin/node/master-config.yaml
+fi
+flags=$( /usr/bin/openshift-master-config --scheduler=true "--config=${config}" )
+eval "exec /usr/bin/hyperkube scheduler --v=${DEBUG_LOGLEVEL:-2} ${flags}"

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -50,6 +50,9 @@ type MasterArgs struct {
 	// StartControllers controls whether the controller component of the master is started (to support
 	// the controller role)
 	StartControllers bool
+	// StartScheduler controls whether the scheduler component of the master is started (to support
+	// the scheduler role)
+	StartScheduler bool
 
 	// DNSBindAddr exposed for integration tests to set
 	DNSBindAddr flagtypes.Addr

--- a/pkg/cmd/server/start/start_allinone.go
+++ b/pkg/cmd/server/start/start_allinone.go
@@ -144,6 +144,7 @@ func GetAllInOneArgs() (*MasterArgs, *NodeArgs, *ListenArg, *ImageFormatArgs, *K
 	masterArgs := NewDefaultMasterArgs()
 	masterArgs.StartAPI = true
 	masterArgs.StartControllers = true
+	masterArgs.StartScheduler = true
 	masterArgs.OverrideConfig = func(config *configapi.MasterConfig) error {
 		// use node DNS
 		// config.DNSConfig = nil

--- a/pkg/cmd/server/start/start_kube_scheduler.go
+++ b/pkg/cmd/server/start/start_kube_scheduler.go
@@ -8,6 +8,7 @@ import (
 
 	schedulerapp "k8s.io/kubernetes/cmd/kube-scheduler/app"
 	_ "k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
+
 )
 
 func computeSchedulerArgs(kubeconfigFile, schedulerConfigFile string, qps float32, burst int, schedulerArgs map[string][]string) []string {

--- a/pkg/cmd/server/start/start_kube_scheduler.go
+++ b/pkg/cmd/server/start/start_kube_scheduler.go
@@ -11,7 +11,7 @@ import (
 
 )
 
-func computeSchedulerArgs(kubeconfigFile, schedulerConfigFile string, qps float32, burst int, schedulerArgs map[string][]string) []string {
+func ComputeSchedulerArgs(kubeconfigFile, schedulerConfigFile string, qps float32, burst int, schedulerArgs map[string][]string) []string {
 	cmdLineArgs := map[string][]string{}
 	// deep-copy the input args to avoid mutation conflict.
 	for k, v := range schedulerArgs {
@@ -56,7 +56,7 @@ func computeSchedulerArgs(kubeconfigFile, schedulerConfigFile string, qps float3
 
 func runEmbeddedScheduler(kubeconfigFile, schedulerConfigFile string, qps float32, burst int, cmdLineArgs map[string][]string) {
 	cmd := schedulerapp.NewSchedulerCommand()
-	args := computeSchedulerArgs(kubeconfigFile, schedulerConfigFile, qps, burst, cmdLineArgs)
+	args := ComputeSchedulerArgs(kubeconfigFile, schedulerConfigFile, qps, burst, cmdLineArgs)
 	if err := cmd.ParseFlags(args); err != nil {
 		glog.Fatal(err)
 	}

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -35,6 +35,7 @@ import (
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/version"
+	restclient "k8s.io/client-go/rest"
 )
 
 type MasterOptions struct {
@@ -103,6 +104,7 @@ func NewCommandStartMaster(basename string, out, errout io.Writer) (*cobra.Comma
 	options.MasterArgs = NewDefaultMasterArgs()
 	options.MasterArgs.StartAPI = true
 	options.MasterArgs.StartControllers = true
+	options.MasterArgs.StartScheduler = true
 	options.MasterArgs.OverrideConfig = func(config *configapi.MasterConfig) error {
 		if options.MasterArgs.MasterAddr.Provided {
 			if ip := net.ParseIP(options.MasterArgs.MasterAddr.Host); ip != nil {
@@ -133,8 +135,10 @@ func NewCommandStartMaster(basename string, out, errout io.Writer) (*cobra.Comma
 
 	startControllers, _ := NewCommandStartMasterControllers("controllers", basename, out, errout)
 	startAPI, _ := NewCommandStartMasterAPI("api", basename, out, errout)
+	startScheduler, _ := NewCommandStartMasterScheduler("scheduler", basename, out, errout)
 	cmd.AddCommand(startAPI)
 	cmd.AddCommand(startControllers)
+	cmd.AddCommand(startScheduler)
 
 	return cmd, options
 }
@@ -278,6 +282,7 @@ func (o MasterOptions) RunMaster() error {
 		config:      masterConfig,
 		api:         o.MasterArgs.StartAPI,
 		controllers: o.MasterArgs.StartControllers,
+		scheduler:   o.MasterArgs.StartScheduler,
 	}
 	return m.Start()
 }
@@ -323,14 +328,16 @@ type Master struct {
 	config      *configapi.MasterConfig
 	controllers bool
 	api         bool
+	scheduler   bool
 }
 
 // NewMaster create a master launcher
-func NewMaster(config *configapi.MasterConfig, controllers, api bool) *Master {
+func NewMaster(config *configapi.MasterConfig, controllers, api, scheduler bool) *Master {
 	return &Master{
 		config:      config,
 		controllers: controllers,
 		api:         api,
+		scheduler:   scheduler,
 	}
 }
 
@@ -354,12 +361,15 @@ func (m *Master) Start() error {
 	aggregatorinstall.Install(legacyscheme.Scheme)
 
 	controllersEnabled := m.controllers && len(m.config.ControllerConfig.Controllers) > 0
-	if controllersEnabled {
-		privilegedLoopbackConfig, err := configapi.GetClientConfig(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
+	var privilegedLoopbackConfig *restclient.Config
+	var err error
+	if m.scheduler || controllersEnabled {
+		privilegedLoopbackConfig, err = configapi.GetClientConfig(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
 		if err != nil {
 			return err
 		}
-
+	}
+	if m.scheduler {
 		go runEmbeddedScheduler(
 			m.config.MasterClients.OpenShiftLoopbackKubeConfig,
 			m.config.KubernetesMasterConfig.SchedulerConfigFile,
@@ -367,7 +377,9 @@ func (m *Master) Start() error {
 			privilegedLoopbackConfig.Burst,
 			m.config.KubernetesMasterConfig.SchedulerArguments,
 		)
+	}
 
+	if controllersEnabled {
 		go func() {
 			kubeControllerConfigShallowCopy := *m.config
 			// this creates using 0700

--- a/pkg/cmd/server/start/start_scheduler.go
+++ b/pkg/cmd/server/start/start_scheduler.go
@@ -1,0 +1,76 @@
+package start
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/server/origin"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+var schedulerLong = templates.LongDesc(`
+	Start the master scheduler
+
+	This command starts the scheduler for the master.  Running
+
+	    %[1]s start master %[2]s
+
+	will start the the scheduler. The scheduler will run in the foreground until you terminate the process.`)
+
+// NewCommandStartMasterScheduler starts only the scheduler
+func NewCommandStartMasterScheduler(name, basename string, out, errout io.Writer) (*cobra.Command, *MasterOptions) {
+	options := &MasterOptions{Output: out}
+	options.DefaultsFromName(basename)
+
+	cmd := &cobra.Command{
+		Use:   "scheduler",
+		Short: "Launch master Scheduler",
+		Long:  fmt.Sprintf(schedulerLong, basename, name),
+		Run: func(c *cobra.Command, args []string) {
+			if err := options.Complete(); err != nil {
+				fmt.Fprintln(errout, kcmdutil.UsageErrorf(c, err.Error()))
+				return
+			}
+
+			if len(options.ConfigFile) == 0 {
+				fmt.Fprintln(errout, kcmdutil.UsageErrorf(c, "--config is required for this command"))
+				return
+			}
+
+			if err := options.Validate(args); err != nil {
+				fmt.Fprintln(errout, kcmdutil.UsageErrorf(c, err.Error()))
+				return
+			}
+
+			origin.StartProfiler()
+
+			if err := options.StartMaster(); err != nil {
+				if kerrors.IsInvalid(err) {
+					if details := err.(*kerrors.StatusError).ErrStatus.Details; details != nil {
+						fmt.Fprintf(errout, "Invalid %s %s\n", details.Kind, details.Name)
+						for _, cause := range details.Causes {
+							fmt.Fprintf(errout, "  %s: %s\n", cause.Field, cause.Message)
+						}
+						os.Exit(255)
+					}
+				}
+				glog.Fatal(err)
+			}
+		},
+	}
+
+	options.MasterArgs = NewDefaultMasterArgs()
+	options.MasterArgs.StartScheduler = true
+	flags := cmd.Flags()
+	// This command only supports reading from config and the listen argument
+	flags.StringVar(&options.ConfigFile, "config", "", "Location of the master configuration file to run from. Required")
+	cmd.MarkFlagFilename("config", "yaml", "yml")
+
+	return cmd, options
+}

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -456,7 +456,7 @@ func StartConfiguredMasterWithOptions(masterConfig *configapi.MasterConfig) (str
 	if masterConfig.EtcdConfig != nil && len(masterConfig.EtcdConfig.StorageDir) > 0 {
 		os.RemoveAll(masterConfig.EtcdConfig.StorageDir)
 	}
-	if err := start.NewMaster(masterConfig, true /* always needed for cluster role aggregation */, true).Start(); err != nil {
+	if err := start.NewMaster(masterConfig, true /* always needed for cluster role aggregation */, true, true).Start(); err != nil {
 		return "", err
 	}
 	adminKubeConfigFile := util.KubeConfigPath()


### PR DESCRIPTION
This is first step in making scheduler 
- As a static pod similar to apiserver and etcd.
- Breaking it from controllers.

The master config is still going to be similar, sample scheduler config is going to look like this:

https://gist.github.com/ravisantoshgudimetla/abb9c2d869aa54141c1b1a0a8e782859#file-scheduler-yaml

Note to myself: I need to create a ansible template for kube-scheduler.

/cc @deads2k @sjenning @aveshagarwal 