### PR TITLE
Revert "use namespace labels to prevent SCC usage"

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -206,15 +206,6 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 		return fn(baseName, c, labels)
 	}
 
-	// if we're running an upstream test, make sure to skip openshift admission.
-	// TODO we may be able to relax this after the openshift apiserver is back in the openshift/installer
-	if isKubernetesE2ETest() && !skipTestNamespaceCustomization() {
-		if labels == nil {
-			labels = map[string]string{}
-		}
-		labels["openshift.io/run-level"] = "0"
-	}
-
 	// Otherwise use the upstream default
 	ns, err := e2e.CreateTestingNS(baseName, c, labels)
 	if err != nil {
@@ -227,26 +218,21 @@ func createTestingNS(baseName string, c kclientset.Interface, labels map[string]
 		if err != nil {
 			return ns, err
 		}
-
-		// TODO we may restore this after the openshift apiserver is back in the openshift/installer.  For now
-		// TODO the SCC isn't needed because of the runlevel
-		if false {
-			securityClient, err := securityclient.NewForConfig(clientConfig)
-			if err != nil {
-				return ns, err
-			}
-			e2e.Logf("About to run a Kube e2e test, ensuring namespace is privileged")
-			// add the "privileged" scc to ensure pods that explicitly
-			// request extra capabilities are not rejected
-			addE2EServiceAccountsToSCC(securityClient, []kapiv1.Namespace{*ns}, "privileged")
-			// add the "anyuid" scc to ensure pods that don't specify a
-			// uid don't get forced into a range (mimics upstream
-			// behavior)
-			addE2EServiceAccountsToSCC(securityClient, []kapiv1.Namespace{*ns}, "anyuid")
-			// add the "hostmount-anyuid" scc to ensure pods using hostPath
-			// can execute tests
-			addE2EServiceAccountsToSCC(securityClient, []kapiv1.Namespace{*ns}, "hostmount-anyuid")
+		securityClient, err := securityclient.NewForConfig(clientConfig)
+		if err != nil {
+			return ns, err
 		}
+		e2e.Logf("About to run a Kube e2e test, ensuring namespace is privileged")
+		// add the "privileged" scc to ensure pods that explicitly
+		// request extra capabilities are not rejected
+		addE2EServiceAccountsToSCC(securityClient, []kapiv1.Namespace{*ns}, "privileged")
+		// add the "anyuid" scc to ensure pods that don't specify a
+		// uid don't get forced into a range (mimics upstream
+		// behavior)
+		addE2EServiceAccountsToSCC(securityClient, []kapiv1.Namespace{*ns}, "anyuid")
+		// add the "hostmount-anyuid" scc to ensure pods using hostPath
+		// can execute tests
+		addE2EServiceAccountsToSCC(securityClient, []kapiv1.Namespace{*ns}, "hostmount-anyuid")
 
 		// The intra-pod test requires that the service account have
 		// permission to retrieve service endpoints.


### PR DESCRIPTION
Reverts openshift/origin#21183

The openshift-apiserver can now be successfully installed by openshift/installer.  Let's see how this goes.

