### PR TITLE
An image represents a manifest (and is a blob) and also references a config

### DIFF
--- a/pkg/image/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/registry/imagestream/etcd/etcd.go
@@ -192,7 +192,7 @@ func (r *LayersREST) Get(ctx context.Context, name string, options *metav1.GetOp
 						isl.Blobs[layer.Name] = imageapi.ImageLayerData{LayerSize: &layer.LayerSize, MediaType: layer.MediaType}
 					}
 				}
-				if blob := entry.Manifest; blob != nil {
+				if blob := entry.Config; blob != nil {
 					reference.Manifest = &blob.Name
 					if _, ok := isl.Blobs[blob.Name]; !ok {
 						if blob.LayerSize == 0 {
@@ -202,6 +202,10 @@ func (r *LayersREST) Get(ctx context.Context, name string, options *metav1.GetOp
 							isl.Blobs[blob.Name] = imageapi.ImageLayerData{LayerSize: &blob.LayerSize, MediaType: blob.MediaType}
 						}
 					}
+				}
+				// the image manifest is always a blob - schema2 images also have a config blob referenced from the manifest
+				if _, ok := isl.Blobs[item.Image]; !ok {
+					isl.Blobs[item.Image] = imageapi.ImageLayerData{MediaType: entry.MediaType}
 				}
 				isl.Images[item.Image] = reference
 			}

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -72,10 +72,14 @@ var _ = g.Describe("[Feature:ImageLayers] Image layer subresource", func() {
 				o.Expect(ok).To(o.BeTrue())
 				o.Expect(len(l.Layers)).To(o.BeNumerically(">", 0))
 				o.Expect(l.Manifest).ToNot(o.BeNil())
+				o.Expect(layers.Blobs[*l.Manifest]).ToNot(o.BeNil())
+				o.Expect(layers.Blobs[*l.Manifest].MediaType).To(o.Equal("application/vnd.docker.container.image.v1+json"))
 				for _, layerID := range l.Layers {
 					o.Expect(layers.Blobs).To(o.HaveKey(layerID))
 					o.Expect(layers.Blobs[layerID].MediaType).NotTo(o.BeEmpty())
 				}
+				o.Expect(layers.Blobs).To(o.HaveKey(image.Image.Name))
+				o.Expect(layers.Blobs[image.Image.Name].MediaType).To(o.Equal("application/vnd.docker.distribution.manifest.v2+json"))
 				if i == 0 {
 					busyboxLayers = l.Layers
 				}


### PR DESCRIPTION
Our external API and internal structure is wrong. All images are manifests, and all manifests are blobs.
In addition, a v2 schema 2 manifest references a blob that is a "config", not a "manifest".

Corrected the internal code so that the image/manifest digest now shows up in blobs, renamed the internal
field "config", and set the correct mime types and fixed tests.

Replaces https://github.com/openshift/image-registry/pull/115