### PR TITLE
Support setting storageClassName: "" when "" is specified by claim-class

### DIFF
--- a/pkg/oc/cli/set/volume.go
+++ b/pkg/oc/cli/set/volume.go
@@ -152,7 +152,8 @@ type AddVolumeOptions struct {
 	ClaimMode   string
 	ClaimClass  string
 
-	TypeChanged bool
+	TypeChanged  bool
+	ClassChanged bool
 }
 
 func NewVolumeOptions(streams genericclioptions.IOStreams) *VolumeOptions {
@@ -358,6 +359,7 @@ func (o *VolumeOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []
 	o.UpdatePodSpecForObject = polymorphichelpers.UpdatePodSpecForObjectFn
 
 	o.AddOpts.TypeChanged = cmd.Flag("type").Changed
+	o.AddOpts.ClassChanged = cmd.Flag("claim-class").Changed
 
 	o.DryRun = kcmdutil.GetDryRunFlag(cmd)
 	if o.DryRun {
@@ -638,7 +640,7 @@ func (a *AddVolumeOptions) createClaim() *kapi.PersistentVolumeClaim {
 			},
 		},
 	}
-	if len(a.ClaimClass) > 0 {
+	if a.ClassChanged {
 		pvc.Annotations = map[string]string{
 			storageAnnClass: a.ClaimClass,
 		}


### PR DESCRIPTION
When cluster has default storageclass and PVC is created, all PVCs
that have no storageClassName can be bound only to PVs of that
default. In other words, it is not possible to bound to static PV by
oc set volume.

If storageClassName: "" can be defined, it is possible, though. The
detail is described in
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1

Hence, this patch changes to assign "" to storageClassName, when oc
set volume --claim-class="" was used.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1626373