### PR TITLE
Master replica can also contend and cause us to exceed our hard limit

### DIFF
--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -249,8 +249,8 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 						break Wait
 					}
 				}
-				// we expect to see no more than 10 writes per router (we should hit the hard limit)
-				o.Expect(writes).To(o.BeNumerically("<=", 30))
+				// we expect to see no more than 10 writes per router (we should hit the hard limit) (3 replicas and 1 master)
+				o.Expect(writes).To(o.BeNumerically("<=", 40))
 			}()
 
 			// the os_http_be.map file will vary, so only check the haproxy config


### PR DESCRIPTION
Each router instance is capped at 10 conflicts, but we are running 4
routers (primary cluster router instance, and the three in this test).
In the future if we add router exclusion we could potentially reduce
this back down to 30.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/20772/pull-ci-origin-e2e-gcp/3154/#conformanceareanetworkingfeaturerouter-the-haproxy-router-converges-when-multiple-routers-are-writing-conflicting-status-suiteopenshiftconformanceparallelminimal