### PR TITLE
UPSTREAM: 66617: Do not set cgroup parent when --cgroups-per-qos is disabled

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -299,7 +299,7 @@ func (m *podContainerManagerNoop) EnsureExists(_ *v1.Pod) error {
 }
 
 func (m *podContainerManagerNoop) GetPodContainerName(_ *v1.Pod) (CgroupName, string) {
-	return m.cgroupRoot, m.cgroupRoot.ToCgroupfs()
+	return m.cgroupRoot, ""
 }
 
 func (m *podContainerManagerNoop) GetPodContainerNameForDriver(_ *v1.Pod) string {


### PR DESCRIPTION
This will fix launching pods on dind cluster.

When --cgroups-per-qos=false (default is true), kubelet sets pod
container management to podContainerManagerNoop implementation and
GetPodContainerName() returns '/' as cgroup parent (default cgroup root).

(1) In case of 'systemd' cgroup driver, '/' is invalid parent as
docker daemon expects '.slice' suffix and throws this error:
'cgroup-parent for systemd cgroup should be a valid slice named as \"xxx.slice\"'
(https://github.com/moby/moby/blob/5fc12449d830ae9005138fb3d3782728fa8d137a/daemon/daemon_unix.go#L618)
'/' corresponds to '-.slice' (root slice) in systemd but I don't think
we want to assign root slice instead of runtime specific default value.
In case of docker runtime, this will be 'system.slice'
(https://github.com/moby/moby/blob/e2593239d949eee454935daea7a5fe025477322f/daemon/oci_linux.go#L698)

(2) In case of 'cgroupfs' cgroup driver, '/' is valid parent but I don't
think we want to assign root instead of runtime specific default value.
In case of docker runtime, this will be '/docker'
(https://github.com/moby/moby/blob/e2593239d949eee454935daea7a5fe025477322f/daemon/oci_linux.go#L695)

Current fix will not set the cgroup parent when --cgroups-per-qos is disabled.