### PR TITLE
oc image extract should be able to print which layer files come from

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -10952,6 +10952,8 @@ _oc_image_extract()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--all-layers")
+    local_nonpersistent_flags+=("--all-layers")
     flags+=("--confirm")
     local_nonpersistent_flags+=("--confirm")
     flags+=("--dry-run")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -11094,6 +11094,8 @@ _oc_image_extract()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--all-layers")
+    local_nonpersistent_flags+=("--all-layers")
     flags+=("--confirm")
     local_nonpersistent_flags+=("--confirm")
     flags+=("--dry-run")

--- a/pkg/oc/cli/admin/release/extract.go
+++ b/pkg/oc/cli/admin/release/extract.go
@@ -95,7 +95,7 @@ func (o *ExtractOptions) Run() error {
 			},
 		}
 		found := false
-		opts.TarEntryCallback = func(hdr *tar.Header, r io.Reader) (bool, error) {
+		opts.TarEntryCallback = func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
 			if hdr.Name != o.File {
 				return true, nil
 			}


### PR DESCRIPTION
Add a column to the --dry-run output that includes the layer the image
came from. The --all-layers flag will show the highest layer.

Mostly for debugging.