### PR TITLE
Set ExecSync tty to true by default in dockershim

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_streaming.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_streaming.go
@@ -84,8 +84,8 @@ func (ds *dockerService) ExecSync(_ context.Context, req *runtimeapi.ExecSyncReq
 		nil, // in
 		ioutils.WriteCloserWrapper(&stdoutBuffer),
 		ioutils.WriteCloserWrapper(&stderrBuffer),
-		false, // tty
-		nil,   // resize
+		true, // tty
+		nil,  // resize
 		timeout)
 
 	var exitCode int32


### PR DESCRIPTION
Many probes run "sh -i -c" to pick up defaults, which fails
with an ioctl error as tty was set to false by default. Makes
sense to change the default to true.

This fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1590762 and there is an open PR for the same thing in k8s https://github.com/kubernetes/kubernetes/pull/66084.

Creating this PR as we need to get this moving along for the BZ.

Signed-off-by: umohnani8 <umohnani@redhat.com>