### PR TITLE
Filter out non-participating images from the payload list

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -382,6 +382,13 @@ func (o *NewOptions) Run() error {
 		if err := opts.Run(); err != nil {
 			return err
 		}
+		var filteredNames []string
+		for _, s := range ordered {
+			if _, ok := metadata[s]; ok {
+				filteredNames = append(filteredNames, s)
+			}
+		}
+		ordered = filteredNames
 	}
 
 	var operators []string


### PR DESCRIPTION
When reading from a stream, only images that declare release participation
should get extracted.