### PR TITLE
Prevent panic in build controller when pod has already been deleted

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -1017,6 +1017,9 @@ func (bc *BuildController) handleActiveBuild(build *buildapi.Build, pod *v1.Pod)
 }
 
 func isOOMKilled(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
 	if pod.Status.Reason == "OOMKilled" {
 		return true
 	}


### PR DESCRIPTION
handleCompletedBuild may be called with a nil pod, but isOOMKilled()
doesn't check whether the pod is nil first.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608112

@bparees

Blocks upgrading api.ci to 3.11