### PR TITLE
[POC] create a second proxy transport for cyclical requests

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/config.go
@@ -116,6 +116,9 @@ type Config struct {
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string
+
+	// CacheAnnotation allows bucketing of special kinds of config in the cache.
+	CacheAnnotation string
 }
 
 // ImpersonationConfig has all the available impersonation options

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/transport.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/transport.go
@@ -82,7 +82,8 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
-		Dial: c.Dial,
+		Dial:            c.Dial,
+		CacheAnnotation: c.CacheAnnotation,
 	}
 
 	if c.ExecProvider != nil && c.AuthProvider != nil {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/cache.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/cache.go
@@ -39,13 +39,14 @@ const idleConnsPerHost = 25
 var tlsCache = &tlsTransportCache{transports: make(map[tlsCacheKey]*http.Transport)}
 
 type tlsCacheKey struct {
-	insecure   bool
-	caData     string
-	certData   string
-	keyData    string
-	getCert    string
-	serverName string
-	dial       string
+	insecure        bool
+	caData          string
+	certData        string
+	keyData         string
+	getCert         string
+	serverName      string
+	dial            string
+	cacheAnnotation string
 }
 
 func (t tlsCacheKey) String() string {
@@ -60,6 +61,10 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 	key, err := tlsConfigKey(config)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(key.cacheAnnotation) > 0 {
+		fmt.Printf("#### checking with %q\n", key.cacheAnnotation)
 	}
 
 	// Ensure we only create a single transport for the given TLS options
@@ -106,12 +111,13 @@ func tlsConfigKey(c *Config) (tlsCacheKey, error) {
 		return tlsCacheKey{}, err
 	}
 	return tlsCacheKey{
-		insecure:   c.TLS.Insecure,
-		caData:     string(c.TLS.CAData),
-		certData:   string(c.TLS.CertData),
-		keyData:    string(c.TLS.KeyData),
-		getCert:    fmt.Sprintf("%p", c.TLS.GetCert),
-		serverName: c.TLS.ServerName,
-		dial:       fmt.Sprintf("%p", c.Dial),
+		insecure:        c.TLS.Insecure,
+		caData:          string(c.TLS.CAData),
+		certData:        string(c.TLS.CertData),
+		keyData:         string(c.TLS.KeyData),
+		getCert:         fmt.Sprintf("%p", c.TLS.GetCert),
+		serverName:      c.TLS.ServerName,
+		dial:            fmt.Sprintf("%p", c.Dial),
+		cacheAnnotation: c.CacheAnnotation,
 	}, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/transport/config.go
@@ -56,6 +56,9 @@ type Config struct {
 
 	// Dial specifies the dial function for creating unencrypted TCP connections.
 	Dial func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// CacheAnnotation allows bucketing of special kinds of config in the cache.
+	CacheAnnotation string
 }
 
 // ImpersonationConfig has all the available impersonation options


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1620272

Why the current flow fails.  Based on exploration in https://github.com/openshift/origin/pull/20745 it appears that this is happening:
 1. client to aggregator for instantiate build
 2. aggregator gets connection from our transport pool, finds a shared http2 connection
 3. aggregator uses connection to go aggregator to openshift binarybuild handler
 4. binarybuild handler receives request and does not consume body
 5. binarybuild handler creates a build
 6. binarybuild handler waits to observe a build pod
 7. controller observes build and issues a PSPReview (openshift). 
 8. controller to aggregator for pspreview
 9. aggregator gets connection from our transport pool, finds a shared http2 connection
 10. aggregator users connection to go aggregator to openshift pspreview
 11. BUT, that particular connection is waiting on sending the body to the binarybuild handler (step 3) which won't complete until the binarybuild handler consumes the body which won't happen until a build pod exists, which won't happen until the pspreview finishes (step 7), which won't complete until step 3 is finished.

Solutions
 1. figure out how to prevent the http2 client from getting stuck. This is clearly the best solution, but I don't see how to do it at the moment.
 2. make the openshfit controllers talk directly to the openshift server. This doesn't work.  It seems like it would, but if the pod fails to create for any reason, every aggregator connection still gets wedged.
 3. stop using http2.  This setting appears to be done per transport https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/net/http.go#L112, so we can't realistically do that for all connections to a backend
 4. create new connections for binary builds.  This involves patching the aggregator to recognize our thing and then manage our connection.
 5. use a normal cached connection for binary builds.  This is what this pull does.  It creates a second roundtripper which will re-use one connection for all binary builds.  I think this approach fails when multiple binary builds are requests and one of them gets stuck.

@smarterclayton @bparees @liggitt I explored an idea here, but I think that option 4 is a better short to mid-term approach.   I'm honestly open to anything else that works.

/hold

don't merge this, it's a POC that I think fails.