### PR TITLE
UPSTREAM: 61071: Fix potential segfault in kubelet volume reconstruction

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -484,7 +484,7 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (*reconstructedVolume,
 	// Check existence of mount point for filesystem volume or symbolic link for block volume
 	isExist, checkErr := volumeHandler.CheckVolumeExistence(volume.mountPath, volumeSpec.Name(), rc.mounter, uniqueVolumeName, volume.podName, pod.UID, attachablePlugin)
 	if checkErr != nil {
-		return nil, err
+		return nil, checkErr
 	}
 	// If mount or symlink doesn't exist, volume reconstruction should be failed
 	if !isExist {


### PR DESCRIPTION
There is an apparent typo in the reconstructVolume method that may cause the kubelet to enter a crash loop if the mount point of the reconstructed volume does not exist.

This was fixed as a side-effect of unrelated problem in Kuberentes 1.10.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1612006