### PR TITLE
Use kubernetes prefix for its API server

### DIFF
--- a/pkg/configconversion/legacyconfig_conversion.go
+++ b/pkg/configconversion/legacyconfig_conversion.go
@@ -76,7 +76,7 @@ func ConvertMasterConfigToKubeAPIServerConfig(input *legacyconfigv1.MasterConfig
 		GenericAPIServerConfig: configv1.GenericAPIServerConfig{
 			CORSAllowedOrigins: input.CORSAllowedOrigins,
 			StorageConfig: configv1.EtcdStorageConfig{
-				StoragePrefix: input.EtcdStorageConfig.OpenShiftStoragePrefix,
+				StoragePrefix: input.EtcdStorageConfig.KubernetesStoragePrefix,
 			},
 		},
 


### PR DESCRIPTION
Another finding in the path to split integation #21096.

/assign @deads2k 