### PR TITLE
allow versions to be specified for bc logs

### DIFF
--- a/pkg/oc/originpolymorphichelpers/logsforobject.go
+++ b/pkg/oc/originpolymorphichelpers/logsforobject.go
@@ -77,9 +77,6 @@ func NewLogsForObjectFn(delegate polymorphichelpers.LogsForObjectFunc) polymorph
 			if !ok {
 				return nil, errors.New("provided options object is not a v1.BuildLogOptions")
 			}
-			if bopts.Version != nil {
-				return nil, errors.New("cannot specify a version and a build")
-			}
 			buildClient, err := buildv1client.NewForConfig(clientConfig)
 			if err != nil {
 				return nil, err

--- a/test/cmd/builds.sh
+++ b/test/cmd/builds.sh
@@ -162,6 +162,8 @@ os::cmd::expect_success_and_not_text "oc describe ${build_name}" 'No Cache'
 build_name="$(oc start-build -o=name --no-cache test)"
 os::cmd::expect_success_and_text "oc describe ${build_name}" 'No Cache'
 os::cmd::expect_failure_and_text "oc start-build test --incremental" 'Cannot specify Source build specific options'
+# ensure a specific version can be specified for buildconfigs
+os::cmd::expect_failure_and_not_text "oc logs bc/test --version=1" "cannot specify a version and a build"
 os::cmd::expect_success 'oc delete all --selector="name=test"'
 echo "start-build: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1612021

Allows --version to be specified when viewing logs for a buildconfig

cc @soltysh @deads2k 