### PR TITLE
Image sort is flaky because of order

### DIFF
--- a/pkg/image/apis/image/sort_test.go
+++ b/pkg/image/apis/image/sort_test.go
@@ -47,6 +47,39 @@ func TestSortStatusTags(t *testing.T) {
 			},
 			expected: []string{"third", "latest", "other"},
 		},
+		{
+			name: "two equal timestamps",
+			tags: map[string]TagEventList{
+				"other": {
+					Items: []TagEvent{
+						{
+							DockerImageReference: "other-ref",
+							Created:              metav1.Date(2015, 9, 4, 13, 52, 0, 0, time.UTC),
+							Image:                "other-image",
+						},
+					},
+				},
+				"latest": {
+					Items: []TagEvent{
+						{
+							DockerImageReference: "latest-ref",
+							Created:              metav1.Date(2015, 9, 4, 13, 52, 0, 0, time.UTC),
+							Image:                "latest-image",
+						},
+					},
+				},
+				"third": {
+					Items: []TagEvent{
+						{
+							DockerImageReference: "third-ref",
+							Created:              metav1.Date(2015, 9, 4, 13, 53, 0, 0, time.UTC),
+							Image:                "third-image",
+						},
+					},
+				},
+			},
+			expected: []string{"third", "latest", "other"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/21089/pull-ci-openshift-origin-master-unit/30

Only when date is equal should we fall through to name.