### PR TITLE
Add rsync back to the base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -8,7 +8,7 @@ FROM openshift/origin-source
 
 COPY *.repo /etc/yum.repos.d/
 RUN INSTALL_PKGS=" \
-      which tar wget hostname sysvinit-tools util-linux \
+      which tar rsync wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils \
       " && \
     yum install -y ${INSTALL_PKGS} && \

--- a/images/base/Dockerfile.centos7
+++ b/images/base/Dockerfile.centos7
@@ -7,7 +7,7 @@
 FROM openshift/origin-source
 
 RUN INSTALL_PKGS=" \
-      which tar wget hostname sysvinit-tools util-linux \
+      which tar rsync wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils \
       " && \
     yum install -y ${INSTALL_PKGS} && \

--- a/images/base/Dockerfile.rhel7
+++ b/images/base/Dockerfile.rhel7
@@ -7,7 +7,7 @@
 FROM rhel7
 
 RUN INSTALL_PKGS=" \
-      which tar wget hostname sysvinit-tools util-linux \
+      which tar rsync wget hostname sysvinit-tools util-linux \
       socat tree findutils lsof bind-utils \
       " && \
     yum --disablerepo=origin-local-release install -y $INSTALL_PKGS && \


### PR DESCRIPTION
https://github.com/openshift/origin/commit/4333db3960e1f134bbf606bd5a8ea7f4fd062c93 removed git from base image, this resulted in `rsync` not being pulled in as well. See https://bugzilla.redhat.com/show_bug.cgi?id=1614841. This adds it to the base image. 

/assign @smarterclayton 