### PR TITLE
Don't allow pods to send VXLAN packets out of the SDN

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -200,6 +200,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	otx.AddFlow("table=90, priority=0, actions=drop")
 
 	// Table 100: egress routing; edited by SetNamespaceEgress*()
+	otx.AddFlow("table=100, priority=300,udp,udp_dst=%d,actions=drop", vxlanPort)
 	otx.AddFlow("table=100, priority=200,tcp,tcp_dst=53,nw_dst=%s,actions=output:2", oc.localIP)
 	otx.AddFlow("table=100, priority=200,udp,udp_dst=53,nw_dst=%s,actions=output:2", oc.localIP)
 	// eg, "table=100, priority=100, reg0=${tenant_id}, ip, actions=set_field:${tun0_mac}->eth_dst,set_field:${egress_mark}->pkt_mark,goto_table:101"


### PR DESCRIPTION
I think we didn't add this before because we didn't want to rule out the possibility of a pod participating in a VXLAN with some external host. However, it seems like that's not really a possibility: a host that isn't on the SDN wouldn't be able to send packets directly to the pod's IP, and a host that is on the SDN wouldn't be able to accept packets on the vxlan port because OVS would already have claimed it. So there is no way for an external host to send VXLAN packets to a pod (other than by using some alternate port, which wouldn't be affected by this patch).

The more-complicated alternative to this patch would be to add per-node flows to specifically recognize pod-to-node traffic, and only filter out pod-to-node-vxlan-port traffic.

@openshift/sig-networking please discuss.