### PR TITLE
examples/prometheus: fix storage path of alert-buffer

### DIFF
--- a/examples/prometheus/prometheus.yaml
+++ b/examples/prometheus/prometheus.yaml
@@ -343,11 +343,11 @@ objects:
 
         - name: alert-buffer
           args:
-          - --storage-path=/alert-buffer/messages.db
+          - --storage-path=/message-buffer/messages.db
           image: ${IMAGE_ALERT_BUFFER}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-          - mountPath: /alert-buffer
+          - mountPath: /message-buffer
             name: alerts-data
 
         - name: alertmanager-proxy

--- a/pkg/oc/clusterup/manifests/bindata.go
+++ b/pkg/oc/clusterup/manifests/bindata.go
@@ -15619,11 +15619,11 @@ objects:
 
         - name: alert-buffer
           args:
-          - --storage-path=/alert-buffer/messages.db
+          - --storage-path=/message-buffer/messages.db
           image: ${IMAGE_ALERT_BUFFER}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-          - mountPath: /alert-buffer
+          - mountPath: /message-buffer
             name: alerts-data
 
         - name: alertmanager-proxy

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -28743,11 +28743,11 @@ objects:
 
         - name: alert-buffer
           args:
-          - --storage-path=/alert-buffer/messages.db
+          - --storage-path=/message-buffer/messages.db
           image: ${IMAGE_ALERT_BUFFER}
           imagePullPolicy: IfNotPresent
           volumeMounts:
-          - mountPath: /alert-buffer
+          - mountPath: /message-buffer
             name: alerts-data
 
         - name: alertmanager-proxy


### PR DESCRIPTION
Change storage path of alert-buffer from /alert-buffer to /message-buffer
to match the path specified in the container volume.  This prevents
permissions errors when the container tries to mount the /message-buffer
directory.