### PR TITLE
Explicitly disable admission plugins that we have off in the legacy path

### DIFF
--- a/pkg/apiserver/admission/chain_builder.go
+++ b/pkg/apiserver/admission/chain_builder.go
@@ -208,7 +208,7 @@ func NewAdmissionChains(
 		admissionPluginConfigFilename = tempFile.Name()
 	}
 
-	admissionPluginNames := CombinedAdmissionControlPlugins
+	admissionPluginNames := openshiftAdmissionControlPlugins
 	admissionPluginNames = fixupAdmissionPlugins(admissionPluginNames)
 
 	admissionChain, err := newAdmissionChainFunc(admissionPluginNames, admissionPluginConfigFilename, admissionInitializer, admissionDecorator)

--- a/pkg/apiserver/admission/config_test.go
+++ b/pkg/apiserver/admission/config_test.go
@@ -117,8 +117,8 @@ func TestSeparateAdmissionChainDetection(t *testing.T) {
 				},
 			},
 			admissionChainBuilder: func(pluginNames []string, admissionConfigFilename string, pluginInitializer admission.PluginInitializer, decorator admission.Decorator) (admission.Interface, error) {
-				isKube := reflect.DeepEqual(pluginNames, CombinedAdmissionControlPlugins)
-				isOrigin := reflect.DeepEqual(pluginNames, CombinedAdmissionControlPlugins)
+				isKube := reflect.DeepEqual(pluginNames, KubeAdmissionPlugins)
+				isOrigin := reflect.DeepEqual(pluginNames, openshiftAdmissionControlPlugins)
 				if !isKube && !isOrigin {
 					t.Errorf("%s: expected either %v or %v, got %v", "specified conflicting plugin configs 01", KubeAdmissionPlugins, openshiftAdmissionControlPlugins, pluginNames)
 				}

--- a/pkg/apiserver/admission/register.go
+++ b/pkg/apiserver/admission/register.go
@@ -132,10 +132,6 @@ var (
 	)
 )
 
-func init() {
-	admission.PluginEnabledFn = IsAdmissionPluginActivated
-}
-
 func IsAdmissionPluginActivated(name string, config io.Reader) bool {
 	// only intercept if we have an explicit enable or disable.  If the check fails in any way,
 	// assume that the config was a different type and let the actual admission plugin check it

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -43,6 +43,7 @@ func RunOpenShiftKubeAPIServerServer(kubeAPIServerConfig *kubecontrolplanev1.Kub
 	kubeDefaultOffAdmission := options.DefaultOffAdmissionPlugins
 	options.DefaultOffAdmissionPlugins = func() sets.String {
 		kubeOff := kubeDefaultOffAdmission()
+		kubeOff.Insert(originadmission.DefaultOffPlugins.List()...)
 		kubeOff.Delete(originadmission.DefaultOnPlugins.List()...)
 		return kubeOff
 	}

--- a/pkg/cmd/server/origin/legacyadmission/register.go
+++ b/pkg/cmd/server/origin/legacyadmission/register.go
@@ -136,10 +136,6 @@ var (
 	)
 )
 
-func init() {
-	admission.PluginEnabledFn = IsAdmissionPluginActivated
-}
-
 func IsAdmissionPluginActivated(name string, config io.Reader) bool {
 	// only intercept if we have an explicit enable or disable.  If the check fails in any way,
 	// assume that the config was a different type and let the actual admission plugin check it

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -10,8 +10,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 
 	"github.com/coreos/go-systemd/daemon"
@@ -20,7 +18,9 @@ import (
 	"github.com/spf13/cobra"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/client-go/tools/cache"
 	aggregatorinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
 	"github.com/openshift/origin/pkg/cmd/server/etcd/etcdserver"
 	"github.com/openshift/origin/pkg/cmd/server/origin"
+	"github.com/openshift/origin/pkg/cmd/server/origin/legacyadmission"
 	"github.com/openshift/origin/pkg/cmd/server/origin/legacyconfigprocessing"
 	"github.com/openshift/origin/pkg/cmd/server/start/options"
 	cmdutil "github.com/openshift/origin/pkg/cmd/util"
@@ -470,6 +471,9 @@ func (m *Master) Start() error {
 		if m.config.EtcdConfig != nil {
 			etcdserver.RunEtcd(m.config.EtcdConfig)
 		}
+
+		// enable admission plugin checks
+		admission.PluginEnabledFn = legacyadmission.IsAdmissionPluginActivated
 
 		if err := legacyconfigprocessing.ConvertNetworkConfigToAdmissionConfig(m.config); err != nil {
 			return err


### PR DESCRIPTION
These are the changes necessary to admission wiring to make https://github.com/openshift/origin/pull/21096 working.

/assign @deads2k 
