### PR TITLE
add kube-apiserver wiring

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -50,7 +50,8 @@
       "github.com/openshift/origin/pkg/quota/admission/clusterresourceoverride",
       "github.com/openshift/origin/pkg/oc/cli/admin/createbootstrapprojecttemplate",
       "github.com/openshift/origin/pkg/cmd/server",
-      "github.com/openshift/origin/pkg/cmd/openshift-apiserver"
+      "github.com/openshift/origin/pkg/cmd/openshift-apiserver",
+      "github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver"
     ],
     "forbiddenImportPackageRoots": [
       "github.com/openshift/origin/pkg/apps/apiserver",

--- a/install/kube-dns/install.yaml
+++ b/install/kube-dns/install.yaml
@@ -42,7 +42,7 @@ objects:
       spec:
         serviceAccountName: kube-dns
         containers:
-        - name: kube-proxy
+        - name: kube-dns
           image: ${IMAGE}
           imagePullPolicy: ${OPENSHIFT_PULL_POLICY}
           command: ["openshift", "start", "network"]

--- a/install/kube-proxy/install.yaml
+++ b/install/kube-proxy/install.yaml
@@ -30,6 +30,8 @@ objects:
     - kind: ServiceAccount
       name: kube-proxy
       namespace: ${NAMESPACE}
+    - kind: Group
+      name: system:nodes
   roleRef:
     kind: ClusterRole
     name: system:node-proxier

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags.go
@@ -1,0 +1,268 @@
+package openshiftkubeapiserver
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"io/ioutil"
+
+	"bytes"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
+	originadmission "github.com/openshift/origin/pkg/cmd/server/origin/admission"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ConfigToFlags(kubeAPIServerConfig *configapi.MasterConfig) ([]string, error) {
+	args := map[string][]string{}
+	for key, slice := range kubeAPIServerConfig.KubernetesMasterConfig.APIServerArguments {
+		for _, val := range slice {
+			args[key] = append(args[key], val)
+		}
+	}
+
+	host, portString, err := net.SplitHostPort(kubeAPIServerConfig.ServingInfo.BindAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO this list (and the content below) will be used to drive a config struct and a reflective test matching config to flags
+	// these flags are overridden by a patch
+	// admission-control
+	// authentication-token-webhook-cache-ttl
+	// authentication-token-webhook-config-file
+	// authorization-mode
+	// authorization-policy-file
+	// authorization-webhook-cache-authorized-ttl
+	// authorization-webhook-cache-unauthorized-ttl
+	// authorization-webhook-config-file
+	// basic-auth-file
+	// enable-aggregator-routing
+	// enable-bootstrap-token-auth
+	// oidc-client-id
+	// oidc-groups-claim
+	// oidc-groups-prefix
+	// oidc-issuer-url
+	// oidc-required-claim
+	// oidc-signing-algs
+	// oidc-username-claim
+	// oidc-username-prefix
+	// service-account-lookup
+	// token-auth-file
+
+	// alsologtostderr - don't know whether to change it
+	// apiserver-count - ignored, hopefully we don't have to fix via patch
+	// cert-dir - ignored because we set certs
+
+	// these flags were never supported via config
+	// cloud-config
+	// cloud-provider
+	// cloud-provider-gce-lb-src-cidrs
+	// contention-profiling
+	// default-not-ready-toleration-seconds
+	// default-unreachable-toleration-seconds
+	// default-watch-cache-size
+	// delete-collection-workers
+	// deserialization-cache-size
+	// enable-garbage-collector
+	// etcd-compaction-interval
+	// etcd-count-metric-poll-period
+	// etcd-servers-overrides
+	// experimental-encryption-provider-config
+	// feature-gates
+	// http2-max-streams-per-connection
+	// insecure-bind-address
+	// kubelet-timeout
+	// log-backtrace-at
+	// log-dir
+	// log-flush-frequency
+	// logtostderr
+	// master-service-namespace
+	// max-connection-bytes-per-sec
+	// profiling
+	// request-timeout
+	// runtime-config
+	// service-account-api-audiences
+	// service-account-issuer
+	// service-account-key-file
+	// service-account-max-token-expiration
+	// service-account-signing-key-file
+	// stderrthreshold
+	// storage-versions
+	// target-ram-mb
+	// v
+	// version
+	// vmodule
+	// watch-cache
+	// watch-cache-sizes
+
+	// TODO, we need to set these in order to enable the right admission plugins in each of the servers
+	// TODO this is needed for a viable cluster up
+	admissionFlags, err := admissionFlags(kubeAPIServerConfig)
+	if err != nil {
+		return nil, err
+	}
+	for flag, value := range admissionFlags {
+		setIfUnset(args, flag, value...)
+	}
+	setIfUnset(args, "allow-privileged", "true")
+	setIfUnset(args, "anonymous-auth", "false")
+	setIfUnset(args, "authorization-mode", "RBAC", "Node") // overridden later, but this runs the poststarthook for bootstrapping RBAC
+	for flag, value := range auditFlags(kubeAPIServerConfig) {
+		setIfUnset(args, flag, value...)
+	}
+	setIfUnset(args, "bind-address", host)
+	setIfUnset(args, "client-ca-file", kubeAPIServerConfig.ServingInfo.ClientCA)
+	setIfUnset(args, "cors-allowed-origins", kubeAPIServerConfig.CORSAllowedOrigins...)
+	setIfUnset(args, "enable-logs-handler", "false")
+	setIfUnset(args, "enable-swagger-ui", "true")
+	setIfUnset(args, "endpoint-reconciler-type", "lease")
+	setIfUnset(args, "etcd-cafile", kubeAPIServerConfig.EtcdClientInfo.CA)
+	setIfUnset(args, "etcd-certfile", kubeAPIServerConfig.EtcdClientInfo.ClientCert.CertFile)
+	setIfUnset(args, "etcd-keyfile", kubeAPIServerConfig.EtcdClientInfo.ClientCert.KeyFile)
+	setIfUnset(args, "etcd-prefix", kubeAPIServerConfig.EtcdStorageConfig.KubernetesStoragePrefix)
+	setIfUnset(args, "etcd-servers", kubeAPIServerConfig.EtcdClientInfo.URLs...)
+	setIfUnset(args, "insecure-port", "0")
+	setIfUnset(args, "kubelet-certificate-authority", kubeAPIServerConfig.KubeletClientInfo.CA)
+	setIfUnset(args, "kubelet-client-certificate", kubeAPIServerConfig.KubeletClientInfo.ClientCert.CertFile)
+	setIfUnset(args, "kubelet-client-key", kubeAPIServerConfig.KubeletClientInfo.ClientCert.KeyFile)
+	setIfUnset(args, "kubelet-https", "true")
+	setIfUnset(args, "kubelet-preferred-address-types", "Hostname", "InternalIP", "ExternalIP")
+	setIfUnset(args, "kubelet-read-only-port", "0")
+	setIfUnset(args, "kubernetes-service-node-port", "0")
+	setIfUnset(args, "max-mutating-requests-inflight", fmt.Sprintf("%d", kubeAPIServerConfig.ServingInfo.MaxRequestsInFlight/2))
+	setIfUnset(args, "max-requests-inflight", fmt.Sprintf("%d", kubeAPIServerConfig.ServingInfo.MaxRequestsInFlight))
+	setIfUnset(args, "min-request-timeout", fmt.Sprintf("%d", kubeAPIServerConfig.ServingInfo.RequestTimeoutSeconds))
+	setIfUnset(args, "proxy-client-cert-file", kubeAPIServerConfig.AggregatorConfig.ProxyClientInfo.CertFile)
+	setIfUnset(args, "proxy-client-key-file", kubeAPIServerConfig.AggregatorConfig.ProxyClientInfo.KeyFile)
+	setIfUnset(args, "requestheader-allowed-names", kubeAPIServerConfig.AuthConfig.RequestHeader.ClientCommonNames...)
+	setIfUnset(args, "requestheader-client-ca-file", kubeAPIServerConfig.AuthConfig.RequestHeader.ClientCA)
+	setIfUnset(args, "requestheader-extra-headers-prefix", kubeAPIServerConfig.AuthConfig.RequestHeader.ExtraHeaderPrefixes...)
+	setIfUnset(args, "requestheader-group-headers", kubeAPIServerConfig.AuthConfig.RequestHeader.GroupHeaders...)
+	setIfUnset(args, "requestheader-username-headers", kubeAPIServerConfig.AuthConfig.RequestHeader.UsernameHeaders...)
+	setIfUnset(args, "secure-port", portString)
+	setIfUnset(args, "service-cluster-ip-range", kubeAPIServerConfig.KubernetesMasterConfig.ServicesSubnet)
+	setIfUnset(args, "service-node-port-range", kubeAPIServerConfig.KubernetesMasterConfig.ServicesNodePortRange)
+	setIfUnset(args, "storage-backend", "etcd3")
+	setIfUnset(args, "storage-media-type", "application/vnd.kubernetes.protobuf")
+	setIfUnset(args, "tls-cert-file", kubeAPIServerConfig.ServingInfo.ServerCert.CertFile)
+	setIfUnset(args, "tls-cipher-suites", kubeAPIServerConfig.ServingInfo.CipherSuites...)
+	setIfUnset(args, "tls-min-version", kubeAPIServerConfig.ServingInfo.MinTLSVersion)
+	setIfUnset(args, "tls-private-key-file", kubeAPIServerConfig.ServingInfo.ServerCert.KeyFile)
+	// TODO re-enable SNI for cluster up
+	// tls-sni-cert-key
+	setIfUnset(args, "secure-port", portString)
+
+	var keys []string
+	for key := range args {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var arguments []string
+	for _, key := range keys {
+		for _, token := range args[key] {
+			arguments = append(arguments, fmt.Sprintf("--%s=%v", key, token))
+		}
+	}
+	return arguments, nil
+}
+
+// currently for cluster up, audit is just broken.
+// TODO fix this
+func auditFlags(kubeAPIServerConfig *configapi.MasterConfig) map[string][]string {
+	args := map[string][]string{}
+	for key, slice := range kubeAPIServerConfig.KubernetesMasterConfig.APIServerArguments {
+		for _, val := range slice {
+			args[key] = append(args[key], val)
+		}
+	}
+
+	return args
+}
+
+func setIfUnset(cmdLineArgs map[string][]string, key string, value ...string) {
+	if _, ok := cmdLineArgs[key]; !ok {
+		cmdLineArgs[key] = value
+	}
+}
+
+func admissionFlags(kubeAPIServerConfig *configapi.MasterConfig) (map[string][]string, error) {
+	args := map[string][]string{}
+
+	forceOn := []string{}
+	forceOff := []string{}
+	pluginConfig := map[string]configapi.AdmissionPluginConfig{}
+	for pluginName, config := range kubeAPIServerConfig.AdmissionConfig.DeepCopy().PluginConfig {
+		if len(config.Location) > 0 {
+			content, err := ioutil.ReadFile(config.Location)
+			if err != nil {
+				return nil, err
+			}
+			// if the config isn't a DefaultAdmissionConfig, then assume we're enabled (we were called out after all)
+			// if the config *is* a DefaultAdmissionConfig and it explicitly said to disable us, we are disabled
+			obj, err := configapilatest.ReadYAML(bytes.NewBuffer(content))
+			// if we can't read it, let the plugin deal with it
+			// if nothing was there, let the plugin deal with it
+			if err != nil || obj == nil {
+				forceOn = append(forceOn, pluginName)
+				config.Location = ""
+				config.Configuration = &runtime.Unknown{Raw: content}
+				pluginConfig[pluginName] = *config
+				continue
+			}
+
+			if defaultConfig, ok := obj.(*configapi.DefaultAdmissionConfig); !ok {
+				forceOn = append(forceOn, pluginName)
+				config.Location = ""
+				config.Configuration = &runtime.Unknown{Raw: content}
+				pluginConfig[pluginName] = *config
+
+			} else if defaultConfig.Disable {
+				forceOff = append(forceOff, pluginName)
+
+			} else {
+				forceOn = append(forceOn, pluginName)
+			}
+
+			continue
+		}
+		// if it wasn't a DefaultAdmissionConfig object, let the plugin deal with it
+		if defaultConfig, ok := config.Configuration.(*configapi.DefaultAdmissionConfig); !ok {
+			forceOn = append(forceOn, pluginName)
+			pluginConfig[pluginName] = *config
+
+		} else if defaultConfig.Disable {
+			forceOff = append(forceOff, pluginName)
+
+		} else {
+			forceOn = append(forceOn, pluginName)
+		}
+
+	}
+	upstreamAdmissionConfig, err := originadmission.ConvertOpenshiftAdmissionConfigToKubeAdmissionConfig(pluginConfig)
+	if err != nil {
+		return nil, err
+	}
+	configBytes, err := configapilatest.WriteYAML(upstreamAdmissionConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	tempFile, err := ioutil.TempFile("", "kubeapiserver-admission-config.yaml")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := tempFile.Write(configBytes); err != nil {
+		return nil, err
+	}
+	tempFile.Close()
+
+	setIfUnset(args, "admission-control-config-file", tempFile.Name())
+	setIfUnset(args, "disable-admission-plugins", forceOff...)
+	setIfUnset(args, "enable-admission-plugins", forceOn...)
+
+	return args, nil
+}

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -1,20 +1,25 @@
 package openshift_kube_apiserver
 
 import (
+	"fmt"
+
 	"github.com/golang/glog"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/pkg/version"
-	aggregatorinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/apiserver/pkg/admission"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/pkg/capabilities"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 
+	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config/validation"
-	"github.com/openshift/origin/pkg/cmd/server/origin"
-	"github.com/openshift/origin/pkg/cmd/util/variable"
+	originadmission "github.com/openshift/origin/pkg/cmd/server/origin/admission"
+	"k8s.io/kubernetes/pkg/kubeapiserver/options"
 )
 
 func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error {
@@ -28,11 +33,6 @@ func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error
 		},
 	})
 
-	// install aggregator types into the scheme so that "normal" RESTOptionsGetters can work for us.
-	// done in Start() prior to doing any other initialization so we don't mutate the scheme after it is being used by clients in other goroutines.
-	// TODO: make scheme threadsafe and do this as part of aggregator config building
-	aggregatorinstall.Install(legacyscheme.Scheme)
-
 	validationResults := validation.ValidateMasterConfig(masterConfig, nil)
 	if len(validationResults.Warnings) != 0 {
 		for _, warning := range validationResults.Warnings {
@@ -43,22 +43,38 @@ func RunOpenShiftKubeAPIServerServer(masterConfig *configapi.MasterConfig) error
 		return kerrors.NewInvalid(configapi.Kind("MasterConfig"), "master-config.yaml", validationResults.Errors)
 	}
 
-	informers := origin.InformerAccess(nil) // use real kube-apiserver loopback client with secret token instead of that from masterConfig.MasterClients.OpenShiftLoopbackKubeConfig
-	openshiftConfig, err := origin.BuildMasterConfig(*masterConfig, informers)
+	bootstrappolicy.ClusterRoles = bootstrappolicy.OpenshiftClusterRoles
+	bootstrappolicy.ClusterRoleBindings = bootstrappolicy.OpenshiftClusterRoleBindings
+
+	options.AllOrderedPlugins = originadmission.CombinedAdmissionControlPlugins
+	kubeRegisterAdmission := options.RegisterAllAdmissionPlugins
+	options.RegisterAllAdmissionPlugins = func(plugins *admission.Plugins) {
+		kubeRegisterAdmission(plugins)
+		originadmission.RegisterOpenshiftAdmissionPlugins(plugins)
+	}
+	kubeDefaultOffAdmission := options.DefaultOffAdmissionPlugins
+	options.DefaultOffAdmissionPlugins = func() sets.String {
+		kubeOff := kubeDefaultOffAdmission()
+		kubeOff.Delete(originadmission.DefaultOnPlugins.List()...)
+		return kubeOff
+	}
+
+	configPatchFn, serverPatchContext := openshiftkubeapiserver.NewOpenShiftKubeAPIServerConfigPatch(genericapiserver.NewEmptyDelegate(), masterConfig)
+	app.OpenShiftKubeAPIServerConfigPatch = configPatchFn
+	app.OpenShiftKubeAPIServerServerPatch = serverPatchContext.PatchServer
+
+	cmd := app.NewAPIServerCommand(utilwait.NeverStop)
+	args, err := openshiftkubeapiserver.ConfigToFlags(masterConfig)
 	if err != nil {
 		return err
 	}
-
-	glog.Infof("Starting master on %s (%s)", masterConfig.ServingInfo.BindAddress, version.Get().String())
-	glog.Infof("Public master address is %s", masterConfig.MasterPublicURL)
-	imageTemplate := variable.NewDefaultImageTemplate()
-	imageTemplate.Format = masterConfig.ImageConfig.Format
-	imageTemplate.Latest = masterConfig.ImageConfig.Latest
-	glog.Infof("Using images from %q", imageTemplate.ExpandOrDie("<component>"))
-
-	if err := openshiftConfig.RunKubeAPIServer(utilwait.NeverStop); err != nil {
+	if err := cmd.ParseFlags(args); err != nil {
+		return err
+	}
+	glog.Infof("`kube-apiserver %v`", args)
+	if err := cmd.RunE(cmd, nil); err != nil {
 		return err
 	}
 
-	return nil
+	return fmt.Errorf("`kube-apiserver %v` exited", args)
 }

--- a/pkg/cmd/server/origin/admission/chain_builder.go
+++ b/pkg/cmd/server/origin/admission/chain_builder.go
@@ -61,8 +61,8 @@ var (
 		"ResourceQuota",
 	}
 
-	// kubeAdmissionPlugins gives the in-order default admission chain for kube resources.
-	kubeAdmissionPlugins = []string{
+	// KubeAdmissionPlugins gives the in-order default admission chain for kube resources.
+	KubeAdmissionPlugins = []string{
 		"AlwaysAdmit",
 		"NamespaceAutoProvision",
 		"NamespaceExists",
@@ -112,7 +112,7 @@ var (
 	// combinedAdmissionControlPlugins gives the in-order default admission chain for all resources resources.
 	// When possible, this list is used.  The set of openshift+kube chains must exactly match this set.  In addition,
 	// the order specified in the openshift and kube chains must match the order here.
-	combinedAdmissionControlPlugins = []string{
+	CombinedAdmissionControlPlugins = []string{
 		"AlwaysAdmit",
 		"NamespaceAutoProvision",
 		"NamespaceExists",
@@ -187,7 +187,7 @@ func NewAdmissionChains(
 		for pluginName, config := range options.AdmissionConfig.PluginConfig {
 			pluginConfig[pluginName] = *config
 		}
-		upstreamAdmissionConfig, err := convertOpenshiftAdmissionConfigToKubeAdmissionConfig(pluginConfig)
+		upstreamAdmissionConfig, err := ConvertOpenshiftAdmissionConfigToKubeAdmissionConfig(pluginConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -208,7 +208,7 @@ func NewAdmissionChains(
 		admissionPluginConfigFilename = tempFile.Name()
 	}
 
-	admissionPluginNames := combinedAdmissionControlPlugins
+	admissionPluginNames := CombinedAdmissionControlPlugins
 	if len(options.AdmissionConfig.PluginOrderOverride) > 0 {
 		admissionPluginNames = options.AdmissionConfig.PluginOrderOverride
 	}
@@ -334,7 +334,7 @@ func splitStream(config io.Reader) (io.Reader, io.Reader, error) {
 	return bytes.NewBuffer(configBytes), bytes.NewBuffer(configBytes), nil
 }
 
-func convertOpenshiftAdmissionConfigToKubeAdmissionConfig(in map[string]configapi.AdmissionPluginConfig) (*apiserver.AdmissionConfiguration, error) {
+func ConvertOpenshiftAdmissionConfigToKubeAdmissionConfig(in map[string]configapi.AdmissionPluginConfig) (*apiserver.AdmissionConfiguration, error) {
 	ret := &apiserver.AdmissionConfiguration{}
 
 	for _, pluginName := range sets.StringKeySet(in).List() {

--- a/pkg/cmd/server/origin/admission/register.go
+++ b/pkg/cmd/server/origin/admission/register.go
@@ -50,10 +50,10 @@ func init() {
 func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	kubeapiserver.RegisterAllAdmissionPlugins(plugins)
 	genericapiserver.RegisterAllAdmissionPlugins(plugins)
-	registerOpenshiftAdmissionPlugins(plugins)
+	RegisterOpenshiftAdmissionPlugins(plugins)
 }
 
-func registerOpenshiftAdmissionPlugins(plugins *admission.Plugins) {
+func RegisterOpenshiftAdmissionPlugins(plugins *admission.Plugins) {
 	authorizationrestrictusers.Register(plugins)
 	buildjenkinsbootstrapper.Register(plugins)
 	buildsecretinjector.Register(plugins)

--- a/pkg/cmd/server/origin/admission/sync_test.go
+++ b/pkg/cmd/server/origin/admission/sync_test.go
@@ -44,7 +44,7 @@ func TestKubeAdmissionControllerUsage(t *testing.T) {
 	kubeapiserver.RegisterAllAdmissionPlugins(admission.NewPlugins())
 	registeredKubePlugins := sets.NewString(OriginAdmissionPlugins.Registered()...)
 
-	usedAdmissionPlugins := sets.NewString(kubeAdmissionPlugins...)
+	usedAdmissionPlugins := sets.NewString(KubeAdmissionPlugins...)
 
 	if missingPlugins := usedAdmissionPlugins.Difference(registeredKubePlugins); len(missingPlugins) != 0 {
 		t.Errorf("%v not found", missingPlugins.List())
@@ -60,7 +60,7 @@ func TestKubeAdmissionControllerUsage(t *testing.T) {
 }
 
 func TestAdmissionOnOffCoverage(t *testing.T) {
-	configuredAdmissionPlugins := sets.NewString(combinedAdmissionControlPlugins...)
+	configuredAdmissionPlugins := sets.NewString(CombinedAdmissionControlPlugins...)
 	allCoveredAdmissionPlugins := sets.String{}
 	allCoveredAdmissionPlugins.Insert(DefaultOnPlugins.List()...)
 	allCoveredAdmissionPlugins.Insert(DefaultOffPlugins.List()...)

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -176,7 +176,7 @@ func (c *MasterConfig) Run(stopCh <-chan struct{}) error {
 	var delegateAPIServer apiserver.DelegationTarget
 	var extraPostStartHooks map[string]apiserver.PostStartHookFunc
 
-	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = openshiftkubeapiserver.BuildHandlerChain(c.kubeAPIServerConfig.GenericConfig, c.ClientGoKubeInformers, &c.Options, stopCh)
+	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = openshiftkubeapiserver.BuildHandlerChain(c.kubeAPIServerConfig.GenericConfig, c.ClientGoKubeInformers, &c.Options)
 	if err != nil {
 		return err
 	}
@@ -225,9 +225,6 @@ func (c *MasterConfig) Run(stopCh <-chan struct{}) error {
 	}
 
 	// add post-start hooks
-	aggregatedAPIServer.GenericAPIServer.AddPostStartHookOrDie("authorization.openshift.io-bootstrapclusterroles", bootstrapData(bootstrappolicy.Policy()).EnsureRBACPolicy())
-	aggregatedAPIServer.GenericAPIServer.AddPostStartHookOrDie("authorization.openshift.io-ensureopenshift-infra", openshiftapiserver.EnsureOpenShiftInfraNamespace)
-
 	for name, fn := range c.additionalPostStartHooks {
 		aggregatedAPIServer.GenericAPIServer.AddPostStartHookOrDie(name, fn)
 	}
@@ -247,7 +244,7 @@ func (c *MasterConfig) RunKubeAPIServer(stopCh <-chan struct{}) error {
 	var delegateAPIServer apiserver.DelegationTarget
 	var extraPostStartHooks map[string]apiserver.PostStartHookFunc
 
-	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = openshiftkubeapiserver.BuildHandlerChain(c.kubeAPIServerConfig.GenericConfig, c.ClientGoKubeInformers, &c.Options, stopCh)
+	c.kubeAPIServerConfig.GenericConfig.BuildHandlerChainFunc, extraPostStartHooks, err = openshiftkubeapiserver.BuildHandlerChain(c.kubeAPIServerConfig.GenericConfig, c.ClientGoKubeInformers, &c.Options)
 	if err != nil {
 		return err
 	}
@@ -284,7 +281,6 @@ func (c *MasterConfig) RunKubeAPIServer(stopCh <-chan struct{}) error {
 	}
 
 	aggregatedAPIServer.GenericAPIServer.AddPostStartHookOrDie("authorization.openshift.io-bootstrapclusterroles", bootstrapData(bootstrappolicy.Policy()).EnsureRBACPolicy())
-	aggregatedAPIServer.GenericAPIServer.AddPostStartHookOrDie("authorization.openshift.io-ensureopenshift-infra", openshiftapiserver.EnsureOpenShiftInfraNamespace)
 	aggregatedAPIServer.GenericAPIServer.AddPostStartHookOrDie("openshift.io-startinformers", func(context apiserver.PostStartHookContext) error {
 		c.InformerStart(context.StopCh)
 		return nil

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -16941,7 +16941,7 @@ objects:
       spec:
         serviceAccountName: kube-dns
         containers:
-        - name: kube-proxy
+        - name: kube-dns
           image: ${IMAGE}
           imagePullPolicy: ${OPENSHIFT_PULL_POLICY}
           command: ["openshift", "start", "network"]
@@ -17031,6 +17031,8 @@ objects:
     - kind: ServiceAccount
       name: kube-proxy
       namespace: ${NAMESPACE}
+    - kind: Group
+      name: system:nodes
   roleRef:
     kind: ClusterRole
     name: system:node-proxier

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -32485,7 +32485,7 @@ objects:
       spec:
         serviceAccountName: kube-dns
         containers:
-        - name: kube-proxy
+        - name: kube-dns
           image: ${IMAGE}
           imagePullPolicy: ${OPENSHIFT_PULL_POLICY}
           command: ["openshift", "start", "network"]
@@ -32575,6 +32575,8 @@ objects:
     - kind: ServiceAccount
       name: kube-proxy
       namespace: ${NAMESPACE}
+    - kind: Group
+      name: system:nodes
   roleRef:
     kind: ClusterRole
     name: system:node-proxier

--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -122,6 +122,7 @@ var expectedIndex = []string{
 	"/healthz/poststarthook/oauth.openshift.io-startoauthclientsbootstrapping",
 	"/healthz/poststarthook/openshift.io-restmapperupdater",
 	"/healthz/poststarthook/openshift.io-startinformers",
+	"/healthz/poststarthook/openshift.io-webconsolepublicurl",
 	"/healthz/poststarthook/project.openshift.io-projectauthorizationcache",
 	"/healthz/poststarthook/project.openshift.io-projectcache",
 	"/healthz/poststarthook/quota.openshift.io-clusterquotamapping",

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go
@@ -35,10 +35,10 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
-	genericoptions "k8s.io/apiserver/pkg/server/options"
 	kubeexternalinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	aggregatorinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
@@ -47,6 +47,7 @@ import (
 	informers "k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion"
 	"k8s.io/kube-aggregator/pkg/controllers/autoregister"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/master/controller/crdregistration"
 )
 
@@ -78,7 +79,10 @@ func createAggregatorConfig(
 	// copy the etcd options so we don't mutate originals.
 	etcdOptions := *commandOptions.Etcd
 	etcdOptions.StorageConfig.Codec = aggregatorscheme.Codecs.LegacyCodec(v1beta1.SchemeGroupVersion, v1.SchemeGroupVersion)
-	genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
+	// openshift accidentally wired the wrong RESTOptionsGetter here and stored in apiservices instead under a group.
+	// this patch installs the types in the scheme and re-uses the restoptions from the kubeapiserver
+	aggregatorinstall.Install(legacyscheme.Scheme)
+	//genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
 
 	// override MergedResourceConfig with aggregator defaults and registry
 	if err := commandOptions.APIEnablement.ApplyTo(

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/patch_openshift.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/patch_openshift.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	clientgoinformers "k8s.io/client-go/informers"
+	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
+	"k8s.io/kubernetes/pkg/master"
+)
+
+type KubeAPIServerConfigFunc func(config *genericapiserver.Config, sharedInformers informers.SharedInformerFactory, versionedInformers clientgoinformers.SharedInformerFactory, pluginInitializers *[]admission.PluginInitializer) (genericapiserver.DelegationTarget, error)
+
+var OpenShiftKubeAPIServerConfigPatch KubeAPIServerConfigFunc = nil
+
+type KubeAPIServerServerFunc func(server *master.Master) error
+
+func PatchKubeAPIServerConfig(config *genericapiserver.Config, sharedInformers informers.SharedInformerFactory, versionedInformers clientgoinformers.SharedInformerFactory, pluginInitializers *[]admission.PluginInitializer) (genericapiserver.DelegationTarget, error) {
+	if OpenShiftKubeAPIServerConfigPatch == nil {
+		return genericapiserver.NewEmptyDelegate(), nil
+	}
+
+	return OpenShiftKubeAPIServerConfigPatch(config, sharedInformers, versionedInformers, pluginInitializers)
+}
+
+var OpenShiftKubeAPIServerServerPatch KubeAPIServerServerFunc = nil
+
+func PatchKubeAPIServerServer(server *master.Master) error {
+	if OpenShiftKubeAPIServerServerPatch == nil {
+		return nil
+	}
+
+	return OpenShiftKubeAPIServerServerPatch(server)
+}
+
+var StartingDelegate genericapiserver.DelegationTarget = genericapiserver.NewEmptyDelegate()

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -634,6 +634,8 @@ func BuildStorageFactory(s *options.ServerRunOptions, apiResourceConfig *servers
 		return nil, fmt.Errorf("error in initializing storage factory: %s", err)
 	}
 
+	storageFactory.SetResourceEtcdPrefix(schema.GroupResource{Group: "apiregistration.k8s.io", Resource: "apiservices"}, "apiservices")
+
 	storageFactory.AddCohabitatingResources(networking.Resource("networkpolicies"), extensions.Resource("networkpolicies"))
 	storageFactory.AddCohabitatingResources(apps.Resource("deployments"), extensions.Resource("deployments"))
 	storageFactory.AddCohabitatingResources(apps.Resource("daemonsets"), extensions.Resource("daemonsets"))

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/patch.go
@@ -1,0 +1,5 @@
+package options
+
+var RegisterAllAdmissionPlugins = registerAllAdmissionPlugins
+
+var DefaultOffAdmissionPlugins = defaultOffAdmissionPlugins

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/plugins.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/plugins.go
@@ -98,7 +98,7 @@ var AllOrderedPlugins = []string{
 
 // RegisterAllAdmissionPlugins registers all admission plugins and
 // sets the recommended plugins order.
-func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
+func registerAllAdmissionPlugins(plugins *admission.Plugins) {
 	admit.Register(plugins) // DEPRECATED as no real meaning
 	alwayspullimages.Register(plugins)
 	antiaffinity.Register(plugins)
@@ -128,7 +128,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 }
 
 // DefaultOffAdmissionPlugins get admission plugins off by default for kube-apiserver.
-func DefaultOffAdmissionPlugins() sets.String {
+func defaultOffAdmissionPlugins() sets.String {
 	defaultOnPlugins := sets.NewString(
 		lifecycle.PluginName,                //NamespaceLifecycle
 		limitranger.PluginName,              //LimitRanger

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/patch_policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/patch_policy.go
@@ -1,0 +1,65 @@
+package bootstrappolicy
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
+)
+
+var ClusterRoles = clusterRoles
+
+func OpenshiftClusterRoles() []rbacv1.ClusterRole {
+	const (
+		// These are valid under the "nodes" resource
+		NodeMetricsSubresource = "metrics"
+		NodeStatsSubresource   = "stats"
+		NodeSpecSubresource    = "spec"
+		NodeLogSubresource     = "log"
+	)
+
+	roles := clusterRoles()
+	roles = append(roles, []rbacv1.ClusterRole{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:node-admin",
+			},
+			Rules: []rbacv1.PolicyRule{
+				// Allow read-only access to the API objects
+				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				// Allow all API calls to the nodes
+				rbacv1helpers.NewRule("proxy").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				rbacv1helpers.NewRule("*").Groups(legacyGroup).Resources("nodes/proxy", "nodes/"+NodeMetricsSubresource, "nodes/"+NodeSpecSubresource, "nodes/"+NodeStatsSubresource, "nodes/"+NodeLogSubresource).RuleOrDie(),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:node-reader",
+			},
+			Rules: []rbacv1.PolicyRule{
+				// Allow read-only access to the API objects
+				rbacv1helpers.NewRule(Read...).Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				// Allow read access to node metrics
+				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("nodes/"+NodeMetricsSubresource, "nodes/"+NodeSpecSubresource).RuleOrDie(),
+				// Allow read access to stats
+				// Node stats requests are submitted as POSTs.  These creates are non-mutating
+				rbacv1helpers.NewRule("get", "create").Groups(legacyGroup).Resources("nodes/" + NodeStatsSubresource).RuleOrDie(),
+				// TODO: expose other things like /healthz on the node once we figure out non-resource URL policy across systems
+			},
+		},
+	}...)
+
+	addClusterRoleLabel(roles)
+	return roles
+}
+
+var ClusterRoleBindings = clusterRoleBindings
+
+func OpenshiftClusterRoleBindings() []rbacv1.ClusterRoleBinding {
+	bindings := clusterRoleBindings()
+	bindings = append(bindings, []rbacv1.ClusterRoleBinding{
+		rbacv1helpers.NewClusterBinding("system:node-admin").Users("system:master").Groups("system:node-admins").BindingOrDie(),
+	}...)
+
+	addClusterRoleBindingLabel(bindings)
+	return bindings
+}

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -162,8 +162,8 @@ func NodeRules() []rbacv1.PolicyRule {
 	return nodePolicyRules
 }
 
-// ClusterRoles returns the cluster roles to bootstrap an API server with
-func ClusterRoles() []rbacv1.ClusterRole {
+// clusterRoles returns the cluster roles to bootstrap an API server with
+func clusterRoles() []rbacv1.ClusterRole {
 	roles := []rbacv1.ClusterRole{
 		{
 			// a "root" role which can do absolutely anything
@@ -526,7 +526,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 const systemNodeRoleName = "system:node"
 
 // ClusterRoleBindings return default rolebindings to the default roles
-func ClusterRoleBindings() []rbacv1.ClusterRoleBinding {
+func clusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	rolebindings := []rbacv1.ClusterRoleBinding{
 		rbacv1helpers.NewClusterBinding("cluster-admin").Groups(user.SystemPrivilegedGroup).BindingOrDie(),
 		rbacv1helpers.NewClusterBinding("system:discovery").Groups(user.AllAuthenticated, user.AllUnauthenticated).BindingOrDie(),

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -145,7 +145,7 @@ func (a *AdmissionOptions) ApplyTo(
 	pluginInitializers = append(pluginInitializers, genericInitializer)
 	initializersChain = append(initializersChain, pluginInitializers...)
 
-	admissionChain, err := a.Plugins.NewFromPlugins(pluginNames, pluginsConfigProvider, initializersChain, admission.DecoratorFunc(admissionmetrics.WithControllerMetrics))
+	admissionChain, err := a.Plugins.NewFromPlugins(pluginNames, pluginsConfigProvider, initializersChain, AdmissionDecorator)
 	if err != nil {
 		return err
 	}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/patch_admission.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/patch_admission.go
@@ -1,0 +1,8 @@
+package options
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
+)
+
+var AdmissionDecorator admission.Decorator = admission.DecoratorFunc(admissionmetrics.WithControllerMetrics)


### PR DESCRIPTION
@sttts I've come around.  This is where my head's at.  Not pretty, but I think we can fit most everything into those two spots.


 - [x] OAuth server (but not backing APIs)
 - [x] /.well-known
 - [x] Our authenticator (oauth tokens via loopback)
 - [x] Our authorizer (scopes, browser-safe, deny?)
 - [x] Our admission
     - [x] initializers
         - [x] clients/informers for openshift APIs
    - [x]  namespace filters
     - [x] our ordered list
    - [x] externalippluginname
    - [x] restrictedendpointsplugin
 - [ ] SCC
 - [x] Non-standard etcd storage paths (APIService, others?) https://github.com/openshift/origin/pull/20719


