### PR TITLE
Add Probes for oc adm diagnostics NetworkCheck

### DIFF
--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/objects.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/objects.go
@@ -119,6 +119,8 @@ func GetTestPod(testPodImage, testPodProtocol, podName, nodeName string, testPod
 			fmt.Sprintf("%s-l:%d,reuseaddr,fork,crlf", testPodProtocol, testPodPort),
 			"system:\"echo 'HTTP/1.0 200 OK'; echo 'Content-Type: text/plain'; echo; echo 'Hello OpenShift'\"",
 		}
+		pod.Spec.Containers[0].ReadinessProbe = &kapi.Probe{Handler: kapi.Handler{HTTPGet: &kapi.HTTPGetAction{Port: intstr.FromInt(testPodPort), Scheme: kapi.URISchemeHTTP}}}
+		pod.Spec.Containers[0].LivenessProbe = &kapi.Probe{Handler: kapi.Handler{HTTPGet: &kapi.HTTPGetAction{Port: intstr.FromInt(testPodPort), Scheme: kapi.URISchemeHTTP}}}
 	}
 	return pod
 }


### PR DESCRIPTION
oc adm diagnostics creates a series of pods to test services.

This causes intermittent failures:
ERROR: [DNet2008 from diagnostic NetworkCheck@openshift/origin/pkg/oc/admin/diagnostics/diagnostics/cluster/network/run_pod.go:199]
       [...]
       , See the errors below in the output from the network diagnostic pod on node "<node name>":
       [...]
       ERROR: [DSvcNet1010 from diagnostic CheckServiceNetwork@openshift/origin/pkg/oc/admin/diagnostics/diagnostics/cluster/network/in_pod/service.go:193]
              Connectivity from pod "network-diag-ns-srxmm/network-diag-test-pod-ppdrs" to service "network-diag-ns-srxmm/network-diag-test-service-2h8t4" failed. Error: exit status 1, Out: bash: connect: Connection refused
              bash: /dev/tcp/10.36.34.45/9876: Connection refused

       [...]

       , See the errors below in the output from the network diagnostic pod on node "<node name>":
       [...]
       ERROR: [DSvcNet1010 from diagnostic CheckServiceNetwork@openshift/origin/pkg/oc/admin/diagnostics/diagnostics/cluster/network/in_pod/service.go:193]
              Connectivity from pod "network-diag-ns-srxmm/network-diag-test-pod-8br97" to service "network-diag-ns-srxmm/network-diag-test-service-2h8t4" failed. Error: exit status 124, Out:
       [...]