### PR TITLE
Avoid using nginx:latest tag in extended tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -9886,7 +9886,7 @@ items:
       app: serving-cert
   spec:
     containers:
-    - image: nginx:latest
+    - image: nginx:1.15.3
       name: serve
       command:
         - /usr/sbin/nginx
@@ -10312,7 +10312,7 @@ objects:
       app: secure-endpoint
   spec:
     containers:
-    - image: nginx:latest
+    - image: nginx:1.15.3
       name: serve
       command:
         - /usr/sbin/nginx

--- a/test/extended/testdata/reencrypt-serving-cert.yaml
+++ b/test/extended/testdata/reencrypt-serving-cert.yaml
@@ -9,7 +9,7 @@ items:
       app: serving-cert
   spec:
     containers:
-    - image: nginx:latest
+    - image: nginx:1.15.3
       name: serve
       command:
         - /usr/sbin/nginx

--- a/test/extended/testdata/router-config-manager.yaml
+++ b/test/extended/testdata/router-config-manager.yaml
@@ -150,7 +150,7 @@ objects:
       app: secure-endpoint
   spec:
     containers:
-    - image: nginx:latest
+    - image: nginx:1.15.3
       name: serve
       command:
         - /usr/sbin/nginx


### PR DESCRIPTION
Use a specific tag for the nginx image used in extended tests.

Using a specific version ensures a more consistent test environment, and using a tag that is not "latest" changes the implicit image pull policy from "Always" to "IfNotPresent", which should reduce the impact of intermittent problems pulling the image during tests.

* `test/extended/testdata/reencrypt-serving-cert.yaml`:
* `test/extended/testdata/router-config-manager.yaml`: Change from using the `nginx:latest` image to using the `nginx:1.15.3` image.
* `test/extended/testdata/bindata.go`: Regenerate.