### PR TITLE
cluster-up: remove remote docker

### DIFF
--- a/pkg/oc/clusterup/docker/util/client.go
+++ b/pkg/oc/clusterup/docker/util/client.go
@@ -15,8 +15,6 @@ import (
 	"github.com/docker/docker/cli/config"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/golang/glog"
-
 	dockererrors "github.com/openshift/origin/pkg/oc/clusterup/docker/errors"
 )
 
@@ -302,28 +300,7 @@ func GetDockerClient() (Interface, error) {
 		dockerCertPath = config.Dir()
 		os.Setenv("DOCKER_CERT_PATH", dockerCertPath)
 	}
-
-	if glog.V(4) {
-		dockerHost := os.Getenv("DOCKER_HOST")
-		if len(dockerHost) == 0 && len(dockerTLSVerify) == 0 && len(dockerCertPath) == 0 {
-			glog.Infof("No Docker environment variables found. Will attempt default socket.")
-		}
-		if len(dockerHost) > 0 {
-			glog.Infof("Will try Docker connection with host (DOCKER_HOST) %q", dockerHost)
-		} else {
-			glog.Infof("No Docker host (DOCKER_HOST) configured. Will attempt default socket.")
-		}
-		if len(dockerTLSVerify) > 0 {
-			glog.Infof("DOCKER_TLS_VERIFY=%s", dockerTLSVerify)
-		}
-		if len(dockerCertPath) > 0 {
-			glog.Infof("DOCKER_CERT_PATH=%s", dockerCertPath)
-		}
-	}
-	dockerHost := os.Getenv("DOCKER_HOST")
-	if len(dockerHost) == 0 {
-		dockerHost = client.DefaultDockerHost
-	}
+	dockerHost := client.DefaultDockerHost
 	engineAPIClient, err := client.NewEnvClient()
 	if err != nil {
 		return nil, dockererrors.ErrNoDockerClient(err)

--- a/pkg/oc/clusterup/required_images.go
+++ b/pkg/oc/clusterup/required_images.go
@@ -26,6 +26,9 @@ var OpenShiftImages = Images{
 	{Name: "etcd", PullSpec: "quay.io/coreos/etcd:v3.2.24"},
 }
 
+// forcePull specifies whether the images should always be pulled.
+var forcePull bool
+
 type Image struct {
 	Name string
 
@@ -43,7 +46,7 @@ func (i *Image) ToPullSpec(tpl variable.ImageTemplate) PullSpec {
 }
 
 func (s PullSpec) Pull(puller *dockerutil.Helper) error {
-	return puller.CheckAndPull(string(s), os.Stdout)
+	return puller.CheckAndPullImage(string(s), forcePull, os.Stdout)
 }
 
 func (s PullSpec) String() string {

--- a/pkg/oc/clusterup/up.go
+++ b/pkg/oc/clusterup/up.go
@@ -141,7 +141,9 @@ func NewCmdUp(name, fullName string, f genericclioptions.RESTClientGetter, strea
 
 func (c *ClusterUpConfig) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&c.ImageTag, "tag", "", "Specify an explicit version for OpenShift images")
+	flags.BoolVar(&forcePull, "force-pull", false, "Force to pull all required images")
 	flags.MarkHidden("tag")
+	flags.MarkHidden("force-pull")
 	flags.StringVar(&c.ImageTemplate.Format, "image", c.ImageTemplate.Format, "Specify the images to use for OpenShift")
 	flags.StringVar(&c.PublicHostname, "public-hostname", "", "Public hostname for OpenShift cluster")
 	flags.StringVar(&c.BaseDir, "base-dir", c.BaseDir, "Directory on Docker host for cluster up configuration")


### PR DESCRIPTION
Add `--force-pull` hidden flag to force the cluster up to pull all images. Allows for faster iterations when the operator images are changing and you don't have to pull them manually... 

Also removes traces of "remote docker daemon" support as that is something we decided not to support anymore.

/cc @deads2k 