### PR TITLE
Fix oc cluster up quick start guide

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -58,7 +58,7 @@ Currently Linux (including a Linux VM running on another platform) is the only s
      [registries.insecure]
      registries = ['172.30.0.0/16']
      ```
-     or edit the `/etc/docker/daemon.json` file and add the following:
+     and create/edit the `/etc/docker/daemon.json` file and add the following:
      ```json
      {
         "insecure-registries": [


### PR DESCRIPTION
Fix oc cluster up quick start guide to avoid
'did not detect an --insecure-registry argument on the Docker daemon'
error on Centos 7.

Fixes https://github.com/openshift/origin/issues/21172