### PR TITLE
backport to 3.10: PR 20433 - use release string if tito provides it

### DIFF
--- a/.tito/lib/origin/tagger/__init__.py
+++ b/.tito/lib/origin/tagger/__init__.py
@@ -40,5 +40,8 @@ class OriginTagger(VersionTagger):
         super(OriginTagger, self)._tag_release()
 
     def _get_tag_for_version(self, version, release=None):
-        return "v{}".format(version)
+        if release is None:
+            return "v{}".format(version)
+        else:
+            return "v{}-{}".format(version, release)
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:


### PR DESCRIPTION
This change backports PR 20433  which allows builds with modern versions of tito