### PR TITLE
Add stress test for logs following a pod deleted right after it finishes

### DIFF
--- a/test/extended/cli/logs.go
+++ b/test/extended/cli/logs.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+func readPodFixture(path string) (*corev1.Pod, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	content, err := kyaml.ToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := runtime.Decode(scheme.Codecs.UniversalDecoder(corev1.SchemeGroupVersion), content)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*corev1.Pod), err
+}
+
+var _ = g.Describe("[cli] oc logs", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLI("cli-deployment", exutil.KubeConfigPath())
+
+	g.JustBeforeEach(func() {
+		// FIXME: remove this when https://github.com/openshift/origin/issues/20225 gets fixed
+		g.By("waiting for default service account")
+		err := exutil.WaitForServiceAccount(oc.KubeClient().CoreV1().ServiceAccounts(oc.Namespace()), "default")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	var (
+		echoPodFixture = exutil.FixturePath("testdata", "cli", "echo-pod.yaml")
+	)
+
+	g.It("should get all logs with --follow if the pod is gonna be terminated right after", func() {
+		namespace := oc.Namespace()
+		podName := "test-pod"
+
+		pod, err := readPodFixture(echoPodFixture)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pod.Name).To(o.Equal(podName))
+		o.Expect(pod.Spec.RestartPolicy).To(o.Equal(corev1.RestartPolicyNever))
+
+		pod, err = oc.KubeClient().CoreV1().Pods(namespace).Create(pod)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Created the pod")
+
+		w, err := oc.KubeClient().CoreV1().Pods(namespace).Watch(metav1.SingleObject(pod.ObjectMeta))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		e2e.Logf("Waiting for the pod to become running")
+		event, err := watch.Until(5*time.Minute, w, func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Modified:
+				phase := event.Object.(*corev1.Pod).Status.Phase
+				switch phase {
+				case corev1.PodRunning:
+					return true, nil
+				case corev1.PodPending:
+					return false, nil
+				default:
+					return true, fmt.Errorf("unexpected pod phase: %q", phase)
+				}
+			default:
+				return true, fmt.Errorf("unexpected event: %#v", event)
+			}
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		pod = event.Object.(*corev1.Pod)
+		e2e.Logf("Observed pod as running")
+
+		logCh := make(chan struct{})
+		var out string
+		go func() {
+			var err error
+			out, err = oc.Run("logs").Args("--follow", "pod/"+podName).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("oc logs finished")
+			logCh <- struct{}{}
+		}()
+
+		w, err = oc.KubeClient().CoreV1().Pods(namespace).Watch(metav1.SingleObject(pod.ObjectMeta))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		e2e.Logf("Waiting for the pod to finish")
+		_, err = watch.Until(5*time.Minute, w, func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Modified:
+				return event.Object.(*corev1.Pod).Status.Phase == corev1.PodSucceeded, nil
+			default:
+				return true, fmt.Errorf("unexpected event: %#v", event)
+			}
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		e2e.Logf("Deleting the pod right after it finished")
+		gracePeriod := int64(0)
+		err = oc.KubeClient().CoreV1().Pods(namespace).Delete(pod.Name, &metav1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriod,
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		<-logCh
+		e2e.Logf("out: %#v", out)
+		// TODO: investigate why the last \n is stripped
+		o.Expect(out).To(o.BeEquivalentTo("line 1\nline 2\nline 3"))
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -89,6 +89,7 @@
 // test/extended/testdata/builds/valuefrom/test-configmap.yaml
 // test/extended/testdata/builds/valuefrom/test-is.json
 // test/extended/testdata/builds/valuefrom/test-secret.yaml
+// test/extended/testdata/cli/echo-pod.yaml
 // test/extended/testdata/cluster/master-vert.yaml
 // test/extended/testdata/config-map-jenkins-slave-pods.yaml
 // test/extended/testdata/custom-secret-builder/Dockerfile
@@ -4689,6 +4690,42 @@ func testExtendedTestdataBuildsValuefromTestSecretYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataCliEchoPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test
+    image: centos:centos7
+    command:
+    - /bin/sh
+    - -c
+    - |
+      set -e
+      sleep 15  # give some time for the test logic to be set up
+      echo line 1
+      sleep 1
+      echo line 2
+      echo line 3
+`)
+
+func testExtendedTestdataCliEchoPodYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataCliEchoPodYaml, nil
+}
+
+func testExtendedTestdataCliEchoPodYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataCliEchoPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/cli/echo-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataClusterMasterVertYaml = []byte(`provider: local
 ClusterLoader:
   cleanup: true
@@ -4925,7 +4962,6 @@ spec:
         echo Halfway
         openshift-deploy
         echo Finished
-        sleep 1
   template:
     metadata:
       labels:
@@ -4938,7 +4974,7 @@ spec:
         name: myapp
         command:
         - /bin/sleep
-        - "10"
+        - "infinity"
   triggers:
   - type: ConfigChange
 `)
@@ -34352,6 +34388,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/valuefrom/test-configmap.yaml": testExtendedTestdataBuildsValuefromTestConfigmapYaml,
 	"test/extended/testdata/builds/valuefrom/test-is.json": testExtendedTestdataBuildsValuefromTestIsJson,
 	"test/extended/testdata/builds/valuefrom/test-secret.yaml": testExtendedTestdataBuildsValuefromTestSecretYaml,
+	"test/extended/testdata/cli/echo-pod.yaml": testExtendedTestdataCliEchoPodYaml,
 	"test/extended/testdata/cluster/master-vert.yaml": testExtendedTestdataClusterMasterVertYaml,
 	"test/extended/testdata/config-map-jenkins-slave-pods.yaml": testExtendedTestdataConfigMapJenkinsSlavePodsYaml,
 	"test/extended/testdata/custom-secret-builder/Dockerfile": testExtendedTestdataCustomSecretBuilderDockerfile,
@@ -34843,6 +34880,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"test-is.json": &bintree{testExtendedTestdataBuildsValuefromTestIsJson, map[string]*bintree{}},
 						"test-secret.yaml": &bintree{testExtendedTestdataBuildsValuefromTestSecretYaml, map[string]*bintree{}},
 					}},
+				}},
+				"cli": &bintree{nil, map[string]*bintree{
+					"echo-pod.yaml": &bintree{testExtendedTestdataCliEchoPodYaml, map[string]*bintree{}},
 				}},
 				"cluster": &bintree{nil, map[string]*bintree{
 					"master-vert.yaml": &bintree{testExtendedTestdataClusterMasterVertYaml, map[string]*bintree{}},

--- a/test/extended/testdata/cli/echo-pod.yaml
+++ b/test/extended/testdata/cli/echo-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test
+    image: centos:centos7
+    command:
+    - /bin/sh
+    - -c
+    - |
+      set -e
+      sleep 15  # give some time for the test logic to be set up
+      echo line 1
+      sleep 1
+      echo line 2
+      echo line 3

--- a/test/extended/testdata/deployments/custom-deployment.yaml
+++ b/test/extended/testdata/deployments/custom-deployment.yaml
@@ -26,7 +26,6 @@ spec:
         echo Halfway
         openshift-deploy
         echo Finished
-        sleep 1
   template:
     metadata:
       labels:
@@ -39,6 +38,6 @@ spec:
         name: myapp
         command:
         - /bin/sleep
-        - "10"
+        - "infinity"
   triggers:
   - type: ConfigChange


### PR DESCRIPTION
A stress test for `oc logs` so deployments don't get blamed just for using it :)

/assign @mfojtik 

@mrunalp @runcom also a great way to make sure it works on cri-o where issues have been encountered
```bash
go test -v -race ./test/extended -test.timeout=1h -count=20 -failfast -args -ginkgo.progress -ginkgo.focus=".*oc logs.*"
```
Hope this will help us hunt down the root cause without involving deployments.

/cc @derekwaynecarr @damemi 