### PR TITLE
Fix router issue to use tcp balance scheme if configured

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -511,7 +511,7 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
 {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
   option tcplog
 {{- end }}
-    {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
+    {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
   balance {{ $balanceAlgo }}
     {{- else }}
   balance {{ if gt $cfg.ActiveServiceUnits 1 }}roundrobin{{ else }}source{{ end }}


### PR DESCRIPTION
and use the default router load balance algorithm if tcp balance scheme is not specified.
fixes bugz #1618563

/cc @openshift/sig-network-edge 