### PR TITLE
make sure that the openshift apiserver includes namespace lifecycle admission

### DIFF
--- a/pkg/apiserver/admission/chain_builder.go
+++ b/pkg/apiserver/admission/chain_builder.go
@@ -50,6 +50,7 @@ var (
 
 	// openshiftAdmissionControlPlugins gives the in-order default admission chain for openshift resources.
 	openshiftAdmissionControlPlugins = []string{
+		lifecycle.PluginName,
 		"ProjectRequestLimit",
 		"openshift.io/JenkinsBootstrapper",
 		"openshift.io/BuildConfigSecretInjector",


### PR DESCRIPTION
We forgot the namespace lifecycle admission plugin.

@openshift/sig-master 
@soltysh  please add test for this to test-integration for an openshift resource
@juanvallejo pick up this commit to get test-cmd to pass for now.  