### PR TITLE
Remove semantic modifiers from image format string

### DIFF
--- a/pkg/cmd/util/variable/variable.go
+++ b/pkg/cmd/util/variable/variable.go
@@ -64,7 +64,7 @@ func Versions(key string) (string, bool) {
 		}
 		return s, true
 	case "version":
-		s := lastSemanticVersion(overrideVersion.GitVersion)
+		s := lastSemanticVersionWithoutModifiers(overrideVersion.GitVersion)
 		return s, true
 	default:
 		return "", false
@@ -81,7 +81,7 @@ var overrideVersion = version.Get()
 
 // lastSemanticVersion attempts to return a semantic version from the GitVersion - which
 // is either <semver>+<commit> or <semver> on release boundaries.
-func lastSemanticVersion(version string) string {
-	parts := strings.Split(version, "+")
-	return parts[0]
+func lastSemanticVersionWithoutModifiers(version string) string {
+	parts := strings.Split(version, "-")
+	return strings.Split(parts[0], "+")[0]
 }

--- a/pkg/cmd/util/variable/variable_test.go
+++ b/pkg/cmd/util/variable/variable_test.go
@@ -10,18 +10,18 @@ func TestLastSemanticVersion(t *testing.T) {
 	}{
 		{"v1.3", "v1.3"},
 		{"v1.3+dirty", "v1.3"},
-		{"v1.3-11+abcdef-dirty", "v1.3-11"},
-		{"v1.3-11+abcdef", "v1.3-11"},
-		{"v1.3-11", "v1.3-11"},
+		{"v1.3-11+abcdef-dirty", "v1.3"},
+		{"v1.3-11+abcdef", "v1.3"},
+		{"v1.3-11", "v1.3"},
 		{"v1.3.0+abcdef", "v1.3.0"},
 		{"v1.3+abcdef", "v1.3"},
-		{"v1.3.0-alpha.1", "v1.3.0-alpha.1"},
-		{"v1.3.0-alpha.1-dirty", "v1.3.0-alpha.1-dirty"},
-		{"v1.3.0-alpha.1+abc-dirty", "v1.3.0-alpha.1"},
-		{"v1.3.0-alpha.1+abcdef-dirty", "v1.3.0-alpha.1"},
+		{"v1.3.0-alpha.1", "v1.3.0"},
+		{"v1.3.0-alpha.1-dirty", "v1.3.0"},
+		{"v1.3.0-alpha.1+abc-dirty", "v1.3.0"},
+		{"v1.3.0-alpha.1+abcdef-dirty", "v1.3.0"},
 	}
 	for _, test := range testCases {
-		out := lastSemanticVersion(test.in)
+		out := lastSemanticVersionWithoutModifiers(test.in)
 		if out != test.out {
 			t.Errorf("expected %s for %s, got %s", test.out, test.in, out)
 		}


### PR DESCRIPTION
Starting with 4.0, we are going to stop using the format string as
the primary vehicle to lock code, and we have not used the -alpha.0
tagging format for two releases. Make it so that image format strings
only consider the MAJOR.MINOR.MICRO part of the semantic version.

This will break locking to prerelease versions intentionally.