### PR TITLE
Bug 1609676 - Fix missing bind values regression

### DIFF
--- a/pkg/templateservicebroker/servicebroker/bind_test.go
+++ b/pkg/templateservicebroker/servicebroker/bind_test.go
@@ -64,6 +64,10 @@ func TestEvaluateJSONPathExpression(t *testing.T) {
 			expectedError: "FindResults failed on annotation a: DoesntExist is not found",
 		},
 		{
+			expression:     "http://{.String}/{.DoesntExist}",
+			expectedResult: "http://teststring/",
+		},
+		{
 			expression:    "{.IntSlice[*]}",
 			expectedError: "3 JSONPath results found on annotation a",
 		},


### PR DESCRIPTION
This PR fixes a regression that caused template service broker bindings to fail to evaluate.