### PR TITLE
3.10 Fixed subpath cleanup when /var/lib/kubelet is a symlink

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/container_manager_linux_test.go
@@ -112,6 +112,10 @@ func (mi *fakeMountInterface) GetSELinuxSupport(pathname string) (bool, error) {
 	return false, errors.New("not implemented")
 }
 
+func (mi *fakeMountInterface) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/exec_mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/exec_mount.go
@@ -140,6 +140,10 @@ func (m *execMounter) ExistsPath(pathname string) bool {
 	return m.wrappedMounter.ExistsPath(pathname)
 }
 
+func (m *execMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return m.wrappedMounter.EvalHostSymlinks(pathname)
+}
+
 func (m *execMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return m.wrappedMounter.PrepareSafeSubpath(subPath)
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/exec_mount_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/exec_mount_test.go
@@ -168,3 +168,7 @@ func (fm *fakeMounter) SafeMakeDir(pathname string, base string, perm os.FileMod
 func (fm *fakeMounter) GetSELinuxSupport(pathname string) (bool, error) {
 	return false, errors.New("not implemented")
 }
+
+func (fm *fakeMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/exec_mount_unsupported.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/exec_mount_unsupported.go
@@ -87,6 +87,10 @@ func (mounter *execMounter) ExistsPath(pathname string) bool {
 	return true
 }
 
+func (m *execMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (mounter *execMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return subPath.Path, nil, nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/fake.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/fake.go
@@ -199,6 +199,10 @@ func (f *FakeMounter) ExistsPath(pathname string) bool {
 	return false
 }
 
+func (f *FakeMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return pathname, nil
+}
+
 func (f *FakeMounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return subPath.Path, nil, nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
@@ -95,6 +95,9 @@ type Interface interface {
 	// ExistsPath checks whether the path exists.
 	// Will operate in the host mount namespace if kubelet is running in a container
 	ExistsPath(pathname string) bool
+	// EvalHostSymlinks returns the path name after evaluating symlinks.
+	// Will operate in the host mount namespace if kubelet is running in a container.
+	EvalHostSymlinks(pathname string) (string, error)
 	// CleanSubPaths removes any bind-mounts created by PrepareSafeSubpath in given
 	// pod volume directory.
 	CleanSubPaths(podDir string, volumeName string) error

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
@@ -252,9 +252,14 @@ func isNotDirErr(err error) bool {
 // It is more extensive than IsLikelyNotMountPoint
 // and it detects bind mounts in linux
 func IsNotMountPoint(mounter Interface, file string) (bool, error) {
+	// Resolve any symlinks in file, kernel would do the same and use the resolved path in /proc/mounts
+	resolvedFile, err := mounter.EvalHostSymlinks(file)
+	if err != nil {
+		return true, err
+	}
 	// IsLikelyNotMountPoint provides a quick check
 	// to determine whether file IS A mountpoint
-	notMnt, notMntErr := mounter.IsLikelyNotMountPoint(file)
+	notMnt, notMntErr := mounter.IsLikelyNotMountPoint(resolvedFile)
 	if notMntErr != nil && os.IsPermission(notMntErr) {
 		// We were not allowed to do the simple stat() check, e.g. on NFS with
 		// root_squash. Fall back to /proc/mounts check below.
@@ -275,7 +280,7 @@ func IsNotMountPoint(mounter Interface, file string) (bool, error) {
 		return notMnt, mountPointsErr
 	}
 	for _, mp := range mountPoints {
-		if mounter.IsMountPointMatch(mp, file) {
+		if mounter.IsMountPointMatch(mp, resolvedFile) {
 			notMnt = false
 			break
 		}

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount.go
@@ -252,14 +252,9 @@ func isNotDirErr(err error) bool {
 // It is more extensive than IsLikelyNotMountPoint
 // and it detects bind mounts in linux
 func IsNotMountPoint(mounter Interface, file string) (bool, error) {
-	// Resolve any symlinks in file, kernel would do the same and use the resolved path in /proc/mounts
-	resolvedFile, err := mounter.EvalHostSymlinks(file)
-	if err != nil {
-		return true, err
-	}
 	// IsLikelyNotMountPoint provides a quick check
 	// to determine whether file IS A mountpoint
-	notMnt, notMntErr := mounter.IsLikelyNotMountPoint(resolvedFile)
+	notMnt, notMntErr := mounter.IsLikelyNotMountPoint(file)
 	if notMntErr != nil && os.IsPermission(notMntErr) {
 		// We were not allowed to do the simple stat() check, e.g. on NFS with
 		// root_squash. Fall back to /proc/mounts check below.
@@ -273,6 +268,13 @@ func IsNotMountPoint(mounter Interface, file string) (bool, error) {
 	if notMnt == false {
 		return notMnt, nil
 	}
+
+	// Resolve any symlinks in file, kernel would do the same and use the resolved path in /proc/mounts
+	resolvedFile, err := mounter.EvalHostSymlinks(file)
+	if err != nil {
+		return true, err
+	}
+
 	// check all mountpoints since IsLikelyNotMountPoint
 	// is not reliable for some mountpoint types
 	mountPoints, mountPointsErr := mounter.List()

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount_linux.go
@@ -455,6 +455,10 @@ func (mounter *Mounter) ExistsPath(pathname string) bool {
 	return true
 }
 
+func (mounter *Mounter) EvalHostSymlinks(pathname string) (string, error) {
+	return filepath.EvalSymlinks(pathname)
+}
+
 // formatAndMount uses unix utils to format and mount the given disk
 func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, fstype string, options []string) error {
 	readOnly := false

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount_unsupported.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount_unsupported.go
@@ -110,6 +110,10 @@ func (mounter *Mounter) ExistsPath(pathname string) bool {
 	return true
 }
 
+func (mounter *Mounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", unsupportedErr
+}
+
 func (mounter *Mounter) PrepareSafeSubpath(subPath Subpath) (newHostPath string, cleanupAction func(), err error) {
 	return subPath.Path, nil, nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/mount_windows.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/mount_windows.go
@@ -236,6 +236,11 @@ func (mounter *Mounter) ExistsPath(pathname string) bool {
 	return true
 }
 
+// EvalHostSymlinks returns the path name after evaluating symlinks
+func (mounter *Mounter) EvalHostSymlinks(pathname string) (string, error) {
+	return filepath.EvalSymlinks(pathname)
+}
+
 // check whether hostPath is within volume path
 // this func will lock all intermediate subpath directories, need to close handle outside of this func after container started
 func lockAndCheckSubPath(volumePath, hostPath string) ([]uintptr, error) {

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/nsenter_mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/nsenter_mount.go
@@ -167,15 +167,22 @@ func (n *NsenterMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 		glog.V(5).Infof("findmnt: directory %s does not exist", file)
 		return true, err
 	}
+
+	// Resolve any symlinks in file, kernel would do the same and use the resolved path in /proc/mounts
+	resolvedFile, err := n.EvalHostSymlinks(file)
+	if err != nil {
+		return true, err
+	}
+
 	// Add --first-only option: since we are testing for the absence of a mountpoint, it is sufficient to get only
 	// the first of multiple possible mountpoints using --first-only.
 	// Also add fstype output to make sure that the output of target file will give the full path
 	// TODO: Need more refactoring for this function. Track the solution with issue #26996
-	args := []string{"-o", "target,fstype", "--noheadings", "--first-only", "--target", file}
+	args := []string{"-o", "target,fstype", "--noheadings", "--first-only", "--target", resolvedFile}
 	glog.V(5).Infof("nsenter findmnt args: %v", args)
 	out, err := n.ne.Exec("findmnt", args).CombinedOutput()
 	if err != nil {
-		glog.V(2).Infof("Failed findmnt command for path %s: %s %v", file, out, err)
+		glog.V(2).Infof("Failed findmnt command for path %s: %s %v", resolvedFile, out, err)
 		// Different operating systems behave differently for paths which are not mount points.
 		// On older versions (e.g. 2.20.1) we'd get error, on newer ones (e.g. 2.26.2) we'd get "/".
 		// It's safer to assume that it's not a mount point.
@@ -186,13 +193,13 @@ func (n *NsenterMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 		return false, err
 	}
 
-	glog.V(5).Infof("IsLikelyNotMountPoint findmnt output for path %s: %v:", file, mountTarget)
+	glog.V(5).Infof("IsLikelyNotMountPoint findmnt output for path %s: %v:", resolvedFile, mountTarget)
 
-	if mountTarget == file {
-		glog.V(5).Infof("IsLikelyNotMountPoint: %s is a mount point", file)
+	if mountTarget == resolvedFile {
+		glog.V(5).Infof("IsLikelyNotMountPoint: %s is a mount point", resolvedFile)
 		return false, nil
 	}
-	glog.V(5).Infof("IsLikelyNotMountPoint: %s is not a mount point", file)
+	glog.V(5).Infof("IsLikelyNotMountPoint: %s is not a mount point", resolvedFile)
 	return true, nil
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/nsenter_mount.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/nsenter_mount.go
@@ -286,6 +286,10 @@ func (mounter *NsenterMounter) ExistsPath(pathname string) bool {
 	return false
 }
 
+func (mounter *NsenterMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return mounter.ne.EvalSymlinks(pathname, true)
+}
+
 func (mounter *NsenterMounter) CleanSubPaths(podDir string, volumeName string) error {
 	return doCleanSubPaths(mounter, podDir, volumeName)
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/mount/nsenter_mount_unsupported.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/mount/nsenter_mount_unsupported.go
@@ -87,6 +87,10 @@ func (*NsenterMounter) ExistsPath(pathname string) bool {
 	return true
 }
 
+func (*NsenterMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (*NsenterMounter) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
 	return nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/util/nsenter/nsenter.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/nsenter/nsenter.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/utils/exec"
 

--- a/vendor/k8s.io/kubernetes/pkg/util/removeall/removeall_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/removeall/removeall_test.go
@@ -95,6 +95,10 @@ func (mounter *fakeMounter) GetSELinuxSupport(pathname string) (bool, error) {
 	return false, errors.New("not implemented")
 }
 
+func (mounter *fakeMounter) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func (mounter *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	name := path.Base(file)
 	if strings.HasPrefix(name, "mount") {

--- a/vendor/k8s.io/kubernetes/pkg/volume/host_path/host_path_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/host_path/host_path_test.go
@@ -393,6 +393,10 @@ func (fftc *fakeFileTypeChecker) GetSELinuxSupport(pathname string) (bool, error
 	return false, errors.New("not implemented")
 }
 
+func (fftc *fakeFileTypeChecker) EvalHostSymlinks(pathname string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func setUp() error {
 	err := os.MkdirAll("/tmp/ExistingFolder", os.FileMode(0755))
 	if err != nil {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1640077

https://github.com/kubernetes/kubernetes/pull/68741
https://github.com/kubernetes/kubernetes/pull/69565
@openshift/storage 