### PR TITLE
UPSTREAM: 66464: Avoid overflowing int64 in RoundUpSize and return error if overflow int

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
@@ -2487,9 +2487,8 @@ func (c *Cloud) ResizeDisk(
 		descErr := fmt.Errorf("AWS.ResizeDisk Error describing volume %s with %v", diskName, err)
 		return oldSize, descErr
 	}
-	requestBytes := newSize.Value()
 	// AWS resizes in chunks of GiB (not GB)
-	requestGiB := volumeutil.RoundUpSize(requestBytes, 1024*1024*1024)
+	requestGiB := volumeutil.RoundUpToGiB(newSize)
 	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", requestGiB))
 
 	// If disk already if of greater or equal size than requested we return

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -747,8 +747,8 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 	}
 
 	requestBytes := newSize.Value()
-	// GCE resizes in chunks of GBs (not GiB)
-	requestGB := volumeutil.RoundUpSize(requestBytes, 1000*1000*1000)
+	// GCE resizes in chunks of GiBs
+	requestGB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
 	newSizeQuant := resource.MustParse(fmt.Sprintf("%dG", requestGB))
 
 	// If disk is already of size equal or greater than requested size, we simply return

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -746,9 +746,8 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 		return oldSize, err
 	}
 
-	requestBytes := newSize.Value()
 	// GCE resizes in chunks of GiBs
-	requestGIB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
+	requestGIB := volumeutil.RoundUpToGiB(newSize)
 	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", requestGIB))
 
 	// If disk is already of size equal or greater than requested size, we simply return

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -748,11 +748,11 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 
 	requestBytes := newSize.Value()
 	// GCE resizes in chunks of GiBs
-	requestGB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
-	newSizeQuant := resource.MustParse(fmt.Sprintf("%dG", requestGB))
+	requestGIB := volumeutil.RoundUpSize(requestBytes, volumeutil.GIB)
+	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", requestGIB))
 
 	// If disk is already of size equal or greater than requested size, we simply return
-	if disk.SizeGb >= requestGB {
+	if disk.SizeGb >= requestGIB {
 		return newSizeQuant, nil
 	}
 
@@ -761,7 +761,7 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 	switch zoneInfo := disk.ZoneInfo.(type) {
 	case singleZone:
 		mc = newDiskMetricContextZonal("resize", disk.Region, zoneInfo.zone)
-		err := gce.manager.ResizeDiskOnCloudProvider(disk, requestGB, zoneInfo.zone)
+		err := gce.manager.ResizeDiskOnCloudProvider(disk, requestGIB, zoneInfo.zone)
 
 		if err != nil {
 			return oldSize, mc.Observe(err)
@@ -774,7 +774,7 @@ func (gce *GCECloud) ResizeDisk(diskToResize string, oldSize resource.Quantity, 
 		}
 
 		mc = newDiskMetricContextRegional("resize", disk.Region)
-		err := gce.manager.RegionalResizeDiskOnCloudProvider(disk, requestGB)
+		err := gce.manager.RegionalResizeDiskOnCloudProvider(disk, requestGIB)
 
 		if err != nil {
 			return oldSize, mc.Observe(err)

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -104,6 +104,7 @@ func TestReadConfig(t *testing.T) {
  auth-url = http://auth.url
  user-id = user
  tenant-name = demo
+ region = RegionOne
  [LoadBalancer]
  create-monitor = yes
  monitor-delay = 1m
@@ -134,6 +135,10 @@ func TestReadConfig(t *testing.T) {
 	// config file wins over environment variable
 	if cfg.Global.TenantName != "demo" {
 		t.Errorf("incorrect tenant name: %s", cfg.Global.TenantName)
+	}
+
+	if cfg.Global.Region != "RegionOne" {
+		t.Errorf("incorrect region: %s", cfg.Global.Region)
 	}
 
 	if !cfg.LoadBalancer.CreateMonitor {
@@ -554,7 +559,7 @@ func TestVolumes(t *testing.T) {
 	tags := map[string]string{
 		"test": "value",
 	}
-	vol, _, _, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, "", "", &tags)
+	vol, _, _, _, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, "", "", &tags)
 	if err != nil {
 		t.Fatalf("Cannot create a new Cinder volume: %v", err)
 	}

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -443,10 +443,10 @@ func (os *OpenStack) getVolume(volumeID string) (Volume, error) {
 }
 
 // CreateVolume creates a volume of given size (in GiB)
-func (os *OpenStack) CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, bool, error) {
+func (os *OpenStack) CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, string, bool, error) {
 	volumes, err := os.volumeService("")
 	if err != nil {
-		return "", "", os.bsOpts.IgnoreVolumeAZ, fmt.Errorf("unable to initialize cinder client for region: %s, err: %v", os.region, err)
+		return "", "", "", os.bsOpts.IgnoreVolumeAZ, fmt.Errorf("unable to initialize cinder client for region: %s, err: %v", os.region, err)
 	}
 
 	opts := volumeCreateOpts{
@@ -462,11 +462,11 @@ func (os *OpenStack) CreateVolume(name string, size int, vtype, availability str
 	volumeID, volumeAZ, err := volumes.createVolume(opts)
 
 	if err != nil {
-		return "", "", os.bsOpts.IgnoreVolumeAZ, fmt.Errorf("failed to create a %d GB volume: %v", size, err)
+		return "", "", "", os.bsOpts.IgnoreVolumeAZ, fmt.Errorf("failed to create a %d GB volume: %v", size, err)
 	}
 
-	glog.Infof("Created volume %v in Availability Zone: %v Ignore volume AZ: %v", volumeID, volumeAZ, os.bsOpts.IgnoreVolumeAZ)
-	return volumeID, volumeAZ, os.bsOpts.IgnoreVolumeAZ, nil
+	glog.Infof("Created volume %v in Availability Zone: %v Region: %v Ignore volume AZ: %v", volumeID, volumeAZ, os.region, os.bsOpts.IgnoreVolumeAZ)
+	return volumeID, volumeAZ, os.region, os.bsOpts.IgnoreVolumeAZ, nil
 }
 
 // GetDevicePathBySerialID returns the path of an attached block storage volume, specified by its id.

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -411,13 +411,15 @@ func (os *OpenStack) ExpandVolume(volumeID string, oldSize resource.Quantity, ne
 		return oldSize, fmt.Errorf("volume status is not available")
 	}
 
-	volSizeBytes := newSize.Value()
 	// Cinder works with gigabytes, convert to GiB with rounding up
-	volSizeGB := int(volumeutil.RoundUpSize(volSizeBytes, 1024*1024*1024))
-	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", volSizeGB))
+	volSizeGiB, err := volumeutil.RoundUpToGiBInt(newSize)
+	if err != nil {
+		return oldSize, err
+	}
+	newSizeQuant := resource.MustParse(fmt.Sprintf("%dGi", volSizeGiB))
 
 	// if volume size equals to or greater than the newSize, return nil
-	if volume.Size >= volSizeGB {
+	if volume.Size >= volSizeGiB {
 		return newSizeQuant, nil
 	}
 
@@ -426,7 +428,7 @@ func (os *OpenStack) ExpandVolume(volumeID string, oldSize resource.Quantity, ne
 		return oldSize, err
 	}
 
-	err = volumes.expandVolume(volumeID, volSizeGB)
+	err = volumes.expandVolume(volumeID, volSizeGiB)
 	if err != nil {
 		return oldSize, err
 	}

--- a/vendor/k8s.io/kubernetes/pkg/volume/azure_dd/azure_provision.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/azure_dd/azure_provision.go
@@ -100,8 +100,10 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 	// maxLength = 79 - (4 for ".vhd") = 75
 	name := util.GenerateVolumeName(p.options.ClusterName, p.options.PVName, 75)
 	capacity := p.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	requestBytes := capacity.Value()
-	requestGB := int(util.RoundUpSize(requestBytes, 1024*1024*1024))
+	requestGiB, err := util.RoundUpToGiBInt(capacity)
+	if err != nil {
+		return nil, err
+	}
 
 	for k, v := range p.options.Parameters {
 		switch strings.ToLower(k) {
@@ -157,18 +159,18 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 		if p.options.CloudTags != nil {
 			tags = *(p.options.CloudTags)
 		}
-		diskURI, err = diskController.CreateManagedDisk(name, skuName, resourceGroup, requestGB, tags)
+		diskURI, err = diskController.CreateManagedDisk(name, skuName, resourceGroup, requestGiB, tags)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		if kind == v1.AzureDedicatedBlobDisk {
-			_, diskURI, _, err = diskController.CreateVolume(name, account, storageAccountType, location, requestGB)
+			_, diskURI, _, err = diskController.CreateVolume(name, account, storageAccountType, location, requestGiB)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			diskURI, err = diskController.CreateBlobDisk(name, skuName, requestGB)
+			diskURI, err = diskController.CreateBlobDisk(name, skuName, requestGiB)
 			if err != nil {
 				return nil, err
 			}
@@ -187,7 +189,7 @@ func (p *azureDiskProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 			PersistentVolumeReclaimPolicy: p.options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   supportedModes,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", requestGB)),
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", requestGiB)),
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				AzureDisk: &v1.AzureDiskVolumeSource{

--- a/vendor/k8s.io/kubernetes/pkg/volume/cinder/attacher_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/cinder/attacher_test.go
@@ -615,8 +615,8 @@ func (testcase *testcase) DiskIsAttachedByName(nodeName types.NodeName, volumeID
 	return expected.isAttached, expected.instanceID, expected.ret
 }
 
-func (testcase *testcase) CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, bool, error) {
-	return "", "", false, errors.New("Not implemented")
+func (testcase *testcase) CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, string, bool, error) {
+	return "", "", "", false, errors.New("Not implemented")
 }
 
 func (testcase *testcase) GetDevicePath(volumeID string) string {

--- a/vendor/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/cinder/cinder.go
@@ -53,7 +53,7 @@ type BlockStorageProvider interface {
 	AttachDisk(instanceID, volumeID string) (string, error)
 	DetachDisk(instanceID, volumeID string) error
 	DeleteVolume(volumeID string) error
-	CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, bool, error)
+	CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, string, bool, error)
 	GetDevicePath(volumeID string) string
 	InstanceID() (string, error)
 	GetAttachmentDiskPath(instanceID, volumeID string) (string, error)

--- a/vendor/k8s.io/kubernetes/pkg/volume/cinder/cinder_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/cinder/cinder_util.go
@@ -208,10 +208,10 @@ func (util *DiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID string,
 		}
 	}
 
-	volumeID, volumeAZ, IgnoreVolumeAZ, errr := cloud.CreateVolume(name, volSizeGB, vtype, availability, c.options.CloudTags)
-	if errr != nil {
-		glog.V(2).Infof("Error creating cinder volume: %v", errr)
-		return "", 0, nil, "", errr
+	volumeID, volumeAZ, volumeRegion, IgnoreVolumeAZ, err := cloud.CreateVolume(name, volSizeGB, vtype, availability, c.options.CloudTags)
+	if err != nil {
+		glog.V(2).Infof("Error creating cinder volume: %v", err)
+		return "", 0, nil, "", err
 	}
 	glog.V(2).Infof("Successfully created cinder volume %s", volumeID)
 
@@ -219,6 +219,7 @@ func (util *DiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID string,
 	volumeLabels = make(map[string]string)
 	if IgnoreVolumeAZ == false {
 		volumeLabels[kubeletapis.LabelZoneFailureDomain] = volumeAZ
+		volumeLabels[kubeletapis.LabelZoneRegion] = volumeRegion
 	}
 	return volumeID, volSizeGB, volumeLabels, fstype, nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/volume/flocker/flocker_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/flocker/flocker_util.go
@@ -49,7 +49,7 @@ func (util *FlockerUtil) DeleteVolume(d *flockerVolumeDeleter) error {
 	return d.flockerClient.DeleteDataset(datasetUUID)
 }
 
-func (util *FlockerUtil) CreateVolume(c *flockerVolumeProvisioner) (datasetUUID string, volumeSizeGB int, labels map[string]string, err error) {
+func (util *FlockerUtil) CreateVolume(c *flockerVolumeProvisioner) (datasetUUID string, volumeSizeGiB int, labels map[string]string, err error) {
 
 	if c.flockerClient == nil {
 		c.flockerClient, err = c.plugin.newFlockerClient("")
@@ -74,7 +74,10 @@ func (util *FlockerUtil) CreateVolume(c *flockerVolumeProvisioner) (datasetUUID 
 
 	capacity := c.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestBytes := capacity.Value()
-	volumeSizeGB = int(volutil.RoundUpSize(requestBytes, 1024*1024*1024))
+	volumeSizeGiB, err = volutil.RoundUpToGiBInt(capacity)
+	if err != nil {
+		return
+	}
 
 	createOptions := &flockerapi.CreateDatasetOptions{
 		MaximumSize: requestBytes,

--- a/vendor/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd.go
@@ -492,7 +492,7 @@ func (c *gcePersistentDiskProvisioner) Provision(selectedNode *v1.Node, allowedT
 			PersistentVolumeReclaimPolicy: c.options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   c.options.PVC.Spec.AccessModes,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dG", sizeGB)),
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{

--- a/vendor/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/gce_pd/gce_pd_test.go
@@ -177,7 +177,7 @@ func TestPlugin(t *testing.T) {
 	}
 	cap := persistentSpec.Spec.Capacity[v1.ResourceStorage]
 	size := cap.Value()
-	if size != 100*util.GB {
+	if size != 100*util.GIB {
 		t.Errorf("Provision() returned unexpected volume size: %v", size)
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/volume/gce_pd/gce_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/gce_pd/gce_util.go
@@ -86,8 +86,8 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (strin
 
 	name := volumeutil.GenerateVolumeName(c.options.ClusterName, c.options.PVName, 63) // GCE PD name can have up to 63 characters
 	capacity := c.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	// GCE PDs are allocated in chunks of GBs (not GiBs)
-	requestGB := volumeutil.RoundUpToGB(capacity)
+	// GCE PDs are allocated in chunks of GiBs
+	requestGB := volumeutil.RoundUpToGiB(capacity)
 
 	// Apply Parameters.
 	// Values for parameter "replication-type" are canonicalized to lower case.

--- a/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
@@ -744,7 +744,10 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 	capacity := p.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 
 	// GlusterFS/heketi creates volumes in units of GiB.
-	sz := int(volutil.RoundUpToGiB(capacity))
+	sz, err := volutil.RoundUpToGiBInt(capacity)
+	if err != nil {
+		return nil, 0, "", err
+	}
 	glog.V(2).Infof("create volume of size %dGiB", sz)
 
 	if p.url == "" {

--- a/vendor/k8s.io/kubernetes/pkg/volume/photon_pd/photon_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/photon_pd/photon_util.go
@@ -88,9 +88,11 @@ func (util *PhotonDiskUtil) CreateVolume(p *photonPersistentDiskProvisioner) (pd
 	}
 
 	capacity := p.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	volSizeBytes := capacity.Value()
-	// PhotonController works with GB, convert to GB with rounding up
-	volSizeGB := int(volumeutil.RoundUpSize(volSizeBytes, 1024*1024*1024))
+	// PhotonController works with GiB, convert to GiB with rounding up
+	volSizeGB, err := volumeutil.RoundUpToGiBInt(capacity)
+	if err != nil {
+		return "", 0, "", err
+	}
 	name := volumeutil.GenerateVolumeName(p.options.ClusterName, p.options.PVName, 255)
 	volumeOptions := &photon.VolumeOptions{
 		CapacityGB: volSizeGB,

--- a/vendor/k8s.io/kubernetes/pkg/volume/quobyte/quobyte_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/quobyte/quobyte_util.go
@@ -35,7 +35,10 @@ type quobyteVolumeManager struct {
 
 func (manager *quobyteVolumeManager) createVolume(provisioner *quobyteVolumeProvisioner, createQuota bool) (quobyte *v1.QuobyteVolumeSource, size int, err error) {
 	capacity := provisioner.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	volumeSize := int(util.RoundUpSize(capacity.Value(), 1024*1024*1024))
+	volumeSize, err := util.RoundUpToGiBInt(capacity)
+	if err != nil {
+		return nil, 0, err
+	}
 	// Quobyte has the concept of Volumes which doen't have a specific size (they can grow unlimited)
 	// to simulate a size constraint we set here a Quota for logical space
 	volumeRequest := &quobyteapi.CreateVolumeRequest{

--- a/vendor/k8s.io/kubernetes/pkg/volume/rbd/rbd_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/rbd/rbd_util.go
@@ -575,7 +575,10 @@ func (util *RBDUtil) CreateImage(p *rbdVolumeProvisioner) (r *v1.RBDPersistentVo
 	capacity := p.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	volSizeBytes := capacity.Value()
 	// Convert to MB that rbd defaults on.
-	sz := int(volutil.RoundUpSize(volSizeBytes, 1024*1024))
+	sz, err := volutil.RoundUpSizeInt(volSizeBytes, 1024*1024)
+	if err != nil {
+		return nil, 0, err
+	}
 	volSz := fmt.Sprintf("%d", sz)
 	mon := util.kernelRBDMonitorsOpt(p.Mon)
 	if p.rbdMounter.imageFormat == rbdImageFormat2 {

--- a/vendor/k8s.io/kubernetes/pkg/volume/storageos/storageos.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/storageos/storageos.go
@@ -602,7 +602,11 @@ func (c *storageosProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 		c.labels[k] = v
 	}
 	capacity := c.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	c.sizeGB = int(util.RoundUpSize(capacity.Value(), 1024*1024*1024))
+	var err error
+	c.sizeGB, err = util.RoundUpToGiBInt(capacity)
+	if err != nil {
+		return nil, err
+	}
 
 	apiCfg, err := parsePVSecret(adminSecretNamespace, adminSecretName, c.plugin.host.GetKubeClient())
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -93,10 +93,13 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (volSpec 
 	capacity := v.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	volSizeBytes := capacity.Value()
 	// vSphere works with kilobytes, convert to KiB with rounding up
-	volSizeKB := int(volumeutil.RoundUpSize(volSizeBytes, 1024))
+	volSizeKiB, err := volumeutil.RoundUpSizeInt(volSizeBytes, 1024)
+	if err != nil {
+		return nil, err
+	}
 	name := volumeutil.GenerateVolumeName(v.options.ClusterName, v.options.PVName, 255)
 	volumeOptions := &vclib.VolumeOptions{
-		CapacityKB: volSizeKB,
+		CapacityKB: volSizeKiB,
 		Tags:       *v.options.CloudTags,
 		Name:       name,
 	}
@@ -146,7 +149,7 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (volSpec 
 	}
 	volSpec = &VolumeSpec{
 		Path:              vmDiskPath,
-		Size:              volSizeKB,
+		Size:              volSizeKiB,
 		Fstype:            fstype,
 		StoragePolicyName: volumeOptions.StoragePolicyName,
 		StoragePolicyID:   volumeOptions.StoragePolicyID,

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
@@ -265,8 +265,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 						"type": "pd-ssd",
 						"zone": cloudZone,
 					},
-					claimSize:    "1.5G",
-					expectedSize: "2G",
+					claimSize:    "1.5Gi",
+					expectedSize: "2Gi",
 					pvCheck: func(volume *v1.PersistentVolume) error {
 						return checkGCEPD(volume, "pd-ssd")
 					},
@@ -278,8 +278,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					parameters: map[string]string{
 						"type": "pd-standard",
 					},
-					claimSize:    "1.5G",
-					expectedSize: "2G",
+					claimSize:    "1.5Gi",
+					expectedSize: "2Gi",
 					pvCheck: func(volume *v1.PersistentVolume) error {
 						return checkGCEPD(volume, "pd-standard")
 					},
@@ -443,8 +443,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				parameters: map[string]string{
 					"type": "pd-standard",
 				},
-				claimSize:    "1G",
-				expectedSize: "1G",
+				claimSize:    "1Gi",
+				expectedSize: "1Gi",
 				pvCheck: func(volume *v1.PersistentVolume) error {
 					return checkGCEPD(volume, "pd-standard")
 				},
@@ -477,8 +477,8 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				parameters: map[string]string{
 					"type": "pd-standard",
 				},
-				claimSize:    "1G",
-				expectedSize: "1G",
+				claimSize:    "1Gi",
+				expectedSize: "1Gi",
 				pvCheck: func(volume *v1.PersistentVolume) error {
 					return checkGCEPD(volume, "pd-standard")
 				},
@@ -526,7 +526,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				name:        "unmanaged_zone",
 				provisioner: "kubernetes.io/gce-pd",
 				parameters:  map[string]string{"zone": unmanagedZone},
-				claimSize:   "1G",
+				claimSize:   "1Gi",
 			}
 			sc := newStorageClass(test, ns, suffix)
 			sc, err = c.StorageV1().StorageClasses().Create(sc)
@@ -714,13 +714,6 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				claimSize:    "2Gi",
 				expectedSize: "2Gi",
 			}
-			// gce or gke
-			if getDefaultPluginName() == "kubernetes.io/gce-pd" {
-				// using GB not GiB as e2e test unit since gce-pd returns GB,
-				// or expectedSize may be greater than claimSize.
-				test.claimSize = "2G"
-				test.expectedSize = "2G"
-			}
 
 			claim := newClaim(test, ns, "default")
 			testDynamicProvisioning(test, c, claim, nil)
@@ -803,17 +796,6 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				parameters:   map[string]string{"resturl": serverUrl},
 				attach:       false,
 			}
-
-			// GCE/GKE
-			if getDefaultPluginName() == "kubernetes.io/gce-pd" {
-				// Keeping an extra condition here based on below facts:
-				//*) gce-pd rounds up to the next gb.
-				//*) GlusterFS provisioner rounduptoGiB() and send it to backend,
-				//      which does 'size/number' from provisioner*1024*1024*1024
-				test.claimSize = "2Gi"
-				test.expectedSize = "3G"
-			}
-
 			suffix := fmt.Sprintf("glusterdptest")
 			class := newStorageClass(test, ns, suffix)
 
@@ -838,14 +820,6 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				expectedSize: "2Gi",
 				volumeMode:   &block,
 			}
-			// gce or gke
-			if getDefaultPluginName() == "kubernetes.io/gce-pd" {
-				// using GB not GiB as e2e test unit since gce-pd returns GB,
-				// or expectedSize may be greater than claimSize.
-				test.claimSize = "2G"
-				test.expectedSize = "2G"
-			}
-
 			claim := newClaim(test, ns, "default")
 			claim.Spec.VolumeMode = &block
 			testDynamicProvisioning(test, c, claim, nil)


### PR DESCRIPTION
This fixes/mitigates https://bugzilla.redhat.com/show_bug.cgi?id=1592653

commits 1 & 2 are needed for patching GCE files cleanly. They fix a bug with GCE GiB vs GB and they were cherrypicked into kubernetes 1.11 (and 1.10) as well so there is no harm in doing the same here.

commit 3 is for patching cinder files cleanly. it is arguable whether it's needed or I should have just manually fixed the conflict but It seems harmless to me.

commit 4 is the patch I actually want to cherry-pick