### PR TITLE
Dynamically update the kube-apiserver service proxy CA

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
@@ -25,10 +25,14 @@ const (
 func BuildHandlerChain(genericConfig *genericapiserver.Config, kubeInformers informers.SharedInformerFactory, legacyServiceServingCertSignerCABundle string, oauthConfig *configapi.OAuthConfig, userAgentMatchingConfig configapi.UserAgentMatchingConfig) (func(apiHandler http.Handler, kc *genericapiserver.Config) http.Handler, map[string]genericapiserver.PostStartHookFunc, error) {
 	extraPostStartHooks := map[string]genericapiserver.PostStartHookFunc{}
 
-	webconsoleProxyHandler, err := newWebConsoleProxy(kubeInformers, legacyServiceServingCertSignerCABundle)
+	webconsoleProxyHandler, proxyPostStartHooks, err := newWebConsoleProxy(kubeInformers, legacyServiceServingCertSignerCABundle)
 	if err != nil {
 		return nil, nil, err
 	}
+	for name, fn := range proxyPostStartHooks {
+		extraPostStartHooks[name] = fn
+	}
+
 	oauthServerHandler, newPostStartHooks, err := NewOAuthServerHandler(genericConfig, oauthConfig)
 	if err != nil {
 		return nil, nil, err
@@ -37,16 +41,15 @@ func BuildHandlerChain(genericConfig *genericapiserver.Config, kubeInformers inf
 		extraPostStartHooks[name] = fn
 	}
 
-	return func(apiHandler http.Handler, genericConfig *genericapiserver.Config) http.Handler {
-			// Machinery that let's use discover the Web Console Public URL
-			accessor := newWebConsolePublicURLAccessor(genericConfig.LoopbackClientConfig)
-			// the webconsole is proxied through the API server.  This starts a small controller that keeps track of where to proxy.
-			// TODO stop proxying the webconsole. Should happen in a future release.
-			extraPostStartHooks["openshift.io-webconsolepublicurl"] = func(context genericapiserver.PostStartHookContext) error {
-				go accessor.Run(context.StopCh)
-				return nil
-			}
+	// Machinery that let's use discover the Web Console Public URL.
+	// The webconsole is proxied through the API server.  This starts a small controller that keeps track of where to proxy.
+	// TODO stop proxying the webconsole. Should happen in a future release.
+	accessor, consolePostStartHooks := newWebConsolePublicURLAccessor(genericConfig.LoopbackClientConfig)
+	for name, fn := range consolePostStartHooks {
+		extraPostStartHooks[name] = fn
+	}
 
+	return func(apiHandler http.Handler, genericConfig *genericapiserver.Config) http.Handler {
 			// these are after the kube handler
 			handler := versionSkewFilter(apiHandler, userAgentMatchingConfig)
 
@@ -71,16 +74,32 @@ func BuildHandlerChain(genericConfig *genericapiserver.Config, kubeInformers inf
 		nil
 }
 
-func newWebConsoleProxy(kubeInformers informers.SharedInformerFactory, legacyServiceServingCertSignerCABundle string) (http.Handler, error) {
+func newWebConsoleProxy(kubeInformers informers.SharedInformerFactory, legacyServiceServingCertSignerCABundle string) (http.Handler, map[string]genericapiserver.PostStartHookFunc, error) {
+	postStartHooks := map[string]genericapiserver.PostStartHookFunc{}
+
 	caBundle, err := ioutil.ReadFile(legacyServiceServingCertSignerCABundle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	proxyHandler, err := newServiceProxyHandler("webconsole", "openshift-web-console", aggregatorapiserver.NewClusterIPServiceResolver(kubeInformers.Core().V1().Services().Lister()), caBundle, "OpenShift web console")
+
+	caBundleUpdater, err := NewServiceCABundleUpdater(kubeInformers, "webconsole.openshift-web-console.svc", caBundle)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return proxyHandler, nil
+
+	proxyHandler := &serviceProxyHandler{
+		serviceName:            "webconsole",
+		serviceNamespace:       "openshift-web-console",
+		serviceResolver:        aggregatorapiserver.NewClusterIPServiceResolver(kubeInformers.Core().V1().Services().Lister()),
+		applicationDisplayName: "OpenShift web console",
+		proxyRoundTripper:      caBundleUpdater.rt,
+	}
+
+	postStartHooks["openshift.io-catransportupdater"] = func(context genericapiserver.PostStartHookContext) error {
+		go caBundleUpdater.Run(context.StopCh)
+		return nil
+	}
+	return proxyHandler, postStartHooks, nil
 }
 
 func withOAuthRedirection(oauthConfig *configapi.OAuthConfig, handler, oauthServerHandler http.Handler) http.Handler {

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/service_proxy_handler.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/service_proxy_handler.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/proxy"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
-	restclient "k8s.io/client-go/rest"
 )
 
 var proxyErrorPageTemplate = template.Must(template.New("proxyErrorPage").Parse(proxyErrorPageTemplateString))
@@ -86,31 +85,6 @@ type serviceProxyHandler struct {
 
 	// proxyRoundTripper is the re-useable portion of the transport.  It does not vary with any request.
 	proxyRoundTripper http.RoundTripper
-
-	restConfig *restclient.Config
-}
-
-// newServiceProxyHandler is a simple proxy that doesn't handle upgrades, passes headers directly through, and doesn't assert any identity.
-func newServiceProxyHandler(serviceName string, serviceNamespace string, serviceResolver ServiceResolver, caBundle []byte, applicationDisplayName string) (*serviceProxyHandler, error) {
-	restConfig := &restclient.Config{
-		TLSClientConfig: restclient.TLSClientConfig{
-			ServerName: serviceName + "." + serviceNamespace + ".svc",
-			CAData:     caBundle,
-		},
-	}
-	proxyRoundTripper, err := restclient.TransportFor(restConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return &serviceProxyHandler{
-		serviceName:            serviceName,
-		serviceNamespace:       serviceNamespace,
-		serviceResolver:        serviceResolver,
-		applicationDisplayName: applicationDisplayName,
-		proxyRoundTripper:      proxyRoundTripper,
-		restConfig:             restConfig,
-	}, nil
 }
 
 func (r *serviceProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/service_proxy_transport.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/service_proxy_transport.go
@@ -1,0 +1,237 @@
+package openshiftkubeapiserver
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	restclient "k8s.io/client-go/rest"
+	cache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// serviceCABundleRoundTripper creates a new RoundTripper (or uses cachedTransport) for each request with serverName and
+// caBundle input into the TLSClientConfig. It is expected that caBundle is kept up to date and cachedTransport
+// cleared by the serviceCABundleUpdater controller.
+type serviceCABundleRoundTripper struct {
+	serverName      string
+	caBundle        atomic.Value
+	cachedTransport http.RoundTripper
+}
+
+func (r *serviceCABundleRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := r.cachedTransport
+	if rt == nil {
+		caBundle, ok := r.caBundle.Load().([]byte)
+		if !ok || len(caBundle) == 0 {
+			return nil, fmt.Errorf("error loading caBundle")
+		}
+		newRestConfig := &restclient.Config{
+			TLSClientConfig: restclient.TLSClientConfig{
+				ServerName: r.serverName,
+				CAData:     caBundle,
+			},
+		}
+		var err error
+		rt, err = restclient.TransportFor(newRestConfig)
+		if err != nil {
+			return nil, err
+		}
+		r.cachedTransport = rt
+	}
+	return rt.RoundTrip(req)
+}
+
+// These must align with the service-ca operator configuration
+const (
+	caBundleDataKey              = "cabundle.crt"
+	serviceCABundleNamespace     = "openshift-service-cert-signer"
+	serviceCABundleConfigMapName = "signing-cabundle"
+)
+
+// serviceCABundleUpdater runs a simple controller to keep rt.caBundle updated with CAs from the service-ca controller.
+type serviceCABundleUpdater struct {
+	// Initial CA bundle that CA updates are tacked on to.
+	startingHandlerCA []byte
+	// RoundTripper that utilizes the updated CA bundle.
+	rt *serviceCABundleRoundTripper
+
+	lister      listersv1.ConfigMapLister
+	queue       workqueue.RateLimitingInterface
+	hasSynced   cache.InformerSynced
+	syncHandler func(serviceKey string) error
+}
+
+func (u *serviceCABundleUpdater) isServiceCABundleConfigMap(obj interface{}) bool {
+	configMap, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		return false
+	}
+	return configMap.Namespace == serviceCABundleNamespace && configMap.Name == serviceCABundleConfigMapName
+}
+
+// addCABundle is the informer's AddFunc.
+func (u *serviceCABundleUpdater) addCABundle(obj interface{}) {
+	cm, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(cm)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", cm, err)
+		return
+	}
+
+	glog.V(4).Infof("serviceCABundleUpdater controller: queuing an add of %v", key)
+	u.queue.Add(key)
+}
+
+// updateCABundle is the informer's UpdateFunc.
+func (u *serviceCABundleUpdater) updateCABundle(old, cur interface{}) {
+	cm, ok := cur.(*v1.ConfigMap)
+	if !ok {
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(cm)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", cm, err)
+		return
+	}
+
+	glog.V(4).Infof("serviceCABundleUpdater controller: queuing an update of %v", key)
+	u.queue.Add(key)
+}
+
+// processNextWorkItem processes the queued items.
+func (u *serviceCABundleUpdater) processNextWorkItem() bool {
+	key, quit := u.queue.Get()
+	if quit {
+		return false
+	}
+	defer u.queue.Done(key)
+
+	err := u.syncHandler(key.(string))
+	if err == nil {
+		u.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
+	u.queue.AddRateLimited(key)
+
+	return true
+}
+
+// Run runs the controller until stopCh is closed.
+func (u *serviceCABundleUpdater) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer u.queue.ShutDown()
+	glog.V(2).Infof("starting serviceCABundleUpdater controller")
+
+	if !cache.WaitForCacheSync(stopCh, u.hasSynced) {
+		return
+	}
+
+	go wait.Until(u.runWorker, time.Second, stopCh)
+	<-stopCh
+	glog.V(2).Infof("stopping serviceCABundleUpdater controller")
+}
+
+func (u *serviceCABundleUpdater) runWorker() {
+	for u.processNextWorkItem() {
+	}
+}
+
+// Updates the RoundTripper CA bundle and clears the cache for the next request.
+func (u *serviceCABundleUpdater) updateRoundTripper(caBundle []byte) {
+	u.rt.caBundle.Store(caBundle)
+	u.rt.cachedTransport = nil
+}
+
+func (u *serviceCABundleUpdater) getRoundTripperCABundle() interface{} {
+	return u.rt.caBundle.Load()
+}
+
+// syncCABundle will update the RoundTripper's CA bundle by combining the starting CA with the updated CA from the
+// service CA configMap.
+func (u *serviceCABundleUpdater) syncCABundle(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	sharedConfigMap, err := u.lister.ConfigMaps(namespace).Get(name)
+	if kapierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	data, ok := sharedConfigMap.Data[caBundleDataKey]
+	if !ok {
+		return nil
+	}
+
+	combinedCA := make([]byte, len(u.startingHandlerCA))
+	copy(combinedCA, u.startingHandlerCA)
+	combinedCA = append(combinedCA, data...)
+
+	curBundle, ok := u.getRoundTripperCABundle().([]byte)
+	if !ok {
+		return fmt.Errorf("error loading caBundle")
+	}
+
+	if string(curBundle) == string(combinedCA) {
+		return nil
+	}
+
+	u.updateRoundTripper(combinedCA)
+
+	glog.V(4).Infof("serviceCABundleUpdater controller: updated proxy transport CA bundle")
+	return nil
+}
+
+// NewServiceCABundleUpdater creates a new serviceCABundleUpdater controller.
+func NewServiceCABundleUpdater(kubeInformers informers.SharedInformerFactory, serverName string, caBundle []byte) (*serviceCABundleUpdater, error) {
+	initialBundle := atomic.Value{}
+	initialBundle.Store(caBundle)
+
+	roundTripper := &serviceCABundleRoundTripper{
+		serverName:      serverName,
+		caBundle:        initialBundle,
+		cachedTransport: nil,
+	}
+
+	updater := &serviceCABundleUpdater{
+		rt:                roundTripper,
+		lister:            kubeInformers.Core().V1().ConfigMaps().Lister(),
+		startingHandlerCA: caBundle,
+		queue:             workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+	}
+
+	kubeInformers.Core().V1().ConfigMaps().Informer().AddEventHandler(
+		cache.FilteringResourceEventHandler{
+			Handler: &cache.ResourceEventHandlerFuncs{
+				AddFunc:    updater.addCABundle,
+				UpdateFunc: updater.updateCABundle,
+			},
+			FilterFunc: updater.isServiceCABundleConfigMap,
+		},
+	)
+
+	updater.hasSynced = kubeInformers.Core().V1().ConfigMaps().Informer().HasSynced
+	updater.syncHandler = updater.syncCABundle
+	return updater, nil
+}


### PR DESCRIPTION
Wrap the service proxy transport with a RoundTripper that trusts the SSCS CA
obtained from its signing-cabundle configMap. This fixes the connection to the
web console with oc cluster up.

https://bugzilla.redhat.com/show_bug.cgi?id=1607913