### PR TITLE
 add kube-apiserver-operator to cluster up

### DIFF
--- a/install/cluster-kube-apiserver-operator/install.yaml
+++ b/install/cluster-kube-apiserver-operator/install.yaml
@@ -1,0 +1,111 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: NAMESPACE
+  # This namespace must not be changed.
+  value: openshift-core-operators
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      openshift.io/run-level: "0"
+    name: openshift-core-operators
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io
+  spec:
+    scope: Cluster
+    group: kubeapiserver.operator.openshift.io
+    version: v1alpha1
+    names:
+      kind: KubeApiserverOperatorConfig
+      plural: kubeapiserveroperatorconfigs
+      singular: kubeapiserveroperatorconfig
+    subresources:
+      status: {}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:operator:cluster-kube-apiserver-operator
+  roleRef:
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator-config
+  data:
+    config.yaml: |
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: GenericOperatorConfig
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+    labels:
+      app: openshift-cluster-kube-apiserver-operator
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: openshift-cluster-kube-apiserver-operator
+    template:
+      metadata:
+        name: openshift-cluster-kube-apiserver-operator
+        labels:
+          app: openshift-cluster-kube-apiserver-operator
+      spec:
+        serviceAccountName: openshift-cluster-kube-apiserver-operator
+        containers:
+        - name: operator
+          image: openshift/origin-cluster-kube-apiserver-operator:latest
+          imagePullPolicy: IfNotPresent
+          command: ["cluster-kube-apiserver-operator", "operator"]
+          args:
+          - "--config=/var/run/configmaps/config/config.yaml"
+          - "-v=4"
+          volumeMounts:
+          - mountPath: /var/run/configmaps/config
+            name: config
+        volumes:
+        - name: serving-cert
+          secret:
+            defaultMode: 400
+            secretName: openshift-cluster-kube-apiserver-operator-serving-cert
+            optional: true
+        - name: config
+          configMap:
+            defaultMode: 440
+            name: openshift-cluster-kube-apiserver-operator-config
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+    labels:
+      app: openshift-cluster-kube-apiserver-operator
+
+- apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
+  kind: KubeApiserverOperatorConfig
+  metadata:
+    name: instance
+  spec:
+    managementState: Managed
+    imagePullSpec: openshift/origin-hypershift:latest
+    version: 3.11.0
+    logging:
+      level: 4
+    replicas: 2

--- a/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go
+++ b/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go
@@ -27,6 +27,9 @@ func SetRecommendedKubeAPIServerConfigDefaults(config *kubecontrolplanev1.KubeAP
 			panic(err) // some weird, unexpected error
 		default:
 			for _, content := range contents {
+				if !content.Mode().IsRegular() {
+					continue
+				}
 				config.ServiceAccountPublicKeyFiles = append(config.ServiceAccountPublicKeyFiles, path.Join("/var/run/configmaps/sa-token-signing-certs", content.Name()))
 			}
 		}
@@ -37,7 +40,7 @@ func SetRecommendedKubeAPIServerConfigDefaults(config *kubecontrolplanev1.KubeAP
 	if config.AuthConfig.RequestHeader == nil {
 		config.AuthConfig.RequestHeader = &kubecontrolplanev1.RequestHeaderAuthenticationOptions{}
 		DefaultStringSlice(&config.AuthConfig.RequestHeader.ClientCommonNames, []string{"system:openshift-aggregator"})
-		DefaultString(&config.AuthConfig.RequestHeader.ClientCA, "/var/run/secrets/aggregator-client-ca/ca-bundle.crt")
+		DefaultString(&config.AuthConfig.RequestHeader.ClientCA, "/var/run/configmaps/aggregator-client-ca/ca-bundle.crt")
 		DefaultStringSlice(&config.AuthConfig.RequestHeader.UsernameHeaders, []string{"X-Remote-User"})
 		DefaultStringSlice(&config.AuthConfig.RequestHeader.GroupHeaders, []string{"X-Remote-Group"})
 		DefaultStringSlice(&config.AuthConfig.RequestHeader.ExtraHeaderPrefixes, []string{"X-Remote-Extra-"})

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -484,6 +484,7 @@ func (args MasterArgs) GetServerCertHostnames() (sets.String, error) {
 		"kubernetes.default.svc",
 		"kubernetes.default",
 		"kubernetes",
+		"etcd.kube-system.svc",
 		masterAddr.Host, masterPublicAddr.Host, assetPublicAddr.Host)
 
 	if _, ipnet, err := net.ParseCIDR(args.NetworkArgs.ServiceNetworkCIDR); err == nil {

--- a/pkg/oc/clusterup/coreinstall/components/pivot/initialconfig.go
+++ b/pkg/oc/clusterup/coreinstall/components/pivot/initialconfig.go
@@ -1,0 +1,144 @@
+package pivot
+
+import (
+	"io/ioutil"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/origin/pkg/oc/clusterup/componentinstall"
+	"github.com/openshift/origin/pkg/oc/clusterup/docker/dockerhelper"
+)
+
+type Component interface {
+	Name() string
+	Install(dockerClient dockerhelper.Interface) error
+}
+
+type KubeAPIServerContent struct {
+	InstallContext componentinstall.Context
+}
+
+func (k *KubeAPIServerContent) Name() string {
+	return "KubeAPIServerContent"
+}
+
+// this ia list of all the secrets and configmaps we need to create
+const (
+	namespace = "openshift-kube-apiserver"
+
+	// saTokenSigningCerts contains certificates corresponding to the valid keys that are and were used to sign SA tokens
+	saTokenSigningCerts = "sa-token-signing-certs"
+	// aggregatorClientCABundle is the ca-bundle to use to verify that the aggregator is proxying to your apiserver
+	aggregatorClientCABundle = "aggregator-client-ca"
+	// aggregatorClientCertKeyPair is the client cert/key pair used by the aggregator when proxying
+	aggregatorClientCertKeyPair = "aggregator-client"
+	// kubeletClientCertKeyPair is the client cert/key used by the kube-apiserver when communicating with the kubelet
+	kubeletClientCertKeyPair = "kubelet-client"
+	// kubeletServingCABundle is the ca-bundle to use to verify connections to the kubelet
+	kubeletServingCABundle = "kubelet-serving-ca"
+	// apiserverServingCertKeyPair is the serving cert/key used by the kube-apiserver to secure its https server
+	apiserverServingCertKeyPair = "serving-cert"
+	// apiserverClientCABundle is the ca-bundle used to identify users from incoming connections to the kube-apiserver
+	apiserverClientCABundle = "client-ca"
+	// etcdClientCertKeyPair is the client cert/key pair used by the kube-apiserver when communicating with etcd
+	etcdClientCertKeyPair = "etcd-client"
+	// etcdServingCABundle is the ca-bundle to use to verify connections to etcd
+	etcdServingCABundle = "etcd-serving-ca"
+)
+
+func (c *KubeAPIServerContent) Install(dockerClient dockerhelper.Interface) error {
+	kubAPIServerConfigDir := path.Join(c.InstallContext.BaseDir(), "kube-apiserver")
+	kubeClient, err := kubernetes.NewForConfig(c.InstallContext.ClusterAdminClientConfig())
+	if err != nil {
+		return err
+	}
+
+	_, err = kubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{"openshift.io/run-level": "0"}}})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	if err := ensureCABundle(kubeClient, kubAPIServerConfigDir, saTokenSigningCerts, "serviceaccounts.public.key"); err != nil {
+		return err
+	}
+	if err := ensureCABundle(kubeClient, kubAPIServerConfigDir, aggregatorClientCABundle, "frontproxy-ca.crt"); err != nil {
+		return err
+	}
+	if err := ensureCABundle(kubeClient, kubAPIServerConfigDir, kubeletServingCABundle, "ca.crt"); err != nil {
+		return err
+	}
+	if err := ensureCABundle(kubeClient, kubAPIServerConfigDir, apiserverClientCABundle, "ca.crt"); err != nil {
+		return err
+	}
+	if err := ensureCABundle(kubeClient, kubAPIServerConfigDir, etcdServingCABundle, "ca.crt"); err != nil {
+		return err
+	}
+
+	if err := ensureCertKeyPair(kubeClient, kubAPIServerConfigDir, aggregatorClientCertKeyPair, "openshift-aggregator"); err != nil {
+		return err
+	}
+	if err := ensureCertKeyPair(kubeClient, kubAPIServerConfigDir, kubeletClientCertKeyPair, "master.kubelet-client"); err != nil {
+		return err
+	}
+	if err := ensureCertKeyPair(kubeClient, kubAPIServerConfigDir, apiserverServingCertKeyPair, "master.server"); err != nil {
+		return err
+	}
+	if err := ensureCertKeyPair(kubeClient, kubAPIServerConfigDir, etcdClientCertKeyPair, "master.etcd-client"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureConfigMap(kubeClient kubernetes.Interface, obj *corev1.ConfigMap) error {
+	_, err := kubeClient.CoreV1().ConfigMaps(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
+	if err == nil || !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	_, err = kubeClient.CoreV1().ConfigMaps(obj.Namespace).Create(obj)
+	return err
+}
+
+func ensureSecret(kubeClient kubernetes.Interface, obj *corev1.Secret) error {
+	_, err := kubeClient.CoreV1().Secrets(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
+	if err == nil || !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	_, err = kubeClient.CoreV1().Secrets(obj.Namespace).Create(obj)
+	return err
+}
+
+func ensureCABundle(kubeClient kubernetes.Interface, kubeAPIServerDir, name, filename string) error {
+	content, err := ioutil.ReadFile(path.Join(kubeAPIServerDir, filename))
+	if err != nil {
+		return err
+	}
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data: map[string]string{
+			"ca-bundle.crt": string(content),
+		}}
+	return ensureConfigMap(kubeClient, obj)
+}
+
+func ensureCertKeyPair(kubeClient kubernetes.Interface, kubeAPIServerDir, name, baseFilename string) error {
+	cert, err := ioutil.ReadFile(path.Join(kubeAPIServerDir, baseFilename+".crt"))
+	if err != nil {
+		return err
+	}
+	key, err := ioutil.ReadFile(path.Join(kubeAPIServerDir, baseFilename+".key"))
+	if err != nil {
+		return err
+	}
+	obj := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data: map[string][]byte{
+			"tls.crt": cert,
+			"tls.key": key,
+		}}
+	return ensureSecret(kubeClient, obj)
+}

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -40,6 +40,7 @@
 // examples/service-catalog/service-catalog.yaml
 // install/automationservicebroker/install-rbac.yaml
 // install/automationservicebroker/install.yaml
+// install/cluster-kube-apiserver-operator/install.yaml
 // install/etcd/etcd.yaml
 // install/etcd/install.yaml
 // install/kube-apiserver/apiserver.yaml
@@ -16713,6 +16714,134 @@ func installAutomationservicebrokerInstallYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installClusterKubeApiserverOperatorInstallYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: NAMESPACE
+  # This namespace must not be changed.
+  value: openshift-core-operators
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      openshift.io/run-level: "0"
+    name: openshift-core-operators
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io
+  spec:
+    scope: Cluster
+    group: kubeapiserver.operator.openshift.io
+    version: v1alpha1
+    names:
+      kind: KubeApiserverOperatorConfig
+      plural: kubeapiserveroperatorconfigs
+      singular: kubeapiserveroperatorconfig
+    subresources:
+      status: {}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:operator:cluster-kube-apiserver-operator
+  roleRef:
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator-config
+  data:
+    config.yaml: |
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: GenericOperatorConfig
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+    labels:
+      app: openshift-cluster-kube-apiserver-operator
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: openshift-cluster-kube-apiserver-operator
+    template:
+      metadata:
+        name: openshift-cluster-kube-apiserver-operator
+        labels:
+          app: openshift-cluster-kube-apiserver-operator
+      spec:
+        serviceAccountName: openshift-cluster-kube-apiserver-operator
+        containers:
+        - name: operator
+          image: openshift/origin-cluster-kube-apiserver-operator:latest
+          imagePullPolicy: IfNotPresent
+          command: ["cluster-kube-apiserver-operator", "operator"]
+          args:
+          - "--config=/var/run/configmaps/config/config.yaml"
+          - "-v=4"
+          volumeMounts:
+          - mountPath: /var/run/configmaps/config
+            name: config
+        volumes:
+        - name: serving-cert
+          secret:
+            defaultMode: 400
+            secretName: openshift-cluster-kube-apiserver-operator-serving-cert
+            optional: true
+        - name: config
+          configMap:
+            defaultMode: 440
+            name: openshift-cluster-kube-apiserver-operator-config
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+    labels:
+      app: openshift-cluster-kube-apiserver-operator
+
+- apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
+  kind: KubeApiserverOperatorConfig
+  metadata:
+    name: instance
+  spec:
+    managementState: Managed
+    imagePullSpec: openshift/origin-hypershift:latest
+    version: 3.11.0
+    logging:
+      level: 4
+    replicas: 2
+`)
+
+func installClusterKubeApiserverOperatorInstallYamlBytes() ([]byte, error) {
+	return _installClusterKubeApiserverOperatorInstallYaml, nil
+}
+
+func installClusterKubeApiserverOperatorInstallYaml() (*asset, error) {
+	bytes, err := installClusterKubeApiserverOperatorInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/cluster-kube-apiserver-operator/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installEtcdEtcdYaml = []byte(`kind: Pod
 apiVersion: v1
 metadata:
@@ -18693,6 +18822,7 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/service-catalog/service-catalog.yaml": examplesServiceCatalogServiceCatalogYaml,
 	"install/automationservicebroker/install-rbac.yaml": installAutomationservicebrokerInstallRbacYaml,
 	"install/automationservicebroker/install.yaml": installAutomationservicebrokerInstallYaml,
+	"install/cluster-kube-apiserver-operator/install.yaml": installClusterKubeApiserverOperatorInstallYaml,
 	"install/etcd/etcd.yaml": installEtcdEtcdYaml,
 	"install/etcd/install.yaml": installEtcdInstallYaml,
 	"install/kube-apiserver/apiserver.yaml": installKubeApiserverApiserverYaml,
@@ -18816,6 +18946,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"automationservicebroker": &bintree{nil, map[string]*bintree{
 			"install-rbac.yaml": &bintree{installAutomationservicebrokerInstallRbacYaml, map[string]*bintree{}},
 			"install.yaml": &bintree{installAutomationservicebrokerInstallYaml, map[string]*bintree{}},
+		}},
+		"cluster-kube-apiserver-operator": &bintree{nil, map[string]*bintree{
+			"install.yaml": &bintree{installClusterKubeApiserverOperatorInstallYaml, map[string]*bintree{}},
 		}},
 		"etcd": &bintree{nil, map[string]*bintree{
 			"etcd.yaml": &bintree{installEtcdEtcdYaml, map[string]*bintree{}},

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -269,6 +269,7 @@
 // examples/quickstarts/cakephp-mysql.json
 // install/automationservicebroker/install-rbac.yaml
 // install/automationservicebroker/install.yaml
+// install/cluster-kube-apiserver-operator/install.yaml
 // install/etcd/etcd.yaml
 // install/etcd/install.yaml
 // install/kube-apiserver/apiserver.yaml
@@ -32400,6 +32401,134 @@ func installAutomationservicebrokerInstallYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installClusterKubeApiserverOperatorInstallYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+parameters:
+- name: NAMESPACE
+  # This namespace must not be changed.
+  value: openshift-core-operators
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    labels:
+      openshift.io/run-level: "0"
+    name: openshift-core-operators
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: kubeapiserveroperatorconfigs.kubeapiserver.operator.openshift.io
+  spec:
+    scope: Cluster
+    group: kubeapiserver.operator.openshift.io
+    version: v1alpha1
+    names:
+      kind: KubeApiserverOperatorConfig
+      plural: kubeapiserveroperatorconfigs
+      singular: kubeapiserveroperatorconfig
+    subresources:
+      status: {}
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:openshift:operator:cluster-kube-apiserver-operator
+  roleRef:
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator-config
+  data:
+    config.yaml: |
+      apiVersion: operator.openshift.io/v1alpha1
+      kind: GenericOperatorConfig
+
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+    labels:
+      app: openshift-cluster-kube-apiserver-operator
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: openshift-cluster-kube-apiserver-operator
+    template:
+      metadata:
+        name: openshift-cluster-kube-apiserver-operator
+        labels:
+          app: openshift-cluster-kube-apiserver-operator
+      spec:
+        serviceAccountName: openshift-cluster-kube-apiserver-operator
+        containers:
+        - name: operator
+          image: openshift/origin-cluster-kube-apiserver-operator:latest
+          imagePullPolicy: IfNotPresent
+          command: ["cluster-kube-apiserver-operator", "operator"]
+          args:
+          - "--config=/var/run/configmaps/config/config.yaml"
+          - "-v=4"
+          volumeMounts:
+          - mountPath: /var/run/configmaps/config
+            name: config
+        volumes:
+        - name: serving-cert
+          secret:
+            defaultMode: 400
+            secretName: openshift-cluster-kube-apiserver-operator-serving-cert
+            optional: true
+        - name: config
+          configMap:
+            defaultMode: 440
+            name: openshift-cluster-kube-apiserver-operator-config
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-cluster-kube-apiserver-operator
+    labels:
+      app: openshift-cluster-kube-apiserver-operator
+
+- apiVersion: kubeapiserver.operator.openshift.io/v1alpha1
+  kind: KubeApiserverOperatorConfig
+  metadata:
+    name: instance
+  spec:
+    managementState: Managed
+    imagePullSpec: openshift/origin-hypershift:latest
+    version: 3.11.0
+    logging:
+      level: 4
+    replicas: 2
+`)
+
+func installClusterKubeApiserverOperatorInstallYamlBytes() ([]byte, error) {
+	return _installClusterKubeApiserverOperatorInstallYaml, nil
+}
+
+func installClusterKubeApiserverOperatorInstallYaml() (*asset, error) {
+	bytes, err := installClusterKubeApiserverOperatorInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/cluster-kube-apiserver-operator/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installEtcdEtcdYaml = []byte(`kind: Pod
 apiVersion: v1
 metadata:
@@ -34573,6 +34702,7 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/quickstarts/cakephp-mysql.json/cakephp-mysql.json": examplesQuickstartsCakephpMysqlJsonCakephpMysqlJson,
 	"install/automationservicebroker/install-rbac.yaml": installAutomationservicebrokerInstallRbacYaml,
 	"install/automationservicebroker/install.yaml": installAutomationservicebrokerInstallYaml,
+	"install/cluster-kube-apiserver-operator/install.yaml": installClusterKubeApiserverOperatorInstallYaml,
 	"install/etcd/etcd.yaml": installEtcdEtcdYaml,
 	"install/etcd/install.yaml": installEtcdInstallYaml,
 	"install/kube-apiserver/apiserver.yaml": installKubeApiserverApiserverYaml,
@@ -34705,6 +34835,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"automationservicebroker": &bintree{nil, map[string]*bintree{
 			"install-rbac.yaml": &bintree{installAutomationservicebrokerInstallRbacYaml, map[string]*bintree{}},
 			"install.yaml": &bintree{installAutomationservicebrokerInstallYaml, map[string]*bintree{}},
+		}},
+		"cluster-kube-apiserver-operator": &bintree{nil, map[string]*bintree{
+			"install.yaml": &bintree{installClusterKubeApiserverOperatorInstallYaml, map[string]*bintree{}},
 		}},
 		"etcd": &bintree{nil, map[string]*bintree{
 			"etcd.yaml": &bintree{installEtcdEtcdYaml, map[string]*bintree{}},


### PR DESCRIPTION
This provides an install component that primes the `openshift-kube-apiserver` namespace with the required configmaps and secrets, then installs the cluster-kube-apiserver-operator which will create a deployment with an empty config that will leverage them.

/assign @sttts @mfojtik 