### PR TITLE
test/extended/util/framework: Reword to avoid "an is importer"

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1032,7 +1032,7 @@ func WaitForAnImageStreamTag(oc *CLI, namespace, name, tag string) error {
 // TimedWaitForAnImageStreamTag waits until an image stream with given name has non-empty history for given tag.
 // Gives up waiting after the specified waitTimeout
 func TimedWaitForAnImageStreamTag(oc *CLI, namespace, name, tag string, waitTimeout time.Duration) error {
-	g.By(fmt.Sprintf("waiting for an is importer to import a tag %s into a stream %s", tag, name))
+	g.By(fmt.Sprintf("waiting for tag %s in imagestream %s/%s to be imported", tag, namespace, name))
 	start := time.Now()
 	c := make(chan error)
 	go func() {


### PR DESCRIPTION
The previous wording is originally from 23f729d8 (#8195).  But seen on its own (e.g. in the output of a test-suite run), it's not particularly clear what "is" means (or even whether it's an abbreviation or not).  I've reworded the string to more closely match the function name.  I've also added the namespace to the string, to more closely match the timeout message later in this function.