### PR TITLE
separate controller manager and apiserver informers

### DIFF
--- a/pkg/client/genericinformers/interface.go
+++ b/pkg/client/genericinformers/interface.go
@@ -1,0 +1,80 @@
+package genericinformers
+
+import (
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+)
+
+type GenericResourceInformer interface {
+	ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error)
+	Start(stopCh <-chan struct{})
+}
+
+// genericInternalResourceInformerFunc will return an internal informer for any resource matching
+// its group resource, instead of the external version. Only valid for use where the type is accessed
+// via generic interfaces, such as the garbage collector with ObjectMeta.
+type GenericInternalResourceInformerFunc func(resource schema.GroupVersionResource) (informers.GenericInformer, error)
+
+func (fn GenericInternalResourceInformerFunc) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	resource.Version = runtime.APIVersionInternal
+	return fn(resource)
+}
+
+// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
+func (fn GenericInternalResourceInformerFunc) Start(stopCh <-chan struct{}) {}
+
+// genericResourceInformerFunc will handle a cast to a matching type
+type GenericResourceInformerFunc func(resource schema.GroupVersionResource) (informers.GenericInformer, error)
+
+func (fn GenericResourceInformerFunc) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	return fn(resource)
+}
+
+// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
+func (fn GenericResourceInformerFunc) Start(stopCh <-chan struct{}) {}
+
+type genericInformers struct {
+	// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
+	startFn func(stopCh <-chan struct{})
+	generic []GenericResourceInformer
+	// bias is a map that tries loading an informer from another GVR before using the original
+	bias map[schema.GroupVersionResource]schema.GroupVersionResource
+}
+
+func NewGenericInformers(startFn func(stopCh <-chan struct{}), informers ...GenericResourceInformer) genericInformers {
+	return genericInformers{
+		startFn: startFn,
+		generic: informers,
+	}
+}
+
+func (i genericInformers) ForResource(resource schema.GroupVersionResource) (informers.GenericInformer, error) {
+	if try, ok := i.bias[resource]; ok {
+		if res, err := i.ForResource(try); err == nil {
+			return res, nil
+		}
+	}
+
+	var firstErr error
+	for _, generic := range i.generic {
+		informer, err := generic.ForResource(resource)
+		if err == nil {
+			return informer, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	glog.V(4).Infof("Couldn't find informer for %v", resource)
+	return nil, firstErr
+}
+
+func (i genericInformers) Start(stopCh <-chan struct{}) {
+	i.startFn(stopCh)
+	for _, generic := range i.generic {
+		generic.Start(stopCh)
+	}
+}

--- a/pkg/cmd/openshift-controller-manager/controller/apps.go
+++ b/pkg/cmd/openshift-controller-manager/controller/apps.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
 
-func RunDeployerController(ctx ControllerContext) (bool, error) {
+func RunDeployerController(ctx *ControllerContext) (bool, error) {
 	clientConfig, err := ctx.ClientBuilder.Config(bootstrappolicy.InfraDeployerControllerServiceAccountName)
 	if err != nil {
 		return true, err
@@ -36,7 +36,7 @@ func RunDeployerController(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func RunDeploymentConfigController(ctx ControllerContext) (bool, error) {
+func RunDeploymentConfigController(ctx *ControllerContext) (bool, error) {
 	saName := bootstrappolicy.InfraDeploymentConfigControllerServiceAccountName
 
 	kubeClient, err := ctx.ClientBuilder.Client(saName)

--- a/pkg/cmd/openshift-controller-manager/controller/authorization.go
+++ b/pkg/cmd/openshift-controller-manager/controller/authorization.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 )
 
-func RunDefaultRoleBindingController(ctx ControllerContext) (bool, error) {
+func RunDefaultRoleBindingController(ctx *ControllerContext) (bool, error) {
 	kubeClient, err := ctx.ClientBuilder.Client(bootstrappolicy.InfraDefaultRoleBindingsControllerServiceAccountName)
 	if err != nil {
 		return true, err

--- a/pkg/cmd/openshift-controller-manager/controller/build.go
+++ b/pkg/cmd/openshift-controller-manager/controller/build.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RunController starts the build sync loop for builds and buildConfig processing.
-func RunBuildController(ctx ControllerContext) (bool, error) {
+func RunBuildController(ctx *ControllerContext) (bool, error) {
 	imageTemplate := variable.NewDefaultImageTemplate()
 	imageTemplate.Format = ctx.OpenshiftControllerConfig.Build.ImageTemplateFormat.Format
 	imageTemplate.Latest = ctx.OpenshiftControllerConfig.Build.ImageTemplateFormat.Latest
@@ -52,7 +52,7 @@ func RunBuildController(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func RunBuildConfigChangeController(ctx ControllerContext) (bool, error) {
+func RunBuildConfigChangeController(ctx *ControllerContext) (bool, error) {
 	clientName := bootstrappolicy.InfraBuildConfigChangeControllerServiceAccountName
 	kubeExternalClient := ctx.ClientBuilder.ClientOrDie(clientName)
 	buildClient := ctx.ClientBuilder.OpenshiftInternalBuildClientOrDie(clientName)

--- a/pkg/cmd/openshift-controller-manager/controller/image.go
+++ b/pkg/cmd/openshift-controller-manager/controller/image.go
@@ -26,7 +26,7 @@ import (
 	triggerdeploymentconfigs "github.com/openshift/origin/pkg/image/trigger/deploymentconfigs"
 )
 
-func RunImageTriggerController(ctx ControllerContext) (bool, error) {
+func RunImageTriggerController(ctx *ControllerContext) (bool, error) {
 	informer := ctx.InternalImageInformers.Image().InternalVersion().ImageStreams()
 
 	buildClient, err := ctx.ClientBuilder.OpenshiftInternalBuildClient(bootstrappolicy.InfraImageTriggerControllerServiceAccountName)
@@ -139,7 +139,7 @@ func (u podSpecUpdater) Update(obj runtime.Object) error {
 	}
 }
 
-func RunImageSignatureImportController(ctx ControllerContext) (bool, error) {
+func RunImageSignatureImportController(ctx *ControllerContext) (bool, error) {
 	// TODO these should really be configurable
 	resyncPeriod := 1 * time.Hour
 	signatureFetchTimeout := 1 * time.Minute
@@ -157,7 +157,7 @@ func RunImageSignatureImportController(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func RunImageImportController(ctx ControllerContext) (bool, error) {
+func RunImageImportController(ctx *ControllerContext) (bool, error) {
 	informer := ctx.InternalImageInformers.Image().InternalVersion().ImageStreams()
 	controller := imagecontroller.NewImageStreamController(
 		ctx.ClientBuilder.OpenshiftInternalImageClientOrDie(bootstrappolicy.InfraImageImportControllerServiceAccountName),

--- a/pkg/cmd/openshift-controller-manager/controller/ingress.go
+++ b/pkg/cmd/openshift-controller-manager/controller/ingress.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/origin/pkg/route/controller/ingress"
 )
 
-func RunIngressToRouteController(ctx ControllerContext) (bool, error) {
+func RunIngressToRouteController(ctx *ControllerContext) (bool, error) {
 	clientConfig := ctx.ClientBuilder.ConfigOrDie(bootstrappolicy.InfraIngressToRouteControllerServiceAccountName)
 	coreClient, err := coreclient.NewForConfig(clientConfig)
 	if err != nil {

--- a/pkg/cmd/openshift-controller-manager/controller/network.go
+++ b/pkg/cmd/openshift-controller-manager/controller/network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/origin/pkg/service/controller/ingressip"
 )
 
-func RunIngressIPController(ctx ControllerContext) (bool, error) {
+func RunIngressIPController(ctx *ControllerContext) (bool, error) {
 	// TODO configurable?
 	resyncPeriod := 10 * time.Minute
 

--- a/pkg/cmd/openshift-controller-manager/controller/network_sdn.go
+++ b/pkg/cmd/openshift-controller-manager/controller/network_sdn.go
@@ -8,7 +8,7 @@ import (
 	sdnmaster "github.com/openshift/origin/pkg/network/master"
 )
 
-func RunSDNController(ctx ControllerContext) (bool, error) {
+func RunSDNController(ctx *ControllerContext) (bool, error) {
 	if !network.IsOpenShiftNetworkPlugin(ctx.OpenshiftControllerConfig.Network.NetworkPluginName) {
 		return false, nil
 	}

--- a/pkg/cmd/openshift-controller-manager/controller/project.go
+++ b/pkg/cmd/openshift-controller-manager/controller/project.go
@@ -5,7 +5,7 @@ import (
 	projectcontroller "github.com/openshift/origin/pkg/project/controller"
 )
 
-func RunOriginNamespaceController(ctx ControllerContext) (bool, error) {
+func RunOriginNamespaceController(ctx *ControllerContext) (bool, error) {
 	controller := projectcontroller.NewProjectFinalizerController(
 		ctx.KubernetesInformers.Core().V1().Namespaces(),
 		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraOriginNamespaceServiceAccountName),

--- a/pkg/cmd/openshift-controller-manager/controller/quota.go
+++ b/pkg/cmd/openshift-controller-manager/controller/quota.go
@@ -14,7 +14,7 @@ import (
 	quotainstall "k8s.io/kubernetes/pkg/quota/install"
 )
 
-func RunResourceQuotaManager(ctx ControllerContext) (bool, error) {
+func RunResourceQuotaManager(ctx *ControllerContext) (bool, error) {
 	concurrentResourceQuotaSyncs := int(ctx.OpenshiftControllerConfig.ResourceQuota.ConcurrentSyncs)
 	resourceQuotaSyncPeriod := ctx.OpenshiftControllerConfig.ResourceQuota.SyncPeriod.Duration
 	replenishmentSyncPeriodFunc := calculateResyncPeriod(ctx.OpenshiftControllerConfig.ResourceQuota.MinResyncPeriod.Duration)
@@ -47,7 +47,7 @@ func RunResourceQuotaManager(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func RunClusterQuotaReconciliationController(ctx ControllerContext) (bool, error) {
+func RunClusterQuotaReconciliationController(ctx *ControllerContext) (bool, error) {
 	defaultResyncPeriod := 5 * time.Minute
 	defaultReplenishmentSyncPeriod := 12 * time.Hour
 

--- a/pkg/cmd/openshift-controller-manager/controller/security.go
+++ b/pkg/cmd/openshift-controller-manager/controller/security.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/origin/pkg/security/uid"
 )
 
-func RunNamespaceSecurityAllocationController(ctx ControllerContext) (bool, error) {
+func RunNamespaceSecurityAllocationController(ctx *ControllerContext) (bool, error) {
 	uidRange, err := uid.ParseRange(ctx.OpenshiftControllerConfig.SecurityAllocator.UIDAllocatorRange)
 	if err != nil {
 		return true, fmt.Errorf("unable to describe UID range: %v", err)

--- a/pkg/cmd/openshift-controller-manager/controller/service.go
+++ b/pkg/cmd/openshift-controller-manager/controller/service.go
@@ -9,7 +9,7 @@ import (
 	servingcertcontroller "github.com/openshift/service-serving-cert-signer/pkg/controller/servingcert"
 )
 
-func RunServiceServingCertsController(ctx ControllerContext) (bool, error) {
+func RunServiceServingCertsController(ctx *ControllerContext) (bool, error) {
 	signer := ctx.OpenshiftControllerConfig.ServiceServingCert.Signer
 	if signer == nil || len(signer.CertFile) == 0 || len(signer.KeyFile) == 0 {
 		return false, nil

--- a/pkg/cmd/openshift-controller-manager/controller/serviceaccount.go
+++ b/pkg/cmd/openshift-controller-manager/controller/serviceaccount.go
@@ -10,7 +10,7 @@ import (
 	serviceaccountcontrollers "github.com/openshift/origin/pkg/serviceaccounts/controllers"
 )
 
-func RunServiceAccountController(ctx ControllerContext) (bool, error) {
+func RunServiceAccountController(ctx *ControllerContext) (bool, error) {
 	if len(ctx.OpenshiftControllerConfig.ServiceAccount.ManagedNames) == 0 {
 		glog.Infof("Skipped starting Service Account Manager, no managed names specified")
 		return false, nil
@@ -43,7 +43,7 @@ func RunServiceAccountController(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func RunServiceAccountPullSecretsController(ctx ControllerContext) (bool, error) {
+func RunServiceAccountPullSecretsController(ctx *ControllerContext) (bool, error) {
 	kc := ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceAccountPullSecretsControllerServiceAccountName)
 
 	go serviceaccountcontrollers.NewDockercfgDeletedController(

--- a/pkg/cmd/openshift-controller-manager/controller/template.go
+++ b/pkg/cmd/openshift-controller-manager/controller/template.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-func RunTemplateInstanceController(ctx ControllerContext) (bool, error) {
+func RunTemplateInstanceController(ctx *ControllerContext) (bool, error) {
 	saName := bootstrappolicy.InfraTemplateInstanceControllerServiceAccountName
 
 	restConfig, err := ctx.ClientBuilder.Config(saName)
@@ -31,7 +31,7 @@ func RunTemplateInstanceController(ctx ControllerContext) (bool, error) {
 	return true, nil
 }
 
-func RunTemplateInstanceFinalizerController(ctx ControllerContext) (bool, error) {
+func RunTemplateInstanceFinalizerController(ctx *ControllerContext) (bool, error) {
 	saName := bootstrappolicy.InfraTemplateInstanceFinalizerControllerServiceAccountName
 
 	restConfig, err := ctx.ClientBuilder.Config(saName)

--- a/pkg/cmd/openshift-controller-manager/controller/unidling.go
+++ b/pkg/cmd/openshift-controller-manager/controller/unidling.go
@@ -9,7 +9,7 @@ import (
 	unidlingcontroller "github.com/openshift/origin/pkg/unidling/controller"
 )
 
-func RunUnidlingController(ctx ControllerContext) (bool, error) {
+func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 	// TODO this should be configurable
 	resyncPeriod := 2 * time.Hour
 

--- a/pkg/cmd/server/origin/informers.go
+++ b/pkg/cmd/server/origin/informers.go
@@ -3,19 +3,12 @@ package origin
 import (
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	kexternalinformers "k8s.io/client-go/informers"
 	kubeclientgoclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
-	"github.com/golang/glog"
-	appsclient "github.com/openshift/client-go/apps/clientset/versioned"
-	appsinformer "github.com/openshift/client-go/apps/informers/externalversions"
-	networkclient "github.com/openshift/client-go/network/clientset/versioned"
-	networkinformer "github.com/openshift/client-go/network/informers/externalversions"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned"
 	oauthinformer "github.com/openshift/client-go/oauth/informers/externalversions"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
@@ -24,95 +17,13 @@ import (
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	authorizationinformer "github.com/openshift/origin/pkg/authorization/generated/informers/internalversion"
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
-	buildinformer "github.com/openshift/origin/pkg/build/generated/informers/internalversion"
-	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
 	imageinformer "github.com/openshift/origin/pkg/image/generated/informers/internalversion"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion"
 	quotaclient "github.com/openshift/origin/pkg/quota/generated/internalclientset"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
 	securityclient "github.com/openshift/origin/pkg/security/generated/internalclientset"
-	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
-	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
 )
-
-type GenericResourceInformer interface {
-	ForResource(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error)
-	Start(stopCh <-chan struct{})
-}
-
-// genericInternalResourceInformerFunc will return an internal informer for any resource matching
-// its group resource, instead of the external version. Only valid for use where the type is accessed
-// via generic interfaces, such as the garbage collector with ObjectMeta.
-type genericInternalResourceInformerFunc func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error)
-
-func (fn genericInternalResourceInformerFunc) ForResource(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-	resource.Version = runtime.APIVersionInternal
-	return fn(resource)
-}
-
-// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
-func (fn genericInternalResourceInformerFunc) Start(stopCh <-chan struct{}) {}
-
-// genericResourceInformerFunc will handle a cast to a matching type
-type genericResourceInformerFunc func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error)
-
-func (fn genericResourceInformerFunc) ForResource(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-	return fn(resource)
-}
-
-// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
-func (fn genericResourceInformerFunc) Start(stopCh <-chan struct{}) {}
-
-type genericInformers struct {
-	// this is a temporary condition until we rewrite enough of generation to auto-conform to the required interface and no longer need the internal version shim
-	startFn func(stopCh <-chan struct{})
-	generic []GenericResourceInformer
-	// bias is a map that tries loading an informer from another GVR before using the original
-	bias map[schema.GroupVersionResource]schema.GroupVersionResource
-}
-
-func newGenericInformers(startFn func(stopCh <-chan struct{}), informers ...GenericResourceInformer) genericInformers {
-	return genericInformers{
-		startFn: startFn,
-		generic: informers,
-		bias: map[schema.GroupVersionResource]schema.GroupVersionResource{
-			{Group: "rbac.authorization.k8s.io", Resource: "rolebindings", Version: "v1beta1"}:        {Group: "rbac.authorization.k8s.io", Resource: "rolebindings", Version: runtime.APIVersionInternal},
-			{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Version: "v1beta1"}: {Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Version: runtime.APIVersionInternal},
-			{Group: "rbac.authorization.k8s.io", Resource: "roles", Version: "v1beta1"}:               {Group: "rbac.authorization.k8s.io", Resource: "roles", Version: runtime.APIVersionInternal},
-			{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Version: "v1beta1"}:        {Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Version: runtime.APIVersionInternal},
-			{Group: "", Resource: "securitycontextconstraints", Version: "v1"}:                        {Group: "", Resource: "securitycontextconstraints", Version: runtime.APIVersionInternal},
-		},
-	}
-}
-
-func (i genericInformers) ForResource(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-	if try, ok := i.bias[resource]; ok {
-		if res, err := i.ForResource(try); err == nil {
-			return res, nil
-		}
-	}
-
-	var firstErr error
-	for _, generic := range i.generic {
-		informer, err := generic.ForResource(resource)
-		if err == nil {
-			return informer, nil
-		}
-		if firstErr == nil {
-			firstErr = err
-		}
-	}
-	glog.V(4).Infof("Couldn't find informer for %v", resource)
-	return nil, firstErr
-}
-
-func (i genericInformers) Start(stopCh <-chan struct{}) {
-	i.startFn(stopCh)
-	for _, generic := range i.generic {
-		generic.Start(stopCh)
-	}
-}
 
 // informerHolder is a convenient way for us to keep track of the informers, but
 // is intentionally private.  We don't want to leak it out further than this package.
@@ -121,19 +32,13 @@ type informerHolder struct {
 	internalKubernetesInformers kinternalinformers.SharedInformerFactory
 	kubernetesInformers         kexternalinformers.SharedInformerFactory
 
-	// External OpenShift informers
-	appsInformer appsinformer.SharedInformerFactory
-
 	// Internal OpenShift informers
 	authorizationInformers authorizationinformer.SharedInformerFactory
-	buildInformers         buildinformer.SharedInformerFactory
 	imageInformers         imageinformer.SharedInformerFactory
-	networkInformers       networkinformer.SharedInformerFactory
 	oauthInformers         oauthinformer.SharedInformerFactory
 	quotaInformers         quotainformer.SharedInformerFactory
 	routeInformers         routeinformer.SharedInformerFactory
 	securityInformers      securityinformer.SharedInformerFactory
-	templateInformers      templateinformer.SharedInformerFactory
 	userInformers          userinformer.SharedInformerFactory
 }
 
@@ -148,24 +53,11 @@ func NewInformers(clientConfig *rest.Config) (InformerAccess, error) {
 		return nil, err
 	}
 
-	appsClient, err := appsclient.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	authorizationClient, err := authorizationclient.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, err
 	}
-	buildClient, err := buildclient.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, err
-	}
 	imageClient, err := imageclient.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, err
-	}
-	networkClient, err := networkclient.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -185,10 +77,6 @@ func NewInformers(clientConfig *rest.Config) (InformerAccess, error) {
 	if err != nil {
 		return nil, err
 	}
-	templateClient, err := templateclient.NewForConfig(clientConfig)
-	if err != nil {
-		return nil, err
-	}
 	userClient, err := userclient.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, err
@@ -201,16 +89,12 @@ func NewInformers(clientConfig *rest.Config) (InformerAccess, error) {
 	return &informerHolder{
 		internalKubernetesInformers: kinternalinformers.NewSharedInformerFactory(kubeInternal, defaultInformerResyncPeriod),
 		kubernetesInformers:         kexternalinformers.NewSharedInformerFactory(kubeExternal, defaultInformerResyncPeriod),
-		appsInformer:                appsinformer.NewSharedInformerFactory(appsClient, defaultInformerResyncPeriod),
 		authorizationInformers:      authorizationinformer.NewSharedInformerFactory(authorizationClient, defaultInformerResyncPeriod),
-		buildInformers:              buildinformer.NewSharedInformerFactory(buildClient, defaultInformerResyncPeriod),
 		imageInformers:              imageinformer.NewSharedInformerFactory(imageClient, defaultInformerResyncPeriod),
-		networkInformers:            networkinformer.NewSharedInformerFactory(networkClient, defaultInformerResyncPeriod),
 		oauthInformers:              oauthinformer.NewSharedInformerFactory(oauthClient, defaultInformerResyncPeriod),
 		quotaInformers:              quotainformer.NewSharedInformerFactory(quotaClient, defaultInformerResyncPeriod),
 		routeInformers:              routeinformer.NewSharedInformerFactory(routerClient, defaultInformerResyncPeriod),
 		securityInformers:           securityinformer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
-		templateInformers:           templateinformer.NewSharedInformerFactory(templateClient, defaultInformerResyncPeriod),
 		userInformers:               userinformer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
 	}, nil
 }
@@ -221,20 +105,11 @@ func (i *informerHolder) GetInternalKubernetesInformers() kinternalinformers.Sha
 func (i *informerHolder) GetKubernetesInformers() kexternalinformers.SharedInformerFactory {
 	return i.kubernetesInformers
 }
-func (i *informerHolder) GetOpenshiftAppInformers() appsinformer.SharedInformerFactory {
-	return i.appsInformer
-}
 func (i *informerHolder) GetInternalOpenshiftAuthorizationInformers() authorizationinformer.SharedInformerFactory {
 	return i.authorizationInformers
 }
-func (i *informerHolder) GetInternalOpenshiftBuildInformers() buildinformer.SharedInformerFactory {
-	return i.buildInformers
-}
 func (i *informerHolder) GetInternalOpenshiftImageInformers() imageinformer.SharedInformerFactory {
 	return i.imageInformers
-}
-func (i *informerHolder) GetOpenshiftNetworkInformers() networkinformer.SharedInformerFactory {
-	return i.networkInformers
 }
 func (i *informerHolder) GetOpenshiftOauthInformers() oauthinformer.SharedInformerFactory {
 	return i.oauthInformers
@@ -248,9 +123,6 @@ func (i *informerHolder) GetOpenshiftRouteInformers() routeinformer.SharedInform
 func (i *informerHolder) GetInternalOpenshiftSecurityInformers() securityinformer.SharedInformerFactory {
 	return i.securityInformers
 }
-func (i *informerHolder) GetInternalOpenshiftTemplateInformers() templateinformer.SharedInformerFactory {
-	return i.templateInformers
-}
 func (i *informerHolder) GetOpenshiftUserInformers() userinformer.SharedInformerFactory {
 	return i.userInformers
 }
@@ -259,55 +131,11 @@ func (i *informerHolder) GetOpenshiftUserInformers() userinformer.SharedInformer
 func (i *informerHolder) Start(stopCh <-chan struct{}) {
 	i.internalKubernetesInformers.Start(stopCh)
 	i.kubernetesInformers.Start(stopCh)
-	i.appsInformer.Start(stopCh)
 	i.authorizationInformers.Start(stopCh)
-	i.buildInformers.Start(stopCh)
 	i.imageInformers.Start(stopCh)
-	i.networkInformers.Start(stopCh)
 	i.oauthInformers.Start(stopCh)
 	i.quotaInformers.Start(stopCh)
 	i.routeInformers.Start(stopCh)
 	i.securityInformers.Start(stopCh)
-	i.templateInformers.Start(stopCh)
 	i.userInformers.Start(stopCh)
-}
-
-func (i *informerHolder) ToGenericInformer() GenericResourceInformer {
-	return newGenericInformers(
-		i.Start,
-		i.GetKubernetesInformers(),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetOpenshiftAppInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftAuthorizationInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftBuildInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftImageInformers().ForResource(resource)
-		}),
-		genericResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetOpenshiftNetworkInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetOpenshiftOauthInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftQuotaInformers().ForResource(resource)
-		}),
-		genericResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetOpenshiftRouteInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftSecurityInformers().ForResource(resource)
-		}),
-		genericInternalResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetInternalOpenshiftTemplateInformers().ForResource(resource)
-		}),
-		genericResourceInformerFunc(func(resource schema.GroupVersionResource) (kexternalinformers.GenericInformer, error) {
-			return i.GetOpenshiftUserInformers().ForResource(resource)
-		}),
-	)
 }

--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -29,13 +29,10 @@ import (
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
-	appsinformer "github.com/openshift/client-go/apps/informers/externalversions"
-	networkinformer "github.com/openshift/client-go/network/informers/externalversions"
 	oauthinformer "github.com/openshift/client-go/oauth/informers/externalversions"
 	routeinformer "github.com/openshift/client-go/route/informers/externalversions"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	authorizationinformer "github.com/openshift/origin/pkg/authorization/generated/informers/internalversion"
-	buildinformer "github.com/openshift/origin/pkg/build/generated/informers/internalversion"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	kubernetes "github.com/openshift/origin/pkg/cmd/server/kubernetes/master"
 	originadmission "github.com/openshift/origin/pkg/cmd/server/origin/admission"
@@ -47,7 +44,6 @@ import (
 	projectcache "github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion"
-	templateinformer "github.com/openshift/origin/pkg/template/generated/informers/internalversion"
 
 	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	securityinformer "github.com/openshift/origin/pkg/security/generated/informers/internalversion"
@@ -107,20 +103,14 @@ type InformerAccess interface {
 	GetInternalKubernetesInformers() kinternalinformers.SharedInformerFactory
 	GetKubernetesInformers() kinformers.SharedInformerFactory
 
-	GetOpenshiftAppInformers() appsinformer.SharedInformerFactory
 	GetOpenshiftOauthInformers() oauthinformer.SharedInformerFactory
-	GetOpenshiftNetworkInformers() networkinformer.SharedInformerFactory
 	GetOpenshiftRouteInformers() routeinformer.SharedInformerFactory
 	GetOpenshiftUserInformers() userinformer.SharedInformerFactory
 
 	GetInternalOpenshiftAuthorizationInformers() authorizationinformer.SharedInformerFactory
-	GetInternalOpenshiftBuildInformers() buildinformer.SharedInformerFactory
 	GetInternalOpenshiftImageInformers() imageinformer.SharedInformerFactory
 	GetInternalOpenshiftQuotaInformers() quotainformer.SharedInformerFactory
 	GetInternalOpenshiftSecurityInformers() securityinformer.SharedInformerFactory
-	GetInternalOpenshiftTemplateInformers() templateinformer.SharedInformerFactory
-
-	ToGenericInformer() GenericResourceInformer
 
 	Start(stopCh <-chan struct{})
 }


### PR DESCRIPTION
The controller manager and apiserver now have very different sets of informers and some of my other separate work is hitting construction problems so I'm separating these here.

@openshift/sig-master 
/assign @mfojtik @sttts 