### PR TITLE
sanitize some cluster up imports

### DIFF
--- a/pkg/oc/cli/admin/policy/authz_helpers.go
+++ b/pkg/oc/cli/admin/policy/authz_helpers.go
@@ -1,0 +1,54 @@
+package policy
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+)
+
+func buildSubjects(users, groups []string) []corev1.ObjectReference {
+	subjects := []corev1.ObjectReference{}
+
+	for _, user := range users {
+		saNamespace, saName, err := serviceaccount.SplitUsername(user)
+		if err == nil {
+			subjects = append(subjects, corev1.ObjectReference{Kind: "ServiceAccount", Namespace: saNamespace, Name: saName})
+			continue
+		}
+
+		subjects = append(subjects, corev1.ObjectReference{Kind: "User", Name: user})
+	}
+
+	for _, group := range groups {
+		subjects = append(subjects, corev1.ObjectReference{Kind: "Group", Name: group})
+	}
+
+	return subjects
+}
+
+// stringSubjectsFor returns users and groups for comparison against user.Info.  currentNamespace is used to
+// to create usernames for service accounts where namespace=="".
+func stringSubjectsFor(currentNamespace string, subjects []corev1.ObjectReference) ([]string, []string) {
+	// these MUST be nil to indicate empty
+	var users, groups []string
+
+	for _, subject := range subjects {
+		switch subject.Kind {
+		case "ServiceAccount":
+			namespace := currentNamespace
+			if len(subject.Namespace) > 0 {
+				namespace = subject.Namespace
+			}
+			if len(namespace) > 0 {
+				users = append(users, serviceaccount.MakeUsername(namespace, subject.Name))
+			}
+
+		case "User":
+			users = append(users, subject.Name)
+
+		case "Group":
+			groups = append(groups, subject.Name)
+		}
+	}
+
+	return users, groups
+}

--- a/pkg/oc/clusteradd/componentinstall/privileged.go
+++ b/pkg/oc/clusteradd/componentinstall/privileged.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 
+	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	"github.com/openshift/origin/pkg/oc/lib/errors"
-	securityclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
 )
 
 // AddPrivilegedUser adds the provided user to list of users allowed to use privileged SCC.

--- a/pkg/oc/clusteradd/components/template-service-broker/template_service_broker.go
+++ b/pkg/oc/clusteradd/components/template-service-broker/template_service_broker.go
@@ -5,16 +5,16 @@ import (
 	"path"
 
 	"github.com/golang/glog"
-	"github.com/openshift/origin/pkg/oc/clusteradd/components/register-template-service-broker"
-	"github.com/openshift/origin/pkg/oc/clusterup/coreinstall/kubeapiserver"
-	"github.com/openshift/origin/pkg/oc/clusterup/manifests"
-	"k8s.io/client-go/kubernetes"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 	"github.com/openshift/origin/pkg/oc/clusteradd/componentinstall"
+	"github.com/openshift/origin/pkg/oc/clusteradd/components/register-template-service-broker"
+	"github.com/openshift/origin/pkg/oc/clusterup/coreinstall/kubeapiserver"
 	"github.com/openshift/origin/pkg/oc/clusterup/docker/dockerhelper"
+	"github.com/openshift/origin/pkg/oc/clusterup/manifests"
 	"github.com/openshift/origin/pkg/oc/lib/errors"
 )
 

--- a/pkg/oc/clusterup/docker/openshift/helper.go
+++ b/pkg/oc/clusterup/docker/openshift/helper.go
@@ -10,9 +10,9 @@ import (
 	"github.com/golang/glog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	_ "github.com/openshift/origin/pkg/cmd/server/apis/config/install"
@@ -177,8 +177,8 @@ func (h *Helper) OtherIPs(excludeIP string) ([]string, error) {
 
 // CheckNodes determines if there is more than one node that corresponds to the
 // current machine and removes the one that doesn't match the default node name
-func (h *Helper) CheckNodes(kclient kclientset.Interface) error {
-	nodes, err := kclient.Core().Nodes().List(metav1.ListOptions{})
+func (h *Helper) CheckNodes(kclient kubernetes.Interface) error {
+	nodes, err := kclient.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return errors.NewError("cannot retrieve nodes").WithCause(err)
 	}
@@ -206,7 +206,7 @@ func (h *Helper) CheckNodes(kclient kclientset.Interface) error {
 
 		for i := 0; i < len(nodesToRemove); i++ {
 			glog.V(2).Infof("Deleting extra node %s", nodesToRemove[i])
-			err = kclient.Core().Nodes().Delete(nodesToRemove[i], nil)
+			err = kclient.CoreV1().Nodes().Delete(nodesToRemove[i], nil)
 			if err != nil {
 				return errors.NewError("cannot delete duplicate node %s", nodesToRemove[i]).WithCause(err)
 			}

--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -31,9 +31,6 @@ import (
 	"github.com/openshift/origin/pkg/oc/clusterup/docker/dockerhelper"
 	"github.com/openshift/origin/pkg/oc/clusterup/docker/host"
 	"github.com/openshift/origin/pkg/oc/clusterup/manifests"
-
-	// install our apis into the legacy scheme
-	_ "github.com/openshift/origin/pkg/api/install"
 )
 
 type staticInstall struct {

--- a/pkg/oc/clusterup/up.go
+++ b/pkg/oc/clusterup/up.go
@@ -21,12 +21,12 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	aggregatorinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
@@ -803,7 +803,7 @@ func (c *ClusterUpConfig) PostClusterStartupMutations(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	kClient, err := kclientset.NewForConfig(restConfig)
+	kClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* first commit move modify SCC to external (@enj do we use this anywhere else? the only usage I found was setup persistent volume component in cluster up...)
* second commit moves router to use external client/types
* last commit removes post-startup mutations which were there to support `oc cluster join` (which we don't support) and moves webconsole oauth client to external

This is moving us closer to cluster up extraction. 
/cc @deads2k 

