### PR TITLE
admission: split plugins into validating-only and mutating+validating

### DIFF
--- a/pkg/admission/namespaceconditions/labelcondition.go
+++ b/pkg/admission/namespaceconditions/labelcondition.go
@@ -37,6 +37,9 @@ type pluginHandlerWithNamespaceLabelConditions struct {
 	namespaceSelector labels.Selector
 }
 
+var _ admission.ValidationInterface = &pluginHandlerWithNamespaceLabelConditions{}
+var _ admission.MutationInterface = &pluginHandlerWithNamespaceLabelConditions{}
+
 func (p pluginHandlerWithNamespaceLabelConditions) Handles(operation admission.Operation) bool {
 	return p.admissionPlugin.Handles(operation)
 }

--- a/pkg/admission/namespaceconditions/namecondition.go
+++ b/pkg/admission/namespaceconditions/namecondition.go
@@ -12,6 +12,9 @@ type pluginHandlerWithNamespaceNameConditions struct {
 	namespacesToExclude sets.String
 }
 
+var _ admission.ValidationInterface = &pluginHandlerWithNamespaceNameConditions{}
+var _ admission.MutationInterface = &pluginHandlerWithNamespaceNameConditions{}
+
 func (p pluginHandlerWithNamespaceNameConditions) Handles(operation admission.Operation) bool {
 	return p.admissionPlugin.Handles(operation)
 }

--- a/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
@@ -35,7 +35,7 @@ type GroupCache interface {
 	GroupsFor(string) ([]*userapi.Group, error)
 }
 
-// restrictUsersAdmission implements admission.Interface and enforces
+// restrictUsersAdmission implements admission.ValidateInterface and enforces
 // restrictions on adding rolebindings in a project to permit only designated
 // subjects.
 type restrictUsersAdmission struct {
@@ -50,6 +50,7 @@ type restrictUsersAdmission struct {
 var _ = oadmission.WantsRESTClientConfig(&restrictUsersAdmission{})
 var _ = oadmission.WantsUserInformer(&restrictUsersAdmission{})
 var _ = kadmission.WantsInternalKubeClientSet(&restrictUsersAdmission{})
+var _ = admission.ValidationInterface(&restrictUsersAdmission{})
 
 // NewRestrictUsersAdmission configures an admission plugin that enforces
 // restrictions on adding role bindings in a project.
@@ -106,7 +107,7 @@ func subjectsDelta(elementsToIgnore, elements []rbac.Subject) []rbac.Subject {
 // project-scoped role-bindings.  In order for a role binding to be permitted,
 // each subject in the binding must be matched by some rolebinding restriction
 // in the namespace.
-func (q *restrictUsersAdmission) Admit(a admission.Attributes) (err error) {
+func (q *restrictUsersAdmission) Validate(a admission.Attributes) (err error) {
 
 	// We only care about rolebindings
 	if a.GetResource().GroupResource() != rbac.Resource("rolebindings") {

--- a/pkg/authorization/apiserver/admission/restrictusers/restrictusers_test.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/restrictusers_test.go
@@ -384,7 +384,7 @@ func TestAdmission(t *testing.T) {
 			&user.DefaultInfo{},
 		)
 
-		err = plugin.(admission.MutationInterface).Admit(attributes)
+		err = plugin.(admission.ValidationInterface).Validate(attributes)
 		switch {
 		case len(tc.expectedErr) == 0 && err == nil:
 		case len(tc.expectedErr) == 0 && err != nil:

--- a/pkg/build/apiserver/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/apiserver/admission/jenkinsbootstrapper/admission.go
@@ -50,6 +50,7 @@ var _ = WantsJenkinsPipelineConfig(&jenkinsBootstrapper{})
 var _ = oadmission.WantsRESTClientConfig(&jenkinsBootstrapper{})
 var _ = kadmission.WantsInternalKubeClientSet(&jenkinsBootstrapper{})
 var _ = kadmission.WantsRESTMapper(&jenkinsBootstrapper{})
+var _ = admission.ValidationInterface(&jenkinsBootstrapper{})
 
 // NewJenkinsBootstrapper returns an admission plugin that will create required jenkins resources as the user if they are needed.
 func NewJenkinsBootstrapper() admission.Interface {
@@ -58,7 +59,7 @@ func NewJenkinsBootstrapper() admission.Interface {
 	}
 }
 
-func (a *jenkinsBootstrapper) Admit(attributes admission.Attributes) error {
+func (a *jenkinsBootstrapper) Validate(attributes admission.Attributes) error {
 	if a.jenkinsConfig.AutoProvisionEnabled != nil && !*a.jenkinsConfig.AutoProvisionEnabled {
 		return nil
 	}

--- a/pkg/build/apiserver/admission/jenkinsbootstrapper/admission_test.go
+++ b/pkg/build/apiserver/admission/jenkinsbootstrapper/admission_test.go
@@ -139,7 +139,7 @@ func TestAdmission(t *testing.T) {
 		}
 		admission.SetInternalKubeClientSet(kubeClient)
 
-		err := admission.Admit(tc.attributes)
+		err := admission.Validate(tc.attributes)
 		switch {
 		case len(tc.expectedErr) == 0 && err == nil:
 		case len(tc.expectedErr) == 0 && err != nil:

--- a/pkg/build/apiserver/admission/secretinjector/admission.go
+++ b/pkg/build/apiserver/admission/secretinjector/admission.go
@@ -1,6 +1,7 @@
 package secretinjector
 
 import (
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -33,8 +34,18 @@ type secretInjector struct {
 }
 
 var _ = oadmission.WantsRESTClientConfig(&secretInjector{})
+var _ = admission.MutationInterface(&secretInjector{})
+var _ = admission.ValidationInterface(&secretInjector{})
 
 func (si *secretInjector) Admit(attr admission.Attributes) (err error) {
+	return si.admit(attr, true)
+}
+
+func (si *secretInjector) Validate(attr admission.Attributes) (err error) {
+	return si.admit(attr, false)
+}
+
+func (si *secretInjector) admit(attr admission.Attributes, mutationAllowed bool) (err error) {
 	bc, ok := attr.GetObject().(*buildapi.BuildConfig)
 	if !ok {
 		return nil
@@ -93,7 +104,11 @@ func (si *secretInjector) Admit(attr admission.Attributes) (err error) {
 	if match := urlpattern.Match(patterns, url); match != nil {
 		secretName := match.Cookie.(string)
 		glog.V(4).Infof(`secretinjector: matched secret "%s/%s" to buildconfig "%s"`, namespace, secretName, bc.GetName())
-		bc.Spec.Source.SourceSecret = &api.LocalObjectReference{Name: secretName}
+		if mutationAllowed {
+			bc.Spec.Source.SourceSecret = &api.LocalObjectReference{Name: secretName}
+		} else {
+			return admission.NewForbidden(attr, fmt.Errorf("mutated spec.source.sourceSecret, expected: %v, got %v", api.LocalObjectReference{Name: secretName}, bc.Spec.Source.SourceSecret))
+		}
 	}
 
 	return nil

--- a/pkg/build/apiserver/admission/strategyrestrictions/admission.go
+++ b/pkg/build/apiserver/admission/strategyrestrictions/admission.go
@@ -42,6 +42,7 @@ type buildByStrategy struct {
 
 var _ = initializer.WantsExternalKubeClientSet(&buildByStrategy{})
 var _ = oadmission.WantsRESTClientConfig(&buildByStrategy{})
+var _ = admission.ValidationInterface(&buildByStrategy{})
 
 // NewBuildByStrategy returns an admission control for builds that checks
 // on policy based on the build strategy type
@@ -51,7 +52,7 @@ func NewBuildByStrategy() admission.Interface {
 	}
 }
 
-func (a *buildByStrategy) Admit(attr admission.Attributes) error {
+func (a *buildByStrategy) Validate(attr admission.Attributes) error {
 	gr := attr.GetResource().GroupResource()
 	switch gr {
 	case build.Resource("buildconfigs"),

--- a/pkg/build/apiserver/admission/strategyrestrictions/admission_test.go
+++ b/pkg/build/apiserver/admission/strategyrestrictions/admission_test.go
@@ -212,7 +212,7 @@ func TestBuildAdmission(t *testing.T) {
 				c.(*buildByStrategy).sarClient = fakeKubeClient.AuthorizationV1().SubjectAccessReviews()
 				c.(*buildByStrategy).buildClient = fakeBuildClient
 				attrs := admission.NewAttributesRecord(test.object, test.oldObject, test.kind.WithVersion("version"), "foo", "test-build", test.resource.WithVersion("version"), test.subResource, op, fakeUser())
-				err := c.(admission.MutationInterface).Admit(attrs)
+				err := c.(admission.ValidationInterface).Validate(attrs)
 				if err != nil && test.expectAccept {
 					t.Errorf("unexpected error: %v", err)
 				}

--- a/pkg/image/apiserver/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/apiserver/admission/imagepolicy/imagepolicy.go
@@ -54,9 +54,6 @@ func Register(plugins *admission.Plugins) {
 		})
 }
 
-var _ admission.MutationInterface = &imagePolicyPlugin{}
-var _ admission.ValidationInterface = &imagePolicyPlugin{}
-
 type imagePolicyPlugin struct {
 	*admission.Handler
 	config *imagepolicy.ImagePolicyConfig
@@ -72,6 +69,8 @@ type imagePolicyPlugin struct {
 
 var _ = oadmission.WantsRESTClientConfig(&imagePolicyPlugin{})
 var _ = oadmission.WantsDefaultRegistryFunc(&imagePolicyPlugin{})
+var _ = admission.ValidationInterface(&imagePolicyPlugin{})
+var _ = admission.MutationInterface(&imagePolicyPlugin{})
 
 type integratedRegistryMatcher struct {
 	rules.RegistryMatcher

--- a/pkg/image/apiserver/admission/limitrange/admission.go
+++ b/pkg/image/apiserver/admission/limitrange/admission.go
@@ -50,6 +50,8 @@ type imageLimitRangerPlugin struct {
 var _ limitranger.LimitRangerActions = &imageLimitRangerPlugin{}
 var _ kadmission.WantsInternalKubeInformerFactory = &imageLimitRangerPlugin{}
 var _ kadmission.WantsInternalKubeClientSet = &imageLimitRangerPlugin{}
+var _ admission.ValidationInterface = &imageLimitRangerPlugin{}
+var _ admission.MutationInterface = &imageLimitRangerPlugin{}
 
 // NewImageLimitRangerPlugin provides a new imageLimitRangerPlugin.
 func NewImageLimitRangerPlugin(config io.Reader) (admission.Interface, error) {

--- a/pkg/network/apiserver/admission/ingress_admission.go
+++ b/pkg/network/apiserver/admission/ingress_admission.go
@@ -42,6 +42,7 @@ type ingressAdmission struct {
 }
 
 var _ = initializer.WantsAuthorizer(&ingressAdmission{})
+var _ = admission.ValidationInterface(&ingressAdmission{})
 
 func NewIngressAdmission(config *ingressadmission.IngressAdmissionConfig) *ingressAdmission {
 	return &ingressAdmission{
@@ -80,7 +81,7 @@ func (r *ingressAdmission) ValidateInitialization() error {
 	return nil
 }
 
-func (r *ingressAdmission) Admit(a admission.Attributes) error {
+func (r *ingressAdmission) Validate(a admission.Attributes) error {
 	if a.GetResource().GroupResource() == kextensions.Resource("ingresses") {
 		switch a.GetOperation() {
 		case admission.Create:

--- a/pkg/network/apiserver/admission/ingress_admission_test.go
+++ b/pkg/network/apiserver/admission/ingress_admission_test.go
@@ -147,7 +147,7 @@ func TestAdmission(t *testing.T) {
 			oldIngress = nil
 		}
 
-		err := handler.Admit(admission.NewAttributesRecord(newIngress, oldIngress, kextensions.Kind("ingresses").WithVersion("Version"), "namespace", newIngress.ObjectMeta.Name, kextensions.Resource("ingresses").WithVersion("version"), "", test.op, nil))
+		err := handler.Validate(admission.NewAttributesRecord(newIngress, oldIngress, kextensions.Kind("ingresses").WithVersion("Version"), "namespace", newIngress.ObjectMeta.Name, kextensions.Resource("ingresses").WithVersion("version"), "", test.op, nil))
 		if test.admit && err != nil {
 			t.Errorf("%s: expected no error but got: %s", test.testName, err)
 		} else if !test.admit && err == nil {

--- a/pkg/project/apiserver/admission/nodeenv/admission.go
+++ b/pkg/project/apiserver/admission/nodeenv/admission.go
@@ -22,7 +22,7 @@ func Register(plugins *admission.Plugins) {
 		})
 }
 
-// podNodeEnvironment is an implementation of admission.Interface.
+// podNodeEnvironment is an implementation of admission.MutationInterface.
 type podNodeEnvironment struct {
 	*admission.Handler
 	client kclientset.Interface
@@ -31,9 +31,11 @@ type podNodeEnvironment struct {
 
 var _ = oadmission.WantsProjectCache(&podNodeEnvironment{})
 var _ = kadmission.WantsInternalKubeClientSet(&podNodeEnvironment{})
+var _ = admission.ValidationInterface(&podNodeEnvironment{})
+var _ = admission.MutationInterface(&podNodeEnvironment{})
 
 // Admit enforces that pod and its project node label selectors matches at least a node in the cluster.
-func (p *podNodeEnvironment) Admit(a admission.Attributes) (err error) {
+func (p *podNodeEnvironment) admit(a admission.Attributes, mutationAllowed bool) (err error) {
 	resource := a.GetResource().GroupResource()
 	if resource != kapi.Resource("pods") {
 		return nil
@@ -67,10 +69,23 @@ func (p *podNodeEnvironment) Admit(a admission.Attributes) (err error) {
 		return apierrors.NewForbidden(resource, name, fmt.Errorf("pod node label selector conflicts with its project node label selector"))
 	}
 
+	if !mutationAllowed && len(labelselector.Merge(projectNodeSelector, pod.Spec.NodeSelector)) != len(pod.Spec.NodeSelector) {
+		// no conflict, different size => pod.Spec.NodeSelector does not contain projectNodeSelector
+		return apierrors.NewForbidden(resource, name, fmt.Errorf("pod node label selector does not extend project node label selector"))
+	}
+
 	// modify pod node selector = project node selector + current pod node selector
 	pod.Spec.NodeSelector = labelselector.Merge(projectNodeSelector, pod.Spec.NodeSelector)
 
 	return nil
+}
+
+func (p *podNodeEnvironment) Admit(a admission.Attributes) (err error) {
+	return p.admit(a, true)
+}
+
+func (p *podNodeEnvironment) Validate(a admission.Attributes) (err error) {
+	return p.admit(a, false)
 }
 
 func (p *podNodeEnvironment) SetProjectCache(c *cache.ProjectCache) {

--- a/pkg/project/apiserver/admission/requestlimit/admission.go
+++ b/pkg/project/apiserver/admission/requestlimit/admission.go
@@ -74,9 +74,10 @@ type projectRequestLimit struct {
 // ensure that the required Openshift admission interfaces are implemented
 var _ = oadmission.WantsProjectCache(&projectRequestLimit{})
 var _ = oadmission.WantsRESTClientConfig(&projectRequestLimit{})
+var _ = admission.ValidationInterface(&projectRequestLimit{})
 
 // Admit ensures that only a configured number of projects can be requested by a particular user.
-func (o *projectRequestLimit) Admit(a admission.Attributes) (err error) {
+func (o *projectRequestLimit) Validate(a admission.Attributes) (err error) {
 	if o.config == nil {
 		return nil
 	}

--- a/pkg/project/apiserver/admission/requestlimit/admission_test.go
+++ b/pkg/project/apiserver/admission/requestlimit/admission_test.go
@@ -283,7 +283,7 @@ func TestAdmit(t *testing.T) {
 		if err = reqLimit.(admission.InitializationValidator).ValidateInitialization(); err != nil {
 			t.Fatalf("validation error: %v", err)
 		}
-		err = reqLimit.(admission.MutationInterface).Admit(admission.NewAttributesRecord(
+		err = reqLimit.(admission.ValidationInterface).Validate(admission.NewAttributesRecord(
 			&projectapi.ProjectRequest{},
 			nil,
 			project.Kind("ProjectRequest").WithVersion("version"),

--- a/pkg/quota/apiserver/admission/clusterresourceoverride/admission_test.go
+++ b/pkg/quota/apiserver/admission/clusterresourceoverride/admission_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -319,44 +320,56 @@ func TestLimitRequestAdmission(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c, err := newClusterResourceOverride(test.config)
-		if err != nil {
-			t.Errorf("%s: config de/serialize failed: %v", test.name, err)
-			continue
-		}
-		// Override LimitRanger with limits from test case
-		c.(*clusterResourceOverridePlugin).limitRangesLister = fakeLimitRangeLister{
-			namespaceLister: fakeLimitRangeNamespaceLister{
-				limits: test.namespaceLimits,
-			},
-		}
-		c.(*clusterResourceOverridePlugin).SetProjectCache(fakeProjectCache(test.namespace))
-		attrs := admission.NewAttributesRecord(test.pod, nil, schema.GroupVersionKind{}, test.namespace.Name, "name", kapi.Resource("pods").WithVersion("version"), "", admission.Create, fakeUser())
-		if err = c.(admission.MutationInterface).Admit(attrs); err != nil {
-			t.Errorf("%s: admission controller returned error: %v", test.name, err)
-			continue
-		}
-		resources := test.pod.Spec.InitContainers[0].Resources // only test one container
-		if actual := resources.Requests[kapi.ResourceMemory]; test.expectedMemRequest.Cmp(actual) != 0 {
-			t.Errorf("%s: memory requests do not match; %v should be %v", test.name, actual, test.expectedMemRequest)
-		}
-		if actual := resources.Requests[kapi.ResourceCPU]; test.expectedCpuRequest.Cmp(actual) != 0 {
-			t.Errorf("%s: cpu requests do not match; %v should be %v", test.name, actual, test.expectedCpuRequest)
-		}
-		if actual := resources.Limits[kapi.ResourceCPU]; test.expectedCpuLimit.Cmp(actual) != 0 {
-			t.Errorf("%s: cpu limits do not match; %v should be %v", test.name, actual, test.expectedCpuLimit)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			c, err := newClusterResourceOverride(test.config)
+			if err != nil {
+				t.Fatalf("%s: config de/serialize failed: %v", test.name, err)
+			}
+			// Override LimitRanger with limits from test case
+			c.(*clusterResourceOverridePlugin).limitRangesLister = fakeLimitRangeLister{
+				namespaceLister: fakeLimitRangeNamespaceLister{
+					limits: test.namespaceLimits,
+				},
+			}
+			c.(*clusterResourceOverridePlugin).SetProjectCache(fakeProjectCache(test.namespace))
+			attrs := admission.NewAttributesRecord(test.pod, nil, schema.GroupVersionKind{}, test.namespace.Name, "name", kapi.Resource("pods").WithVersion("version"), "", admission.Create, fakeUser())
+			clone := test.pod.DeepCopy()
+			if err = c.(admission.MutationInterface).Admit(attrs); err != nil {
+				t.Fatalf("%s: admission controller returned error: %v", test.name, err)
+			}
+			if err = c.(admission.ValidationInterface).Validate(attrs); err != nil {
+				t.Fatalf("%s: admission controller returned error: %v", test.name, err)
+			}
 
-		resources = test.pod.Spec.Containers[0].Resources // only test one container
-		if actual := resources.Requests[kapi.ResourceMemory]; test.expectedMemRequest.Cmp(actual) != 0 {
-			t.Errorf("%s: memory requests do not match; %v should be %v", test.name, actual, test.expectedMemRequest)
-		}
-		if actual := resources.Requests[kapi.ResourceCPU]; test.expectedCpuRequest.Cmp(actual) != 0 {
-			t.Errorf("%s: cpu requests do not match; %v should be %v", test.name, actual, test.expectedCpuRequest)
-		}
-		if actual := resources.Limits[kapi.ResourceCPU]; test.expectedCpuLimit.Cmp(actual) != 0 {
-			t.Errorf("%s: cpu limits do not match; %v should be %v", test.name, actual, test.expectedCpuLimit)
-		}
+			if !reflect.DeepEqual(test.pod, clone) {
+				attrs := admission.NewAttributesRecord(clone, nil, schema.GroupVersionKind{}, test.namespace.Name, "name", kapi.Resource("pods").WithVersion("version"), "", admission.Create, fakeUser())
+				if err = c.(admission.ValidationInterface).Validate(attrs); err == nil {
+					t.Fatalf("%s: admission controller returned no error, but should", test.name)
+				}
+			}
+
+			resources := test.pod.Spec.InitContainers[0].Resources // only test one container
+			if actual := resources.Requests[kapi.ResourceMemory]; test.expectedMemRequest.Cmp(actual) != 0 {
+				t.Errorf("%s: memory requests do not match; %v should be %v", test.name, actual, test.expectedMemRequest)
+			}
+			if actual := resources.Requests[kapi.ResourceCPU]; test.expectedCpuRequest.Cmp(actual) != 0 {
+				t.Errorf("%s: cpu requests do not match; %v should be %v", test.name, actual, test.expectedCpuRequest)
+			}
+			if actual := resources.Limits[kapi.ResourceCPU]; test.expectedCpuLimit.Cmp(actual) != 0 {
+				t.Errorf("%s: cpu limits do not match; %v should be %v", test.name, actual, test.expectedCpuLimit)
+			}
+
+			resources = test.pod.Spec.Containers[0].Resources // only test one container
+			if actual := resources.Requests[kapi.ResourceMemory]; test.expectedMemRequest.Cmp(actual) != 0 {
+				t.Errorf("%s: memory requests do not match; %v should be %v", test.name, actual, test.expectedMemRequest)
+			}
+			if actual := resources.Requests[kapi.ResourceCPU]; test.expectedCpuRequest.Cmp(actual) != 0 {
+				t.Errorf("%s: cpu requests do not match; %v should be %v", test.name, actual, test.expectedCpuRequest)
+			}
+			if actual := resources.Limits[kapi.ResourceCPU]; test.expectedCpuLimit.Cmp(actual) != 0 {
+				t.Errorf("%s: cpu limits do not match; %v should be %v", test.name, actual, test.expectedCpuLimit)
+			}
+		})
 	}
 }
 

--- a/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
@@ -60,6 +60,7 @@ type clusterQuotaAdmission struct {
 var _ kubeapiserveradmission.WantsInternalKubeInformerFactory = &clusterQuotaAdmission{}
 var _ oadmission.WantsRESTClientConfig = &clusterQuotaAdmission{}
 var _ oadmission.WantsClusterQuota = &clusterQuotaAdmission{}
+var _ admission.ValidationInterface = &clusterQuotaAdmission{}
 
 const (
 	timeToWaitForCacheSync = 10 * time.Second
@@ -77,7 +78,7 @@ func NewClusterResourceQuota() (admission.Interface, error) {
 }
 
 // Admit makes admission decisions while enforcing clusterQuota
-func (q *clusterQuotaAdmission) Admit(a admission.Attributes) (err error) {
+func (q *clusterQuotaAdmission) Validate(a admission.Attributes) (err error) {
 	// ignore all operations that correspond to sub-resource actions
 	if len(a.GetSubresource()) != 0 {
 		return nil

--- a/pkg/quota/apiserver/admission/runonceduration/admission_test.go
+++ b/pkg/quota/apiserver/admission/runonceduration/admission_test.go
@@ -138,11 +138,11 @@ func TestRunOnceDurationAdmit(t *testing.T) {
 		runOnceDuration.(oadmission.WantsProjectCache).SetProjectCache(testCache(tc.projectAnnotations))
 		pod := tc.pod
 		attrs := admission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion("version"), "default", "test", kapi.Resource("pods").WithVersion("version"), "", admission.Create, nil)
-		err := runOnceDuration.(admission.MutationInterface).Admit(attrs)
-		if err != nil {
-			t.Errorf("%s: unexpected admission error: %v", tc.name, err)
+		if err := runOnceDuration.(admission.MutationInterface).Admit(attrs); err != nil {
+			t.Errorf("%s: unexpected mutating admission error: %v", tc.name, err)
 			continue
 		}
+
 		switch {
 		case tc.expectedActiveDeadlineSeconds == nil && pod.Spec.ActiveDeadlineSeconds == nil:
 			// continue

--- a/pkg/scheduler/admission/podnodeconstraints/admission_test.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission_test.go
@@ -145,7 +145,7 @@ func TestPodNodeConstraints(t *testing.T) {
 		if tc.expectedErrorMsg != "" {
 			expectedError = admission.NewForbidden(attrs, fmt.Errorf(tc.expectedErrorMsg))
 		}
-		err = prc.(admission.MutationInterface).Admit(attrs)
+		err = prc.(admission.ValidationInterface).Validate(attrs)
 		checkAdmitError(t, err, expectedError, errPrefix)
 	}
 }
@@ -162,7 +162,7 @@ func TestPodNodeConstraintsPodUpdate(t *testing.T) {
 		return
 	}
 	attrs := admission.NewAttributesRecord(nodeNamePod(), nodeNamePod(), kapi.Kind("Pod").WithVersion("version"), ns, "test", kapi.Resource("pods").WithVersion("version"), "", admission.Update, serviceaccount.UserInfo("", "", ""))
-	err = prc.(admission.MutationInterface).Admit(attrs)
+	err = prc.(admission.ValidationInterface).Validate(attrs)
 	checkAdmitError(t, err, expectedError, errPrefix)
 }
 
@@ -178,7 +178,7 @@ func TestPodNodeConstraintsNonHandledResources(t *testing.T) {
 		return
 	}
 	attrs := admission.NewAttributesRecord(resourceQuota(), nil, kapi.Kind("ResourceQuota").WithVersion("version"), ns, "test", kapi.Resource("resourcequotas").WithVersion("version"), "", admission.Create, serviceaccount.UserInfo("", "", ""))
-	err = prc.(admission.MutationInterface).Admit(attrs)
+	err = prc.(admission.ValidationInterface).Validate(attrs)
 	checkAdmitError(t, err, expectedError, errPrefix)
 }
 
@@ -299,7 +299,7 @@ func TestPodNodeConstraintsResources(t *testing.T) {
 					if tp.expectedErrorMsg != "" {
 						expectedError = admission.NewForbidden(attrs, fmt.Errorf(tp.expectedErrorMsg))
 					}
-					err = prc.(admission.MutationInterface).Admit(attrs)
+					err = prc.(admission.ValidationInterface).Validate(attrs)
 					checkAdmitError(t, err, expectedError, errPrefix)
 				}
 			}

--- a/pkg/security/apiserver/admission/sccadmission/admission.go
+++ b/pkg/security/apiserver/admission/sccadmission/admission.go
@@ -44,10 +44,11 @@ type constraint struct {
 }
 
 var (
-	_ = admission.Interface(&constraint{})
 	_ = initializer.WantsAuthorizer(&constraint{})
 	_ = oadmission.WantsSecurityInformer(&constraint{})
 	_ = kadmission.WantsInternalKubeClientSet(&constraint{})
+	_ = admission.ValidationInterface(&constraint{})
+	_ = admission.MutationInterface(&constraint{})
 )
 
 // NewConstraint creates a new SCC constraint admission plugin.

--- a/pkg/security/apiserver/admission/sccadmission/admission_test.go
+++ b/pkg/security/apiserver/admission/sccadmission/admission_test.go
@@ -168,12 +168,19 @@ func testSCCAdmit(testCaseName string, sccs []*securityapi.SecurityContextConstr
 
 	attrs := kadmission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, kapi.Resource("pods").WithVersion("version"), "", kadmission.Create, &user.DefaultInfo{})
 	err := plugin.(kadmission.MutationInterface).Admit(attrs)
-
 	if shouldPass && err != nil {
-		t.Errorf("%s expected no errors but received %v", testCaseName, err)
+		t.Errorf("%s expected no mutating admission errors but received %v", testCaseName, err)
 	}
 	if !shouldPass && err == nil {
-		t.Errorf("%s expected errors but received none", testCaseName)
+		t.Errorf("%s expected mutating admission errors but received none", testCaseName)
+	}
+
+	err = plugin.(kadmission.ValidationInterface).Validate(attrs)
+	if shouldPass && err != nil {
+		t.Errorf("%s expected no validating admission errors but received %v", testCaseName, err)
+	}
+	if !shouldPass && err == nil {
+		t.Errorf("%s expected validating admission errors but received none", testCaseName)
 	}
 }
 

--- a/pkg/security/apiserver/admission/sccadmission/scc_exec.go
+++ b/pkg/security/apiserver/admission/sccadmission/scc_exec.go
@@ -25,13 +25,13 @@ func RegisterSCCExecRestrictions(plugins *admission.Plugins) {
 }
 
 var (
-	_ = admission.Interface(&sccExecRestrictions{})
 	_ = initializer.WantsAuthorizer(&sccExecRestrictions{})
 	_ = oadmission.WantsSecurityInformer(&sccExecRestrictions{})
 	_ = kadmission.WantsInternalKubeClientSet(&sccExecRestrictions{})
+	_ = admission.ValidationInterface(&sccExecRestrictions{})
 )
 
-// sccExecRestrictions is an implementation of admission.Interface which says no to a pod/exec on
+// sccExecRestrictions is an implementation of admission.ValidationInterface which says no to a pod/exec on
 // a pod that the user would not be allowed to create
 type sccExecRestrictions struct {
 	*admission.Handler
@@ -39,7 +39,7 @@ type sccExecRestrictions struct {
 	client              kclientset.Interface
 }
 
-func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
+func (d *sccExecRestrictions) Validate(a admission.Attributes) (err error) {
 	if a.GetOperation() != admission.Connect {
 		return nil
 	}
@@ -58,7 +58,7 @@ func (d *sccExecRestrictions) Admit(a admission.Attributes) (err error) {
 	// TODO, if we want to actually limit who can use which service account, then we'll need to add logic here to make sure that
 	// we're allowed to use the SA the pod is using.  Otherwise, user-A creates pod and user-B (who can't use the SA) can exec into it.
 	createAttributes := admission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion(""), a.GetNamespace(), a.GetName(), a.GetResource(), "", admission.Create, a.GetUserInfo())
-	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
+	if err := d.constraintAdmission.Validate(createAttributes); err != nil {
 		return admission.NewForbidden(a, fmt.Errorf("%s operation is not allowed because the pod's security context exceeds your permissions: %v", a.GetSubresource(), err))
 	}
 

--- a/pkg/security/apiserver/admission/sccadmission/scc_exec.go
+++ b/pkg/security/apiserver/admission/sccadmission/scc_exec.go
@@ -58,7 +58,9 @@ func (d *sccExecRestrictions) Validate(a admission.Attributes) (err error) {
 	// TODO, if we want to actually limit who can use which service account, then we'll need to add logic here to make sure that
 	// we're allowed to use the SA the pod is using.  Otherwise, user-A creates pod and user-B (who can't use the SA) can exec into it.
 	createAttributes := admission.NewAttributesRecord(pod, nil, kapi.Kind("Pod").WithVersion(""), a.GetNamespace(), a.GetName(), a.GetResource(), "", admission.Create, a.GetUserInfo())
-	if err := d.constraintAdmission.Validate(createAttributes); err != nil {
+	// call SCC.Admit instead of SCC.Validate because we accept that a different SCC is chosen. SCC.Validate would require
+	// that the chosen SCC (stored in the "openshift.io/scc" annotation) does not change.
+	if err := d.constraintAdmission.Admit(createAttributes); err != nil {
 		return admission.NewForbidden(a, fmt.Errorf("%s operation is not allowed because the pod's security context exceeds your permissions: %v", a.GetSubresource(), err))
 	}
 

--- a/pkg/security/apiserver/admission/sccadmission/scc_exec_test.go
+++ b/pkg/security/apiserver/admission/sccadmission/scc_exec_test.go
@@ -99,7 +99,7 @@ func TestExecAdmit(t *testing.T) {
 		p.SetInternalKubeClientSet(tc)
 
 		attrs := kadmission.NewAttributesRecord(v.pod, v.oldPod, kapi.Kind("Pod").WithVersion("version"), "namespace", "pod-name", kapi.Resource(v.resource).WithVersion("version"), v.subresource, v.operation, &user.DefaultInfo{})
-		err := p.Admit(attrs)
+		err := p.Validate(attrs)
 
 		if v.shouldAdmit && err != nil {
 			t.Errorf("%s: expected no errors but received %v", k, err)

--- a/pkg/service/admission/externalipranger/externalip_admission.go
+++ b/pkg/service/admission/externalipranger/externalip_admission.go
@@ -70,6 +70,7 @@ type externalIPRanger struct {
 }
 
 var _ admission.Interface = &externalIPRanger{}
+var _ admission.ValidationInterface = &externalIPRanger{}
 
 // ParseRejectAdmitCIDRRules calculates a blacklist and whitelist from a list of string CIDR rules (treating
 // a leading ! as a negation). Returns an error if any rule is invalid.
@@ -117,7 +118,7 @@ func (s NetworkSlice) Contains(ip net.IP) bool {
 }
 
 // Admit determines if the service should be admitted based on the configured network CIDR.
-func (r *externalIPRanger) Admit(a admission.Attributes) error {
+func (r *externalIPRanger) Validate(a admission.Attributes) error {
 	if a.GetResource().GroupResource() != kapi.Resource("services") {
 		return nil
 	}

--- a/pkg/service/admission/externalipranger/externalip_admission_test.go
+++ b/pkg/service/admission/externalipranger/externalip_admission_test.go
@@ -217,7 +217,7 @@ func TestAdmission(t *testing.T) {
 			oldSvc = nil
 		}
 
-		err := handler.Admit(admission.NewAttributesRecord(svc, oldSvc, kapi.Kind("Service").WithVersion("version"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services").WithVersion("version"), "", test.op, nil))
+		err := handler.Validate(admission.NewAttributesRecord(svc, oldSvc, kapi.Kind("Service").WithVersion("version"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services").WithVersion("version"), "", test.op, nil))
 		if test.admit && err != nil {
 			t.Errorf("%s: expected no error but got: %s", test.testName, err)
 		} else if !test.admit && err == nil {

--- a/pkg/service/admission/restrictedendpoints/endpoint_admission.go
+++ b/pkg/service/admission/restrictedendpoints/endpoint_admission.go
@@ -67,6 +67,7 @@ type restrictedEndpointsAdmission struct {
 }
 
 var _ = initializer.WantsAuthorizer(&restrictedEndpointsAdmission{})
+var _ = admission.ValidationInterface(&restrictedEndpointsAdmission{})
 
 // ParseSimpleCIDRRules parses a list of CIDR strings
 func ParseSimpleCIDRRules(rules []string) (networks []*net.IPNet, err error) {
@@ -132,7 +133,7 @@ func (r *restrictedEndpointsAdmission) checkAccess(attr admission.Attributes) (b
 }
 
 // Admit determines if the endpoints object should be admitted
-func (r *restrictedEndpointsAdmission) Admit(a admission.Attributes) error {
+func (r *restrictedEndpointsAdmission) Validate(a admission.Attributes) error {
 	if a.GetResource().GroupResource() != kapi.Resource("endpoints") {
 		return nil
 	}


### PR DESCRIPTION
Prerequisite to enable admission webhooks by default.