### PR TITLE
Updating postcommit hooks to use correct options

### DIFF
--- a/examples/sample-app/application-template-custombuild.json
+++ b/examples/sample-app/application-template-custombuild.json
@@ -156,7 +156,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/examples/sample-app/application-template-dockerbuild.json
+++ b/examples/sample-app/application-template-dockerbuild.json
@@ -155,7 +155,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/examples/sample-app/application-template-pullspecbuild.json
+++ b/examples/sample-app/application-template-pullspecbuild.json
@@ -145,7 +145,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/examples/sample-app/application-template-stibuild.json
+++ b/examples/sample-app/application-template-stibuild.json
@@ -155,7 +155,7 @@
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -19154,7 +19154,7 @@ var _examplesSampleAppApplicationTemplateCustombuildJson = []byte(`{
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },
@@ -19661,7 +19661,7 @@ var _examplesSampleAppApplicationTemplateDockerbuildJson = []byte(`{
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },
@@ -20108,7 +20108,7 @@ var _examplesSampleAppApplicationTemplatePullspecbuildJson = []byte(`{
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },
@@ -20615,7 +20615,7 @@ var _examplesSampleAppApplicationTemplateStibuildJson = []byte(`{
           }
         },
         "postCommit": {
-          "args": ["bundle", "exec", "rake", "test"]
+          "script": "bundle exec rake test"
         },
         "resources": {}
       },


### PR DESCRIPTION
Corrects issue referenced at https://jira.coreos.com/browse/DEVEXP-170?focusedCommentId=52856&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-52856

Rails should use the "script" option for postCommit hooks, as referenced in the below templates:
https://github.com/sclorg/rails-ex/blob/master/openshift/templates/rails-postgresql-persistent.json
https://github.com/sclorg/rails-ex/blob/master/openshift/templates/rails-postgresql.json

And also by looking at the documentation the "script" options seems correct instead of the "args" option, as "args" is supposed to be for supplying arguments to the default entrypoint for the image.