### PR TITLE
switch template controller to external

### DIFF
--- a/pkg/api/legacy/install.go
+++ b/pkg/api/legacy/install.go
@@ -18,6 +18,11 @@ func Kind(kind string) schema.GroupKind {
 }
 
 // DEPRECATED
+func GroupVersionKind(kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: GroupName, Version: GroupVersion.Version, Kind: kind}
+}
+
+// DEPRECATED
 func Resource(resource string) schema.GroupResource {
 	return schema.GroupResource{Group: GroupName, Resource: resource}
 }

--- a/pkg/cmd/openshift-controller-manager/controller/template.go
+++ b/pkg/cmd/openshift-controller-manager/controller/template.go
@@ -22,8 +22,8 @@ func RunTemplateInstanceController(ctx *ControllerContext) (bool, error) {
 		ctx.RestMapper,
 		dynamicClient,
 		ctx.ClientBuilder.ClientGoClientOrDie(saName).AuthorizationV1(),
-		ctx.ClientBuilder.KubeInternalClientOrDie(saName),
-		ctx.ClientBuilder.OpenshiftInternalBuildClientOrDie(saName),
+		ctx.ClientBuilder.ClientGoClientOrDie(saName),
+		ctx.ClientBuilder.OpenshiftBuildClientOrDie(saName),
 		ctx.ClientBuilder.OpenshiftTemplateClientOrDie(saName).TemplateV1(),
 		ctx.InternalTemplateInformers.Template().V1().TemplateInstances(),
 	).Run(5, ctx.Stop)

--- a/pkg/template/controller/metrics.go
+++ b/pkg/template/controller/metrics.go
@@ -3,11 +3,12 @@ package controller
 import (
 	"time"
 
-	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	templatev1 "github.com/openshift/api/template/v1"
 )
 
 var templateInstanceCompleted = prometheus.NewCounterVec(

--- a/pkg/template/controller/readiness.go
+++ b/pkg/template/controller/readiness.go
@@ -1,90 +1,157 @@
 package controller
 
 import (
+	"fmt"
 	"strconv"
 
+	kappsv1 "k8s.io/api/apps/v1"
+	kappsv1beta1 "k8s.io/api/apps/v1beta1"
+	kappsv1beta2 "k8s.io/api/apps/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	kextensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/apis/apps"
-	"k8s.io/kubernetes/pkg/apis/batch"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/extensions"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 
-	oapps "github.com/openshift/api/apps"
-	"github.com/openshift/api/build"
-	"github.com/openshift/api/route"
+	appsv1 "github.com/openshift/api/apps/v1"
+	buildv1 "github.com/openshift/api/build/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	buildv1client "github.com/openshift/client-go/build/clientset/versioned"
 	"github.com/openshift/origin/pkg/api/legacy"
-	appsapi "github.com/openshift/origin/pkg/apps/apis/apps"
-	buildapi "github.com/openshift/origin/pkg/build/apis/build"
-	buildinternalhelpers "github.com/openshift/origin/pkg/build/apis/build/internal_helpers"
-	buildclient "github.com/openshift/origin/pkg/build/generated/internalclientset"
+	appsutil "github.com/openshift/origin/pkg/apps/util"
 	buildutil "github.com/openshift/origin/pkg/build/util"
-	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 )
+
+// readinessScheme defines a scheme which include only resources this controller understand how to get the readiness checks.
+var readinessScheme = runtime.NewScheme()
+
+func init() {
+	kappsv1.AddToScheme(readinessScheme)
+	kappsv1beta1.AddToScheme(readinessScheme)
+	kappsv1beta2.AddToScheme(readinessScheme)
+	kextensionsv1beta1.AddToScheme(readinessScheme)
+	batchv1.AddToScheme(readinessScheme)
+	corev1.AddToScheme(readinessScheme)
+	appsv1.Install(readinessScheme)
+	buildv1.Install(readinessScheme)
+	routev1.Install(readinessScheme)
+}
 
 // checkBuildReadiness determins if a Build is ready, failed or neither.
 func checkBuildReadiness(obj runtime.Object) (bool, bool, error) {
-	b := obj.(*buildapi.Build)
+	b, ok := obj.(*buildv1.Build)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.Build", obj)
+	}
 
-	ready := buildinternalhelpers.IsTerminalPhase(b.Status.Phase) &&
-		b.Status.Phase == buildapi.BuildPhaseComplete
+	ready := buildutil.IsTerminalPhase(b.Status.Phase) &&
+		b.Status.Phase == buildv1.BuildPhaseComplete
 
-	failed := buildinternalhelpers.IsTerminalPhase(b.Status.Phase) &&
-		b.Status.Phase != buildapi.BuildPhaseComplete
+	failed := buildutil.IsTerminalPhase(b.Status.Phase) &&
+		b.Status.Phase != buildv1.BuildPhaseComplete
 
 	return ready, failed, nil
 }
 
 // checkBuildConfigReadiness determins if a BuildConfig is ready, failed or
 // neither.  TODO: this should be reported on the BuildConfig object itself.
-func checkBuildConfigReadiness(oc buildclient.Interface, obj runtime.Object) (bool, bool, error) {
-	bc := obj.(*buildapi.BuildConfig)
+func checkBuildConfigReadiness(oc buildv1client.Interface, obj runtime.Object) (bool, bool, error) {
+	bc, ok := obj.(*buildv1.BuildConfig)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.BuildConfig", obj)
+	}
 
-	builds, err := oc.Build().Builds(bc.Namespace).List(metav1.ListOptions{LabelSelector: buildutil.BuildConfigSelector(bc.Name).String()})
+	builds, err := oc.BuildV1().Builds(bc.Namespace).List(metav1.ListOptions{LabelSelector: buildutil.BuildConfigSelector(bc.Name).String()})
 	if err != nil {
 		return false, false, err
 	}
 
-	for _, build := range builds.Items {
-		if build.Annotations[buildapi.BuildNumberAnnotation] == strconv.FormatInt(bc.Status.LastVersion, 10) {
-			return checkBuildReadiness(&build)
+	for _, item := range builds.Items {
+		if item.Annotations[buildutil.BuildNumberAnnotation] == strconv.FormatInt(bc.Status.LastVersion, 10) {
+			return checkBuildReadiness(&item)
 		}
 	}
 
 	return false, false, nil
 }
 
+type deploymentCondition struct {
+	status corev1.ConditionStatus
+	reason string
+}
+
+func newDeploymentCondition(status corev1.ConditionStatus, reason string) *deploymentCondition {
+	return &deploymentCondition{
+		status: status,
+		reason: reason,
+	}
+}
+
 // checkDeploymentReadiness determins if a Deployment is ready, failed or
 // neither.
 func checkDeploymentReadiness(obj runtime.Object) (bool, bool, error) {
-	d := obj.(*extensions.Deployment)
-
-	var progressing, available *extensions.DeploymentCondition
-	for i, condition := range d.Status.Conditions {
-		switch condition.Type {
-		case extensions.DeploymentProgressing:
-			progressing = &d.Status.Conditions[i]
-
-		case extensions.DeploymentAvailable:
-			available = &d.Status.Conditions[i]
+	var (
+		isSynced               bool
+		progressing, available *deploymentCondition
+	)
+	switch d := obj.(type) {
+	case *kappsv1.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kappsv1.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kappsv1.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
 		}
+	case *kappsv1beta1.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kappsv1beta1.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kappsv1beta1.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	case *kappsv1beta2.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kappsv1beta2.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kappsv1beta2.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	case *kextensionsv1beta1.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kextensionsv1beta1.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kextensionsv1beta1.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	default:
+		return false, false, fmt.Errorf("unsupported deployment version: %T", d)
 	}
 
-	ready := d.Status.ObservedGeneration == d.Generation &&
-		progressing != nil &&
-		progressing.Status == kapi.ConditionTrue &&
-		progressing.Reason == deploymentutil.NewRSAvailableReason &&
-		available != nil &&
-		available.Status == kapi.ConditionTrue
+	if !isSynced || progressing == nil {
+		return false, false, nil
+	}
 
-	failed := d.Status.ObservedGeneration == d.Generation &&
-		progressing != nil &&
-		progressing.Status == kapi.ConditionFalse
+	ready := progressing.status == corev1.ConditionTrue &&
+		progressing.reason == deploymentutil.NewRSAvailableReason &&
+		available != nil &&
+		available.status == corev1.ConditionTrue
+
+	failed := progressing.status == corev1.ConditionFalse
 
 	return ready, failed, nil
 }
@@ -92,112 +159,147 @@ func checkDeploymentReadiness(obj runtime.Object) (bool, bool, error) {
 // checkDeploymentConfigReadiness determins if a DeploymentConfig is ready,
 // failed or neither.
 func checkDeploymentConfigReadiness(obj runtime.Object) (bool, bool, error) {
-	dc := obj.(*appsapi.DeploymentConfig)
+	dc, ok := obj.(*appsv1.DeploymentConfig)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.DeploymentConfig", obj)
+	}
 
-	var progressing, available *appsapi.DeploymentCondition
+	var progressing, available *appsv1.DeploymentCondition
 	for i, condition := range dc.Status.Conditions {
 		switch condition.Type {
-		case appsapi.DeploymentProgressing:
+		case appsv1.DeploymentProgressing:
 			progressing = &dc.Status.Conditions[i]
 
-		case appsapi.DeploymentAvailable:
+		case appsv1.DeploymentAvailable:
 			available = &dc.Status.Conditions[i]
 		}
 	}
 
 	ready := dc.Status.ObservedGeneration == dc.Generation &&
 		progressing != nil &&
-		progressing.Status == kapi.ConditionTrue &&
-		progressing.Reason == appsapi.NewRcAvailableReason &&
+		progressing.Status == corev1.ConditionTrue &&
+		progressing.Reason == appsutil.NewRcAvailableReason &&
 		available != nil &&
-		available.Status == kapi.ConditionTrue
+		available.Status == corev1.ConditionTrue
 
 	failed := dc.Status.ObservedGeneration == dc.Generation &&
 		progressing != nil &&
-		progressing.Status == kapi.ConditionFalse
+		progressing.Status == corev1.ConditionFalse
 
 	return ready, failed, nil
 }
 
 // checkJobReadiness determins if a Job is ready, failed or neither.
 func checkJobReadiness(obj runtime.Object) (bool, bool, error) {
-	job := obj.(*batch.Job)
-
-	ready := job.Status.CompletionTime != nil
-	failed := job.Status.Failed > 0
-
-	return ready, failed, nil
+	var (
+		hasCompletionTime bool
+		isJobFailed       bool
+	)
+	switch j := obj.(type) {
+	case *batchv1.Job:
+		hasCompletionTime = j.Status.CompletionTime != nil
+		isJobFailed = j.Status.Failed > 0
+	default:
+		return false, false, fmt.Errorf("unsupported job version: %T", j)
+	}
+	return hasCompletionTime, isJobFailed, nil
 }
 
 // checkStatefulSetReadiness determins if a StatefulSet is ready, failed or
 // neither.
 func checkStatefulSetReadiness(obj runtime.Object) (bool, bool, error) {
-	ss := obj.(*apps.StatefulSet)
+	var (
+		isSynced         bool
+		hasReplicasReady bool
+	)
 
-	ready := ss.Status.ObservedGeneration != nil &&
-		*ss.Status.ObservedGeneration == ss.Generation &&
-		ss.Status.ReadyReplicas == ss.Spec.Replicas
-	failed := false
+	switch s := obj.(type) {
+	case *kappsv1.StatefulSet:
+		isSynced = s.Status.ObservedGeneration == s.Generation
+		hasReplicasReady = s.Spec.Replicas != nil && s.Status.ReadyReplicas == *s.Spec.Replicas
+	case *kappsv1beta1.StatefulSet:
+		isSynced = s.Status.ObservedGeneration != nil && *s.Status.ObservedGeneration == s.Generation
+		hasReplicasReady = s.Spec.Replicas != nil && s.Status.ReadyReplicas == *s.Spec.Replicas
+	case *kappsv1beta2.StatefulSet:
+		isSynced = s.Status.ObservedGeneration == s.Generation
+		hasReplicasReady = s.Spec.Replicas != nil && s.Status.ReadyReplicas == *s.Spec.Replicas
+	default:
+		return false, false, fmt.Errorf("unsupported statefulset version: %T", s)
+	}
 
-	return ready, failed, nil
+	return isSynced && hasReplicasReady, false, nil
 }
 
 // checkRouteReadiness checks if host field was prepopulated already.
 func checkRouteReadiness(obj runtime.Object) (bool, bool, error) {
-	route := obj.(*routeapi.Route)
-	ready := route.Spec.Host != ""
-	failed := false
+	route, ok := obj.(*routev1.Route)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.Route", obj)
+	}
+	return len(route.Spec.Host) > 0, false, nil
+}
 
-	return ready, failed, nil
+func groupVersionKind(gv schema.GroupVersion, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   gv.Group,
+		Version: gv.Version,
+		Kind:    kind,
+	}
 }
 
 // readinessCheckers maps GroupKinds to the appropriate function.  Note that in
 // some cases more than one GK maps to the same function.
-var readinessCheckers = map[schema.GroupKind]func(runtime.Object) (bool, bool, error){
-	build.Kind("Build"):             checkBuildReadiness,
-	apps.Kind("Deployment"):         checkDeploymentReadiness,
-	extensions.Kind("Deployment"):   checkDeploymentReadiness,
-	oapps.Kind("DeploymentConfig"):  checkDeploymentConfigReadiness,
-	batch.Kind("Job"):               checkJobReadiness,
-	apps.Kind("StatefulSet"):        checkStatefulSetReadiness,
-	route.Kind("Route"):             checkRouteReadiness,
-	legacy.Kind("Build"):            checkBuildReadiness,
-	legacy.Kind("DeploymentConfig"): checkDeploymentConfigReadiness,
-	legacy.Kind("Route"):            checkRouteReadiness,
+var readinessCheckers = map[schema.GroupVersionKind]func(runtime.Object) (bool, bool, error){
+	// OpenShift kinds:
+	groupVersionKind(buildv1.GroupVersion, "Build"):           checkBuildReadiness,
+	groupVersionKind(appsv1.GroupVersion, "DeploymentConfig"): checkDeploymentConfigReadiness,
+	groupVersionKind(routev1.GroupVersion, "Route"):           checkRouteReadiness,
+
+	// Legacy (/oapi) kinds:
+	legacy.GroupVersionKind("Build"):            checkBuildReadiness,
+	legacy.GroupVersionKind("DeploymentConfig"): checkDeploymentConfigReadiness,
+	legacy.GroupVersionKind("Route"):            checkRouteReadiness,
+
+	// Kubernetes kinds:
+	groupVersionKind(kappsv1.SchemeGroupVersion, "Deployment"):            checkDeploymentReadiness,
+	groupVersionKind(kappsv1beta1.SchemeGroupVersion, "Deployment"):       checkDeploymentReadiness,
+	groupVersionKind(kappsv1beta2.SchemeGroupVersion, "Deployment"):       checkDeploymentReadiness,
+	groupVersionKind(kextensionsv1beta1.SchemeGroupVersion, "Deployment"): checkDeploymentReadiness,
+	groupVersionKind(kappsv1.SchemeGroupVersion, "StatefulSet"):           checkStatefulSetReadiness,
+	groupVersionKind(kappsv1beta1.SchemeGroupVersion, "StatefulSet"):      checkStatefulSetReadiness,
+	groupVersionKind(kappsv1beta2.SchemeGroupVersion, "StatefulSet"):      checkStatefulSetReadiness,
+	groupVersionKind(batchv1.SchemeGroupVersion, "Job"):                   checkJobReadiness,
 }
 
 // CanCheckReadiness indicates whether a readiness check exists for a GK.
 func CanCheckReadiness(ref corev1.ObjectReference) bool {
-	switch ref.GroupVersionKind().GroupKind() {
-	case build.Kind("BuildConfig"), schema.GroupKind{Group: "", Kind: "BuildConfig"}:
+	switch ref.GroupVersionKind() {
+	case groupVersionKind(buildv1.GroupVersion, "BuildConfig"), groupVersionKind(legacy.GroupVersion, "BuildConfig"):
 		return true
 	}
-	_, found := readinessCheckers[ref.GroupVersionKind().GroupKind()]
+	_, found := readinessCheckers[ref.GroupVersionKind()]
 	return found
 }
 
-// CheckReadiness runs the readiness check on a given object.  TODO: remove
-// "oc client.Interface" and error once BuildConfigs can report on the status of
-// their latest build.
-func CheckReadiness(oc buildclient.Interface, ref corev1.ObjectReference, obj *unstructured.Unstructured) (bool, bool, error) {
-	castObj, err := legacyscheme.Scheme.New(ref.GroupVersionKind())
+// CheckReadiness runs the readiness check on a given object.
+// TODO: remove "oc client.Interface" and error once BuildConfigs can report on the status of their latest build.
+func CheckReadiness(oc buildv1client.Interface, ref corev1.ObjectReference, obj *unstructured.Unstructured) (bool, bool, error) {
+	castObj, err := readinessScheme.New(ref.GroupVersionKind())
 	if err != nil {
 		return false, false, err
 	}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, castObj); err != nil {
 		return false, false, err
 	}
-	internalObj, err := legacyscheme.Scheme.New(ref.GroupVersionKind().GroupKind().WithVersion(runtime.APIVersionInternal))
-	if err != nil {
-		return false, false, err
-	}
-	if err := legacyscheme.Scheme.Convert(castObj, internalObj, nil); err != nil {
-		return false, false, err
+
+	switch ref.GroupVersionKind() {
+	case groupVersionKind(buildv1.GroupVersion, "BuildConfig"), groupVersionKind(legacy.GroupVersion, "BuildConfig"):
+		return checkBuildConfigReadiness(oc, castObj)
 	}
 
-	switch ref.GroupVersionKind().GroupKind() {
-	case build.Kind("BuildConfig"), schema.GroupKind{Group: "", Kind: "BuildConfig"}:
-		return checkBuildConfigReadiness(oc, internalObj)
+	readinessCheckFunc, ok := readinessCheckers[ref.GroupVersionKind()]
+	if !ok {
+		return false, false, fmt.Errorf("readiness check for %+v is not defined", ref.GroupVersionKind())
 	}
-	return readinessCheckers[ref.GroupVersionKind().GroupKind()](internalObj)
+	return readinessCheckFunc(castObj)
 }

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -159,7 +159,7 @@ func dumpObjectReadiness(oc *exutil.CLI, templateInstance *templatev1.TemplateIn
 			continue
 		}
 
-		ready, failed, err := controller.CheckReadiness(oc.InternalBuildClient(), object.Ref, obj)
+		ready, failed, err := controller.CheckReadiness(oc.BuildClient(), object.Ref, obj)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Switches the template controller to external types and external build client. This is on a path for eliminating the internal build client entirely.

/cc @bparees 
/cc @deads2k 