### PR TITLE
Only add X-Forwarded-For header when it does not exist

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -352,7 +352,7 @@ frontend fe_no_sni
 
 backend openshift_default
   mode http
-  option forwardfor
+  option forwardfor if-none
   #option http-keep-alive
   option http-pretend-keepalive
 
@@ -380,7 +380,7 @@ backend openshift_default
 backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
   mode http
   option redispatch
-  option forwardfor
+  option forwardfor if-none
 
     {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
   balance {{ $balanceAlgo }}


### PR DESCRIPTION
haproxy forwardfor will add a new http X-Forwarded-For header even when
the request already have the header. Then the origin X-Forwarded-For
information may be ignored by benkend applications.

This patch is trying to not add the header if the original request
already have X-Forwarded-For header.