### PR TITLE
Require confirmation before extracting into directories

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -10952,6 +10952,8 @@ _oc_image_extract()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--confirm")
+    local_nonpersistent_flags+=("--confirm")
     flags+=("--dry-run")
     local_nonpersistent_flags+=("--dry-run")
     flags+=("--filter-by-os=")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -11094,6 +11094,8 @@ _oc_image_extract()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--confirm")
+    local_nonpersistent_flags+=("--confirm")
     flags+=("--dry-run")
     local_nonpersistent_flags+=("--dry-run")
     flags+=("--filter-by-os=")

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -62,14 +62,18 @@ var _ = g.Describe("[Feature:ImageExtract] Image extract", func() {
 
 			# command exits if directory doesn't exist
 			! oc image extract --insecure docker-registry.default.svc:5000/%[1]s/1:busybox --path=/:/tmp/doesnotexist
+			# command exits if directory isn't empty
+			! oc image extract --insecure docker-registry.default.svc:5000/%[1]s/1:busybox --path=/:/
 
 			# extract busybox to a directory, verify the contents
 			mkdir -p /tmp/test
 			oc image extract --insecure docker-registry.default.svc:5000/%[1]s/1:busybox --path=/:/tmp/test
 			[ -d /tmp/test/etc ] && [ -d /tmp/test/bin ]
 			[ -f /tmp/test/bin/ls ] && /tmp/test/bin/ls /tmp/test
-			oc image extract --insecure docker-registry.default.svc:5000/%[1]s/1:busybox --path=/etc/shadow:/tmp --path=/etc/localtime:/tmp
-			[ -f /tmp/shadow ] && [ -f /tmp/localtime ]
+
+			mkdir -p /tmp/test2
+			oc image extract --insecure docker-registry.default.svc:5000/%[1]s/1:busybox --path=/etc/shadow:/tmp/test2 --path=/etc/localtime:/tmp/test2
+			[ -f /tmp/test2/shadow ] && [ -f /tmp/test2/localtime ]
 		`, ns)))
 		cli.WaitForSuccess(pod.Name, podStartupTimeout)
 	})


### PR DESCRIPTION
Images can contain whiteout directives that will result in existing
contents being deleted. Since it's easy to accidentally do this in
your working dir, make `--confirm` required if any destination path
is non-empty.

@deads2k sorry :)