### PR TITLE
Don't ignore errors reported during Docker push/pull

### DIFF
--- a/pkg/oc/clusterup/docker/dockerhelper/helper.go
+++ b/pkg/oc/clusterup/docker/dockerhelper/helper.go
@@ -204,7 +204,7 @@ func (h *Helper) CheckAndPull(image string, out io.Writer) error {
 		return starterrors.NewError("error pulling Docker image %s", image).WithCause(err)
 	}
 
-	// This is to work around issue https://github.com/docker/docker/api/issues/138
+	// This is to work around issue https://github.com/docker/engine-api/issues/138
 	// where engine-api/client/ImagePull does not return an error when it should.
 	// which also still seems to exist in https://github.com/moby/moby/blob/master/client/image_pull.go
 	_, _, err = h.client.ImageInspectWithRaw(image, false)

--- a/pkg/oc/clusterup/docker/dockerhelper/helper.go
+++ b/pkg/oc/clusterup/docker/dockerhelper/helper.go
@@ -193,15 +193,18 @@ func (h *Helper) CheckAndPull(image string, out io.Writer) error {
 		auth = base64.URLEncoding.EncodeToString(buf.Bytes())
 	}
 
-	pw := imageprogress.NewPullWriter(logProgress)
-	defer pw.Close()
-	outputStream := pw.(io.Writer)
-	if glog.V(5) {
-		outputStream = out
-	}
-	err = h.client.ImagePull(normalized.String(), types.ImagePullOptions{RegistryAuth: auth}, outputStream)
-	if err != nil {
-		return starterrors.NewError("error pulling Docker image %s", image).WithCause(err)
+	var pullErr error
+	func() { // A scope for defer
+		pw := imageprogress.NewPullWriter(logProgress)
+		defer pw.Close()
+		outputStream := pw.(io.Writer)
+		if glog.V(5) {
+			outputStream = out
+		}
+		pullErr = h.client.ImagePull(normalized.String(), types.ImagePullOptions{RegistryAuth: auth}, outputStream)
+	}()
+	if pullErr != nil {
+		return starterrors.NewError("error pulling Docker image %s", image).WithCause(pullErr)
 	}
 
 	// This is to work around issue https://github.com/docker/engine-api/issues/138

--- a/pkg/oc/clusterup/docker/dockerhelper/helper.go
+++ b/pkg/oc/clusterup/docker/dockerhelper/helper.go
@@ -155,12 +155,6 @@ func (h *Helper) CheckAndPull(image string, out io.Writer) error {
 	logProgress := func(s string) {
 		fmt.Fprintf(out, "%s\n", s)
 	}
-	pw := imageprogress.NewPullWriter(logProgress)
-	defer pw.Close()
-	outputStream := pw.(io.Writer)
-	if glog.V(5) {
-		outputStream = out
-	}
 
 	normalized, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
@@ -199,6 +193,12 @@ func (h *Helper) CheckAndPull(image string, out io.Writer) error {
 		auth = base64.URLEncoding.EncodeToString(buf.Bytes())
 	}
 
+	pw := imageprogress.NewPullWriter(logProgress)
+	defer pw.Close()
+	outputStream := pw.(io.Writer)
+	if glog.V(5) {
+		outputStream = out
+	}
 	err = h.client.ImagePull(normalized.String(), types.ImagePullOptions{RegistryAuth: auth}, outputStream)
 	if err != nil {
 		return starterrors.NewError("error pulling Docker image %s", image).WithCause(err)

--- a/pkg/oc/clusterup/docker/dockerhelper/helper.go
+++ b/pkg/oc/clusterup/docker/dockerhelper/helper.go
@@ -196,7 +196,12 @@ func (h *Helper) CheckAndPull(image string, out io.Writer) error {
 	var pullErr error
 	func() { // A scope for defer
 		pw := imageprogress.NewPullWriter(logProgress)
-		defer pw.Close()
+		defer func() {
+			err := pw.Close()
+			if pullErr == nil {
+				pullErr = err
+			}
+		}()
 		outputStream := pw.(io.Writer)
 		if glog.V(5) {
 			outputStream = out


### PR DESCRIPTION
DO NOT MERGE AS IS: This includes a commit which manually patches in https://github.com/openshift/imagebuilder/pull/97 ; that probably needs to happen in some other way than this manual patch; apparently `glide` is somehow involved (`imagebuilder` is mentioned in `glide.lock`), but `HACKING.md` documents `godep` instead.

(This is a 3.11 version of #20941.)

Longer-lived Docker API operations report only trivial errors (e.g. invalid syntax) as HTTP status codes; the rest is reported in the body of the response, along with other progress messages.

Right now `openshift/imagebuilder/imageprogress` ignores such errors; https://github.com/openshift/imagebuilder/pull/97 fixes that, and this PR modifies OpenShift to take advantage of this (and, in some cases, to close the `imageprogress` objects and to terminate the associated goroutines).

`pkg/builder/dockerutil.{pullImage,pushImage}` had existing unit tests, so I have extended them to verify this as well; `pkg/oc/clusterup/docker/dockerhelper` has almost no tests, so I’m not too inclined to build all that infrastructure right now.

See individual commit messages for details.