### PR TITLE
 Bug 1614660 - Network diagnostic will auto detect runtime 

### DIFF
--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/cmd.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/cmd.go
@@ -132,7 +132,7 @@ func (o NetworkPodDiagnosticsOptions) buildNetworkPodDiagnostics() ([]types.Diag
 		return nil, err
 	}
 
-	runtime, err := netutil.GetRuntime()
+	runtime, err := netutil.GetRuntime(kubeClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/results.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/results.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/source-to-image/pkg/tar"
 	s2ifs "github.com/openshift/source-to-image/pkg/util/fs"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrs "k8s.io/apimachinery/pkg/util/errors"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
@@ -99,7 +100,7 @@ func (d *NetworkDiagnostic) copyNetworkPodInfo(pod *kapi.Pod) error {
 
 func (d *NetworkDiagnostic) getNetworkPodLogs(pod *kapi.Pod) error {
 	bytelim := int64(1024000)
-	opts := &kapi.PodLogOptions{
+	opts := &corev1.PodLogOptions{
 		TypeMeta:   pod.TypeMeta,
 		Container:  pod.Name,
 		Follow:     true,


### PR DESCRIPTION
Don't default to crio runtime when crio and docker binaries are installed.
Node object has the container runtime version, so now we fetch the runtime
info from there.

Fix provided options object is not a PodLogOptions error in network diags
This seems fallout from 1.11 rebase (#20033)