### PR TITLE
apps: raise trigger timeout for slow servers

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -405,7 +405,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 				dc, err := oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Get(dcName, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				latestVersion := dc.Status.LatestVersion
-				err = wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+				err = wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
 					dc, err = oc.AppsClient().AppsV1().DeploymentConfigs(oc.Namespace()).Get(dcName, metav1.GetOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
 					latestVersion = dc.Status.LatestVersion

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -575,6 +575,12 @@ func failureTrap(oc *exutil.CLI, name string, failed bool) {
 		}
 		e2e.Logf("\n%s\n", out)
 	}
+	out, err = oc.Run("get").Args("istag", "-o", "wide").Output()
+	if err != nil {
+		e2e.Logf("Error getting image stream tags: %v", err)
+	}
+	e2e.Logf("\n%s\n", out)
+
 }
 
 func failureTrapForDetachedRCs(oc *exutil.CLI, dcName string, failed bool) {


### PR DESCRIPTION
Raises the timeout for triggering new deployment after tagging an image. On slow servers it might take more than 10s.
Also print the image stream tags in failure trap to confirm the tag exists.

/cc @tnozicka
/cc @smarterclayton