### PR TITLE
Cluster loader: Link to latest OKD docs instead of 3.9 OCP docs

### DIFF
--- a/test/extended/cluster/README.md
+++ b/test/extended/cluster/README.md
@@ -62,4 +62,4 @@ $ ./extended.test --ginko.focus="Load cluster" --viper-config=config/test
 After the execution completes the cluster will have deployed the ojects defined
 in the configuration.
 
-[OpenShift.com -- Using Cluster Loader](https://docs.openshift.com/container-platform/3.9/scaling_performance/using_cluster_loader.html)
+[OpenShift.com -- Using Cluster Loader](https://docs.okd.io/latest/scaling_performance/using_cluster_loader.html)


### PR DESCRIPTION
Update cluster loader README to link to latest OKD documentation instead of a hardcoded link to 3.9 OCP documentation.

@sjug PTAL