### PR TITLE
Move SDN controller out of openshift-controller-manager

### DIFF
--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/openshift-controller-manager"
 	"github.com/openshift/origin/pkg/cmd/openshift-etcd"
 	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver"
+	"github.com/openshift/origin/pkg/cmd/openshift-network-controller"
 	"github.com/openshift/origin/pkg/version"
 )
 
@@ -67,6 +68,9 @@ func NewHyperShiftCommand() *cobra.Command {
 
 	startOpenShiftControllerManager := openshift_controller_manager.NewOpenShiftControllerManagerCommand(openshift_controller_manager.RecommendedStartControllerManagerName, "hypershift", os.Stdout, os.Stderr)
 	cmd.AddCommand(startOpenShiftControllerManager)
+
+	startOpenShiftNetworkController := openshift_network_controller.NewOpenShiftNetworkControllerCommand(openshift_network_controller.RecommendedStartNetworkControllerName, "hypershift", os.Stdout, os.Stderr)
+	cmd.AddCommand(startOpenShiftNetworkController)
 
 	return cmd
 }

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -716,6 +716,7 @@ function copy-runtime() {
   cp "$(os::util::find::built_binary hyperkube)" "${target}"
   cp "$(os::util::find::built_binary openshift-node-config)" "${target}"
   cp "$(os::util::find::built_binary openshift)" "${target}"
+  cp "$(os::util::find::built_binary hypershift)" "${target}"
   cp "$(os::util::find::built_binary oc)" "${target}"
   cp "$(os::util::find::built_binary host-local)" "${target}"
   cp "$(os::util::find::built_binary loopback)" "${target}"

--- a/images/dind/master/Dockerfile
+++ b/images/dind/master/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM openshift/dind-node
 
+RUN ln -sf /data/openshift /usr/local/bin/ && \
+    ln -sf /data/hypershift /usr/local/bin/
+
 # Disable iptables on the master since it will prevent access to the
 # openshift api from outside the master.
 RUN systemctl disable iptables.service
@@ -31,6 +34,9 @@ COPY master-node.conf /etc/systemd/system/openshift-node.service.d/
 COPY openshift-sdn-master-setup.service /etc/systemd/system/
 COPY openshift-sdn-master-setup.sh /usr/local/bin/
 RUN systemctl enable openshift-sdn-master-setup.service
+
+COPY openshift-sdn-master.service /etc/systemd/system/
+RUN systemctl enable openshift-sdn-master.service
 
 COPY ovn-kubernetes-master-setup.service /etc/systemd/system/
 COPY ovn-kubernetes-master-setup.sh /usr/local/bin/

--- a/images/dind/master/openshift-generate-master-config.sh
+++ b/images/dind/master/openshift-generate-master-config.sh
@@ -55,6 +55,9 @@ function ensure-master-config() {
      ${image_format_str} \
      --network-plugin="${OPENSHIFT_NETWORK_PLUGIN}" \
      ${OPENSHIFT_ADDITIONAL_ARGS}
+
+   mv "${config_file}" "${config_file}.bak"
+   oc patch --config="${master_path}/admin.kubeconfig" --local --type=json -o yaml -f "${config_file}.bak" --patch='[{"op": "add", "path": "/controllerConfig/controllers/0", "value": "-openshift.io/sdn"}]' > "${config_file}"
   ) 200>"${config_path}"/.openshift-ca.lock
 
   # ensure the configuration can be used outside of the container

--- a/images/dind/master/openshift-sdn-master-setup.sh
+++ b/images/dind/master/openshift-sdn-master-setup.sh
@@ -34,6 +34,8 @@ function openshift-sdn-setup() {
     /usr/local/bin/oc --config="${kube_config}" adm policy add-scc-to-user anyuid -z openshift-sdn
   fi
 
+  /usr/local/bin/oc --config="${kube_config}" create namespace openshift-sdn
+
   os::util::wait-for-condition "kubernetes token" "ensure-token ${config_dir} ${kube_config}" "120"
 }
 

--- a/images/dind/master/openshift-sdn-master.service
+++ b/images/dind/master/openshift-sdn-master.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenShift SDN Controller
+Requires=openshift-master.service openshift-sdn-master-setup.service
+After=openshift-master.service openshift-sdn-master-setup.service
+
+[Service]
+ExecStart=/usr/local/bin/hypershift openshift-network-controller -v=4 \
+  --config=/data/openshift.local.config/master/master-config.yaml
+WorkingDirectory=/data
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/images/dind/node/Dockerfile
+++ b/images/dind/node/Dockerfile
@@ -66,8 +66,7 @@ RUN mkdir -p /opt/cni/bin
 # Symlink from the data path intended to be mounted as a volume to
 # make reloading easy.  Revisit if/when dind becomes useful for more
 # than dev/test.
-RUN ln -sf /data/openshift /usr/local/bin/ && \
-    ln -sf /data/oc        /usr/local/bin/ && \
+RUN ln -sf /data/oc        /usr/local/bin/ && \
     ln -sf /data/hyperkube /usr/local/bin/ && \
     ln -sf /data/openshift-node-config /usr/local/bin/ && \
     ln -sf /data/openshift-sdn-node /usr/local/bin/openshift-sdn-node && \

--- a/pkg/cmd/openshift-controller-manager/controller_manager.go
+++ b/pkg/cmd/openshift-controller-manager/controller_manager.go
@@ -55,7 +55,7 @@ func RunOpenShiftControllerManager(config *openshiftcontrolplanev1.OpenShiftCont
 	}
 
 	originControllerManager := func(stopCh <-chan struct{}) {
-		if err := waitForHealthyAPIServer(kubeClient.Discovery().RESTClient()); err != nil {
+		if err := WaitForHealthyAPIServer(kubeClient.Discovery().RESTClient()); err != nil {
 			glog.Fatal(err)
 		}
 
@@ -105,7 +105,7 @@ func RunOpenShiftControllerManager(config *openshiftcontrolplanev1.OpenShiftCont
 	return nil
 }
 
-func waitForHealthyAPIServer(client rest.Interface) error {
+func WaitForHealthyAPIServer(client rest.Interface) error {
 	var healthzContent string
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.

--- a/pkg/cmd/openshift-network-controller/network_controller.go
+++ b/pkg/cmd/openshift-network-controller/network_controller.go
@@ -1,0 +1,83 @@
+package openshift_network_controller
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+
+	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
+	"github.com/openshift/origin/pkg/cmd/openshift-controller-manager"
+	origincontrollers "github.com/openshift/origin/pkg/cmd/openshift-controller-manager/controller"
+	"github.com/openshift/origin/pkg/cmd/util"
+)
+
+func RunOpenShiftNetworkController(config *openshiftcontrolplanev1.OpenShiftControllerManagerConfig, clientConfig *rest.Config) error {
+	util.InitLogrus()
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	originControllerManager := func(stopCh <-chan struct{}) {
+		if err := openshift_controller_manager.WaitForHealthyAPIServer(kubeClient.Discovery().RESTClient()); err != nil {
+			glog.Fatal(err)
+		}
+
+		controllerContext, err := origincontrollers.NewControllerContext(*config, clientConfig, nil)
+		if err != nil {
+			glog.Fatal(err)
+		}
+		enabled, err := origincontrollers.RunSDNController(controllerContext)
+		if err != nil {
+			glog.Fatalf("Error starting OpenShift Network Controller: %v", err)
+		} else if !enabled {
+			glog.Fatalf("OpenShift Network Controller requested, but not running an OpenShift Network plugin")
+		}
+		glog.Infof("Started OpenShift Network Controller")
+		controllerContext.StartInformers(nil)
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	eventRecorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "openshift-network-controller"})
+	id, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	rl, err := resourcelock.New(
+		"configmaps",
+		"openshift-sdn",
+		"openshift-network-controller",
+		kubeClient.CoreV1(),
+		resourcelock.ResourceLockConfig{
+			Identity:      id,
+			EventRecorder: eventRecorder,
+		})
+	if err != nil {
+		return err
+	}
+	go leaderelection.RunOrDie(leaderelection.LeaderElectionConfig{
+		Lock:          rl,
+		LeaseDuration: config.LeaderElection.LeaseDuration.Duration,
+		RenewDeadline: config.LeaderElection.RenewDeadline.Duration,
+		RetryPeriod:   config.LeaderElection.RetryPeriod.Duration,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: originControllerManager,
+			OnStoppedLeading: func() {
+				glog.Fatalf("leaderelection lost")
+			},
+		},
+	})
+
+	return nil
+}


### PR DESCRIPTION
This moves the SDN controller out of the controller manager as step 1 of the plan to be able to bring up the network without needing the openshift apiserver or controllers.

After some false starts last week I realized this can actually be done pretty simply by basically just making a duplicate of openshift-controller-manager that only includes the network controller.

I ripped out `origincontrollers.RunControllerServer()` because I wasn't sure what it was doing, but it didn't seem necessary (and probably would end up conflicting with the actual controller manager if I'd left it in?)

This updates dind to start a separate network controller, but we'll need to have an ansible patch too.