### PR TITLE
cmd/server: replace raw literals with named constants

### DIFF
--- a/pkg/cmd/server/apis/config/v1/conversions.go
+++ b/pkg/cmd/server/apis/config/v1/conversions.go
@@ -249,7 +249,7 @@ func SetDefaults_IdentityProvider(obj *IdentityProvider) {
 }
 func SetDefaults_GrantConfig(obj *GrantConfig) {
 	if len(obj.ServiceAccountMethod) == 0 {
-		obj.ServiceAccountMethod = "prompt"
+		obj.ServiceAccountMethod = GrantHandlerPrompt
 	}
 }
 

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -348,7 +348,7 @@ func (args MasterArgs) BuildSerializeableOAuthConfig() (*configapi.OAuthConfig, 
 
 		IdentityProviders: []configapi.IdentityProvider{},
 		GrantConfig: configapi.GrantConfig{
-			Method: "auto",
+			Method: configapi.GrantHandlerAuto,
 		},
 
 		SessionConfig: &configapi.SessionConfig{


### PR DESCRIPTION
Skipped test files to make tests fail if const value is changed.
In the normal code though, it may be better to use named constants
explicitly.

Found using https://go-critic.github.io/overview#namedConst-ref