### PR TITLE
Add env variable to disable old TLS

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -57,8 +57,11 @@ global
   tune.maxrewrite 8192
   tune.bufsize 32768
 
-  # Prevent vulnerability to POODLE attacks
+{{- if isTrue (env "ROUTER_DISABLE_OLD_TLS") }}
+  ssl-default-bind-options no-sslv3 no-tlsv10 no-tlsv11
+{{ else }}
   ssl-default-bind-options no-sslv3
+{{- end }}
 
 # The default cipher suite can be selected from the three sets recommended by https://wiki.mozilla.org/Security/Server_Side_TLS,
 # or the user can provide one using the ROUTER_CIPHERS environment variable.


### PR DESCRIPTION
Disable TLS 1.0 and 1.1 if ROUTER_DISABLE_OLD_TLS=true

This feature has been requested a lot, I think it's a good idea to provide and env var on it.