### PR TITLE
HA for fully-automatic egress IPs

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -864,9 +864,6 @@ func TestEgressCIDRAllocation(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 	allocation = eit.ReallocateEgressIPs()
-	if len(allocation) != 0 {
-		t.Fatalf("Unexpected allocation: %#v", allocation)
-	}
 	updateAllocations(eit, allocation)
 	err = w.assertNoChanges()
 	if err != nil {


### PR DESCRIPTION
Tracks node online/offline state and handles reassigning egress IPs as needed.

The tracking code is very similar to the semi-automatic tracking code, but couldn't easily be shared since we don't do the OVS flow tracking in this case. Like the semi-automatic code, it needs to be made more configurable at some point...

@openshift/sig-networking PTAL