### PR TITLE
UPSTREAM: 70311: fix ContinueOnError visitor

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource/builder.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource/builder.go
@@ -1089,9 +1089,10 @@ func (b *Builder) Do() *Result {
 	if b.requireObject {
 		helpers = append(helpers, RetrieveLazy)
 	}
-	r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	if b.continueOnError {
-		r.visitor = ContinueOnErrorVisitor{r.visitor}
+		r.visitor = NewDecoratedVisitor(ContinueOnErrorVisitor{r.visitor}, helpers...)
+	} else {
+		r.visitor = NewDecoratedVisitor(r.visitor, helpers...)
 	}
 	return r
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1641991

Based on the godoc and desired behavior of the ContinueOnError visitor, encountering an error while visiting results should not short-circuit a visitor chain.

This patch removes existing behavior, which wraps a decorated visitor in a ContinueOnError visitor, and introduces the originally-intended behavior which uses a ContinueOnError visitor as the visitor in a DecoratedVisitor list.

cc @soltysh 