### PR TITLE
Bug 1632155 - Accept logFormat when passed to audit config

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/configprocessing/audit.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/configprocessing/audit.go
@@ -38,7 +38,11 @@ func GetAuditConfig(auditConfig configv1.AuditConfig) (audit.Backend, auditpolic
 		// backwards compatible writer to regular log
 		writer = cmdutil.NewGLogWriterV(0)
 	}
-	backend = auditlog.NewBackend(writer, auditlog.FormatJson, auditv1beta1.SchemeGroupVersion)
+	format := auditConfig.LogFormat
+	if len(format) == 0 {
+		format = auditlog.FormatJson
+	}
+	backend = auditlog.NewBackend(writer, string(format), auditv1beta1.SchemeGroupVersion)
 	policyChecker = auditpolicy.NewChecker(&auditinternal.Policy{
 		// This is for backwards compatibility maintaining the old visibility, ie. just
 		// raw overview of the requests comming in.


### PR DESCRIPTION
We should've defaulted the logformat to `legacy`, but since we didn't back when we first introduced it we need to default to `json` but still allow administrators to set it correctly to whatever they want.

/assign @deads2k @mfojtik 