### PR TITLE
Add ConfigMap for CAs to build pods

### DIFF
--- a/pkg/api/apihelpers/namer.go
+++ b/pkg/api/apihelpers/namer.go
@@ -41,6 +41,11 @@ func GetPodName(base, suffix string) string {
 	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
 }
 
+// GetConfigMapName calls GetName with the length restriction for ConfigMaps
+func GetConfigMapName(base, suffix string) string {
+	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
 // max returns the greater of its 2 inputs
 func max(a, b int) int {
 	if b > a {

--- a/pkg/build/buildapihelpers/util.go
+++ b/pkg/build/buildapihelpers/util.go
@@ -9,12 +9,19 @@ import (
 
 const (
 	// buildPodSuffix is the suffix used to append to a build pod name given a build name
-	buildPodSuffix = "build"
+	buildPodSuffix    = "build"
+	caConfigMapSuffix = "ca"
 )
 
 // GetBuildPodName returns name of the build pod.
 func GetBuildPodName(build *buildv1.Build) string {
 	return apihelpers.GetPodName(build.Name, buildPodSuffix)
+}
+
+// GetBuildCAConfigMapName returns the name of the ConfigMap containing the build's
+// certificate authority bundles.
+func GetBuildCAConfigMapName(build *buildv1.Build) string {
+	return apihelpers.GetConfigMapName(build.Name, caConfigMapSuffix)
 }
 
 func StrategyType(strategy buildv1.BuildStrategy) string {

--- a/pkg/build/controller/strategy/custom.go
+++ b/pkg/build/controller/strategy/custom.go
@@ -138,7 +138,7 @@ func (bs *CustomBuildStrategy) CreateBuildPod(build *buildv1.Build) (*corev1.Pod
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
 	setupAdditionalSecrets(pod, &pod.Spec.Containers[0], build.Spec.Strategy.CustomStrategy.Secrets)
 	setupContainersConfigs(pod, &pod.Spec.Containers[0])
-	//	setupContainersCertificates(pod, &pod.Spec.Containers[0])
+	setupBuildCAs(build, pod)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	return pod, nil
 }

--- a/pkg/build/controller/strategy/custom_test.go
+++ b/pkg/build/controller/strategy/custom_test.go
@@ -62,12 +62,26 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	// expected volumes:
 	// docker socket
 	// push secret
-	// gitclone secret
-	// input secret
+	// source secret
+	// additional secrets
 	// build-system-configmap
+	// certificate authorities
 	// container storage
-	if len(container.VolumeMounts) != 6 {
-		t.Fatalf("Expected 6 volumes in container, got %d: %v", len(container.VolumeMounts), container.VolumeMounts)
+	if len(container.VolumeMounts) != 7 {
+		t.Fatalf("Expected 7 volumes in container, got %d", len(container.VolumeMounts))
+	}
+	expectedMounts := []string{"/var/run/docker.sock",
+		DockerPushSecretMountPath,
+		sourceSecretMountPath,
+		"secret",
+		ConfigMapBuildSystemConfigsMountPath,
+		ConfigMapCertsMountPath,
+		"/var/lib/containers/storage",
+	}
+	for i, expected := range expectedMounts {
+		if container.VolumeMounts[i].MountPath != expected {
+			t.Fatalf("Expected %s in VolumeMount[%d], got %s", expected, i, container.VolumeMounts[i].MountPath)
+		}
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
@@ -80,8 +94,8 @@ func TestCustomCreateBuildPod(t *testing.T) {
 	if !kapihelper.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)
 	}
-	if len(actual.Spec.Volumes) != 6 {
-		t.Fatalf("Expected 6 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 7 {
+		t.Fatalf("Expected 7 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	buildJSON, _ := runtime.Encode(customBuildEncodingCodecFactory.LegacyCodec(buildv1.GroupVersion), build)
 	errorCases := map[int][]string{

--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -181,7 +181,7 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build) (*v1.Pod, er
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
 	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
 	setupContainersConfigs(pod, &pod.Spec.Containers[0])
-	//	setupContainersCertificates(pod, &pod.Spec.Containers[0])
+	setupBuildCAs(build, pod)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds
 	return pod, nil

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -69,21 +69,31 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	// inputsecret
 	// inputconfigmap
 	// build-system-config
+	// certificate authorities
 	// container storage
-	if len(container.VolumeMounts) != 7 {
-		t.Fatalf("Expected 7 volumes in container, got %d", len(container.VolumeMounts))
+	if len(container.VolumeMounts) != 8 {
+		t.Fatalf("Expected 8 volumes in container, got %d", len(container.VolumeMounts))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
 	}
-	for i, expected := range []string{buildutil.BuildWorkDirMount, DockerPushSecretMountPath, DockerPullSecretMountPath, filepath.Join(SecretBuildSourceBaseMountPath, "super-secret"), filepath.Join(ConfigMapBuildSourceBaseMountPath, "build-config"), ConfigMapBuildSystemConfigsMountPath, "/var/lib/containers/storage"} {
+	expectedMounts := []string{buildutil.BuildWorkDirMount,
+		DockerPushSecretMountPath,
+		DockerPullSecretMountPath,
+		filepath.Join(SecretBuildSourceBaseMountPath, "super-secret"),
+		filepath.Join(ConfigMapBuildSourceBaseMountPath, "build-config"),
+		ConfigMapBuildSystemConfigsMountPath,
+		ConfigMapCertsMountPath,
+		"/var/lib/containers/storage",
+	}
+	for i, expected := range expectedMounts {
 		if container.VolumeMounts[i].MountPath != expected {
 			t.Fatalf("Expected %s in VolumeMount[%d], got %s", expected, i, container.VolumeMounts[i].MountPath)
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 8 {
-		t.Fatalf("Expected 8 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 9 {
+		t.Fatalf("Expected 9 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if !kapihelper.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -186,7 +186,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build) (*corev1.Pod
 	setupInputSecrets(pod, &pod.Spec.Containers[0], build.Spec.Source.Secrets)
 	setupInputConfigMaps(pod, &pod.Spec.Containers[0], build.Spec.Source.ConfigMaps)
 	setupContainersConfigs(pod, &pod.Spec.Containers[0])
-	//setupContainersCertificates(pod, &pod.Spec.Containers[0])
+	setupBuildCAs(build, pod)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds
 	return pod, nil

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -109,18 +109,28 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	// inputsecret
 	// inputconfigmap
 	// build-system-configmap
+	// certificate authorities
 	// container storage
-	if len(container.VolumeMounts) != 7 {
-		t.Fatalf("Expected 7 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
+	if len(container.VolumeMounts) != 8 {
+		t.Fatalf("Expected 8 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
 	}
-	for i, expected := range []string{buildutil.BuildWorkDirMount, DockerPushSecretMountPath, DockerPullSecretMountPath, filepath.Join(SecretBuildSourceBaseMountPath, "secret"), filepath.Join(ConfigMapBuildSourceBaseMountPath, "configmap"), ConfigMapBuildSystemConfigsMountPath, "/var/lib/containers/storage"} {
+	expectedMounts := []string{buildutil.BuildWorkDirMount,
+		DockerPushSecretMountPath,
+		DockerPullSecretMountPath,
+		filepath.Join(SecretBuildSourceBaseMountPath, "secret"),
+		filepath.Join(ConfigMapBuildSourceBaseMountPath, "configmap"),
+		ConfigMapBuildSystemConfigsMountPath,
+		ConfigMapCertsMountPath,
+		"/var/lib/containers/storage",
+	}
+	for i, expected := range expectedMounts {
 		if container.VolumeMounts[i].MountPath != expected {
 			t.Fatalf("Expected %s in VolumeMount[%d], got %s", expected, i, container.VolumeMounts[i].MountPath)
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 8 {
-		t.Fatalf("Expected 8 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 9 {
+		t.Fatalf("Expected 9 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)

--- a/pkg/build/util/consts.go
+++ b/pkg/build/util/consts.go
@@ -88,6 +88,7 @@ const (
 const (
 	StatusMessageCannotCreateBuildPodSpec        = "Failed to create pod spec."
 	StatusMessageCannotCreateBuildPod            = "Failed creating build pod."
+	StatusMessageCannotCreateCAConfigMap         = "Failed creating build certificate authority configMap."
 	StatusMessageInvalidOutputRef                = "Output image could not be resolved."
 	StatusMessageInvalidImageRef                 = "Referenced image could not be resolved."
 	StatusMessageBuildPodDeleted                 = "The pod for this build was deleted before the build completed."

--- a/pkg/cmd/server/bootstrappolicy/controller_policy.go
+++ b/pkg/cmd/server/bootstrappolicy/controller_policy.go
@@ -106,7 +106,7 @@ func init() {
 			rbacv1helpers.NewRule("create").Groups(buildGroup, legacyBuildGroup).Resources("builds/optimizeddocker", "builds/docker", "builds/source", "builds/custom", "builds/jenkinspipeline").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list").Groups(imageGroup, legacyImageGroup).Resources("imagestreams").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list").Groups(kapiGroup).Resources("secrets").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list").Groups(kapiGroup).Resources("configmaps").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "create").Groups(kapiGroup).Resources("configmaps").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list", "create", "delete").Groups(kapiGroup).Resources("pods").RuleOrDie(),
 			rbacv1helpers.NewRule("get").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "list").Groups(kapiGroup).Resources("serviceaccounts").RuleOrDie(),

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -60,6 +60,7 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -56,6 +56,7 @@ var _ = g.Describe("[Feature:Builds][timing] capture build stages and durations"
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/completiondeadlineseconds.go
+++ b/test/extended/builds/completiondeadlineseconds.go
@@ -37,6 +37,7 @@ var _ = g.Describe("[Feature:Builds][Slow] builds should have deadlines", func()
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -38,6 +38,7 @@ var _ = g.Describe("[Feature:Builds][Slow] builds with a context directory", fun
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -38,6 +38,7 @@ var _ = g.Describe("[Feature:Builds][Slow] completed builds should have digest o
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -39,6 +39,7 @@ var _ = g.Describe("[Feature:Builds][pullsecret][Conformance] docker build using
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -45,6 +45,7 @@ USER 1001
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -55,6 +55,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/forcepull.go
+++ b/test/extended/builds/forcepull.go
@@ -104,6 +104,7 @@ var _ = g.Describe("[Feature:Builds] forcePull should affect pulling builder ima
 
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -47,6 +47,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use private repositories as build
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/hooks.go
+++ b/test/extended/builds/hooks.go
@@ -39,6 +39,7 @@ var _ = g.Describe("[Feature:Builds][Slow] testing build configuration hooks", f
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -51,6 +51,7 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/imagechangetriggers.go
+++ b/test/extended/builds/imagechangetriggers.go
@@ -38,6 +38,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] imagechangetriggers", func() {
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -37,6 +37,7 @@ var _ = g.Describe("[Feature:Builds][Slow][Smoke] result image should have prope
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/long_names.go
+++ b/test/extended/builds/long_names.go
@@ -25,6 +25,7 @@ var _ = g.Describe("[Feature:Builds][Slow] extremely long build/bc names are not
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -41,6 +41,7 @@ COPY --from=test /usr/bin/curl /test/
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -43,6 +43,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 			deployutil.DeploymentConfigFailureTrap(oc, a58, g.CurrentGinkgoTestDescription().Failed)

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -26,6 +26,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] build without output image", f
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -39,6 +39,7 @@ var _ = g.Describe("[Feature:Builds] build with empty source", func() {
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -44,6 +44,7 @@ USER 1001
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -38,6 +38,7 @@ var _ = g.Describe("[Feature:Builds][Slow] the s2i build should support proxies"
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -37,6 +37,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] remove all builds when build c
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -37,6 +37,7 @@ var _ = g.Describe("[Feature:Builds] build have source revision metadata", func(
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -44,6 +44,7 @@ var _ = g.Describe("[Feature:Builds][Slow] using build configuration runPolicy",
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/s2i_dropcaps.go
+++ b/test/extended/builds/s2i_dropcaps.go
@@ -34,6 +34,7 @@ var _ = g.Describe("[Feature:Builds][Slow] Capabilities should be dropped for s2
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -43,6 +43,7 @@ var _ = g.Describe("[Feature:Builds][Slow] s2i build with environment file in so
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -43,6 +43,7 @@ var _ = g.Describe("[Feature:Builds][Slow] incremental s2i build", func() {
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -40,6 +40,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func(
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -45,6 +45,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a root user ima
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -35,6 +35,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -31,6 +31,7 @@ var _ = g.Describe("[Feature:Builds][Conformance][valueFrom] process valueFrom i
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(oc)
+				exutil.DumpConfigMapStates(oc)
 				exutil.DumpPodLogsStartingWith("", oc)
 			}
 		})

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -118,6 +118,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance readiness test", f
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
 				exutil.DumpPodStates(cli)
+				exutil.DumpConfigMapStates(cli)
 				exutil.DumpPodLogsStartingWith("", cli)
 			}
 		})

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -208,6 +208,7 @@ func DumpApplicationPodLogs(dcName string, oc *CLI) {
 	DumpPodLogs(pods.Items, oc)
 }
 
+// DumpPodStates dumps the state of all pods in the CLI's current namespace.
 func DumpPodStates(oc *CLI) {
 	e2e.Logf("Dumping pod state for namespace %s", oc.Namespace())
 	out, err := oc.AsAdmin().Run("get").Args("pods", "-o", "yaml").Output()
@@ -296,6 +297,17 @@ func DumpPodsCommand(c kubernetes.Interface, ns string, selector labels.Selector
 		stdout = strings.TrimSuffix(stdout, "\n")
 		e2e.Logf(name + ": " + strings.Join(strings.Split(stdout, "\n"), fmt.Sprintf("\n%s: ", name)))
 	}
+}
+
+// DumpConfigMapStates dumps the state of all ConfigMaps in the CLI's current namespace.
+func DumpConfigMapStates(oc *CLI) {
+	e2e.Logf("Dumping configMap state for namespace %s", oc.Namespace())
+	out, err := oc.AsAdmin().Run("get").Args("configmaps", "-o", "yaml").Output()
+	if err != nil {
+		e2e.Logf("Error dumping configMap states: %v", err)
+		return
+	}
+	e2e.Logf(out)
 }
 
 // GetMasterThreadDump will get a golang thread stack dump

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2244,6 +2244,7 @@ items:
     resources:
     - configmaps
     verbs:
+    - create
     - get
     - list
   - apiGroups:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -2244,6 +2244,7 @@ items:
     resources:
     - configmaps
     verbs:
+    - create
     - get
     - list
   - apiGroups:


### PR DESCRIPTION
* Always create the configMap for new builds
* Handle edge cases if CA ConfigMap fails to be created
* Allow build controller to create ConfigMaps

This lays down the foundation for adding the service signing CA to build pods, and any additional CAs that cluster admins provide for image push/pull. The ConfigMap in its current form is empty.

JIRA-IDs: [DEVEXP-181](https://jira.coreos.com/browse/DEVEXP-181), [DEVEXP-182](https://jira.coreos.com/browse/DEVEXP-182)