### PR TITLE
WIP: Extend ResourcePrinter interface

### DIFF
--- a/pkg/oc/cli/newapp/newapp.go
+++ b/pkg/oc/cli/newapp/newapp.go
@@ -174,6 +174,10 @@ type versionedPrintObj struct {
 	cmd     *cobra.Command
 }
 
+func (p *versionedPrintObj) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 func (p *versionedPrintObj) PrintObj(obj runtime.Object, out io.Writer) error {
 	printFn := print.VersionedPrintObject(func(cmd *cobra.Command, obj runtime.Object, out io.Writer) error {
 		return p.printer.PrintObj(obj, out)

--- a/pkg/oc/cli/process/process.go
+++ b/pkg/oc/cli/process/process.go
@@ -174,6 +174,10 @@ type processPrinter struct {
 	outputFormat string
 }
 
+func (p *processPrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 func (p *processPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	if p.outputFormat == "describe" {
 		templateObj, ok := obj.(*templatev1.Template)

--- a/pkg/oc/cli/rollout/latest.go
+++ b/pkg/oc/cli/rollout/latest.go
@@ -212,6 +212,10 @@ func (o *RolloutLatestOptions) RunRolloutLatest() error {
 
 type revisionPrinter struct{}
 
+func (p *revisionPrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 func (p *revisionPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 	dc, ok := obj.(*appsv1.DeploymentConfig)
 	if !ok {

--- a/pkg/oc/cli/set/routebackends.go
+++ b/pkg/oc/cli/set/routebackends.go
@@ -94,7 +94,7 @@ type BackendsOptions struct {
 
 func NewBackendsOptions(streams genericclioptions.IOStreams) *BackendsOptions {
 	return &BackendsOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("backends updated").WithTypeSetter(scheme.Scheme),
+		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
 		IOStreams:  streams,
 	}
 }
@@ -157,9 +157,6 @@ func (o *BackendsOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args 
 	}
 	o.Builder = f.NewBuilder
 
-	if o.DryRun {
-		o.PrintFlags.Complete("%s (dry run)")
-	}
 	o.Printer, err = o.PrintFlags.ToPrinter()
 	if err != nil {
 		return err
@@ -238,7 +235,7 @@ func (o *BackendsOptions) Run() error {
 		}
 
 		if o.Local || o.DryRun {
-			if err := o.Printer.PrintObj(info.Object, o.Out); err != nil {
+			if err := o.Printer.PrintfObj("%s backends updated (dry run)", info.Object, o.Out); err != nil {
 				allErrs = append(allErrs, err)
 			}
 			continue
@@ -250,7 +247,7 @@ func (o *BackendsOptions) Run() error {
 			continue
 		}
 
-		if err := o.Printer.PrintObj(actual, o.Out); err != nil {
+		if err := o.Printer.PrintfObj("%s backends updated", actual, o.Out); err != nil {
 			allErrs = append(allErrs, err)
 		}
 	}

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/interface.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/interface.go
@@ -30,8 +30,15 @@ func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
 	return fn(obj, w)
 }
 
+// PrintObj implements ResourcePrinter
+func (fn ResourcePrinterFunc) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return fn(obj, w)
+}
+
 // ResourcePrinter is an interface that knows how to print runtime objects.
 type ResourcePrinter interface {
 	// Print receives a runtime object, formats it and prints it to a writer.
 	PrintObj(runtime.Object, io.Writer) error
+	// Print receives a runtime object, formats it according to passed format and prints it to a writer.
+	PrintfObj(string, runtime.Object, io.Writer) error
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/json.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/json.go
@@ -32,6 +32,10 @@ import (
 // JSONPrinter is an implementation of ResourcePrinter which outputs an object as JSON.
 type JSONPrinter struct{}
 
+func (p *JSONPrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 // PrintObj is an implementation of ResourcePrinter.PrintObj which simply writes the object to the Writer.
 func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	// we use reflect.Indirect here in order to obtain the actual value from a pointer.
@@ -75,6 +79,10 @@ func (p *JSONPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 type YAMLPrinter struct {
 	version   string
 	converter runtime.ObjectConvertor
+}
+
+func (p *YAMLPrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
 }
 
 // PrintObj prints the data as YAML.

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/jsonpath.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/jsonpath.go
@@ -114,6 +114,10 @@ func NewJSONPathPrinter(tmpl string) (*JSONPathPrinter, error) {
 	}, nil
 }
 
+func (p *JSONPathPrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 // PrintObj formats the obj with the JSONPath Template.
 func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	// we use reflect.Indirect here in order to obtain the actual value from a pointer.

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/template.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/template.go
@@ -60,6 +60,10 @@ func (p *TemplatePrinter) AfterPrint(w io.Writer, res string) error {
 	return nil
 }
 
+func (p *TemplatePrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 // PrintObj formats the obj with the Go Template.
 func (p *TemplatePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 	if InternalObjectPreventer.IsForbidden(reflect.Indirect(reflect.ValueOf(obj)).Type().PkgPath()) {
@@ -152,6 +156,10 @@ func (p *GoTemplatePrinter) AllowMissingKeys(allow bool) {
 	} else {
 		p.template.Option("missingkey=error")
 	}
+}
+
+func (p *GoTemplatePrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
 }
 
 // PrintObj formats the obj with the Go Template.

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/typesetter.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/printers/typesetter.go
@@ -36,6 +36,10 @@ func NewTypeSetter(typer runtime.ObjectTyper) *TypeSetterPrinter {
 	return &TypeSetterPrinter{Typer: typer}
 }
 
+func (p *TypeSetterPrinter) PrintfObj(format string, obj runtime.Object, w io.Writer) error {
+	return p.PrintObj(obj, w)
+}
+
 // PrintObj is an implementation of ResourcePrinter.PrintObj which sets type information on the obj for the duration
 // of printing.  It is NOT threadsafe.
 func (p *TypeSetterPrinter) PrintObj(obj runtime.Object, w io.Writer) error {


### PR DESCRIPTION
This PR is presenting how we could extend the `ResourcePrinter` interface, or eventually change it to the new method. There are 3 commits here:
1. is the actual change (the upstream commit)
2. you can ignore this one, it's only to make stuff compilable 
3. example invocation in `oc set routebackeds` and `oc cancel-build`

/assign @deads2k @juanvallejo 