### PR TITLE
fix unbound var check in localup temp dir cleanup

### DIFF
--- a/hack/local-up-master/util.sh
+++ b/hack/local-up-master/util.sh
@@ -70,7 +70,9 @@ kube::util::trap_add() {
 
 # Opposite of kube::util::ensure-temp-dir()
 kube::util::cleanup-temp-dir() {
-  rm -rf "${KUBE_TEMP}"
+  if [[ -n "${KUBE_TEMP-}" ]]; then
+    rm -rf "${KUBE_TEMP}"
+  fi
 }
 
 # Create a temp dir that'll be deleted at the end of this bash session.


### PR DESCRIPTION
cc @enj 

Fixes the following error sometimes seen during `localup/master.sh` cleanup
```
hack/local-up-master/../local-up-master/util.sh: line 73: KUBE_TEMP: unbound variable
```