### PR TITLE
fixed typo in README.md

### DIFF
--- a/test/extended/cluster/README.md
+++ b/test/extended/cluster/README.md
@@ -29,7 +29,7 @@ Once you have the `extended.test` binary installed on your system, run:
 
 ```console
 $ export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
-$ ./extended.test --ginko.focus="Mirror cluster"
+$ ./extended.test --ginkgo.focus="Mirror cluster"
 ```
 
 After the command completes there will be a file created in the current
@@ -56,7 +56,7 @@ Once you have the `extended.test` binary installed on your system, run:
 
 ```console
 $ export KUBECONFIG=${KUBECONFIG-$HOME/.kube/config}
-$ ./extended.test --ginko.focus="Load cluster" --viper-config=config/test
+$ ./extended.test --ginkgo.focus="Load cluster" --viper-config=config/test
 ```
 
 After the execution completes the cluster will have deployed the ojects defined


### PR DESCRIPTION
small typo in README.md 
 ./extended.test --ginkg.focus ->  ./extended.test --ginkgo.focus

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>

