### PR TITLE
Remove --routing-suffix since it's not supported anymore

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -107,7 +107,7 @@ If you are running `oc cluster up` on a virtual machine in Amazon AWS EC2, you s
 $ metadata_endpoint="http://169.254.169.254/latest/meta-data"
 $ public_hostname="$( curl "${metadata_endpoint}/public-hostname" )"
 $ public_ip="$( curl "${metadata_endpoint}/public-ipv4" )"
-$ oc cluster up --public-hostname="${public_hostname}" --routing-suffix="${public_ip}.nip.io"
+$ oc cluster up --public-hostname="${public_hostname}"
 ```
 
 To stop your cluster, run:
@@ -228,7 +228,6 @@ If a host data directory is not specified, the data directory used by OpenShift 
 ## Routing
 
 The default routing suffix used by `oc cluster up` is CLUSTER_IP.nip.io where CLUSTER_IP is the IP address of your cluster.
-To use a different suffix, specify it with `--routing-suffix`.
 
 ## Specifying Images to Use
 

--- a/pkg/oc/cli/cluster/cluster.go
+++ b/pkg/oc/cli/cluster/cluster.go
@@ -27,8 +27,7 @@ var (
 		To use an existing Docker connection, ensure that Docker commands are working and that you
 		can create new containers.
 
-		Default routes are setup using nip.io and the host ip of your cluster. To use a different
-		routing suffix, use the --routing-suffix flag.`)
+		Default routes are setup using nip.io and the host ip of your cluster.`)
 )
 
 func NewCmdCluster(name, fullName string, f kcmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {

--- a/pkg/oc/clusterup/up.go
+++ b/pkg/oc/clusterup/up.go
@@ -69,8 +69,7 @@ var (
 		the command, ensure that you can execute docker commands successfully (i.e. 'docker ps').
 
 		By default, the OpenShift cluster will be setup to use a routing suffix that ends in nip.io.
-		This is to allow dynamic host names to be created for routes. An alternate routing suffix
-		can be specified using the --routing-suffix flag.
+		This is to allow dynamic host names to be created for routes.
 
 		A public hostname can also be specified for the server with the --public-hostname flag.`)
 


### PR DESCRIPTION
Followup to #20821 to clear all the places from `--routing-suffix`.

/assign @deads2k 
@openshift/sig-master 