### PR TITLE
add missed dashboard_file variable

### DIFF
--- a/examples/grafana/setup-grafana.sh
+++ b/examples/grafana/setup-grafana.sh
@@ -62,6 +62,7 @@ systemctl restart atomic-openshift-master-api.service
 # deploy node exporter
 node::exporter(){
 oc annotate ns kube-system openshift.io/node-selector= --overwrite
+dashboard_file="./node-exporter-full-dashboard.json"
 sed -i.bak "s/Xs/${graph_granularity}/" "${dashboard_file}"
 sed -i.bak "s/\${DS_PR}/${datasource_name}/" "${dashboard_file}"
 curl --insecure -H "Content-Type: application/json" -u admin:admin "${grafana_host}/api/dashboards/db" -X POST -d "@./node-exporter-full-dashboard.json"

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -356,7 +356,7 @@ function os::build::check_binaries() {
   fi
   if [[ -f "${OS_OUTPUT_BINPATH}/${platform}/openshift-node-config" ]]; then
     size=$($duexe --apparent-size -m "${OS_OUTPUT_BINPATH}/${platform}/openshift-node-config" | cut -f 1)
-    if [[ "${size}" -gt "30" ]]; then
+    if [[ "${size}" -gt "32" ]]; then
       os::log::fatal "openshift-node-config binary has grown substantially to ${size}. You must have approval before bumping this limit."
     fi
   fi


### PR DESCRIPTION
the dashboard_file variable is missing, when deploymented with this script,
and access the node-exporter dashboard, error message "Datasource named ${DS_PR} was not found" will appear.