### PR TITLE
Bug 1600741 - Provide better help for network diagnostic flags

### DIFF
--- a/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/run_pod.go
+++ b/pkg/oc/cli/admin/diagnostics/diagnostics/cluster/network/run_pod.go
@@ -85,25 +85,26 @@ func (d *NetworkDiagnostic) AvailableParameters() []types.Parameter {
 		},
 		{
 			Name:        FlagNetworkDiagPodImage,
-			Description: "Image to use for diagnostic pod",
+			Description: "Override the default diagnostic pod image. Any image with bash and chroot support",
 			Target:      &d.PodImage,
-			Default:     util.GetNetworkDiagDefaultPodImage(),
+			Default:     "",
 		},
 		{
-			Name:        FlagNetworkDiagTestPodImage,
-			Description: "Image to use for diagnostic test pod",
-			Target:      &d.TestPodImage,
-			Default:     util.GetNetworkDiagDefaultTestPodImage(),
+			Name: FlagNetworkDiagTestPodImage,
+			Description: fmt.Sprintf("Override the default diagnostic test pod image. Any image that accepts protocol --%s on port --%s",
+				FlagNetworkDiagTestPodProtocol, FlagNetworkDiagTestPodPort),
+			Target:  &d.TestPodImage,
+			Default: "",
 		},
 		{
 			Name:        FlagNetworkDiagTestPodProtocol,
-			Description: "Protocol used to connect to diagnostic test pod",
+			Description: "Override the default diagnostic test pod protocol",
 			Target:      &d.TestPodProtocol,
 			Default:     util.NetworkDiagDefaultTestPodProtocol,
 		},
 		{
 			Name:        FlagNetworkDiagTestPodPort,
-			Description: "Serving port on the diagnostic test pod",
+			Description: "Override the default diagnostic test pod port",
 			Target:      &d.TestPodPort,
 			Default:     util.NetworkDiagDefaultTestPodPort,
 		},
@@ -119,6 +120,13 @@ func (d *NetworkDiagnostic) Complete(logger *log.Logger) error {
 		return fmt.Errorf("Network log path %q exists but is not a directory", d.LogDir)
 	}
 	d.LogDir = logdir
+
+	if len(d.PodImage) == 0 {
+		d.PodImage = util.GetNetworkDiagDefaultPodImage()
+	}
+	if len(d.TestPodImage) == 0 {
+		d.TestPodImage = util.GetNetworkDiagDefaultTestPodImage()
+	}
 
 	supportedProtocols := sets.NewString(string(kapi.ProtocolTCP), string(kapi.ProtocolUDP))
 	if !supportedProtocols.Has(d.TestPodProtocol) {


### PR DESCRIPTION
We expect network diagnostics to work out of the box without any additional
inputs, '--test-pod-image' and '--pod-image' options were exposed for testing
and to handle the situation where diag pod image pull fails for some reason.

We are not using the exact deployer/ose image directly, instead we are customizing
these images by injecting commands. Showing these image names as defaults will
mislead the user, just like what we saw in the bug.
This change will remove the defaults and instead improves the help message for
these flags.