### PR TITLE
Ignore errors caused by unkonwn scopes where it makes sense to do so.

### DIFF
--- a/pkg/authorization/apis/authorization/rbacconversion/conversion.go
+++ b/pkg/authorization/apis/authorization/rbacconversion/conversion.go
@@ -41,7 +41,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 func Convert_authorization_ClusterRole_To_rbac_ClusterRole(in *authorizationapi.ClusterRole, out *rbac.ClusterRole, _ conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Annotations = convert_authorization_Annotations_To_rbac_Annotations(in.Annotations)
-	out.Rules = convert_api_PolicyRules_To_rbac_PolicyRules(in.Rules)
+	out.Rules = Convert_api_PolicyRules_To_rbac_PolicyRules(in.Rules)
 	out.AggregationRule = in.AggregationRule.DeepCopy()
 	return nil
 }
@@ -49,7 +49,7 @@ func Convert_authorization_ClusterRole_To_rbac_ClusterRole(in *authorizationapi.
 func Convert_authorization_Role_To_rbac_Role(in *authorizationapi.Role, out *rbac.Role, _ conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Annotations = convert_authorization_Annotations_To_rbac_Annotations(in.Annotations)
-	out.Rules = convert_api_PolicyRules_To_rbac_PolicyRules(in.Rules)
+	out.Rules = Convert_api_PolicyRules_To_rbac_PolicyRules(in.Rules)
 	return nil
 }
 
@@ -81,7 +81,7 @@ func Convert_authorization_RoleBinding_To_rbac_RoleBinding(in *authorizationapi.
 	return nil
 }
 
-func convert_api_PolicyRules_To_rbac_PolicyRules(in []authorizationapi.PolicyRule) []rbac.PolicyRule {
+func Convert_api_PolicyRules_To_rbac_PolicyRules(in []authorizationapi.PolicyRule) []rbac.PolicyRule {
 	rules := make([]rbac.PolicyRule, 0, len(in))
 	for _, rule := range in {
 		// Origin's authorizer's RuleMatches func ignores rules that have AttributeRestrictions.

--- a/pkg/authorization/apiserver/registry/subjectrulesreview/storage.go
+++ b/pkg/authorization/apiserver/registry/subjectrulesreview/storage.go
@@ -99,7 +99,7 @@ func GetEffectivePolicyRules(ctx context.Context, ruleResolver rbacregistryvalid
 	if scopes := user.GetExtra()[authorizationapi.ScopesKey]; len(scopes) > 0 {
 		rules, err = filterRulesByScopes(rules, scopes, namespace, clusterRoleGetter)
 		if err != nil {
-			return nil, []error{kapierrors.NewInternalError(err)}
+			errors = append(errors, err)
 		}
 	}
 
@@ -113,9 +113,7 @@ func GetEffectivePolicyRules(ctx context.Context, ruleResolver rbacregistryvalid
 
 func filterRulesByScopes(rules []rbacv1.PolicyRule, scopes []string, namespace string, clusterRoleGetter rbaclisters.ClusterRoleLister) ([]rbacv1.PolicyRule, error) {
 	scopeRules, err := scope.ScopesToRules(scopes, namespace, clusterRoleGetter)
-	if err != nil {
-		return nil, err
-	}
+	// it's ok if there are errors, we'll just bubble them up
 
 	filteredRules := []rbacv1.PolicyRule{}
 	for _, rule := range rules {
@@ -124,5 +122,5 @@ func filterRulesByScopes(rules []rbacv1.PolicyRule, scopes []string, namespace s
 		}
 	}
 
-	return filteredRules, nil
+	return filteredRules, err
 }

--- a/pkg/authorization/authorizer/scope/authorizer.go
+++ b/pkg/authorization/authorizer/scope/authorizer.go
@@ -3,7 +3,6 @@ package scope
 import (
 	"fmt"
 
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
@@ -30,12 +29,12 @@ func (a *scopeAuthorizer) Authorize(attributes authorizer.Attributes) (authorize
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
-	nonFatalErrors := []error{}
+	nonFatalErrors := ""
 
 	// scopeResolutionErrors aren't fatal.  If any of the scopes we find allow this, then the overall scope limits allow it
 	rules, err := ScopesToRules(scopes, attributes.GetNamespace(), a.clusterRoleGetter)
 	if err != nil {
-		nonFatalErrors = append(nonFatalErrors, err)
+		nonFatalErrors = fmt.Sprintf(", additionally the following non-fatal errors were reported: %v", err)
 	}
 
 	// check rules against attributes
@@ -44,5 +43,5 @@ func (a *scopeAuthorizer) Authorize(attributes authorizer.Attributes) (authorize
 	}
 
 	// the scope prevent this.  We need to authoritatively deny
-	return authorizer.DecisionDeny, fmt.Sprintf("scopes %v prevent this action", scopes), kerrors.NewAggregate(nonFatalErrors)
+	return authorizer.DecisionDeny, fmt.Sprintf("scopes %v prevent this action%s", scopes, nonFatalErrors), nil
 }

--- a/pkg/authorization/authorizer/scope/authorizer_test.go
+++ b/pkg/authorization/authorizer/scope/authorizer_test.go
@@ -62,19 +62,17 @@ func TestAuthorize(t *testing.T) {
 				Namespace:       "ns",
 			},
 			expectedAllowed: kauthorizer.DecisionDeny,
-			expectedMsg:     `scopes [does-not-exist] prevent this action`,
-			expectedErr:     `no scope evaluator found for "does-not-exist"`,
+			expectedMsg:     `scopes [does-not-exist] prevent this action, additionally the following non-fatal errors were reported: no scope evaluator found for "does-not-exist"`,
 		},
 		{
 			name: "bad scope 2",
 			attributes: kauthorizer.AttributesRecord{
-				User:            &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"user:dne"}}},
+				User:            &user.DefaultInfo{Extra: map[string][]string{authorizationapi.ScopesKey: {"role:dne"}}},
 				ResourceRequest: true,
 				Namespace:       "ns",
 			},
 			expectedAllowed: kauthorizer.DecisionDeny,
-			expectedMsg:     `scopes [user:dne] prevent this action`,
-			expectedErr:     `unrecognized scope: user:dne`,
+			expectedMsg:     `scopes [role:dne] prevent this action, additionally the following non-fatal errors were reported: bad format for scope role:dne`,
 		},
 		{
 			name: "scope doesn't cover",

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -56,7 +57,7 @@ func ScopesToRules(scopes []string, namespace string, clusterRoleGetter rbaclist
 
 // ScopesToVisibleNamespaces returns a list of namespaces that the provided scopes have "get" access to.
 // This exists only to support efficiently list/watch of projects (ACLed namespaces)
-func ScopesToVisibleNamespaces(scopes []string, clusterRoleGetter rbaclisters.ClusterRoleLister) (sets.String, error) {
+func ScopesToVisibleNamespaces(scopes []string, clusterRoleGetter rbaclisters.ClusterRoleLister, ignoreUnhandledScopes bool) (sets.String, error) {
 	if len(scopes) == 0 {
 		return sets.NewString("*"), nil
 	}
@@ -81,7 +82,7 @@ func ScopesToVisibleNamespaces(scopes []string, clusterRoleGetter rbaclisters.Cl
 			}
 		}
 
-		if !found {
+		if !found && !ignoreUnhandledScopes {
 			errors = append(errors, fmt.Errorf("no scope evaluator found for %q", scope))
 		}
 	}
@@ -170,12 +171,15 @@ func DescribeScopes(scopes []string) map[string]string {
 type userEvaluator struct{}
 
 func (userEvaluator) Handles(scope string) bool {
-	return strings.HasPrefix(scope, UserIndicator)
-}
-
-func (userEvaluator) Validate(scope string) error {
 	switch scope {
 	case UserFull, UserInfo, UserAccessCheck, UserListScopedProjects, UserListAllProjects:
+		return true
+	}
+	return false
+}
+
+func (e userEvaluator) Validate(scope string) error {
+	if e.Handles(scope) {
 		return nil
 	}
 
@@ -389,6 +393,9 @@ func (e clusterRoleEvaluator) resolveRules(scope string, clusterRoleGetter rbacl
 
 	role, err := clusterRoleGetter.Get(roleName)
 	if err != nil {
+		if kapierrors.IsNotFound(err) {
+			return []rbacv1.PolicyRule{}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -23,13 +23,13 @@ func TestUserEvaluator(t *testing.T) {
 		{
 			name:     "missing-part",
 			scopes:   []string{UserIndicator},
-			err:      "unrecognized scope",
+			err:      "no scope evaluator found",
 			numRules: 1, // we always add the discovery rules
 		},
 		{
 			name:     "bad-part",
 			scopes:   []string{UserIndicator + "foo"},
-			err:      "unrecognized scope",
+			err:      "no scope evaluator found",
 			numRules: 1, // we always add the discovery rules
 		},
 		{
@@ -40,7 +40,7 @@ func TestUserEvaluator(t *testing.T) {
 		{
 			name:     "one-error",
 			scopes:   []string{UserIndicator, UserInfo},
-			err:      "unrecognized scope",
+			err:      "no scope evaluator found",
 			numRules: 2,
 		},
 		{

--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -112,7 +112,7 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 
 	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"
 
-	allowedNamespaces, err := scope.ScopesToVisibleNamespaces(userInfo.GetExtra()[authorizationapi.ScopesKey], s.authCache.GetClusterRoleLister())
+	allowedNamespaces, err := scope.ScopesToVisibleNamespaces(userInfo.GetExtra()[authorizationapi.ScopesKey], s.authCache.GetClusterRoleLister(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -486,7 +486,7 @@ func (ac *AuthorizationCache) List(userInfo user.Info) (*kapi.NamespaceList, err
 		}
 	}
 
-	allowedNamespaces, err := scope.ScopesToVisibleNamespaces(userInfo.GetExtra()[authorizationapi.ScopesKey], ac.clusterRoleLister)
+	allowedNamespaces, err := scope.ScopesToVisibleNamespaces(userInfo.GetExtra()[authorizationapi.ScopesKey], ac.clusterRoleLister, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows us to interop with an OIDC/OAuth server that sends us tokens with additional scopes used for other applications than Openshift