### PR TITLE
remove "does not alter the object" text

### DIFF
--- a/pkg/oc/cli/set/env.go
+++ b/pkg/oc/cli/set/env.go
@@ -60,7 +60,7 @@ var (
 	  # List the environment variables defined on all pods
 	  %[1]s env pods --all --list
 
-	  # Output modified build config in YAML, and does not alter the object on the server
+	  # Output modified build config in YAML
 	  %[1]s env bc/sample-build STORAGE_DIR=/data -o yaml
 
 	  # Update all containers in all replication controllers in the project to have ENV=prod


### PR DESCRIPTION
The behavior of an object being altered when `-o yaml` or `-o json` is specified without `--dry-run` should be expected. Removing incorrect text asserting otherwise from this command's help output.

cc @soltysh 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1615214