### PR TITLE
Disable wildcard dns extended test

### DIFF
--- a/test/extended/setup.sh
+++ b/test/extended/setup.sh
@@ -15,9 +15,13 @@ function os::test::extended::focus () {
 	if [[ -n "${FOCUS:-}" ]]; then
 		exitstatus=0
 
+		local skip="\[Serial\]"
+		if [[ -n "${SKIP:-}" ]]; then
+		    skip+="|${SKIP}"
+		fi
 		# first run anything that isn't explicitly declared [Serial], and matches the $FOCUS, in a parallel mode.
 		os::log::info "Running parallel tests N=${PARALLEL_NODES:-<default>} with focus ${FOCUS}"
-		TEST_REPORT_FILE_NAME=focus_parallel TEST_PARALLEL="${PARALLEL_NODES:-5}" os::test::extended::run -- -ginkgo.skip "\[Serial\]" -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
+		TEST_REPORT_FILE_NAME=focus_parallel TEST_PARALLEL="${PARALLEL_NODES:-5}" os::test::extended::run -- -ginkgo.skip "${skip}" -test.timeout 6h ${TEST_EXTENDED_ARGS-} || exitstatus=$?
 
 		# Then run everything that requires serial and matches the $FOCUS, serially.
 		# there is bit of overlap here because not all serial tests declare [Serial], so they might have run in the

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -321,6 +321,7 @@ var (
 			`Services should be able to up and down services`,                // we don't have wget installed on nodes
 			`Network should set TCP CLOSE_WAIT timeout`,                      // possibly some difference between ubuntu and fedora
 			`should allow ingress access on one named port`,                  // broken even with network policy on
+			`should answer endpoint and wildcard queries for the cluster`,    // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
 
 			`\[NodeFeature:Sysctls\]`, // needs SCC support
 


### PR DESCRIPTION
- Currently not supported by openshift dns operator
This functionality is needed to ensure backward compatibility.

- Extended tests should honor SKIP env when FOCUS env is set
