### PR TITLE
invert tag string selection logic

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -40,7 +40,7 @@ class OriginTagger(VersionTagger):
         super(OriginTagger, self)._tag_release()
 
     def _get_tag_for_version(self, version, release=None):
-        if release:
+        if release is None:
             return "v{}".format(version)
         else:
             return "v{}-{}".format(version, release)


### PR DESCRIPTION
The prior PR that added logic to use the release value in titio tagger got the test inverted.

This PR corrects the logic.