### PR TITLE
Use standard node roles for conformance isolation

### DIFF
--- a/test/extended/conformance-k8s.sh
+++ b/test/extended/conformance-k8s.sh
@@ -67,8 +67,9 @@ oc adm policy add-scc-to-group privileged system:authenticated system:serviceacc
 oc adm policy remove-scc-from-group restricted system:authenticated
 oc adm policy remove-scc-from-group anyuid system:cluster-admins
 # Mark the masters and infra nodes as unschedulable so tests ignore them
-oc get nodes -o name -l 'role in (infra,master)' | xargs -L1 oc adm cordon
-unschedulable="$( oc get nodes -o name -l 'role in (infra,master)' | wc -l )"
+oc get nodes -o name -l 'node-role.kubernetes.io/master=true' | xargs -L1 oc adm cordon
+oc get nodes -o name -l 'node-role.kubernetes.io/infra=true' | xargs -L1 oc adm cordon
+unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master=true'; oc get nodes -o name -l 'node-role.kubernetes.io/infra=true' ) | wc -l )"
 # TODO: undo these operations
 
 # Execute Kubernetes prerequisites


### PR DESCRIPTION
'role' was deprecated after 3.9