### PR TITLE
split scc admission into mutating and validating

### DIFF
--- a/pkg/security/apiserver/admission/sccadmission/admission.go
+++ b/pkg/security/apiserver/admission/sccadmission/admission.go
@@ -71,35 +71,67 @@ func NewConstraint() *constraint {
 // any change that claims the pod is no longer privileged will be removed.  That should hold until
 // we get a true old/new set of objects in.
 func (c *constraint) Admit(a admission.Attributes) error {
-	if a.GetResource().GroupResource() != kapi.Resource("pods") {
+	if ignore, err := shouldIgnore(a); err != nil {
+		return err
+	} else if ignore {
 		return nil
 	}
-	if len(a.GetSubresource()) != 0 {
+	pod := a.GetObject().(*kapi.Pod)
+
+	// TODO(liggitt): allow spec mutation during initializing updates?
+	specMutationAllowed := a.GetOperation() == admission.Create
+
+	allowedPod, sccName, validationErrs, err := c.computeSecurityContext(a, pod, specMutationAllowed, "")
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+
+	if allowedPod != nil {
+		*pod = *allowedPod
+		// annotate and accept the pod
+		glog.V(4).Infof("pod %s (generate: %s) validated against provider %s", pod.Name, pod.GenerateName, sccName)
+		if pod.ObjectMeta.Annotations == nil {
+			pod.ObjectMeta.Annotations = map[string]string{}
+		}
+		pod.ObjectMeta.Annotations[allocator.ValidatedSCCAnnotation] = sccName
 		return nil
 	}
 
-	pod, ok := a.GetObject().(*kapi.Pod)
-	// if we can't convert then fail closed since we've already checked that this is supposed to be a pod object.
-	// this shouldn't normally happen during admission but could happen if an integrator passes a versioned
-	// pod object rather than an internal object.
-	if !ok {
-		return admission.NewForbidden(a, fmt.Errorf("object was marked as kind pod but was unable to be converted: %v", a.GetObject()))
-	}
+	// we didn't validate against any security context constraint provider, reject the pod and give the errors for each attempt
+	glog.V(4).Infof("unable to validate pod %s (generate: %s) against any security context constraint: %v", pod.Name, pod.GenerateName, validationErrs)
+	return admission.NewForbidden(a, fmt.Errorf("unable to validate against any security context constraint: %v", validationErrs))
+}
 
-	// if this is an update, see if we are only updating the ownerRef.  Garbage collection does this
-	// and we should allow it in general, since you had the power to update and the power to delete.
-	// The worst that happens is that you delete something, but you aren't controlling the privileged object itself
-	if a.GetOldObject() != nil && rbacregistry.IsOnlyMutatingGCFields(a.GetObject(), a.GetOldObject(), kapihelper.Semantic) {
+func (c *constraint) Validate(a admission.Attributes) error {
+	if ignore, err := shouldIgnore(a); err != nil {
+		return err
+	} else if ignore {
+		return nil
+	}
+	pod := a.GetObject().(*kapi.Pod)
+
+	// compute the context. Mutation is not allowed. ValidatedSCCAnnotation is used as a hint to gain same speed-up.
+	allowedPod, _, validationErrs, err := c.computeSecurityContext(a, pod, false, pod.ObjectMeta.Annotations[allocator.ValidatedSCCAnnotation])
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+	if allowedPod != nil && apiequality.Semantic.DeepEqual(pod, allowedPod) {
 		return nil
 	}
 
+	// we didn't validate against any provider, reject the pod and give the errors for each attempt
+	glog.V(4).Infof("unable to validate pod %s (generate: %s) in namespace %s against any pod security policy: %v", pod.Name, pod.GenerateName, a.GetNamespace(), validationErrs)
+	return admission.NewForbidden(a, fmt.Errorf("unable to validate against any pod security policy: %v", validationErrs))
+}
+
+func (c *constraint) computeSecurityContext(a admission.Attributes, pod *kapi.Pod, specMutationAllowed bool, validatedSCCHint string) (*kapi.Pod, string, field.ErrorList, error) {
 	// get all constraints that are usable by the user
 	glog.V(4).Infof("getting security context constraints for pod %s (generate: %s) in namespace %s with user info %v", pod.Name, pod.GenerateName, a.GetNamespace(), a.GetUserInfo())
 
 	sccMatcher := scc.NewDefaultSCCMatcher(c.sccLister, c.authorizer)
 	matchedConstraints, err := sccMatcher.FindApplicableSCCs(a.GetUserInfo(), a.GetNamespace())
 	if err != nil {
-		return admission.NewForbidden(a, err)
+		return nil, "", nil, admission.NewForbidden(a, err)
 	}
 
 	// get all constraints that are usable by the SA
@@ -108,7 +140,7 @@ func (c *constraint) Admit(a admission.Attributes) error {
 		glog.V(4).Infof("getting security context constraints for pod %s (generate: %s) with service account info %v", pod.Name, pod.GenerateName, userInfo)
 		saConstraints, err := sccMatcher.FindApplicableSCCs(userInfo, a.GetNamespace())
 		if err != nil {
-			return admission.NewForbidden(a, err)
+			return nil, "", nil, admission.NewForbidden(a, err)
 		}
 		matchedConstraints = append(matchedConstraints, saConstraints...)
 	}
@@ -116,16 +148,26 @@ func (c *constraint) Admit(a admission.Attributes) error {
 	// remove duplicate constraints and sort
 	matchedConstraints = scc.DeduplicateSecurityContextConstraints(matchedConstraints)
 	sort.Sort(scc.ByPriority(matchedConstraints))
+	// If mutation is not allowed and validatedSCCHint is provided, check the validated policy first.
+	// Keep the other the same for everything else
+	sort.SliceStable(matchedConstraints, func(i, j int) bool {
+		if !specMutationAllowed {
+			if matchedConstraints[i].Name == validatedSCCHint {
+				return true
+			}
+			if matchedConstraints[j].Name == validatedSCCHint {
+				return false
+			}
+		}
+		return i < j
+	})
 
 	providers, errs := scc.CreateProvidersFromConstraints(a.GetNamespace(), matchedConstraints, c.client)
 	logProviders(pod, providers, errs)
 
 	if len(providers) == 0 {
-		return admission.NewForbidden(a, fmt.Errorf("no providers available to validate pod request"))
+		return nil, "", nil, admission.NewForbidden(a, fmt.Errorf("no providers available to validate pod request"))
 	}
-
-	// TODO(liggitt): allow spec mutation during initializing updates?
-	specMutationAllowed := a.GetOperation() == admission.Create
 
 	// all containers in a single pod must validate under a single provider or we will reject the request
 	validationErrs := field.ErrorList{}
@@ -151,33 +193,49 @@ loop:
 			// even on creating. We prefer most restrictive SCC in this case even if it mutates a pod.
 			allowedPod = podCopy
 			allowingProvider = provider
-			glog.V(6).Infof("pod %s (generate: %s) validated against provider %s with mutation", pod.Name, pod.GenerateName, provider.GetSCCName())
+			glog.V(5).Infof("pod %s (generate: %s) validated against provider %s with mutation", pod.Name, pod.GenerateName, provider.GetSCCName())
 			break loop
 		case apiequality.Semantic.DeepEqual(pod, podCopy):
 			// if we don't allow mutation, only use the validated pod if it didn't require any spec changes
 			allowedPod = podCopy
 			allowingProvider = provider
-			glog.V(6).Infof("pod %s (generate: %s) validated against provider %s without mutation", pod.Name, pod.GenerateName, provider.GetSCCName())
+			glog.V(5).Infof("pod %s (generate: %s) validated against provider %s without mutation", pod.Name, pod.GenerateName, provider.GetSCCName())
 			break loop
 		default:
-			glog.V(6).Infof("pod %s (generate: %s) validated against provider %s, but required mutation, skipping", pod.Name, pod.GenerateName, provider.GetSCCName())
+			glog.V(5).Infof("pod %s (generate: %s) validated against provider %s, but required mutation, skipping", pod.Name, pod.GenerateName, provider.GetSCCName())
 		}
 	}
 
-	if allowedPod != nil {
-		*pod = *allowedPod
-		// annotate and accept the pod
-		glog.V(4).Infof("pod %s (generate: %s) validated against provider %s", pod.Name, pod.GenerateName, allowingProvider.GetSCCName())
-		if pod.ObjectMeta.Annotations == nil {
-			pod.ObjectMeta.Annotations = map[string]string{}
-		}
-		pod.ObjectMeta.Annotations[allocator.ValidatedSCCAnnotation] = allowingProvider.GetSCCName()
-		return nil
+	if allowedPod == nil || allowingProvider == nil {
+		return nil, "", validationErrs, nil
+	}
+	return allowedPod, allowingProvider.GetSCCName(), validationErrs, nil
+}
+
+func shouldIgnore(a admission.Attributes) (bool, error) {
+	if a.GetResource().GroupResource() != kapi.Resource("pods") {
+		return true, nil
+	}
+	if len(a.GetSubresource()) != 0 {
+		return true, nil
 	}
 
-	// we didn't validate against any security context constraint provider, reject the pod and give the errors for each attempt
-	glog.V(4).Infof("unable to validate pod %s (generate: %s) against any security context constraint: %v", pod.Name, pod.GenerateName, validationErrs)
-	return admission.NewForbidden(a, fmt.Errorf("unable to validate against any security context constraint: %v", validationErrs))
+	_, ok := a.GetObject().(*kapi.Pod)
+	// if we can't convert then fail closed since we've already checked that this is supposed to be a pod object.
+	// this shouldn't normally happen during admission but could happen if an integrator passes a versioned
+	// pod object rather than an internal object.
+	if !ok {
+		return false, admission.NewForbidden(a, fmt.Errorf("object was marked as kind pod but was unable to be converted: %v", a.GetObject()))
+	}
+
+	// if this is an update, see if we are only updating the ownerRef.  Garbage collection does this
+	// and we should allow it in general, since you had the power to update and the power to delete.
+	// The worst that happens is that you delete something, but you aren't controlling the privileged object itself
+	if a.GetOperation() == admission.Update && rbacregistry.IsOnlyMutatingGCFields(a.GetObject(), a.GetOldObject(), kapihelper.Semantic) {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // SetSecurityInformers implements WantsSecurityInformer interface for constraint.


### PR DESCRIPTION
We have not split our admission chain into validating and mutating.  Because of this we disable the webhook admission plugins by default and don't claim support.  When they are turned on, they bypass our admission chain checks.  There are more to do, but SCC stands out as one that is super important and we don't want people to get used to bypassing.

@openshift/sig-master 
@liggitt as discussed