### PR TITLE
fix set build-hook panic on empty file

### DIFF
--- a/pkg/oc/cli/set/buildhook.go
+++ b/pkg/oc/cli/set/buildhook.go
@@ -207,6 +207,10 @@ func (o *BuildHookOptions) Run() error {
 		return err
 	}
 
+	if len(infos) == 0 {
+		return fmt.Errorf("no resources found")
+	}
+
 	patches := CalculatePatchesExternal(infos, func(info *resource.Info) (bool, error) {
 		bc, ok := info.Object.(*buildv1.BuildConfig)
 		if !ok {

--- a/test/cmd/setbuildhook.sh
+++ b/test/cmd/setbuildhook.sh
@@ -35,5 +35,9 @@ os::cmd::expect_success_and_text "oc get bc -o yaml" "all bc"
 os::cmd::expect_success_and_text "oc set build-hook bc/test-buildconfig --post-commit --remove" "updated"
 os::cmd::expect_success_and_not_text "oc get bc/test-buildconfig -o yaml" "args:"
 os::cmd::expect_success "oc delete bc/test-buildconfig"
+# ensure command behaves as expected when an empty file is given
+workingdir=$(mktemp -d)
+touch "${workingdir}/emptyfile.json"
+os::cmd::expect_failure_and_text "oc set build-hook -f ${workingdir}/emptyfile.json --post-commit=true --script=foo" "no resources found"
 echo "set build-hook: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Returns an error when dealing with an empty file, or no infos are returned from the resource builder.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1612023

cc @deads2k @soltysh 