### PR TITLE
UPSTREAM: 66725: update exit code to 0 if patch not needed

### DIFF
--- a/test/cmd/basicresources.sh
+++ b/test/cmd/basicresources.sh
@@ -325,6 +325,10 @@ os::cmd::expect_success          "echo '${group_json}' | oc create -f -"
 os::cmd::expect_success          "oc patch group patch-group -p 'users: [\"myuser\"]' --loglevel=8"
 os::cmd::expect_success_and_text 'oc get group patch-group -o yaml' 'myuser'
 os::cmd::expect_success          "oc patch group patch-group -p 'users: []' --loglevel=8"
+# applying the same patch twice results in exit code 0, and "not patched" text
+os::cmd::expect_success_and_text "oc patch group patch-group -p 'users: []'" "not patched"
+# applying an invalid patch results in exit code 1 and an error
+os::cmd::expect_failure_and_text "oc patch group patch-group -p 'users: \"\"'" "cannot restore slice from string"
 os::cmd::expect_success_and_text 'oc get group patch-group -o yaml' 'users: \[\]'
 echo "patch: ok"
 os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/patch.go
@@ -245,14 +245,7 @@ func (o *PatchOptions) RunPatch() error {
 			if err != nil {
 				return err
 			}
-			printer.PrintObj(info.Object, o.Out)
-
-			// if object was not successfully patched, exit with error code 1
-			if !didPatch {
-				return cmdutil.ErrExit
-			}
-
-			return nil
+			return printer.PrintObj(info.Object, o.Out)
 		}
 
 		count++


### PR DESCRIPTION
The specific logic in the patch command that exited with code 1, was only doing so when there was no diff between an existing object and its patched counterpart. (In case of errors, we just return those, which eventually ends up exiting with code 1 anyway). This patch removes this block, as we should not be treating patch no-ops as errors.

Fixes https://github.com/kubernetes/kubernetes/issues/58212
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609179

UPSTREAM: https://github.com/kubernetes/kubernetes/pull/66725

cc @soltysh 