### PR TITLE
git: copy struct fields and lose the s2i dependency

### DIFF
--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -16,8 +16,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-
-	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
 )
 
 // Repository represents a git source repository
@@ -64,7 +62,45 @@ var ErrGitNotAvailable = errors.New("git binary not available")
 
 // SourceInfo stores information about the source code
 type SourceInfo struct {
-	s2igit.SourceInfo
+	// Ref represents a commit SHA-1, valid Git branch name or a Git tag
+	// The output image will contain this information as 'io.openshift.build.commit.ref' label.
+	Ref string
+
+	// CommitID represents an arbitrary extended object reference in Git as SHA-1
+	// The output image will contain this information as 'io.openshift.build.commit.id' label.
+	CommitID string
+
+	// Date contains a date when the committer created the commit.
+	// The output image will contain this information as 'io.openshift.build.commit.date' label.
+	Date string
+
+	// AuthorName contains the name of the author
+	// The output image will contain this information (along with AuthorEmail) as 'io.openshift.build.commit.author' label.
+	AuthorName string
+
+	// AuthorEmail contains the e-mail of the author
+	// The output image will contain this information (along with AuthorName) as 'io.openshift.build.commit.author' lablel.
+	AuthorEmail string
+
+	// CommitterName contains the name of the committer
+	CommitterName string
+
+	// CommitterEmail contains the e-mail of the committer
+	CommitterEmail string
+
+	// Message represents the first 80 characters from the commit message.
+	// The output image will contain this information as 'io.openshift.build.commit.message' label.
+	Message string
+
+	// Location contains a valid URL to the original repository.
+	// The output image will contain this information as 'io.openshift.build.source-location' label.
+	Location string
+
+	// ContextDir contains path inside the Location directory that
+	// contains the application source code.
+	// The output image will contain this information as 'io.openshift.build.source-context-dir'
+	// label.
+	ContextDir string
 }
 
 // execGitFunc is a function that executes a Git command


### PR DESCRIPTION
Prepare pkg/git to be moved to library-go, lose the s2i dependency and just copy the s2i struct fields.

/cc @deads2k 
/cc @smarterclayton 