### PR TITLE
backport to 3.8: PR 20433 - use the release string 

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -39,6 +39,9 @@ class OriginTagger(VersionTagger):
         inject_os_git_vars(self.spec_file)
         super(OriginTagger, self)._tag_release()
 
-    def _get_tag_for_version(self, version):
-        return "v{}".format(version)
+    def _get_tag_for_version(self, version, release=None):
+        if release is None:
+            return "v{}".format(version)
+        else:
+            return "v{}-{}".format(version, release)
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:


### PR DESCRIPTION
- use the release string if tito provides it for the tag string