### PR TITLE
Fix dnsmasq/node dependency

### DIFF
--- a/images/node/system-container/service.template
+++ b/images/node/system-container/service.template
@@ -1,7 +1,7 @@
 [Unit]
 After=${DOCKER_SERVICE}
 Wants=${DOCKER_SERVICE}
-Requires=dnsmasq.service
+Wants=dnsmasq.service
 After=dnsmasq.service
 
 [Service]


### PR DESCRIPTION
Port of an installer fix[1] for a RHEL environment bug[2] which has been
reproduced on Atomic Host environments. The dnsmasq service should start with
the node, but both services should then operate independently (e.g. stopping
dnsmasq should not stop the node service).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1617976.

[1] https://github.com/openshift/openshift-ansible/pull/6843
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1532960