### PR TITLE
avoid unnecessary admission plugin initializers

### DIFF
--- a/pkg/authorization/util/util.go
+++ b/pkg/authorization/util/util.go
@@ -3,24 +3,24 @@ package util
 import (
 	"errors"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/kubernetes/pkg/apis/authorization"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
 // AddUserToSAR adds the requisite user information to a SubjectAccessReview.
 // It returns the modified SubjectAccessReview.
-func AddUserToSAR(user user.Info, sar *authorization.SubjectAccessReview) *authorization.SubjectAccessReview {
+func AddUserToSAR(user user.Info, sar *authorizationv1.SubjectAccessReview) *authorizationv1.SubjectAccessReview {
 	sar.Spec.User = user.GetName()
 	// reminiscent of the bad old days of C.  Copies copy the min number of elements of both source and dest
 	sar.Spec.Groups = make([]string, len(user.GetGroups()))
 	copy(sar.Spec.Groups, user.GetGroups())
-	sar.Spec.Extra = map[string]authorization.ExtraValue{}
+	sar.Spec.Extra = map[string]authorizationv1.ExtraValue{}
 
 	for k, v := range user.GetExtra() {
-		sar.Spec.Extra[k] = authorization.ExtraValue(v)
+		sar.Spec.Extra[k] = authorizationv1.ExtraValue(v)
 	}
 
 	return sar
@@ -29,9 +29,9 @@ func AddUserToSAR(user user.Info, sar *authorization.SubjectAccessReview) *autho
 // Authorize verifies that a given user is permitted to carry out a given
 // action.  If this cannot be determined, or if the user is not permitted, an
 // error is returned.
-func Authorize(sarClient internalversion.SubjectAccessReviewInterface, user user.Info, resourceAttributes *authorization.ResourceAttributes) error {
-	sar := AddUserToSAR(user, &authorization.SubjectAccessReview{
-		Spec: authorization.SubjectAccessReviewSpec{
+func Authorize(sarClient authorizationclient.SubjectAccessReviewInterface, user user.Info, resourceAttributes *authorizationv1.ResourceAttributes) error {
+	sar := AddUserToSAR(user, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
 			ResourceAttributes: resourceAttributes,
 		},
 	})

--- a/pkg/build/apiserver/admission/strategyrestrictions/admission.go
+++ b/pkg/build/apiserver/admission/strategyrestrictions/admission.go
@@ -5,16 +5,15 @@ import (
 	"io"
 	"strings"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/kubernetes"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/kubernetes/pkg/apis/authorization"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
-	kubeadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 
 	"github.com/openshift/api/build"
@@ -25,6 +24,7 @@ import (
 	"github.com/openshift/origin/pkg/build/buildscheme"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
+	"k8s.io/apiserver/pkg/admission/initializer"
 )
 
 func Register(plugins *admission.Plugins) {
@@ -40,7 +40,7 @@ type buildByStrategy struct {
 	buildClient buildclient.Interface
 }
 
-var _ = kubeadmission.WantsInternalKubeClientSet(&buildByStrategy{})
+var _ = initializer.WantsExternalKubeClientSet(&buildByStrategy{})
 var _ = oadmission.WantsRESTClientConfig(&buildByStrategy{})
 
 // NewBuildByStrategy returns an admission control for builds that checks
@@ -86,8 +86,8 @@ func (a *buildByStrategy) Admit(attr admission.Attributes) error {
 	}
 }
 
-func (a *buildByStrategy) SetInternalKubeClientSet(c internalclientset.Interface) {
-	a.sarClient = c.Authorization().SubjectAccessReviews()
+func (a *buildByStrategy) SetExternalKubeClientSet(c kubernetes.Interface) {
+	a.sarClient = c.AuthorizationV1().SubjectAccessReviews()
 }
 
 func (a *buildByStrategy) SetRESTClientConfig(restClientConfig rest.Config) {
@@ -146,9 +146,9 @@ func (a *buildByStrategy) checkBuildAuthorization(build *buildapi.Build, attr ad
 		subresource = tokens[1]
 	}
 
-	sar := util.AddUserToSAR(attr.GetUserInfo(), &authorization.SubjectAccessReview{
-		Spec: authorization.SubjectAccessReviewSpec{
-			ResourceAttributes: &authorization.ResourceAttributes{
+	sar := util.AddUserToSAR(attr.GetUserInfo(), &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace:   attr.GetNamespace(),
 				Verb:        "create",
 				Group:       resource.Group,
@@ -174,9 +174,9 @@ func (a *buildByStrategy) checkBuildConfigAuthorization(buildConfig *buildapi.Bu
 		subresource = tokens[1]
 	}
 
-	sar := util.AddUserToSAR(attr.GetUserInfo(), &authorization.SubjectAccessReview{
-		Spec: authorization.SubjectAccessReviewSpec{
-			ResourceAttributes: &authorization.ResourceAttributes{
+	sar := util.AddUserToSAR(attr.GetUserInfo(), &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace:   attr.GetNamespace(),
 				Verb:        "create",
 				Group:       resource.Group,
@@ -220,7 +220,7 @@ func (a *buildByStrategy) checkBuildRequestAuthorization(req *buildapi.BuildRequ
 	}
 }
 
-func (a *buildByStrategy) checkAccess(strategy buildapi.BuildStrategy, subjectAccessReview *authorization.SubjectAccessReview, attr admission.Attributes) error {
+func (a *buildByStrategy) checkAccess(strategy buildapi.BuildStrategy, subjectAccessReview *authorizationv1.SubjectAccessReview, attr admission.Attributes) error {
 	resp, err := a.sarClient.Create(subjectAccessReview)
 	if err != nil {
 		return admission.NewForbidden(attr, err)

--- a/pkg/cmd/openshift-apiserver/server.go
+++ b/pkg/cmd/openshift-apiserver/server.go
@@ -51,7 +51,7 @@ func RunOpenShiftAPIServer(masterConfig *configapi.MasterConfig) error {
 		return err
 	}
 
-	if err := informers.GetInternalOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
+	if err := informers.GetOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
 		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
 	}); err != nil {
 		return err

--- a/pkg/cmd/openshift-controller-manager/controller/template.go
+++ b/pkg/cmd/openshift-controller-manager/controller/template.go
@@ -21,6 +21,7 @@ func RunTemplateInstanceController(ctx ControllerContext) (bool, error) {
 	go templatecontroller.NewTemplateInstanceController(
 		ctx.RestMapper,
 		dynamicClient,
+		ctx.ClientBuilder.ClientGoClientOrDie(saName).AuthorizationV1(),
 		ctx.ClientBuilder.KubeInternalClientOrDie(saName),
 		ctx.ClientBuilder.OpenshiftInternalBuildClientOrDie(saName),
 		ctx.ClientBuilder.OpenshiftInternalTemplateClientOrDie(saName),

--- a/pkg/cmd/openshift-controller-manager/controller_manager.go
+++ b/pkg/cmd/openshift-controller-manager/controller_manager.go
@@ -146,7 +146,7 @@ func newControllerContext(
 		InternalNetworkInformers:       originInformers.GetInternalOpenshiftNetworkInformers(),
 		InternalQuotaInformers:         originInformers.GetInternalOpenshiftQuotaInformers(),
 		InternalSecurityInformers:      originInformers.GetInternalOpenshiftSecurityInformers(),
-		InternalRouteInformers:         originInformers.GetInternalOpenshiftRouteInformers(),
+		InternalRouteInformers:         originInformers.GetOpenshiftRouteInformers(),
 		InternalTemplateInformers:      originInformers.GetInternalOpenshiftTemplateInformers(),
 		GenericResourceInformer:        originInformers.ToGenericInformer(),
 		Stop:             stopCh,

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -2,84 +2,44 @@ package admission
 
 import (
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/apiserver/pkg/admission/initializer"
-	kauthorizer "k8s.io/apiserver/pkg/authorization/authorizer"
 	restclient "k8s.io/client-go/rest"
-	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
-	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/quota"
 
-	authorizationclient "github.com/openshift/client-go/authorization/clientset/versioned"
-	buildclient "github.com/openshift/client-go/build/clientset/versioned"
-	userclient "github.com/openshift/client-go/user/clientset/versioned"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
-	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
-	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 )
 
 type PluginInitializer struct {
-	OpenshiftInternalAuthorizationClient authorizationclient.Interface
-	OpenshiftInternalBuildClient         buildclient.Interface
-	OpenshiftInternalImageClient         imageclient.Interface
-	OpenshiftInternalQuotaClient         quotaclient.Interface
-	OpenshiftInternalUserClient          userclient.Interface
-	ProjectCache                         *cache.ProjectCache
-	OriginQuotaRegistry                  quota.Registry
-	Authorizer                           kauthorizer.Authorizer
-	JenkinsPipelineConfig                configapi.JenkinsPipelineConfig
-	RESTClientConfig                     restclient.Config
-	Informers                            kinternalinformers.SharedInformerFactory
-	ClusterResourceQuotaInformer         quotainformer.ClusterResourceQuotaInformer
-	ClusterQuotaMapper                   clusterquotamapping.ClusterQuotaMapper
-	RegistryHostnameRetriever            imageapi.RegistryHostnameRetriever
-	SecurityInformers                    securityinformer.SharedInformerFactory
-	UserInformers                        userinformer.SharedInformerFactory
+	ProjectCache                 *cache.ProjectCache
+	OriginQuotaRegistry          quota.Registry
+	JenkinsPipelineConfig        configapi.JenkinsPipelineConfig
+	RESTClientConfig             restclient.Config
+	ClusterResourceQuotaInformer quotainformer.ClusterResourceQuotaInformer
+	ClusterQuotaMapper           clusterquotamapping.ClusterQuotaMapper
+	RegistryHostnameRetriever    imageapi.RegistryHostnameRetriever
+	SecurityInformers            securityinformer.SharedInformerFactory
+	UserInformers                userinformer.SharedInformerFactory
 }
 
 // Initialize will check the initialization interfaces implemented by each plugin
 // and provide the appropriate initialization data
 func (i *PluginInitializer) Initialize(plugin admission.Interface) {
-	if wantsOpenshiftAuthorizationClient, ok := plugin.(WantsOpenshiftInternalAuthorizationClient); ok {
-		wantsOpenshiftAuthorizationClient.SetOpenshiftInternalAuthorizationClient(i.OpenshiftInternalAuthorizationClient)
-	}
-	if wantsOpenshiftBuildClient, ok := plugin.(WantsOpenshiftInternalBuildClient); ok {
-		wantsOpenshiftBuildClient.SetOpenshiftInternalBuildClient(i.OpenshiftInternalBuildClient)
-	}
-	if wantsOpenshiftImageClient, ok := plugin.(WantsOpenshiftInternalImageClient); ok {
-		wantsOpenshiftImageClient.SetOpenshiftInternalImageClient(i.OpenshiftInternalImageClient)
-	}
-	if wantsOpenshiftQuotaClient, ok := plugin.(WantsOpenshiftInternalQuotaClient); ok {
-		wantsOpenshiftQuotaClient.SetOpenshiftInternalQuotaClient(i.OpenshiftInternalQuotaClient)
-	}
-	if wantsOpenshiftInternalUserClient, ok := plugin.(WantsOpenshiftInternalUserClient); ok {
-		wantsOpenshiftInternalUserClient.SetOpenshiftInternalUserClient(i.OpenshiftInternalUserClient)
-	}
 	if wantsProjectCache, ok := plugin.(WantsProjectCache); ok {
 		wantsProjectCache.SetProjectCache(i.ProjectCache)
 	}
 	if wantsOriginQuotaRegistry, ok := plugin.(WantsOriginQuotaRegistry); ok {
 		wantsOriginQuotaRegistry.SetOriginQuotaRegistry(i.OriginQuotaRegistry)
 	}
-	if kubeWantsAuthorizer, ok := plugin.(initializer.WantsAuthorizer); ok {
-		kubeWantsAuthorizer.SetAuthorizer(i.Authorizer)
-	}
 	if wantsJenkinsPipelineConfig, ok := plugin.(WantsJenkinsPipelineConfig); ok {
 		wantsJenkinsPipelineConfig.SetJenkinsPipelineConfig(i.JenkinsPipelineConfig)
 	}
 	if wantsRESTClientConfig, ok := plugin.(WantsRESTClientConfig); ok {
 		wantsRESTClientConfig.SetRESTClientConfig(i.RESTClientConfig)
-	}
-	if wantsInformers, ok := plugin.(WantsInternalKubernetesInformers); ok {
-		wantsInformers.SetInternalKubernetesInformers(i.Informers)
-	}
-	if wantsInformerFactory, ok := plugin.(kubeapiserveradmission.WantsInternalKubeInformerFactory); ok {
-		wantsInformerFactory.SetInternalKubeInformerFactory(i.Informers)
 	}
 	if wantsClusterQuota, ok := plugin.(WantsClusterQuota); ok {
 		wantsClusterQuota.SetClusterQuota(i.ClusterQuotaMapper, i.ClusterResourceQuotaInformer)

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -3,52 +3,15 @@ package admission
 import (
 	"k8s.io/apiserver/pkg/admission"
 	restclient "k8s.io/client-go/rest"
-	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/quota"
 
-	authorizationclient "github.com/openshift/client-go/authorization/clientset/versioned"
-	buildclient "github.com/openshift/client-go/build/clientset/versioned"
-	userclient "github.com/openshift/client-go/user/clientset/versioned"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
-	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 )
-
-type WantsOpenshiftInternalAuthorizationClient interface {
-	SetOpenshiftInternalAuthorizationClient(authorizationclient.Interface)
-	admission.InitializationValidator
-}
-
-type WantsOpenshiftInternalBuildClient interface {
-	SetOpenshiftInternalBuildClient(buildclient.Interface)
-	admission.InitializationValidator
-}
-
-// WantsOpenshiftInternalQuotaClient should be implemented by admission plugins that need
-// an Openshift internal quota client
-type WantsOpenshiftInternalQuotaClient interface {
-	SetOpenshiftInternalQuotaClient(quotaclient.Interface)
-	admission.InitializationValidator
-}
-
-// WantsOpenshiftInternalUserClient should be implemented by admission plugins that need
-// an Openshift internal user client
-type WantsOpenshiftInternalUserClient interface {
-	SetOpenshiftInternalUserClient(userclient.Interface)
-	admission.InitializationValidator
-}
-
-// WantsOpenshiftInternalImageClient should be implemented by admission plugins that need
-// an Openshift internal image client
-type WantsOpenshiftInternalImageClient interface {
-	SetOpenshiftInternalImageClient(imageclient.Interface)
-	admission.InitializationValidator
-}
 
 // WantsProjectCache should be implemented by admission plugins that need a
 // project cache
@@ -73,13 +36,6 @@ type WantsJenkinsPipelineConfig interface {
 // WantsRESTClientConfig gives access to a RESTClientConfig.  It's useful for doing unusual things with transports.
 type WantsRESTClientConfig interface {
 	SetRESTClientConfig(restclient.Config)
-	admission.InitializationValidator
-}
-
-// WantsInternalKubernetesInformers should be implemented by admission plugins that need the internal kubernetes
-// informers.
-type WantsInternalKubernetesInformers interface {
-	SetInternalKubernetesInformers(kinternalinformers.SharedInformerFactory)
 	admission.InitializationValidator
 }
 

--- a/pkg/cmd/server/origin/authenticator.go
+++ b/pkg/cmd/server/origin/authenticator.go
@@ -68,7 +68,7 @@ func NewAuthenticator(
 		serviceAccountTokenGetter,
 		userClient.User().Users(),
 		apiClientCAs,
-		usercache.NewGroupCache(informers.GetInternalOpenshiftUserInformers().User().V1().Groups()),
+		usercache.NewGroupCache(informers.GetOpenshiftUserInformers().User().V1().Groups()),
 	)
 }
 

--- a/pkg/cmd/server/origin/informers.go
+++ b/pkg/cmd/server/origin/informers.go
@@ -242,7 +242,7 @@ func (i *informerHolder) GetInternalOpenshiftOauthInformers() oauthinformer.Shar
 func (i *informerHolder) GetInternalOpenshiftQuotaInformers() quotainformer.SharedInformerFactory {
 	return i.quotaInformers
 }
-func (i *informerHolder) GetInternalOpenshiftRouteInformers() routeinformer.SharedInformerFactory {
+func (i *informerHolder) GetOpenshiftRouteInformers() routeinformer.SharedInformerFactory {
 	return i.routeInformers
 }
 func (i *informerHolder) GetInternalOpenshiftSecurityInformers() securityinformer.SharedInformerFactory {
@@ -251,7 +251,7 @@ func (i *informerHolder) GetInternalOpenshiftSecurityInformers() securityinforme
 func (i *informerHolder) GetInternalOpenshiftTemplateInformers() templateinformer.SharedInformerFactory {
 	return i.templateInformers
 }
-func (i *informerHolder) GetInternalOpenshiftUserInformers() userinformer.SharedInformerFactory {
+func (i *informerHolder) GetOpenshiftUserInformers() userinformer.SharedInformerFactory {
 	return i.userInformers
 }
 
@@ -298,7 +298,7 @@ func (i *informerHolder) ToGenericInformer() GenericResourceInformer {
 			return i.GetInternalOpenshiftQuotaInformers().ForResource(resource)
 		}),
 		genericResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftRouteInformers().ForResource(resource)
+			return i.GetOpenshiftRouteInformers().ForResource(resource)
 		}),
 		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
 			return i.GetInternalOpenshiftSecurityInformers().ForResource(resource)
@@ -307,7 +307,7 @@ func (i *informerHolder) ToGenericInformer() GenericResourceInformer {
 			return i.GetInternalOpenshiftTemplateInformers().ForResource(resource)
 		}),
 		genericResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftUserInformers().ForResource(resource)
+			return i.GetOpenshiftUserInformers().ForResource(resource)
 		}),
 	)
 }

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -110,6 +110,8 @@ type InformerAccess interface {
 	GetKubernetesInformers() kinformers.SharedInformerFactory
 
 	GetOpenshiftAppInformers() appsinformer.SharedInformerFactory
+	GetOpenshiftRouteInformers() routeinformer.SharedInformerFactory
+	GetOpenshiftUserInformers() userinformer.SharedInformerFactory
 
 	GetInternalOpenshiftAuthorizationInformers() authorizationinformer.SharedInformerFactory
 	GetInternalOpenshiftBuildInformers() buildinformer.SharedInformerFactory
@@ -118,8 +120,6 @@ type InformerAccess interface {
 	GetInternalOpenshiftOauthInformers() oauthinformer.SharedInformerFactory
 	GetInternalOpenshiftQuotaInformers() quotainformer.SharedInformerFactory
 	GetInternalOpenshiftSecurityInformers() securityinformer.SharedInformerFactory
-	GetInternalOpenshiftRouteInformers() routeinformer.SharedInformerFactory
-	GetInternalOpenshiftUserInformers() userinformer.SharedInformerFactory
 	GetInternalOpenshiftTemplateInformers() templateinformer.SharedInformerFactory
 
 	ToGenericInformer() GenericResourceInformer
@@ -145,7 +145,7 @@ func BuildMasterConfig(
 		if err != nil {
 			return nil, err
 		}
-		if err := realLoopbackInformers.GetInternalOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
+		if err := realLoopbackInformers.GetOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
 			usercache.ByUserIndexName: usercache.ByUserIndexKeys,
 		}); err != nil {
 			return nil, err
@@ -257,7 +257,7 @@ func BuildMasterConfig(
 		AuthorizationInformers: informers.GetInternalOpenshiftAuthorizationInformers(),
 		QuotaInformers:         informers.GetInternalOpenshiftQuotaInformers(),
 		SecurityInformers:      informers.GetInternalOpenshiftSecurityInformers(),
-		RouteInformers:         informers.GetInternalOpenshiftRouteInformers(),
+		RouteInformers:         informers.GetOpenshiftRouteInformers(),
 	}
 
 	for name, hook := range authenticatorPostStartHooks {

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -449,7 +449,7 @@ func (m *Master) Start() error {
 			return err
 		}
 
-		if err := informers.GetInternalOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
+		if err := informers.GetOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
 			usercache.ByUserIndexName: usercache.ByUserIndexKeys,
 		}); err != nil {
 			return err

--- a/pkg/image/apiserver/admission/imagepolicy/imagepolicy_test.go
+++ b/pkg/image/apiserver/admission/imagepolicy/imagepolicy_test.go
@@ -128,7 +128,7 @@ func TestDefaultPolicy(t *testing.T) {
 	})
 
 	store := setDefaultCache(plugin)
-	plugin.SetOpenshiftInternalImageClient(client)
+	plugin.client = client.Image()
 	plugin.SetDefaultRegistryFunc(func() (string, bool) {
 		return "integrated.registry", true
 	})
@@ -1304,7 +1304,7 @@ func TestAdmissionResolveImages(t *testing.T) {
 			}
 
 			setDefaultCache(p)
-			p.SetOpenshiftInternalImageClient(test.client)
+			p.client = test.client.Image()
 			p.SetDefaultRegistryFunc(func() (string, bool) {
 				return "integrated.registry", true
 			})

--- a/pkg/image/apiserver/apiserver.go
+++ b/pkg/image/apiserver/apiserver.go
@@ -14,9 +14,9 @@ import (
 	knet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 
 	imageapiv1 "github.com/openshift/api/image/v1"

--- a/pkg/image/apiserver/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/apiserver/registry/imagestream/etcd/etcd.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 

--- a/pkg/image/apiserver/registry/imagestream/etcd/etcd_test.go
+++ b/pkg/image/apiserver/registry/imagestream/etcd/etcd_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/origin/pkg/image/apis/image/validation/fake"
 	admfake "github.com/openshift/origin/pkg/image/apiserver/admission/fake"
 	"github.com/openshift/origin/pkg/util/restoptions"
+	authorizationapi "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
 
 	// install all APIs

--- a/pkg/image/apiserver/registry/imagestream/strategy.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	authorizationapi "k8s.io/api/authorization/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,11 +15,10 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"

--- a/pkg/image/apiserver/registry/imagestream/strategy_test.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kquota "k8s.io/kubernetes/pkg/quota"
 

--- a/pkg/image/apiserver/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreamimage/rest_test.go
@@ -6,6 +6,7 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	"golang.org/x/net/context"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,7 +14,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"

--- a/pkg/image/apiserver/registry/imagestreamimport/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamimport/rest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/glog"
 	gocontext "golang.org/x/net/context"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,11 +19,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	"github.com/openshift/api/image"
 	imageapiv1 "github.com/openshift/api/image/v1"

--- a/pkg/image/apiserver/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreammapping/rest_test.go
@@ -11,6 +11,7 @@ import (
 	etcd "github.com/coreos/etcd/clientv3"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +23,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	imagegroup "github.com/openshift/api/image"

--- a/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,7 +19,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	imagev1 "github.com/openshift/api/image/v1"

--- a/pkg/project/apiserver/admission/requestlimit/admission_test.go
+++ b/pkg/project/apiserver/admission/requestlimit/admission_test.go
@@ -154,7 +154,7 @@ func TestMaxProjectByRequester(t *testing.T) {
 		}
 		user := fakeUser("testuser", tc.userLabels)
 		client := fakeuserclient.NewSimpleClientset(user)
-		reqLimit.(oadmission.WantsOpenshiftInternalUserClient).SetOpenshiftInternalUserClient(client)
+		reqLimit.(*projectRequestLimit).userClient = client.UserV1()
 
 		maxProjects, hasLimit, err := reqLimit.(*projectRequestLimit).maxProjectsByRequester("testuser")
 		if err != nil {
@@ -278,7 +278,7 @@ func TestAdmit(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
-		reqLimit.(oadmission.WantsOpenshiftInternalUserClient).SetOpenshiftInternalUserClient(client)
+		reqLimit.(*projectRequestLimit).userClient = client.UserV1()
 		reqLimit.(oadmission.WantsProjectCache).SetProjectCache(pCache)
 		if err = reqLimit.(admission.InitializationValidator).ValidateInitialization(); err != nil {
 			t.Fatalf("validation error: %v", err)

--- a/pkg/project/apiserver/apiserver.go
+++ b/pkg/project/apiserver/apiserver.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	restclient "k8s.io/client-go/rest"
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	projectapiv1 "github.com/openshift/api/project/v1"

--- a/pkg/project/apiserver/registry/projectrequest/delegated/delegated.go
+++ b/pkg/project/apiserver/registry/projectrequest/delegated/delegated.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	authorizationapi "k8s.io/api/authorization/v1"
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -21,11 +22,10 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/dynamic"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 	rbaclisters "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion"
 
 	"github.com/openshift/api/project"

--- a/pkg/route/apiserver/apiserver.go
+++ b/pkg/route/apiserver/apiserver.go
@@ -9,12 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	restclient "k8s.io/client-go/rest"
 
 	routeapiv1 "github.com/openshift/api/route/v1"
 	routeetcd "github.com/openshift/origin/pkg/route/apiserver/registry/route/etcd"
 	routeallocationcontroller "github.com/openshift/origin/pkg/route/controller/allocation"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 )
 
 type ExtraConfig struct {

--- a/pkg/route/apiserver/registry/route/etcd/etcd_test.go
+++ b/pkg/route/apiserver/registry/route/etcd/etcd_test.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	"testing"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -13,7 +14,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 
 	routetypes "github.com/openshift/origin/pkg/route"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"

--- a/pkg/route/apiserver/registry/route/strategy.go
+++ b/pkg/route/apiserver/registry/route/strategy.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	kvalidation "k8s.io/kubernetes/pkg/apis/core/validation"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	authorizationutil "github.com/openshift/origin/pkg/authorization/util"
 	"github.com/openshift/origin/pkg/route"

--- a/pkg/route/apiserver/registry/route/strategy_test.go
+++ b/pkg/route/apiserver/registry/route/strategy_test.go
@@ -4,12 +4,12 @@ import (
 	"reflect"
 	"testing"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 )

--- a/pkg/template/apiserver/apiserver.go
+++ b/pkg/template/apiserver/apiserver.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	restclient "k8s.io/client-go/rest"
-	authorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 
 	templateapiv1 "github.com/openshift/api/template/v1"
 	brokertemplateinstanceetcd "github.com/openshift/origin/pkg/template/apiserver/registry/brokertemplateinstance/etcd"

--- a/pkg/template/apiserver/registry/templateinstance/etcd/etcd.go
+++ b/pkg/template/apiserver/registry/templateinstance/etcd/etcd.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
-	authorizationinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -27,7 +27,7 @@ type REST struct {
 var _ rest.StandardStorage = &REST{}
 
 // NewREST returns a RESTStorage object that will work against templateinstances.
-func NewREST(optsGetter restoptions.Getter, authorizationClient authorizationinternalversion.AuthorizationInterface) (*REST, *StatusREST, error) {
+func NewREST(optsGetter restoptions.Getter, authorizationClient authorizationclient.AuthorizationV1Interface) (*REST, *StatusREST, error) {
 	strategy := templateinstance.NewStrategy(authorizationClient)
 
 	store := &registry.Store{

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake/fake_subjectaccessreview_expansion.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/fake/fake_subjectaccessreview_expansion.go
@@ -23,5 +23,8 @@ import (
 
 func (c *FakeSubjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
 	obj, err := c.Fake.Invokes(core.NewRootCreateAction(authorizationapi.SchemeGroupVersion.WithResource("subjectaccessreviews"), sar), &authorizationapi.SubjectAccessReview{})
+	if obj == nil {
+		return nil, err
+	}
 	return obj.(*authorizationapi.SubjectAccessReview), err
 }


### PR DESCRIPTION
This removes most of our plugin initializers by building clients in the admission plugins themselves and switching to upstream initializers and external types.  It also fixes some names which had fallen out of sync.

@mfojtik 