### PR TITLE
update jenkins test to use pod/curl util for rest calls; add header s…

### DIFF
--- a/test/extended/builds/jenkins_plugin.go
+++ b/test/extended/builds/jenkins_plugin.go
@@ -238,7 +238,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			g.It("jenkins-plugin test trigger build including clone", func() {
 
 				jobName := "test-build-job"
-				data := j.ReadJenkinsJob("build-job.xml", oc.Namespace())
+				data := j.ProcessJenkinsJob("build-job.xml", oc.Namespace())
 				j.CreateItem(jobName, data)
 				jmon := j.StartJob(jobName)
 				err := jmon.Await(10 * time.Minute)
@@ -268,7 +268,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				o.Expect(strings.Contains(out, "Jenkins job")).To(o.BeTrue())
 
 				jobName = "test-build-clone-job"
-				data = j.ReadJenkinsJob("build-job-clone.xml", oc.Namespace())
+				data = j.ProcessJenkinsJob("build-job-clone.xml", oc.Namespace())
 				j.CreateItem(jobName, data)
 				jmon = j.StartJob(jobName)
 				jmon.Await(10 * time.Minute)
@@ -290,7 +290,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			g.It("jenkins-plugin test trigger build with slave", func() {
 
 				jobName := "test-build-job-slave"
-				data := j.ReadJenkinsJob("build-job-slave.xml", oc.Namespace())
+				data := j.ProcessJenkinsJob("build-job-slave.xml", oc.Namespace())
 				j.CreateItem(jobName, data)
 				jmon := j.StartJob(jobName)
 				err := jmon.Await(10 * time.Minute)
@@ -325,7 +325,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 
 				jobsToCreate := map[string]string{"test-create-obj": "create-job.xml", "test-delete-obj": "delete-job.xml", "test-delete-obj-labels": "delete-job-labels.xml", "test-delete-obj-keys": "delete-job-keys.xml"}
 				for jobName, jobConfig := range jobsToCreate {
-					data := j.ReadJenkinsJob(jobConfig, oc.Namespace())
+					data := j.ProcessJenkinsJob(jobConfig, oc.Namespace())
 					j.CreateItem(jobName, data)
 				}
 
@@ -354,7 +354,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			g.It("jenkins-plugin test trigger build with envs", func() {
 
 				jobName := "test-build-with-env-job"
-				data := j.ReadJenkinsJob("build-with-env-job.xml", oc.Namespace())
+				data := j.ProcessJenkinsJob("build-with-env-job.xml", oc.Namespace())
 				j.CreateItem(jobName, data)
 				jmon := j.StartJob(jobName)
 				err := jmon.Await(10 * time.Minute)
@@ -396,9 +396,12 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 					"openshiftBuild( namespace:'PROJECT_NAME', bldCfg: 'frontend', env: [ [ name : 'a', value : 'b' ], [ name : 'C', value : 'D' ], [ name : 'e', value : '' ] ] )",
 					"}",
 				)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				filename, err := exutil.CreateTempFile(data)
+				o.Expect(err).NotTo(o.HaveOccurred())
 
 				jobName := "test-build-dsl-job"
-				j.CreateItem(jobName, data)
+				j.CreateItem(jobName, filename)
 				monitor := j.StartJob(jobName)
 				err = monitor.Await(10 * time.Minute)
 				if err != nil {
@@ -443,9 +446,12 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 					fmt.Sprintf("openshiftExec( namespace:'PROJECT_NAME', pod: '%s', container: '%s', command: 'echo', arguments : [ [ value: 'hello' ], [ value : 'world' ], [ value : '6' ] ] )", targetPod.Name, targetContainer.Name),
 					"}",
 				)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				filename, err := exutil.CreateTempFile(data)
+				o.Expect(err).NotTo(o.HaveOccurred())
 
 				jobName := "test-exec-dsl-job"
-				j.CreateItem(jobName, data)
+				j.CreateItem(jobName, filename)
 				monitor := j.StartJob(jobName)
 				err = monitor.Await(10 * time.Minute)
 				if err != nil {
@@ -471,7 +477,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				targetContainer := targetPod.Spec.Containers[0]
 
 				jobName := "test-build-with-env-steps"
-				data := j.ReadJenkinsJobUsingVars("build-with-exec-steps.xml", oc.Namespace(), map[string]string{
+				data := j.ProcessJenkinsJobUsingVars("build-with-exec-steps.xml", oc.Namespace(), map[string]string{
 					"POD_NAME":       targetPod.Name,
 					"CONTAINER_NAME": targetContainer.Name,
 				})
@@ -488,7 +494,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 
 				// Now run without specifying container
 				jobName = "test-build-with-env-steps-no-container"
-				data = j.ReadJenkinsJobUsingVars("build-with-exec-steps.xml", oc.Namespace(), map[string]string{
+				data = j.ProcessJenkinsJobUsingVars("build-with-exec-steps.xml", oc.Namespace(), map[string]string{
 					"POD_NAME":       targetPod.Name,
 					"CONTAINER_NAME": "",
 				})
@@ -518,7 +524,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				jobName := "test-multitag-job"
-				data := j.ReadJenkinsJob("multitag-job.xml", oc.Namespace())
+				data := j.ProcessJenkinsJob("multitag-job.xml", oc.Namespace())
 				j.CreateItem(jobName, data)
 				monitor := j.StartJob(jobName)
 				err = monitor.Await(10 * time.Minute)
@@ -611,9 +617,12 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 					fmt.Sprintf("openshiftTag( namespace:'PROJECT_NAME', destinationNamespace: '%s', srcStream: 'multitag', srcTag: 'orig', destStream: 'multitag5,multitag6', destTag: 'prod5, prod6' )", anotherNamespace),
 					"}",
 				)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				filename, err := exutil.CreateTempFile(data)
+				o.Expect(err).NotTo(o.HaveOccurred())
 
 				jobName := "test-multitag-dsl-job"
-				j.CreateItem(jobName, data)
+				j.CreateItem(jobName, filename)
 				monitor := j.StartJob(jobName)
 				err = monitor.Await(10 * time.Minute)
 				if err != nil {
@@ -658,7 +667,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			testImageStreamSCM := func(jobXMLFile string) {
 				jobName := "test-imagestream-scm"
 				g.By("creating a jenkins job with an imagestream SCM")
-				data := j.ReadJenkinsJob(jobXMLFile, oc.Namespace())
+				data := j.ProcessJenkinsJob(jobXMLFile, oc.Namespace())
 				j.CreateItem(jobName, data)
 
 				// Because polling is enabled, a job should start automatically and fail
@@ -699,12 +708,13 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			g.It("jenkins-plugin test connection test", func() {
 
 				jobName := "test-build-job"
-				data := j.ReadJenkinsJob("build-job.xml", oc.Namespace())
+				data := j.ProcessJenkinsJob("build-job.xml", oc.Namespace())
 				j.CreateItem(jobName, data)
 
 				g.By("trigger test connection logic, check for success")
-				testConnectionBody := bytes.NewBufferString("apiURL=&authToken=")
-				result, code, err := j.Post(testConnectionBody, "job/test-build-job/descriptorByName/com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder/testConnection", "application/x-www-form-urlencoded")
+				filename, err := exutil.CreateTempFile("apiURL=&authToken=")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				result, code, err := j.Post(filename, "job/test-build-job/descriptorByName/com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder/testConnection", "application/x-www-form-urlencoded")
 				if code != 200 {
 					err = fmt.Errorf("Expected return code of 200")
 				}
@@ -714,8 +724,9 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("trigger test connection logic, check for failure")
-				testConnectionBody = bytes.NewBufferString("apiURL=https%3A%2F%2F1.2.3.4&authToken=")
-				result, code, err = j.Post(testConnectionBody, "job/test-build-job/descriptorByName/com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder/testConnection", "application/x-www-form-urlencoded")
+				filename, err = exutil.CreateTempFile("apiURL=https%3A%2F%2F1.2.3.4&authToken=")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				result, code, err = j.Post(filename, "job/test-build-job/descriptorByName/com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder/testConnection", "application/x-www-form-urlencoded")
 				if code != 200 {
 					err = fmt.Errorf("Expected return code of 200")
 				}

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -898,7 +898,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 						}
 
 						g.By("Approving the current build")
-						_, _, err = j.Post(nil, jenkinsBuildURI+"/input/Approval/proceedEmpty", "")
+						_, _, err = j.Post("", jenkinsBuildURI+"/input/Approval/proceedEmpty", "")
 						if err != nil {
 							errs <- fmt.Errorf("error approving the current build: %s", err)
 						}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -8452,9 +8452,8 @@ var _testExtendedTestdataJenkinsPluginImagestreamScmDslJobXml = []byte(`<?xml ve
   </properties>
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.6">
     <script>node {
-   stage &apos;Stage 1&apos;
-   openshiftImageStream name: &apos;testimage&apos;, tag: &apos;v1&apos;, namespace: &apos;${PROJECT_NAME}&apos;
-   openshiftTag destStream: &apos;localjenkins&apos;, destTag: &apos;develop&apos;, destinationNamespace: &apos;${PROJECT_NAME}&apos;, namespace: &apos;openshift&apos;, srcStream: &apos;jenkins&apos;, srcTag: &apos;latest&apos;
+   openshiftImageStream name: "testimage", tag: "v1", namespace: "${PROJECT_NAME}" &#xD; &#xA;
+   openshiftTag destStream: "localjenkins", destTag: "develop", destinationNamespace: "${PROJECT_NAME}", namespace: "openshift", srcStream: "jenkins", srcTag: "latest"
 }</script>
     <sandbox>true</sandbox>
   </definition>

--- a/test/extended/testdata/jenkins-plugin/imagestream-scm-dsl-job.xml
+++ b/test/extended/testdata/jenkins-plugin/imagestream-scm-dsl-job.xml
@@ -14,9 +14,8 @@
   </properties>
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.6">
     <script>node {
-   stage &apos;Stage 1&apos;
-   openshiftImageStream name: &apos;testimage&apos;, tag: &apos;v1&apos;, namespace: &apos;${PROJECT_NAME}&apos;
-   openshiftTag destStream: &apos;localjenkins&apos;, destTag: &apos;develop&apos;, destinationNamespace: &apos;${PROJECT_NAME}&apos;, namespace: &apos;openshift&apos;, srcStream: &apos;jenkins&apos;, srcTag: &apos;latest&apos;
+   openshiftImageStream name: "testimage", tag: "v1", namespace: "${PROJECT_NAME}" &#xD; &#xA;
+   openshiftTag destStream: "localjenkins", destTag: "develop", destinationNamespace: "${PROJECT_NAME}", namespace: "openshift", srcStream: "jenkins", srcTag: "latest"
 }</script>
     <sandbox>true</sandbox>
   </definition>

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1317,6 +1317,23 @@ func (r *podExecutor) Exec(script string) (string, error) {
 	return out, waitErr
 }
 
+// CreateTempFile stores the specified data in a temp dir/temp file
+// for the test who calls it
+func CreateTempFile(data string) (string, error) {
+	testDir, err := ioutil.TempDir(util.GetBaseDir(), "test-files")
+	if err != nil {
+		return "", err
+	}
+	testFile, err := ioutil.TempFile(testDir, "test-file")
+	if err != nil {
+		return "", err
+	}
+	if err := ioutil.WriteFile(testFile.Name(), []byte(data), 0666); err != nil {
+		return "", err
+	}
+	return testFile.Name(), nil
+}
+
 type GitRepo struct {
 	baseTempDir  string
 	upstream     git.Repository

--- a/test/extended/util/url/url.go
+++ b/test/extended/util/url/url.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
 	o "github.com/onsi/gomega"
 
+	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -21,9 +23,10 @@ import (
 )
 
 type Tester struct {
-	client    kclientset.Interface
-	namespace string
-	podName   string
+	client           kclientset.Interface
+	namespace        string
+	podName          string
+	errorPassThrough bool
 }
 
 func NewTester(client kclientset.Interface, ns string) *Tester {
@@ -37,21 +40,66 @@ func (ut *Tester) Close() {
 	ut.podName = ""
 }
 
+func (ut *Tester) Response(test *Test) *Response {
+	responses := ut.Responses(test)
+	if responses == nil {
+		return nil
+	}
+	if len(responses) == 0 {
+		return nil
+	}
+	return responses[0]
+}
+
 func (ut *Tester) Responses(tests ...*Test) []*Response {
-	script := testsToScript(tests)
 	if len(ut.podName) == 0 {
 		name, err := createExecPod(ut.client, ut.namespace, "execpod")
+		// exit even on error passthrough
 		o.Expect(err).NotTo(o.HaveOccurred())
 		ut.podName = name
 	}
+	// testToScript needs to run after creating the pod
+	// in case we need to rsync files for a post body
+	script := testsToScript(tests)
 	output, err := e2e.RunHostCmd(ut.namespace, ut.podName, script)
-	o.Expect(err).NotTo(o.HaveOccurred())
+	if !ut.errorPassThrough {
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+	if err != nil {
+		return []*Response{
+			{
+				Error: fmt.Sprintf("%#v", err),
+			},
+		}
+
+	}
 	responses, err := parseResponses(output)
-	o.Expect(err).NotTo(o.HaveOccurred())
+	if !ut.errorPassThrough {
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+	if err != nil {
+		return []*Response{
+			{
+				Error: fmt.Sprintf("%#v", err),
+				Body:  []byte(output),
+			},
+		}
+	}
 	if len(responses) != len(tests) {
+		// exit even on error passthrough
 		o.Expect(fmt.Errorf("number of tests did not match number of responses: %d and %d", len(responses), len(tests))).NotTo(o.HaveOccurred())
+
 	}
 	return responses
+}
+
+func (ut *Tester) WithErrorPassthrough(pt bool) *Tester {
+	ut.errorPassThrough = pt
+	return ut
+}
+
+func (ut *Tester) Podname() string {
+	return ut.podName
 }
 
 func (ut *Tester) Within(t time.Duration, tests ...*Test) {
@@ -189,6 +237,11 @@ type Test struct {
 	Name       string
 	Req        *http.Request
 	SkipVerify bool
+	// we capture this here vs. the httpRequest
+	// to facilitate passing to curl
+	PostBodyFile string
+	PodName      string
+	Oc           *exutil.CLI
 
 	Wants []func(*http.Response) error
 }
@@ -201,6 +254,22 @@ func Expect(method, url string) *Test {
 	return &Test{
 		Req: req,
 	}
+}
+
+func (ut *Test) WithBodyToUpload(filename, podname string, oc *exutil.CLI) *Test {
+	ut.PostBodyFile = filename
+	ut.PodName = podname
+	ut.Oc = oc
+	return ut
+}
+
+func (ut *Test) WithToken(token string) *Test {
+	return ut.WithHeader("Authorization", "Bearer "+token)
+}
+
+func (ut *Test) WithHeader(hdr, value string) *Test {
+	ut.Req.Header.Set(hdr, value)
+	return ut
 }
 
 func (ut *Test) Through(addr string) *Test {
@@ -272,7 +341,21 @@ func (ut *Test) ToShell(i int) string {
 		}
 	}
 	lines = append(lines, `rc=0`)
-	cmd := fmt.Sprintf(`curl -X %s %s -s -S -o /tmp/body -D /tmp/headers %q`, ut.Req.Method, strings.Join(headers, " "), ut.Req.URL)
+	post := ""
+	if strings.ToLower(strings.Trim(ut.Req.Method, " ")) == "post" {
+		post = " -H 'Expect:' "
+		if len(ut.PostBodyFile) > 0 {
+			basename := filepath.Base(ut.PostBodyFile)
+			dirname := filepath.Dir(ut.PostBodyFile)
+			lastsubdir := filepath.Base(dirname)
+			err := ut.Oc.AsAdmin().Run("rsync").Args(dirname, ut.PodName+":"+"/tmp", "--strategy=tar").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			post = post + " -d @/tmp/" + lastsubdir + "/" + basename
+		} else {
+			post = post + " -d '' "
+		}
+	}
+	cmd := fmt.Sprintf(`curl -X %s %s %s -s -S -o /tmp/body -D /tmp/headers %q`, ut.Req.Method, strings.Join(headers, " "), post, ut.Req.URL)
 	cmd += ` -w '{"code":%{http_code}}'`
 	if ut.SkipVerify {
 		cmd += ` -k`


### PR DESCRIPTION
…etting to pod/curl util; enable posting data with pod/curl util

@openshift/sig-developer-experience ptal

this adjusts the jenkins extended test so that they can run on multi-node gcp clusters vs. our current aws all-in-one clusters used for ext tests