### PR TITLE
Set the X-Forwarded-Proto header only when it does not exist

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -426,6 +426,8 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
   timeout check 5000ms
   http-request set-header X-Forwarded-Host %[req.hdr(host)]
   http-request set-header X-Forwarded-Port %[dst_port]
+  acl existing-x-forwarded-proto req.hdr(X-Forwarded-Proto) -m found
+  http-request set-header X-Forwarded-Proto http if !existing-x-forwarded-proto !{ ssl_fc }
   http-request set-header X-Forwarded-Proto http if !{ ssl_fc }
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   http-request set-header X-Forwarded-Proto-Version h2 if { ssl_fc_alpn -i h2 }


### PR DESCRIPTION
This patch is trying fix #13771.

Based on forwarded header RFC

> A proxy server that wants to add a new "Forwarded" header field value
> can either append it to the last existing "Forwarded" header field
> after a comma separator or add a new field at the end of the header
> block.

X-Forwarded-Proto should support multi value separate by comma. But I
guess most applicates may not implement this and assume there is only
one value. So This patch is trying to not replace the X-Forwarded-Proto
if the original header has this header.