### PR TITLE
Router metrics change to use http1 cockroach db matcher 

### DIFF
--- a/pkg/router/metrics/metrics.go
+++ b/pkg/router/metrics/metrics.go
@@ -132,7 +132,7 @@ func (l Listener) Listen() {
 	m := cmux.New(tcpl)
 
 	// match HTTP first
-	httpl := m.Match(cmux.HTTP1Fast())
+	httpl := m.Match(cmux.HTTP1())
 	go func() {
 		s := &http.Server{
 			Handler: handler,


### PR DESCRIPTION
Router metrics change to use http1 cockroach db matcher  instead of Http1Fast 
for backward compatibility.

fixes bugz 1623632 ( https://bugzilla.redhat.com/show_bug.cgi?id=1623632 )

/cc @openshift/sig-network-edge 