### PR TITLE
 RPMS - Add stub /etc/sysconfig/origin-node 

### DIFF
--- a/contrib/systemd/origin-node.sysconfig
+++ b/contrib/systemd/origin-node.sysconfig
@@ -1,0 +1,1 @@
+# populated by openshift-ansible

--- a/origin.spec
+++ b/origin.spec
@@ -304,6 +304,9 @@ done
 
 install -d -m 0755 %{buildroot}%{_sysconfdir}/origin/{master,node}
 
+# stub filed required to ensure config is not reverted during upgrades
+install -m 0644 contrib/systemd/origin-node.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/%{name}-node
+
 # Install man1 man pages
 install -d -m 0755 %{buildroot}%{_mandir}/man1
 install -m 0644 docs/man/man1/* %{buildroot}%{_mandir}/man1/
@@ -385,6 +388,7 @@ touch --reference=%{SOURCE0} $RPM_BUILD_ROOT/usr/sbin/%{name}-docker-excluder
 %files node
 %{_bindir}/openshift-node-config
 %{_sysconfdir}/systemd/system.conf.d/origin-accounting.conf
+%config(noreplace) %{_sysconfdir}/sysconfig/%{name}-node
 %defattr(-,root,root,0700)
 %config(noreplace) %{_sysconfdir}/origin/node
 


### PR DESCRIPTION
This file is wholely managed by openshift-ansible. However if we remove
the file from the RPM entirely then that will delete the file during
upgrades to the newer version. So leave the file in the package with
empty contents. The %config(noreplace) directive will ensure that RPM
doesn't replace local modifications when upgrading.

/cc @sjenning @vrutkovs @smarterclayton 
Supersedes #20683 