### PR TITLE
hack/cherry-pick.sh: use dead simple selector for PR merge

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -39,9 +39,8 @@ if [[ -n "${APPLY_PR_COMMITS-}" ]]; then
     selector="$(os::build::commit_range $pr ${remote}/${UPSTREAM_BRANCH:-master})"
 else
     pr_commit="$(git rev-parse ${remote}/pr/$1)"
-    merge="$(git merge-base ${pr_commit} ${remote}/${UPSTREAM_BRANCH:-master})"
-    echo "++ Will apply merge ${merge} as one commit ..."
-    selector="$(git rev-parse ${merge}^1)..${merge}"
+    echo "++ PR merge commit on branch ${UPSTREAM_BRANCH:-master}: ${pr_commit}"
+    selector="${pr_commit}^1..${pr_commit}"
 fi
 
 if [[ -z "${NO_REBASE-}" ]]; then


### PR DESCRIPTION
Not sure why we use the complicated merge-base before, which could break and does in 50% of the time. This PR changes the cherry-pick script to just you `pr_merge^1..pr_merge` as the selector, without any magic.