### PR TITLE
Take dependency on selinux to fix openvswitch failure

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -175,6 +175,8 @@ Summary:        %{product_name} Pod
 %package sdn-ovs
 Summary:          %{product_name} SDN Plugin for Open vSwitch
 Requires:         openvswitch >= %{openvswitch_version}
+# selinux-policy is required because openvswitch doesn't yet take a dependency on selinux-policy but changes the files
+Requires:         selinux-policy
 Requires:         %{name}-node = %{version}-%{release}
 Requires:         bridge-utils
 Requires:         ethtool


### PR DESCRIPTION
openvswitch-selinux-policy depends on being able to change /etc/sysconfig/selinux,
but doesn't take a dependency on selinux-policy. Until they change it, we need to
take that dependency ourselves.

@ahaile