### PR TITLE
Fix for router with dynamic config changes not reloading 

### DIFF
--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -658,11 +658,12 @@ func (cm *haproxyConfigManager) commitRouterConfig() {
 	cm.commitTimer = nil
 	cm.lock.Unlock()
 
-	// [Re]Adding a blueprint pool route triggers a router state change.
-	// And calling Commit ensures that the config gets written out.
+	// Adding (+removing) a new blueprint pool route triggers a router state
+	// change. And calling Commit ensures that the config gets written out.
 	route := createBlueprintRoute(routeapi.TLSTerminationEdge)
-	route.Name = fmt.Sprintf("%v-1", route.Name)
+	route.Name = fmt.Sprintf("%s-temp-%d", route.Name, time.Now().Unix())
 	cm.router.AddRoute(route)
+	cm.router.RemoveRoute(route)
 
 	glog.V(4).Infof("Committing associated template router ... ")
 	cm.router.Commit()


### PR DESCRIPTION
we need to simulate an actual change otherwise router commit doesn't call reload (as it detects no diffs), so use a generated name and cleanup after.
fixes bugz #1612019

/cc @openshift/sig-network-edge 