### PR TITLE
cluster-up: add locks for controller manager

### DIFF
--- a/pkg/oc/clusterup/coreinstall/controlplane-operator/run_render.go
+++ b/pkg/oc/clusterup/coreinstall/controlplane-operator/run_render.go
@@ -20,7 +20,7 @@ type RenderConfig struct {
 	// AssetsOutputDir is the location where the operator will generate the static pod manifests, ready to be used with bootkube start.
 	AssetsOutputDir string
 
-	// LockDir specifies a directory mounted into api server that holds the lock.
+	// LockDir specifies a directory mounted into container that hold the locks.
 	LockDir string
 
 	// ConfigOutputDir is the location where the operator will create the component config file.
@@ -44,12 +44,6 @@ type RenderConfig struct {
 // default values overridden according to ConfigOverrides.
 func (opt *RenderConfig) RunRender(component string, image string, dockerClient util.Interface, hostIP string) (string, error) {
 	imageRunHelper := run.NewRunHelper(util.NewHelper(dockerClient)).New()
-
-	// Set the lock dir for kube-apiserver
-	if component == "kube-apiserver" {
-		opt.AdditionalFlags = append(opt.AdditionalFlags, fmt.Sprintf("--manifest-lock-host-path=%s", opt.LockDir))
-	}
-
 	renderCommand := append([]string{
 		"render",
 		"--asset-input-dir=/asset-input",
@@ -60,6 +54,7 @@ func (opt *RenderConfig) RunRender(component string, image string, dockerClient 
 		fmt.Sprintf("--manifest-config-host-path=%s", opt.ConfigOutputDir),
 		fmt.Sprintf("--manifest-config-file-name=%s", opt.ConfigFileName),
 		fmt.Sprintf("--manifest-secrets-host-path=%s", opt.AssetInputDir),
+		fmt.Sprintf("--manifest-lock-host-path=%s", opt.LockDir),
 	}, opt.AdditionalFlags...)
 
 	binds := opt.ContainerBinds

--- a/pkg/oc/clusterup/docker/util/client.go
+++ b/pkg/oc/clusterup/docker/util/client.go
@@ -15,8 +15,6 @@ import (
 	"github.com/docker/docker/cli/config"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/golang/glog"
-
 	dockererrors "github.com/openshift/origin/pkg/oc/clusterup/docker/errors"
 )
 
@@ -302,28 +300,7 @@ func GetDockerClient() (Interface, error) {
 		dockerCertPath = config.Dir()
 		os.Setenv("DOCKER_CERT_PATH", dockerCertPath)
 	}
-
-	if glog.V(4) {
-		dockerHost := os.Getenv("DOCKER_HOST")
-		if len(dockerHost) == 0 && len(dockerTLSVerify) == 0 && len(dockerCertPath) == 0 {
-			glog.Infof("No Docker environment variables found. Will attempt default socket.")
-		}
-		if len(dockerHost) > 0 {
-			glog.Infof("Will try Docker connection with host (DOCKER_HOST) %q", dockerHost)
-		} else {
-			glog.Infof("No Docker host (DOCKER_HOST) configured. Will attempt default socket.")
-		}
-		if len(dockerTLSVerify) > 0 {
-			glog.Infof("DOCKER_TLS_VERIFY=%s", dockerTLSVerify)
-		}
-		if len(dockerCertPath) > 0 {
-			glog.Infof("DOCKER_CERT_PATH=%s", dockerCertPath)
-		}
-	}
-	dockerHost := os.Getenv("DOCKER_HOST")
-	if len(dockerHost) == 0 {
-		dockerHost = client.DefaultDockerHost
-	}
+	dockerHost := client.DefaultDockerHost
 	engineAPIClient, err := client.NewEnvClient()
 	if err != nil {
 		return nil, dockererrors.ErrNoDockerClient(err)

--- a/pkg/oc/clusterup/required_images.go
+++ b/pkg/oc/clusterup/required_images.go
@@ -42,8 +42,8 @@ func (i *Image) ToPullSpec(tpl variable.ImageTemplate) PullSpec {
 	return PullSpec(tpl.ExpandOrDie(i.Name))
 }
 
-func (s PullSpec) Pull(puller *dockerutil.Helper) error {
-	return puller.CheckAndPull(string(s), os.Stdout)
+func (s PullSpec) Pull(puller *dockerutil.Helper, forcePull bool) error {
+	return puller.CheckAndPullImage(string(s), forcePull, os.Stdout)
 }
 
 func (s PullSpec) String() string {
@@ -52,10 +52,10 @@ func (s PullSpec) String() string {
 
 type Images []Image
 
-func (i Images) EnsurePulled(puller *dockerutil.Helper, tpl variable.ImageTemplate) error {
+func (i Images) EnsurePulled(puller *dockerutil.Helper, tpl variable.ImageTemplate, forcePull bool) error {
 	errors := []error{}
 	for _, image := range i {
-		if err := image.ToPullSpec(tpl).Pull(puller); err != nil {
+		if err := image.ToPullSpec(tpl).Pull(puller, forcePull); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/pkg/oc/clusterup/run_self_hosted.go
+++ b/pkg/oc/clusterup/run_self_hosted.go
@@ -203,6 +203,7 @@ kind: KubeControllerManagerConfig
 		AssetInputDir:   filepath.Join(configs.assetsDir, "tls"),
 		AssetsOutputDir: configs.assetsDir,
 		ConfigOutputDir: configDir,
+		LockDir:         filepath.Join(configs.kubernetesDir, "lock"),
 		ConfigFileName:  "kube-controller-manager-config.yaml",
 		ConfigOverrides: controllerManagerConfigOverride,
 	}

--- a/pkg/oc/clusterup/up.go
+++ b/pkg/oc/clusterup/up.go
@@ -59,6 +59,7 @@ var (
 type ClusterUpConfig struct {
 	ImageTemplate variable.ImageTemplate
 	ImageTag      string
+	ForcePull     bool
 
 	// BaseTempDir is the directory to use as the root for temp directories
 	// This allows us to bundle all of the cluster-up directories in one spot for easier cleanup and ensures we aren't
@@ -141,7 +142,9 @@ func NewCmdUp(name, fullName string, f genericclioptions.RESTClientGetter, strea
 
 func (c *ClusterUpConfig) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&c.ImageTag, "tag", "", "Specify an explicit version for OpenShift images")
+	flags.BoolVar(&c.ForcePull, "force-pull", false, "Force to pull all required images")
 	flags.MarkHidden("tag")
+	flags.MarkHidden("force-pull")
 	flags.StringVar(&c.ImageTemplate.Format, "image", c.ImageTemplate.Format, "Specify the images to use for OpenShift")
 	flags.StringVar(&c.PublicHostname, "public-hostname", "", "Public hostname for OpenShift cluster")
 	flags.StringVar(&c.BaseDir, "base-dir", c.BaseDir, "Directory on Docker host for cluster up configuration")
@@ -216,7 +219,7 @@ func (c *ClusterUpConfig) Complete(f genericclioptions.RESTClientGetter, cmd *co
 	c.dockerClient = client
 
 	c.printProgress(fmt.Sprintf("Pulling all required images"))
-	if err := OpenShiftImages.EnsurePulled(c.Docker(), c.ImageTemplate); err != nil {
+	if err := OpenShiftImages.EnsurePulled(c.Docker(), c.ImageTemplate, c.ForcePull); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Follow up on https://github.com/openshift/cluster-kube-controller-manager-operator/pull/19

The controller manager needs locks to orchestrate hand-off of host port from bootstrap to real controller manager. 

/cc @deads2k 
/cc @soltysh 