### PR TITLE
Drop master-config.yaml support from openshift-network-controller

### DIFF
--- a/images/dind/master/openshift-sdn-master.service
+++ b/images/dind/master/openshift-sdn-master.service
@@ -5,7 +5,7 @@ After=openshift-master.service openshift-sdn-master-setup.service
 
 [Service]
 ExecStart=/usr/local/bin/hypershift openshift-network-controller -v=4 \
-  --config=/data/openshift.local.config/master/master-config.yaml
+  --config=/data/openshift.local.config/master/sdn-config.yaml
 WorkingDirectory=/data
 Restart=on-failure
 RestartSec=10s

--- a/pkg/cmd/openshift-network-controller/cmd.go
+++ b/pkg/cmd/openshift-network-controller/cmd.go
@@ -23,14 +23,9 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	configv1 "github.com/openshift/api/config/v1"
-	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"github.com/openshift/library-go/pkg/serviceability"
-	"github.com/openshift/origin/pkg/cmd/openshift-controller-manager"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
-	"github.com/openshift/origin/pkg/cmd/server/apis/config/validation"
 	"github.com/openshift/origin/pkg/configconversion"
 )
 
@@ -110,57 +105,31 @@ func (o *OpenShiftNetworkController) RunNetworkController() error {
 	utilruntime.Must(openshiftcontrolplanev1.Install(scheme))
 	codecs := serializer.NewCodecFactory(scheme)
 	obj, err := runtime.Decode(codecs.UniversalDecoder(openshiftcontrolplanev1.GroupVersion, configv1.GroupVersion), configContent)
-	if err == nil {
-		// Resolve relative to CWD
-		absoluteConfigFile, err := api.MakeAbs(o.ConfigFilePath, "")
-		if err != nil {
-			return err
-		}
-		configFileLocation := path.Dir(absoluteConfigFile)
-
-		config := obj.(*openshiftcontrolplanev1.OpenShiftControllerManagerConfig)
-		/// this isn't allowed to be nil when by itself.
-		// TODO remove this when the old path is gone.
-		if config.ServingInfo == nil {
-			config.ServingInfo = &configv1.HTTPServingInfo{}
-		}
-		if err := helpers.ResolvePaths(configconversion.GetOpenShiftControllerConfigFileReferences(config), configFileLocation); err != nil {
-			return err
-		}
-		configdefault.SetRecommendedOpenShiftControllerConfigDefaults(config)
-
-		clientConfig, err := helpers.GetKubeClientConfig(config.KubeClientConfig)
-		if err != nil {
-			return err
-		}
-		return RunOpenShiftNetworkController(config, clientConfig)
-	}
-
-	masterConfig, err := configapilatest.ReadAndResolveMasterConfig(o.ConfigFilePath)
 	if err != nil {
 		return err
 	}
 
-	validationResults := validation.ValidateMasterConfig(masterConfig, nil)
-	if len(validationResults.Warnings) != 0 {
-		for _, warning := range validationResults.Warnings {
-			glog.Warningf("%v", warning)
-		}
-	}
-	if len(validationResults.Errors) != 0 {
-		return kerrors.NewInvalid(configapi.Kind("MasterConfig"), "master-config.yaml", validationResults.Errors)
-	}
-
-	// round trip to external
-	externalMasterConfig, err := configapi.Scheme.ConvertToVersion(masterConfig, legacyconfigv1.LegacySchemeGroupVersion)
+	// Resolve relative to CWD
+	absoluteConfigFile, err := api.MakeAbs(o.ConfigFilePath, "")
 	if err != nil {
 		return err
 	}
-	config := openshift_controller_manager.ConvertMasterConfigToOpenshiftControllerConfig(externalMasterConfig.(*legacyconfigv1.MasterConfig))
+	configFileLocation := path.Dir(absoluteConfigFile)
+
+	config := obj.(*openshiftcontrolplanev1.OpenShiftControllerManagerConfig)
+	/// this isn't allowed to be nil when by itself.
+	// TODO remove this when the old path is gone.
+	if config.ServingInfo == nil {
+		config.ServingInfo = &configv1.HTTPServingInfo{}
+	}
+	if err := helpers.ResolvePaths(configconversion.GetOpenShiftControllerConfigFileReferences(config), configFileLocation); err != nil {
+		return err
+	}
+	configdefault.SetRecommendedOpenShiftControllerConfigDefaults(config)
+
 	clientConfig, err := helpers.GetKubeClientConfig(config.KubeClientConfig)
 	if err != nil {
 		return err
 	}
-
 	return RunOpenShiftNetworkController(config, clientConfig)
 }


### PR DESCRIPTION
https://github.com/openshift/cluster-network-operator/pull/19 will create an OpenShiftControllerManagerConfig rather than a master-config.yaml, so drop the master-config.yaml support that had been copied from openshift-controller-manager.

Also updates the dind setup (with a hack to make it keep working if https://github.com/openshift/api/pull/112 gets merged).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639896