### PR TITLE
pin to v4.0 so that the latest image problem can be bypassed for now

### DIFF
--- a/install/cluster-kube-apiserver-operator/install.yaml
+++ b/install/cluster-kube-apiserver-operator/install.yaml
@@ -72,7 +72,7 @@ objects:
         serviceAccountName: openshift-cluster-kube-apiserver-operator
         containers:
         - name: operator
-          image: openshift/origin-cluster-kube-apiserver-operator:latest
+          image: openshift/origin-cluster-kube-apiserver-operator:v4.0
           imagePullPolicy: IfNotPresent
           command: ["cluster-kube-apiserver-operator", "operator"]
           args:
@@ -106,7 +106,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4

--- a/install/cluster-openshift-apiserver-operator/install.yaml
+++ b/install/cluster-openshift-apiserver-operator/install.yaml
@@ -105,7 +105,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4

--- a/install/cluster-openshift-controller-manager-operator/install.yaml
+++ b/install/cluster-openshift-controller-manager-operator/install.yaml
@@ -105,7 +105,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -16681,7 +16681,7 @@ objects:
         serviceAccountName: openshift-cluster-kube-apiserver-operator
         containers:
         - name: operator
-          image: openshift/origin-cluster-kube-apiserver-operator:latest
+          image: openshift/origin-cluster-kube-apiserver-operator:v4.0
           imagePullPolicy: IfNotPresent
           command: ["cluster-kube-apiserver-operator", "operator"]
           args:
@@ -16715,7 +16715,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4
@@ -16844,7 +16844,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4
@@ -16972,10 +16972,11 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
-      level: 4`)
+      level: 4
+`)
 
 func installClusterOpenshiftControllerManagerOperatorInstallYamlBytes() ([]byte, error) {
 	return _installClusterOpenshiftControllerManagerOperatorInstallYaml, nil

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -32360,7 +32360,7 @@ objects:
         serviceAccountName: openshift-cluster-kube-apiserver-operator
         containers:
         - name: operator
-          image: openshift/origin-cluster-kube-apiserver-operator:latest
+          image: openshift/origin-cluster-kube-apiserver-operator:v4.0
           imagePullPolicy: IfNotPresent
           command: ["cluster-kube-apiserver-operator", "operator"]
           args:
@@ -32394,7 +32394,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4
@@ -32523,7 +32523,7 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
       level: 4
@@ -32651,10 +32651,11 @@ objects:
     name: instance
   spec:
     managementState: Managed
-    imagePullSpec: openshift/origin-hypershift:latest
+    imagePullSpec: openshift/origin-hypershift:v4.0
     version: 3.11.0
     logging:
-      level: 4`)
+      level: 4
+`)
 
 func installClusterOpenshiftControllerManagerOperatorInstallYamlBytes() ([]byte, error) {
 	return _installClusterOpenshiftControllerManagerOperatorInstallYaml, nil


### PR DESCRIPTION
The latest image tag is having some trouble, this should pin us to unblock CI until we get it sorted out.

/assign @bparees 

@derekwaynecarr fyi, oc cluster up now openshift apiserver and openshift controller manager via operator.