### PR TITLE
Minor fixup to egress IP monitoring

### DIFF
--- a/pkg/network/node/vxlan_monitor.go
+++ b/pkg/network/node/vxlan_monitor.go
@@ -183,7 +183,7 @@ func (evm *egressVXLANMonitor) check(retryOnly bool) bool {
 			utilruntime.HandleError(fmt.Errorf("Could not parse %q: %v", flow, err))
 			continue
 		}
-		outTraffic[tunDst] = nPackets
+		outTraffic[tunDst] += nPackets
 	}
 
 	retry := false


### PR DESCRIPTION
For nodes that host multiple egress IPs, we were accidentally only monitoring the traffic on the last IP, so we wouldn't notice that the node had gone down until someone tried and failed to access *that* egress IP, rather than trying and failing to access *any* egress IP on the node.

The actual fix is one character long; most of this is just updating the unit test...