### PR TITLE
remove aggressive default for kubelet

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go
+++ b/pkg/cmd/openshift-kube-apiserver/configdefault/kubecontrolplane_default.go
@@ -79,5 +79,4 @@ func SetRecommendedKubeletConnectionInfoDefaults(config *kubecontrolplanev1.Kube
 	}
 	configdefaults.DefaultString(&config.CertInfo.KeyFile, "/var/run/secrets/kubelet-client/tls.key")
 	configdefaults.DefaultString(&config.CertInfo.CertFile, "/var/run/secrets/kubelet-client/tls.crt")
-	configdefaults.DefaultString(&config.CA, "/var/run/configmaps/kubelet-serving-ca/ca-bundle.crt")
 }


### PR DESCRIPTION
This default constrained choice used by the openshift/installer at the moment.

/assign @mfojtik @sttts 