### PR TITLE
dind - add default --service-cluster-ip-range

### DIFF
--- a/images/dind/master/ovn-kubernetes-master.sh
+++ b/images/dind/master/ovn-kubernetes-master.sh
@@ -15,6 +15,7 @@ function ovn-kubernetes-master() {
 
   local master_config="${config_dir}/master-config.yaml"
   cluster_cidr=$(python -c "import yaml; stream = file('${master_config}', 'r'); y = yaml.load(stream); print y['networkConfig']['clusterNetworks'][0]['cidr']")
+  svc_cidr=$(python -c "import yaml; stream = file('${master_config}', 'r'); y = yaml.load(stream); print y['networkConfig']['serviceNetworkCIDR']")
   apiserver=$(awk '/server:/ { print $2; exit }' ${kube_config})
   ovn_master_ip=$(echo -n ${apiserver} | cut -d "/" -f 3 | cut -d ":" -f 1)
 
@@ -24,6 +25,7 @@ function ovn-kubernetes-master() {
 	--k8s-cacert "${config_dir}/ca.crt" \
 	--k8s-token "${token}" \
 	--cluster-subnet "${cluster_cidr}" \
+	--service-cluster-ip-range "${svc_cidr}" \
 	--nb-address "tcp://${ovn_master_ip}:6641" \
 	--sb-address "tcp://${ovn_master_ip}:6642" \
 	--init-master `hostname` \

--- a/images/dind/node/ovn-kubernetes-node.sh
+++ b/images/dind/node/ovn-kubernetes-node.sh
@@ -42,6 +42,7 @@ EOF
   local node_config="${config_dir}/node-config.yaml"
   local master_config="${master_dir}/master-config.yaml"
   cluster_cidr=$(python -c "import yaml; stream = file('${master_config}', 'r'); y = yaml.load(stream); print y['networkConfig']['clusterNetworks'][0]['cidr']")
+  svc_cidr=$(python -c "import yaml; stream = file('${master_config}', 'r'); y = yaml.load(stream); print y['networkConfig']['serviceNetworkCIDR']")
   apiserver=$(awk '/server:/ { print $2; exit }' ${kube_config})
   ovn_master_ip=$(echo -n ${apiserver} | cut -d "/" -f 3 | cut -d ":" -f 1)
 
@@ -56,6 +57,7 @@ EOF
 	--k8s-cacert "${config_dir}/ca.crt" \
 	--k8s-token "${token}" \
 	--cluster-subnet "${cluster_cidr}" \
+	--service-cluster-ip-range "${svc_cidr}" \
 	--nb-address "tcp://${ovn_master_ip}:6641" \
 	--sb-address "tcp://${ovn_master_ip}:6642" \
 	--init-node ${host} \


### PR DESCRIPTION
The default service cidr range, found in the master-config.yaml file (usually, 172.30.0.0/16) is now passed into ovnkube through the --service-cluster-ip-range command line option.

Signed-off-by: Phil Cameron <pcameron@redhat.com>