### PR TITLE
UPSTREAM: 0000: verify event object matches initially specified obj

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go
@@ -583,6 +583,12 @@ func (o *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []string)
 				return false, nil
 			}
 
+			// if we are watching a single resource, ignore events meant for other resources
+			info, err := meta.Accessor(e.Object)
+			if !isList && err == nil && len(infos) > 0 && info.GetName() != infos[0].Name {
+				return false, err
+			}
+
 			// printing always takes the internal version, but the watch event uses externals
 			// TODO fix printing to use server-side or be version agnostic
 			internalGV := mapping.GroupVersionKind.GroupKind().WithVersion(runtime.APIVersionInternal).GroupVersion()


### PR DESCRIPTION
For cases such as `oc get project foobar --watch`, a cluster-admin will
receive watch events for every project in the cluster.
This patch verifies that event objects match the one initially requested
by a user, if a specific resource was requested.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1633101

cc @soltysh @deads2k 