### PR TITLE
[3.10] migrate: ignore resources that cannot be listed and updated

### DIFF
--- a/pkg/oc/admin/migrate/migrator.go
+++ b/pkg/oc/admin/migrate/migrator.go
@@ -214,6 +214,7 @@ func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error
 	}
 	mapper, _ := f.Object()
 
+	// if o.Include has * we need to update it via discovery and o.DefaultExcludes and o.OverlappingResources
 	resourceNames := sets.NewString()
 	for i, s := range o.Include {
 		if resourceNames.Has(s) {
@@ -221,7 +222,7 @@ func (o *ResourceOptions) Complete(f *clientcmd.Factory, c *cobra.Command) error
 		}
 		if s != "*" {
 			resourceNames.Insert(s)
-			break
+			continue
 		}
 
 		all, err := clientcmd.FindAllCanonicalResources(discoveryClient, mapper)

--- a/pkg/oc/cli/util/clientcmd/factory.go
+++ b/pkg/oc/cli/util/clientcmd/factory.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -470,6 +471,10 @@ func FindAllCanonicalResources(d discovery.DiscoveryInterface, m meta.RESTMapper
 		for _, r := range serverResource.APIResources {
 			// ignore subresources
 			if strings.Contains(r.Name, "/") {
+				continue
+			}
+			// ignore resources that cannot be listed and updated
+			if !sets.NewString(r.Verbs...).HasAll("list", "update") {
 				continue
 			}
 			// because discovery info doesn't tell us whether the object is virtual or not, perform a lookup


### PR DESCRIPTION
This change updates FindAllCanonicalResources to check the verbs
asserted by discovery for listing and updating capability.  This
prevents us from trying to update aggregated resources such as pod
metrics.

Bug 1631517

Signed-off-by: Monis Khan <mkhan@redhat.com>

Note: this is a minimal cherrypick since the CLI code has changed a
lot during the last few releases.

xref: #21071 