### PR TITLE
tighten usage of oauthserver package in openshift

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -71,15 +71,7 @@
       "github.com/openshift/origin/pkg/oauthserver",
 
       "github.com/openshift/origin/pkg/cmd/server/origin",
-      "github.com/openshift/origin/pkg/authorization/registry/clusterrole",
-      "github.com/openshift/origin/pkg/authorization/registry/clusterrolebinding",
-      "github.com/openshift/origin/pkg/authorization/registry/role",
-      "github.com/openshift/origin/pkg/authorization/registry/rolebinding",
-      "github.com/openshift/origin/pkg/build/admission/jenkinsbootstrapper",
-      "github.com/openshift/origin/pkg/build/admission/secretinjector",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/validation",
-      "github.com/openshift/origin/pkg/cmd/server/handlers",
-      "github.com/openshift/origin/pkg/oauth/util",
       "github.com/openshift/origin/pkg/oc/cli/admin",
       "github.com/openshift/origin/pkg/oc/cli/admin/createerrortemplate",
       "github.com/openshift/origin/pkg/oc/cli/admin/createlogintemplate",
@@ -89,8 +81,7 @@
       "github.com/openshift/origin/pkg/oc/lib/groupsync/ad",
       "github.com/openshift/origin/pkg/oc/lib/groupsync/groupdetector",
       "github.com/openshift/origin/pkg/oc/lib/groupsync/rfc2307",
-      "github.com/openshift/origin/pkg/oc/lib/groupsync/syncerror",
-      "github.com/openshift/origin/pkg/user"
+      "github.com/openshift/origin/pkg/oc/lib/groupsync/syncerror"
     ],
     "forbiddenImportPackageRoots": [
       "github.com/openshift/origin/pkg/oauthserver"

--- a/pkg/oauth/util/discovery.go
+++ b/pkg/oauth/util/discovery.go
@@ -13,7 +13,6 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/oauth/apis/oauth/validation"
 	"github.com/openshift/origin/pkg/oauth/urls"
-	"github.com/openshift/origin/pkg/oauthserver/osinserver"
 )
 
 // OauthAuthorizationServerMetadata holds OAuth 2.0 Authorization Server Metadata used for discovery
@@ -51,15 +50,14 @@ type OauthAuthorizationServerMetadata struct {
 // validate configuration using LoadOAuthMetadataFile
 
 func getOauthMetadata(masterPublicURL string) OauthAuthorizationServerMetadata {
-	config := osinserver.NewDefaultServerConfig()
 	return OauthAuthorizationServerMetadata{
 		Issuer:                masterPublicURL,
 		AuthorizationEndpoint: urls.OpenShiftOAuthAuthorizeURL(masterPublicURL),
 		TokenEndpoint:         urls.OpenShiftOAuthTokenURL(masterPublicURL),
 		// Note: this list is incomplete, which is allowed per the draft spec
 		ScopesSupported:               scope.DefaultSupportedScopes(),
-		ResponseTypesSupported:        config.AllowedAuthorizeTypes,
-		GrantTypesSupported:           osin.AllowedAccessType{osin.AUTHORIZATION_CODE, osin.AccessRequestType("implicit")}, // TODO use config.AllowedAccessTypes once our implementation handles other grant types
+		ResponseTypesSupported:        osin.AllowedAuthorizeType{osin.CODE, osin.TOKEN},
+		GrantTypesSupported:           osin.AllowedAccessType{osin.AUTHORIZATION_CODE, osin.AccessRequestType("implicit")},
 		CodeChallengeMethodsSupported: validation.CodeChallengeMethodsSupported,
 	}
 }


### PR DESCRIPTION
Trying to snip out more links coupling separate components together.  I found this easy one while tidying up the list.  It's better to have separate chains indicate their acceptance separately than pulling in the dep.

@openshift/sig-security 