### PR TITLE
Fix haproxy router config manager issue where sanitize pems cause a blueprint route to not be selected 

### DIFF
--- a/pkg/cmd/infra/router/template.go
+++ b/pkg/cmd/infra/router/template.go
@@ -468,6 +468,7 @@ func (o *TemplateRouterOptions) Run() error {
 			BlueprintRoutePoolSize: o.BlueprintRoutePoolSize,
 			MaxDynamicServers:      o.MaxDynamicServers,
 			WildcardRoutesAllowed:  o.AllowWildcardRoutes,
+			ExtendedValidation:     o.ExtendedValidation,
 		}
 		cfgManager = haproxyconfigmanager.NewHAProxyConfigManager(cmopts)
 		if len(o.BlueprintRouteNamespace) > 0 {

--- a/pkg/router/template/types.go
+++ b/pkg/router/template/types.go
@@ -166,6 +166,9 @@ type ConfigManagerOptions struct {
 
 	// WildcardRoutesAllowed indicates if wildcard routes are allowed.
 	WildcardRoutesAllowed bool
+
+	// ExtendedValidation indicates if extended route validation is enabled.
+	ExtendedValidation bool
 }
 
 // ConfigManager is used by the router to make configuration changes using


### PR DESCRIPTION
 Fix haproxy router config manager issue where sanitize pems don't match when
 extended validation is enabled (causes a reload where none is needed).
 fixes bugz #1615802
(Sorta depends on #20630 to merge to test dynamic blueprint changes).

/cc @openshift/sig-network-edge 