### PR TITLE
add git package to origin-node image for gitrepo volumes

### DIFF
--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -20,7 +20,7 @@ RUN INSTALL_PKGS=" \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute bridge-utils procps-ng openssl \
       binutils xz kmod-libs kmod sysvinit-tools device-mapper-libs dbus \
-      iscsi-initiator-utils \
+      iscsi-initiator-utils git \
       " && \
     yum install -y centos-release-ceph-luminous && \
     rpm -V centos-release-ceph-luminous && \


### PR DESCRIPTION
git command is missing when running containerized kubelet in origin-node image
```
$ oc describe pod gitrepo

Actual results:
Events:
  Type     Reason       Age               From                                   Message
  ----     ------       ----              ----                                   -------
  Normal   Scheduled    16s               default-scheduler                      Successfully assigned default/gitrepo to ip-172-18-8-135.ec2.internal
  Warning  FailedMount  8s (x5 over 16s)  kubelet, ip-172-18-8-135.ec2.internal  MountVolume.SetUp failed for volume "gitrepo" : failed to exec 'git clone -- https://github.com/jhou1/gitrepoVolume.git': : executable file not found in $PATH
```

xref https://bugzilla.redhat.com/show_bug.cgi?id=1613677

@derekwaynecarr @smarterclayton @liangxia 