### PR TITLE
enable override of agent pod template images during prow/gcp invocati…

### DIFF
--- a/test/extended/builds/jenkins_plugin.go
+++ b/test/extended/builds/jenkins_plugin.go
@@ -161,6 +161,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline plugin", func() {
 			// with the startup costs now of jenkins 2.89 or greater and trying to incur those during startup, need more memory
 			// to avoid deployment timeouts
 			newAppArgs := []string{"-f", exutil.FixturePath("..", "..", "examples", "jenkins", "jenkins-ephemeral-template.json"), "-p", "MEMORY_LIMIT=2Gi", "-p", "DISABLE_ADMINISTRATIVE_MONITORS=true"}
+			newAppArgs = jenkins.OverridePodTemplateImages(newAppArgs)
 
 			useSnapshotImage := false
 			origPluginNewAppArgs, useOrigPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalPluginSnapshotEnvVarName, localPluginSnapshotImage, localPluginSnapshotImageStream, newAppArgs, oc)

--- a/test/extended/builds/pipeline.go
+++ b/test/extended/builds/pipeline.go
@@ -145,6 +145,7 @@ var _ = g.Describe("[Feature:Builds][Slow] openshift pipeline build", func() {
 
 			// our pipeline jobs, between jenkins and oc invocations, need more mem than the default
 			newAppArgs := []string{"--template", fmt.Sprintf("%s/%s", oc.Namespace(), jenkinsTemplateName), "-p", "MEMORY_LIMIT=2Gi", "-p", "DISABLE_ADMINISTRATIVE_MONITORS=true"}
+			newAppArgs = jenkins.OverridePodTemplateImages(newAppArgs)
 			clientPluginNewAppArgs, useClientPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalClientPluginSnapshotEnvVarName, localClientPluginSnapshotImage, localClientPluginSnapshotImageStream, newAppArgs, oc)
 			syncPluginNewAppArgs, useSyncPluginSnapshotImage := jenkins.SetupSnapshotImage(jenkins.UseLocalSyncPluginSnapshotEnvVarName, localSyncPluginSnapshotImage, localSyncPluginSnapshotImageStream, newAppArgs, oc)
 

--- a/test/extended/util/jenkins/ref.go
+++ b/test/extended/util/jenkins/ref.go
@@ -356,6 +356,20 @@ func FindJenkinsPod(oc *exutil.CLI) *kapiv1.Pod {
 	return &pods.Items[0]
 }
 
+// OverridePodTemplateImages sees if this is a prow-gcp e2e test invocation, and we want to override the agent image for the default pod templates;
+// the jenkins image will pick up the env vars passed to new-app and update the image field of the pod templates with the values
+func OverridePodTemplateImages(newAppArgs []string) []string {
+	nodejsAgent := os.Getenv("IMAGE_NODEJS_AGENT")
+	if len(strings.TrimSpace(nodejsAgent)) > 0 {
+		newAppArgs = append(newAppArgs, "-e", fmt.Sprintf("NODEJS_SLAVE_IMAGE=%s", nodejsAgent))
+	}
+	mavenAgent := os.Getenv("IMAGE_MAVEN_AGENT")
+	if len(strings.TrimSpace(mavenAgent)) > 0 {
+		newAppArgs = append(newAppArgs, "-e", fmt.Sprintf("MAVEN_SLAVE_IMAGE=%s", mavenAgent))
+	}
+	return newAppArgs
+}
+
 // pulls in a jenkins image built from a PR change for one of our plugins
 func SetupSnapshotImage(envVarName, localImageName, snapshotImageStream string, newAppArgs []string, oc *exutil.CLI) ([]string, bool) {
 	tag := []string{localImageName}


### PR DESCRIPTION
…on of jenkins extended tests

@openshift/sig-developer-experience fyi

@bparees - with this change and the associated openshift/release change to set IMAGE_MAVEN_AGENT and IMAGE_NODEJS_AGENT, I think we will have achieved a viable meets min for https://trello.com/c/l3kGmkza/1466-8-run-jenkins-extended-tests-in-jenkins-repo-techdebtjenkinsintegration

(or at least we are close of enough such that we can have the discussion where I try to convince you we've achieved meets min :-) )