### PR TITLE
remove the ability to limit secret refs based on service account

### DIFF
--- a/pkg/cmd/server/apis/config/validation/master.go
+++ b/pkg/cmd/server/apis/config/validation/master.go
@@ -383,6 +383,10 @@ func ValidateServiceAccountConfig(config configapi.ServiceAccountConfig, fldPath
 		}
 	}
 
+	if config.LimitSecretReferences {
+		validationResults.AddErrors(field.NotSupported(fldPath.Child("limitSecretReferences"), config.LimitSecretReferences, []string{"false"}))
+	}
+
 	if len(config.PrivateKeyFile) > 0 {
 		privateKeyFilePath := fldPath.Child("privateKeyFile")
 		if fileErrs := common.ValidateFile(config.PrivateKeyFile, privateKeyFilePath); len(fileErrs) > 0 {

--- a/pkg/cmd/server/origin/admission/chain_builder.go
+++ b/pkg/cmd/server/origin/admission/chain_builder.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	noderestriction "k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
-	saadmit "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	expandpvcadmission "k8s.io/kubernetes/plugin/pkg/admission/storage/persistentvolume/resize"
 	storageclassdefaultadmission "k8s.io/kubernetes/plugin/pkg/admission/storage/storageclass/setdefault"
 
@@ -262,13 +261,6 @@ func newAdmissionChain(pluginNames []string, admissionConfigFilename string, opt
 				return nil, err
 			}
 			plugin = serviceadmit.NewRestrictedEndpointsAdmission(restrictedNetworks)
-			admissionInitializer.Initialize(plugin)
-
-		case saadmit.PluginName:
-			// we need to set some custom parameters on the service account admission controller, so create that one by hand
-			saAdmitter := saadmit.NewServiceAccount()
-			saAdmitter.LimitSecretReferences = options.ServiceAccountConfig.LimitSecretReferences
-			plugin = saAdmitter
 			admissionInitializer.Initialize(plugin)
 
 		default:

--- a/test/integration/node_authorizer_test.go
+++ b/test/integration/node_authorizer_test.go
@@ -31,9 +31,6 @@ func TestNodeAuthorizer(t *testing.T) {
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
-	// we care about pods getting rejected for referencing secrets at all, not because the pod's service account doesn't reference them
-	masterConfig.ServiceAccountConfig.LimitSecretReferences = false
-
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -236,7 +236,6 @@ func getServiceAccountPullSecret(client kclientset.Interface, ns, name string) (
 
 func TestEnforcingServiceAccount(t *testing.T) {
 	masterConfig, err := testserver.DefaultMasterOptions()
-	masterConfig.ServiceAccountConfig.LimitSecretReferences = false
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -222,9 +222,6 @@ func DefaultMasterOptionsWithTweaks(useDefaultPort bool) (*configapi.MasterConfi
 	}
 	masterConfig.ImagePolicyConfig.AllowedRegistriesForImport = &allowedRegistries
 
-	// force strict handling of service account secret references by default, so that all our examples and controllers will handle it.
-	masterConfig.ServiceAccountConfig.LimitSecretReferences = true
-
 	glog.Infof("Starting integration server from master %s", startOptions.MasterArgs.ConfigDir.Value())
 
 	return masterConfig, nil


### PR DESCRIPTION
We don't know of anything supporting this.  It was never turned on downstream.  One release after producing it, we realized it was impractical to use.  This removes the ability to configure it and clearly fails in case anyone actually managed to run with it on.  Our plan is to apologize to those people and explain that the ACL boundary for openshift and kubernetes is on namespaces

@liggitt we talked about doing this

@openshift/sig-master 