### PR TITLE
Network diags: Determine runtime based on local node object

### DIFF
--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/collect.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/collect.go
@@ -47,7 +47,7 @@ func (d CollectNetworkInfo) CanRun() (bool, error) {
 func (d CollectNetworkInfo) Check() types.DiagnosticResult {
 	r := types.NewDiagnosticResult(CollectNetworkInfoName)
 
-	nodeName, _, err := util.GetLocalNode(d.KubeClient)
+	node, _, err := util.GetLocalNode(d.KubeClient)
 	if err != nil {
 		r.Error("DColNet1001", err, fmt.Sprintf("Fetching local node info failed: %s", err))
 		return r
@@ -55,7 +55,7 @@ func (d CollectNetworkInfo) Check() types.DiagnosticResult {
 
 	l := util.LogInterface{
 		Result: r,
-		Logdir: filepath.Join(util.NetworkDiagDefaultLogDir, util.NetworkDiagNodeLogDirPrefix, nodeName),
+		Logdir: filepath.Join(util.NetworkDiagDefaultLogDir, util.NetworkDiagNodeLogDirPrefix, node.Name),
 	}
 	l.LogNode(d.KubeClient, d.Runtime)
 	return r

--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/util.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/in_pod/util/util.go
@@ -107,15 +107,15 @@ func GetSchedulableNodes(kubeClient kclientset.Interface) ([]kapi.Node, error) {
 	return filteredNodes, nil
 }
 
-func GetLocalNode(kubeClient kclientset.Interface) (string, string, error) {
+func GetLocalNode(kubeClient kclientset.Interface) (*kapi.Node, string, error) {
 	nodeList, err := kubeClient.Core().Nodes().List(metav1.ListOptions{})
 	if err != nil {
-		return "", "", err
+		return nil, "", err
 	}
 
 	_, hostIPs, err := netutils.GetHostIPNetworks(nil)
 	if err != nil {
-		return "", "", err
+		return nil, "", err
 	}
 	for _, node := range nodeList.Items {
 		if len(node.Status.Addresses) == 0 {
@@ -124,12 +124,12 @@ func GetLocalNode(kubeClient kclientset.Interface) (string, string, error) {
 		for _, ip := range hostIPs {
 			for _, addr := range node.Status.Addresses {
 				if addr.Type == kapi.NodeInternalIP && ip.String() == addr.Address {
-					return node.Name, addr.Address, nil
+					return &node, addr.Address, nil
 				}
 			}
 		}
 	}
-	return "", "", fmt.Errorf("unable to find local node IP")
+	return nil, "", fmt.Errorf("unable to find local node IP")
 }
 
 // Get local/non-local pods in network diagnostic namespaces


### PR DESCRIPTION
Follow up of https://github.com/openshift/origin/pull/20647
We could have some nodes running crio and others with docker runtime.
Starter clusters are doing this but this could change with 4.0+ release.
Fetch the runtime info from the local node object so that it works
on all cases.