### PR TITLE
Print better debug info about release creation

### DIFF
--- a/pkg/oc/cli/admin/release/extract.go
+++ b/pkg/oc/cli/admin/release/extract.go
@@ -24,7 +24,7 @@ func NewExtractOptions(streams genericclioptions.IOStreams) *ExtractOptions {
 	}
 }
 
-func NewExtract(f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+func NewExtract(f kcmdutil.Factory, parentName string, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewExtractOptions(streams)
 	cmd := &cobra.Command{
 		Use:   "extract",

--- a/pkg/oc/cli/admin/release/release.go
+++ b/pkg/oc/cli/admin/release/release.go
@@ -18,7 +18,7 @@ func NewCmd(f kcmdutil.Factory, parentName string, streams genericclioptions.IOS
 			Experimental: This command is under active development and may change without notice.
 			`),
 	}
-	cmd.AddCommand(NewRelease(f, streams))
-	cmd.AddCommand(NewExtract(f, streams))
+	cmd.AddCommand(NewRelease(f, parentName+" release", streams))
+	cmd.AddCommand(NewExtract(f, parentName+" release", streams))
 	return cmd
 }

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -94,7 +94,11 @@ var _ = g.Describe("[Feature:ImageAppend] Image append", func() {
 			oc image append --insecure --to docker-registry.default.svc:5000/%[1]s/test:scratch2 --image='{"Cmd":["/bin/sleep"]}' --created-at=0
 
 			# modify a busybox image
-			oc image append --insecure --from=docker.io/library/busybox:latest --to docker-registry.default.svc:5000/%[1]s/test:busybox1 --image='{"Cmd":["/bin/sleep"]}'
+			oc image append --insecure --from docker.io/library/busybox:latest --to docker-registry.default.svc:5000/%[1]s/test:busybox1 --image '{"Cmd":["/bin/sleep"]}'
+
+			# verify mounting works
+			oc create is test2
+			oc image append --insecure --from docker-registry.default.svc:5000/%[1]s/test:scratch2 --to docker-registry.default.svc:5000/%[1]s/test2:scratch2 --force
 
 			# add a simple layer to the image
 			mkdir -p /tmp/test/dir


### PR DESCRIPTION
Make it clear that omitting --to-file and --to-image are allowed, also accept
'-' as --to-file to pipe.

Also fix an error where mounting a blob from one repo to another caused the command to exit because we didn't handle the special "mount error" returned by the server, like we do in other commands.  Added an e2e test.