### PR TITLE
add default values for kubeapiserverconfig to make it easier to use

### DIFF
--- a/install/etcd/install.yaml
+++ b/install/etcd/install.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: etcd
+parameters:
+- name: NAMESPACE
+  value: kube-system
+objects:
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: etcd
+    namespace: ${NAMESPACE}
+  spec:
+    selector:
+      openshift.io/component: etcd
+    ports:
+    - name: listen
+      port: 4001
+      protocol: TCP

--- a/pkg/cmd/openshift-kube-apiserver/cmd.go
+++ b/pkg/cmd/openshift-kube-apiserver/cmd.go
@@ -23,6 +23,7 @@ import (
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
+	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/configdefault"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config/validation"
@@ -121,6 +122,7 @@ func (o *OpenShiftKubeAPIServerServer) RunAPIServer() error {
 		if err := helpers.ResolvePaths(configconversion.GetKubeAPIServerConfigFileReferences(config), configFileLocation); err != nil {
 			return err
 		}
+		configdefault.SetRecommendedKubeAPIServerConfigDefaults(config)
 
 		return RunOpenShiftKubeAPIServerServer(config)
 	}

--- a/pkg/cmd/openshift-kube-apiserver/configdefault/config_default.go
+++ b/pkg/cmd/openshift-kube-apiserver/configdefault/config_default.go
@@ -1,0 +1,54 @@
+package configdefault
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func DefaultString(target *string, defaultVal string) {
+	if len(*target) == 0 {
+		*target = defaultVal
+	}
+}
+
+func DefaultStringSlice(target *[]string, defaultVal []string) {
+	if len(*target) == 0 {
+		*target = defaultVal
+	}
+}
+
+func SetRecommendedHTTPServingInfoDefaults(config *configv1.HTTPServingInfo) {
+	if config.MaxRequestsInFlight == 0 {
+		config.MaxRequestsInFlight = 3000
+	}
+	if config.RequestTimeoutSeconds == 0 {
+		config.RequestTimeoutSeconds = 60 * 60 // one hour
+	}
+
+	SetRecommendedServingInfoDefaults(&config.ServingInfo)
+}
+
+func SetRecommendedServingInfoDefaults(config *configv1.ServingInfo) {
+	DefaultString(&config.BindAddress, "0.0.0.0:8443")
+	DefaultString(&config.BindNetwork, "tcp4")
+	DefaultString(&config.CertInfo.KeyFile, "/var/run/secrets/serving-cert/tls.key")
+	DefaultString(&config.CertInfo.CertFile, "/var/run/secrets/serving-cert/tls.crt")
+	DefaultString(&config.ClientCA, "/var/run/configmaps/client-ca/ca-bundle.crt")
+	DefaultString(&config.MinTLSVersion, crypto.TLSVersionToNameOrDie(crypto.DefaultTLSVersion()))
+
+	if len(config.CipherSuites) == 0 {
+		config.CipherSuites = crypto.CipherSuitesToNamesOrDie(crypto.DefaultCiphers())
+	}
+}
+
+func SetRecommendedGenericAPIServerConfigDefaults(config *configv1.GenericAPIServerConfig) {
+	SetRecommendedHTTPServingInfoDefaults(&config.ServingInfo)
+	SetRecommendedEtcdConnectionInfoDefaults(&config.StorageConfig.EtcdConnectionInfo)
+}
+
+func SetRecommendedEtcdConnectionInfoDefaults(config *configv1.EtcdConnectionInfo) {
+	DefaultStringSlice(&config.URLs, []string{"https://etcd.kube-system.svc:4001"})
+	DefaultString(&config.CertInfo.KeyFile, "/var/run/secrets/etcd-client/tls.key")
+	DefaultString(&config.CertInfo.CertFile, "/var/run/secrets/etcd-client/tls.crt")
+	DefaultString(&config.CA, "/var/run/configmaps/etcd-serving-ca/ca-bundle.crt")
+}

--- a/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go
+++ b/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go
@@ -1,0 +1,62 @@
+package configdefault
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
+)
+
+func SetRecommendedKubeAPIServerConfigDefaults(config *kubecontrolplanev1.KubeAPIServerConfig) {
+	DefaultString(&config.GenericAPIServerConfig.StorageConfig.StoragePrefix, "kubernetes.io")
+
+	SetRecommendedGenericAPIServerConfigDefaults(&config.GenericAPIServerConfig)
+	SetRecommendedMasterAuthConfigDefaults(&config.AuthConfig)
+	SetRecommendedAggregatorConfigDefaults(&config.AggregatorConfig)
+	SetRecommendedKubeletConnectionInfoDefaults(&config.KubeletClientInfo)
+
+	DefaultString(&config.ServicesSubnet, "10.0.0.0/24")
+	DefaultString(&config.ServicesNodePortRange, "30000-32767")
+
+	if len(config.ServiceAccountPublicKeyFiles) == 0 {
+		contents, err := ioutil.ReadDir("/var/run/configmaps/sa-token-signing-certs")
+		switch {
+		case os.IsNotExist(err) || os.IsPermission(err):
+		case err != nil:
+			panic(err) // some weird, unexpected error
+		default:
+			for _, content := range contents {
+				config.ServiceAccountPublicKeyFiles = append(config.ServiceAccountPublicKeyFiles, path.Join("/var/run/configmaps/sa-token-signing-certs", content.Name()))
+			}
+		}
+	}
+
+	// after the aggregator defaults are set, we can default the auth config values
+	// TODO this indicates that we're set two different things to the same value
+	if config.AuthConfig.RequestHeader == nil {
+		config.AuthConfig.RequestHeader = &kubecontrolplanev1.RequestHeaderAuthenticationOptions{}
+		DefaultStringSlice(&config.AuthConfig.RequestHeader.ClientCommonNames, []string{"system:openshift-aggregator"})
+		DefaultString(&config.AuthConfig.RequestHeader.ClientCA, "/var/run/secrets/aggregator-client-ca/ca-bundle.crt")
+		DefaultStringSlice(&config.AuthConfig.RequestHeader.UsernameHeaders, []string{"X-Remote-User"})
+		DefaultStringSlice(&config.AuthConfig.RequestHeader.GroupHeaders, []string{"X-Remote-Group"})
+		DefaultStringSlice(&config.AuthConfig.RequestHeader.ExtraHeaderPrefixes, []string{"X-Remote-Extra-"})
+	}
+}
+
+func SetRecommendedMasterAuthConfigDefaults(config *kubecontrolplanev1.MasterAuthConfig) {
+}
+
+func SetRecommendedAggregatorConfigDefaults(config *kubecontrolplanev1.AggregatorConfig) {
+	DefaultString(&config.ProxyClientInfo.KeyFile, "/var/run/secrets/aggregator-client/tls.key")
+	DefaultString(&config.ProxyClientInfo.CertFile, "/var/run/secrets/aggregator-client/tls.crt")
+}
+
+func SetRecommendedKubeletConnectionInfoDefaults(config *kubecontrolplanev1.KubeletConnectionInfo) {
+	if config.Port == 0 {
+		config.Port = 10250
+	}
+	DefaultString(&config.CertInfo.KeyFile, "/var/run/secrets/kubelet-client/tls.key")
+	DefaultString(&config.CertInfo.CertFile, "/var/run/secrets/kubelet-client/tls.crt")
+	DefaultString(&config.CA, "/var/run/configmaps/kubelet-serving-ca/ca-bundle.crt")
+}

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -41,6 +41,7 @@
 // install/automationservicebroker/install-rbac.yaml
 // install/automationservicebroker/install.yaml
 // install/etcd/etcd.yaml
+// install/etcd/install.yaml
 // install/kube-apiserver/apiserver.yaml
 // install/kube-controller-manager/kube-controller-manager.yaml
 // install/kube-dns/install.yaml
@@ -16765,6 +16766,44 @@ func installEtcdEtcdYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installEtcdInstallYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: etcd
+parameters:
+- name: NAMESPACE
+  value: kube-system
+objects:
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: etcd
+    namespace: ${NAMESPACE}
+  spec:
+    selector:
+      openshift.io/component: etcd
+    ports:
+    - name: listen
+      port: 4001
+      protocol: TCP
+`)
+
+func installEtcdInstallYamlBytes() ([]byte, error) {
+	return _installEtcdInstallYaml, nil
+}
+
+func installEtcdInstallYaml() (*asset, error) {
+	bytes, err := installEtcdInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/etcd/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installKubeApiserverApiserverYaml = []byte(`kind: Pod
 apiVersion: v1
 metadata:
@@ -18655,6 +18694,7 @@ var _bindata = map[string]func() (*asset, error){
 	"install/automationservicebroker/install-rbac.yaml": installAutomationservicebrokerInstallRbacYaml,
 	"install/automationservicebroker/install.yaml": installAutomationservicebrokerInstallYaml,
 	"install/etcd/etcd.yaml": installEtcdEtcdYaml,
+	"install/etcd/install.yaml": installEtcdInstallYaml,
 	"install/kube-apiserver/apiserver.yaml": installKubeApiserverApiserverYaml,
 	"install/kube-controller-manager/kube-controller-manager.yaml": installKubeControllerManagerKubeControllerManagerYaml,
 	"install/kube-dns/install.yaml": installKubeDnsInstallYaml,
@@ -18779,6 +18819,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 		"etcd": &bintree{nil, map[string]*bintree{
 			"etcd.yaml": &bintree{installEtcdEtcdYaml, map[string]*bintree{}},
+			"install.yaml": &bintree{installEtcdInstallYaml, map[string]*bintree{}},
 		}},
 		"kube-apiserver": &bintree{nil, map[string]*bintree{
 			"apiserver.yaml": &bintree{installKubeApiserverApiserverYaml, map[string]*bintree{}},

--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -68,8 +68,18 @@ var (
 		},
 	}
 
+	runlevelZeroLabel         = map[string]string{"openshift.io/run-level": "0"}
 	runlevelOneLabel          = map[string]string{"openshift.io/run-level": "1"}
 	runLevelOneKubeComponents = []componentInstallTemplate{
+		{
+			ComponentImage: "hypershift",
+			Template: componentinstall.Template{
+				Name:            "etcd",
+				Namespace:       "kube-system",
+				NamespaceObj:    newNamespaceBytes("kube-system", runlevelZeroLabel),
+				InstallTemplate: manifests.MustAsset("install/etcd/install.yaml"),
+			},
+		},
 		{
 			ComponentImage: "control-plane",
 			Template: componentinstall.Template{

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -270,6 +270,7 @@
 // install/automationservicebroker/install-rbac.yaml
 // install/automationservicebroker/install.yaml
 // install/etcd/etcd.yaml
+// install/etcd/install.yaml
 // install/kube-apiserver/apiserver.yaml
 // install/kube-controller-manager/kube-controller-manager.yaml
 // install/kube-dns/install.yaml
@@ -32450,6 +32451,44 @@ func installEtcdEtcdYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installEtcdInstallYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: etcd
+parameters:
+- name: NAMESPACE
+  value: kube-system
+objects:
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: etcd
+    namespace: ${NAMESPACE}
+  spec:
+    selector:
+      openshift.io/component: etcd
+    ports:
+    - name: listen
+      port: 4001
+      protocol: TCP
+`)
+
+func installEtcdInstallYamlBytes() ([]byte, error) {
+	return _installEtcdInstallYaml, nil
+}
+
+func installEtcdInstallYaml() (*asset, error) {
+	bytes, err := installEtcdInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/etcd/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installKubeApiserverApiserverYaml = []byte(`kind: Pod
 apiVersion: v1
 metadata:
@@ -34533,6 +34572,7 @@ var _bindata = map[string]func() (*asset, error){
 	"install/automationservicebroker/install-rbac.yaml": installAutomationservicebrokerInstallRbacYaml,
 	"install/automationservicebroker/install.yaml": installAutomationservicebrokerInstallYaml,
 	"install/etcd/etcd.yaml": installEtcdEtcdYaml,
+	"install/etcd/install.yaml": installEtcdInstallYaml,
 	"install/kube-apiserver/apiserver.yaml": installKubeApiserverApiserverYaml,
 	"install/kube-controller-manager/kube-controller-manager.yaml": installKubeControllerManagerKubeControllerManagerYaml,
 	"install/kube-dns/install.yaml": installKubeDnsInstallYaml,
@@ -34666,6 +34706,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 		"etcd": &bintree{nil, map[string]*bintree{
 			"etcd.yaml": &bintree{installEtcdEtcdYaml, map[string]*bintree{}},
+			"install.yaml": &bintree{installEtcdInstallYaml, map[string]*bintree{}},
 		}},
 		"kube-apiserver": &bintree{nil, map[string]*bintree{
 			"apiserver.yaml": &bintree{installKubeApiserverApiserverYaml, map[string]*bintree{}},


### PR DESCRIPTION
Just the last commit is unique.  This adds value defaulting for the kubeapiserverconfig.

I plan to add some logic cluster up to prime the configmaps and secrets with content that currently exists in the local folder.

/assign @sttts @mfojtik 