### PR TITLE
Fix help examples for image append/extract

### DIFF
--- a/pkg/oc/cli/image/append/append.go
+++ b/pkg/oc/cli/image/append/append.go
@@ -112,7 +112,7 @@ func NewCmdAppendImage(name string, streams genericclioptions.IOStreams) *cobra.
 		Use:     "append",
 		Short:   "Add layers to images and push them to a registry",
 		Long:    desc,
-		Example: fmt.Sprintf(example, name),
+		Example: fmt.Sprintf(example, name+" append"),
 		Run: func(c *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(c, args))
 			kcmdutil.CheckErr(o.Run())

--- a/pkg/oc/cli/image/extract/extract.go
+++ b/pkg/oc/cli/image/extract/extract.go
@@ -143,7 +143,7 @@ func New(name string, streams genericclioptions.IOStreams) *cobra.Command {
 		Use:     "extract",
 		Short:   "Copy files from an image to the filesystem",
 		Long:    desc,
-		Example: fmt.Sprintf(example, name),
+		Example: fmt.Sprintf(example, name+" extract"),
 		Run: func(c *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(c, args))
 			kcmdutil.CheckErr(o.Run())


### PR DESCRIPTION
Fix bug #21247 which show properly the baseline of the command for the examples.