### PR TITLE
Added OPENSHIFT-ADMIN-INPUT-RULES chain to allow administrator override rules

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -150,6 +150,13 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 	chainArray = append(chainArray,
 		Chain{
 			table:    "filter",
+			name:     "OPENSHIFT-ADMIN-INPUT-RULES",
+			srcChain: "INPUT",
+			srcRule:  []string{"-m", "comment", "--comment", "administrator overrides"},
+			rules:    nil,
+		},
+		Chain{
+			table:    "filter",
 			name:     "OPENSHIFT-FIREWALL-ALLOW",
 			srcChain: "INPUT",
 			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},


### PR DESCRIPTION
Tries to fix https://github.com/openshift/origin/issues/20938 by creating a new chain OPENSHIFT-ADMIN-INPUT-RULES which is processed before OPENSHIFT-FIREWALL-ALLOW so administrators can effectively block incoming traffic no matter if the traffic comes from outside the node or from pods running inside the node.