### PR TITLE
use the release string if tito provides it for the tag string

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -40,5 +40,8 @@ class OriginTagger(VersionTagger):
         super(OriginTagger, self)._tag_release()
 
     def _get_tag_for_version(self, version, release=None):
-        return "v{}".format(version)
+        if release:
+            return "v{}".format(version)
+        else:
+            return "v{}-{}".format(version, release)
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:


### PR DESCRIPTION
This change allows the CD process to proceed correctly when building with tito-0.6.11., It is backward compatible with the tito-0.6.10, currently in use, but out of date.

tito-0.6.11 corrects a bug. In 0.6.10 the version string is passed to ttio.tagger.VersionTagger._get_tag_for_version() with the release suffix included in the version string parameter. 0.6.11 passes the version and release in separate arguments. This change allows the build process to handle either input.

Without this change, building with tito-0.6.11 generates an error:

```
Getting latest package info from: /home/bos/mlamouri/sample/ose/.tito/packages/
atomic-openshift
Command: awk '{ print $1 ; exit }' /home/bos/mlamouri/sample/ose/.tito/packages
/atomic-openshift
Status code: 0
Command output: 3.9.37-1

Traceback (most recent call last):
  File "/usr/bin/tito", line 23, in <module>
    CLI().main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 203, in main
    return module.main(argv)
  File "/usr/lib/python2.7/site-packages/tito/cli.py", line 671, in main
    return tagger.run(self.options)
  File "/usr/lib/python2.7/site-packages/tito/tagger/main.py", line 114, in run
    self._tag_release()
  File "/home/bos/mlamouri/sample/ose/.tito/lib/origin/tagger/__init__.py", lin
e 40, in _tag_release
    super(OriginTagger, self)._tag_release()
  File "/usr/lib/python2.7/site-packages/tito/tagger/main.py", line 134, in _ta
g_release
    self._make_changelog()
  File "/usr/lib/python2.7/site-packages/tito/tagger/main.py", line 261, in _ma
ke_changelog
    output = self._generate_default_changelog(last_tag)
  File "/usr/lib/python2.7/site-packages/tito/tagger/main.py", line 213, in _ge
nerate_default_changelog
    output = run_command(patch_command)
  File "/usr/lib/python2.7/site-packages/tito/common.py", line 426, in run_comm
and
    raise RunCommandException(command, status, output)
tito.exception.RunCommandException: Error running command: git log --no-merges 
--pretty='format:%s (%ae)' --relative v3.9.37..HEAD -- .
```