### PR TITLE
allow patching configapi using oc patch

### DIFF
--- a/pkg/cmd/server/apis/config/v1/register.go
+++ b/pkg/cmd/server/apis/config/v1/register.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	coreinternalconversions "k8s.io/kubernetes/pkg/apis/core"
 
+	buildv1 "github.com/openshift/api/build/v1"
 	buildinternalconversions "github.com/openshift/origin/pkg/build/apis/build/v1"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config"
 )
@@ -23,6 +24,12 @@ var (
 		addDefaultingFuncs,
 	)
 	InstallLegacy = legacySchemeBuilder.AddToScheme
+
+	externalLegacySchemeBuilder = runtime.NewSchemeBuilder(
+		addKnownTypesToLegacy,
+		buildv1.Install,
+	)
+	InstallLegacyExternal = externalLegacySchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to api.Scheme.

--- a/vendor/k8s.io/kubernetes/cluster/clientbin.sh
+++ b/vendor/k8s.io/kubernetes/cluster/clientbin.sh
@@ -47,6 +47,9 @@ case "$(uname -m)" in
   arm*)
     host_arch=arm
     ;;
+  aarch64*)
+    host_arch=arm64
+    ;;
   i?86*)
     host_arch=386
     ;;


### PR DESCRIPTION
Fixes upstream patch and scheme registration to allow `oc patch --local -f openshift.local.config/master/master-config.yaml --patch="{\"etcdConfig\": {\"address\": \"${API_HOST}:${ETCD_PORT}\"}}" --loglevel=8 -o yaml`

@soltysh @juanvallejo 

I think the upstream is out of date
/hold
