### PR TITLE
ImageLayers test should loop until image is missing

### DIFF
--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -66,8 +66,7 @@ var _ = g.Describe("[Feature:ImageLayers] Image layer subresource", func() {
 			if !ok {
 				return false, nil
 			}
-			o.Expect(ref.ImageMissing).To(o.BeTrue())
-			return true, nil
+			return ref.ImageMissing, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})


### PR DESCRIPTION
In the event we do fill the cache in time

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/20488/pull-ci-origin-e2e-gcp/3168/#featureimagelayers-image-layer-subresource-should-identify-a-deleted-image-as-missing-suiteopenshiftconformanceparallel