### PR TITLE
Add fast typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,15 @@ update:
 	hack/update-generated-docs.sh
 .PHONY: update
 
+# Do a cross architecture typecheck.
+#
+# Examples:
+#   make verify-typecheck
+#   make verify-typecheck PLATFORMS=linux/amd64
+verify-typecheck:
+	hack/verify-typecheck.sh
+.PHONY: verify-typecheck
+
 # Update all generated artifacts for the API
 #
 # Example:

--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Usage:
+#
+# To typecheck all the architectures run:
+# $ ./hack/verify-typecheck.sh
+#
+# Additionally, to typecheck only e.g. linux/amd64:
+# $ PLATFORMS=linux/amd64 ./hack/verify-typecheck.sh
+#
+# PLATFORMS is a string containing comma separated list of architectures to run typecheck for.
+# see `./vendor/k8s.io/kubernetes/test/typecheck/main.go -h` for detailed list of arguments
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib/init.sh"
+
+os::golang::verify_go_version
+
+platforms=${PLATFORMS:-'linux/amd64,darwin/amd64,linux/arm,linux/386,linux/arm64,linux/ppc64le,linux/s390x,darwin/386'}
+
+if ! go run ./vendor/k8s.io/kubernetes/test/typecheck/main.go -platform="${platforms}" "$@"; then
+  os::log::fatal "Type Check has failed. This may cause cross platform build failures.
+Please see https://git.k8s.io/kubernetes/test/typecheck for more information."
+fi


### PR DESCRIPTION
Great tool from upstream that we are missing. I use it to validate that all the code compiles even including tests in significantly shorter times than normal compilation.

The only alternative I found is to build binaries, e2e, integration, and run dummy unit tests like this:
```
make test-unit TEST_KUBE=false TESTFLAGS='-run=^$'
```
taking significantly longer time.

https://github.com/kubernetes/kubernetes/blob/master/test/typecheck/README

run simply as
```
make verify-typecheck

# or if you want it really fast
make verify-typecheck PLATFORMS=linux/amd64
```

(Upstream uses `make verify WHAT=typecheck` but that would be more intrusive as our Makefile differs significantly.)

/cc @smarterclayton @openshift/sig-master WDYT?

I'd add this as a presubmit for fast feedback if we get consensus. EDIT: (non-blocking)