### PR TITLE
cluster up: create the service-ca operator signing secret

### DIFF
--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -179,6 +180,15 @@ func (c *ClusterUpConfig) StartSelfHosted(out io.Writer) error {
 	// wait for the apiserver to be ready
 	glog.Info("Waiting for the kube-apiserver to be ready ...")
 	if err := waitForHealthyKubeAPIServer(clientConfig); err != nil {
+		return err
+	}
+
+	// bootstrap the service-ca operator with the legacy service-signer.crt and key.
+	err = createServiceCASigningSecret(clientConfig,
+		path.Join(c.BaseDir, "openshift-apiserver", "service-signer.crt"),
+		path.Join(c.BaseDir, "openshift-apiserver", "service-signer.key"),
+	)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/oc/clusterup/signing_secret.go
+++ b/pkg/oc/clusterup/signing_secret.go
@@ -1,0 +1,65 @@
+package clusterup
+
+import (
+	"io/ioutil"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	serviceCANamespace  = "openshift-service-cert-signer"
+	serviceCASecretName = "service-serving-cert-signer-signing-key"
+)
+
+func createServiceCASigningSecret(clientConfig *rest.Config, certFile, keyFile string) error {
+	cert, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return err
+	}
+
+	key, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return err
+	}
+
+	client, err := coreclientv1.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceCANamespace,
+			Labels: map[string]string{
+				"openshift.io/run-level": "1",
+			},
+			Annotations: nil,
+		},
+	}
+	_, err = client.Namespaces().Create(ns)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: serviceCANamespace,
+			Name:      serviceCASecretName,
+		},
+		Type: "kubernetes.io/tls",
+		Data: map[string][]byte{
+			"tls.crt": cert,
+			"tls.key": key,
+		},
+	}
+
+	_, err = client.Secrets(serviceCANamespace).Create(secret)
+	if errors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
Create the service-ca (SSCS) signing key secret with the legacy signing CA (service-signer.{crt,key}) ahead of launching the operator. This bootstraps the operator with the legacy signing CA so it does not create a new signing CA, allowing components that still trust the legacy signing CA to properly verify
service-signing certificates.

(We may prefer this for a 3.11 fix of https://bugzilla.redhat.com/show_bug.cgi?id=1607913
rather than https://github.com/openshift/origin/pull/20760)
@openshift/sig-master @deads2k 
