### PR TITLE
[3.10] Don't allow pods to send VXLAN packets out of the SDN

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -193,6 +193,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	otx.AddFlow("table=90, priority=0, actions=drop")
 
 	// Table 100: egress routing; edited by SetNamespaceEgress*()
+	otx.AddFlow("table=100, priority=300,udp,udp_dst=%s,actions=drop", vxlanPort)
 	otx.AddFlow("table=100, priority=200,tcp,tcp_dst=53,nw_dst=%s,actions=output:2", oc.localIP)
 	otx.AddFlow("table=100, priority=200,udp,udp_dst=53,nw_dst=%s,actions=output:2", oc.localIP)
 	// eg, "table=100, priority=100, reg0=${tenant_id}, ip, actions=set_field:${tun0_mac}->eth_dst,set_field:${egress_mark}->pkt_mark,goto_table:101"


### PR DESCRIPTION
Backport of #21363. (But now without configurable VXLAN port.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643965