### PR TITLE
Use group resource in migrate reporting

### DIFF
--- a/pkg/oc/cli/admin/migrate/migrator.go
+++ b/pkg/oc/cli/admin/migrate/migrator.go
@@ -594,12 +594,14 @@ type migrateTracker struct {
 func (t *migrateTracker) report(prefix string, info *resource.Info, err error) {
 	ns := info.Namespace
 	if len(ns) > 0 {
-		ns = "-n " + ns
+		ns = " -n " + ns
 	}
+	groupResource := info.Mapping.Resource.GroupResource()
+	groupResourceStr := (&groupResource).String()
 	if err != nil {
-		fmt.Fprintf(t.out, "E%s %-10s %s %s/%s: %v\n", timeStampNow(), prefix, ns, info.Mapping.Resource.Resource, info.Name, err)
+		fmt.Fprintf(t.out, "E%s %-10s%s %s/%s: %v\n", timeStampNow(), prefix, ns, groupResourceStr, info.Name, err)
 	} else {
-		fmt.Fprintf(t.out, "I%s %-10s %s %s/%s\n", timeStampNow(), prefix, ns, info.Mapping.Resource.Resource, info.Name)
+		fmt.Fprintf(t.out, "I%s %-10s%s %s/%s\n", timeStampNow(), prefix, ns, groupResourceStr, info.Name)
 	}
 }
 
@@ -619,7 +621,8 @@ func (t *migrateTracker) run() {
 		case attemptResultError:
 			t.report("error:", r.data.info, r.data.err)
 			t.errors++
-			t.resourcesWithErrors.Insert(r.data.info.Mapping.Resource.Resource)
+			groupResource := r.data.info.Mapping.Resource.GroupResource()
+			t.resourcesWithErrors.Insert((&groupResource).String())
 		case attemptResultIgnore:
 			t.ignored++
 			if glog.V(2) {

--- a/test/cmd/migrate.sh
+++ b/test/cmd/migrate.sh
@@ -63,7 +63,7 @@ os::cmd::expect_failure_and_text     'oc adm migrate image-references a/b=a/b --
 os::cmd::expect_failure_and_text     'oc adm migrate image-references */*=*/* --loglevel=1' 'at least one change'
 # verify dry run
 os::cmd::expect_success_and_text     'oc adm migrate image-references my.docker.io/*=docker.io/* --loglevel=1' 'migrated=0'
-os::cmd::expect_success_and_text     'oc adm migrate image-references --include=imagestreams docker.io/*=my.docker.io/* --loglevel=1' "migrated \(dry run\): -n ${project} imagestreams/test"
+os::cmd::expect_success_and_text     'oc adm migrate image-references --include=imagestreams docker.io/*=my.docker.io/* --loglevel=1' "migrated \(dry run\): -n ${project} imagestreams.image.openshift.io/test"
 os::cmd::expect_success_and_text     'oc adm migrate image-references --include=imagestreams docker.io/mysql=my.docker.io/* --all-namespaces=false --loglevel=1' 'migrated=1'
 os::cmd::expect_success_and_text     'oc adm migrate image-references --include=imagestreams docker.io/mysql=my.docker.io/* --all-namespaces=false --loglevel=1 -o yaml' 'dockerImageReference: my.docker.io/mysql@sha256:'
 os::cmd::expect_success_and_text     'oc adm migrate image-references --include=imagestreams docker.io/other=my.docker.io/* --all-namespaces=false --loglevel=1' 'migrated=0'


### PR DESCRIPTION
This change updates the reporting during migration to use the group resource instead of just the resource.

Thus the confusing messages with "the server does not allow this method on the requested resource" for pod metrics will go from:

-n hasha-pro1 pods/nodejs-ex-2-kmzrv

to:

-n hasha-pro1 pods.metrics.k8s.io/nodejs-ex-2-kmzrv

This makes it clear what resource is being referenced.

Bug 1631517

Signed-off-by: Monis Khan <mkhan@redhat.com>