### PR TITLE
Fix NameFromCommandArgs when passing command after -- 

### DIFF
--- a/pkg/oc/cli/create/create.go
+++ b/pkg/oc/cli/create/create.go
@@ -1,8 +1,6 @@
 package create
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/origin/pkg/oc/util/ocscheme"
@@ -36,7 +34,7 @@ func NewCreateSubcommandOptions(ioStreams genericclioptions.IOStreams) *CreateSu
 }
 
 func (o *CreateSubcommandOptions) Complete(f genericclioptions.RESTClientGetter, cmd *cobra.Command, args []string) error {
-	name, err := NameFromCommandArgs(args)
+	name, err := NameFromCommandArgs(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -60,9 +58,15 @@ func (o *CreateSubcommandOptions) Complete(f genericclioptions.RESTClientGetter,
 }
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name
-func NameFromCommandArgs(args []string) (string, error) {
-	if len(args) != 1 {
-		return "", fmt.Errorf("exactly one NAME is required, got %d", len(args))
+func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
+	argsLen := cmd.ArgsLenAtDash()
+	// ArgsLenAtDash returns -1 when -- was not specified
+	if argsLen == -1 {
+		argsLen = len(args)
+	}
+	if argsLen != 1 {
+		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", argsLen)
 	}
 	return args[0], nil
+
 }

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -13,6 +13,8 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/create"
 # validate --dry-run outputs correct success message
 os::cmd::expect_success_and_text 'oc create quota quota --dry-run' 'resourcequota/quota created \(dry run\)'
+# validate -- works in create
+os::cmd::expect_success_and_text 'oc create deploymentconfig sleep --image=busybox -- /bin/sleep infinity' 'deploymentconfig.apps.openshift.io/sleep created'
 
 echo "oc create: ok"
 os::test::junit::declare_suite_end

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create/create.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/create/create.go
@@ -327,8 +327,13 @@ func createAndRefresh(info *resource.Info) error {
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name
 func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
-	if len(args) != 1 {
-		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", len(args))
+	argsLen := cmd.ArgsLenAtDash()
+	// ArgsLenAtDash returns -1 when -- was not specified
+	if argsLen == -1 {
+		argsLen = len(args)
+	}
+	if argsLen != 1 {
+		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", argsLen)
 	}
 	return args[0], nil
 }


### PR DESCRIPTION
Fix following invocation:
`oc create deploymentconfig name --image=myimage -- myargs`

/assign @juanvallejo @mfojtik 

Fixes #20728.