### PR TITLE
move authorizer into the construction of the kubeapiserver

### DIFF
--- a/pkg/cmd/openshift-apiserver/server.go
+++ b/pkg/cmd/openshift-apiserver/server.go
@@ -6,7 +6,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/pkg/version"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/capabilities"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	"github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
-	usercache "github.com/openshift/origin/pkg/user/cache"
 )
 
 func RunOpenShiftAPIServer(masterConfig *configapi.MasterConfig) error {
@@ -46,18 +44,8 @@ func RunOpenShiftAPIServer(masterConfig *configapi.MasterConfig) error {
 	if err != nil {
 		return err
 	}
-	informers, err := origin.NewInformers(clientConfig)
-	if err != nil {
-		return err
-	}
 
-	if err := informers.GetOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
-		usercache.ByUserIndexName: usercache.ByUserIndexKeys,
-	}); err != nil {
-		return err
-	}
-
-	openshiftConfig, err := origin.BuildMasterConfig(*masterConfig, informers)
+	openshiftConfig, err := origin.BuildMasterConfig(*masterConfig, clientConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -43,8 +43,7 @@ func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error
 		return kerrors.NewInvalid(configapi.Kind("MasterConfig"), "master-config.yaml", validationResults.Errors)
 	}
 
-	informers := origin.InformerAccess(nil) // use real kube-apiserver loopback client with secret token instead of that from masterConfig.MasterClients.OpenShiftLoopbackKubeConfig
-	openshiftConfig, err := origin.BuildMasterConfig(*masterConfig, informers)
+	openshiftConfig, err := origin.BuildMasterConfig(*masterConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/apis/config/helpers.go
+++ b/pkg/cmd/server/apis/config/helpers.go
@@ -257,7 +257,7 @@ func GetKubeConfigOrInClusterConfig(kubeConfigFile string, overrides *ClientConn
 	if err != nil {
 		return nil, err
 	}
-	applyClientConnectionOverrides(overrides, clientConfig)
+	ApplyClientConnectionOverrides(overrides, clientConfig)
 	clientConfig.WrapTransport = DefaultClientTransport
 
 	return clientConfig, nil
@@ -276,14 +276,14 @@ func GetClientConfig(kubeConfigFile string, overrides *ClientConnectionOverrides
 	if err != nil {
 		return nil, err
 	}
-	applyClientConnectionOverrides(overrides, clientConfig)
+	ApplyClientConnectionOverrides(overrides, clientConfig)
 	clientConfig.WrapTransport = DefaultClientTransport
 
 	return clientConfig, nil
 }
 
 // applyClientConnectionOverrides updates a kubeConfig with the overrides from the config.
-func applyClientConnectionOverrides(overrides *ClientConnectionOverrides, kubeConfig *restclient.Config) {
+func ApplyClientConnectionOverrides(overrides *ClientConnectionOverrides, kubeConfig *restclient.Config) {
 	if overrides == nil {
 		return
 	}

--- a/pkg/cmd/server/kubernetes/master/authorizer.go
+++ b/pkg/cmd/server/kubernetes/master/authorizer.go
@@ -1,0 +1,55 @@
+package master
+
+import (
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
+	kinformers "k8s.io/client-go/informers"
+	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
+	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/node"
+	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
+	kbootstrappolicy "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
+
+	openshiftauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
+	"github.com/openshift/origin/pkg/authorization/authorizer/browsersafe"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
+)
+
+func NewAuthorizer(internalInformers kinternalinformers.SharedInformerFactory, informers kinformers.SharedInformerFactory, projectRequestDenyMessage string) authorizer.Authorizer {
+	messageMaker := openshiftauthorizer.NewForbiddenMessageResolver(projectRequestDenyMessage)
+	rbacInformers := informers.Rbac().V1()
+
+	scopeLimitedAuthorizer := scope.NewAuthorizer(rbacInformers.ClusterRoles().Lister(), messageMaker)
+
+	kubeAuthorizer := rbacauthorizer.New(
+		&rbacauthorizer.RoleGetter{Lister: rbacInformers.Roles().Lister()},
+		&rbacauthorizer.RoleBindingLister{Lister: rbacInformers.RoleBindings().Lister()},
+		&rbacauthorizer.ClusterRoleGetter{Lister: rbacInformers.ClusterRoles().Lister()},
+		&rbacauthorizer.ClusterRoleBindingLister{Lister: rbacInformers.ClusterRoleBindings().Lister()},
+	)
+
+	graph := node.NewGraph()
+	node.AddGraphEventHandlers(
+		graph,
+		internalInformers.Core().InternalVersion().Nodes(),
+		internalInformers.Core().InternalVersion().Pods(),
+		internalInformers.Core().InternalVersion().PersistentVolumes(),
+		informers.Storage().V1beta1().VolumeAttachments(),
+	)
+	nodeAuthorizer := node.NewAuthorizer(graph, nodeidentifier.NewDefaultNodeIdentifier(), kbootstrappolicy.NodeRules())
+
+	openshiftAuthorizer := authorizerunion.New(
+		// Wrap with an authorizer that detects unsafe requests and modifies verbs/resources appropriately so policy can address them separately.
+		// Scopes are first because they will authoritatively deny and can logically be attached to anyone.
+		browsersafe.NewBrowserSafeAuthorizer(scopeLimitedAuthorizer, user.AllAuthenticated),
+		// authorizes system:masters to do anything, just like upstream
+		authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup),
+		nodeAuthorizer,
+		// Wrap with an authorizer that detects unsafe requests and modifies verbs/resources appropriately so policy can address them separately
+		browsersafe.NewBrowserSafeAuthorizer(openshiftauthorizer.NewAuthorizer(kubeAuthorizer, messageMaker), user.AllAuthenticated),
+	)
+
+	return openshiftAuthorizer
+}

--- a/pkg/cmd/server/origin/authorizer.go
+++ b/pkg/cmd/server/origin/authorizer.go
@@ -1,58 +1,10 @@
 package origin
 
 import (
-	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
-	authorizerunion "k8s.io/apiserver/pkg/authorization/union"
 	rbacinformers "k8s.io/client-go/informers/rbac/v1"
-	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
-	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/node"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
-	kbootstrappolicy "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
-
-	openshiftauthorizer "github.com/openshift/origin/pkg/authorization/authorizer"
-	"github.com/openshift/origin/pkg/authorization/authorizer/browsersafe"
-	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 )
-
-func NewAuthorizer(informers InformerAccess, projectRequestDenyMessage string) authorizer.Authorizer {
-	messageMaker := openshiftauthorizer.NewForbiddenMessageResolver(projectRequestDenyMessage)
-	rbacInformers := informers.GetKubernetesInformers().Rbac().V1()
-
-	scopeLimitedAuthorizer := scope.NewAuthorizer(rbacInformers.ClusterRoles().Lister(), messageMaker)
-
-	kubeAuthorizer := rbacauthorizer.New(
-		&rbacauthorizer.RoleGetter{Lister: rbacInformers.Roles().Lister()},
-		&rbacauthorizer.RoleBindingLister{Lister: rbacInformers.RoleBindings().Lister()},
-		&rbacauthorizer.ClusterRoleGetter{Lister: rbacInformers.ClusterRoles().Lister()},
-		&rbacauthorizer.ClusterRoleBindingLister{Lister: rbacInformers.ClusterRoleBindings().Lister()},
-	)
-
-	graph := node.NewGraph()
-	node.AddGraphEventHandlers(
-		graph,
-		informers.GetInternalKubernetesInformers().Core().InternalVersion().Nodes(),
-		informers.GetInternalKubernetesInformers().Core().InternalVersion().Pods(),
-		informers.GetInternalKubernetesInformers().Core().InternalVersion().PersistentVolumes(),
-		informers.GetKubernetesInformers().Storage().V1beta1().VolumeAttachments(),
-	)
-	nodeAuthorizer := node.NewAuthorizer(graph, nodeidentifier.NewDefaultNodeIdentifier(), kbootstrappolicy.NodeRules())
-
-	openshiftAuthorizer := authorizerunion.New(
-		// Wrap with an authorizer that detects unsafe requests and modifies verbs/resources appropriately so policy can address them separately.
-		// Scopes are first because they will authoritatively deny and can logically be attached to anyone.
-		browsersafe.NewBrowserSafeAuthorizer(scopeLimitedAuthorizer, user.AllAuthenticated),
-		// authorizes system:masters to do anything, just like upstream
-		authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup),
-		nodeAuthorizer,
-		// Wrap with an authorizer that detects unsafe requests and modifies verbs/resources appropriately so policy can address them separately
-		browsersafe.NewBrowserSafeAuthorizer(openshiftauthorizer.NewAuthorizer(kubeAuthorizer, messageMaker), user.AllAuthenticated),
-	)
-
-	return openshiftAuthorizer
-}
 
 func NewRuleResolver(informers rbacinformers.Interface) rbacregistryvalidation.AuthorizationRuleResolver {
 	return rbacregistryvalidation.NewDefaultRuleResolver(

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -230,7 +230,7 @@ func (c *MasterConfig) Run(stopCh <-chan struct{}) error {
 	var delegateAPIServer apiserver.DelegationTarget
 	var extraPostStartHooks map[string]apiserver.PostStartHookFunc
 
-	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = c.buildHandlerChain(c.kubeAPIServerConfig.GenericConfig, stopCh)
+	c.KubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = c.buildHandlerChain(c.KubeAPIServerConfig.GenericConfig, stopCh)
 	if err != nil {
 		return err
 	}
@@ -241,23 +241,23 @@ func (c *MasterConfig) Run(stopCh <-chan struct{}) error {
 	}
 
 	delegateAPIServer = apiserver.NewEmptyDelegate()
-	delegateAPIServer, apiExtensionsInformers, err = c.withAPIExtensions(delegateAPIServer, kubeAPIServerOptions, *c.kubeAPIServerConfig.GenericConfig)
+	delegateAPIServer, apiExtensionsInformers, err = c.withAPIExtensions(delegateAPIServer, kubeAPIServerOptions, *c.KubeAPIServerConfig.GenericConfig)
 	if err != nil {
 		return err
 	}
-	delegateAPIServer, err = c.withNonAPIRoutes(delegateAPIServer, *c.kubeAPIServerConfig.GenericConfig)
+	delegateAPIServer, err = c.withNonAPIRoutes(delegateAPIServer, *c.KubeAPIServerConfig.GenericConfig)
 	if err != nil {
 		return err
 	}
-	delegateAPIServer, err = c.withOpenshiftAPI(delegateAPIServer, *c.kubeAPIServerConfig.GenericConfig)
+	delegateAPIServer, err = c.withOpenshiftAPI(delegateAPIServer, *c.KubeAPIServerConfig.GenericConfig)
 	if err != nil {
 		return err
 	}
-	delegateAPIServer, err = c.withKubeAPI(delegateAPIServer, *c.kubeAPIServerConfig)
+	delegateAPIServer, err = c.withKubeAPI(delegateAPIServer, *c.KubeAPIServerConfig)
 	if err != nil {
 		return err
 	}
-	aggregatedAPIServer, err := c.withAggregator(delegateAPIServer, kubeAPIServerOptions, *c.kubeAPIServerConfig.GenericConfig, apiExtensionsInformers)
+	aggregatedAPIServer, err := c.withAggregator(delegateAPIServer, kubeAPIServerOptions, *c.KubeAPIServerConfig.GenericConfig, apiExtensionsInformers)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ func (c *MasterConfig) RunKubeAPIServer(stopCh <-chan struct{}) error {
 	var delegateAPIServer apiserver.DelegationTarget
 	var extraPostStartHooks map[string]apiserver.PostStartHookFunc
 
-	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = c.buildHandlerChain(c.kubeAPIServerConfig.GenericConfig, stopCh)
+	c.KubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = c.buildHandlerChain(c.KubeAPIServerConfig.GenericConfig, stopCh)
 	if err != nil {
 		return err
 	}
@@ -313,19 +313,19 @@ func (c *MasterConfig) RunKubeAPIServer(stopCh <-chan struct{}) error {
 	}
 
 	delegateAPIServer = apiserver.NewEmptyDelegate()
-	delegateAPIServer, apiExtensionsInformers, err = c.withAPIExtensions(delegateAPIServer, kubeAPIServerOptions, *c.kubeAPIServerConfig.GenericConfig)
+	delegateAPIServer, apiExtensionsInformers, err = c.withAPIExtensions(delegateAPIServer, kubeAPIServerOptions, *c.KubeAPIServerConfig.GenericConfig)
 	if err != nil {
 		return err
 	}
-	delegateAPIServer, err = c.withNonAPIRoutes(delegateAPIServer, *c.kubeAPIServerConfig.GenericConfig)
+	delegateAPIServer, err = c.withNonAPIRoutes(delegateAPIServer, *c.KubeAPIServerConfig.GenericConfig)
 	if err != nil {
 		return err
 	}
-	delegateAPIServer, err = c.withKubeAPI(delegateAPIServer, *c.kubeAPIServerConfig)
+	delegateAPIServer, err = c.withKubeAPI(delegateAPIServer, *c.KubeAPIServerConfig)
 	if err != nil {
 		return err
 	}
-	aggregatedAPIServer, err := c.withAggregator(delegateAPIServer, kubeAPIServerOptions, *c.kubeAPIServerConfig.GenericConfig, apiExtensionsInformers)
+	aggregatedAPIServer, err := c.withAggregator(delegateAPIServer, kubeAPIServerOptions, *c.KubeAPIServerConfig.GenericConfig, apiExtensionsInformers)
 	if err != nil {
 		return err
 	}
@@ -362,11 +362,11 @@ func (c *MasterConfig) RunOpenShift(stopCh <-chan struct{}) error {
 	// to handle the distinction between loopback and kube-apiserver
 
 	// the openshift apiserver shouldn't need to host these and they make us crashloop
-	c.kubeAPIServerConfig.GenericConfig.EnableSwaggerUI = false
-	c.kubeAPIServerConfig.GenericConfig.SwaggerConfig = nil
-	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc = openshiftHandlerChain
+	c.KubeAPIServerConfig.GenericConfig.EnableSwaggerUI = false
+	c.KubeAPIServerConfig.GenericConfig.SwaggerConfig = nil
+	c.KubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc = openshiftHandlerChain
 
-	openshiftAPIServer, err := c.withOpenshiftAPI(apiserver.NewEmptyDelegate(), *c.kubeAPIServerConfig.GenericConfig)
+	openshiftAPIServer, err := c.withOpenshiftAPI(apiserver.NewEmptyDelegate(), *c.KubeAPIServerConfig.GenericConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -60,7 +60,7 @@ import (
 type MasterConfig struct {
 	Options configapi.MasterConfig
 
-	kubeAPIServerConfig      *kubeapiserver.Config
+	KubeAPIServerConfig      *kubeapiserver.Config
 	additionalPostStartHooks map[string]genericapiserver.PostStartHookFunc
 
 	// RESTOptionsGetter provides access to storage and RESTOptions for a particular resource
@@ -233,7 +233,7 @@ func BuildMasterConfig(
 	config := &MasterConfig{
 		Options: options,
 
-		kubeAPIServerConfig: kubeAPIServerConfig,
+		KubeAPIServerConfig: kubeAPIServerConfig,
 		additionalPostStartHooks: map[string]genericapiserver.PostStartHookFunc{
 			"openshift.io-StartInformers": func(context genericapiserver.PostStartHookContext) error {
 				informers.Start(context.StopCh)

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -17,7 +17,6 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
 	aggregatorinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -35,7 +34,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/origin"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
-	usercache "github.com/openshift/origin/pkg/user/cache"
 	"github.com/openshift/origin/pkg/version"
 )
 
@@ -438,24 +436,7 @@ func (m *Master) Start() error {
 			return err
 		}
 
-		// informers are shared amongst all the various api components we build
-		// TODO the needs of the apiserver and the controllers are drifting. We should consider two different skins here
-		clientConfig, err := configapi.GetClientConfig(m.config.MasterClients.OpenShiftLoopbackKubeConfig, m.config.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
-		if err != nil {
-			return err
-		}
-		informers, err := origin.NewInformers(clientConfig)
-		if err != nil {
-			return err
-		}
-
-		if err := informers.GetOpenshiftUserInformers().User().V1().Groups().Informer().AddIndexers(cache.Indexers{
-			usercache.ByUserIndexName: usercache.ByUserIndexKeys,
-		}); err != nil {
-			return err
-		}
-
-		openshiftConfig, err := origin.BuildMasterConfig(*m.config, informers)
+		openshiftConfig, err := origin.BuildMasterConfig(*m.config, nil)
 		if err != nil {
 			return err
 		}

--- a/test/integration/buildcontroller_test.go
+++ b/test/integration/buildcontroller_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -110,7 +111,15 @@ func setupBuildControllerTest(counts controllerCount, t *testing.T) (buildtypedc
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	informers, err := origin.NewInformers(clusterAdminClientConfig)
+	kubeExternal, err := kclientsetexternal.NewForConfig(clusterAdminClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const defaultInformerResyncPeriod = 10 * time.Minute
+	kubeInformers := kinformers.NewSharedInformerFactory(kubeExternal, defaultInformerResyncPeriod)
+
+	informers, err := origin.NewInformers(nil, kubeInformers, clusterAdminClientConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/testdebug/cmd/load_etcd.go
+++ b/tools/testdebug/cmd/load_etcd.go
@@ -112,8 +112,7 @@ func (o *DebugAPIServerOptions) Run() error {
 }
 
 func (o *DebugAPIServerOptions) StartAPIServer(masterConfig configapi.MasterConfig) error {
-	informers := origin.InformerAccess(nil)
-	openshiftConfig, err := origin.BuildMasterConfig(masterConfig, informers)
+	openshiftConfig, err := origin.BuildMasterConfig(masterConfig, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This builds a valid authorizer when constructing the kubeapiserver config.

/assign @sttts 

On the path to creating a reasonable `hypershift openshift-kube-apiserver` command