### PR TITLE
duplicate some build helpers and consts for internal use

### DIFF
--- a/pkg/build/apis/build/internal_helpers/internal_helpers.go
+++ b/pkg/build/apis/build/internal_helpers/internal_helpers.go
@@ -1,0 +1,162 @@
+package internal_helpers
+
+import (
+	kapi "k8s.io/kubernetes/pkg/apis/core"
+
+	"github.com/openshift/origin/pkg/api/apihelpers"
+	buildapi "github.com/openshift/origin/pkg/build/apis/build"
+)
+
+// NOTE: These helpers are used by apiserver only as the apiserver use the internal types.
+//       These were copied from pkg/build/util and any change to original helpers should be reflected here as well.
+
+const (
+	// buildPodSuffix is the suffix used to append to a build pod name given a build name
+	buildPodSuffix = "build"
+)
+
+// BuildToPodLogOptions builds a PodLogOptions object out of a BuildLogOptions.
+// Currently BuildLogOptions.Container and BuildLogOptions.Previous aren't used
+// so they won't be copied to PodLogOptions.
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func BuildToPodLogOptions(opts *buildapi.BuildLogOptions) *kapi.PodLogOptions {
+	return &kapi.PodLogOptions{
+		Follow:       opts.Follow,
+		SinceSeconds: opts.SinceSeconds,
+		SinceTime:    opts.SinceTime,
+		Timestamps:   opts.Timestamps,
+		TailLines:    opts.TailLines,
+		LimitBytes:   opts.LimitBytes,
+	}
+}
+
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func IsBuildComplete(b *buildapi.Build) bool {
+	return IsTerminalPhase(b.Status.Phase)
+}
+
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func IsTerminalPhase(p buildapi.BuildPhase) bool {
+	switch p {
+	case buildapi.BuildPhaseNew,
+		buildapi.BuildPhasePending,
+		buildapi.BuildPhaseRunning:
+		return false
+	}
+	return true
+}
+
+// GetBuildPodName returns name of the build pod.
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func GetBuildPodName(build *buildapi.Build) string {
+	return apihelpers.GetPodName(build.Name, buildPodSuffix)
+}
+
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func StrategyType(strategy buildapi.BuildStrategy) string {
+	switch {
+	case strategy.DockerStrategy != nil:
+		return "Docker"
+	case strategy.CustomStrategy != nil:
+		return "Custom"
+	case strategy.SourceStrategy != nil:
+		return "Source"
+	case strategy.JenkinsPipelineStrategy != nil:
+		return "JenkinsPipeline"
+	}
+	return ""
+}
+
+// GetInputReference returns the From ObjectReference associated with the
+// BuildStrategy.
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func GetInputReference(strategy buildapi.BuildStrategy) *kapi.ObjectReference {
+	switch {
+	case strategy.SourceStrategy != nil:
+		return &strategy.SourceStrategy.From
+	case strategy.DockerStrategy != nil:
+		return strategy.DockerStrategy.From
+	case strategy.CustomStrategy != nil:
+		return &strategy.CustomStrategy.From
+	default:
+		return nil
+	}
+}
+
+// GetBuildEnv gets the build strategy environment
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func GetBuildEnv(build *buildapi.Build) []kapi.EnvVar {
+	switch {
+	case build.Spec.Strategy.SourceStrategy != nil:
+		return build.Spec.Strategy.SourceStrategy.Env
+	case build.Spec.Strategy.DockerStrategy != nil:
+		return build.Spec.Strategy.DockerStrategy.Env
+	case build.Spec.Strategy.CustomStrategy != nil:
+		return build.Spec.Strategy.CustomStrategy.Env
+	case build.Spec.Strategy.JenkinsPipelineStrategy != nil:
+		return build.Spec.Strategy.JenkinsPipelineStrategy.Env
+	default:
+		return nil
+	}
+}
+
+// SetBuildEnv replaces the current build environment
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func SetBuildEnv(build *buildapi.Build, env []kapi.EnvVar) {
+	var oldEnv *[]kapi.EnvVar
+
+	switch {
+	case build.Spec.Strategy.SourceStrategy != nil:
+		oldEnv = &build.Spec.Strategy.SourceStrategy.Env
+	case build.Spec.Strategy.DockerStrategy != nil:
+		oldEnv = &build.Spec.Strategy.DockerStrategy.Env
+	case build.Spec.Strategy.CustomStrategy != nil:
+		oldEnv = &build.Spec.Strategy.CustomStrategy.Env
+	case build.Spec.Strategy.JenkinsPipelineStrategy != nil:
+		oldEnv = &build.Spec.Strategy.JenkinsPipelineStrategy.Env
+	default:
+		return
+	}
+	*oldEnv = env
+}
+
+// UpdateBuildEnv updates the strategy environment
+// This will replace the existing variable definitions with provided env
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+func UpdateBuildEnv(build *buildapi.Build, env []kapi.EnvVar) {
+	buildEnv := GetBuildEnv(build)
+
+	newEnv := []kapi.EnvVar{}
+	for _, e := range buildEnv {
+		exists := false
+		for _, n := range env {
+			if e.Name == n.Name {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			newEnv = append(newEnv, e)
+		}
+	}
+	newEnv = append(newEnv, env...)
+	SetBuildEnv(build, newEnv)
+}
+
+// BuildSliceByCreationTimestamp implements sort.Interface for []Build
+// based on the CreationTimestamp field.
+// DEPRECATED: Reserved for apiserver, do not use outside of it
+// +k8s:deepcopy-gen=false
+type BuildSliceByCreationTimestamp []buildapi.Build
+
+func (b BuildSliceByCreationTimestamp) Len() int {
+	return len(b)
+}
+
+func (b BuildSliceByCreationTimestamp) Less(i, j int) bool {
+	return b[i].CreationTimestamp.Before(&b[j].CreationTimestamp)
+}
+
+func (b BuildSliceByCreationTimestamp) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}

--- a/pkg/build/util/consts.go
+++ b/pkg/build/util/consts.go
@@ -1,0 +1,107 @@
+package util
+
+// TODO: This list needs triage and move to openshift/api and library-go:
+
+var (
+	WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY"}
+)
+
+const (
+	// BuildAnnotation is an annotation that identifies a Pod as being for a Build
+	BuildAnnotation = "openshift.io/build.name"
+	// BuildConfigAnnotation is an annotation that identifies the BuildConfig that a Build was created from
+	BuildConfigAnnotation = "openshift.io/build-config.name"
+	// BuildNumberAnnotation is an annotation whose value is the sequential number for this Build
+	BuildNumberAnnotation = "openshift.io/build.number"
+	// BuildCloneAnnotation is an annotation whose value is the name of the build this build was cloned from
+	BuildCloneAnnotation = "openshift.io/build.clone-of"
+	// BuildPodNameAnnotation is an annotation whose value is the name of the pod running this build
+	BuildPodNameAnnotation = "openshift.io/build.pod-name"
+	// BuildJenkinsStatusJSONAnnotation is an annotation holding the Jenkins status information
+	BuildJenkinsStatusJSONAnnotation = "openshift.io/jenkins-status-json"
+	// BuildJenkinsLogURLAnnotation is an annotation holding a link to the raw Jenkins build console log
+	BuildJenkinsLogURLAnnotation = "openshift.io/jenkins-log-url"
+	// BuildJenkinsConsoleLogURLAnnotation is an annotation holding a link to the Jenkins build console log (including Jenkins chrome wrappering)
+	BuildJenkinsConsoleLogURLAnnotation = "openshift.io/jenkins-console-log-url"
+	// BuildJenkinsBlueOceanLogURLAnnotation is an annotation holding a link to the Jenkins build console log via the Jenkins BlueOcean UI Plugin
+	BuildJenkinsBlueOceanLogURLAnnotation = "openshift.io/jenkins-blueocean-log-url"
+	// BuildJenkinsBuildURIAnnotation is an annotation holding a link to the Jenkins build
+	BuildJenkinsBuildURIAnnotation = "openshift.io/jenkins-build-uri"
+	// BuildSourceSecretMatchURIAnnotationPrefix is a prefix for annotations on a Secret which indicate a source URI against which the Secret can be used
+	BuildSourceSecretMatchURIAnnotationPrefix = "build.openshift.io/source-secret-match-uri-"
+	// BuildLabel is the key of a Pod label whose value is the Name of a Build which is run.
+	// NOTE: The value for this label may not contain the entire Build name because it will be
+	// truncated to maximum label length.
+	BuildLabel = "openshift.io/build.name"
+	// BuildRunPolicyLabel represents the start policy used to to start the build.
+	BuildRunPolicyLabel = "openshift.io/build.start-policy"
+	// AllowedUIDs is an environment variable that contains ranges of UIDs that are allowed in
+	// Source builder images
+	AllowedUIDs = "ALLOWED_UIDS"
+	// DropCapabilities is an environment variable that contains a list of capabilities to drop when
+	// executing a Source build
+	DropCapabilities = "DROP_CAPS"
+	// BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig
+	// on which the Build is based. NOTE: The value for this label may not contain the entire
+	// BuildConfig name because it will be truncated to maximum label length.
+	BuildConfigLabel = "openshift.io/build-config.name"
+	// BuildConfigLabelDeprecated was used as BuildConfigLabel before adding namespaces.
+	// We keep it for backward compatibility.
+	BuildConfigLabelDeprecated = "buildconfig"
+	// BuildConfigPausedAnnotation is an annotation that marks a BuildConfig as paused.
+	// New Builds cannot be instantiated from a paused BuildConfig.
+	BuildConfigPausedAnnotation = "openshift.io/build-config.paused"
+	// BuildStartedEventReason is the reason associated with the event registered when a build is started (pod is created).
+	BuildStartedEventReason = "BuildStarted"
+	// BuildStartedEventMessage is the message associated with the event registered when a build is started (pod is created).
+	BuildStartedEventMessage = "Build %s/%s is now running"
+	// BuildCompletedEventReason is the reason associated with the event registered when build completes successfully.
+	BuildCompletedEventReason = "BuildCompleted"
+	// BuildCompletedEventMessage is the message associated with the event registered when build completes successfully.
+	BuildCompletedEventMessage = "Build %s/%s completed successfully"
+	// BuildFailedEventReason is the reason associated with the event registered when build fails.
+	BuildFailedEventReason = "BuildFailed"
+	// BuildFailedEventMessage is the message associated with the event registered when build fails.
+	BuildFailedEventMessage = "Build %s/%s failed"
+	// BuildCancelledEventReason is the reason associated with the event registered when build is cancelled.
+	BuildCancelledEventReason = "BuildCancelled"
+	// BuildCancelledEventMessage is the message associated with the event registered when build is cancelled.
+	BuildCancelledEventMessage = "Build %s/%s has been cancelled"
+)
+
+const (
+	BuildTriggerCauseManualMsg    = "Manually triggered"
+	BuildTriggerCauseConfigMsg    = "Build configuration change"
+	BuildTriggerCauseImageMsg     = "Image change"
+	BuildTriggerCauseGithubMsg    = "GitHub WebHook"
+	BuildTriggerCauseGenericMsg   = "Generic WebHook"
+	BuildTriggerCauseGitLabMsg    = "GitLab WebHook"
+	BuildTriggerCauseBitbucketMsg = "Bitbucket WebHook"
+)
+
+const (
+	StatusMessageCannotCreateBuildPodSpec        = "Failed to create pod spec."
+	StatusMessageCannotCreateBuildPod            = "Failed creating build pod."
+	StatusMessageInvalidOutputRef                = "Output image could not be resolved."
+	StatusMessageInvalidImageRef                 = "Referenced image could not be resolved."
+	StatusMessageBuildPodDeleted                 = "The pod for this build was deleted before the build completed."
+	StatusMessageMissingPushSecret               = "Missing push secret."
+	StatusMessageCancelledBuild                  = "The build was cancelled by the user."
+	StatusMessageBuildPodExists                  = "The pod for this build already exists and is older than the build."
+	StatusMessageNoBuildContainerStatus          = "The pod for this build has no container statuses indicating success or failure."
+	StatusMessageFailedContainer                 = "The pod for this build has at least one container with a non-zero exit status."
+	StatusMessageGenericBuildFailed              = "Generic Build failure - check logs for details."
+	StatusMessageOutOfMemoryKilled               = "The build pod was killed due to an out of memory condition."
+	StatusMessageUnresolvableEnvironmentVariable = "Unable to resolve build environment variable reference."
+	StatusMessageCannotRetrieveServiceAccount    = "Unable to look up the service account secrets for this build."
+)
+
+const (
+	// WebHookSecretKey is the key used to identify the value containing the webhook invocation
+	// secret within a secret referenced by a webhook trigger.
+	WebHookSecretKey = "WebHookSecretKey"
+
+	// CustomBuildStrategyBaseImageKey is the environment variable that indicates the base image to be used when
+	// performing a custom build, if needed.
+	CustomBuildStrategyBaseImageKey = "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE"
+)


### PR DESCRIPTION
This is part of https://github.com/openshift/origin/pull/20659 and this PR just copies out some helpers that we need to use with internal build types into `pkg/build/apis/build/internal_helpers`.

In addition to helpers this also picks some consts and vars from the internal build api to be used by external build helpers. These should be probably distributed into library-go and openshift/api as a follow up (will link an issue).

/cc @deads2k 
/cc @bparees 

