### PR TITLE
apps: replace func lits with wrapped func value

### DIFF
--- a/pkg/apps/metrics/prometheus/metrics.go
+++ b/pkg/apps/metrics/prometheus/metrics.go
@@ -58,7 +58,7 @@ type appsCollector struct {
 
 func InitializeMetricsCollector(rcLister kcorelisters.ReplicationControllerLister) {
 	apps.lister = rcLister
-	apps.nowFn = func() time.Time { return time.Now() }
+	apps.nowFn = time.Now
 	if !registered {
 		prometheus.MustRegister(&apps)
 		registered = true

--- a/pkg/apps/strategy/rolling/rolling_updater.go
+++ b/pkg/apps/strategy/rolling/rolling_updater.go
@@ -167,7 +167,7 @@ func NewRollingUpdater(namespace string, rcClient coreclient.ReplicationControll
 	updater.getOrCreateTargetController = updater.getOrCreateTargetControllerWithClient
 	updater.getReadyPods = updater.readyPods
 	updater.cleanup = updater.cleanupWithClients
-	updater.nowFn = func() metav1.Time { return metav1.Now() }
+	updater.nowFn = metav1.Now
 	return updater
 }
 
@@ -445,7 +445,7 @@ func (r *RollingUpdater) readyPods(oldRc, newRc *api.ReplicationController, minR
 	oldReady := int32(0)
 	newReady := int32(0)
 	if r.nowFn == nil {
-		r.nowFn = func() metav1.Time { return metav1.Now() }
+		r.nowFn = metav1.Now
 	}
 
 	for i := range controllers {


### PR DESCRIPTION
If func lit is only used for arg forwarding without actual
convensions or var enclosing, it can be simply replaced
by function (or method) value itself.

Found using https://go-critic.github.io/overview#unlambda-ref