### PR TITLE
Make the router tests tolerate multiple namespaces

### DIFF
--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -1,7 +1,6 @@
 package images
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -23,12 +22,8 @@ func cliPodWithPullSecret(cli *exutil.CLI, shell string) *kapiv1.Pod {
 	o.Expect(sa.ImagePullSecrets).NotTo(o.BeEmpty())
 	pullSecretName := sa.ImagePullSecrets[0].Name
 
-	// best effort to get the format string for the release
-	router, err := cli.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{})
-	if err != nil {
-		g.Fail(fmt.Sprintf("Unable to find router in order to query format string: %v", err))
-	}
-	cliImage := strings.Replace(router.Spec.Template.Spec.Containers[0].Image, "haproxy-router", "cli", 1)
+	format, _ := exutil.FindImageFormatString(cli)
+	cliImage := strings.Replace(format, "${component}", "cli", -1)
 
 	return &kapiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -44,19 +43,10 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		image := os.Getenv("OS_IMAGE_PREFIX")
-		if len(image) == 0 {
-			image = "openshift/origin"
-		}
-		image += "-haproxy-router"
+		routerImage, _ := exutil.FindImageFormatString(oc)
+		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 
-		if dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{}); err == nil {
-			if len(dc.Spec.Template.Spec.Containers) > 0 && dc.Spec.Template.Spec.Containers[0].Image != "" {
-				image = dc.Spec.Template.Spec.Containers[0].Image
-			}
-		}
-
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+image).Execute()
+		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -28,13 +28,13 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	)
 
 	g.BeforeEach(func() {
-		svc, err := oc.AdminKubeClient().Core().Services("default").Get("router", metav1.GetOptions{})
+		var err error
+		routerIP, err = waitForRouterServiceIP(oc)
 		if kapierrs.IsNotFound(err) {
 			g.Skip("no router installed on the cluster")
 			return
 		}
 		o.Expect(err).NotTo(o.HaveOccurred())
-		routerIP = svc.Spec.ClusterIP
 	})
 
 	g.Describe("The HAProxy router", func() {

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -39,13 +39,14 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	oc = exutil.NewCLI("router-reencrypt", exutil.KubeConfigPath())
 
 	g.BeforeEach(func() {
-		svc, err := oc.AdminKubeClient().Core().Services("default").Get("router", metav1.GetOptions{})
+		var err error
+		ip, err = waitForRouterServiceIP(oc)
 		if kapierrs.IsNotFound(err) {
 			g.Skip("no router installed on the cluster")
 			return
 		}
 		o.Expect(err).NotTo(o.HaveOccurred())
-		ip = svc.Spec.ClusterIP
+
 		ns = oc.KubeFramework().Namespace.Name
 	})
 
@@ -79,3 +80,23 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		})
 	})
 })
+
+func waitForRouterServiceIP(oc *exutil.CLI) (string, error) {
+	_, ns, err := exutil.GetRouterPodTemplate(oc)
+	if err != nil {
+		return "", err
+	}
+
+	// wait for the service to show up
+	var host string
+	err = wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+		svc, err := oc.AdminKubeClient().CoreV1().Services(ns).Get("router", metav1.GetOptions{})
+		if kapierrs.IsNotFound(err) {
+			return false, nil
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		host = svc.Spec.ClusterIP
+		return true, nil
+	})
+	return host, err
+}

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -3,7 +3,6 @@ package router
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -48,19 +47,10 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		image := os.Getenv("OS_IMAGE_PREFIX")
-		if len(image) == 0 {
-			image = "openshift/origin"
-		}
-		image += "-haproxy-router"
+		routerImage, _ := exutil.FindImageFormatString(oc)
+		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 
-		if dc, err := oc.AdminAppsClient().AppsV1().DeploymentConfigs("default").Get("router", metav1.GetOptions{}); err == nil {
-			if len(dc.Spec.Template.Spec.Containers) > 0 && dc.Spec.Template.Spec.Containers[0].Image != "" {
-				image = dc.Spec.Template.Spec.Containers[0].Image
-			}
-		}
-
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+image).Execute()
+		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -4,7 +4,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,11 +26,9 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	)
 
 	g.BeforeEach(func() {
-		imagePrefix := os.Getenv("OS_IMAGE_PREFIX")
-		if len(imagePrefix) == 0 {
-			imagePrefix = "openshift/origin"
-		}
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+imagePrefix+"-haproxy-router").Execute()
+		routerImage, _ := exutil.FindImageFormatString(oc)
+		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
+		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1410,4 +1411,39 @@ func WaitForUserBeAuthorized(oc *CLI, user, verb, resource string) error {
 		}
 		return false, err
 	})
+}
+
+// GetRouterPodTemplate finds the router pod template across different namespaces,
+// helping to mitigate the transition from the default namespace to an operator
+// namespace.
+func GetRouterPodTemplate(oc *CLI) (*corev1.PodTemplateSpec, string, error) {
+	appsclient := oc.AdminAppsClient().AppsV1()
+	k8sappsclient := oc.AdminKubeClient().AppsV1()
+	for _, ns := range []string{"default", "openshift-ingress", "tectonic-ingress"} {
+		dc, err := appsclient.DeploymentConfigs(ns).Get("router", metav1.GetOptions{})
+		if err == nil {
+			return dc.Spec.Template, ns, nil
+		}
+		if !errors.IsNotFound(err) {
+			return nil, "", err
+		}
+		deploy, err := k8sappsclient.Deployments(ns).Get("router", metav1.GetOptions{})
+		if err == nil {
+			return &deploy.Spec.Template, ns, nil
+		}
+		if !errors.IsNotFound(err) {
+			return nil, "", err
+		}
+	}
+	return nil, "", errors.NewNotFound(schema.GroupResource{Group: "apps.openshift.io", Resource: "deploymentconfigs"}, "router")
+}
+
+func FindImageFormatString(oc *CLI) (string, bool) {
+	// the router is expected to be on all clusters
+	// TODO: switch this to read from the global config
+	template, _, err := GetRouterPodTemplate(oc)
+	if err == nil {
+		return strings.Replace(template.Spec.Containers[0].Image, "haproxy-router", "${component}", -1), true
+	}
+	return "openshift/origin-${component}:latest", false
 }


### PR DESCRIPTION
In preparation for the move to operators, look at both DC and deployments
and at multiple namespaces. Abstract format string lookup into its own
method for future changes.

@ironcladlou