### PR TITLE
Remove Simo Sorce from OWNERS

### DIFF
--- a/images/openldap/OWNERS
+++ b/images/openldap/OWNERS
@@ -2,7 +2,5 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - enj
-  - simo5

--- a/pkg/apiserver/authentication/OWNERS
+++ b/pkg/apiserver/authentication/OWNERS
@@ -2,7 +2,5 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - enj
-  - simo5

--- a/pkg/authorization/OWNERS
+++ b/pkg/authorization/OWNERS
@@ -2,9 +2,7 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - deads2k
   - smarterclayton
   - enj
-  - simo5

--- a/pkg/cmd/OWNERS
+++ b/pkg/cmd/OWNERS
@@ -7,7 +7,6 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
   - knobunc
   - squeed
   - dcbw

--- a/pkg/oauth/OWNERS
+++ b/pkg/oauth/OWNERS
@@ -2,10 +2,8 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - smarterclayton
   - deads2k
   - soltysh
   - enj
-  - simo5

--- a/pkg/oauthserver/OWNERS
+++ b/pkg/oauthserver/OWNERS
@@ -2,9 +2,7 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - deads2k
   - smarterclayton
   - enj
-  - simo5

--- a/pkg/security/OWNERS
+++ b/pkg/security/OWNERS
@@ -4,11 +4,9 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - deads2k
   - smarterclayton
   - pweil-
   - soltysh
   - enj
-  - simo5

--- a/pkg/serviceaccounts/OWNERS
+++ b/pkg/serviceaccounts/OWNERS
@@ -6,7 +6,6 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - deads2k
   - smarterclayton

--- a/pkg/user/OWNERS
+++ b/pkg/user/OWNERS
@@ -2,11 +2,9 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - smarterclayton
   - deads2k
   - mfojtik
   - soltysh
   - enj
-  - simo5

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -9,7 +9,6 @@ reviewers:
   - enj
   - ericavonb
   - mrogers950
-  - simo5
   - tnozicka
 approvers:
   - smarterclayton

--- a/test/testdata/OWNERS
+++ b/test/testdata/OWNERS
@@ -11,7 +11,6 @@ reviewers:
   - danwinship
   - ericavonb
   - mrogers950
-  - simo5
 approvers:
   - deads2k
   - smarterclayton


### PR DESCRIPTION
As a courtesy since Simo is no longer working on OpenShift.

Signed-off-by: Monis Khan <mkhan@redhat.com>