### PR TITLE
Backport to 3.5 (1.5): PR 20433 - use release string if tito provides it.

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -39,6 +39,9 @@ class OriginTagger(VersionTagger):
         inject_os_git_vars(self.spec_file)
         super(OriginTagger, self)._tag_release()
 
-    def _get_tag_for_version(self, version):
-        return "v{}".format(version)
+    def _get_tag_for_version(self, version, release=None):
+        if release is None:
+            return "v{}".format(version)
+        else:
+            return "v{}-{}".format(version, release)
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:


### PR DESCRIPTION
This change backports PR 20433 .  This is needed to build with current tito versions.