### PR TITLE
Ignore resources with deletion timestamp during storage migration

### DIFF
--- a/pkg/oc/cli/admin/migrate/storage/storage.go
+++ b/pkg/oc/cli/admin/migrate/storage/storage.go
@@ -302,6 +302,13 @@ func (o *MigrateAPIStorageOptions) save(info *resource.Info, reporter migrate.Re
 			defer o.rateLimit(oldObject)
 		}
 
+		// ignore objects that are being deleted
+		// sometimes objects get stuck in this state
+		// we do not want storage migration to fail in that case
+		if oldObject.GetDeletionTimestamp() != nil {
+			return migrate.ErrUnchanged
+		}
+
 		// we are relying on unstructured types being lossless and unchanging
 		// across a decode and encode round trip (otherwise this command will mutate data)
 		newObject, err := o.client.


### PR DESCRIPTION
This change updates the storage migration code to ignore resources that are in the process of being deleted.  While these resources normally do not cause any issues for storage migration, if something causes the resource to get stuck in a pending deletion state, it can cause storage migration to fail (the no-op PUT can fail if the object no longer accepts updates).

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @smarterclayton