### PR TITLE
Re-enable emptydir test, no longer uses git volume

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -322,7 +322,6 @@ var (
 		// tests that are known broken and need to be fixed upstream or in openshift
 		// always add an issue here
 		"[Disabled:Broken]": {
-			`EmptyDir wrapper volumes should not conflict`,                   // uses git volume https://bugzilla.redhat.com/show_bug.cgi?id=1622195
 			`\[Feature:BlockVolume\]`,                                        // directory failure https://bugzilla.redhat.com/show_bug.cgi?id=1622193
 			`\[Feature:Example\]`,                                            // has cleanup issues
 			`mount an API token into pods`,                                   // We add 6 secrets, not 1


### PR DESCRIPTION
now that https://github.com/openshift/origin/pull/20959 has merged, the test should pass. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1622195