### PR TITLE
UPSTREAM: 68009: apiserver: forward panic in WithTimeout filter

### DIFF
--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -39,9 +39,8 @@ if [[ -n "${APPLY_PR_COMMITS-}" ]]; then
     selector="$(os::build::commit_range $pr ${remote}/${UPSTREAM_BRANCH:-master})"
 else
     pr_commit="$(git rev-parse ${remote}/pr/$1)"
-    merge="$(git merge-base ${pr_commit} ${remote}/${UPSTREAM_BRANCH:-master})"
-    echo "++ Will apply merge ${merge} as one commit ..."
-    selector="$(git rev-parse ${merge}^1)..${merge}"
+    echo "++ PR merge commit on branch ${UPSTREAM_BRANCH:-master}: ${pr_commit}"
+    selector="${pr_commit}^1..${pr_commit}"
 fi
 
 if [[ -z "${NO_REBASE-}" ]]; then

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -885,8 +885,8 @@ func (az *Cloud) reconcileSecurityGroup(clusterName string, service *v1.Service,
 	// update security rules
 	dirtySg := false
 	var updatedRules []network.SecurityRule
-	if sg.SecurityGroupPropertiesFormat != nil && sg.SecurityGroupPropertiesFormat.SecurityRules != nil {
-		updatedRules = *sg.SecurityGroupPropertiesFormat.SecurityRules
+	if sg.SecurityRules != nil {
+		updatedRules = *sg.SecurityRules
 	}
 
 	for _, r := range updatedRules {

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -153,10 +153,6 @@ func (az *Cloud) getAzureLoadBalancer(name string) (lb network.LoadBalancer, exi
 }
 
 func (az *Cloud) getSecurityGroup() (nsg network.SecurityGroup, err error) {
-	if az.SecurityGroupName == "" {
-		return nsg, fmt.Errorf("securityGroupName is not configured")
-	}
-
 	securityGroup, err := az.nsgCache.Get(az.SecurityGroupName)
 	if err != nil {
 		return nsg, err

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
@@ -20,6 +20,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/filters:go_default_library",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -87,14 +87,19 @@ func (t *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	done := make(chan struct{})
+	result := make(chan interface{})
 	tw := newTimeoutWriter(w)
 	go func() {
+		defer func() {
+			result <- recover()
+		}()
 		t.handler.ServeHTTP(tw, r)
-		close(done)
 	}()
 	select {
-	case <-done:
+	case err := <-result:
+		if err != nil {
+			panic(err)
+		}
 		return
 	case <-after:
 		recordFn()

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
 type recorder struct {
@@ -50,22 +51,33 @@ func (r *recorder) Count() int {
 }
 
 func TestTimeout(t *testing.T) {
+	origReallyCrash := runtime.ReallyCrash
+	runtime.ReallyCrash = false
+	defer func() {
+		runtime.ReallyCrash = origReallyCrash
+	}()
+
 	sendResponse := make(chan struct{}, 1)
+	doPanic := make(chan struct{}, 1)
 	writeErrors := make(chan error, 1)
 	timeout := make(chan time.Time, 1)
 	resp := "test response"
 	timeoutErr := apierrors.NewServerTimeout(schema.GroupResource{Group: "foo", Resource: "bar"}, "get", 0)
 	record := &recorder{}
 
-	ts := httptest.NewServer(WithTimeout(http.HandlerFunc(
+	ts := httptest.NewServer(WithPanicRecovery(WithTimeout(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			<-sendResponse
-			_, err := w.Write([]byte(resp))
-			writeErrors <- err
+			select {
+			case <-sendResponse:
+				_, err := w.Write([]byte(resp))
+				writeErrors <- err
+			case <-doPanic:
+				panic("inner handler panics")
+			}
 		}),
 		func(*http.Request) (<-chan time.Time, func(), *apierrors.StatusError) {
 			return timeout, record.Record, timeoutErr
-		}))
+		})))
 	defer ts.Close()
 
 	// No timeouts
@@ -113,5 +125,15 @@ func TestTimeout(t *testing.T) {
 	sendResponse <- struct{}{}
 	if err := <-writeErrors; err != http.ErrHandlerTimeout {
 		t.Errorf("got Write error of %v; expected %v", err, http.ErrHandlerTimeout)
+	}
+
+	// Panics
+	doPanic <- struct{}{}
+	res, err = http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Errorf("got res.StatusCode %d; expected %d due to panic", res.StatusCode, http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
- Revert of https://github.com/openshift/origin/pull/20832 because the cherry-pick contents was wrong.
- fixed cherry pick of kubernetes/kubernetes#68001 onto release-3.10.