### PR TITLE
Set empty source type after we switched to versioned build client

### DIFF
--- a/pkg/build/generator/generator.go
+++ b/pkg/build/generator/generator.go
@@ -864,6 +864,9 @@ func generateBuildFromBuild(build *buildv1.Build, buildConfig *buildv1.BuildConf
 		},
 	}
 	// TODO remove/update this when we support cloning binary builds
+	// we need to explicitly set type to empty string so that this does not get
+	// defaulted to non-empty binary build
+	newBuild.Spec.Source.Type = ""
 	newBuild.Spec.Source.Binary = nil
 	if newBuild.Annotations == nil {
 		newBuild.Annotations = make(map[string]string)
@@ -946,6 +949,9 @@ func setBuildSource(binary *buildv1.BinaryBuildSource, build *buildv1.Build) {
 		}
 	} else {
 		// must explicitly set this because we copied the source values from the buildconfig.
+		// we need to explicitly set type to empty string so that this does not get
+		// defaulted to non-empty binary build
+		build.Spec.Source.Type = ""
 		build.Spec.Source.Binary = nil
 	}
 }

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -231,18 +231,15 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
 					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
 
-					// TODO: Investigate why is this failing.
-					/*
-						g.By("starting a build without a --from-xxxx value")
-						br, err = exutil.StartBuildAndWait(oc, "sample-build-binary")
-						o.Expect(br.StartBuildErr).To(o.HaveOccurred())
-						o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("has no valid source inputs"))
+					g.By("starting a build without a --from-xxxx value")
+					br, err = exutil.StartBuildAndWait(oc, "sample-build-binary")
+					o.Expect(br.StartBuildErr).To(o.HaveOccurred())
+					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("has no valid source inputs"))
 
-						g.By("starting a build from an existing binary build")
-						br, err = exutil.StartBuildAndWait(oc, "sample-build-binary", fmt.Sprintf("--from-build=%s", "sample-build-binary-1"))
-						o.Expect(br.StartBuildErr).To(o.HaveOccurred())
-						o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("has no valid source inputs"))
-					*/
+					g.By("starting a build from an existing binary build")
+					br, err = exutil.StartBuildAndWait(oc, "sample-build-binary", fmt.Sprintf("--from-build=%s", "sample-build-binary-1"))
+					o.Expect(br.StartBuildErr).To(o.HaveOccurred())
+					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("has no valid source inputs"))
 				})
 
 				g.It("shoud accept --from-file with https URL as an input", func() {


### PR DESCRIPTION
When we switched to versioned client the defaulting mechanism kicks in which results in `.spec.source.binary` to be set to non-nil value. This in turn fails validation we were previously relying on.

This PR changes the generator so that not only it clears `.spec.source.binary` but also clears `.spec.source.type` which is available only in external and ensures the `.spec.source.binary` is not defaulted. 

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1624950

/assign @mfojtik @bparees 