### PR TITLE
Fix issue where routes are not cleaned up when a namespace label is deleted or updated.

### DIFF
--- a/pkg/router/controller/router_controller.go
+++ b/pkg/router/controller/router_controller.go
@@ -132,7 +132,11 @@ func (c *RouterController) processNamespace(eventType watch.EventType, ns *kapi.
 }
 
 func (c *RouterController) UpdateNamespaces() {
-	namespaces := c.FilteredNamespaceNames
+	// Note: Need to clone the filtered namespace names or else any updates
+	//       we make locally in processNamespace() will be immediately
+	//       reflected to plugins in the chain beneath us. This creates
+	//       cleanup issues as old == new in Plugin.HandleNamespaces().
+	namespaces := sets.NewString(c.FilteredNamespaceNames.List()...)
 
 	glog.V(4).Infof("Updating watched namespaces: %v", namespaces)
 	if err := c.Plugin.HandleNamespaces(namespaces); err != nil {

--- a/pkg/router/template/router.go
+++ b/pkg/router/template/router.go
@@ -351,8 +351,8 @@ func (r *templateRouter) commitAndReload() error {
 		}
 
 		r.stateChanged = false
-		r.dynamicallyConfigured = true
 		if r.dynamicConfigManager != nil {
+			r.dynamicallyConfigured = true
 			r.dynamicConfigManager.Notify(RouterEventReloadStart)
 		}
 
@@ -509,6 +509,10 @@ func (r *templateRouter) FilterNamespaces(namespaces sets.String) {
 		}
 		delete(r.state, k)
 		r.stateChanged = true
+	}
+
+	if r.stateChanged {
+		r.dynamicallyConfigured = false
 	}
 }
 


### PR DESCRIPTION
Fix an issue where routes are not cleaned up if a namespace label is deleted or updated. 
fixes bugz #1613163

/cc @openshift/sig-network-edge 