### PR TITLE
add local-up-master for running a controller manager without a kubelet

### DIFF
--- a/hack/local-up-master/etcd.sh
+++ b/hack/local-up-master/etcd.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# A set of helpers for starting/running etcd for tests
+
+ETCD_VERSION=${ETCD_VERSION:-3.2.24}
+ETCD_HOST=${ETCD_HOST:-127.0.0.1}
+ETCD_PORT=${ETCD_PORT:-2379}
+export KUBE_INTEGRATION_ETCD_URL="https://${ETCD_HOST}:${ETCD_PORT}"
+
+kube::etcd::validate() {
+  # validate if in path
+  command -v etcd >/dev/null || {
+    kube::log::usage "etcd must be in your PATH"
+    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
+    exit 1
+  }
+
+  # validate etcd port is free
+  local port_check_command
+  if command -v ss &> /dev/null && ss -Version | grep 'iproute2' &> /dev/null; then
+    port_check_command="ss"
+  elif command -v netstat &>/dev/null; then
+    port_check_command="netstat"
+  else
+    kube::log::usage "unable to identify if etcd is bound to port ${ETCD_PORT}. unable to find ss or netstat utilities."
+    exit 1
+  fi
+  if ${port_check_command} -nat | grep "LISTEN" | grep "[\.:]${ETCD_PORT:?}" >/dev/null 2>&1; then
+    kube::log::usage "unable to start etcd as port ${ETCD_PORT} is in use. please stop the process listening on this port and retry."
+    kube::log::usage "`netstat -nat | grep "[\.:]${ETCD_PORT:?} .*LISTEN"`"
+    exit 1
+  fi
+
+  # validate installed version is at least equal to minimum
+  version=$(etcd --version | tail -n +1 | head -n 1 | cut -d " " -f 3)
+  if [[ $(kube::etcd::version $ETCD_VERSION) -gt $(kube::etcd::version $version) ]]; then
+   hash etcd
+   echo $PATH
+   version=$(etcd --version | head -n 1 | cut -d " " -f 3)
+   if [[ $(kube::etcd::version $ETCD_VERSION) -gt $(kube::etcd::version $version) ]]; then
+    kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
+    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
+    exit 1
+   fi
+  fi
+}
+
+kube::etcd::version() {
+  printf '%s\n' "${@}" | awk -F . '{ printf("%d%03d%03d\n", $1, $2, $3) }'
+}
+
+kube::etcd::start() {
+  # validate before running
+  kube::etcd::validate
+
+  # Start etcd
+  ETCD_DIR=${ETCD_DIR:-$(mktemp -d 2>/dev/null || mktemp -d -t test-etcd.XXXXXX)}
+  if [[ -d "${ARTIFACTS_DIR:-}" ]]; then
+    ETCD_LOGFILE="${ARTIFACTS_DIR}/etcd.$(uname -n).$(id -un).log.DEBUG.$(date +%Y%m%d-%H%M%S).$$"
+  else
+    ETCD_LOGFILE=${ETCD_LOGFILE:-"/dev/null"}
+  fi
+  kube::log::info "etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --data-dir ${ETCD_DIR}/data --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT} --debug > \"${ETCD_LOGFILE}\" 2>/dev/null"
+  etcd --advertise-client-urls ${KUBE_INTEGRATION_ETCD_URL} --cert-file=${ETCD_DIR}/serving-etcd-server.crt --key-file=${ETCD_DIR}/serving-etcd-server.key --data-dir ${ETCD_DIR}/data --listen-client-urls ${KUBE_INTEGRATION_ETCD_URL} --debug 2> "${ETCD_LOGFILE}" >/dev/null &
+  ETCD_PID=$!
+
+#  echo "Waiting for etcd to come up."
+#  kube::util::wait_for_url "${KUBE_INTEGRATION_ETCD_URL}/v2/machines" "etcd: " 0.25 80
+#  curl -fs -X PUT "${KUBE_INTEGRATION_ETCD_URL}/v2/keys/_test"
+}
+
+kube::etcd::stop() {
+  if [[ -n "${ETCD_PID-}" ]]; then
+    kill "${ETCD_PID}" &>/dev/null || :
+    wait "${ETCD_PID}" &>/dev/null || :
+  fi
+}
+
+kube::etcd::clean_etcd_dir() {
+  if [[ -n "${ETCD_DIR-}" ]]; then
+    rm -rf "${ETCD_DIR}/data"
+  fi
+}
+
+kube::etcd::cleanup() {
+  kube::etcd::stop
+  kube::etcd::clean_etcd_dir
+}
+

--- a/hack/local-up-master/kube-apiserver.yaml
+++ b/hack/local-up-master/kube-apiserver.yaml
@@ -1,0 +1,79 @@
+apiVersion: kubecontrolplane.config.openshift.io/v1
+kind: KubeAPIServerConfig
+aggregatorConfig:
+  proxyClientInfo:
+    certFile: client-kube-aggregator.crt
+    keyFile: client-kube-aggregator.key
+apiServerArguments:
+  storage-backend:
+  - etcd3
+  storage-media-type:
+  - application/vnd.kubernetes.protobuf
+  enable-aggregator-routing:
+  - "true"
+authConfig:
+  requestHeader:
+    clientCA: client-kube-aggregator.crt
+    clientCommonNames:
+    - kube-apiserver-proxy
+    - system:openshift-aggregator
+    - system:kube-aggregator
+    extraHeaderPrefixes:
+    - X-Remote-Extra-
+    groupHeaders:
+    - X-Remote-Group
+    usernameHeaders:
+    - X-Remote-User
+  webhookTokenAuthenticators: null
+corsAllowedOrigins:
+- //127\.0\.0\.1(:|$)
+- //localhost(:|$)
+kubeletClientInfo:
+  ca: server-ca.crt
+  certFile: client-kubelet.crt
+  keyFile: client-kubelet.key
+  port: 10250
+oauthConfig:
+  alwaysShowProviderSelection: false
+  assetPublicURL: https://127.0.0.1:8443
+  grantConfig:
+    method: auto
+    serviceAccountMethod: prompt
+  masterCA: server-ca.crt
+  masterPublicURL: https://127.0.0.1:8443
+  masterURL: https://127.0.0.1:8443
+  sessionConfig:
+    sessionMaxAgeSeconds: 300
+    sessionName: ssn
+    sessionSecretsFile: ""
+  templates: null
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 300
+  identityProviders:
+  - name: alwaysallow
+    challenge: true
+    login: true
+    mappingMethod: claim
+    provider:
+      apiVersion: v1
+      kind: AllowAllPasswordIdentityProvider
+serviceAccountPublicKeyFiles:
+- service-account
+servicesNodePortRange: 30000-32767
+servicesSubnet: 10.3.0.0/16 # ServiceCIDR
+servingInfo:
+  bindAddress: 0.0.0.0:8443
+  bindNetwork: tcp4
+  certFile: serving-kube-apiserver.crt
+  clientCA: client-ca.crt
+  keyFile: serving-kube-apiserver.key
+  maxRequestsInFlight: 1200
+  namedCertificates: null
+  requestTimeoutSeconds: 3600
+storageConfig:
+  ca: etcd-serving-ca.crt
+  certFile: client-etcd-client.crt
+  keyFile: client-etcd-client.key
+  urls:
+  - https://127.0.0.1:2379

--- a/hack/local-up-master/logging.sh
+++ b/hack/local-up-master/logging.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Controls verbosity of the script output and logging.
+KUBE_VERBOSE="${KUBE_VERBOSE:-5}"
+
+# Handler for when we exit automatically on an error.
+# Borrowed from https://gist.github.com/ahendrix/7030300
+kube::log::errexit() {
+  local err="${PIPESTATUS[@]}"
+
+  # If the shell we are in doesn't have errexit set (common in subshells) then
+  # don't dump stacks.
+  set +o | grep -qe "-o errexit" || return
+
+  set +o xtrace
+  local code="${1:-1}"
+  # Print out the stack trace described by $function_stack  
+  if [ ${#FUNCNAME[@]} -gt 2 ]
+  then
+    kube::log::error "Call tree:"
+    for ((i=1;i<${#FUNCNAME[@]}-1;i++))
+    do
+      kube::log::error " $i: ${BASH_SOURCE[$i+1]}:${BASH_LINENO[$i]} ${FUNCNAME[$i]}(...)"
+    done
+  fi  
+  kube::log::error_exit "Error in ${BASH_SOURCE[1]}:${BASH_LINENO[0]}. '${BASH_COMMAND}' exited with status $err" "${1:-1}" 1
+}
+
+kube::log::install_errexit() {
+  # trap ERR to provide an error handler whenever a command exits nonzero  this
+  # is a more verbose version of set -o errexit
+  trap 'kube::log::errexit' ERR
+
+  # setting errtrace allows our ERR trap handler to be propagated to functions,
+  # expansions and subshells
+  set -o errtrace
+}
+
+# Print out the stack trace
+#
+# Args:
+#   $1 The number of stack frames to skip when printing.
+kube::log::stack() {
+  local stack_skip=${1:-0}
+  stack_skip=$((stack_skip + 1))
+  if [[ ${#FUNCNAME[@]} -gt $stack_skip ]]; then
+    echo "Call stack:" >&2
+    local i
+    for ((i=1 ; i <= ${#FUNCNAME[@]} - $stack_skip ; i++))
+    do
+      local frame_no=$((i - 1 + stack_skip))
+      local source_file=${BASH_SOURCE[$frame_no]}
+      local source_lineno=${BASH_LINENO[$((frame_no - 1))]}
+      local funcname=${FUNCNAME[$frame_no]}
+      echo "  $i: ${source_file}:${source_lineno} ${funcname}(...)" >&2
+    done
+  fi
+}
+
+# Log an error and exit.
+# Args:
+#   $1 Message to log with the error
+#   $2 The error code to return
+#   $3 The number of stack frames to skip when printing.
+kube::log::error_exit() {
+  local message="${1:-}"
+  local code="${2:-1}"
+  local stack_skip="${3:-0}"
+  stack_skip=$((stack_skip + 1))
+
+  if [[ ${KUBE_VERBOSE} -ge 4 ]]; then
+    local source_file=${BASH_SOURCE[$stack_skip]}
+    local source_line=${BASH_LINENO[$((stack_skip - 1))]}
+    echo "!!! Error in ${source_file}:${source_line}" >&2
+    [[ -z ${1-} ]] || {
+      echo "  ${1}" >&2
+    }
+
+    kube::log::stack $stack_skip
+
+    echo "Exiting with status ${code}" >&2
+  fi
+
+  exit "${code}"
+}
+
+# Log an error but keep going.  Don't dump the stack or exit.
+kube::log::error() {
+  timestamp=$(date +"[%m%d %H:%M:%S]")
+  echo "!!! $timestamp ${1-}" >&2
+  shift
+  for message; do
+    echo "    $message" >&2
+  done
+}
+
+# Print an usage message to stderr.  The arguments are printed directly.
+kube::log::usage() {
+  echo >&2
+  local message
+  for message; do
+    echo "$message" >&2
+  done
+  echo >&2
+}
+
+kube::log::usage_from_stdin() {
+  local messages=()
+  while read -r line; do
+    messages+=("$line")
+  done
+
+  kube::log::usage "${messages[@]}"
+}
+
+# Print out some info that isn't a top level status line
+kube::log::info() {
+  local V="${V:-0}"
+  if [[ $KUBE_VERBOSE < $V ]]; then
+    return
+  fi
+
+  for message; do
+    echo "$message"
+  done
+}
+
+# Just like kube::log::info, but no \n, so you can make a progress bar
+kube::log::progress() {
+  for message; do
+    echo -e -n "$message"
+  done
+}
+
+kube::log::info_from_stdin() {
+  local messages=()
+  while read -r line; do
+    messages+=("$line")
+  done
+
+  kube::log::info "${messages[@]}"
+}
+
+# Print a status line.  Formatted to show up in a stream of output.
+kube::log::status() {
+  local V="${V:-0}"
+  if [[ $KUBE_VERBOSE < $V ]]; then
+    return
+  fi
+
+  timestamp=$(date +"[%m%d %H:%M:%S]")
+  echo "+++ $timestamp $1"
+  shift
+  for message; do
+    echo "    $message"
+  done
+}

--- a/hack/local-up-master/master.sh
+++ b/hack/local-up-master/master.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+
+set -e
+
+# preserve etcd data. you also need to set ETCD_DIR.
+PRESERVE_ETCD="${PRESERVE_ETCD:-false}"
+API_PORT=${API_PORT:-8080}
+API_SECURE_PORT=${API_SECURE_PORT:-8443}
+
+# WARNING: For DNS to work on most setups you should export API_HOST as the docker0 ip address,
+API_HOST=${API_HOST:-localhost}
+API_HOST_IP=${API_HOST_IP:-"127.0.0.1"}
+ADVERTISE_ADDRESS=${ADVERTISE_ADDRESS:-""}
+FIRST_SERVICE_CLUSTER_IP=${FIRST_SERVICE_CLUSTER_IP:-10.0.0.1}
+HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"127.0.0.1"}
+CONTROLPLANE_SUDO=
+LOG_LEVEL=${LOG_LEVEL:-3}
+# Use to increase verbosity on particular files, e.g. LOG_SPEC=token_controller*=5,other_controller*=4
+LOG_SPEC=${LOG_SPEC:-""}
+WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-60}
+MAX_TIME_FOR_URL_API_SERVER=${MAX_TIME_FOR_URL_API_SERVER:-1}
+
+
+source "$(dirname "${BASH_SOURCE}")/../lib/init.sh"
+KUBE_ROOT=OS_ROOT
+source "${OS_ROOT}/hack/local-up-master/logging.sh"
+source "${OS_ROOT}/hack/local-up-master/util.sh"
+source "${OS_ROOT}/hack/local-up-master/etcd.sh"
+
+
+CONFIG=$(pwd)/openshift.local.masterup
+mkdir -p ${CONFIG}/logs
+ETCD_DIR=$(pwd)/openshift.local.masterup/etcd
+CERT_DIR=${CONFIG}/kube-apiserver
+LOG_DIR=${CONFIG}/logs
+ROOT_CA_FILE=${CERT_DIR}/server-ca.crt
+
+
+
+cleanup()
+{
+  echo "Cleaning up..."
+  set +e
+  # Check if the API server is still running
+  [[ -n "${KUBE_APISERVER_PID-}" ]] && KUBE_APISERVER_PIDS=$(pgrep -P ${KUBE_APISERVER_PID} ; ps -o pid= -p ${KUBE_APISERVER_PID})
+  [[ -n "${KUBE_APISERVER_PIDS-}" ]] && sudo kill ${KUBE_APISERVER_PIDS} 2>/dev/null
+
+  # Check if the controller-manager is still running
+  [[ -n "${KUBE_CONTROLLER_MANAGER_PID-}" ]] && KUBE_CONTROLLER_MANAGER_PIDS=$(pgrep -P ${KUBE_CONTROLLER_MANAGER_PID} ; ps -o pid= -p ${KUBE_CONTROLLER_MANAGER_PID})
+  [[ -n "${KUBE_CONTROLLER_MANAGER_PIDS-}" ]] && sudo kill ${KUBE_CONTROLLER_MANAGER_PIDS} 2>/dev/null
+
+  [[ -n "${OPENSHIFT_APISERVER_PID-}" ]] && OPENSHIFT_APISERVER_PIDS=$(pgrep -P ${OPENSHIFT_APISERVER_PID} ; ps -o pid= -p ${OPENSHIFT_APISERVER_PID})
+  [[ -n "${OPENSHIFT_APISERVER_PIDS-}" ]] && sudo kill ${OPENSHIFT_APISERVER_PIDS} 2>/dev/null
+
+  [[ -n "${OPENSHIFT_CONTROLLER_MANAGER_PID-}" ]] && OPENSHIFT_CONTROLLER_MANAGER_PIDS=$(pgrep -P ${OPENSHIFT_CONTROLLER_MANAGER_PID} ; ps -o pid= -p ${OPENSHIFT_CONTROLLER_MANAGER_PID})
+  [[ -n "${OPENSHIFT_CONTROLLER_MANAGER_PIDS-}" ]] && sudo kill ${OPENSHIFT_CONTROLLER_MANAGER_PIDS} 2>/dev/null
+
+
+  # Check if the etcd is still running
+  [[ -n "${ETCD_PID-}" ]] && kube::etcd::stop
+  if [[ "${PRESERVE_ETCD}" == "false" ]]; then
+    [[ -n "${ETCD_DIR-}" ]] && kube::etcd::clean_etcd_dir
+  fi
+  exit 0
+}
+
+trap cleanup EXIT
+
+# Check if all processes are still running. Prints a warning once each time
+# a process dies unexpectedly.
+function healthcheck {
+  if [[ -n "${KUBE_APISERVER_PID-}" ]] && ! sudo kill -0 ${KUBE_APISERVER_PID} 2>/dev/null; then
+    warning_log "API server terminated unexpectedly, see ${KUBE_APISERVER_LOG}"
+    KUBE_APISERVER_PID=
+  fi
+
+  if [[ -n "${KUBE_CONTROLLER_MANAGER_PID-}" ]] && ! sudo kill -0 ${KUBE_CONTROLLER_MANAGER_PID} 2>/dev/null; then
+    warning_log "kube-controller-manager terminated unexpectedly, see ${KUBE_CONTROLLER_MANAGER_LOG}"
+    KUBE_CONTROLLER_MANAGER_PID=
+  fi
+
+  if [[ -n "${OPENSHIFT_APISERVER_PID-}" ]] && ! sudo kill -0 ${OPENSHIFT_APISERVER_PID} 2>/dev/null; then
+    warning_log "API server terminated unexpectedly, see ${OPENSHIFT_APISERVER_LOG}"
+    OPENSHIFT_APISERVER_PID=
+  fi
+
+  if [[ -n "${OPENSHIFT_CONTROLLER_MANAGER_PID-}" ]] && ! sudo kill -0 ${OPENSHIFT_CONTROLLER_MANAGER_PID} 2>/dev/null; then
+    warning_log "kube-controller-manager terminated unexpectedly, see ${OPENSHIFT_CONTROLLER_MANAGER_LOG}"
+    OPENSHIFT_CONTROLLER_MANAGER_PID=
+  fi
+
+
+  if [[ -n "${ETCD_PID-}" ]] && ! sudo kill -0 ${ETCD_PID} 2>/dev/null; then
+    warning_log "etcd terminated unexpectedly"
+    ETCD_PID=
+  fi
+}
+
+function print_color {
+  message=$1
+  prefix=${2:+$2: } # add colon only if defined
+  color=${3:-1}     # default is red
+  echo -n $(tput bold)$(tput setaf ${color})
+  echo "${prefix}${message}"
+  echo -n $(tput sgr0)
+}
+
+function warning_log {
+  print_color "$1" "W$(date "+%m%d %H:%M:%S")]" 1
+}
+
+
+function generate_etcd_certs {
+    # Create CA signers
+    kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${ETCD_DIR}" server '"client auth","server auth"'
+    cp "${ETCD_DIR}/server-ca.key" "${ETCD_DIR}/client-ca.key"
+    cp "${ETCD_DIR}/server-ca.crt" "${ETCD_DIR}/client-ca.crt"
+    cp "${ETCD_DIR}/server-ca-config.json" "${ETCD_DIR}/client-ca-config.json"
+
+    # Create client certs signed with client-ca, given id, given CN and a number of groups
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${ETCD_DIR}" 'client-ca' etcd-client etcd-clients
+
+    # Create matching certificates for kube-aggregator
+    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${ETCD_DIR}" "server-ca" etcd-server "localhost" "127.0.0.1" ${API_HOST_IP}
+}
+
+function generate_kubeapiserver_certs {
+    openssl genrsa -out "${CERT_DIR}/service-account" 2048 2>/dev/null
+
+    # Create CA signers
+    kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" server '"client auth","server auth"'
+    cp "${CERT_DIR}/server-ca.key" "${CERT_DIR}/client-ca.key"
+    cp "${CERT_DIR}/server-ca.crt" "${CERT_DIR}/client-ca.crt"
+    cp "${CERT_DIR}/server-ca-config.json" "${CERT_DIR}/client-ca-config.json"
+
+    # Create auth proxy client ca
+    kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" request-header '"client auth"'
+
+    # serving cert for kube-apiserver
+    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" kube-apiserver kubernetes.default kubernetes.default.svc "localhost" ${API_HOST_IP} ${API_HOST} ${FIRST_SERVICE_CLUSTER_IP}
+
+    # Create client certs signed with client-ca, given id, given CN and a number of groups
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' kubelet system:node:${HOSTNAME_OVERRIDE} system:nodes
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' controller system:kube-controller-manager
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' admin system:admin system:masters
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' openshift-apiserver openshift-apiserver system:masters
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' openshift-controller-manager openshift-controller-manager system:masters
+
+    # Create matching certificates for kube-aggregator
+    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" kube-aggregator api.kube-public.svc "localhost" ${API_HOST_IP}
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" request-header-ca auth-proxy system:auth-proxy
+    # TODO remove masters and add rolebinding
+    kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' kube-aggregator system:kube-aggregator system:masters
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" kube-aggregator
+
+    cp ${ETCD_DIR}/server-ca.crt ${CERT_DIR}/etcd-serving-ca.crt
+    cp ${ETCD_DIR}/client-etcd-client.crt ${CERT_DIR}/client-etcd-client.crt
+    cp ${ETCD_DIR}/client-etcd-client.key ${CERT_DIR}/client-etcd-client.key
+}
+
+function generate_kubecontrollermanager_certs {
+    cp ${CONFIG}/kube-apiserver/service-account ${CONFIG}/kube-controller-manager/etcd-serving-ca.crt
+    cp ${CONFIG}/kube-apiserver/client-controller.crt ${CONFIG}/kube-controller-manager/client-controller.crt
+    cp ${CONFIG}/kube-apiserver/client-controller.key ${CONFIG}/kube-controller-manager/client-controller.key
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CONFIG}/kube-controller-manager" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" controller
+}
+
+
+function generate_openshiftapiserver_certs {
+    # Create CA signers
+    kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CONFIG}/openshift-apiserver" server '"client auth","server auth"'
+
+    # serving cert for kube-apiserver
+    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CONFIG}/openshift-apiserver" "server-ca" openshift-apiserver openshift.default openshift.default.svc "localhost" ${API_HOST_IP} ${API_HOST} ${FIRST_SERVICE_CLUSTER_IP}
+
+    cp ${CONFIG}/kube-apiserver/client-openshift-apiserver.crt ${CONFIG}/openshift-apiserver/client-openshift-apiserver.crt
+    cp ${CONFIG}/kube-apiserver/client-openshift-apiserver.key ${CONFIG}/openshift-apiserver/client-openshift-apiserver.key
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CONFIG}/openshift-apiserver" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" openshift-apiserver
+
+    cp ${ETCD_DIR}/server-ca.crt ${CONFIG}/openshift-apiserver/etcd-serving-ca.crt
+    cp ${ETCD_DIR}/client-etcd-client.crt ${CONFIG}/openshift-apiserver/client-etcd-client.crt
+    cp ${ETCD_DIR}/client-etcd-client.key ${CONFIG}/openshift-apiserver/client-etcd-client.key
+}
+
+function generate_openshiftcontrollermanager_certs {
+    # Create CA signers
+    kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CONFIG}/openshift-controller-manager" server '"client auth","server auth"'
+
+    # serving cert for kube-apiserver
+    kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CONFIG}/openshift-controller-manager" "server-ca" openshift-controller-manager openshift.default openshift.default.svc "localhost" ${API_HOST_IP} ${API_HOST} ${FIRST_SERVICE_CLUSTER_IP}
+
+    cp ${CONFIG}/kube-apiserver/client-ca.crt ${CONFIG}/openshift-controller-manager/client-ca.crt
+    cp ${CONFIG}/kube-apiserver/client-openshift-controller-manager.crt ${CONFIG}/openshift-controller-manager/client-openshift-controller-manager.crt
+    cp ${CONFIG}/kube-apiserver/client-openshift-controller-manager.key ${CONFIG}/openshift-controller-manager/client-openshift-controller-manager.key
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CONFIG}/openshift-controller-manager" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" openshift-controller-manager
+}
+
+function start_etcd {
+    if [ ! -d "${CONFIG}/etcd" ]; then
+        mkdir -p ${CONFIG}/etcd
+        generate_etcd_certs
+    fi
+    echo "Starting etcd"
+    ETCD_LOGFILE=${LOG_DIR}/etcd.log
+    kube::etcd::start
+}
+
+function start_kubeapiserver {
+    if [ ! -d "${CONFIG}/kube-apiserver" ]; then
+        mkdir -p ${CONFIG}/kube-apiserver
+        cp ${OS_ROOT}/hack/local-up-master/kube-apiserver.yaml ${CONFIG}/kube-apiserver
+        generate_kubeapiserver_certs
+    fi
+
+    KUBE_APISERVER_LOG=${LOG_DIR}/kube-apiserver.log
+    hypershift openshift-kube-apiserver \
+      --v=${LOG_LEVEL} \
+      --vmodule="${LOG_SPEC}" \
+      --config=${CONFIG}/kube-apiserver/kube-apiserver.yaml >"${KUBE_APISERVER_LOG}" 2>&1 &
+    KUBE_APISERVER_PID=$!
+
+    # Wait for kube-apiserver to come up before launching the rest of the components.
+    echo "Waiting for kube-apiserver to come up"
+    kube::util::wait_for_url "https://${API_HOST_IP}:${API_SECURE_PORT}/healthz" "kube-apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} ${MAX_TIME_FOR_URL_API_SERVER} \
+        || { echo "check kube-apiserver logs: ${KUBE_APISERVER_LOG}" ; exit 1 ; }
+
+    # Create kubeconfigs for all components, using client certs
+    kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" admin
+    chown "${USER}" "${CERT_DIR}/client-admin.key" # make readable for kubectl
+}
+
+function start_kubecontrollermanager {
+    if [ ! -d "${CONFIG}/kube-controller-manager" ]; then
+        mkdir -p ${CONFIG}/kube-controller-manager
+        generate_kubecontrollermanager_certs
+    fi
+
+    KUBE_CONTROLLER_MANAGER_LOG=${LOG_DIR}/kube-controller-manager.log
+    hyperkube controller-manager \
+      --v=${LOG_LEVEL} \
+      --vmodule="${LOG_SPEC}" \
+      --service-account-private-key-file="${CONFIG}/kube-controller-manager/etcd-serving-ca.crt" \
+      --root-ca-file="${ROOT_CA_FILE}" \
+      --kubeconfig  ${CONFIG}/kube-controller-manager/controller.kubeconfig \
+      --use-service-account-credentials \
+      --leader-elect=false >"${KUBE_CONTROLLER_MANAGER_LOG}" 2>&1 &
+    KUBE_CONTROLLER_MANAGER_PID=$!
+
+    echo "Waiting for kube-controller-manager to come up"
+    kube::util::wait_for_url "http://localhost:10252/healthz" "kube-controller-manager: " 1 ${WAIT_FOR_URL_API_SERVER} ${MAX_TIME_FOR_URL_API_SERVER} \
+        || { echo "check kube-controller-manager logs: ${KUBE_CONTROLLER_MANAGER_LOG}" ; exit 1 ; }
+}
+
+function start_openshiftapiserver {
+    if [ ! -d "${CONFIG}/openshift-apiserver" ]; then
+        mkdir -p ${CONFIG}/openshift-apiserver
+        cp ${OS_ROOT}/hack/local-up-master/openshift-apiserver.yaml ${CONFIG}/openshift-apiserver
+        generate_openshiftapiserver_certs
+    fi
+
+    OPENSHIFT_APISERVER_LOG=${LOG_DIR}/openshift-apiserver.log
+    hypershift openshift-apiserver \
+      --v=${LOG_LEVEL} \
+      --vmodule="${LOG_SPEC}" \
+      --config=${CONFIG}/openshift-apiserver/openshift-apiserver.yaml >"${OPENSHIFT_APISERVER_LOG}" 2>&1 &
+    OPENSHIFT_APISERVER_PID=$!
+
+    # Wait for openshift-apiserver to come up before launching the rest of the components.
+    echo "Waiting for openshift-apiserver to come up"
+    kube::util::wait_for_url "https://${API_HOST_IP}:8444/healthz" "openshift-apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} ${MAX_TIME_FOR_URL_API_SERVER} \
+        || { echo "check kube-apiserver logs: ${OPENSHIFT_APISERVER_LOG}" ; exit 1 ; }
+
+    NON_LOOPBACK_IPV4=$(ifconfig | grep -A1 -e "wlp\|enp" | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | head -n 1)
+    for filename in ${OS_ROOT}/hack/local-up-master/openshift-apiserver-manifests/*.yaml; do
+        sed "s/NON_LOOPBACK_HOST/${NON_LOOPBACK_IPV4}/g" ${filename} | oc --config=${CONFIG}/openshift-apiserver/openshift-apiserver.kubeconfig apply -f -
+    done
+}
+
+function start_openshiftcontrollermanager {
+#    if [ ! -d "${CONFIG}/openshift-controller-manager" ]; then
+        mkdir -p ${CONFIG}/openshift-controller-manager
+        cp ${OS_ROOT}/hack/local-up-master/openshift-controller-manager.yaml ${CONFIG}/openshift-controller-manager
+        generate_openshiftcontrollermanager_certs
+#    fi
+
+    OPENSHIFT_CONTROLLER_MANAGER_LOG=${LOG_DIR}/openshift-controller-manager.log
+    hypershift openshift-controller-manager \
+      --v=${LOG_LEVEL} \
+      --vmodule="${LOG_SPEC}" \
+      --config=${CONFIG}/openshift-controller-manager/openshift-controller-manager.yaml >"${OPENSHIFT_CONTROLLER_MANAGER_LOG}" 2>&1 &
+    OPENSHIFT_CONTROLLER_MANAGER_PID=$!
+
+    echo "Waiting for openshift-controller-manager to come up"
+    kube::util::wait_for_url "https://localhost:8445/healthz" "openshift-controller-manager: " 1 ${WAIT_FOR_URL_API_SERVER} ${MAX_TIME_FOR_URL_API_SERVER} \
+        || { echo "check openshift-controller-manager logs: ${OPENSHIFT_CONTROLLER_MANAGER_LOG}" ; exit 1 ; }
+}
+
+
+
+kube::util::test_openssl_installed
+kube::util::ensure-cfssl
+
+start_etcd
+start_kubeapiserver
+start_kubecontrollermanager
+start_openshiftapiserver
+start_openshiftcontrollermanager
+
+cp ${CONFIG}/kube-apiserver/admin.kubeconfig ${CONFIG}/admin.kubeconfig
+
+echo
+echo "Cluster is available, the following kubeconfig to interact with it"
+echo "export KUBECONFIG=${CONFIG}/admin.kubeconfig"
+echo "Press ctrl+C to finish"
+
+while true; do sleep 1; healthcheck; done

--- a/hack/local-up-master/openshift-apiserver-manifests/01_service.yaml
+++ b/hack/local-up-master/openshift-apiserver-manifests/01_service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: default
+  name: openshift
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - port: 443
+    targetPort: 8444

--- a/hack/local-up-master/openshift-apiserver-manifests/02_endpoint.yaml
+++ b/hack/local-up-master/openshift-apiserver-manifests/02_endpoint.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  namespace: default
+  name: openshift
+subsets:
+- addresses:
+  - ip: NON_LOOPBACK_HOST
+  ports:
+  - port: 8444

--- a/hack/local-up-master/openshift-apiserver-manifests/03_apiservice.yaml
+++ b/hack/local-up-master/openshift-apiserver-manifests/03_apiservice.yaml
@@ -1,0 +1,159 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.apps.openshift.io
+  spec:
+    group: apps.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.authorization.openshift.io
+  spec:
+    group: authorization.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.build.openshift.io
+  spec:
+    group: build.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.image.openshift.io
+  spec:
+    group: image.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.network.openshift.io
+  spec:
+    group: network.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.oauth.openshift.io
+  spec:
+    group: oauth.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.project.openshift.io
+  spec:
+    group: project.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.quota.openshift.io
+  spec:
+    group: quota.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.route.openshift.io
+  spec:
+    group: route.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.security.openshift.io
+  spec:
+    group: security.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.template.openshift.io
+  spec:
+    group: template.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15
+- apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1.user.openshift.io
+  spec:
+    group: user.openshift.io
+    version: v1
+    service:
+      namespace: default
+      name: openshift
+    insecureSkipTLSVerify: true
+    groupPriorityMinimum: 20000
+    versionPriority: 15

--- a/hack/local-up-master/openshift-apiserver.yaml
+++ b/hack/local-up-master/openshift-apiserver.yaml
@@ -1,0 +1,28 @@
+apiVersion: openshiftcontrolplane.config.openshift.io/v1
+kind: OpenShiftAPIServerConfig
+kubeClientConfig:
+  kubeConfig: openshift-apiserver.kubeconfig
+apiServerArguments:
+  storage-backend:
+  - etcd3
+  storage-media-type:
+  - application/vnd.kubernetes.protobuf
+corsAllowedOrigins:
+- //127\.0\.0\.1(:|$)
+- //localhost(:|$)
+servingInfo:
+  bindAddress: 0.0.0.0:8444
+  bindNetwork: tcp4
+  certFile: serving-openshift-apiserver.crt
+  clientCA: client-ca.crt
+  keyFile: serving-openshift-apiserver.key
+  maxRequestsInFlight: 1200
+  namedCertificates: null
+  requestTimeoutSeconds: 3600
+storageConfig:
+  ca: etcd-serving-ca.crt
+  certFile: client-etcd-client.crt
+  keyFile: client-etcd-client.key
+  urls:
+  - https://127.0.0.1:2379
+

--- a/hack/local-up-master/openshift-controller-manager.yaml
+++ b/hack/local-up-master/openshift-controller-manager.yaml
@@ -1,0 +1,16 @@
+apiVersion: openshiftcontrolplane.config.openshift.io/v1
+kind: OpenShiftControllerManagerConfig
+kubeClientConfig:
+  kubeConfig: openshift-controller-manager.kubeconfig
+corsAllowedOrigins:
+- //127\.0\.0\.1(:|$)
+- //localhost(:|$)
+servingInfo:
+  bindAddress: 0.0.0.0:8445
+  bindNetwork: tcp4
+  certFile: serving-openshift-controller-manager.crt
+  clientCA: client-ca.crt
+  keyFile: serving-openshift-controller-manager.key
+  maxRequestsInFlight: 1200
+  namedCertificates: null
+  requestTimeoutSeconds: 3600

--- a/hack/local-up-master/util.sh
+++ b/hack/local-up-master/util.sh
@@ -1,0 +1,810 @@
+#!/usr/bin/env bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kube::util::sortable_date() {
+  date "+%Y%m%d-%H%M%S"
+}
+
+# arguments: target, item1, item2, item3, ...
+# returns 0 if target is in the given items, 1 otherwise.
+kube::util::array_contains() {
+  local search="$1"
+  local element
+  shift
+  for element; do
+    if [[ "${element}" == "${search}" ]]; then
+      return 0
+     fi
+  done
+  return 1
+}
+
+kube::util::wait_for_url() {
+  local url=$1
+  local prefix=${2:-}
+  local wait=${3:-1}
+  local times=${4:-30}
+  local maxtime=${5:-1}
+
+  which curl >/dev/null || {
+    kube::log::usage "curl must be installed"
+    exit 1
+  }
+
+  local i
+  for i in $(seq 1 "$times"); do
+    local out
+    if out=$(curl --max-time "$maxtime" -gkfs "$url" 2>/dev/null); then
+      kube::log::status "On try ${i}, ${prefix}: ${out}"
+      return 0
+    fi
+    sleep "${wait}"
+  done
+  kube::log::error "Timed out waiting for ${prefix} to answer at ${url}; tried ${times} waiting ${wait} between each"
+  return 1
+}
+
+# Example:  kube::util::trap_add 'echo "in trap DEBUG"' DEBUG
+# See: http://stackoverflow.com/questions/3338030/multiple-bash-traps-for-the-same-signal
+kube::util::trap_add() {
+  local trap_add_cmd
+  trap_add_cmd=$1
+  shift
+
+  for trap_add_name in "$@"; do
+    local existing_cmd
+    local new_cmd
+
+    # Grab the currently defined trap commands for this trap
+    existing_cmd=`trap -p "${trap_add_name}" |  awk -F"'" '{print $2}'`
+
+    if [[ -z "${existing_cmd}" ]]; then
+      new_cmd="${trap_add_cmd}"
+    else
+      new_cmd="${trap_add_cmd};${existing_cmd}"
+    fi
+
+    # Assign the test
+    trap "${new_cmd}" "${trap_add_name}"
+  done
+}
+
+# Opposite of kube::util::ensure-temp-dir()
+kube::util::cleanup-temp-dir() {
+  rm -rf "${KUBE_TEMP}"
+}
+
+# Create a temp dir that'll be deleted at the end of this bash session.
+#
+# Vars set:
+#   KUBE_TEMP
+kube::util::ensure-temp-dir() {
+  if [[ -z ${KUBE_TEMP-} ]]; then
+    KUBE_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t kubernetes.XXXXXX)
+    kube::util::trap_add kube::util::cleanup-temp-dir EXIT
+  fi
+}
+
+# This figures out the host platform without relying on golang.  We need this as
+# we don't want a golang install to be a prerequisite to building yet we need
+# this info to figure out where the final binaries are placed.
+kube::util::host_platform() {
+  local host_os
+  local host_arch
+  case "$(uname -s)" in
+    Darwin)
+      host_os=darwin
+      ;;
+    Linux)
+      host_os=linux
+      ;;
+    *)
+      kube::log::error "Unsupported host OS.  Must be Linux or Mac OS X."
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64*)
+      host_arch=amd64
+      ;;
+    i?86_64*)
+      host_arch=amd64
+      ;;
+    amd64*)
+      host_arch=amd64
+      ;;
+    aarch64*)
+      host_arch=arm64
+      ;;
+    arm64*)
+      host_arch=arm64
+      ;;
+    arm*)
+      host_arch=arm
+      ;;
+    i?86*)
+      host_arch=x86
+      ;;
+    s390x*)
+      host_arch=s390x
+      ;;
+    ppc64le*)
+      host_arch=ppc64le
+      ;;
+    *)
+      kube::log::error "Unsupported host arch. Must be x86_64, 386, arm, arm64, s390x or ppc64le."
+      exit 1
+      ;;
+  esac
+  echo "${host_os}/${host_arch}"
+}
+
+kube::util::find-binary-for-platform() {
+  local -r lookfor="$1"
+  local -r platform="$2"
+  local locations=(
+    "${KUBE_ROOT}/_output/bin/${lookfor}"
+    "${KUBE_ROOT}/_output/dockerized/bin/${platform}/${lookfor}"
+    "${KUBE_ROOT}/_output/local/bin/${platform}/${lookfor}"
+    "${KUBE_ROOT}/platforms/${platform}/${lookfor}"
+  )
+  # Also search for binary in bazel build tree.
+  # The bazel go rules place binaries in subtrees like
+  # "bazel-bin/source/path/linux_amd64_pure_stripped/binaryname", so make sure
+  # the platform name is matched in the path.
+  locations+=($(find "${KUBE_ROOT}/bazel-bin/" -type f -executable \
+    -path "*/${platform/\//_}*/${lookfor}" 2>/dev/null || true) )
+
+  # List most recently-updated location.
+  local -r bin=$( (ls -t "${locations[@]}" 2>/dev/null || true) | head -1 )
+  echo -n "${bin}"
+}
+
+kube::util::find-binary() {
+  kube::util::find-binary-for-platform "$1" "$(kube::util::host_platform)"
+}
+
+# Run all known doc generators (today gendocs and genman for kubectl)
+# $1 is the directory to put those generated documents
+kube::util::gen-docs() {
+  local dest="$1"
+
+  # Find binary
+  gendocs=$(kube::util::find-binary "gendocs")
+  genkubedocs=$(kube::util::find-binary "genkubedocs")
+  genman=$(kube::util::find-binary "genman")
+  genyaml=$(kube::util::find-binary "genyaml")
+  genfeddocs=$(kube::util::find-binary "genfeddocs")
+
+  mkdir -p "${dest}/docs/user-guide/kubectl/"
+  "${gendocs}" "${dest}/docs/user-guide/kubectl/"
+  mkdir -p "${dest}/docs/admin/"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-apiserver"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-controller-manager"
+  "${genkubedocs}" "${dest}/docs/admin/" "cloud-controller-manager"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-proxy"
+  "${genkubedocs}" "${dest}/docs/admin/" "kube-scheduler"
+  "${genkubedocs}" "${dest}/docs/admin/" "kubelet"
+  "${genkubedocs}" "${dest}/docs/admin/" "kubeadm"
+
+  mkdir -p "${dest}/docs/man/man1/"
+  "${genman}" "${dest}/docs/man/man1/" "kube-apiserver"
+  "${genman}" "${dest}/docs/man/man1/" "kube-controller-manager"
+  "${genman}" "${dest}/docs/man/man1/" "cloud-controller-manager"
+  "${genman}" "${dest}/docs/man/man1/" "kube-proxy"
+  "${genman}" "${dest}/docs/man/man1/" "kube-scheduler"
+  "${genman}" "${dest}/docs/man/man1/" "kubelet"
+  "${genman}" "${dest}/docs/man/man1/" "kubectl"
+  "${genman}" "${dest}/docs/man/man1/" "kubeadm"
+
+  mkdir -p "${dest}/docs/yaml/kubectl/"
+  "${genyaml}" "${dest}/docs/yaml/kubectl/"
+
+  # create the list of generated files
+  pushd "${dest}" > /dev/null
+  touch docs/.generated_docs
+  find . -type f | cut -sd / -f 2- | LC_ALL=C sort > docs/.generated_docs
+  popd > /dev/null
+}
+
+# Puts a placeholder for every generated doc. This makes the link checker work.
+kube::util::set-placeholder-gen-docs() {
+  local list_file="${KUBE_ROOT}/docs/.generated_docs"
+  if [[ -e "${list_file}" ]]; then
+    # remove all of the old docs; we don't want to check them in.
+    while read file; do
+      if [[ "${list_file}" != "${KUBE_ROOT}/${file}" ]]; then
+        cp "${KUBE_ROOT}/hack/autogenerated_placeholder.txt" "${KUBE_ROOT}/${file}"
+      fi
+    done <"${list_file}"
+    # The docs/.generated_docs file lists itself, so we don't need to explicitly
+    # delete it.
+  fi
+}
+
+# Removes previously generated docs-- we don't want to check them in. $KUBE_ROOT
+# must be set.
+kube::util::remove-gen-docs() {
+  if [ -e "${KUBE_ROOT}/docs/.generated_docs" ]; then
+    # remove all of the old docs; we don't want to check them in.
+    while read file; do
+      rm "${KUBE_ROOT}/${file}" 2>/dev/null || true
+    done <"${KUBE_ROOT}/docs/.generated_docs"
+    # The docs/.generated_docs file lists itself, so we don't need to explicitly
+    # delete it.
+  fi
+}
+
+# Takes a group/version and returns the path to its location on disk, sans
+# "pkg". E.g.:
+# * default behavior: extensions/v1beta1 -> apis/extensions/v1beta1
+# * default behavior for only a group: experimental -> apis/experimental
+# * Special handling for empty group: v1 -> api/v1, unversioned -> api/unversioned
+# * Special handling for groups suffixed with ".k8s.io": foo.k8s.io/v1 -> apis/foo/v1
+# * Very special handling for when both group and version are "": / -> api
+kube::util::group-version-to-pkg-path() {
+  staging_apis=(
+  $(
+    cd "${KUBE_ROOT}/staging/src/k8s.io/api" &&
+    find . -name types.go -exec dirname {} \; | sed "s|\./||g" | sort
+  ))
+
+  local group_version="$1"
+
+  if [[ " ${staging_apis[@]} " =~ " ${group_version/.*k8s.io/} " ]]; then
+    echo "vendor/k8s.io/api/${group_version/.*k8s.io/}"
+    return
+  fi
+
+  # "v1" is the API GroupVersion
+  if [[ "${group_version}" == "v1" ]]; then
+    echo "vendor/k8s.io/api/core/v1"
+    return
+  fi
+
+  # Special cases first.
+  # TODO(lavalamp): Simplify this by moving pkg/api/v1 and splitting pkg/api,
+  # moving the results to pkg/apis/api.
+  case "${group_version}" in
+    # both group and version are "", this occurs when we generate deep copies for internal objects of the legacy v1 API.
+    __internal)
+      echo "pkg/apis/core"
+      ;;
+    meta/v1)
+      echo "vendor/k8s.io/apimachinery/pkg/apis/meta/v1"
+      ;;
+    meta/v1beta1)
+      echo "vendor/k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+      ;;
+    *.k8s.io)
+      echo "pkg/apis/${group_version%.*k8s.io}"
+      ;;
+    *.k8s.io/*)
+      echo "pkg/apis/${group_version/.*k8s.io/}"
+      ;;
+    *)
+      echo "pkg/apis/${group_version%__internal}"
+      ;;
+  esac
+}
+
+# Takes a group/version and returns the swagger-spec file name.
+# default behavior: extensions/v1beta1 -> extensions_v1beta1
+# special case for v1: v1 -> v1
+kube::util::gv-to-swagger-name() {
+  local group_version="$1"
+  case "${group_version}" in
+    v1)
+      echo "v1"
+      ;;
+    *)
+      echo "${group_version%/*}_${group_version#*/}"
+      ;;
+  esac
+}
+
+
+# Fetches swagger spec from apiserver.
+# Assumed vars:
+# SWAGGER_API_PATH: Base path for swaggerapi on apiserver. Ex:
+# http://localhost:8080/swaggerapi.
+# SWAGGER_ROOT_DIR: Root dir where we want to save the fetched spec.
+# VERSIONS: Array of group versions to include in swagger spec.
+kube::util::fetch-swagger-spec() {
+  for ver in ${VERSIONS}; do
+    if [[ " ${KUBE_NONSERVER_GROUP_VERSIONS} " == *" ${ver} "* ]]; then
+      continue
+    fi
+    # fetch the swagger spec for each group version.
+    if [[ ${ver} == "v1" ]]; then
+      SUBPATH="api"
+    else
+      SUBPATH="apis"
+    fi
+    SUBPATH="${SUBPATH}/${ver}"
+    SWAGGER_JSON_NAME="$(kube::util::gv-to-swagger-name ${ver}).json"
+    curl -w "\n" -fs "${SWAGGER_API_PATH}${SUBPATH}" > "${SWAGGER_ROOT_DIR}/${SWAGGER_JSON_NAME}"
+
+    # fetch the swagger spec for the discovery mechanism at group level.
+    if [[ ${ver} == "v1" ]]; then
+      continue
+    fi
+    SUBPATH="apis/"${ver%/*}
+    SWAGGER_JSON_NAME="${ver%/*}.json"
+    curl -w "\n" -fs "${SWAGGER_API_PATH}${SUBPATH}" > "${SWAGGER_ROOT_DIR}/${SWAGGER_JSON_NAME}"
+  done
+
+  # fetch swagger specs for other discovery mechanism.
+  curl -w "\n" -fs "${SWAGGER_API_PATH}" > "${SWAGGER_ROOT_DIR}/resourceListing.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}version" > "${SWAGGER_ROOT_DIR}/version.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}api" > "${SWAGGER_ROOT_DIR}/api.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}apis" > "${SWAGGER_ROOT_DIR}/apis.json"
+  curl -w "\n" -fs "${SWAGGER_API_PATH}logs" > "${SWAGGER_ROOT_DIR}/logs.json"
+}
+
+# Returns the name of the upstream remote repository name for the local git
+# repo, e.g. "upstream" or "origin".
+kube::util::git_upstream_remote_name() {
+  git remote -v | grep fetch |\
+    grep -E 'github.com[/:]kubernetes/kubernetes|k8s.io/kubernetes' |\
+    head -n 1 | awk '{print $1}'
+}
+
+# Ensures the current directory is a git tree for doing things like restoring or
+# validating godeps
+kube::util::create-fake-git-tree() {
+  local -r target_dir=${1:-$(pwd)}
+
+  pushd "${target_dir}" >/dev/null
+    git init >/dev/null
+    git config --local user.email "nobody@k8s.io"
+    git config --local user.name "$0"
+    git add . >/dev/null
+    git commit -q -m "Snapshot" >/dev/null
+    if (( ${KUBE_VERBOSE:-5} >= 6 )); then
+      kube::log::status "${target_dir} is now a git tree."
+    fi
+  popd >/dev/null
+}
+
+# Checks whether godep restore was run in the current GOPATH, i.e. that all referenced repos exist
+# and are checked out to the referenced rev.
+kube::util::godep_restored() {
+  local -r godeps_json=${1:-Godeps/Godeps.json}
+  local -r gopath=${2:-${GOPATH%:*}}
+  if ! which jq &>/dev/null; then
+    echo "jq not found. Please install." 1>&2
+    return 1
+  fi
+  local root
+  local old_rev=""
+  while read path rev; do
+    rev=$(echo "${rev}" | sed "s/['\"]//g") # remove quotes which are around revs sometimes
+
+    if [[ "${rev}" == "${old_rev}" ]] && [[ "${path}" == "${root}"* ]]; then
+      # avoid checking the same git/hg root again
+      continue
+    fi
+
+    root="${path}"
+    while [ "${root}" != "." -a ! -d "${gopath}/src/${root}/.git" -a ! -d "${gopath}/src/${root}/.hg" ]; do
+      root=$(dirname "${root}")
+    done
+    if [ "${root}" == "." ]; then
+      echo "No checkout of ${path} found in GOPATH \"${gopath}\"." 1>&2
+      return 1
+    fi
+    local head
+    if [ -d "${gopath}/src/${root}/.git" ]; then
+      head="$(cd "${gopath}/src/${root}" && git rev-parse HEAD)"
+    else
+      head="$(cd "${gopath}/src/${root}" && hg parent --template '{node}')"
+    fi
+    if [ "${head}" != "${rev}" ]; then
+      echo "Unexpected HEAD '${head}' at ${gopath}/src/${root}, expected '${rev}'." 1>&2
+      return 1
+    fi
+    old_rev="${rev}"
+  done < <(jq '.Deps|.[]|.ImportPath + " " + .Rev' -r < "${godeps_json}")
+  return 0
+}
+
+# Exits script if working directory is dirty. If it's run interactively in the terminal
+# the user can commit changes in a second terminal. This script will wait.
+kube::util::ensure_clean_working_dir() {
+  while ! git diff HEAD --exit-code &>/dev/null; do
+    echo -e "\nUnexpected dirty working directory:\n"
+    if tty -s; then
+        git status -s
+    else
+        git diff -a # be more verbose in log files without tty
+        exit 1
+    fi | sed 's/^/  /'
+    echo -e "\nCommit your changes in another terminal and then continue here by pressing enter."
+    read
+  done 1>&2
+}
+
+# Ensure that the given godep version is installed and in the path.  Almost
+# nobody should use any version but the default.
+kube::util::ensure_godep_version() {
+  GODEP_VERSION=${1:-"v80"} # this version is known to work
+
+  if [[ "$(godep version 2>/dev/null)" == *"godep ${GODEP_VERSION}"* ]]; then
+    return
+  fi
+
+  kube::log::status "Installing godep version ${GODEP_VERSION}"
+  go install k8s.io/kubernetes/vendor/github.com/tools/godep/
+  if ! which godep >/dev/null 2>&1; then
+    kube::log::error "Can't find godep - is your GOPATH 'bin' in your PATH?"
+    kube::log::error "  GOPATH: ${GOPATH}"
+    kube::log::error "  PATH:   ${PATH}"
+    return 1
+  fi
+
+  if [[ "$(godep version 2>/dev/null)" != *"godep ${GODEP_VERSION}"* ]]; then
+    kube::log::error "Wrong godep version - is your GOPATH 'bin' in your PATH?"
+    kube::log::error "  expected: godep ${GODEP_VERSION}"
+    kube::log::error "  got:      $(godep version)"
+    kube::log::error "  GOPATH: ${GOPATH}"
+    kube::log::error "  PATH:   ${PATH}"
+    return 1
+  fi
+}
+
+# Ensure that none of the staging repos is checked out in the GOPATH because this
+# easily confused godep.
+kube::util::ensure_no_staging_repos_in_gopath() {
+  kube::util::ensure_single_dir_gopath
+  local error=0
+  for repo_file in "${KUBE_ROOT}"/staging/src/k8s.io/*; do
+    if [[ ! -d "$repo_file" ]]; then
+      # not a directory or there were no files
+      continue;
+    fi
+    repo="$(basename "$repo_file")"
+    if [ -e "${GOPATH}/src/k8s.io/${repo}" ]; then
+      echo "k8s.io/${repo} exists in GOPATH. Remove before running godep-save.sh." 1>&2
+      error=1
+    fi
+  done
+  if [ "${error}" = "1" ]; then
+    exit 1
+  fi
+}
+
+# Checks that the GOPATH is simple, i.e. consists only of one directory, not multiple.
+kube::util::ensure_single_dir_gopath() {
+  if [[ "${GOPATH}" == *:* ]]; then
+    echo "GOPATH must consist of a single directory." 1>&2
+    exit 1
+  fi
+}
+
+# Checks whether there are any files matching pattern $2 changed between the
+# current branch and upstream branch named by $1.
+# Returns 1 (false) if there are no changes, 0 (true) if there are changes
+# detected.
+kube::util::has_changes_against_upstream_branch() {
+  local -r git_branch=$1
+  local -r pattern=$2
+  local -r not_pattern=${3:-totallyimpossiblepattern}
+  local full_branch
+
+  full_branch="$(kube::util::git_upstream_remote_name)/${git_branch}"
+  echo "Checking for '${pattern}' changes against '${full_branch}'"
+  # make sure the branch is valid, otherwise the check will pass erroneously.
+  if ! git describe "${full_branch}" >/dev/null; then
+    # abort!
+    exit 1
+  fi
+  # notice this uses ... to find the first shared ancestor
+  if git diff --name-only "${full_branch}...HEAD" | grep -v -E "${not_pattern}" | grep "${pattern}" > /dev/null; then
+    return 0
+  fi
+  # also check for pending changes
+  if git status --porcelain | grep -v -E "${not_pattern}" | grep "${pattern}" > /dev/null; then
+    echo "Detected '${pattern}' uncommitted changes."
+    return 0
+  fi
+  echo "No '${pattern}' changes detected."
+  return 1
+}
+
+kube::util::download_file() {
+  local -r url=$1
+  local -r destination_file=$2
+
+  rm  ${destination_file} 2&> /dev/null || true
+
+  for i in $(seq 5)
+  do
+    if ! curl -fsSL --retry 3 --keepalive-time 2 ${url} -o ${destination_file}; then
+      echo "Downloading ${url} failed. $((5-i)) retries left."
+      sleep 1
+    else
+      echo "Downloading ${url} succeed"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Test whether openssl is installed.
+# Sets:
+#  OPENSSL_BIN: The path to the openssl binary to use
+function kube::util::test_openssl_installed {
+    openssl version >& /dev/null
+    if [ "$?" != "0" ]; then
+      echo "Failed to run openssl. Please ensure openssl is installed"
+      exit 1
+    fi
+
+    OPENSSL_BIN=$(command -v openssl)
+}
+
+# creates a client CA, args are sudo, dest-dir, ca-id, purpose
+# purpose is dropped in after "key encipherment", you usually want
+# '"client auth"'
+# '"server auth"'
+# '"client auth","server auth"'
+function kube::util::create_signing_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local id=$3
+    local purpose=$4
+    # Create client ca
+    ${sudo} /usr/bin/env bash -e <<EOF
+    rm -f "${dest_dir}/${id}-ca.crt" "${dest_dir}/${id}-ca.key"
+    ${OPENSSL_BIN} req -x509 -sha256 -new -nodes -days 365 -newkey rsa:2048 -keyout "${dest_dir}/${id}-ca.key" -out "${dest_dir}/${id}-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
+    echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment",${purpose}]}}}' > "${dest_dir}/${id}-ca-config.json"
+EOF
+}
+
+# signs a client certificate: args are sudo, dest-dir, CA, filename (roughly), username, groups...
+function kube::util::create_client_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local ca=$3
+    local id=$4
+    local cn=${5:-$4}
+    local groups=""
+    local SEP=""
+    shift 5
+    while [ -n "${1:-}" ]; do
+        groups+="${SEP}{\"O\":\"$1\"}"
+        SEP=","
+        shift 1
+    done
+    ${sudo} /usr/bin/env bash -e <<EOF
+    cd ${dest_dir}
+    echo '{"CN":"${cn}","names":[${groups}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | ${CFSSL_BIN} gencert -ca=${ca}.crt -ca-key=${ca}.key -config=${ca}-config.json - | ${CFSSLJSON_BIN} -bare client-${id}
+    mv "client-${id}-key.pem" "client-${id}.key"
+    mv "client-${id}.pem" "client-${id}.crt"
+    rm -f "client-${id}.csr"
+EOF
+}
+
+# signs a serving certificate: args are sudo, dest-dir, ca, filename (roughly), subject, hosts...
+function kube::util::create_serving_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local ca=$3
+    local id=$4
+    local cn=${5:-$4}
+    local hosts=""
+    local SEP=""
+    shift 5
+    while [ -n "${1:-}" ]; do
+        hosts+="${SEP}\"$1\""
+        SEP=","
+        shift 1
+    done
+    ${sudo} /usr/bin/env bash -e <<EOF
+    cd ${dest_dir}
+    echo '{"CN":"${cn}","hosts":[${hosts}],"key":{"algo":"rsa","size":2048}}' | ${CFSSL_BIN} gencert -ca=${ca}.crt -ca-key=${ca}.key -config=${ca}-config.json - | ${CFSSLJSON_BIN} -bare serving-${id}
+    mv "serving-${id}-key.pem" "serving-${id}.key"
+    mv "serving-${id}.pem" "serving-${id}.crt"
+    rm -f "serving-${id}.csr"
+EOF
+}
+
+# creates a self-contained kubeconfig: args are sudo, dest-dir, ca file, host, port, client id, token(optional)
+function kube::util::write_client_kubeconfig {
+    local sudo=$1
+    local dest_dir=$2
+    local ca_file=$3
+    local api_host=$4
+    local api_port=$5
+    local client_id=$6
+    local token=${7:-}
+    cat <<EOF | ${sudo} tee "${dest_dir}"/${client_id}.kubeconfig > /dev/null
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      certificate-authority: ${ca_file}
+      server: https://${api_host}:${api_port}/
+    name: local-up-cluster
+users:
+  - user:
+      token: ${token}
+      client-certificate: ${dest_dir}/client-${client_id}.crt
+      client-key: ${dest_dir}/client-${client_id}.key
+    name: local-up-cluster
+contexts:
+  - context:
+      cluster: local-up-cluster
+      user: local-up-cluster
+    name: local-up-cluster
+current-context: local-up-cluster
+EOF
+
+    # flatten the kubeconfig files to make them self contained
+    username=$(whoami)
+    ${sudo} /usr/bin/env bash -e <<EOF
+    oc --config="${dest_dir}/${client_id}.kubeconfig" config view --minify --flatten > "/tmp/${client_id}.kubeconfig"
+    mv -f "/tmp/${client_id}.kubeconfig" "${dest_dir}/${client_id}.kubeconfig"
+    chown ${username} "${dest_dir}/${client_id}.kubeconfig"
+EOF
+}
+
+# Determines if docker can be run, failures may simply require that the user be added to the docker group.
+function kube::util::ensure_docker_daemon_connectivity {
+  DOCKER=(docker ${DOCKER_OPTS})
+  if ! "${DOCKER[@]}" info > /dev/null 2>&1 ; then
+    cat <<'EOF' >&2
+Can't connect to 'docker' daemon.  please fix and retry.
+
+Possible causes:
+  - Docker Daemon not started
+    - Linux: confirm via your init system
+    - macOS w/ docker-machine: run `docker-machine ls` and `docker-machine start <name>`
+    - macOS w/ Docker for Mac: Check the menu bar and start the Docker application
+  - DOCKER_HOST hasn't been set or is set incorrectly
+    - Linux: domain socket is used, DOCKER_* should be unset. In Bash run `unset ${!DOCKER_*}`
+    - macOS w/ docker-machine: run `eval "$(docker-machine env <name>)"`
+    - macOS w/ Docker for Mac: domain socket is used, DOCKER_* should be unset. In Bash run `unset ${!DOCKER_*}`
+  - Other things to check:
+    - Linux: User isn't in 'docker' group.  Add and relogin.
+      - Something like 'sudo usermod -a -G docker ${USER}'
+      - RHEL7 bug and workaround: https://bugzilla.redhat.com/show_bug.cgi?id=1119282#c8
+EOF
+    return 1
+  fi
+}
+
+# Wait for background jobs to finish. Return with
+# an error status if any of the jobs failed.
+kube::util::wait-for-jobs() {
+  local fail=0
+  local job
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+  return ${fail}
+}
+
+# kube::util::join <delim> <list...>
+# Concatenates the list elements with the delimiter passed as first parameter
+#
+# Ex: kube::util::join , a b c
+#  -> a,b,c
+function kube::util::join {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+# Downloads cfssl/cfssljson into $1 directory if they do not already exist in PATH
+#
+# Assumed vars:
+#   $1 (cfssl directory) (optional)
+#
+# Sets:
+#  CFSSL_BIN: The path of the installed cfssl binary
+#  CFSSLJSON_BIN: The path of the installed cfssljson binary
+#
+function kube::util::ensure-cfssl {
+  if command -v cfssl &>/dev/null && command -v cfssljson &>/dev/null; then
+    CFSSL_BIN=$(command -v cfssl)
+    CFSSLJSON_BIN=$(command -v cfssljson)
+    return 0
+  fi
+
+  # Create a temp dir for cfssl if no directory was given
+  local cfssldir=${1:-}
+  if [[ -z "${cfssldir}" ]]; then
+    kube::util::ensure-temp-dir
+    cfssldir="${KUBE_TEMP}/cfssl"
+  fi
+
+  mkdir -p "${cfssldir}"
+  pushd "${cfssldir}" > /dev/null
+
+    echo "Unable to successfully run 'cfssl' from $PATH; downloading instead..."
+    kernel=$(uname -s)
+    case "${kernel}" in
+      Linux)
+        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+        ;;
+      Darwin)
+        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64
+        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_darwin-amd64
+        ;;
+      *)
+        echo "Unknown, unsupported platform: ${kernel}." >&2
+        echo "Supported platforms: Linux, Darwin." >&2
+        exit 2
+    esac
+
+    chmod +x cfssl || true
+    chmod +x cfssljson || true
+
+    CFSSL_BIN="${cfssldir}/cfssl"
+    CFSSLJSON_BIN="${cfssldir}/cfssljson"
+    if [[ ! -x ${CFSSL_BIN} || ! -x ${CFSSLJSON_BIN} ]]; then
+      echo "Failed to download 'cfssl'. Please install cfssl and cfssljson and verify they are in \$PATH."
+      echo "Hint: export PATH=\$PATH:\$GOPATH/bin; go get -u github.com/cloudflare/cfssl/cmd/..."
+      exit 1
+    fi
+  popd > /dev/null
+}
+
+# kube::util::ensure_dockerized
+# Confirms that the script is being run inside a kube-build image
+#
+function kube::util::ensure_dockerized {
+  if [[ -f /kube-build-image ]]; then
+    return 0
+  else
+    echo "ERROR: This script is designed to be run inside a kube-build container"
+    exit 1
+  fi
+}
+
+# kube::util::ensure-gnu-sed
+# Determines which sed binary is gnu-sed on linux/darwin
+#
+# Sets:
+#  SED: The name of the gnu-sed binary
+#
+function kube::util::ensure-gnu-sed {
+  if LANG=C sed --help 2>&1 | grep -q GNU; then
+    SED="sed"
+  elif which gsed &>/dev/null; then
+    SED="gsed"
+  else
+    kube::log::error "Failed to find GNU sed as sed or gsed. If you are on Mac: brew install gnu-sed." >&2
+    return 1
+  fi
+}
+
+# Some useful colors.
+if [[ -z "${color_start-}" ]]; then
+  declare -r color_start="\033["
+  declare -r color_red="${color_start}0;31m"
+  declare -r color_yellow="${color_start}0;33m"
+  declare -r color_green="${color_start}0;32m"
+  declare -r color_blue="${color_start}1;34m"
+  declare -r color_cyan="${color_start}1;36m"
+  declare -r color_norm="${color_start}0m"
+fi
+
+# ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
This is useful for local development and hopefully no one will be confused and think it's actually part of the product we support.

It just so happens I also need this to make `test-cmd.sh` test the binaries we ship.

@soltysh you did this for test-integration, this one is for test-cmd.sh
@openshift/sig-master 