### PR TITLE
Fix up "should not auto-assign egress IPs" cases

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -512,6 +512,32 @@ func TestDuplicateNodeEgressIPs(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
+	// Auto-egress-IP assignment should ignore the IP while it is double-booked
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
+		HostIP:      "172.17.0.5",
+		EgressCIDRs: []string{"172.17.0.0/24"},
+	})
+	err = w.assertChanges(
+		"update egress CIDRs",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	allocation := eit.ReallocateEgressIPs()
+	if node5ips, ok := allocation["node-5"]; !ok {
+		t.Fatalf("Unexpected IP allocation: %#v", allocation)
+	} else if len(node5ips) != 0 {
+		t.Fatalf("Unexpected IP allocation: %#v", allocation)
+	}
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
+		HostIP:      "172.17.0.5",
+		EgressCIDRs: []string{},
+	})
+	err = w.assertNoChanges()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
 	// Removing the duplicate node egressIP should restore traffic to the broken namespace
 	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
 		HostIP:    "172.17.0.4",
@@ -607,6 +633,32 @@ func TestDuplicateNamespaceEgressIPs(t *testing.T) {
 		"namespace 42 dropped",
 		"namespace 43 dropped",
 	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Auto-egress-IP assignment should ignore the IP while it is double-booked
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
+		HostIP:      "172.17.0.5",
+		EgressCIDRs: []string{"172.17.0.0/24"},
+	})
+	err = w.assertChanges(
+		"update egress CIDRs",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	allocation := eit.ReallocateEgressIPs()
+	if node5ips, ok := allocation["node-5"]; !ok {
+		t.Fatalf("Unexpected IP allocation: %#v", allocation)
+	} else if len(node5ips) != 0 {
+		t.Fatalf("Unexpected IP allocation: %#v", allocation)
+	}
+	updateHostSubnetEgress(eit, &networkapi.HostSubnet{
+		HostIP:      "172.17.0.5",
+		EgressCIDRs: []string{},
+	})
+	err = w.assertNoChanges()
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -1001,10 +1053,16 @@ func TestEgressCIDRAllocation(t *testing.T) {
 	// You can't mix multiple-egress-IP HA with auto-allocated-egress-IP HA
 	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
 		NetID:     45,
-		EgressIPs: []string{"172.17.0.102", "172.17.0.302"},
+		EgressIPs: []string{"172.17.0.102", "172.17.1.102"},
+	})
+	updateNetNamespaceEgress(eit, &networkapi.NetNamespace{
+		NetID:     49,
+		EgressIPs: []string{"172.17.0.109", "172.17.1.109"},
 	})
 	err = w.assertChanges(
 		"update egress CIDRs",
+		"update egress CIDRs",
+		"namespace 49 dropped",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)


### PR DESCRIPTION
The new unit test from #20971 was supposed to reject the egress IPs because there were multiple IPs, but in fact it was rejecting them because I made a typo and one of them wasn't actually a valid IP, and the "don't mix auto-assigned-HA with multiple-egress-IP HA" check wasn't actually working at all. So this fixes the test case and the check, and then for good measure also ensures we don't auto-assign egress IPs in two other "broken" cases. (The new "NetID: 49" test case is because I initially thought the problem might have been that we were handling the case of "good namespace goes bad" but not the case of "new namespace is bad from the start". That was a red herring but I left the extra test in anyway.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1633574 (which has been bumped from 3.11.0 to 3.11.z because this code is just there to prevent you from screwing up; as long as you don't screw up in the first place, everything works fine).