### PR TITLE
Fix a few small bugs in image stream describe and printers

### DIFF
--- a/pkg/image/apis/image/sort.go
+++ b/pkg/image/apis/image/sort.go
@@ -18,7 +18,12 @@ func (t byCreationTimestamp) Len() int {
 }
 
 func (t byCreationTimestamp) Less(i, j int) bool {
-	return t[i].Created.Time.After(t[j].Created.Time)
+	if t[i].Created.Time.After(t[j].Created.Time) {
+		return true
+	}
+	// time has only second precision, so we need to have a secondary sort condition
+	// to get stable sorts
+	return t[i].Name < t[j].Name
 }
 
 func (t byCreationTimestamp) Swap(i, j int) {

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -817,9 +817,9 @@ func DescribeImageStream(imageStream *imageapi.ImageStream) (string, error) {
 	return tabbedString(func(out *tabwriter.Writer) error {
 		formatMeta(out, imageStream.ObjectMeta)
 		if len(imageStream.Status.PublicDockerImageRepository) > 0 {
-			formatString(out, "Docker Pull Spec", imageStream.Status.PublicDockerImageRepository)
+			formatString(out, "Image Repository", imageStream.Status.PublicDockerImageRepository)
 		} else {
-			formatString(out, "Docker Pull Spec", imageStream.Status.DockerImageRepository)
+			formatString(out, "Image Repository", imageStream.Status.DockerImageRepository)
 		}
 		formatString(out, "Image Lookup", fmt.Sprintf("local=%t", imageStream.Spec.LookupPolicy.Local))
 		formatImageStreamTags(out, imageStream)

--- a/pkg/printers/internalversion/printer.go
+++ b/pkg/printers/internalversion/printer.go
@@ -35,12 +35,12 @@ import (
 var (
 	buildColumns                = []string{"NAME", "TYPE", "FROM", "STATUS", "STARTED", "DURATION"}
 	buildConfigColumns          = []string{"NAME", "TYPE", "FROM", "LATEST"}
-	imageColumns                = []string{"NAME", "DOCKER REF"}
-	imageStreamTagColumns       = []string{"NAME", "DOCKER REF", "UPDATED"}
-	imageStreamTagWideColumns   = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
+	imageColumns                = []string{"NAME", "IMAGE REF"}
+	imageStreamTagColumns       = []string{"NAME", "IMAGE REF", "UPDATED"}
+	imageStreamTagWideColumns   = []string{"NAME", "IMAGE REF", "UPDATED", "IMAGENAME"}
 	imageStreamImageColumns     = []string{"NAME", "UPDATED"}
-	imageStreamImageWideColumns = []string{"NAME", "DOCKER REF", "UPDATED", "IMAGENAME"}
-	imageStreamColumns          = []string{"NAME", "DOCKER REPO", "TAGS", "UPDATED"}
+	imageStreamImageWideColumns = []string{"NAME", "IMAGE REF", "UPDATED", "IMAGENAME"}
+	imageStreamColumns          = []string{"NAME", "IMAGE REPOSITORY", "TAGS", "UPDATED"}
 	projectColumns              = []string{"NAME", "DISPLAY NAME", "STATUS"}
 	routeColumns                = []string{"NAME", "HOST/PORT", "PATH", "SERVICES", "PORT", "TERMINATION", "WILDCARD"}
 	deploymentConfigColumns     = []string{"NAME", "REVISION", "DESIRED", "CURRENT", "TRIGGERED BY"}


### PR DESCRIPTION
1. Tags were not stable when their creation timestamp was in the same second
2. Use "IMAGE REPOSITORY" as the column name instead of "DOCKER REPO" to remove use of docker
3. Try to pack more tags and make the column less ragged

After:

```
NAME                  DOCKER REPO                                                        TAGS                                                                     UPDATED
release               registry.svc.ci.openshift.org/clayton-test-1/release               4.0-20180921084620,4.0,4.0-20180921072659                                About an hour ago
test                  registry.svc.ci.openshift.org/clayton-test-1/test                  aws-machine-controllers,control-plane,logging-eventrouter + 67 more...   About an hour ago
test-20180921072659   registry.svc.ci.openshift.org/clayton-test-1/test-20180921072659   cluster-ingress-operator,coredns,descheduler + 62 more...                2 hours ago
test-20180921084620   registry.svc.ci.openshift.org/clayton-test-1/test-20180921084620   machine-config-daemon,console,deployer + 67 more...                      About an hour ago
```

```
NAME                  IMAGE REPOSITORY                                                   TAGS                                                         UPDATED
release               registry.svc.ci.openshift.org/clayton-test-1/release               4.0-20180921084620,4.0,4.0-20180921072659                    About an hour ago
test                  registry.svc.ci.openshift.org/clayton-test-1/test                  aws-machine-controllers,base + 68 more...                    About an hour ago
test-20180921072659   registry.svc.ci.openshift.org/clayton-test-1/test-20180921072659   ansible,artifacts,base,cli,cluster-autoscaler + 60 more...   2 hours ago
test-20180921084620   registry.svc.ci.openshift.org/clayton-test-1/test-20180921084620   ansible,artifacts,aws-machine-controllers + 67 more...       About an hour ago
```