### PR TITLE
Fix up logic in TestEgressCIDRAllocationOffline

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -1171,12 +1171,18 @@ func TestEgressCIDRAllocationOffline(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	// Next reallocation should reassign egress IPs to node-3
+	// Next reallocation should reassign the IPs that were removed in the previous
+	// round. While the last reallocation was designed to aim for a next reallocation
+	// where all of the removed IPs end up on node-3, it's possible 1 of them will
+	// end up getting reallocated back to the same node it was removed from.
 	allocation = eit.ReallocateEgressIPs()
 	node3ips = allocation["node-3"]
 	node4ips = allocation["node-4"]
 	node5ips = allocation["node-5"]
-	if len(node3ips) < 2 || len(node4ips) == 0 || len(node5ips) == 0 {
+	if len(node3ips) < 1 || len(node3ips) > 3 ||
+		len(node4ips) < 1 || len(node4ips) > 3 ||
+		len(node5ips) < 1 || len(node5ips) > 3 ||
+		len(node3ips)+len(node4ips)+len(node5ips) != 6 {
 		t.Fatalf("Bad IP allocation: %#v", allocation)
 	}
 	updateAllocations(eit, allocation)


### PR DESCRIPTION
TestEgressCIDRAllocationOffline is flaking. The problem is that the allocation logic uses a greedy algorithm that will give an answer that's mostly right, give or take 1 or 2 IP addresses, but the test case is using a small enough number of IPs that "within 1 or 2 IPs of right" can end up being basically wrong. I should rewrite the test to use a larger number of IPs, but let's get it to stop flaking first.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1624998