### PR TITLE
Add bootstrap policy for resource metrics viewing

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/all_test.go
+++ b/pkg/cmd/server/bootstrappolicy/all_test.go
@@ -16,10 +16,10 @@ const osClusterRoleAggregationPrefix = "system:openshift:"
 // this map must be manually kept up to date as we make changes to aggregation
 // we hard code this data with no constants because we cannot change the underlying values
 var expectedAggregationMap = map[string]sets.String{
-	"admin":          sets.NewString("system:openshift:aggregate-to-admin", "system:aggregate-to-admin"),
+	"admin":          sets.NewString("system:openshift:aggregate-to-admin", "system:aggregate-to-admin", "resource-metrics-view"),
 	"edit":           sets.NewString("system:openshift:aggregate-to-edit", "system:aggregate-to-edit"),
-	"view":           sets.NewString("system:openshift:aggregate-to-view", "system:aggregate-to-view"),
-	"cluster-reader": sets.NewString("system:openshift:aggregate-to-view", "system:aggregate-to-view", "system:openshift:aggregate-to-cluster-reader"),
+	"view":           sets.NewString("system:openshift:aggregate-to-view", "system:aggregate-to-view", "resource-metrics-view"),
+	"cluster-reader": sets.NewString("system:openshift:aggregate-to-view", "system:aggregate-to-view", "system:openshift:aggregate-to-cluster-reader", "resource-metrics-view", "resource-metrics-cluster-view"),
 }
 
 func TestPolicyAggregation(t *testing.T) {

--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/settings"
 	"k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
+	"k8s.io/metrics/pkg/apis/metrics"
 
 	oapps "github.com/openshift/api/apps"
 	"github.com/openshift/api/authorization"
@@ -713,6 +714,20 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 			},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get", "put", "update", "delete").URLs(templateapi.ServiceBrokerRoot + "/*").RuleOrDie(),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "resource-metrics-view",
+				Labels: map[string]string{"rbac.authorization.k8s.io/aggregate-to-view": "true", "rbac.authorization.k8s.io/aggregate-to-admin": "true"}},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule(read...).Groups(metrics.GroupName).Resources("pods").RuleOrDie(),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "resource-metrics-cluster-view", Labels: map[string]string{"rbac.authorization.k8s.io/aggregate-to-cluster-reader": "true"}},
+			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule(read...).Groups(metrics.GroupName).Resources("nodes").RuleOrDie(),
+				rbacv1helpers.NewRule(read...).Groups(metrics.GroupName).Resources("pods").RuleOrDie(),
 			},
 		},
 	}

--- a/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
+++ b/pkg/cmd/server/bootstrappolicy/web_console_role_test.go
@@ -19,6 +19,8 @@ var rolesToHide = sets.NewString(
 	"registry-admin",
 	"registry-editor",
 	"registry-viewer",
+	"resource-metrics-view",
+	"resource-metrics-cluster-view",
 	"self-access-reviewer",
 	"self-provisioner",
 	"storage-admin",

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2210,6 +2210,53 @@ items:
       authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      rbac.authorization.k8s.io/aggregate-to-view: "true"
+    name: resource-metrics-view
+  rules:
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+    name: resource-metrics-cluster-view
+  rules:
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
     name: system:replication-controller
   rules: null
 - apiVersion: rbac.authorization.k8s.io/v1

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -2210,6 +2210,53 @@ items:
       authorization.openshift.io/system-only: "true"
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      rbac.authorization.k8s.io/aggregate-to-view: "true"
+    name: resource-metrics-view
+  rules:
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+    name: resource-metrics-cluster-view
+  rules:
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      authorization.openshift.io/system-only: "true"
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
     name: system:replication-controller
   rules: null
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This adds boostrap policy for resource metrics viewing.  There are two
roles, resource-metrics-view and resource-metrics-cluster-view, which
aggregate to view and cluster-reader, and allow viewing of pod and node
metrics, respectively.

This is added as boostrap policy instead of addon policy from metrics-server, since it's not necessarily tied to metrics server (at some point SOON™ in the future it'll be possible to serve out of the prometheus adapter), and we probably want users to be able to do this out-of-the-box.