### PR TITLE
clean up image registry hostname retrieval

### DIFF
--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -7,7 +7,7 @@ import (
 
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
@@ -21,7 +21,7 @@ type PluginInitializer struct {
 	RESTClientConfig             restclient.Config
 	ClusterResourceQuotaInformer quotainformer.ClusterResourceQuotaInformer
 	ClusterQuotaMapper           clusterquotamapping.ClusterQuotaMapper
-	RegistryHostnameRetriever    imageapi.RegistryHostnameRetriever
+	RegistryHostnameRetriever    registryhostname.RegistryHostnameRetriever
 	SecurityInformers            securityinformer.SharedInformerFactory
 	UserInformers                userinformer.SharedInformerFactory
 }

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -460,15 +459,6 @@ func (c *MasterConfig) RouteAllocator() *routeallocationcontroller.RouteAllocati
 	}
 
 	return factory.Create(plugin)
-}
-
-// env returns an environment variable, or the defaultValue if it is not set.
-func env(key string, defaultValue string) string {
-	val := os.Getenv(key)
-	if len(val) == 0 {
-		return defaultValue
-	}
-	return val
 }
 
 func WithPatternPrefixHandler(handler http.Handler, patternHandler http.Handler, prefixes ...string) http.Handler {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/client-go/restmapper"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
@@ -39,7 +38,6 @@ import (
 	kubernetes "github.com/openshift/origin/pkg/cmd/server/kubernetes/master"
 	originadmission "github.com/openshift/origin/pkg/cmd/server/origin/admission"
 	originrest "github.com/openshift/origin/pkg/cmd/server/origin/rest"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageadmission "github.com/openshift/origin/pkg/image/apiserver/admission/limitrange"
 	imageinformer "github.com/openshift/origin/pkg/image/generated/informers/internalversion"
 	networkinformer "github.com/openshift/origin/pkg/network/generated/informers/internalversion"
@@ -51,8 +49,8 @@ import (
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion"
 	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
 
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
-	"github.com/openshift/origin/pkg/service"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
 
@@ -77,7 +75,7 @@ type MasterConfig struct {
 
 	// RegistryHostnameRetriever retrieves the name of the integrated registry, or false if no such registry
 	// is available.
-	RegistryHostnameRetriever imageapi.RegistryHostnameRetriever
+	RegistryHostnameRetriever registryhostname.RegistryHostnameRetriever
 
 	// PrivilegedLoopbackClientConfig is the client configuration used to call OpenShift APIs from system components
 	// To apply different access control to a system component, create a client config specifically for that component.
@@ -171,11 +169,9 @@ func BuildMasterConfig(
 		return nil, err
 	}
 
-	defaultRegistry := env("OPENSHIFT_DEFAULT_REGISTRY", "${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT}")
-	svcCache := service.NewServiceResolverCache(kubeInternalClient.Core().Services(metav1.NamespaceDefault).Get)
-	defaultRegistryFunc, err := svcCache.Defer(defaultRegistry)
+	registryHostnameRetriever, err := registryhostname.DefaultRegistryHostnameRetriever(privilegedLoopbackConfig, options.ImagePolicyConfig.ExternalRegistryHostname, options.ImagePolicyConfig.InternalRegistryHostname)
 	if err != nil {
-		return nil, fmt.Errorf("OPENSHIFT_DEFAULT_REGISTRY variable is invalid %q: %v", defaultRegistry, err)
+		return nil, err
 	}
 
 	authenticator, authenticatorPostStartHooks, err := NewAuthenticator(options, privilegedLoopbackConfig, informers)
@@ -188,7 +184,7 @@ func BuildMasterConfig(
 		return nil, err
 	}
 	clusterQuotaMappingController := newClusterQuotaMappingController(informers)
-	discoveryClient := cacheddiscovery.NewMemCacheClient(kubeInternalClient.Discovery())
+	discoveryClient := cacheddiscovery.NewMemCacheClient(privilegedLoopbackKubeClientsetExternal.Discovery())
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 	admissionInitializer, err := originadmission.NewPluginInitializer(options, privilegedLoopbackConfig, informers, authorizer, projectCache, restMapper, clusterQuotaMappingController)
 	if err != nil {
@@ -246,7 +242,7 @@ func BuildMasterConfig(
 		ClusterQuotaMappingController: clusterQuotaMappingController,
 		RESTMapper:                    restMapper,
 
-		RegistryHostnameRetriever: imageapi.DefaultRegistryHostnameRetriever(defaultRegistryFunc, options.ImagePolicyConfig.ExternalRegistryHostname, options.ImagePolicyConfig.InternalRegistryHostname),
+		RegistryHostnameRetriever: registryHostnameRetriever,
 
 		PrivilegedLoopbackClientConfig:                *privilegedLoopbackConfig,
 		PrivilegedLoopbackKubernetesClientsetInternal: kubeInternalClient,

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -37,9 +37,9 @@ import (
 	buildapiserver "github.com/openshift/origin/pkg/build/apiserver"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageapiserver "github.com/openshift/origin/pkg/image/apiserver"
 	imageadmission "github.com/openshift/origin/pkg/image/apiserver/admission/limitrange"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	networkapiserver "github.com/openshift/origin/pkg/network/apiserver"
 	oauthapiserver "github.com/openshift/origin/pkg/oauth/apiserver"
 	projectapiserver "github.com/openshift/origin/pkg/project/apiserver"
@@ -92,7 +92,7 @@ type OpenshiftAPIExtraConfig struct {
 	LimitVerifier imageadmission.LimitVerifier
 	// RegistryHostnameRetriever retrieves the internal and external hostname of
 	// the integrated registry, or false if no such registry is available.
-	RegistryHostnameRetriever          imageapi.RegistryHostnameRetriever
+	RegistryHostnameRetriever          registryhostname.RegistryHostnameRetriever
 	AllowedRegistriesForImport         *configapi.AllowedRegistries
 	MaxImagesBulkImportedPerRepository int
 	AdditionalTrustedCA                []byte

--- a/pkg/image/apis/image/helper.go
+++ b/pkg/image/apis/image/helper.go
@@ -33,10 +33,6 @@ const (
 
 	// TagReferenceAnnotationTagHidden indicates that a given TagReference is hidden from search results
 	TagReferenceAnnotationTagHidden = "hidden"
-
-	// ImportRegistryNotAllowed indicates that the image tag was not imported due to
-	// untrusted registry.
-	ImportRegistryNotAllowed = "registry is not allowed for import"
 )
 
 var errNoRegistryURLPathAllowed = errors.New("no path after <host>[:<port>] is allowed")
@@ -58,55 +54,6 @@ var ErrCrossImageStreamReference = errors.New("reference tag points to another i
 
 // ErrInvalidReference is an error when reference tag is invalid.
 var ErrInvalidReference = errors.New("reference tag is invalid")
-
-// RegistryHostnameRetriever represents an interface for retrieving the hostname
-// of internal and external registry.
-type RegistryHostnameRetriever interface {
-	InternalRegistryHostname() (string, bool)
-	ExternalRegistryHostname() (string, bool)
-}
-
-// DefaultRegistryHostnameRetriever is a default implementation of
-// RegistryHostnameRetriever.
-// The first argument is a function that lazy-loads the value of
-// OPENSHIFT_DEFAULT_REGISTRY environment variable which should be deprecated in
-// future.
-func DefaultRegistryHostnameRetriever(deprecatedDefaultRegistryEnvFn func() (string, bool), external, internal string) RegistryHostnameRetriever {
-	return &defaultRegistryHostnameRetriever{
-		deprecatedDefaultFn: deprecatedDefaultRegistryEnvFn,
-		externalHostname:    external,
-		internalHostname:    internal,
-	}
-}
-
-type defaultRegistryHostnameRetriever struct {
-	// deprecatedDefaultFn points to a function that will lazy-load the value of
-	// OPENSHIFT_DEFAULT_REGISTRY.
-	deprecatedDefaultFn func() (string, bool)
-	internalHostname    string
-	externalHostname    string
-}
-
-// InternalRegistryHostnameFn returns a function that can be used to lazy-load
-// the internal Docker Registry hostname. If the master configuration properly
-// InternalRegistryHostname is set, it will prefer that over the lazy-loaded
-// environment variable 'OPENSHIFT_DEFAULT_REGISTRY'.
-func (r *defaultRegistryHostnameRetriever) InternalRegistryHostname() (string, bool) {
-	if len(r.internalHostname) > 0 {
-		return r.internalHostname, true
-	}
-	if r.deprecatedDefaultFn != nil {
-		return r.deprecatedDefaultFn()
-	}
-	return "", false
-}
-
-// ExternalRegistryHostnameFn returns a function that can be used to retrieve an
-// external/public hostname of Docker Registry. External location can be
-// configured in master config using 'ExternalRegistryHostname' property.
-func (r *defaultRegistryHostnameRetriever) ExternalRegistryHostname() (string, bool) {
-	return r.externalHostname, len(r.externalHostname) > 0
-}
 
 // ParseImageStreamImageName splits a string into its name component and ID component, and returns an error
 // if the string is not in the right form.

--- a/pkg/image/apis/image/validation/validation_test.go
+++ b/pkg/image/apis/image/validation/validation_test.go
@@ -1252,10 +1252,7 @@ func TestValidateISTUpdateWithWhitelister(t *testing.T) {
 				Tag:        tc.newTagRef,
 			}
 
-			hostnameFunc := imageapi.DefaultRegistryHostnameRetriever(func() (string, bool) {
-				return tc.registryURL, len(tc.registryURL) > 0
-			}, "", "")
-			whitelister, err := whitelist.NewRegistryWhitelister(*tc.whitelist, hostnameFunc)
+			whitelister, err := whitelist.NewRegistryWhitelister(*tc.whitelist, &simpleHostnameRetriever{registryURL: tc.registryURL})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1265,6 +1262,18 @@ func TestValidateISTUpdateWithWhitelister(t *testing.T) {
 			}
 		})
 	}
+}
+
+type simpleHostnameRetriever struct {
+	registryURL string
+}
+
+func (r *simpleHostnameRetriever) InternalRegistryHostname() (string, bool) {
+	return r.registryURL, len(r.registryURL) > 0
+}
+
+func (r *simpleHostnameRetriever) ExternalRegistryHostname() (string, bool) {
+	return "", false
 }
 
 func TestValidateRegistryAllowedForImport(t *testing.T) {

--- a/pkg/image/apis/image/validation/whitelist/whitelister.go
+++ b/pkg/image/apis/image/validation/whitelist/whitelister.go
@@ -49,6 +49,13 @@ type RegistryWhitelister interface {
 	Copy() RegistryWhitelister
 }
 
+// RegistryHostnameRetriever represents an interface for retrieving the hostname
+// of internal and external registry.
+type RegistryHostnameRetriever interface {
+	InternalRegistryHostname() (string, bool)
+	ExternalRegistryHostname() (string, bool)
+}
+
 type allowedHostPortGlobs struct {
 	host string
 	port string
@@ -57,7 +64,7 @@ type allowedHostPortGlobs struct {
 type registryWhitelister struct {
 	whitelist             []allowedHostPortGlobs
 	pullSpecs             sets.String
-	registryHostRetriever imageapi.RegistryHostnameRetriever
+	registryHostRetriever RegistryHostnameRetriever
 }
 
 var _ RegistryWhitelister = &registryWhitelister{}
@@ -66,7 +73,7 @@ var _ RegistryWhitelister = &registryWhitelister{}
 // list of allowed registries and the current domain name of the integrated Docker registry.
 func NewRegistryWhitelister(
 	whitelist serverapi.AllowedRegistries,
-	registryHostRetriever imageapi.RegistryHostnameRetriever,
+	registryHostRetriever RegistryHostnameRetriever,
 ) (RegistryWhitelister, error) {
 	errs := []error{}
 	rw := registryWhitelister{

--- a/pkg/image/apiserver/apiserver.go
+++ b/pkg/image/apiserver/apiserver.go
@@ -22,7 +22,6 @@ import (
 	imageapiv1 "github.com/openshift/api/image/v1"
 	imageclientv1 "github.com/openshift/client-go/image/clientset/versioned"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 	imageadmission "github.com/openshift/origin/pkg/image/apiserver/admission/limitrange"
 	"github.com/openshift/origin/pkg/image/apiserver/registry/image"
@@ -35,6 +34,7 @@ import (
 	"github.com/openshift/origin/pkg/image/apiserver/registry/imagestreamimport"
 	"github.com/openshift/origin/pkg/image/apiserver/registry/imagestreammapping"
 	"github.com/openshift/origin/pkg/image/apiserver/registry/imagestreamtag"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	"github.com/openshift/origin/pkg/image/importer"
 	imageimporter "github.com/openshift/origin/pkg/image/importer"
@@ -44,7 +44,7 @@ import (
 type ExtraConfig struct {
 	KubeAPIServerClientConfig          *restclient.Config
 	LimitVerifier                      imageadmission.LimitVerifier
-	RegistryHostnameRetriever          imageapi.RegistryHostnameRetriever
+	RegistryHostnameRetriever          registryhostname.RegistryHostnameRetriever
 	AllowedRegistriesForImport         *configapi.AllowedRegistries
 	MaxImagesBulkImportedPerRepository int
 	AdditionalTrustedCA                []byte

--- a/pkg/image/apiserver/registry/imagestream/etcd/etcd.go
+++ b/pkg/image/apiserver/registry/imagestream/etcd/etcd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 	imageadmission "github.com/openshift/origin/pkg/image/apiserver/admission/limitrange"
 	"github.com/openshift/origin/pkg/image/apiserver/registry/imagestream"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	"github.com/openshift/origin/pkg/util/restoptions"
 )
@@ -48,7 +49,7 @@ func (r *REST) ShortNames() []string {
 // NewREST returns a new REST.
 func NewREST(
 	optsGetter restoptions.Getter,
-	registryHostname imageapi.RegistryHostnameRetriever,
+	registryHostname registryhostname.RegistryHostnameRetriever,
 	subjectAccessReviewRegistry authorizationclient.SubjectAccessReviewInterface,
 	limitVerifier imageadmission.LimitVerifier,
 	registryWhitelister whitelist.RegistryWhitelister,

--- a/pkg/image/apiserver/registry/imagestream/etcd/etcd_test.go
+++ b/pkg/image/apiserver/registry/imagestream/etcd/etcd_test.go
@@ -21,6 +21,7 @@ import (
 
 	// install all APIs
 	_ "github.com/openshift/origin/pkg/api/install"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 const (
@@ -52,7 +53,7 @@ func (f *fakeSubjectAccessReviewRegistry) Create(subjectAccessReview *authorizat
 func newStorage(t *testing.T) (*REST, *StatusREST, *InternalREST, *etcdtesting.EtcdTestServer) {
 	server, etcdStorage := etcdtesting.NewUnsecuredEtcd3TestClientServer(t)
 	etcdStorage.Codec = legacyscheme.Codecs.LegacyCodec(schema.GroupVersion{Group: "image.openshift.io", Version: "v1"})
-	registry := imageapi.DefaultRegistryHostnameRetriever(noDefaultRegistry, "", "")
+	registry := registryhostname.TestingRegistryHostnameRetriever(noDefaultRegistry, "", "")
 	imageStorage, _, statusStorage, internalStorage, err := NewREST(
 		restoptions.NewSimpleGetter(etcdStorage),
 		registry,

--- a/pkg/image/apiserver/registry/imagestream/strategy.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/origin/pkg/image/apis/image/validation"
 	"github.com/openshift/origin/pkg/image/apis/image/validation/whitelist"
 	imageadmission "github.com/openshift/origin/pkg/image/apiserver/admission/limitrange"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 type ResourceGetter interface {
@@ -35,7 +36,7 @@ type ResourceGetter interface {
 type Strategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
-	registryHostnameRetriever imageapi.RegistryHostnameRetriever
+	registryHostnameRetriever registryhostname.RegistryHostnameRetriever
 	tagVerifier               *TagVerifier
 	limitVerifier             imageadmission.LimitVerifier
 	registryWhitelister       whitelist.RegistryWhitelister
@@ -45,7 +46,7 @@ type Strategy struct {
 // NewStrategy is the default logic that applies when creating and updating
 // ImageStream objects via the REST API.
 func NewStrategy(
-	registryHostname imageapi.RegistryHostnameRetriever,
+	registryHostname registryhostname.RegistryHostnameRetriever,
 	subjectAccessReviewClient authorizationclient.SubjectAccessReviewInterface,
 	limitVerifier imageadmission.LimitVerifier,
 	registryWhitelister whitelist.RegistryWhitelister,

--- a/pkg/image/apiserver/registry/imagestream/strategy_test.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/image/apis/image/validation/fake"
 	admfake "github.com/openshift/origin/pkg/image/apiserver/admission/fake"
 	"github.com/openshift/origin/pkg/image/apiserver/admission/limitrange"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	"github.com/openshift/origin/pkg/image/util/testutil"
 )
 
@@ -111,7 +112,7 @@ func TestPublicDockerImageRepository(t *testing.T) {
 	}
 
 	for testName, test := range tests {
-		strategy := NewStrategy(imageapi.DefaultRegistryHostnameRetriever(nil, test.publicRegistry, ""), &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, nil, nil)
+		strategy := NewStrategy(registryhostname.TestingRegistryHostnameRetriever(nil, test.publicRegistry, ""), &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, nil, nil)
 		value := strategy.publicDockerImageRepository(test.stream)
 		if e, a := test.expected, value; e != a {
 			t.Errorf("%s: expected %q, got %q", testName, e, a)
@@ -182,7 +183,7 @@ func TestDockerImageRepository(t *testing.T) {
 
 	for testName, test := range tests {
 		fakeRegistry := &fakeDefaultRegistry{test.defaultRegistry}
-		strategy := NewStrategy(imageapi.DefaultRegistryHostnameRetriever(fakeRegistry.DefaultRegistry, "", ""), &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, nil, nil)
+		strategy := NewStrategy(registryhostname.TestingRegistryHostnameRetriever(fakeRegistry.DefaultRegistry, "", ""), &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, nil, nil)
 		value := strategy.dockerImageRepository(test.stream, true)
 		if e, a := test.expected, value; e != a {
 			t.Errorf("%s: expected %q, got %q", testName, e, a)
@@ -576,7 +577,7 @@ func TestLimitVerifier(t *testing.T) {
 				ImageStreamEvaluator: tc.isEvaluator,
 			},
 			registryWhitelister:       &fake.RegistryWhitelister{},
-			registryHostnameRetriever: imageapi.DefaultRegistryHostnameRetriever(fakeRegistry.DefaultRegistry, "", ""),
+			registryHostnameRetriever: registryhostname.TestingRegistryHostnameRetriever(fakeRegistry.DefaultRegistry, "", ""),
 		}
 
 		ctx := apirequest.WithUser(apirequest.NewDefaultContext(), &fakeUser{})
@@ -1140,7 +1141,7 @@ func TestTagsChanged(t *testing.T) {
 
 		fakeRegistry := &fakeDefaultRegistry{}
 		s := &Strategy{
-			registryHostnameRetriever: imageapi.DefaultRegistryHostnameRetriever(fakeRegistry.DefaultRegistry, "", ""),
+			registryHostnameRetriever: registryhostname.TestingRegistryHostnameRetriever(fakeRegistry.DefaultRegistry, "", ""),
 			imageStreamGetter:         &fakeImageStreamGetter{test.otherStream},
 		}
 		err := s.tagsChanged(previousStream, stream)

--- a/pkg/image/apiserver/registry/imagestreamimage/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreamimage/rest_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/origin/pkg/util/restoptions"
 
 	_ "github.com/openshift/origin/pkg/api/install"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 var testDefaultRegistry = func() (string, bool) { return "defaultregistry:5000", true }
@@ -46,7 +47,7 @@ func setup(t *testing.T) (etcd.KV, *etcdtesting.EtcdTestServer, *REST) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defaultRegistry := imageapi.DefaultRegistryHostnameRetriever(testDefaultRegistry, "", "")
+	defaultRegistry := registryhostname.TestingRegistryHostnameRetriever(testDefaultRegistry, "", "")
 	imageStreamStorage, _, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(restoptions.NewSimpleGetter(etcdStorage), defaultRegistry, &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, &fake.RegistryWhitelister{}, imagestreametcd.NewEmptyLayerIndex())
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/image/apiserver/registry/imagestreammapping/rest.go
+++ b/pkg/image/apiserver/registry/imagestreammapping/rest.go
@@ -18,6 +18,7 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/apiserver/registry/image"
 	"github.com/openshift/origin/pkg/image/apiserver/registry/imagestream"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 // maxRetriesOnConflict is the maximum retry count for Create calls which
@@ -37,7 +38,7 @@ var _ rest.Creater = &REST{}
 var _ rest.Scoper = &REST{}
 
 // NewREST returns a new REST.
-func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry, registry imageapi.RegistryHostnameRetriever) *REST {
+func NewREST(imageRegistry image.Registry, imageStreamRegistry imagestream.Registry, registry registryhostname.RegistryHostnameRetriever) *REST {
 	return &REST{
 		imageRegistry:       imageRegistry,
 		imageStreamRegistry: imageStreamRegistry,

--- a/pkg/image/apiserver/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreammapping/rest_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/origin/pkg/util/restoptions"
 
 	_ "github.com/openshift/origin/pkg/api/install"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 const testDefaultRegistryURL = "defaultregistry:5000"
@@ -59,7 +60,7 @@ func setup(t *testing.T) (etcd.KV, *etcdtesting.EtcdTestServer, *REST) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	registry := imageapi.DefaultRegistryHostnameRetriever(testDefaultRegistry, "", "")
+	registry := registryhostname.TestingRegistryHostnameRetriever(testDefaultRegistry, "", "")
 	imageStreamStorage, _, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(restoptions.NewSimpleGetter(etcdStorage), registry, &fakeSubjectAccessReviewRegistry{}, &admfake.ImageStreamLimitVerifier{}, &fake.RegistryWhitelister{}, imagestreametcd.NewEmptyLayerIndex())
 	if err != nil {
 		t.Fatal(err)
@@ -591,7 +592,7 @@ func TestTrackingTags(t *testing.T) {
 // TestCreateRetryUnrecoverable ensures that an attempt to create a mapping
 // using failing registry update calls will return an error.
 func TestCreateRetryUnrecoverable(t *testing.T) {
-	registry := imageapi.DefaultRegistryHostnameRetriever(nil, "", testDefaultRegistryURL)
+	registry := registryhostname.TestingRegistryHostnameRetriever(nil, "", testDefaultRegistryURL)
 	restInstance := &REST{
 		strategy: NewStrategy(registry),
 		imageRegistry: &fakeImageRegistry{
@@ -625,7 +626,7 @@ func TestCreateRetryUnrecoverable(t *testing.T) {
 // that result in resource conflicts that do NOT include tag diffs causes the
 // create to be retried successfully.
 func TestCreateRetryConflictNoTagDiff(t *testing.T) {
-	registry := imageapi.DefaultRegistryHostnameRetriever(nil, "", testDefaultRegistryURL)
+	registry := registryhostname.TestingRegistryHostnameRetriever(nil, "", testDefaultRegistryURL)
 	firstUpdate := true
 	restInstance := &REST{
 		strategy: NewStrategy(registry),
@@ -671,7 +672,7 @@ func TestCreateRetryConflictTagDiff(t *testing.T) {
 	firstGet := true
 	firstUpdate := true
 	restInstance := &REST{
-		strategy: NewStrategy(imageapi.DefaultRegistryHostnameRetriever(nil, "", testDefaultRegistryURL)),
+		strategy: NewStrategy(registryhostname.TestingRegistryHostnameRetriever(nil, "", testDefaultRegistryURL)),
 		imageRegistry: &fakeImageRegistry{
 			createImage: func(ctx context.Context, image *imageapi.Image) error {
 				return nil

--- a/pkg/image/apiserver/registry/imagestreammapping/strategy.go
+++ b/pkg/image/apiserver/registry/imagestreammapping/strategy.go
@@ -10,6 +10,7 @@ import (
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	"github.com/openshift/origin/pkg/image/apis/image/validation"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 // Strategy implements behavior for image stream mappings.
@@ -17,12 +18,12 @@ type Strategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 
-	registryHostRetriever imageapi.RegistryHostnameRetriever
+	registryHostRetriever registryhostname.RegistryHostnameRetriever
 }
 
 // Strategy is the default logic that applies when creating ImageStreamMapping
 // objects via the REST API.
-func NewStrategy(registryHost imageapi.RegistryHostnameRetriever) Strategy {
+func NewStrategy(registryHost registryhostname.RegistryHostnameRetriever) Strategy {
 	return Strategy{
 		ObjectTyper:           legacyscheme.Scheme,
 		NameGenerator:         names.SimpleNameGenerator,

--- a/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/origin/pkg/util/restoptions"
 
 	_ "github.com/openshift/origin/pkg/api/install"
+	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 )
 
 var testDefaultRegistry = func() (string, bool) { return "defaultregistry:5000", true }
@@ -74,7 +75,7 @@ func setup(t *testing.T) (etcd.KV, *etcdtesting.EtcdTestServer, *REST) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	registry := imageapi.DefaultRegistryHostnameRetriever(testDefaultRegistry, "", "")
+	registry := registryhostname.TestingRegistryHostnameRetriever(testDefaultRegistry, "", "")
 	imageStreamStorage, _, imageStreamStatus, internalStorage, err := imagestreametcd.NewREST(
 		restoptions.NewSimpleGetter(etcdStorage),
 		registry,

--- a/pkg/image/apiserver/registryhostname/environmentresolvercache.go
+++ b/pkg/image/apiserver/registryhostname/environmentresolvercache.go
@@ -1,4 +1,4 @@
-package service
+package registryhostname
 
 import (
 	"fmt"
@@ -7,14 +7,9 @@ import (
 	"strings"
 	"sync"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
-
-// ServiceRetriever is an interface for retrieving services
-type ServiceRetriever interface {
-	Get(name string) (*api.Service, error)
-}
 
 type serviceEntry struct {
 	host string
@@ -22,7 +17,7 @@ type serviceEntry struct {
 }
 
 // ResolverCacheFunc is used for resolving names to services
-type ResolverCacheFunc func(name string, options metav1.GetOptions) (*api.Service, error)
+type ResolverCacheFunc func(name string, options metav1.GetOptions) (*corev1.Service, error)
 
 // ServiceResolverCache is a cache used for resolving names to services
 type ServiceResolverCache struct {
@@ -32,7 +27,7 @@ type ServiceResolverCache struct {
 }
 
 // NewServiceResolverCache returns a new ServiceResolverCache
-func NewServiceResolverCache(fill ResolverCacheFunc) *ServiceResolverCache {
+func newServiceResolverCache(fill ResolverCacheFunc) *ServiceResolverCache {
 	return &ServiceResolverCache{
 		cache: make(map[string]serviceEntry),
 		fill:  fill,

--- a/pkg/image/apiserver/registryhostname/retriever.go
+++ b/pkg/image/apiserver/registryhostname/retriever.go
@@ -1,0 +1,88 @@
+package registryhostname
+
+import (
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// RegistryHostnameRetriever represents an interface for retrieving the hostname
+// of internal and external registry.
+type RegistryHostnameRetriever interface {
+	InternalRegistryHostname() (string, bool)
+	ExternalRegistryHostname() (string, bool)
+}
+
+// DefaultRegistryHostnameRetriever is a default implementation of
+// RegistryHostnameRetriever.
+// The first argument is a function that lazy-loads the value of
+// OPENSHIFT_DEFAULT_REGISTRY environment variable which should be deprecated in
+// future.
+func TestingRegistryHostnameRetriever(deprecatedDefaultRegistryEnvFn func() (string, bool), external, internal string) RegistryHostnameRetriever {
+	return &defaultRegistryHostnameRetriever{
+		deprecatedDefaultFn: deprecatedDefaultRegistryEnvFn,
+		externalHostname:    external,
+		internalHostname:    internal,
+	}
+}
+
+func DefaultRegistryHostnameRetriever(clientConfig *rest.Config, external, internal string) (RegistryHostnameRetriever, error) {
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultRegistry := env("OPENSHIFT_DEFAULT_REGISTRY", "${DOCKER_REGISTRY_SERVICE_HOST}:${DOCKER_REGISTRY_SERVICE_PORT}")
+	svcCache := newServiceResolverCache(kubeClient.CoreV1().Services(metav1.NamespaceDefault).Get)
+	defaultRegistryFunc, err := svcCache.Defer(defaultRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("OPENSHIFT_DEFAULT_REGISTRY variable is invalid %q: %v", defaultRegistry, err)
+	}
+
+	return &defaultRegistryHostnameRetriever{
+		deprecatedDefaultFn: defaultRegistryFunc,
+		externalHostname:    external,
+		internalHostname:    internal,
+	}, nil
+}
+
+// env returns an environment variable, or the defaultValue if it is not set.
+func env(key string, defaultValue string) string {
+	val := os.Getenv(key)
+	if len(val) == 0 {
+		return defaultValue
+	}
+	return val
+}
+
+type defaultRegistryHostnameRetriever struct {
+	// deprecatedDefaultFn points to a function that will lazy-load the value of
+	// OPENSHIFT_DEFAULT_REGISTRY.
+	deprecatedDefaultFn func() (string, bool)
+	internalHostname    string
+	externalHostname    string
+}
+
+// InternalRegistryHostnameFn returns a function that can be used to lazy-load
+// the internal Docker Registry hostname. If the master configuration properly
+// InternalRegistryHostname is set, it will prefer that over the lazy-loaded
+// environment variable 'OPENSHIFT_DEFAULT_REGISTRY'.
+func (r *defaultRegistryHostnameRetriever) InternalRegistryHostname() (string, bool) {
+	if len(r.internalHostname) > 0 {
+		return r.internalHostname, true
+	}
+	if r.deprecatedDefaultFn != nil {
+		return r.deprecatedDefaultFn()
+	}
+	return "", false
+}
+
+// ExternalRegistryHostnameFn returns a function that can be used to retrieve an
+// external/public hostname of Docker Registry. External location can be
+// configured in master config using 'ExternalRegistryHostname' property.
+func (r *defaultRegistryHostnameRetriever) ExternalRegistryHostname() (string, bool) {
+	return r.externalHostname, len(r.externalHostname) > 0
+}


### PR DESCRIPTION
This tightens usage of the image registry hostname which is needed to make admission config managable which is needed to make a split kube/openshift server start tractable.

/assign @bparees @mfojtik 