### PR TITLE
remove networking apiserver from hypershift openshift-apiserver

### DIFF
--- a/pkg/cmd/openshift-apiserver/cmd.go
+++ b/pkg/cmd/openshift-apiserver/cmd.go
@@ -92,6 +92,7 @@ func (o *OpenShiftAPIServer) Validate() error {
 
 // StartAPIServer calls RunAPIServer and then waits forever
 func (o *OpenShiftAPIServer) StartAPIServer() error {
+	featureKeepRemovedNetworkingAPI = false
 	if err := o.RunAPIServer(); err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -529,7 +529,7 @@ func addAPIServerOrDie(delegateAPIServer genericapiserver.DelegationTarget, lega
 	return delegateAPIServer, legacyStorageModifiers
 }
 
-func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*OpenshiftAPIServer, error) {
+func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget, keepRemovedNetworkingAPIs bool) (*OpenshiftAPIServer, error) {
 	delegateAPIServer := delegationTarget
 	legacyStorageModifier := legacyStorageMutators{}
 
@@ -537,7 +537,9 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withAuthorizationAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withBuildAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withImageAPIServer)
-	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withNetworkAPIServer)
+	if keepRemovedNetworkingAPIs {
+		delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withNetworkAPIServer)
+	}
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withOAuthAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withProjectAPIServer)
 	delegateAPIServer, legacyStorageModifier = addAPIServerOrDie(delegateAPIServer, legacyStorageModifier, c.withQuotaAPIServer)

--- a/pkg/cmd/openshift-apiserver/server.go
+++ b/pkg/cmd/openshift-apiserver/server.go
@@ -14,6 +14,9 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util"
 )
 
+// default this to true so that the integration tests don't instantly break
+var featureKeepRemovedNetworkingAPI = true
+
 func RunOpenShiftAPIServer(serverConfig *openshiftcontrolplanev1.OpenShiftAPIServerConfig) error {
 	util.InitLogrus()
 	// Allow privileged containers
@@ -30,7 +33,7 @@ func RunOpenShiftAPIServer(serverConfig *openshiftcontrolplanev1.OpenShiftAPISer
 	if err != nil {
 		return err
 	}
-	openshiftAPIServer, err := openshiftAPIServerRuntimeConfig.Complete().New(genericapiserver.NewEmptyDelegate())
+	openshiftAPIServer, err := openshiftAPIServerRuntimeConfig.Complete().New(genericapiserver.NewEmptyDelegate(), featureKeepRemovedNetworkingAPI)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -129,7 +129,7 @@ func (c *MasterConfig) withOpenshiftAPI(delegateAPIServer apiserver.DelegationTa
 	// We need to add an openshift type to the kube's core storage until at least 3.8.  This does that by using a patch we carry.
 	kcorestorage.LegacyStorageMutatorFn = sccstorage.AddSCC(openshiftAPIServerConfig.ExtraConfig.SCCStorage)
 
-	openshiftAPIServer, err := openshiftAPIServerConfig.Complete().New(delegateAPIServer)
+	openshiftAPIServer, err := openshiftAPIServerConfig.Complete().New(delegateAPIServer, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This removes the `network.openshift.io` group from the openshift-apiserver so that the new networking CRDs can run instead.

/assign @sttts @squeed 
@openshift/sig-networking 