### PR TITLE
remove unnecessary internal client

### DIFF
--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -60,7 +60,6 @@ func (c *MasterConfig) newOpenshiftAPIConfig(kubeAPIServerConfig apiserver.Confi
 		GenericConfig: &apiserver.RecommendedConfig{Config: genericConfig},
 		ExtraConfig: OpenshiftAPIExtraConfig{
 			KubeAPIServerClientConfig:          &c.PrivilegedLoopbackClientConfig,
-			KubeClientInternal:                 c.PrivilegedLoopbackKubernetesClientsetInternal,
 			KubeInternalInformers:              c.InternalKubeInformers,
 			KubeInformers:                      c.ClientGoKubeInformers,
 			QuotaInformers:                     c.QuotaInformers,
@@ -449,9 +448,7 @@ func (c *MasterConfig) withOAuthRedirection(handler, oauthServerHandler http.Han
 
 // RouteAllocator returns a route allocation controller.
 func (c *MasterConfig) RouteAllocator() *routeallocationcontroller.RouteAllocationController {
-	factory := routeallocationcontroller.RouteAllocationControllerFactory{
-		KubeClient: c.PrivilegedLoopbackKubernetesClientsetInternal,
-	}
+	factory := routeallocationcontroller.RouteAllocationControllerFactory{}
 
 	plugin, err := routeplugin.NewSimpleAllocationPlugin(c.Options.RoutingConfig.Subdomain)
 	if err != nil {

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -81,11 +81,6 @@ type MasterConfig struct {
 	// To apply different access control to a system component, create a client config specifically for that component.
 	PrivilegedLoopbackClientConfig restclient.Config
 
-	// PrivilegedLoopbackKubernetesClientsetInternal is the client used to call Kubernetes APIs from system components,
-	// built from KubeClientConfig. It should only be accessed via the *TestingClient() helper methods. To apply
-	// different access control to a system component, create a separate client/config specifically for
-	// that component.
-	PrivilegedLoopbackKubernetesClientsetInternal kclientsetinternal.Interface
 	// PrivilegedLoopbackKubernetesClientsetExternal is the client used to call Kubernetes APIs from system components,
 	// built from KubeClientConfig. It should only be accessed via the *TestingClient() helper methods. To apply
 	// different access control to a system component, create a separate client/config specifically for
@@ -157,10 +152,6 @@ func BuildMasterConfig(
 	}
 
 	privilegedLoopbackConfig, err := configapi.GetClientConfig(options.MasterClients.OpenShiftLoopbackKubeConfig, options.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
-	if err != nil {
-		return nil, err
-	}
-	kubeInternalClient, err := kclientsetinternal.NewForConfig(privilegedLoopbackConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +236,6 @@ func BuildMasterConfig(
 		RegistryHostnameRetriever: registryHostnameRetriever,
 
 		PrivilegedLoopbackClientConfig:                *privilegedLoopbackConfig,
-		PrivilegedLoopbackKubernetesClientsetInternal: kubeInternalClient,
 		PrivilegedLoopbackKubernetesClientsetExternal: privilegedLoopbackKubeClientsetExternal,
 
 		InternalKubeInformers:  informers.GetInternalKubernetesInformers(),

--- a/pkg/cmd/server/origin/openshift_apiserver.go
+++ b/pkg/cmd/server/origin/openshift_apiserver.go
@@ -25,7 +25,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
@@ -77,7 +76,6 @@ import (
 
 type OpenshiftAPIExtraConfig struct {
 	KubeAPIServerClientConfig *restclient.Config
-	KubeClientInternal        kclientsetinternal.Interface
 	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 	KubeInformers             kubeinformers.SharedInformerFactory
 
@@ -119,9 +117,6 @@ type OpenshiftAPIExtraConfig struct {
 func (c *OpenshiftAPIExtraConfig) Validate() error {
 	ret := []error{}
 
-	if c.KubeClientInternal == nil {
-		ret = append(ret, fmt.Errorf("KubeClientInternal is required"))
-	}
 	if c.KubeInternalInformers == nil {
 		ret = append(ret, fmt.Errorf("KubeInternalInformers is required"))
 	}

--- a/pkg/cmd/server/origin/reststorage_validation_test.go
+++ b/pkg/cmd/server/origin/reststorage_validation_test.go
@@ -8,7 +8,6 @@ import (
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	restclient "k8s.io/client-go/rest"
-	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	fakeinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
@@ -92,7 +91,6 @@ func fakeOpenshiftAPIServerConfig() *OpenshiftAPIConfig {
 			},
 		},
 		ExtraConfig: OpenshiftAPIExtraConfig{
-			KubeClientInternal:            &kclientsetinternal.Clientset{},
 			KubeInternalInformers:         internalkubeInformerFactory,
 			QuotaInformers:                quotaInformerFactory,
 			SecurityInformers:             securityInformerFactory,

--- a/pkg/route/allocation/simple/plugin_test.go
+++ b/pkg/route/allocation/simple/plugin_test.go
@@ -229,7 +229,7 @@ func TestSimpleAllocationPluginViaController(t *testing.T) {
 	}
 
 	plugin, _ := NewSimpleAllocationPlugin("www.example.org")
-	fac := &rac.RouteAllocationControllerFactory{KubeClient: nil}
+	fac := &rac.RouteAllocationControllerFactory{}
 	sac := fac.Create(plugin)
 
 	for _, tc := range tests {

--- a/pkg/route/controller/allocation/factory.go
+++ b/pkg/route/controller/allocation/factory.go
@@ -1,16 +1,12 @@
 package allocation
 
 import (
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-
 	"github.com/openshift/origin/pkg/route"
 )
 
 // RouteAllocationControllerFactory creates a RouteAllocationController
 // that allocates router shards to specific routes.
 type RouteAllocationControllerFactory struct {
-	// KubeClient is a Kubernetes client.
-	KubeClient kclientset.Interface
 }
 
 // Create a RouteAllocationController instance.

--- a/pkg/route/controller/allocation/route_allocation_controller_test.go
+++ b/pkg/route/controller/allocation/route_allocation_controller_test.go
@@ -83,7 +83,7 @@ func TestRouteAllocationController(t *testing.T) {
 	}
 
 	plugin := &TestAllocationPlugin{Name: "test allocation plugin"}
-	fac := &RouteAllocationControllerFactory{nil}
+	fac := &RouteAllocationControllerFactory{}
 	allocator := fac.Create(plugin)
 	for _, tc := range tests {
 		shard, err := allocator.AllocateRouterShard(tc.route)


### PR DESCRIPTION
found while trying to unwind admission config enough to make a forward building kubeapiserver.

/assign @sttts 