### PR TITLE
Update nodeenv plugin and DS controller to not process openshift.io/node-selector if scheduler.alpha.kubernetes.io/node-selector is set on pods namespace

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/daemon/patch_nodeselector_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/daemon/patch_nodeselector_test.go
@@ -156,8 +156,9 @@ func TestNamespaceNodeSelectorMatches(t *testing.T) {
 			name:      "bothSpecified",
 			namespace: bothSpecified,
 			expected: map[string]bool{
-				"fifth": true,
-				"sixth": true,
+				"second": true,
+				"fifth":  true,
+				"sixth":  true,
 			},
 		},
 	}


### PR DESCRIPTION
@sjenning @derekwaynecarr 

manual pick of https://github.com/openshift/origin/pull/21033