### PR TITLE
apps: fix extended flake

### DIFF
--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -89,7 +89,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use private repositories as build
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("expecting the deployment of the gitserver to be in the Complete phase")
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), gitServerDeploymentConfigName, 1, true, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), gitServerDeploymentConfigName, 1, true, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			sourceSecretName := secretFunc()

--- a/test/extended/builds/jenkins_plugin.go
+++ b/test/extended/builds/jenkins_plugin.go
@@ -190,7 +190,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for jenkins deployment")
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "jenkins", 1, false, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "jenkins", 1, false, oc)
 			if err != nil {
 				exutil.DumpApplicationPodLogs("jenkins", oc)
 			}
@@ -252,9 +252,9 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				// we leverage some of the openshift utilities for waiting for the deployment before we poll
 				// jenkins for the successful job completion
 				g.By("waiting for frontend, frontend-prod deployments as signs that the build has finished")
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "frontend", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "frontend", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "frontend-prod", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "frontend-prod", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("get build console logs and see if succeeded")
@@ -304,9 +304,9 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				// we leverage some of the openshift utilities for waiting for the deployment before we poll
 				// jenkins for the successful job completion
 				g.By("waiting for frontend, frontend-prod deployments as signs that the build has finished")
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "frontend", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "frontend", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "frontend-prod", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "frontend-prod", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("get build console logs and see if succeeded")
@@ -372,7 +372,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 				// we leverage some of the openshift utilities for waiting for the deployment before we poll
 				// jenkins for the successful job completion
 				g.By("waiting for frontend deployments as signs that the build has finished")
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "frontend", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "frontend", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("get build console logs and see if succeeded")

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -62,7 +62,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for the deployment to complete")
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), a58, 1, true, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), a58, 1, true, oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -178,7 +178,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 			}
 
 			g.By("waiting for jenkins deployment")
-			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "jenkins", 1, false, oc)
+			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "jenkins", 1, false, oc)
 			if err != nil {
 				exutil.DumpApplicationPodLogs("jenkins", oc)
 			}

--- a/test/extended/cluster/cm.go
+++ b/test/extended/cluster/cm.go
@@ -81,13 +81,13 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Mirror cluster", func() 
 			e2e.Logf("Listing objects in namespace %v", ns.Name)
 
 			// Check for DeploymentConfigs
-			dcs, err := oc.AdminAppsClient().Apps().DeploymentConfigs(ns.Name).List(metav1.ListOptions{})
+			dcs, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs(ns.Name).List(metav1.ListOptions{})
 			if err != nil {
 				e2e.Failf("Error listing DeploymentConfigs: %v\n", err)
 			}
 
 			for _, dc := range dcs.Items {
-				dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs(ns.Name).Get(dc.Name, metav1.GetOptions{})
+				dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs(ns.Name).Get(dc.Name, metav1.GetOptions{})
 				if err != nil {
 					e2e.Failf("Error DC not found: %v\n", err)
 				}

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -292,7 +292,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(is.Status.Tags["direct"].Items).NotTo(o.BeEmpty())
 			o.Expect(is.Status.Tags["pullthrough"].Items).NotTo(o.BeEmpty())
 
-			dc, err = oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
+			dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Get(name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Spec.Triggers).To(o.HaveLen(3))
 
@@ -350,7 +350,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			})
 
 			g.By("verifying the scale is updated on the deployment config")
-			config, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get("deployment-test", metav1.GetOptions{})
+			config, err := oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Get("deployment-test", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(config.Spec.Replicas).Should(o.BeEquivalentTo(1))
 			o.Expect(config.Spec.Test).Should(o.BeTrue())
@@ -403,11 +403,11 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			expectLatestVersion := func(version int) {
-				dc, err := oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(dcName, metav1.GetOptions{})
+				dc, err := oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Get(dcName, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				latestVersion := dc.Status.LatestVersion
 				err = wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-					dc, err = oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Get(dcName, metav1.GetOptions{})
+					dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Get(dcName, metav1.GetOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
 					latestVersion = dc.Status.LatestVersion
 					return latestVersion == int64(version), nil
@@ -791,7 +791,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 
 			g.By("making sure it updates observedGeneration after being paused")
-			dc, err = oc.AppsClient().Apps().DeploymentConfigs(oc.Namespace()).Patch(dcName, types.StrategicMergePatchType, []byte(`{"spec": {"paused": true}}`))
+			dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Patch(dcName, types.StrategicMergePatchType, []byte(`{"spec": {"paused": true}}`))
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			_, err = waitForDCModification(oc, dc.Namespace, dcName, deploymentChangeTimeout,
@@ -1206,7 +1206,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			})
 
 			g.By("deleting owned RCs when deleted", func() {
-				err = oc.AppsClient().Apps().DeploymentConfigs(namespace).Delete(dcName, &metav1.DeleteOptions{})
+				err = oc.AppsClient().AppsV1().DeploymentConfigs(namespace).Delete(dcName, &metav1.DeleteOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				err = wait.PollImmediate(200*time.Millisecond, 5*time.Minute, func() (bool, error) {
@@ -1286,7 +1286,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 
 			g.By("redeploying immediately by config change")
 			o.Expect(dc.Spec.Template.Annotations["foo"]).NotTo(o.Equal("bar"))
-			dc, err = oc.AppsClient().Apps().DeploymentConfigs(dc.Namespace).Patch(dc.Name, types.StrategicMergePatchType,
+			dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(dc.Namespace).Patch(dc.Name, types.StrategicMergePatchType,
 				[]byte(`{"spec":{"template":{"metadata":{"annotations":{"foo": "bar"}}}}}`))
 			o.Expect(err).NotTo(o.HaveOccurred())
 			dc, err = waitForDCModification(oc, namespace, dcName, deploymentRunTimeout,
@@ -1386,7 +1386,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			dc.Spec.Replicas = 1
 			// Make sure the deployer pod doesn't immediately
 			dc.Spec.MinReadySeconds = 3
-			dc, err = oc.AppsClient().Apps().DeploymentConfigs(namespace).Create(dc)
+			dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(namespace).Create(dc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for RC to be created")
@@ -1431,7 +1431,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 
 			g.By("redeploying immediately by config change")
 			o.Expect(dc.Spec.Template.Annotations["foo"]).NotTo(o.Equal("bar"))
-			dc, err = oc.AppsClient().Apps().DeploymentConfigs(dc.Namespace).Patch(dc.Name, types.StrategicMergePatchType,
+			dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(dc.Namespace).Patch(dc.Name, types.StrategicMergePatchType,
 				[]byte(`{"spec":{"template":{"metadata":{"annotations":{"foo": "bar"}}}}}`))
 			o.Expect(err).NotTo(o.HaveOccurred())
 			dc, err = waitForDCModification(oc, namespace, dcName, deploymentRunTimeout,

--- a/test/extended/image_ecosystem/mariadb_ephemeral.go
+++ b/test/extended/image_ecosystem/mariadb_ephemeral.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[image_ecosystem][mariadb][Slow] openshift mariadb image", f
 
 				// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 				// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "mariadb", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "mariadb", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("expecting the mariadb service get endpoints")

--- a/test/extended/image_ecosystem/mongodb_ephemeral.go
+++ b/test/extended/image_ecosystem/mongodb_ephemeral.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[image_ecosystem][mongodb] openshift mongodb image", func() 
 				o.Expect(oc.Run("new-app").Args("-f", templatePath).Execute()).Should(o.Succeed())
 
 				g.By("waiting for the deployment to complete")
-				err := exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "mongodb", 1, true, oc)
+				err := exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "mongodb", 1, true, oc)
 				o.Expect(err).ShouldNot(o.HaveOccurred())
 
 				g.By("expecting the mongodb pod is running")

--- a/test/extended/image_ecosystem/mysql_ephemeral.go
+++ b/test/extended/image_ecosystem/mysql_ephemeral.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[image_ecosystem][mysql][Slow] openshift mysql image", func(
 
 				// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 				// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "mysql", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "mysql", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("expecting the mysql service get endpoints")

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -88,7 +88,7 @@ func replicationTestFactory(oc *exutil.CLI, tc testCase, cleanup func()) func() 
 		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
 		g.By("waiting for the deployment to complete")
-		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), helperName, 1, true, oc)
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), helperName, 1, true, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("waiting for an endpoint")

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -138,7 +138,7 @@ func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string, cleanup func
 
 		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
 		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
-		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), postgreSQLHelperName, 1, true, oc)
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), postgreSQLHelperName, 1, true, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = e2e.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), postgreSQLHelperName)

--- a/test/extended/image_ecosystem/s2i_perl.go
+++ b/test/extended/image_ecosystem/s2i_perl.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[image_ecosystem][perl][Slow] hot deploy for openshift perl 
 				}
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), dcName, 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for endpoint")
@@ -95,7 +95,7 @@ var _ = g.Describe("[image_ecosystem][perl][Slow] hot deploy for openshift perl 
 				g.By("turning on hot-deploy")
 				err = oc.Run("set", "env").Args("dc", dcName, "PERL_APACHE2_RELOAD=true").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 2, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), dcName, 2, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for a new endpoint")

--- a/test/extended/image_ecosystem/s2i_php.go
+++ b/test/extended/image_ecosystem/s2i_php.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[image_ecosystem][php][Slow] hot deploy for openshift php im
 				}
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), "cakephp-mysql-example", 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "cakephp-mysql-example", 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for endpoint")

--- a/test/extended/image_ecosystem/s2i_python.go
+++ b/test/extended/image_ecosystem/s2i_python.go
@@ -70,7 +70,7 @@ var _ = g.Describe("[image_ecosystem][python][Slow] hot deploy for openshift pyt
 				}
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), dcName, 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for endpoint")
@@ -107,7 +107,7 @@ var _ = g.Describe("[image_ecosystem][python][Slow] hot deploy for openshift pyt
 				g.By("turning on hot-deploy")
 				err = oc.Run("set", "env").Args("dc", dcName, "APP_CONFIG=conf/reload.py").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 2, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), dcName, 2, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for a new endpoint")

--- a/test/extended/image_ecosystem/s2i_ruby.go
+++ b/test/extended/image_ecosystem/s2i_ruby.go
@@ -63,7 +63,7 @@ var _ = g.Describe("[image_ecosystem][ruby][Slow] hot deploy for openshift ruby 
 				}
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 1, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), dcName, 1, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for endpoint")
@@ -98,7 +98,7 @@ var _ = g.Describe("[image_ecosystem][ruby][Slow] hot deploy for openshift ruby 
 				g.By("turning on hot-deploy")
 				err = oc.Run("set", "env").Args("dc", dcName, "RAILS_ENV=development").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), dcName, 2, true, oc)
+				err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), dcName, 2, true, oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("waiting for a new endpoint")

--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -78,12 +78,12 @@ func NewSampleRepoTest(c sampleRepoConfig) func() {
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					g.By("expecting the app deployment to be complete")
-					err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), c.deploymentConfigName, 1, true, oc)
+					err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), c.deploymentConfigName, 1, true, oc)
 					o.Expect(err).NotTo(o.HaveOccurred())
 
 					if len(c.dbDeploymentConfigName) > 0 {
 						g.By("expecting the db deployment to be complete")
-						err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().Apps(), oc.Namespace(), c.dbDeploymentConfigName, 1, true, oc)
+						err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), c.dbDeploymentConfigName, 1, true, oc)
 						o.Expect(err).NotTo(o.HaveOccurred())
 
 						g.By("expecting the db service is available")

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -24,7 +24,7 @@ func cliPodWithPullSecret(cli *exutil.CLI, shell string) *kapiv1.Pod {
 	pullSecretName := sa.ImagePullSecrets[0].Name
 
 	// best effort to get the format string for the release
-	router, err := cli.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
+	router, err := cli.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
 	if err != nil {
 		g.Fail(fmt.Sprintf("Unable to find router in order to query format string: %v", err))
 	}

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		}
 		image += "-haproxy-router"
 
-		if dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{}); err == nil {
+		if dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{}); err == nil {
 			if len(dc.Spec.Template.Spec.Containers) > 0 && dc.Spec.Template.Spec.Containers[0].Image != "" {
 				image = dc.Spec.Template.Spec.Containers[0].Image
 			}

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	)
 
 	g.BeforeEach(func() {
-		dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
+		dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
 		if kapierrs.IsNotFound(err) {
 			g.Skip("no router installed on the cluster")
 			return

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	oc = exutil.NewCLI("router-stress", exutil.KubeConfigPath())
 
 	g.BeforeEach(func() {
-		_, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
+		_, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
 		if kapierrs.IsNotFound(err) {
 			g.Skip("no router installed on the cluster")
 			return

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		}
 		image += "-haproxy-router"
 
-		if dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{}); err == nil {
+		if dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{}); err == nil {
 			if len(dc.Spec.Template.Spec.Containers) > 0 && dc.Spec.Template.Spec.Containers[0].Image != "" {
 				image = dc.Spec.Template.Spec.Containers[0].Image
 			}

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		dc, err := oc.AdminAppsClient().Apps().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
+		dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
 		if kapierrs.IsNotFound(err) {
 			g.Skip("no router installed on the cluster")
 			imagePrefix := os.Getenv("OS_IMAGE_PREFIX")

--- a/test/extended/util/deploymentconfigs.go
+++ b/test/extended/util/deploymentconfigs.go
@@ -14,7 +14,7 @@ func RemoveDeploymentConfigs(oc *CLI, dcs ...string) error {
 	errs := []error{}
 	for _, dc := range dcs {
 		e2e.Logf("Removing deployment config %s/%s", oc.Namespace(), dc)
-		if err := oc.AdminAppsClient().Apps().DeploymentConfigs(oc.Namespace()).Delete(dc, &metav1.DeleteOptions{}); err != nil {
+		if err := oc.AdminAppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Delete(dc, &metav1.DeleteOptions{}); err != nil {
 			e2e.Logf("Error occurred removing deployment config: %v", err)
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
Fixes bad timing in the test. We should wait for the first deployment to finish before we start counting time for the next deployment (in case the first deployment take longer, it cuts the time from second deployment)

/cc @tnozicka 

Fixes: https://github.com/openshift/origin/issues/20522