### PR TITLE
UPSTREAM: 63146: Remove patch retry conflict detection

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -173,18 +173,20 @@ func patchResource(
 
 	namespace := request.NamespaceValue(ctx)
 
-	var (
-		originalObjJS           []byte
-		originalPatchedObjJS    []byte
-		originalObjMap          map[string]interface{}
-		getOriginalPatchMap     func() (map[string]interface{}, error)
-		lastConflictErr         error
-		originalResourceVersion string
-	)
+	var lastConflictErr error
 
 	// applyPatch is called every time GuaranteedUpdate asks for the updated object,
 	// and is given the currently persisted object as input.
 	applyPatch := func(_ request.Context, _, currentObject runtime.Object) (runtime.Object, error) {
+		// make these local vars so every patch attempt is handled as if it were the first attempt
+		var (
+			originalObjJS           []byte
+			originalPatchedObjJS    []byte
+			originalObjMap          map[string]interface{}
+			getOriginalPatchMap     func() (map[string]interface{}, error)
+			originalResourceVersion string
+		)
+
 		// Make sure we actually have a persisted currentObject
 		trace.Step("About to apply patch")
 		if hasUID, err := hasUID(currentObject); err != nil {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -533,8 +533,7 @@ func TestPatchResourceWithConflict(t *testing.T) {
 		startingPod: &example.Pod{},
 		changedPod:  &example.Pod{},
 		updatePod:   &example.Pod{},
-
-		expectedError: `Operation cannot be fulfilled on pods.example.apiserver.k8s.io "foo": existing 2, new 1`,
+		expectedPod: &example.Pod{},
 	}
 
 	tc.startingPod.Name = name
@@ -557,6 +556,13 @@ func TestPatchResourceWithConflict(t *testing.T) {
 	tc.updatePod.ResourceVersion = "2"
 	tc.updatePod.APIVersion = examplev1.SchemeGroupVersion.String()
 	tc.updatePod.Spec.NodeName = "anywhere"
+
+	tc.expectedPod.Name = name
+	tc.expectedPod.Namespace = namespace
+	tc.expectedPod.UID = uid
+	tc.expectedPod.ResourceVersion = "2"
+	tc.expectedPod.APIVersion = examplev1.SchemeGroupVersion.String()
+	tc.expectedPod.Spec.NodeName = "there"
 
 	tc.Run(t)
 }


### PR DESCRIPTION
Minimal backport of 3.11 changes

Fixes patch in cases of stuck watch caches - https://bugzilla.redhat.com/show_bug.cgi?id=1582094

```sh
$ git describe
v3.10.17-1-3-g752e84746d5

$ make
hack/build-go.sh  
++ Building go targets for darwin/amd64: cmd/hypershift cmd/openshift cmd/oc cmd/oadm cmd/template-service-broker cmd/openshift-node-config vendor/k8s.io/kubernetes/cmd/hyperkube
[INFO] [16:27:07-0400] hack/build-go.sh exited with code 0 after 00h 04m 29s

$ go test ./vendor/k8s.io/apiserver/pkg/endpoints/handlers
ok  	github.com/openshift/origin/vendor/k8s.io/apiserver/pkg/endpoints/handlers	0.068s

$ hack/test-integration.sh TestPatch
=== RUN   TestIntegration
=== RUN   TestIntegration/TestPatchConflicts
--- PASS: TestIntegration (0.07s)
    --- PASS: TestIntegration/TestPatchConflicts (23.62s)
```

passed upstream tests in https://github.com/kubernetes/kubernetes/pull/66169