### PR TITLE
Remove ROUTER_BIND_PORTS_BEFORE_SYNC configuration

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -372,10 +372,7 @@ func (o *TemplateRouterOptions) Run() error {
 			return err
 		}
 		checkController := metrics.ControllerLive()
-		liveChecks := []healthz.HealthzChecker{checkController}
-		if !(isTrue(util.Env("ROUTER_BIND_PORTS_BEFORE_SYNC", ""))) {
-			liveChecks = append(liveChecks, checkBackend)
-		}
+		liveChecks := []healthz.HealthzChecker{checkController, checkBackend}
 
 		kubeconfig, _, err := o.Config.KubeConfig()
 		if err != nil {


### PR DESCRIPTION
The ROUTER_BIND_PORTS_BEFORE_SYNC option was added and the liveness checks it
gates was enabled by default. We don't have any strong use case to support
making it configurable. Remove the option to reduce our configuration surface
area.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1603835.

/cc @openshift/sig-network-edge 