### PR TITLE
UPSTREAM: 69313: kubelet: fix cri-o when using unix prefix

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/util.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cadvisor/util.go
@@ -76,5 +76,5 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 // UsingLegacyCadvisorStats returns true if container stats are provided by cadvisor instead of through the CRI
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
 	return (runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux") ||
-		runtimeEndpoint == CrioSocket
+		runtimeEndpoint == CrioSocket || runtimeEndpoint == "unix://"+CrioSocket
 }


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/69313

xref https://bugzilla.redhat.com/show_bug.cgi?id=1631300

@mrunalp @runcom 