### PR TITLE
oc debug: fix crash on attach

### DIFF
--- a/pkg/oc/cli/debug/debug.go
+++ b/pkg/oc/cli/debug/debug.go
@@ -139,21 +139,17 @@ type DebugOptions struct {
 }
 
 func NewDebugOptions(streams genericclioptions.IOStreams) *DebugOptions {
+	attachOpts := kcmd.NewAttachOptions(streams)
+	attachOpts.TTY = true
+	attachOpts.Stdin = true
 	return &DebugOptions{
 		PrintFlags:         genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
 		IOStreams:          streams,
 		Timeout:            15 * time.Minute,
 		KeepInitContainers: true,
 		AsUser:             -1,
-		Attach: kcmd.AttachOptions{
-			StreamOptions: kcmd.StreamOptions{
-				IOStreams: streams,
-				TTY:       true,
-				Stdin:     true,
-			},
-			Attach: &kcmd.DefaultRemoteAttach{},
-		},
-		LogsForObject: polymorphichelpers.LogsForObjectFn,
+		Attach:             *attachOpts,
+		LogsForObject:      polymorphichelpers.LogsForObjectFn,
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/attach.go
@@ -89,7 +89,8 @@ func NewAttachOptions(streams genericclioptions.IOStreams) *AttachOptions {
 		StreamOptions: StreamOptions{
 			IOStreams: streams,
 		},
-		Attach: &DefaultRemoteAttach{},
+		Attach:     &DefaultRemoteAttach{},
+		AttachFunc: defaultAttachFunc,
 	}
 }
 
@@ -192,8 +193,6 @@ func (o *AttachOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 		return err
 	}
 	o.Config = config
-
-	o.AttachFunc = defaultAttachFunc
 
 	if o.CommandName == "" {
 		o.CommandName = cmd.CommandPath()


### PR DESCRIPTION
o.AttachFunc is nil since we use our own custom `oc debug` command.
Attaching the defaultAttachFunc if nil fixes the crash and gives a
prompt.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618522