### PR TITLE
Remove testing function customization

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -186,27 +186,9 @@ func skipTestNamespaceCustomization() bool {
 	return (isPackage("/kubernetes/test/e2e/namespace.go") && (testNameContains("should always delete fast") || testNameContains("should delete fast enough")))
 }
 
-// Holds custom namespace creation functions so we can customize per-test
-var customCreateTestingNSFuncs = map[string]e2e.CreateTestingNSFn{}
-
-// Registers a namespace creation function for the given basename
-// Fails if a create function is already registered
-func setCreateTestingNSFunc(baseName string, fn e2e.CreateTestingNSFn) {
-	if _, exists := customCreateTestingNSFuncs[baseName]; exists {
-		FatalErr("Double registered custom namespace creation function for " + baseName)
-	}
-	customCreateTestingNSFuncs[baseName] = fn
-}
-
 // createTestingNS delegates to custom namespace creation functions if registered.
 // otherwise, it ensures that kubernetes e2e tests have their service accounts in the privileged and anyuid SCCs
 func createTestingNS(baseName string, c kclientset.Interface, labels map[string]string) (*kapiv1.Namespace, error) {
-	// If a custom function exists, call it
-	if fn, exists := customCreateTestingNSFuncs[baseName]; exists {
-		return fn(baseName, c, labels)
-	}
-
-	// Otherwise use the upstream default
 	ns, err := e2e.CreateTestingNS(baseName, c, labels)
 	if err != nil {
 		return ns, err


### PR DESCRIPTION
Code was no longer called, but we're seeing panics around this area.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/21183/pull-ci-openshift-origin-master-e2e-gcp-serial/52/?log#log

panics in roughly this spot, but it's possible dead code elimination is screwing up our line numbers.