### PR TITLE
oc cluster add

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -6563,6 +6563,50 @@ _oc_cancel-build()
     noun_aliases=()
 }
 
+_oc_cluster_add()
+{
+    last_command="oc_cluster_add"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--image=")
+    local_nonpersistent_flags+=("--image=")
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--cache-dir=")
+    flags+=("--certificate-authority=")
+    flags+=("--client-certificate=")
+    flags+=("--client-key=")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--kubeconfig=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    flags_with_completion+=("--namespace")
+    flags_completion+=("__oc_get_namespaces")
+    two_word_flags+=("-n")
+    flags_with_completion+=("-n")
+    flags_completion+=("__oc_get_namespaces")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    two_word_flags+=("-s")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_cluster_down()
 {
     last_command="oc_cluster_down"
@@ -6669,6 +6713,7 @@ _oc_cluster()
 {
     last_command="oc_cluster"
     commands=()
+    commands+=("add")
     commands+=("down")
     commands+=("up")
 

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -6705,6 +6705,50 @@ _oc_cancel-build()
     noun_aliases=()
 }
 
+_oc_cluster_add()
+{
+    last_command="oc_cluster_add"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--image=")
+    local_nonpersistent_flags+=("--image=")
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--cache-dir=")
+    flags+=("--certificate-authority=")
+    flags+=("--client-certificate=")
+    flags+=("--client-key=")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--kubeconfig=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    flags_with_completion+=("--namespace")
+    flags_completion+=("__oc_get_namespaces")
+    two_word_flags+=("-n")
+    flags_with_completion+=("-n")
+    flags_completion+=("__oc_get_namespaces")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    two_word_flags+=("-s")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_cluster_down()
 {
     last_command="oc_cluster_down"
@@ -6811,6 +6855,7 @@ _oc_cluster()
 {
     last_command="oc_cluster"
     commands=()
+    commands+=("add")
     commands+=("down")
     commands+=("up")
 

--- a/pkg/oc/cli/cluster/cluster.go
+++ b/pkg/oc/cli/cluster/cluster.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/openshift/origin/pkg/oc/clusterup/clusteradd"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -40,6 +42,7 @@ func NewCmdCluster(name, fullName string, f kcmdutil.Factory, streams genericcli
 	}
 
 	cmds.AddCommand(clusterup.NewCmdUp(clusterup.CmdUpRecommendedName, fullName+" "+clusterup.CmdUpRecommendedName, f, streams))
+	cmds.AddCommand(clusteradd.NewCmdAdd(f, streams))
 	cmds.AddCommand(clusterup.NewCmdDown(clusterup.CmdDownRecommendedName, fullName+" "+clusterup.CmdDownRecommendedName))
 	return cmds
 }

--- a/pkg/oc/clusterup/clusteradd/add_cmd.go
+++ b/pkg/oc/clusterup/clusteradd/add_cmd.go
@@ -1,0 +1,143 @@
+package clusteradd
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/openshift/origin/pkg/cmd/util/variable"
+	"github.com/openshift/origin/pkg/oc/clusterup/docker/dockerhelper"
+	"github.com/openshift/origin/pkg/version"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
+)
+
+type AddOptions struct {
+	genericclioptions.IOStreams
+
+	BaseDir           string
+	ImageTemplate     variable.ImageTemplate
+	ImageTag          string
+	ComponentsToApply sets.String
+
+	kubeConfigContent []byte
+	dockerClient      dockerhelper.Interface
+}
+
+func NewAddOptions(streams genericclioptions.IOStreams) *AddOptions {
+	return &AddOptions{
+		IOStreams: streams,
+
+		BaseDir:           "openshift.local.clusterup",
+		ImageTemplate:     variable.NewDefaultImageTemplate(),
+		ImageTag:          strings.TrimRight("v"+version.Get().Major+"."+version.Get().Minor, "+"),
+		ComponentsToApply: sets.NewString(),
+	}
+}
+
+func NewCmdAdd(f genericclioptions.RESTClientGetter, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewAddOptions(streams)
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Applies the manifests for an image to the cluster.",
+		Long: templates.LongDesc(`
+			Applies the manifests for an image to the cluster.  There is no ordering guarantee between images.
+
+			Experimental: This command is under active development and may change without notice.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&o.ImageTag, "tag", o.ImageTag, "Specify an explicit version for OpenShift images")
+	flags.MarkHidden("tag")
+	flags.StringVar(&o.ImageTemplate.Format, "image", o.ImageTemplate.Format, "Specify the images to use for OpenShift")
+
+	return cmd
+}
+
+func (o *AddOptions) Complete(f genericclioptions.RESTClientGetter, cmd *cobra.Command, args []string) error {
+	rawConfig, err := f.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return err
+	}
+	if err := clientcmdapi.MinifyConfig(&rawConfig); err != nil {
+		return err
+
+	}
+	if err := clientcmdapi.FlattenConfig(&rawConfig); err != nil {
+		return err
+
+	}
+	o.kubeConfigContent, err = clientcmd.Write(rawConfig)
+	if err != nil {
+		return err
+	}
+
+	o.ComponentsToApply.Insert(args...)
+	o.ImageTemplate.Format = variable.Expand(o.ImageTemplate.Format, func(s string) (string, bool) {
+		if s == "version" {
+			return o.ImageTag, true
+		}
+		return "", false
+	}, variable.Identity)
+
+	if !path.IsAbs(o.BaseDir) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		absHostDir, err := api.MakeAbs(o.BaseDir, cwd)
+		if err != nil {
+			return err
+		}
+		o.BaseDir = absHostDir
+	}
+
+	client, err := dockerhelper.GetDockerClient()
+	if err != nil {
+		return err
+	}
+	o.dockerClient = client
+
+	return nil
+}
+
+func (o *AddOptions) Run() error {
+	ocImage, err := o.ImageTemplate.Expand("cli")
+	if err != nil {
+		return err
+	}
+
+	componentErrors := []error{}
+	for _, component := range o.ComponentsToApply.UnsortedList() {
+		if err := o.Install(ocImage, component); err != nil {
+			componentErrors = append(componentErrors, fmt.Errorf("%q failed: %v", component, err))
+		}
+	}
+
+	return nil
+}
+
+func (o *AddOptions) Install(ocImage, component string) error {
+	image, err := o.ImageTemplate.Expand(component)
+	if err != nil {
+		return err
+	}
+
+	installer := &ManifestInstall{
+		Name:              component,
+		KubeConfigContent: o.kubeConfigContent,
+		Image:             image,
+	}
+	return installer.MakeReady(ocImage, o.BaseDir).Install(o.dockerClient)
+}

--- a/pkg/oc/clusterup/clusteradd/apply_image.go
+++ b/pkg/oc/clusterup/clusteradd/apply_image.go
@@ -1,0 +1,103 @@
+package clusteradd
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/origin/pkg/oc/clusterup/componentinstall"
+	"github.com/openshift/origin/pkg/oc/clusterup/docker/dockerhelper"
+	"github.com/openshift/origin/pkg/oc/clusterup/docker/run"
+	"github.com/openshift/origin/pkg/oc/lib/errors"
+)
+
+type ManifestInstall struct {
+	Name string
+
+	KubeConfigContent []byte
+	Image             string
+
+	WaitCondition func() (bool, error)
+}
+
+func (t ManifestInstall) MakeReady(image, baseDir string) componentinstall.Component {
+	return &installReadyList{
+		list:    t,
+		image:   image,
+		baseDir: baseDir,
+	}
+}
+
+const listBashScript = `#!/bin/sh
+set -e
+set -x
+
+mkdir /manifests
+oc image extract ${IMAGE} --path=/manifests/:/manifests/
+ls -alh /manifests
+
+oc apply --config=/kubeconfig.kubeconfig -f /manifests 
+`
+
+type installReadyList struct {
+	list    ManifestInstall
+	image   string
+	baseDir string
+}
+
+func (opt *installReadyList) Name() string {
+	return opt.list.Name
+}
+
+func (opt *installReadyList) Install(dockerClient dockerhelper.Interface) error {
+	imageRunHelper := run.NewRunHelper(dockerhelper.NewHelper(dockerClient)).New()
+
+	glog.Infof("Installing %q", opt.Name())
+
+	contentToCopy := map[string][]byte{
+		"kubeconfig.kubeconfig": opt.list.KubeConfigContent,
+		"apply.sh":              []byte(listBashScript),
+	}
+
+	var lastErr error
+	// do a very simple retry loop on failure. Six times, ten second gaps
+	wait.PollImmediate(10*time.Second, 60*time.Second, func() (bool, error) {
+		_, rc, err := imageRunHelper.Image(opt.image).
+			Privileged().
+			DiscardContainer().
+			Copy(contentToCopy).
+			Env(fmt.Sprintf("IMAGE=%s", opt.list.Image)).
+			HostNetwork().
+			HostPid().
+			Entrypoint("sh").
+			SaveContainerLogs(opt.Name(), filepath.Join(opt.baseDir, "logs")).
+			Command("-c", "chmod 755 /apply.sh && /apply.sh").Run()
+		if err != nil {
+			lastErr = errors.NewError("failed to install %q: %v", opt.Name(), err).WithCause(err)
+			return false, nil
+		}
+		if rc != 0 {
+			lastErr = errors.NewError("failed to install %q: rc: %d", opt.Name(), rc)
+			return false, nil
+		}
+		lastErr = nil
+		return true, nil
+	})
+	if lastErr != nil {
+		return lastErr
+	}
+
+	if opt.list.WaitCondition == nil {
+		return nil
+	}
+
+	if err := wait.PollImmediate(time.Second, 5*time.Minute, opt.list.WaitCondition); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This creates a new `oc cluster add` command based off our CVO image requirements that applies the content from the image's `/manifest` directory.  There are no other dependencies or checks. This simply applies those manifests until they succeed.

/assign @mfojtik 
@openshift/cli-review 