### PR TITLE
hack: add kubectl to release tars and zip

### DIFF
--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -76,16 +76,19 @@ readonly OC_BINARY_COPY=(
 )
 readonly OS_BINARY_RELEASE_CLIENT_WINDOWS=(
   oc.exe
+  kubectl.exe
   README.md
   ./LICENSE
 )
 readonly OS_BINARY_RELEASE_CLIENT_MAC=(
   oc
+  kubectl
   README.md
   ./LICENSE
 )
 readonly OS_BINARY_RELEASE_CLIENT_LINUX=(
   ./oc
+  ./kubectl
   ./README.md
   ./LICENSE
 )

--- a/origin.spec
+++ b/origin.spec
@@ -428,8 +428,11 @@ touch --reference=%{SOURCE0} $RPM_BUILD_ROOT/usr/sbin/%{name}-docker-excluder
 %dir %{_datadir}/%{name}/macosx/
 %dir %{_datadir}/%{name}/windows/
 %{_datadir}/%{name}/linux/oc
+%{_datadir}/%{name}/linux/kubectl
 %{_datadir}/%{name}/macosx/oc
+%{_datadir}/%{name}/macosx/kubectl
 %{_datadir}/%{name}/windows/oc.exe
+%{_datadir}/%{name}/windows/kubectl.exe
 %{_datadir}/%{name}/linux/oadm
 %{_datadir}/%{name}/macosx/oadm
 %{_datadir}/%{name}/windows/oadm.exe


### PR DESCRIPTION
This should be enough to include the kubectl binary along side with the oc binary.

/cc @smarterclayton