### PR TITLE
tighten admission to avoid unnecessary pieces of config

### DIFF
--- a/pkg/build/apiserver/admission/jenkinsbootstrapper/admission.go
+++ b/pkg/build/apiserver/admission/jenkinsbootstrapper/admission.go
@@ -46,7 +46,7 @@ type jenkinsBootstrapper struct {
 	jenkinsConfig configapi.JenkinsPipelineConfig
 }
 
-var _ = oadmission.WantsJenkinsPipelineConfig(&jenkinsBootstrapper{})
+var _ = WantsJenkinsPipelineConfig(&jenkinsBootstrapper{})
 var _ = oadmission.WantsRESTClientConfig(&jenkinsBootstrapper{})
 var _ = kadmission.WantsInternalKubeClientSet(&jenkinsBootstrapper{})
 var _ = kadmission.WantsRESTMapper(&jenkinsBootstrapper{})

--- a/pkg/build/apiserver/admission/jenkinsbootstrapper/initializer.go
+++ b/pkg/build/apiserver/admission/jenkinsbootstrapper/initializer.go
@@ -1,0 +1,40 @@
+package jenkinsbootstrapper
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+
+	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+)
+
+// WantsJenkinsPipelineConfig gives access to the JenkinsPipelineConfig.  This is a historical oddity.
+// It's likely that what we really wanted was this as an admission plugin config
+type WantsJenkinsPipelineConfig interface {
+	SetJenkinsPipelineConfig(jenkinsConfig configapi.JenkinsPipelineConfig)
+	admission.InitializationValidator
+}
+
+type PluginInitializer struct {
+	JenkinsPipelineConfig configapi.JenkinsPipelineConfig
+}
+
+// Initialize will check the initialization interfaces implemented by each plugin
+// and provide the appropriate initialization data
+func (i *PluginInitializer) Initialize(plugin admission.Interface) {
+	if wantsJenkinsPipelineConfig, ok := plugin.(WantsJenkinsPipelineConfig); ok {
+		wantsJenkinsPipelineConfig.SetJenkinsPipelineConfig(i.JenkinsPipelineConfig)
+	}
+}
+
+// Validate will call the Validate function in each plugin if they implement
+// the Validator interface.
+func Validate(plugins []admission.Interface) error {
+	for _, plugin := range plugins {
+		if validater, ok := plugin.(admission.InitializationValidator); ok {
+			err := validater.ValidateInitialization()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -101,16 +101,12 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 		openshiftPluginInitializer := &oadmission.PluginInitializer{
 			ProjectCache:                 projectCache,
 			OriginQuotaRegistry:          quotaRegistry,
-			JenkinsPipelineConfig:        kubeAPIServerConfig.JenkinsPipelineConfig,
 			RESTClientConfig:             *genericConfig.LoopbackClientConfig,
 			ClusterResourceQuotaInformer: kubeAPIServerInformers.GetInternalOpenshiftQuotaInformers().Quota().InternalVersion().ClusterResourceQuotas(),
 			ClusterQuotaMapper:           clusterQuotaMappingController.GetClusterQuotaMapper(),
 			RegistryHostnameRetriever:    registryHostnameRetriever,
 			SecurityInformers:            kubeAPIServerInformers.GetInternalOpenshiftSecurityInformers(),
 			UserInformers:                kubeAPIServerInformers.GetOpenshiftUserInformers(),
-		}
-		if err != nil {
-			return nil, err
 		}
 		*pluginInitializers = append(*pluginInitializers, openshiftPluginInitializer)
 

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/kubernetes/pkg/quota"
 
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
@@ -17,7 +16,6 @@ import (
 type PluginInitializer struct {
 	ProjectCache                 *cache.ProjectCache
 	OriginQuotaRegistry          quota.Registry
-	JenkinsPipelineConfig        configapi.JenkinsPipelineConfig
 	RESTClientConfig             restclient.Config
 	ClusterResourceQuotaInformer quotainformer.ClusterResourceQuotaInformer
 	ClusterQuotaMapper           clusterquotamapping.ClusterQuotaMapper
@@ -34,9 +32,6 @@ func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	}
 	if wantsOriginQuotaRegistry, ok := plugin.(WantsOriginQuotaRegistry); ok {
 		wantsOriginQuotaRegistry.SetOriginQuotaRegistry(i.OriginQuotaRegistry)
-	}
-	if wantsJenkinsPipelineConfig, ok := plugin.(WantsJenkinsPipelineConfig); ok {
-		wantsJenkinsPipelineConfig.SetJenkinsPipelineConfig(i.JenkinsPipelineConfig)
 	}
 	if wantsRESTClientConfig, ok := plugin.(WantsRESTClientConfig); ok {
 		wantsRESTClientConfig.SetRESTClientConfig(i.RESTClientConfig)

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/kubernetes/pkg/quota"
 
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
 	quotainformer "github.com/openshift/origin/pkg/quota/generated/informers/internalversion/quota/internalversion"
@@ -23,13 +22,6 @@ type WantsProjectCache interface {
 // WantsQuotaRegistry should be implemented by admission plugins that need a quota registry
 type WantsOriginQuotaRegistry interface {
 	SetOriginQuotaRegistry(quota.Registry)
-	admission.InitializationValidator
-}
-
-// WantsJenkinsPipelineConfig gives access to the JenkinsPipelineConfig.  This is a historical oddity.
-// It's likely that what we really wanted was this as an admission plugin config
-type WantsJenkinsPipelineConfig interface {
-	SetJenkinsPipelineConfig(jenkinsConfig configapi.JenkinsPipelineConfig)
 	admission.InitializationValidator
 }
 

--- a/pkg/cmd/server/origin/admission/plugin_initializer.go
+++ b/pkg/cmd/server/origin/admission/plugin_initializer.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/quota/install"
 
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
+	"github.com/openshift/origin/pkg/build/apiserver/admission/jenkinsbootstrapper"
 	"github.com/openshift/origin/pkg/cmd/openshift-apiserver/openshiftapiserver/configprocessing"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
@@ -133,7 +134,6 @@ func NewPluginInitializer(
 	openshiftPluginInitializer := &oadmission.PluginInitializer{
 		ProjectCache:                 projectCache,
 		OriginQuotaRegistry:          quotaRegistry,
-		JenkinsPipelineConfig:        masterConfig.JenkinsPipelineConfig,
 		RESTClientConfig:             *privilegedLoopbackConfig,
 		ClusterResourceQuotaInformer: informers.GetInternalOpenshiftQuotaInformers().Quota().InternalVersion().ClusterResourceQuotas(),
 		ClusterQuotaMapper:           clusterQuotaMappingController.GetClusterQuotaMapper(),
@@ -141,6 +141,9 @@ func NewPluginInitializer(
 		SecurityInformers:            informers.GetInternalOpenshiftSecurityInformers(),
 		UserInformers:                informers.GetOpenshiftUserInformers(),
 	}
+	jenkinsPipelineConfigInitializer := &jenkinsbootstrapper.PluginInitializer{
+		JenkinsPipelineConfig: masterConfig.JenkinsPipelineConfig,
+	}
 
-	return admission.PluginInitializers{genericInitializer, webhookInitializer, kubePluginInitializer, openshiftPluginInitializer}, nil
+	return admission.PluginInitializers{genericInitializer, webhookInitializer, kubePluginInitializer, openshiftPluginInitializer, jenkinsPipelineConfigInitializer}, nil
 }


### PR DESCRIPTION
jenkins config is openshift apiserver only and only for one plugin. This move it to point of use, but keeps it wired for the combined server

@sig-master
/assign @bparees @mfojtik 