### PR TITLE
Fix cluster file system usage dashboards

### DIFF
--- a/examples/grafana/openshift-cluster-monitoring.json
+++ b/examples/grafana/openshift-cluster-monitoring.json
@@ -347,7 +347,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/mapper/docker_.*\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) / sum (container_fs_limit_bytes{device=~\"^/dev/mapper/docker_.*\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) * 100",
+                "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/mapper/docker--.*\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) / sum (container_fs_limit_bytes{device=~\"^/dev/mapper/docker--.*\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"}) * 100",
                 "format": "time_series",
                 "hide": false,
                 "interval": "",
@@ -755,7 +755,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/mapper/docker_.*$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+                "expr": "sum (container_fs_usage_bytes{device=~\"^/dev/mapper/docker--.*$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,
@@ -836,7 +836,7 @@
             "tableColumn": "",
             "targets": [
               {
-                "expr": "sum (container_fs_limit_bytes{device=~\"^/dev/mapper/docker_.*$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
+                "expr": "sum (container_fs_limit_bytes{device=~\"^/dev/mapper/docker--.*$\",id=\"/\",kubernetes_io_hostname=~\"^$Node$\"})",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,


### PR DESCRIPTION
As of OCP 3.9+. The regexp that matches the file system is in the format
`{device=~\"^ /dev/mapper/docker--.*\"}` instead of `{device=~\"^/dev/mapper/docker_.*\"}`.