### PR TITLE
switch oc scheme installation to avoid installing custom resources for apply

### DIFF
--- a/cmd/oc/oc.go
+++ b/cmd/oc/oc.go
@@ -7,10 +7,23 @@ import (
 	"runtime"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 
-	"github.com/openshift/api"
+	"github.com/openshift/api/apps"
+	"github.com/openshift/api/authorization"
+	"github.com/openshift/api/build"
+	"github.com/openshift/api/image"
+	"github.com/openshift/api/network"
+	"github.com/openshift/api/oauth"
+	"github.com/openshift/api/operator"
+	"github.com/openshift/api/project"
+	"github.com/openshift/api/quota"
+	"github.com/openshift/api/route"
+	"github.com/openshift/api/security"
+	"github.com/openshift/api/template"
+	"github.com/openshift/api/user"
 	"github.com/openshift/library-go/pkg/serviceability"
 	"github.com/openshift/origin/pkg/api/install"
 	"github.com/openshift/origin/pkg/api/legacy"
@@ -31,7 +44,20 @@ func main() {
 	}
 
 	// the kubectl scheme expects to have all the recognizable external types it needs to consume.  Install those here.
-	api.Install(scheme.Scheme)
+	// We can't use the "normal" scheme because apply will use that to build stategic merge patches on CustomResources
+	utilruntime.Must(apps.Install(scheme.Scheme))
+	utilruntime.Must(authorization.Install(scheme.Scheme))
+	utilruntime.Must(build.Install(scheme.Scheme))
+	utilruntime.Must(image.Install(scheme.Scheme))
+	utilruntime.Must(network.Install(scheme.Scheme))
+	utilruntime.Must(oauth.Install(scheme.Scheme))
+	utilruntime.Must(operator.Install(scheme.Scheme))
+	utilruntime.Must(project.Install(scheme.Scheme))
+	utilruntime.Must(quota.Install(scheme.Scheme))
+	utilruntime.Must(route.Install(scheme.Scheme))
+	utilruntime.Must(security.Install(scheme.Scheme))
+	utilruntime.Must(template.Install(scheme.Scheme))
+	utilruntime.Must(user.Install(scheme.Scheme))
 	legacy.InstallExternalLegacyAll(scheme.Scheme)
 
 	// the legacyscheme is used in kubectl and expects to have the internal types registered.  Explicitly wire our types here.


### PR DESCRIPTION
This removes the custom resource from the scheme of `oc`, which should keep apply from trying to build a strategic merge patch.

@soltysh you have a test you can run to confirm this?
/assign @soltysh 
@mfojtik @derekwaynecarr this is the `oc cluster up` blocker, right?

Fixes https://github.com/openshift/origin/issues/20462