### PR TITLE
Guide more practical usage for new options replaced

### DIFF
--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -58,7 +58,7 @@ func NewCmdExport(fullName string, f *clientcmd.Factory, in io.Reader, out io.Wr
 		Short:      "Export resources so they can be used elsewhere",
 		Long:       exportLong,
 		Example:    fmt.Sprintf(exportExample, fullName),
-		Deprecated: "use the oc get --export",
+		Deprecated: "use the oc get --export -o yaml",
 		Hidden:     true,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunExport(f, exporter, in, out, cmd, args, filenames)


### PR DESCRIPTION
Fix this issue : https://github.com/openshift/openshift-docs/issues/12409

I think we should guide using more practical usage for suppressing confusing of users, `oc get --export` is just list the object, not export as `yaml` format unless specify the `-o yaml`. So it's not same result with `oc export`. `oc export` that is deprecated is exported as `yaml` format without depended env variables.