### PR TITLE
spec: keep /etc/sysconfig/origin-node

### DIFF
--- a/origin.spec
+++ b/origin.spec
@@ -385,6 +385,7 @@ touch --reference=%{SOURCE0} $RPM_BUILD_ROOT/usr/sbin/%{name}-docker-excluder
 %files node
 %{_bindir}/openshift-node-config
 %{_sysconfdir}/systemd/system.conf.d/origin-accounting.conf
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-node
 %defattr(-,root,root,0700)
 %config(noreplace) %{_sysconfdir}/origin/node
 


### PR DESCRIPTION
This env file should be preserved between major upgrades. 
Currently update from 3.10 to 3.11 would erase it (leaving the backup in 
.rpmsave)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618420