### PR TITLE
Don't regenerate apps and build files

### DIFF
--- a/hack/update-generated-informers.sh
+++ b/hack/update-generated-informers.sh
@@ -8,8 +8,6 @@ os::util::ensure::built_binary_exists 'informer-gen' 'vendor/k8s.io/kubernetes/s
 # list of package to generate informers for
 packages=(
   github.com/openshift/origin/pkg/authorization/apis/authorization
-  github.com/openshift/origin/pkg/build/apis/build
-  github.com/openshift/origin/pkg/apps/apis/apps
   github.com/openshift/origin/pkg/image/apis/image
   github.com/openshift/origin/pkg/oauth/apis/oauth
   github.com/openshift/origin/pkg/project/apis/project

--- a/hack/update-generated-listers.sh
+++ b/hack/update-generated-listers.sh
@@ -8,8 +8,6 @@ os::util::ensure::built_binary_exists 'lister-gen' 'vendor/k8s.io/kubernetes/sta
 # list of package to generate listers for
 packages=(
   github.com/openshift/origin/pkg/authorization/apis/authorization
-  github.com/openshift/origin/pkg/build/apis/build
-  github.com/openshift/origin/pkg/apps/apis/apps
   github.com/openshift/origin/pkg/image/apis/image
   github.com/openshift/origin/pkg/oauth/apis/oauth
   github.com/openshift/origin/pkg/project/apis/project


### PR DESCRIPTION
Currently if you run `make update` you'll end up with

    Untracked files:
      (use "git add <file>..." to include in what will be committed)
    
    	pkg/apps/generated/
    	pkg/build/generated/

Fallout from #20499, #20817.