### PR TITLE
tighten static pod manifest check frequency

### DIFF
--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -510,6 +510,7 @@ func (c *ClusterUpConfig) startKubelet(out io.Writer, masterConfigDir, nodeConfi
 		actualKubeletFlags = append(actualKubeletFlags, curr)
 	}
 	container.Args = append(actualKubeletFlags, "--pod-manifest-path=/var/lib/origin/pod-manifests")
+	container.Args = append(container.Args, "--file-check-frequency=1s")
 	container.Args = append(container.Args, "--cluster-dns=172.30.0.2")
 	container.Args = append(container.Args, fmt.Sprintf("--v=%d", c.ServerLogLevel))
 	glog.V(1).Info(strings.Join(container.Args, " "))


### PR DESCRIPTION
The default is something like 20 seconds.  Change it to one second to pick up the static pod manifests very quickly.

@mfojtik @sjenning 