### PR TITLE
remove default behavior of selecting all resources

### DIFF
--- a/pkg/oc/cli/set/imagelookup.go
+++ b/pkg/oc/cli/set/imagelookup.go
@@ -201,7 +201,7 @@ func (o *ImageLookupOptions) Run() error {
 	case len(o.Args) == 0 && len(o.Filenames) == 0:
 		b = b.
 			LabelSelectorParam(o.Selector).
-			SelectAllParam(true).
+			SelectAllParam(o.All).
 			ResourceTypes("imagestreams")
 	case o.List:
 		b = b.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1640843

By default, all imagestream resources were selected if no arguments
were passed to the "set image-lookup" command. This patch updates
the command so that either the --all flag, or a specific set of
imagestream names must be provided in order for those resources
to be updated.

cc @soltysh @smarterclayton 