### PR TITLE
Don't allow mixing "multiple-egress-IP HA" with "auto-allocated-egress-IP HA"

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -517,7 +517,19 @@ func (eit *EgressIPTracker) findEgressIPAllocation(ip net.IP, allocation map[str
 }
 
 func (eit *EgressIPTracker) makeEmptyAllocation() (map[string][]string, map[string]bool) {
-	return make(map[string][]string), make(map[string]bool)
+	allocation := make(map[string][]string)
+	alreadyAllocated := make(map[string]bool)
+
+	// We don't want to auto-allocate/reallocate IPs for NetNamespaces using
+	// multiple-egress-IP HA, so those should be considered "already allocated"
+	// even before we start.
+	for egressIP, eip := range eit.egressIPs {
+		if eip.assignedNodeIP != "" && len(eip.namespaces[0].requestedIPs) > 1 {
+			alreadyAllocated[egressIP] = true
+		}
+	}
+
+	return allocation, alreadyAllocated
 }
 
 func (eit *EgressIPTracker) allocateExistingEgressIPs(allocation map[string][]string, alreadyAllocated map[string]bool) bool {

--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -997,6 +997,29 @@ func TestEgressCIDRAllocation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+
+	// You can't mix multiple-egress-IP HA with auto-allocated-egress-IP HA
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
+		NetID:     45,
+		EgressIPs: []string{"172.17.0.102", "172.17.0.302"},
+	})
+	err = w.assertChanges(
+		"update egress CIDRs",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	allocation = eit.ReallocateEgressIPs()
+	updateAllocations(eit, allocation)
+	err = w.assertChanges(
+		"release 172.17.0.102 on 172.17.0.4",
+		"namespace 45 dropped",
+		"update egress CIDRs",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 }
 
 func TestEgressNodeRenumbering(t *testing.T) {


### PR DESCRIPTION
We now have two different ways to do egress IP HA:

1. Assign multiple egress IPs to a NetNamespace, so that if the node hosting the first one goes down, we switch to using the second one.
2. Use fully-automatic allocation with `egressCIDRs`, and let the master move the egress IP between nodes if one node goes down.

So clearly someone's going to say "oh boy, I'll use both and then get twice as much high availability!" This is a terrible idea because what will actually happen is:

1. Everyone will be happily using egress IP 1 on node 1
2. Node 1 goes down
3. Nodes notice that egress IP 1 has stopped responding and switch to using egress IP 2
4. The master notices that node 1 has gone down and moves egress IP 1 to a different node
5. Nodes notice that egress IP 1 has started responding again and switch back

So you get twice as much disruption as you would have gotten if you were only using one of the two forms of HA. So this fixes it so that we don't do auto-allocation for egress IPs that are being used as part of multiple-egress-IP HA.