### PR TITLE
UPSTREAM: 66707: Fix that fails to resize pvc of cinder volume.

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -235,6 +235,7 @@ func (volumes *VolumesV3) getVolume(volumeID string) (Volume, error) {
 		ID:               volumeV3.ID,
 		Name:             volumeV3.Name,
 		Status:           volumeV3.Status,
+		Size:             volumeV3.Size,
 	}
 
 	if len(volumeV3.Attachments) > 0 {


### PR DESCRIPTION
I noticed upstream accidentally deleted this line then put it back. https://github.com/kubernetes/kubernetes/issues/66687 We picked up the accident in the rebase but we need to cherrypick to put it back.
@openshift/sig-storage pls review, thank you.