### PR TITLE
UPSTREAM: 66931: Use the passed-in streams in kubectl top

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_node.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_node.go
@@ -98,6 +98,11 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericclioptio
 		}
 	}
 
+	// actually make use of the passed in streams if not already set
+	if (o.IOStreams == genericclioptions.IOStreams{}) {
+		o.IOStreams = streams
+	}
+
 	cmd := &cobra.Command{
 		Use: "node [NAME | -l label]",
 		DisableFlagsInUseLine: true,

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_pod.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_pod.go
@@ -87,6 +87,11 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericclioptions
 		}
 	}
 
+	// actually make use of the passed in streams if not already set
+	if (o.IOStreams == genericclioptions.IOStreams{}) {
+		o.IOStreams = streams
+	}
+
 	cmd := &cobra.Command{
 		Use: "pod [NAME | -l label]",
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
Previously, kubectl top ignored the passed in streams unless no other options were set.  This behavior is a bit confusing, and can lead to strange foot-guns (like when Origin overrides the Heapster options) from people trying to use the kubectl top code.

Now, we make use of the streams as long as something else didn'texplicitly set them in the options struct.