### PR TITLE
test: Set custom deployment template app to sleep infinity

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4929,7 +4929,7 @@ spec:
         name: myapp
         command:
         - /bin/sleep
-        - "10"
+        - "infinity"
   triggers:
   - type: ConfigChange
 `)

--- a/test/extended/testdata/deployments/custom-deployment.yaml
+++ b/test/extended/testdata/deployments/custom-deployment.yaml
@@ -39,6 +39,6 @@ spec:
         name: myapp
         command:
         - /bin/sleep
-        - "10"
+        - "infinity"
   triggers:
   - type: ConfigChange


### PR DESCRIPTION
We are seeing Back-off failures in the test logs as myapp exits after 10 seconds right now.
I have also picked @derekwaynecarr kubelet fix for running tests which we can remove before merging.