### PR TITLE
Collapse on top of upstream ETCD storage test

### DIFF
--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -29,6 +29,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	kapihelper "k8s.io/kubernetes/pkg/apis/core/helper"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	etcddata "k8s.io/kubernetes/test/integration/etcd"
 
 	serverapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
@@ -42,727 +43,722 @@ import (
 )
 
 // Etcd data for all persisted objects.
-var etcdStorageData = map[schema.GroupVersionResource]struct {
-	stub             string                   // Valid JSON stub to use during create
-	prerequisites    []prerequisite           // Optional, ordered list of JSON objects to create before stub
-	expectedEtcdPath string                   // Expected location of object in etcd, do not use any variables, constants, etc to derive this value - always supply the full raw string
-	expectedGVK      *schema.GroupVersionKind // The GVK that we expect this object to be stored as - leave this nil to use the default
-}{
+var etcdStorageData = map[schema.GroupVersionResource]etcddata.StorageData{
 	// github.com/openshift/origin/pkg/authorization/apis/authorization/v1
 	gvr("", "v1", "roles"): {
-		stub:             `{"metadata": {"name": "r1b1o1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1o1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "r1b1o1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1o1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"), // proxy to RBAC
 	},
 	gvr("authorization.openshift.io", "v1", "roles"): {
-		stub:             `{"metadata": {"name": "r1b1o2"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1o2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "r1b1o2"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1o2",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"), // proxy to RBAC
 	},
 	gvr("", "v1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "cr1a1o1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/clusterroles/cr1a1o1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "cr1a1o1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterroles/cr1a1o1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"), // proxy to RBAC
 	},
 	gvr("authorization.openshift.io", "v1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "cr1a1o2"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/clusterroles/cr1a1o2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "cr1a1o2"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterroles/cr1a1o2",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"), // proxy to RBAC
 	},
 	gvr("", "v1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "rb1a1o1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1o1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "rb1a1o1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1o1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"), // proxy to RBAC
 	},
 	gvr("authorization.openshift.io", "v1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "rb1a1o2"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1o2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "rb1a1o2"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1o2",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"), // proxy to RBAC
 	},
 	gvr("", "v1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "crb1a1o1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1o1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "crb1a1o1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1o1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"), // proxy to RBAC
 	},
 	gvr("authorization.openshift.io", "v1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "crb1a1o2"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1o2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"), // proxy to RBAC
+		Stub:             `{"metadata": {"name": "crb1a1o2"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1o2",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"), // proxy to RBAC
 	},
 	gvr("", "v1", "rolebindingrestrictions"): {
-		stub:             `{"metadata": {"name": "rbr"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
-		expectedEtcdPath: "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbr",
-		expectedGVK:      gvkP("authorization.openshift.io", "v1", "RoleBindingRestriction"),
+		Stub:             `{"metadata": {"name": "rbr"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
+		ExpectedEtcdPath: "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbr",
+		ExpectedGVK:      gvkP("authorization.openshift.io", "v1", "RoleBindingRestriction"),
 	},
 	gvr("authorization.openshift.io", "v1", "rolebindingrestrictions"): {
-		stub:             `{"metadata": {"name": "rbrg"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
-		expectedEtcdPath: "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbrg",
+		Stub:             `{"metadata": {"name": "rbrg"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
+		ExpectedEtcdPath: "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbrg",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/build/apis/build/v1
 	gvr("", "v1", "builds"): {
-		stub:             `{"metadata": {"name": "build1"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
-		expectedEtcdPath: "openshift.io/builds/etcdstoragepathtestnamespace/build1",
-		expectedGVK:      gvkP("build.openshift.io", "v1", "Build"),
+		Stub:             `{"metadata": {"name": "build1"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
+		ExpectedEtcdPath: "openshift.io/builds/etcdstoragepathtestnamespace/build1",
+		ExpectedGVK:      gvkP("build.openshift.io", "v1", "Build"),
 	},
 	gvr("build.openshift.io", "v1", "builds"): {
-		stub:             `{"metadata": {"name": "build1g"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
-		expectedEtcdPath: "openshift.io/builds/etcdstoragepathtestnamespace/build1g",
+		Stub:             `{"metadata": {"name": "build1g"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
+		ExpectedEtcdPath: "openshift.io/builds/etcdstoragepathtestnamespace/build1g",
 	},
 	gvr("", "v1", "buildconfigs"): {
-		stub:             `{"metadata": {"name": "bc1"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
-		expectedEtcdPath: "openshift.io/buildconfigs/etcdstoragepathtestnamespace/bc1",
-		expectedGVK:      gvkP("build.openshift.io", "v1", "BuildConfig"),
+		Stub:             `{"metadata": {"name": "bc1"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
+		ExpectedEtcdPath: "openshift.io/buildconfigs/etcdstoragepathtestnamespace/bc1",
+		ExpectedGVK:      gvkP("build.openshift.io", "v1", "BuildConfig"),
 	},
 	gvr("build.openshift.io", "v1", "buildconfigs"): {
-		stub:             `{"metadata": {"name": "bc1g"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
-		expectedEtcdPath: "openshift.io/buildconfigs/etcdstoragepathtestnamespace/bc1g",
+		Stub:             `{"metadata": {"name": "bc1g"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
+		ExpectedEtcdPath: "openshift.io/buildconfigs/etcdstoragepathtestnamespace/bc1g",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/apps/apis/apps/v1
 	gvr("", "v1", "deploymentconfigs"): {
-		stub:             `{"metadata": {"name": "dc1"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
-		expectedEtcdPath: "openshift.io/deploymentconfigs/etcdstoragepathtestnamespace/dc1",
-		expectedGVK:      gvkP("apps.openshift.io", "v1", "DeploymentConfig"),
+		Stub:             `{"metadata": {"name": "dc1"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
+		ExpectedEtcdPath: "openshift.io/deploymentconfigs/etcdstoragepathtestnamespace/dc1",
+		ExpectedGVK:      gvkP("apps.openshift.io", "v1", "DeploymentConfig"),
 	},
 	gvr("apps.openshift.io", "v1", "deploymentconfigs"): {
-		stub:             `{"metadata": {"name": "dc1g"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
-		expectedEtcdPath: "openshift.io/deploymentconfigs/etcdstoragepathtestnamespace/dc1g",
+		Stub:             `{"metadata": {"name": "dc1g"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
+		ExpectedEtcdPath: "openshift.io/deploymentconfigs/etcdstoragepathtestnamespace/dc1g",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/image/apis/image/v1
 	gvr("", "v1", "imagestreams"): {
-		stub:             `{"metadata": {"name": "is1"}, "spec": {"dockerImageRepository": "docker"}}`,
-		expectedEtcdPath: "openshift.io/imagestreams/etcdstoragepathtestnamespace/is1",
-		expectedGVK:      gvkP("image.openshift.io", "v1", "ImageStream"),
+		Stub:             `{"metadata": {"name": "is1"}, "spec": {"dockerImageRepository": "docker"}}`,
+		ExpectedEtcdPath: "openshift.io/imagestreams/etcdstoragepathtestnamespace/is1",
+		ExpectedGVK:      gvkP("image.openshift.io", "v1", "ImageStream"),
 	},
 	gvr("image.openshift.io", "v1", "imagestreams"): {
-		stub:             `{"metadata": {"name": "is1g"}, "spec": {"dockerImageRepository": "docker"}}`,
-		expectedEtcdPath: "openshift.io/imagestreams/etcdstoragepathtestnamespace/is1g",
+		Stub:             `{"metadata": {"name": "is1g"}, "spec": {"dockerImageRepository": "docker"}}`,
+		ExpectedEtcdPath: "openshift.io/imagestreams/etcdstoragepathtestnamespace/is1g",
 	},
 	gvr("", "v1", "images"): {
-		stub:             `{"dockerImageReference": "fedora:latest", "metadata": {"name": "image1"}}`,
-		expectedEtcdPath: "openshift.io/images/image1",
-		expectedGVK:      gvkP("image.openshift.io", "v1", "Image"),
+		Stub:             `{"dockerImageReference": "fedora:latest", "metadata": {"name": "image1"}}`,
+		ExpectedEtcdPath: "openshift.io/images/image1",
+		ExpectedGVK:      gvkP("image.openshift.io", "v1", "Image"),
 	},
 	gvr("image.openshift.io", "v1", "images"): {
-		stub:             `{"dockerImageReference": "fedora:latest", "metadata": {"name": "image1g"}}`,
-		expectedEtcdPath: "openshift.io/images/image1g",
+		Stub:             `{"dockerImageReference": "fedora:latest", "metadata": {"name": "image1g"}}`,
+		ExpectedEtcdPath: "openshift.io/images/image1g",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/oauth/apis/oauth/v1
 	gvr("", "v1", "oauthclientauthorizations"): {
-		stub:             `{"clientName": "system:serviceaccount:etcdstoragepathtestnamespace:client", "metadata": {"name": "user:system:serviceaccount:etcdstoragepathtestnamespace:client"}, "scopes": ["user:info"], "userName": "user", "userUID": "cannot be empty"}`,
-		expectedEtcdPath: "openshift.io/oauth/clientauthorizations/user:system:serviceaccount:etcdstoragepathtestnamespace:client",
-		prerequisites: []prerequisite{
+		Stub:             `{"clientName": "system:serviceaccount:etcdstoragepathtestnamespace:client", "metadata": {"name": "user:system:serviceaccount:etcdstoragepathtestnamespace:client"}, "scopes": ["user:info"], "userName": "user", "userUID": "cannot be empty"}`,
+		ExpectedEtcdPath: "openshift.io/oauth/clientauthorizations/user:system:serviceaccount:etcdstoragepathtestnamespace:client",
+		Prerequisites: []etcddata.Prerequisite{
 			{
-				gvrData: gvr("", "v1", "serviceaccounts"),
-				stub:    `{"metadata": {"annotations": {"serviceaccounts.openshift.io/oauth-redirecturi.foo": "http://bar"}, "name": "client"}}`,
+				GvrData: gvr("", "v1", "serviceaccounts"),
+				Stub:    `{"metadata": {"annotations": {"serviceaccounts.openshift.io/oauth-redirecturi.foo": "http://bar"}, "name": "client"}}`,
 			},
 			{
-				gvrData: gvr("", "v1", "secrets"),
-				stub:    `{"metadata": {"annotations": {"kubernetes.io/service-account.name": "client"}, "generateName": "client"}, "type": "kubernetes.io/service-account-token"}`,
+				GvrData: gvr("", "v1", "secrets"),
+				Stub:    `{"metadata": {"annotations": {"kubernetes.io/service-account.name": "client"}, "generateName": "client"}, "type": "kubernetes.io/service-account-token"}`,
 			},
 		},
-		expectedGVK: gvkP("oauth.openshift.io", "v1", "OAuthClientAuthorization"),
+		ExpectedGVK: gvkP("oauth.openshift.io", "v1", "OAuthClientAuthorization"),
 	},
 	gvr("oauth.openshift.io", "v1", "oauthclientauthorizations"): {
-		stub:             `{"clientName": "system:serviceaccount:etcdstoragepathtestnamespace:clientg", "metadata": {"name": "user:system:serviceaccount:etcdstoragepathtestnamespace:clientg"}, "scopes": ["user:info"], "userName": "user", "userUID": "cannot be empty"}`,
-		expectedEtcdPath: "openshift.io/oauth/clientauthorizations/user:system:serviceaccount:etcdstoragepathtestnamespace:clientg",
-		prerequisites: []prerequisite{
+		Stub:             `{"clientName": "system:serviceaccount:etcdstoragepathtestnamespace:clientg", "metadata": {"name": "user:system:serviceaccount:etcdstoragepathtestnamespace:clientg"}, "scopes": ["user:info"], "userName": "user", "userUID": "cannot be empty"}`,
+		ExpectedEtcdPath: "openshift.io/oauth/clientauthorizations/user:system:serviceaccount:etcdstoragepathtestnamespace:clientg",
+		Prerequisites: []etcddata.Prerequisite{
 			{
-				gvrData: gvr("", "v1", "serviceaccounts"),
-				stub:    `{"metadata": {"annotations": {"serviceaccounts.openshift.io/oauth-redirecturi.foo": "http://bar"}, "name": "clientg"}}`,
+				GvrData: gvr("", "v1", "serviceaccounts"),
+				Stub:    `{"metadata": {"annotations": {"serviceaccounts.openshift.io/oauth-redirecturi.foo": "http://bar"}, "name": "clientg"}}`,
 			},
 			{
-				gvrData: gvr("", "v1", "secrets"),
-				stub:    `{"metadata": {"annotations": {"kubernetes.io/service-account.name": "clientg"}, "generateName": "clientg"}, "type": "kubernetes.io/service-account-token"}`,
+				GvrData: gvr("", "v1", "secrets"),
+				Stub:    `{"metadata": {"annotations": {"kubernetes.io/service-account.name": "clientg"}, "generateName": "clientg"}, "type": "kubernetes.io/service-account-token"}`,
 			},
 		},
 	},
 	gvr("", "v1", "oauthaccesstokens"): {
-		stub:             `{"clientName": "client1", "metadata": {"name": "tokenneedstobelongenoughelseitwontwork"}, "userName": "user", "userUID": "cannot be empty"}`,
-		expectedEtcdPath: "openshift.io/oauth/accesstokens/tokenneedstobelongenoughelseitwontwork",
-		prerequisites: []prerequisite{
+		Stub:             `{"clientName": "client1", "metadata": {"name": "tokenneedstobelongenoughelseitwontwork"}, "userName": "user", "userUID": "cannot be empty"}`,
+		ExpectedEtcdPath: "openshift.io/oauth/accesstokens/tokenneedstobelongenoughelseitwontwork",
+		Prerequisites: []etcddata.Prerequisite{
 			{
-				gvrData: gvr("", "v1", "oauthclients"),
-				stub:    `{"metadata": {"name": "client1"}}`,
+				GvrData: gvr("", "v1", "oauthclients"),
+				Stub:    `{"metadata": {"name": "client1"}}`,
 			},
 		},
-		expectedGVK: gvkP("oauth.openshift.io", "v1", "OAuthAccessToken"),
+		ExpectedGVK: gvkP("oauth.openshift.io", "v1", "OAuthAccessToken"),
 	},
 	gvr("oauth.openshift.io", "v1", "oauthaccesstokens"): {
-		stub:             `{"clientName": "client1g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "userUID": "cannot be empty"}`,
-		expectedEtcdPath: "openshift.io/oauth/accesstokens/tokenneedstobelongenoughelseitwontworkg",
-		prerequisites: []prerequisite{
+		Stub:             `{"clientName": "client1g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "userUID": "cannot be empty"}`,
+		ExpectedEtcdPath: "openshift.io/oauth/accesstokens/tokenneedstobelongenoughelseitwontworkg",
+		Prerequisites: []etcddata.Prerequisite{
 			{
-				gvrData: gvr("oauth.openshift.io", "v1", "oauthclients"),
-				stub:    `{"metadata": {"name": "client1g"}}`,
+				GvrData: gvr("oauth.openshift.io", "v1", "oauthclients"),
+				Stub:    `{"metadata": {"name": "client1g"}}`,
 			},
 		},
 	},
 	gvr("", "v1", "oauthauthorizetokens"): {
-		stub:             `{"clientName": "client0", "metadata": {"name": "tokenneedstobelongenoughelseitwontwork"}, "userName": "user", "userUID": "cannot be empty"}`,
-		expectedEtcdPath: "openshift.io/oauth/authorizetokens/tokenneedstobelongenoughelseitwontwork",
-		prerequisites: []prerequisite{
+		Stub:             `{"clientName": "client0", "metadata": {"name": "tokenneedstobelongenoughelseitwontwork"}, "userName": "user", "userUID": "cannot be empty"}`,
+		ExpectedEtcdPath: "openshift.io/oauth/authorizetokens/tokenneedstobelongenoughelseitwontwork",
+		Prerequisites: []etcddata.Prerequisite{
 			{
-				gvrData: gvr("", "v1", "oauthclients"),
-				stub:    `{"metadata": {"name": "client0"}}`,
+				GvrData: gvr("", "v1", "oauthclients"),
+				Stub:    `{"metadata": {"name": "client0"}}`,
 			},
 		},
-		expectedGVK: gvkP("oauth.openshift.io", "v1", "OAuthAuthorizeToken"),
+		ExpectedGVK: gvkP("oauth.openshift.io", "v1", "OAuthAuthorizeToken"),
 	},
 	gvr("oauth.openshift.io", "v1", "oauthauthorizetokens"): {
-		stub:             `{"clientName": "client0g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "userUID": "cannot be empty"}`,
-		expectedEtcdPath: "openshift.io/oauth/authorizetokens/tokenneedstobelongenoughelseitwontworkg",
-		prerequisites: []prerequisite{
+		Stub:             `{"clientName": "client0g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "userUID": "cannot be empty"}`,
+		ExpectedEtcdPath: "openshift.io/oauth/authorizetokens/tokenneedstobelongenoughelseitwontworkg",
+		Prerequisites: []etcddata.Prerequisite{
 			{
-				gvrData: gvr("oauth.openshift.io", "v1", "oauthclients"),
-				stub:    `{"metadata": {"name": "client0g"}}`,
+				GvrData: gvr("oauth.openshift.io", "v1", "oauthclients"),
+				Stub:    `{"metadata": {"name": "client0g"}}`,
 			},
 		},
 	},
 	gvr("", "v1", "oauthclients"): {
-		stub:             `{"metadata": {"name": "client"}}`,
-		expectedEtcdPath: "openshift.io/oauth/clients/client",
-		expectedGVK:      gvkP("oauth.openshift.io", "v1", "OAuthClient"),
+		Stub:             `{"metadata": {"name": "client"}}`,
+		ExpectedEtcdPath: "openshift.io/oauth/clients/client",
+		ExpectedGVK:      gvkP("oauth.openshift.io", "v1", "OAuthClient"),
 	},
 	gvr("oauth.openshift.io", "v1", "oauthclients"): {
-		stub:             `{"metadata": {"name": "clientg"}}`,
-		expectedEtcdPath: "openshift.io/oauth/clients/clientg",
+		Stub:             `{"metadata": {"name": "clientg"}}`,
+		ExpectedEtcdPath: "openshift.io/oauth/clients/clientg",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/project/apis/project/v1
 	gvr("", "v1", "projects"): {
-		stub:             `{"metadata": {"name": "namespace2"}, "spec": {"finalizers": ["kubernetes", "openshift.io/origin"]}}`,
-		expectedEtcdPath: "kubernetes.io/namespaces/namespace2",
-		expectedGVK:      gvkP("", "v1", "Namespace"), // project is a proxy for namespace
+		Stub:             `{"metadata": {"name": "namespace2"}, "spec": {"finalizers": ["kubernetes", "openshift.io/origin"]}}`,
+		ExpectedEtcdPath: "kubernetes.io/namespaces/namespace2",
+		ExpectedGVK:      gvkP("", "v1", "Namespace"), // project is a proxy for namespace
 	},
 	gvr("project.openshift.io", "v1", "projects"): {
-		stub:             `{"metadata": {"name": "namespace2g"}, "spec": {"finalizers": ["kubernetes", "openshift.io/origin"]}}`,
-		expectedEtcdPath: "kubernetes.io/namespaces/namespace2g",
-		expectedGVK:      gvkP("", "v1", "Namespace"), // project is a proxy for namespace
+		Stub:             `{"metadata": {"name": "namespace2g"}, "spec": {"finalizers": ["kubernetes", "openshift.io/origin"]}}`,
+		ExpectedEtcdPath: "kubernetes.io/namespaces/namespace2g",
+		ExpectedGVK:      gvkP("", "v1", "Namespace"), // project is a proxy for namespace
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/quota/apis/quota/v1
 	gvr("", "v1", "clusterresourcequotas"): {
-		stub:             `{"metadata": {"name": "quota1"}, "spec": {"selector": {"labels": {"matchLabels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "openshift.io/clusterresourcequotas/quota1",
-		expectedGVK:      gvkP("quota.openshift.io", "v1", "ClusterResourceQuota"),
+		Stub:             `{"metadata": {"name": "quota1"}, "spec": {"selector": {"labels": {"matchLabels": {"a": "b"}}}}}`,
+		ExpectedEtcdPath: "openshift.io/clusterresourcequotas/quota1",
+		ExpectedGVK:      gvkP("quota.openshift.io", "v1", "ClusterResourceQuota"),
 	},
 	gvr("quota.openshift.io", "v1", "clusterresourcequotas"): {
-		stub:             `{"metadata": {"name": "quota1g"}, "spec": {"selector": {"labels": {"matchLabels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "openshift.io/clusterresourcequotas/quota1g",
+		Stub:             `{"metadata": {"name": "quota1g"}, "spec": {"selector": {"labels": {"matchLabels": {"a": "b"}}}}}`,
+		ExpectedEtcdPath: "openshift.io/clusterresourcequotas/quota1g",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/route/apis/route/v1
 	gvr("", "v1", "routes"): {
-		stub:             `{"metadata": {"name": "route1"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
-		expectedEtcdPath: "openshift.io/routes/etcdstoragepathtestnamespace/route1",
-		expectedGVK:      gvkP("route.openshift.io", "v1", "Route"),
+		Stub:             `{"metadata": {"name": "route1"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
+		ExpectedEtcdPath: "openshift.io/routes/etcdstoragepathtestnamespace/route1",
+		ExpectedGVK:      gvkP("route.openshift.io", "v1", "Route"),
 	},
 	gvr("route.openshift.io", "v1", "routes"): {
-		stub:             `{"metadata": {"name": "route1g"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
-		expectedEtcdPath: "openshift.io/routes/etcdstoragepathtestnamespace/route1g",
+		Stub:             `{"metadata": {"name": "route1g"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
+		ExpectedEtcdPath: "openshift.io/routes/etcdstoragepathtestnamespace/route1g",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/network/apis/network/v1
 	gvr("", "v1", "netnamespaces"): {
-		stub:             `{"metadata": {"name": "networkname"}, "netid": 100, "netname": "networkname"}`,
-		expectedEtcdPath: "openshift.io/registry/sdnnetnamespaces/networkname",
-		expectedGVK:      gvkP("network.openshift.io", "v1", "NetNamespace"),
+		Stub:             `{"metadata": {"name": "networkname"}, "netid": 100, "netname": "networkname"}`,
+		ExpectedEtcdPath: "openshift.io/registry/sdnnetnamespaces/networkname",
+		ExpectedGVK:      gvkP("network.openshift.io", "v1", "NetNamespace"),
 	},
 	gvr("", "v1", "hostsubnets"): {
-		stub:             `{"host": "hostname", "hostIP": "192.168.1.1", "metadata": {"name": "hostname"}, "subnet": "192.168.1.0/24"}`,
-		expectedEtcdPath: "openshift.io/registry/sdnsubnets/hostname",
-		expectedGVK:      gvkP("network.openshift.io", "v1", "HostSubnet"),
+		Stub:             `{"host": "hostname", "hostIP": "192.168.1.1", "metadata": {"name": "hostname"}, "subnet": "192.168.1.0/24"}`,
+		ExpectedEtcdPath: "openshift.io/registry/sdnsubnets/hostname",
+		ExpectedGVK:      gvkP("network.openshift.io", "v1", "HostSubnet"),
 	},
 	gvr("", "v1", "clusternetworks"): {
-		stub:             `{"metadata": {"name": "cn1"}, "serviceNetwork": "192.168.1.0/24", "clusterNetworks": [{"CIDR": "192.166.0.0/16", "hostSubnetLength": 8}], "vxlan":""}`,
-		expectedEtcdPath: "openshift.io/registry/sdnnetworks/cn1",
-		expectedGVK:      gvkP("network.openshift.io", "v1", "ClusterNetwork"),
+		Stub:             `{"metadata": {"name": "cn1"}, "serviceNetwork": "192.168.1.0/24", "clusterNetworks": [{"CIDR": "192.166.0.0/16", "hostSubnetLength": 8}], "vxlan":""}`,
+		ExpectedEtcdPath: "openshift.io/registry/sdnnetworks/cn1",
+		ExpectedGVK:      gvkP("network.openshift.io", "v1", "ClusterNetwork"),
 	},
 	gvr("", "v1", "egressnetworkpolicies"): {
-		stub:             `{"metadata": {"name": "enp1"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.0/24"}, "type": "Allow"}]}}`,
-		expectedEtcdPath: "openshift.io/registry/egressnetworkpolicy/etcdstoragepathtestnamespace/enp1",
-		expectedGVK:      gvkP("network.openshift.io", "v1", "EgressNetworkPolicy"),
+		Stub:             `{"metadata": {"name": "enp1"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.0/24"}, "type": "Allow"}]}}`,
+		ExpectedEtcdPath: "openshift.io/registry/egressnetworkpolicy/etcdstoragepathtestnamespace/enp1",
+		ExpectedGVK:      gvkP("network.openshift.io", "v1", "EgressNetworkPolicy"),
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/security/apis/security/v1
 	gvr("security.openshift.io", "v1", "securitycontextconstraints"): {
-		stub:             `{"allowPrivilegedContainer": true, "fsGroup": {"type": "RunAsAny"}, "metadata": {"name": "scc2"}, "runAsUser": {"type": "RunAsAny"}, "seLinuxContext": {"type": "MustRunAs"}, "supplementalGroups": {"type": "RunAsAny"}}`,
-		expectedEtcdPath: "openshift.io/securitycontextconstraints/scc2",
+		Stub:             `{"allowPrivilegedContainer": true, "fsGroup": {"type": "RunAsAny"}, "metadata": {"name": "scc2"}, "runAsUser": {"type": "RunAsAny"}, "seLinuxContext": {"type": "MustRunAs"}, "supplementalGroups": {"type": "RunAsAny"}}`,
+		ExpectedEtcdPath: "openshift.io/securitycontextconstraints/scc2",
 	},
 	gvr("security.openshift.io", "v1", "rangeallocations"): {
-		stub:             `{"metadata": {"name": "scc2"}}`,
-		expectedEtcdPath: "openshift.io/rangeallocations/scc2",
+		Stub:             `{"metadata": {"name": "scc2"}}`,
+		ExpectedEtcdPath: "openshift.io/rangeallocations/scc2",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/template/apis/template/v1
 	gvr("", "v1", "templates"): {
-		stub:             `{"message": "Jenkins template", "metadata": {"name": "template1"}}`,
-		expectedEtcdPath: "openshift.io/templates/etcdstoragepathtestnamespace/template1",
-		expectedGVK:      gvkP("template.openshift.io", "v1", "Template"),
+		Stub:             `{"message": "Jenkins template", "metadata": {"name": "template1"}}`,
+		ExpectedEtcdPath: "openshift.io/templates/etcdstoragepathtestnamespace/template1",
+		ExpectedGVK:      gvkP("template.openshift.io", "v1", "Template"),
 	},
 	gvr("template.openshift.io", "v1", "templates"): {
-		stub:             `{"message": "Jenkins template", "metadata": {"name": "template1g"}}`,
-		expectedEtcdPath: "openshift.io/templates/etcdstoragepathtestnamespace/template1g",
+		Stub:             `{"message": "Jenkins template", "metadata": {"name": "template1g"}}`,
+		ExpectedEtcdPath: "openshift.io/templates/etcdstoragepathtestnamespace/template1g",
 	},
 	gvr("template.openshift.io", "v1", "templateinstances"): {
-		stub:             `{"metadata": {"name": "templateinstance1"}, "spec": {"template": {"metadata": {"name": "template1", "namespace": "etcdstoragepathtestnamespace"}}, "requester": {"username": "test"}}}`,
-		expectedEtcdPath: "openshift.io/templateinstances/etcdstoragepathtestnamespace/templateinstance1",
+		Stub:             `{"metadata": {"name": "templateinstance1"}, "spec": {"template": {"metadata": {"name": "template1", "namespace": "etcdstoragepathtestnamespace"}}, "requester": {"username": "test"}}}`,
+		ExpectedEtcdPath: "openshift.io/templateinstances/etcdstoragepathtestnamespace/templateinstance1",
 	},
 	gvr("template.openshift.io", "v1", "brokertemplateinstances"): {
-		stub:             `{"metadata": {"name": "brokertemplateinstance1"}, "spec": {"templateInstance": {"kind": "TemplateInstance", "name": "templateinstance1", "namespace": "etcdstoragepathtestnamespace"}, "secret": {"kind": "Secret", "name": "secret1", "namespace": "etcdstoragepathtestnamespace"}}}`,
-		expectedEtcdPath: "openshift.io/brokertemplateinstances/brokertemplateinstance1",
+		Stub:             `{"metadata": {"name": "brokertemplateinstance1"}, "spec": {"templateInstance": {"kind": "TemplateInstance", "name": "templateinstance1", "namespace": "etcdstoragepathtestnamespace"}, "secret": {"kind": "Secret", "name": "secret1", "namespace": "etcdstoragepathtestnamespace"}}}`,
+		ExpectedEtcdPath: "openshift.io/brokertemplateinstances/brokertemplateinstance1",
 	},
 	// --
 
 	// github.com/openshift/origin/pkg/user/apis/user/v1
 	gvr("", "v1", "groups"): {
-		stub:             `{"metadata": {"name": "group"}, "users": ["user1", "user2"]}`,
-		expectedEtcdPath: "openshift.io/groups/group",
-		expectedGVK:      gvkP("user.openshift.io", "v1", "Group"),
+		Stub:             `{"metadata": {"name": "group"}, "users": ["user1", "user2"]}`,
+		ExpectedEtcdPath: "openshift.io/groups/group",
+		ExpectedGVK:      gvkP("user.openshift.io", "v1", "Group"),
 	},
 	gvr("user.openshift.io", "v1", "groups"): {
-		stub:             `{"metadata": {"name": "groupg"}, "users": ["user1", "user2"]}`,
-		expectedEtcdPath: "openshift.io/groups/groupg",
+		Stub:             `{"metadata": {"name": "groupg"}, "users": ["user1", "user2"]}`,
+		ExpectedEtcdPath: "openshift.io/groups/groupg",
 	},
 	gvr("", "v1", "users"): {
-		stub:             `{"fullName": "user1", "metadata": {"name": "user1"}}`,
-		expectedEtcdPath: "openshift.io/users/user1",
-		expectedGVK:      gvkP("user.openshift.io", "v1", "User"),
+		Stub:             `{"fullName": "user1", "metadata": {"name": "user1"}}`,
+		ExpectedEtcdPath: "openshift.io/users/user1",
+		ExpectedGVK:      gvkP("user.openshift.io", "v1", "User"),
 	},
 	gvr("user.openshift.io", "v1", "users"): {
-		stub:             `{"fullName": "user1g", "metadata": {"name": "user1g"}}`,
-		expectedEtcdPath: "openshift.io/users/user1g",
+		Stub:             `{"fullName": "user1g", "metadata": {"name": "user1g"}}`,
+		ExpectedEtcdPath: "openshift.io/users/user1g",
 	},
 	gvr("", "v1", "identities"): {
-		stub:             `{"metadata": {"name": "github:user2"}, "providerName": "github", "providerUserName": "user2"}`,
-		expectedEtcdPath: "openshift.io/useridentities/github:user2",
-		expectedGVK:      gvkP("user.openshift.io", "v1", "Identity"),
+		Stub:             `{"metadata": {"name": "github:user2"}, "providerName": "github", "providerUserName": "user2"}`,
+		ExpectedEtcdPath: "openshift.io/useridentities/github:user2",
+		ExpectedGVK:      gvkP("user.openshift.io", "v1", "Identity"),
 	},
 	gvr("user.openshift.io", "v1", "identities"): {
-		stub:             `{"metadata": {"name": "github:user2g"}, "providerName": "github", "providerUserName": "user2g"}`,
-		expectedEtcdPath: "openshift.io/useridentities/github:user2g",
+		Stub:             `{"metadata": {"name": "github:user2g"}, "providerName": "github", "providerUserName": "user2g"}`,
+		ExpectedEtcdPath: "openshift.io/useridentities/github:user2g",
 	},
 	// --
 
 	// k8s.io/api/core/v1
 	gvr("", "v1", "configmaps"): {
-		stub:             `{"data": {"foo": "bar"}, "metadata": {"name": "cm1"}}`,
-		expectedEtcdPath: "kubernetes.io/configmaps/etcdstoragepathtestnamespace/cm1",
+		Stub:             `{"data": {"foo": "bar"}, "metadata": {"name": "cm1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/configmaps/etcdstoragepathtestnamespace/cm1",
 	},
 	gvr("", "v1", "services"): {
-		stub:             `{"metadata": {"name": "service1"}, "spec": {"externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000}], "selector": {"test": "data"}}}`,
-		expectedEtcdPath: "kubernetes.io/services/specs/etcdstoragepathtestnamespace/service1",
+		Stub:             `{"metadata": {"name": "service1"}, "spec": {"externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000}], "selector": {"test": "data"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/services/specs/etcdstoragepathtestnamespace/service1",
 	},
 	gvr("", "v1", "podtemplates"): {
-		stub:             `{"metadata": {"name": "pt1name"}, "template": {"metadata": {"labels": {"pt": "01"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container9"}]}}}`,
-		expectedEtcdPath: "kubernetes.io/podtemplates/etcdstoragepathtestnamespace/pt1name",
+		Stub:             `{"metadata": {"name": "pt1name"}, "template": {"metadata": {"labels": {"pt": "01"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container9"}]}}}`,
+		ExpectedEtcdPath: "kubernetes.io/podtemplates/etcdstoragepathtestnamespace/pt1name",
 	},
 	gvr("", "v1", "pods"): {
-		stub:             `{"metadata": {"name": "pod1"}, "spec": {"containers": [{"image": "fedora:latest", "name": "container7", "resources": {"limits": {"cpu": "1M"}, "requests": {"cpu": "1M"}}}]}}`,
-		expectedEtcdPath: "kubernetes.io/pods/etcdstoragepathtestnamespace/pod1",
+		Stub:             `{"metadata": {"name": "pod1"}, "spec": {"containers": [{"image": "fedora:latest", "name": "container7", "resources": {"limits": {"cpu": "1M"}, "requests": {"cpu": "1M"}}}]}}`,
+		ExpectedEtcdPath: "kubernetes.io/pods/etcdstoragepathtestnamespace/pod1",
 	},
 	gvr("", "v1", "endpoints"): {
-		stub:             `{"metadata": {"name": "ep1name"}, "subsets": [{"addresses": [{"hostname": "bar-001", "ip": "192.168.3.1"}], "ports": [{"port": 8000}]}]}`,
-		expectedEtcdPath: "kubernetes.io/services/endpoints/etcdstoragepathtestnamespace/ep1name",
+		Stub:             `{"metadata": {"name": "ep1name"}, "subsets": [{"addresses": [{"hostname": "bar-001", "ip": "192.168.3.1"}], "ports": [{"port": 8000}]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/services/endpoints/etcdstoragepathtestnamespace/ep1name",
 	},
 	gvr("", "v1", "resourcequotas"): {
-		stub:             `{"metadata": {"name": "rq1name"}, "spec": {"hard": {"cpu": "5M"}}}`,
-		expectedEtcdPath: "kubernetes.io/resourcequotas/etcdstoragepathtestnamespace/rq1name",
+		Stub:             `{"metadata": {"name": "rq1name"}, "spec": {"hard": {"cpu": "5M"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/resourcequotas/etcdstoragepathtestnamespace/rq1name",
 	},
 	gvr("", "v1", "limitranges"): {
-		stub:             `{"metadata": {"name": "lr1name"}, "spec": {"limits": [{"type": "Pod"}]}}`,
-		expectedEtcdPath: "kubernetes.io/limitranges/etcdstoragepathtestnamespace/lr1name",
+		Stub:             `{"metadata": {"name": "lr1name"}, "spec": {"limits": [{"type": "Pod"}]}}`,
+		ExpectedEtcdPath: "kubernetes.io/limitranges/etcdstoragepathtestnamespace/lr1name",
 	},
 	gvr("", "v1", "namespaces"): {
-		stub:             `{"metadata": {"name": "namespace1"}, "spec": {"finalizers": ["kubernetes"]}}`,
-		expectedEtcdPath: "kubernetes.io/namespaces/namespace1",
+		Stub:             `{"metadata": {"name": "namespace1"}, "spec": {"finalizers": ["kubernetes"]}}`,
+		ExpectedEtcdPath: "kubernetes.io/namespaces/namespace1",
 	},
 	gvr("", "v1", "nodes"): {
-		stub:             `{"metadata": {"name": "node1"}, "spec": {"unschedulable": true}}`,
-		expectedEtcdPath: "kubernetes.io/minions/node1",
+		Stub:             `{"metadata": {"name": "node1"}, "spec": {"unschedulable": true}}`,
+		ExpectedEtcdPath: "kubernetes.io/minions/node1",
 	},
 	gvr("", "v1", "persistentvolumes"): {
-		stub:             `{"metadata": {"name": "pv1name"}, "spec": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "3M"}, "hostPath": {"path": "/tmp/test/"}}}`,
-		expectedEtcdPath: "kubernetes.io/persistentvolumes/pv1name",
+		Stub:             `{"metadata": {"name": "pv1name"}, "spec": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "3M"}, "hostPath": {"path": "/tmp/test/"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/persistentvolumes/pv1name",
 	},
 	gvr("", "v1", "events"): {
-		stub:             `{"involvedObject": {"namespace": "etcdstoragepathtestnamespace"}, "message": "some data here", "metadata": {"name": "event1"}}`,
-		expectedEtcdPath: "kubernetes.io/events/etcdstoragepathtestnamespace/event1",
+		Stub:             `{"involvedObject": {"namespace": "etcdstoragepathtestnamespace"}, "message": "some data here", "metadata": {"name": "event1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/events/etcdstoragepathtestnamespace/event1",
 	},
 	gvr("", "v1", "persistentvolumeclaims"): {
-		stub:             `{"metadata": {"name": "pvc1"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"limits": {"storage": "1M"}, "requests": {"storage": "2M"}}, "selector": {"matchLabels": {"pvc": "stuff"}}}}`,
-		expectedEtcdPath: "kubernetes.io/persistentvolumeclaims/etcdstoragepathtestnamespace/pvc1",
+		Stub:             `{"metadata": {"name": "pvc1"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"limits": {"storage": "1M"}, "requests": {"storage": "2M"}}, "selector": {"matchLabels": {"pvc": "stuff"}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/persistentvolumeclaims/etcdstoragepathtestnamespace/pvc1",
 	},
 	gvr("", "v1", "serviceaccounts"): {
-		stub:             `{"metadata": {"name": "sa1name"}, "secrets": [{"name": "secret00"}]}`,
-		expectedEtcdPath: "kubernetes.io/serviceaccounts/etcdstoragepathtestnamespace/sa1name",
+		Stub:             `{"metadata": {"name": "sa1name"}, "secrets": [{"name": "secret00"}]}`,
+		ExpectedEtcdPath: "kubernetes.io/serviceaccounts/etcdstoragepathtestnamespace/sa1name",
 	},
 	gvr("", "v1", "secrets"): {
-		stub:             `{"data": {"key": "ZGF0YSBmaWxl"}, "metadata": {"name": "secret1"}}`,
-		expectedEtcdPath: "kubernetes.io/secrets/etcdstoragepathtestnamespace/secret1",
+		Stub:             `{"data": {"key": "ZGF0YSBmaWxl"}, "metadata": {"name": "secret1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/secrets/etcdstoragepathtestnamespace/secret1",
 	},
 	gvr("", "v1", "replicationcontrollers"): {
-		stub:             `{"metadata": {"name": "rc1"}, "spec": {"selector": {"new": "stuff"}, "template": {"metadata": {"labels": {"new": "stuff"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container8"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/controllers/etcdstoragepathtestnamespace/rc1",
+		Stub:             `{"metadata": {"name": "rc1"}, "spec": {"selector": {"new": "stuff"}, "template": {"metadata": {"labels": {"new": "stuff"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container8"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/controllers/etcdstoragepathtestnamespace/rc1",
 	},
 	// --
 
 	// TODO storage is broken somehow.  failing on v1beta1 serialization
 	//// k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1
 	//gvr("admissionregistration.k8s.io", "v1alpha1", "initializerconfigurations"): {
-	//	stub:             `{"metadata": {"name": "ic1"}}`,
-	//	expectedEtcdPath: "kubernetes.io/initializerconfigurations/ic1",
+	//	Stub:             `{"metadata": {"name": "ic1"}}`,
+	//	ExpectedEtcdPath: "kubernetes.io/initializerconfigurations/ic1",
 	//},
 	//// --
 
 	// k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1
 	gvr("admissionregistration.k8s.io", "v1beta1", "mutatingwebhookconfigurations"): {
-		stub:             `{"metadata": {"name": "ic1"}}`,
-		expectedEtcdPath: "kubernetes.io/mutatingwebhookconfigurations/ic1",
+		Stub:             `{"metadata": {"name": "ic1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/mutatingwebhookconfigurations/ic1",
 	},
 	gvr("admissionregistration.k8s.io", "v1beta1", "validatingwebhookconfigurations"): {
-		stub:             `{"metadata": {"name": "ic1"}}`,
-		expectedEtcdPath: "kubernetes.io/validatingwebhookconfigurations/ic1",
+		Stub:             `{"metadata": {"name": "ic1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/validatingwebhookconfigurations/ic1",
 	},
 	// --
 
 	// k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 	gvr("apiextensions.k8s.io", "v1beta1", "customresourcedefinitions"): {
-		stub:             `{"metadata": {"name": "openshiftwebconsoleconfigs.webconsole.operator.openshift.io"},"spec": {"scope": "Cluster","group": "webconsole.operator.openshift.io","version": "v1alpha1","names": {"kind": "OpenShiftWebConsoleConfig","plural": "openshiftwebconsoleconfigs","singular": "openshiftwebconsoleconfig"}}}`,
-		expectedEtcdPath: "kubernetes.io/apiextensions.k8s.io/customresourcedefinitions/openshiftwebconsoleconfigs.webconsole.operator.openshift.io",
+		Stub:             `{"metadata": {"name": "openshiftwebconsoleconfigs.webconsole.operator.openshift.io"},"spec": {"scope": "Cluster","group": "webconsole.operator.openshift.io","version": "v1alpha1","names": {"kind": "OpenShiftWebConsoleConfig","plural": "openshiftwebconsoleconfigs","singular": "openshiftwebconsoleconfig"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/apiextensions.k8s.io/customresourcedefinitions/openshiftwebconsoleconfigs.webconsole.operator.openshift.io",
 	},
 	gvr("cr.bar.com", "v1", "foos"): {
-		stub:             `{"kind": "Foo", "apiVersion": "cr.bar.com/v1", "metadata": {"name": "cr1foo"}, "color": "blue"}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
-		expectedEtcdPath: "kubernetes.io/cr.bar.com/foos/etcdstoragepathtestnamespace/cr1foo",
+		Stub:             `{"kind": "Foo", "apiVersion": "cr.bar.com/v1", "metadata": {"name": "cr1foo"}, "color": "blue"}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+		ExpectedEtcdPath: "kubernetes.io/cr.bar.com/foos/etcdstoragepathtestnamespace/cr1foo",
 	},
 	gvr("custom.fancy.com", "v2", "pants"): {
-		stub:             `{"kind": "Pant", "apiVersion": "custom.fancy.com/v2", "metadata": {"name": "cr2pant"}, "isFancy": true}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
-		expectedEtcdPath: "kubernetes.io/custom.fancy.com/pants/cr2pant",
+		Stub:             `{"kind": "Pant", "apiVersion": "custom.fancy.com/v2", "metadata": {"name": "cr2pant"}, "isFancy": true}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+		ExpectedEtcdPath: "kubernetes.io/custom.fancy.com/pants/cr2pant",
 	},
 	gvr("awesome.bears.com", "v1", "pandas"): {
-		stub:             `{"kind": "Panda", "apiVersion": "awesome.bears.com/v1", "metadata": {"name": "cr3panda"}, "weight": 100}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
-		expectedEtcdPath: "kubernetes.io/awesome.bears.com/pandas/cr3panda",
+		Stub:             `{"kind": "Panda", "apiVersion": "awesome.bears.com/v1", "metadata": {"name": "cr3panda"}, "weight": 100}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+		ExpectedEtcdPath: "kubernetes.io/awesome.bears.com/pandas/cr3panda",
 	},
 	gvr("awesome.bears.com", "v3", "pandas"): {
-		stub:             `{"kind": "Panda", "apiVersion": "awesome.bears.com/v3", "metadata": {"name": "cr4panda"}, "weight": 300}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
-		expectedEtcdPath: "kubernetes.io/awesome.bears.com/pandas/cr4panda",
-		expectedGVK:      gvkP("awesome.bears.com", "v1", "Panda"),
+		Stub:             `{"kind": "Panda", "apiVersion": "awesome.bears.com/v3", "metadata": {"name": "cr4panda"}, "weight": 300}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+		ExpectedEtcdPath: "kubernetes.io/awesome.bears.com/pandas/cr4panda",
+		ExpectedGVK:      gvkP("awesome.bears.com", "v1", "Panda"),
 	},
 	// --
 
 	// k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 	// depends on aggregator using the same ungrouped RESTOptionsGetter as the kube apiserver, not SimpleRestOptionsFactory in aggregator.go
 	gvr("apiregistration.k8s.io", "v1beta1", "apiservices"): {
-		stub:             `{"metadata": {"name": "as1.foo.com"}, "spec": {"group": "foo.com", "version": "as1", "groupPriorityMinimum":100, "versionPriority":10}}`,
-		expectedEtcdPath: "kubernetes.io/apiservices/as1.foo.com",
-		expectedGVK:      gvkP("apiregistration.k8s.io", "v1", "APIService"),
+		Stub:             `{"metadata": {"name": "as1.foo.com"}, "spec": {"group": "foo.com", "version": "as1", "groupPriorityMinimum":100, "versionPriority":10}}`,
+		ExpectedEtcdPath: "kubernetes.io/apiservices/as1.foo.com",
+		ExpectedGVK:      gvkP("apiregistration.k8s.io", "v1", "APIService"),
 	},
 	// --
 
 	// k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 	// depends on aggregator using the same ungrouped RESTOptionsGetter as the kube apiserver, not SimpleRestOptionsFactory in aggregator.go
 	gvr("apiregistration.k8s.io", "v1", "apiservices"): {
-		stub:             `{"metadata": {"name": "as2.foo.com"}, "spec": {"group": "foo.com", "version": "as2", "groupPriorityMinimum":100, "versionPriority":10}}`,
-		expectedEtcdPath: "kubernetes.io/apiservices/as2.foo.com",
+		Stub:             `{"metadata": {"name": "as2.foo.com"}, "spec": {"group": "foo.com", "version": "as2", "groupPriorityMinimum":100, "versionPriority":10}}`,
+		ExpectedEtcdPath: "kubernetes.io/apiservices/as2.foo.com",
 	},
 	// --
 
 	// k8s.io/api/apps/v1
 	gvr("apps", "v1", "daemonsets"): {
-		stub:             `{"metadata": {"name": "ds3"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/daemonsets/etcdstoragepathtestnamespace/ds3",
+		Stub:             `{"metadata": {"name": "ds3"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/daemonsets/etcdstoragepathtestnamespace/ds3",
 	},
 	gvr("apps", "v1", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment4"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment4",
+		Stub:             `{"metadata": {"name": "deployment4"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment4",
 	},
 	gvr("apps", "v1", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss4"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "kubernetes.io/statefulsets/etcdstoragepathtestnamespace/ss4",
+		Stub:             `{"metadata": {"name": "ss4"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/statefulsets/etcdstoragepathtestnamespace/ss4",
 	},
 	gvr("apps", "v1", "controllerrevisions"): {
-		stub:             `{"metadata": {"name": "cr3"}, "data": {}, "revision": 6}`,
-		expectedEtcdPath: "kubernetes.io/controllerrevisions/etcdstoragepathtestnamespace/cr3",
+		Stub:             `{"metadata": {"name": "cr3"}, "data": {}, "revision": 6}`,
+		ExpectedEtcdPath: "kubernetes.io/controllerrevisions/etcdstoragepathtestnamespace/cr3",
 	},
 	gvr("apps", "v1", "replicasets"): {
-		stub:             `{"metadata": {"name": "rs3"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/replicasets/etcdstoragepathtestnamespace/rs3",
+		Stub:             `{"metadata": {"name": "rs3"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/replicasets/etcdstoragepathtestnamespace/rs3",
 	},
 	// --
 
 	// k8s.io/api/apps/v1beta1
 	gvr("apps", "v1beta1", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment2"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment2",
-		expectedGVK:      gvkP("apps", "v1", "Deployment"),
+		Stub:             `{"metadata": {"name": "deployment2"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment2",
+		ExpectedGVK:      gvkP("apps", "v1", "Deployment"),
 	},
 	gvr("apps", "v1beta1", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss1"}, "spec": {"template": {"metadata": {"labels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "kubernetes.io/statefulsets/etcdstoragepathtestnamespace/ss1",
-		expectedGVK:      gvkP("apps", "v1", "StatefulSet"),
+		Stub:             `{"metadata": {"name": "ss1"}, "spec": {"template": {"metadata": {"labels": {"a": "b"}}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/statefulsets/etcdstoragepathtestnamespace/ss1",
+		ExpectedGVK:      gvkP("apps", "v1", "StatefulSet"),
 	},
 	gvr("apps", "v1beta1", "controllerrevisions"): {
-		stub:             `{"metadata": {"name": "cr1"}, "data": {}, "revision": 6}`,
-		expectedEtcdPath: "kubernetes.io/controllerrevisions/etcdstoragepathtestnamespace/cr1",
-		expectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
+		Stub:             `{"metadata": {"name": "cr1"}, "data": {}, "revision": 6}`,
+		ExpectedEtcdPath: "kubernetes.io/controllerrevisions/etcdstoragepathtestnamespace/cr1",
+		ExpectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
 	},
 	// --
 
 	// k8s.io/api/apps/v1beta2
 	gvr("apps", "v1beta2", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss2"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "kubernetes.io/statefulsets/etcdstoragepathtestnamespace/ss2",
-		expectedGVK:      gvkP("apps", "v1", "StatefulSet"),
+		Stub:             `{"metadata": {"name": "ss2"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/statefulsets/etcdstoragepathtestnamespace/ss2",
+		ExpectedGVK:      gvkP("apps", "v1", "StatefulSet"),
 	},
 	gvr("apps", "v1beta2", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment3"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment3",
-		expectedGVK:      gvkP("apps", "v1", "Deployment"),
+		Stub:             `{"metadata": {"name": "deployment3"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment3",
+		ExpectedGVK:      gvkP("apps", "v1", "Deployment"),
 	},
 	gvr("apps", "v1beta2", "daemonsets"): {
-		stub:             `{"metadata": {"name": "ds2"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/daemonsets/etcdstoragepathtestnamespace/ds2",
-		expectedGVK:      gvkP("apps", "v1", "DaemonSet"),
+		Stub:             `{"metadata": {"name": "ds2"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/daemonsets/etcdstoragepathtestnamespace/ds2",
+		ExpectedGVK:      gvkP("apps", "v1", "DaemonSet"),
 	},
 	gvr("apps", "v1beta2", "replicasets"): {
-		stub:             `{"metadata": {"name": "rs2"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/replicasets/etcdstoragepathtestnamespace/rs2",
-		expectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
+		Stub:             `{"metadata": {"name": "rs2"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/replicasets/etcdstoragepathtestnamespace/rs2",
+		ExpectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
 	},
 	gvr("apps", "v1beta2", "controllerrevisions"): {
-		stub:             `{"metadata": {"name": "cr2"}, "data": {}, "revision": 6}`,
-		expectedEtcdPath: "kubernetes.io/controllerrevisions/etcdstoragepathtestnamespace/cr2",
-		expectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
+		Stub:             `{"metadata": {"name": "cr2"}, "data": {}, "revision": 6}`,
+		ExpectedEtcdPath: "kubernetes.io/controllerrevisions/etcdstoragepathtestnamespace/cr2",
+		ExpectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/autoscaling/v1
 	gvr("autoscaling", "v1", "horizontalpodautoscalers"): {
-		stub:             `{"metadata": {"name": "hpa2"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
-		expectedEtcdPath: "kubernetes.io/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa2",
+		Stub:             `{"metadata": {"name": "hpa2"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa2",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1
 	gvr("autoscaling", "v2beta1", "horizontalpodautoscalers"): {
-		stub:             `{"metadata": {"name": "hpa3"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
-		expectedEtcdPath: "kubernetes.io/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa3",
-		expectedGVK:      gvkP("autoscaling", "v1", "HorizontalPodAutoscaler"),
+		Stub:             `{"metadata": {"name": "hpa3"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa3",
+		ExpectedGVK:      gvkP("autoscaling", "v1", "HorizontalPodAutoscaler"),
 	},
 	// --
 
 	// k8s.io/api/batch/v1
 	gvr("batch", "v1", "jobs"): {
-		stub:             `{"metadata": {"name": "job1"}, "spec": {"manualSelector": true, "selector": {"matchLabels": {"controller-uid": "uid1"}}, "template": {"metadata": {"labels": {"controller-uid": "uid1"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container1"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}`,
-		expectedEtcdPath: "kubernetes.io/jobs/etcdstoragepathtestnamespace/job1",
+		Stub:             `{"metadata": {"name": "job1"}, "spec": {"manualSelector": true, "selector": {"matchLabels": {"controller-uid": "uid1"}}, "template": {"metadata": {"labels": {"controller-uid": "uid1"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container1"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/jobs/etcdstoragepathtestnamespace/job1",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/batch/v1beta1
 	gvr("batch", "v1beta1", "cronjobs"): {
-		stub:             `{"metadata": {"name": "cj2"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
-		expectedEtcdPath: "kubernetes.io/cronjobs/etcdstoragepathtestnamespace/cj2",
+		Stub:             `{"metadata": {"name": "cj2"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
+		ExpectedEtcdPath: "kubernetes.io/cronjobs/etcdstoragepathtestnamespace/cj2",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/batch/v2alpha1
 	gvr("batch", "v2alpha1", "cronjobs"): {
-		stub:             `{"metadata": {"name": "cj1"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
-		expectedEtcdPath: "kubernetes.io/cronjobs/etcdstoragepathtestnamespace/cj1",
-		expectedGVK:      gvkP("batch", "v1beta1", "CronJob"),
+		Stub:             `{"metadata": {"name": "cj1"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
+		ExpectedEtcdPath: "kubernetes.io/cronjobs/etcdstoragepathtestnamespace/cj1",
+		ExpectedGVK:      gvkP("batch", "v1beta1", "CronJob"),
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/certificates/v1alpha1
 	gvr("certificates.k8s.io", "v1beta1", "certificatesigningrequests"): {
-		stub:             `{"metadata": {"name": "csr1"}, "spec": {"request": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQnlqQ0NBVE1DQVFBd2dZa3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJRXdwRFlXeHBabTl5Ym1saApNUll3RkFZRFZRUUhFdzFOYjNWdWRHRnBiaUJXYVdWM01STXdFUVlEVlFRS0V3cEhiMjluYkdVZ1NXNWpNUjh3CkhRWURWUVFMRXhaSmJtWnZjbTFoZEdsdmJpQlVaV05vYm05c2IyZDVNUmN3RlFZRFZRUURFdzUzZDNjdVoyOXYKWjJ4bExtTnZiVENCbnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZa0NnWUVBcFp0WUpDSEo0VnBWWEhmVgpJbHN0UVRsTzRxQzAzaGpYK1prUHl2ZFlkMVE0K3FiQWVUd1htQ1VLWUhUaFZSZDVhWFNxbFB6eUlCd2llTVpyCldGbFJRZGRaMUl6WEFsVlJEV3dBbzYwS2VjcWVBWG5uVUsrNWZYb1RJL1VnV3NocmU4dEoreC9UTUhhUUtSL0oKY0lXUGhxYVFoc0p1elpidkFkR0E4MEJMeGRNQ0F3RUFBYUFBTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUlobAo0UHZGcStlN2lwQVJnSTVaTStHWng2bXBDejQ0RFRvMEprd2ZSRGYrQnRyc2FDMHE2OGVUZjJYaFlPc3E0ZmtIClEwdUEwYVZvZzNmNWlKeENhM0hwNWd4YkpRNnpWNmtKMFRFc3VhYU9oRWtvOXNkcENvUE9uUkJtMmkvWFJEMkQKNmlOaDhmOHowU2hHc0ZxakRnRkh5RjNvK2xVeWorVUM2SDFRVzdibgotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0="}}`,
-		expectedEtcdPath: "kubernetes.io/certificatesigningrequests/csr1",
+		Stub:             `{"metadata": {"name": "csr1"}, "spec": {"request": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQnlqQ0NBVE1DQVFBd2dZa3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJRXdwRFlXeHBabTl5Ym1saApNUll3RkFZRFZRUUhFdzFOYjNWdWRHRnBiaUJXYVdWM01STXdFUVlEVlFRS0V3cEhiMjluYkdVZ1NXNWpNUjh3CkhRWURWUVFMRXhaSmJtWnZjbTFoZEdsdmJpQlVaV05vYm05c2IyZDVNUmN3RlFZRFZRUURFdzUzZDNjdVoyOXYKWjJ4bExtTnZiVENCbnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZa0NnWUVBcFp0WUpDSEo0VnBWWEhmVgpJbHN0UVRsTzRxQzAzaGpYK1prUHl2ZFlkMVE0K3FiQWVUd1htQ1VLWUhUaFZSZDVhWFNxbFB6eUlCd2llTVpyCldGbFJRZGRaMUl6WEFsVlJEV3dBbzYwS2VjcWVBWG5uVUsrNWZYb1RJL1VnV3NocmU4dEoreC9UTUhhUUtSL0oKY0lXUGhxYVFoc0p1elpidkFkR0E4MEJMeGRNQ0F3RUFBYUFBTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUlobAo0UHZGcStlN2lwQVJnSTVaTStHWng2bXBDejQ0RFRvMEprd2ZSRGYrQnRyc2FDMHE2OGVUZjJYaFlPc3E0ZmtIClEwdUEwYVZvZzNmNWlKeENhM0hwNWd4YkpRNnpWNmtKMFRFc3VhYU9oRWtvOXNkcENvUE9uUkJtMmkvWFJEMkQKNmlOaDhmOHowU2hHc0ZxakRnRkh5RjNvK2xVeWorVUM2SDFRVzdibgotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0="}}`,
+		ExpectedEtcdPath: "kubernetes.io/certificatesigningrequests/csr1",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/events/v1beta1
 	gvr("events.k8s.io", "v1beta1", "events"): {
-		stub:             `{"metadata": {"name": "event2"}, "regarding": {"namespace": "etcdstoragepathtestnamespace"}, "note": "some data here", "eventTime": "2017-08-09T15:04:05.000000Z", "reportingInstance": "node-xyz", "reportingController": "k8s.io/my-controller", "action": "DidNothing", "reason": "Laziness"}`,
-		expectedEtcdPath: "kubernetes.io/events/etcdstoragepathtestnamespace/event2",
-		expectedGVK:      gvkP("", "v1", "Event"),
+		Stub:             `{"metadata": {"name": "event2"}, "regarding": {"namespace": "etcdstoragepathtestnamespace"}, "note": "some data here", "eventTime": "2017-08-09T15:04:05.000000Z", "reportingInstance": "node-xyz", "reportingController": "k8s.io/my-controller", "action": "DidNothing", "reason": "Laziness"}`,
+		ExpectedEtcdPath: "kubernetes.io/events/etcdstoragepathtestnamespace/event2",
+		ExpectedGVK:      gvkP("", "v1", "Event"),
 	},
 	// --
 
 	// k8s.io/api/extensions/v1beta1
 	gvr("extensions", "v1beta1", "daemonsets"): {
-		stub:             `{"metadata": {"name": "ds1"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/daemonsets/etcdstoragepathtestnamespace/ds1",
-		expectedGVK:      gvkP("apps", "v1", "DaemonSet"),
+		Stub:             `{"metadata": {"name": "ds1"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/daemonsets/etcdstoragepathtestnamespace/ds1",
+		ExpectedGVK:      gvkP("apps", "v1", "DaemonSet"),
 	},
 	gvr("extensions", "v1beta1", "podsecuritypolicies"): {
-		stub:             `{"metadata": {"name": "psp1"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
-		expectedEtcdPath: "kubernetes.io/podsecuritypolicy/psp1",
-		expectedGVK:      gvkP("policy", "v1beta1", "PodSecurityPolicy"),
+		Stub:             `{"metadata": {"name": "psp1"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/podsecuritypolicy/psp1",
+		ExpectedGVK:      gvkP("policy", "v1beta1", "PodSecurityPolicy"),
 	},
 	gvr("extensions", "v1beta1", "ingresses"): {
-		stub:             `{"metadata": {"name": "ingress1"}, "spec": {"backend": {"serviceName": "service", "servicePort": 5000}}}`,
-		expectedEtcdPath: "kubernetes.io/ingress/etcdstoragepathtestnamespace/ingress1",
+		Stub:             `{"metadata": {"name": "ingress1"}, "spec": {"backend": {"serviceName": "service", "servicePort": 5000}}}`,
+		ExpectedEtcdPath: "kubernetes.io/ingress/etcdstoragepathtestnamespace/ingress1",
 	},
 	gvr("extensions", "v1beta1", "networkpolicies"): {
-		stub:             `{"metadata": {"name": "np1"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
-		expectedEtcdPath: "kubernetes.io/networkpolicies/etcdstoragepathtestnamespace/np1",
-		expectedGVK:      gvkP("networking.k8s.io", "v1", "NetworkPolicy"),
+		Stub:             `{"metadata": {"name": "np1"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/networkpolicies/etcdstoragepathtestnamespace/np1",
+		ExpectedGVK:      gvkP("networking.k8s.io", "v1", "NetworkPolicy"),
 	},
 	gvr("extensions", "v1beta1", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment1"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment1",
-		expectedGVK:      gvkP("apps", "v1", "Deployment"),
+		Stub:             `{"metadata": {"name": "deployment1"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/deployments/etcdstoragepathtestnamespace/deployment1",
+		ExpectedGVK:      gvkP("apps", "v1", "Deployment"),
 	},
 	gvr("extensions", "v1beta1", "replicasets"): {
-		stub:             `{"metadata": {"name": "rs1"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
-		expectedEtcdPath: "kubernetes.io/replicasets/etcdstoragepathtestnamespace/rs1",
-		expectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
+		Stub:             `{"metadata": {"name": "rs1"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/replicasets/etcdstoragepathtestnamespace/rs1",
+		ExpectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/network/v1
 	gvr("networking.k8s.io", "v1", "networkpolicies"): {
-		stub:             `{"metadata": {"name": "np2"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
-		expectedEtcdPath: "kubernetes.io/networkpolicies/etcdstoragepathtestnamespace/np2",
+		Stub:             `{"metadata": {"name": "np2"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/networkpolicies/etcdstoragepathtestnamespace/np2",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/policy/v1beta1
 	gvr("policy", "v1beta1", "poddisruptionbudgets"): {
-		stub:             `{"metadata": {"name": "pdb1"}, "spec": {"selector": {"matchLabels": {"anokkey": "anokvalue"}}}}`,
-		expectedEtcdPath: "kubernetes.io/poddisruptionbudgets/etcdstoragepathtestnamespace/pdb1",
+		Stub:             `{"metadata": {"name": "pdb1"}, "spec": {"selector": {"matchLabels": {"anokkey": "anokvalue"}}}}`,
+		ExpectedEtcdPath: "kubernetes.io/poddisruptionbudgets/etcdstoragepathtestnamespace/pdb1",
 	},
 	gvr("policy", "v1beta1", "podsecuritypolicies"): {
-		stub:             `{"metadata": {"name": "psp2"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
-		expectedEtcdPath: "kubernetes.io/podsecuritypolicy/psp2",
+		Stub:             `{"metadata": {"name": "psp2"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/podsecuritypolicy/psp2",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/rbac/v1alpha1
 	gvr("rbac.authorization.k8s.io", "v1alpha1", "roles"): {
-		stub:             `{"metadata": {"name": "r1a1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1a1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
+		Stub:             `{"metadata": {"name": "r1a1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1a1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
 	},
 	gvr("rbac.authorization.k8s.io", "v1alpha1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "rb1a1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
+		Stub:             `{"metadata": {"name": "rb1a1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
 	},
 	gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "cr1a1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/clusterroles/cr1a1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
+		Stub:             `{"metadata": {"name": "cr1a1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterroles/cr1a1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
 	},
 	gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "crb1a1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
+		Stub:             `{"metadata": {"name": "crb1a1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
 	},
 	// --
 
 	// k8s.io/api/rbac/v1beta1
 	gvr("rbac.authorization.k8s.io", "v1beta1", "roles"): {
-		stub:             `{"metadata": {"name": "r1b1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
+		Stub:             `{"metadata": {"name": "r1b1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
 	},
 	gvr("rbac.authorization.k8s.io", "v1beta1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "rb1b1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1b1"}}`,
-		expectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1b1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
+		Stub:             `{"metadata": {"name": "rb1b1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1b1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1b1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
 	},
 	gvr("rbac.authorization.k8s.io", "v1beta1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "cr1b1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/clusterroles/cr1b1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
+		Stub:             `{"metadata": {"name": "cr1b1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterroles/cr1b1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
 	},
 	gvr("rbac.authorization.k8s.io", "v1beta1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "crb1b1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1b1"}}`,
-		expectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1b1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
+		Stub:             `{"metadata": {"name": "crb1b1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1b1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1b1",
+		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/rbac/v1
 	gvr("rbac.authorization.k8s.io", "v1", "roles"): {
-		stub:             `{"metadata": {"name": "r1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1",
+		Stub:             `{"metadata": {"name": "r1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1",
 	},
 	gvr("rbac.authorization.k8s.io", "v1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "rb1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
-		expectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1",
+		Stub:             `{"metadata": {"name": "rb1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1",
 	},
 	gvr("rbac.authorization.k8s.io", "v1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "cr1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath: "kubernetes.io/clusterroles/cr1",
+		Stub:             `{"metadata": {"name": "cr1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterroles/cr1",
 	},
 	gvr("rbac.authorization.k8s.io", "v1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "crb1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1"}}`,
-		expectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1",
+		Stub:             `{"metadata": {"name": "crb1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "ClusterRole", "name": "cr1"}}`,
+		ExpectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1
 	gvr("scheduling.k8s.io", "v1alpha1", "priorityclasses"): {
-		stub:             `{"metadata":{"name":"pc1"},"Value":1000}`,
-		expectedEtcdPath: "kubernetes.io/priorityclasses/pc1",
-		expectedGVK:      gvkP("scheduling.k8s.io", "v1beta1", "PriorityClass"),
+		Stub:             `{"metadata":{"name":"pc1"},"Value":1000}`,
+		ExpectedEtcdPath: "kubernetes.io/priorityclasses/pc1",
+		ExpectedGVK:      gvkP("scheduling.k8s.io", "v1beta1", "PriorityClass"),
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/scheduling/v1beta1
 	gvr("scheduling.k8s.io", "v1beta1", "priorityclasses"): {
-		stub:             `{"metadata":{"name":"pc2"},"Value":1000}`,
-		expectedEtcdPath: "kubernetes.io/priorityclasses/pc2",
+		Stub:             `{"metadata":{"name":"pc2"},"Value":1000}`,
+		ExpectedEtcdPath: "kubernetes.io/priorityclasses/pc2",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/settings/v1alpha1
 	gvr("settings.k8s.io", "v1alpha1", "podpresets"): {
-		stub:             `{"metadata": {"name": "p1"}, "spec": {"selector": {"matchLabels": {"k": "v"}}, "env": [{"name": "n", "value": "v"}]}}`,
-		expectedEtcdPath: "kubernetes.io/podpresets/etcdstoragepathtestnamespace/p1",
+		Stub:             `{"metadata": {"name": "p1"}, "spec": {"selector": {"matchLabels": {"k": "v"}}, "env": [{"name": "n", "value": "v"}]}}`,
+		ExpectedEtcdPath: "kubernetes.io/podpresets/etcdstoragepathtestnamespace/p1",
 	},
 	// --
 
 	// k8s.io/kubernetes/pkg/apis/storage/v1alpha1
 	gvr("storage.k8s.io", "v1alpha1", "volumeattachments"): {
-		stub:             `{"metadata": {"name": "va1"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv1"}}}`,
-		expectedEtcdPath: "kubernetes.io/volumeattachments/va1",
-		expectedGVK:      gvkP("storage.k8s.io", "v1beta1", "VolumeAttachment"),
+		Stub:             `{"metadata": {"name": "va1"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv1"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/volumeattachments/va1",
+		ExpectedGVK:      gvkP("storage.k8s.io", "v1beta1", "VolumeAttachment"),
 	},
 	// --
 
 	// k8s.io/api/storage/v1beta1
 	gvr("storage.k8s.io", "v1beta1", "storageclasses"): {
-		stub:             `{"metadata": {"name": "sc1"}, "provisioner": "aws"}`,
-		expectedEtcdPath: "kubernetes.io/storageclasses/sc1",
-		expectedGVK:      gvkP("storage.k8s.io", "v1", "StorageClass"),
+		Stub:             `{"metadata": {"name": "sc1"}, "provisioner": "aws"}`,
+		ExpectedEtcdPath: "kubernetes.io/storageclasses/sc1",
+		ExpectedGVK:      gvkP("storage.k8s.io", "v1", "StorageClass"),
 	},
 	gvr("storage.k8s.io", "v1beta1", "volumeattachments"): {
-		stub:             `{"metadata": {"name": "va2"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv2"}}}`,
-		expectedEtcdPath: "kubernetes.io/volumeattachments/va2",
+		Stub:             `{"metadata": {"name": "va2"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv2"}}}`,
+		ExpectedEtcdPath: "kubernetes.io/volumeattachments/va2",
 	},
 	// --
 
 	// k8s.io/api/storage/v1
 	gvr("storage.k8s.io", "v1", "storageclasses"): {
-		stub:             `{"metadata": {"name": "sc2"}, "provisioner": "aws"}`,
-		expectedEtcdPath: "kubernetes.io/storageclasses/sc2",
+		Stub:             `{"metadata": {"name": "sc2"}, "provisioner": "aws"}`,
+		ExpectedEtcdPath: "kubernetes.io/storageclasses/sc2",
 	},
 	// --
 }
@@ -948,16 +944,16 @@ func TestEtcd3StoragePath(t *testing.T) {
 			continue
 		}
 
-		if len(testData.expectedEtcdPath) == 0 {
+		if len(testData.ExpectedEtcdPath) == 0 {
 			t.Errorf("empty test data for %v", gvk)
 			continue
 		}
 
-		shouldCreate := len(testData.stub) != 0 // try to create only if we have a stub
+		shouldCreate := len(testData.Stub) != 0 // try to create only if we have a stub
 
 		var input *metaObject
 		if shouldCreate {
-			if input, err = jsonToMetaObject(testData.stub); err != nil || input.isEmpty() {
+			if input, err = jsonToMetaObject(testData.Stub); err != nil || input.isEmpty() {
 				t.Errorf("invalid test data for %v: %v", gvk, err)
 				continue
 			}
@@ -973,27 +969,27 @@ func TestEtcd3StoragePath(t *testing.T) {
 				}
 			}()
 
-			if err := client.createPrerequisites(mapper, testNamespace, testData.prerequisites, all); err != nil {
+			if err := client.createPrerequisites(mapper, testNamespace, testData.Prerequisites, all); err != nil {
 				t.Errorf("failed to create prerequisites for %v: %#v", gvk, err)
 				return
 			}
 
 			if shouldCreate { // do not try to create items with no stub
-				if err := client.create(testData.stub, testNamespace, mapping, all); err != nil {
+				if err := client.create(testData.Stub, testNamespace, mapping, all); err != nil {
 					t.Errorf("failed to create stub for %v: %#v", gvk, err)
 					return
 				}
 			}
 
-			output, err := getFromEtcd(etcdClient3.KV, testData.expectedEtcdPath)
+			output, err := getFromEtcd(etcdClient3.KV, testData.ExpectedEtcdPath)
 			if err != nil {
 				t.Errorf("failed to get from etcd for %v: %#v", gvk, err)
 				return
 			}
 
 			expectedGVK := gvk
-			if testData.expectedGVK != nil {
-				expectedGVK = *testData.expectedGVK
+			if testData.ExpectedGVK != nil {
+				expectedGVK = *testData.ExpectedGVK
 			}
 
 			actualGVK := output.getGVK()
@@ -1005,8 +1001,8 @@ func TestEtcd3StoragePath(t *testing.T) {
 				t.Errorf("Test stub for %v does not match: %s", gvk, diff.ObjectGoPrintDiff(input, output))
 			}
 
-			addGVKToEtcdBucket(cohabitatingResources, actualGVK, getEtcdBucket(testData.expectedEtcdPath))
-			pathSeen[testData.expectedEtcdPath] = append(pathSeen[testData.expectedEtcdPath], gvResource)
+			addGVKToEtcdBucket(cohabitatingResources, actualGVK, getEtcdBucket(testData.ExpectedEtcdPath))
+			pathSeen[testData.ExpectedEtcdPath] = append(pathSeen[testData.ExpectedEtcdPath], gvResource)
 		}()
 	}
 
@@ -1149,11 +1145,6 @@ func (obj *metaObject) DeepCopyObject() runtime.Object {
 	return out
 }
 
-type prerequisite struct {
-	gvrData schema.GroupVersionResource
-	stub    string
-}
-
 type empty struct{}
 
 type cleanupData struct {
@@ -1265,9 +1256,9 @@ func (c *allClient) cleanup(all *[]cleanupData) error {
 	return nil
 }
 
-func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prerequisites []prerequisite, all *[]cleanupData) error {
+func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prerequisites []etcddata.Prerequisite, all *[]cleanupData) error {
 	for _, prerequisite := range prerequisites {
-		gvk, err := mapper.KindFor(prerequisite.gvrData)
+		gvk, err := mapper.KindFor(prerequisite.GvrData)
 		if err != nil {
 			return err
 		}
@@ -1275,7 +1266,7 @@ func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prere
 		if err != nil {
 			return err
 		}
-		if err := c.create(prerequisite.stub, ns, mapping, all); err != nil {
+		if err := c.create(prerequisite.Stub, ns, mapping, all); err != nil {
 			return err
 		}
 	}

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -47,15 +47,12 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 	prerequisites    []prerequisite           // Optional, ordered list of JSON objects to create before stub
 	expectedEtcdPath string                   // Expected location of object in etcd, do not use any variables, constants, etc to derive this value - always supply the full raw string
 	expectedGVK      *schema.GroupVersionKind // The GVK that we expect this object to be stored as - leave this nil to use the default
-
-	namespaceOverride bool // is only set if we won't have a mapping and have to force it to be namedspaced.  Just for legacy resources
 }{
 	// github.com/openshift/origin/pkg/authorization/apis/authorization/v1
 	gvr("", "v1", "roles"): {
-		stub:              `{"metadata": {"name": "r1b1o1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
-		expectedEtcdPath:  "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1o1",
-		expectedGVK:       gvkP("rbac.authorization.k8s.io", "v1", "Role"), // proxy to RBAC
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "r1b1o1"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
+		expectedEtcdPath: "kubernetes.io/roles/etcdstoragepathtestnamespace/r1b1o1",
+		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"), // proxy to RBAC
 	},
 	gvr("authorization.openshift.io", "v1", "roles"): {
 		stub:             `{"metadata": {"name": "r1b1o2"}, "rules": [{"verbs": ["create"], "apiGroups": ["authorization.k8s.io"], "resources": ["selfsubjectaccessreviews"]}]}`,
@@ -73,10 +70,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"), // proxy to RBAC
 	},
 	gvr("", "v1", "rolebindings"): {
-		stub:              `{"metadata": {"name": "rb1a1o1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
-		expectedEtcdPath:  "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1o1",
-		expectedGVK:       gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"), // proxy to RBAC
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "rb1a1o1"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
+		expectedEtcdPath: "kubernetes.io/rolebindings/etcdstoragepathtestnamespace/rb1a1o1",
+		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"), // proxy to RBAC
 	},
 	gvr("authorization.openshift.io", "v1", "rolebindings"): {
 		stub:             `{"metadata": {"name": "rb1a1o2"}, "subjects": [{"kind": "Group", "name": "system:authenticated"}], "roleRef": {"kind": "Role", "name": "r1a1"}}`,
@@ -94,10 +90,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"), // proxy to RBAC
 	},
 	gvr("", "v1", "rolebindingrestrictions"): {
-		stub:              `{"metadata": {"name": "rbr"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
-		expectedEtcdPath:  "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbr",
-		expectedGVK:       gvkP("authorization.openshift.io", "v1", "RoleBindingRestriction"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "rbr"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
+		expectedEtcdPath: "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbr",
+		expectedGVK:      gvkP("authorization.openshift.io", "v1", "RoleBindingRestriction"),
 	},
 	gvr("authorization.openshift.io", "v1", "rolebindingrestrictions"): {
 		stub:             `{"metadata": {"name": "rbrg"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
@@ -107,20 +102,18 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// github.com/openshift/origin/pkg/build/apis/build/v1
 	gvr("", "v1", "builds"): {
-		stub:              `{"metadata": {"name": "build1"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
-		expectedEtcdPath:  "openshift.io/builds/etcdstoragepathtestnamespace/build1",
-		expectedGVK:       gvkP("build.openshift.io", "v1", "Build"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "build1"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
+		expectedEtcdPath: "openshift.io/builds/etcdstoragepathtestnamespace/build1",
+		expectedGVK:      gvkP("build.openshift.io", "v1", "Build"),
 	},
 	gvr("build.openshift.io", "v1", "builds"): {
 		stub:             `{"metadata": {"name": "build1g"}, "spec": {"source": {"dockerfile": "Dockerfile1"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
 		expectedEtcdPath: "openshift.io/builds/etcdstoragepathtestnamespace/build1g",
 	},
 	gvr("", "v1", "buildconfigs"): {
-		stub:              `{"metadata": {"name": "bc1"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
-		expectedEtcdPath:  "openshift.io/buildconfigs/etcdstoragepathtestnamespace/bc1",
-		expectedGVK:       gvkP("build.openshift.io", "v1", "BuildConfig"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "bc1"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
+		expectedEtcdPath: "openshift.io/buildconfigs/etcdstoragepathtestnamespace/bc1",
+		expectedGVK:      gvkP("build.openshift.io", "v1", "BuildConfig"),
 	},
 	gvr("build.openshift.io", "v1", "buildconfigs"): {
 		stub:             `{"metadata": {"name": "bc1g"}, "spec": {"source": {"dockerfile": "Dockerfile0"}, "strategy": {"dockerStrategy": {"noCache": true}}}}`,
@@ -130,10 +123,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// github.com/openshift/origin/pkg/apps/apis/apps/v1
 	gvr("", "v1", "deploymentconfigs"): {
-		stub:              `{"metadata": {"name": "dc1"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
-		expectedEtcdPath:  "openshift.io/deploymentconfigs/etcdstoragepathtestnamespace/dc1",
-		expectedGVK:       gvkP("apps.openshift.io", "v1", "DeploymentConfig"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "dc1"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
+		expectedEtcdPath: "openshift.io/deploymentconfigs/etcdstoragepathtestnamespace/dc1",
+		expectedGVK:      gvkP("apps.openshift.io", "v1", "DeploymentConfig"),
 	},
 	gvr("apps.openshift.io", "v1", "deploymentconfigs"): {
 		stub:             `{"metadata": {"name": "dc1g"}, "spec": {"selector": {"d": "c"}, "template": {"metadata": {"labels": {"d": "c"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container2"}]}}}}`,
@@ -143,10 +135,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// github.com/openshift/origin/pkg/image/apis/image/v1
 	gvr("", "v1", "imagestreams"): {
-		stub:              `{"metadata": {"name": "is1"}, "spec": {"dockerImageRepository": "docker"}}`,
-		expectedEtcdPath:  "openshift.io/imagestreams/etcdstoragepathtestnamespace/is1",
-		expectedGVK:       gvkP("image.openshift.io", "v1", "ImageStream"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "is1"}, "spec": {"dockerImageRepository": "docker"}}`,
+		expectedEtcdPath: "openshift.io/imagestreams/etcdstoragepathtestnamespace/is1",
+		expectedGVK:      gvkP("image.openshift.io", "v1", "ImageStream"),
 	},
 	gvr("image.openshift.io", "v1", "imagestreams"): {
 		stub:             `{"metadata": {"name": "is1g"}, "spec": {"dockerImageRepository": "docker"}}`,
@@ -273,10 +264,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// github.com/openshift/origin/pkg/route/apis/route/v1
 	gvr("", "v1", "routes"): {
-		stub:              `{"metadata": {"name": "route1"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
-		expectedEtcdPath:  "openshift.io/routes/etcdstoragepathtestnamespace/route1",
-		expectedGVK:       gvkP("route.openshift.io", "v1", "Route"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "route1"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
+		expectedEtcdPath: "openshift.io/routes/etcdstoragepathtestnamespace/route1",
+		expectedGVK:      gvkP("route.openshift.io", "v1", "Route"),
 	},
 	gvr("route.openshift.io", "v1", "routes"): {
 		stub:             `{"metadata": {"name": "route1g"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
@@ -301,10 +291,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 		expectedGVK:      gvkP("network.openshift.io", "v1", "ClusterNetwork"),
 	},
 	gvr("", "v1", "egressnetworkpolicies"): {
-		stub:              `{"metadata": {"name": "enp1"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.0/24"}, "type": "Allow"}]}}`,
-		expectedEtcdPath:  "openshift.io/registry/egressnetworkpolicy/etcdstoragepathtestnamespace/enp1",
-		expectedGVK:       gvkP("network.openshift.io", "v1", "EgressNetworkPolicy"),
-		namespaceOverride: true,
+		stub:             `{"metadata": {"name": "enp1"}, "spec": {"egress": [{"to": {"cidrSelector": "192.168.1.0/24"}, "type": "Allow"}]}}`,
+		expectedEtcdPath: "openshift.io/registry/egressnetworkpolicy/etcdstoragepathtestnamespace/enp1",
+		expectedGVK:      gvkP("network.openshift.io", "v1", "EgressNetworkPolicy"),
 	},
 	// --
 
@@ -321,10 +310,9 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// github.com/openshift/origin/pkg/template/apis/template/v1
 	gvr("", "v1", "templates"): {
-		stub:              `{"message": "Jenkins template", "metadata": {"name": "template1"}}`,
-		expectedEtcdPath:  "openshift.io/templates/etcdstoragepathtestnamespace/template1",
-		expectedGVK:       gvkP("template.openshift.io", "v1", "Template"),
-		namespaceOverride: true,
+		stub:             `{"message": "Jenkins template", "metadata": {"name": "template1"}}`,
+		expectedEtcdPath: "openshift.io/templates/etcdstoragepathtestnamespace/template1",
+		expectedGVK:      gvkP("template.openshift.io", "v1", "Template"),
 	},
 	gvr("template.openshift.io", "v1", "templates"): {
 		stub:             `{"message": "Jenkins template", "metadata": {"name": "template1g"}}`,
@@ -924,14 +912,14 @@ func TestEtcd3StoragePath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resourcesToPersist = append(resourcesToPersist, getResourcesToPersist(serverResources, false, t)...)
+	resourcesToPersist = append(resourcesToPersist, getResourcesToPersist(serverResources, t)...)
 	oapiServerResources := &metav1.APIResourceList{
 		GroupVersion: "v1",
 	}
 	if err := kubeClient.Discovery().RESTClient().Get().AbsPath("oapi", "v1").Do().Into(oapiServerResources); err != nil {
 		t.Fatal(err)
 	}
-	resourcesToPersist = append(resourcesToPersist, getResourcesToPersist([]*metav1.APIResourceList{oapiServerResources}, true, t)...)
+	resourcesToPersist = append(resourcesToPersist, getResourcesToPersist([]*metav1.APIResourceList{oapiServerResources}, t)...)
 
 	for _, resourceToPersist := range resourcesToPersist {
 		gvk := resourceToPersist.gvk
@@ -1054,17 +1042,11 @@ func TestEtcd3StoragePath(t *testing.T) {
 type resourceToPersist struct {
 	gvk        schema.GroupVersionKind
 	gvr        schema.GroupVersionResource
-	golangType reflect.Type
 	namespaced bool
-	isOAPI     bool
 }
 
-func getResourcesToPersist(serverResources []*metav1.APIResourceList, isOAPI bool, t *testing.T) []resourceToPersist {
+func getResourcesToPersist(serverResources []*metav1.APIResourceList, t *testing.T) []resourceToPersist {
 	resourcesToPersist := []resourceToPersist{}
-
-	scheme := runtime.NewScheme()
-	install.InstallInternalOpenShift(scheme)
-	install.InstallInternalKube(scheme)
 
 	for _, discoveryGroup := range serverResources {
 		for _, discoveryResource := range discoveryGroup.APIResources {
@@ -1099,13 +1081,11 @@ func getResourcesToPersist(serverResources []*metav1.APIResourceList, isOAPI boo
 				}
 			}
 			gvr := resourceGV.WithResource(discoveryResource.Name)
-			scheme.New(gvk)
 
 			resourcesToPersist = append(resourcesToPersist, resourceToPersist{
 				gvk:        gvk,
 				gvr:        gvr,
 				namespaced: discoveryResource.Namespaced,
-				isOAPI:     isOAPI,
 			})
 		}
 	}

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go
@@ -35,10 +35,10 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
 	kubeexternalinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
-	aggregatorinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
@@ -47,7 +47,6 @@ import (
 	informers "k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion"
 	"k8s.io/kube-aggregator/pkg/controllers/autoregister"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/master/controller/crdregistration"
 )
 
@@ -79,10 +78,7 @@ func createAggregatorConfig(
 	// copy the etcd options so we don't mutate originals.
 	etcdOptions := *commandOptions.Etcd
 	etcdOptions.StorageConfig.Codec = aggregatorscheme.Codecs.LegacyCodec(v1beta1.SchemeGroupVersion, v1.SchemeGroupVersion)
-	// openshift accidentally wired the wrong RESTOptionsGetter here and stored in apiservices instead under a group.
-	// this patch installs the types in the scheme and re-uses the restoptions from the kubeapiserver
-	aggregatorinstall.Install(legacyscheme.Scheme)
-	//genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
+	genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
 
 	// override MergedResourceConfig with aggregator defaults and registry
 	if err := commandOptions.APIEnablement.ApplyTo(

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -645,8 +645,6 @@ func BuildStorageFactory(s *options.ServerRunOptions, apiResourceConfig *servers
 		return nil, fmt.Errorf("error in initializing storage factory: %s", err)
 	}
 
-	storageFactory.SetResourceEtcdPrefix(schema.GroupResource{Group: "apiregistration.k8s.io", Resource: "apiservices"}, "apiservices")
-
 	storageFactory.AddCohabitatingResources(networking.Resource("networkpolicies"), extensions.Resource("networkpolicies"))
 	storageFactory.AddCohabitatingResources(apps.Resource("deployments"), extensions.Resource("deployments"))
 	storageFactory.AddCohabitatingResources(apps.Resource("daemonsets"), extensions.Resource("daemonsets"))

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/BUILD
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/BUILD
@@ -1,9 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",
@@ -12,36 +9,23 @@ go_test(
         "etcd_storage_path_test.go",
         "main_test.go",
     ],
+    embed = [":go_default_library"],
     tags = [
         "etcd",
         "integration",
     ],
     deps = [
-        "//cmd/kube-apiserver/app:go_default_library",
-        "//cmd/kube-apiserver/app/options:go_default_library",
-        "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/apis/core:go_default_library",
-        "//pkg/master:go_default_library",
-        "//test/integration:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
-        "//vendor/k8s.io/client-go/discovery/cached:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/restmapper:go_default_library",
-        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )
 
@@ -56,4 +40,34 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "data.go",
+        "server.go",
+    ],
+    importpath = "k8s.io/kubernetes/test/integration/etcd",
+    deps = [
+        "//cmd/kube-apiserver/app:go_default_library",
+        "//cmd/kube-apiserver/app/options:go_default_library",
+        "//pkg/master:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery/cached:go_default_library",
+        "//staging/src/k8s.io/client-go/dynamic:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/restmapper:go_default_library",
+        "//test/integration:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
+        "//vendor/github.com/coreos/etcd/clientv3/concurrency:go_default_library",
+    ],
 )

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/OWNERS
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- enj
+reviewers:
+- deads2k
+- liggitt
+- enj

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/data.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/data.go
@@ -1,0 +1,455 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// GetEtcdStorageData returns etcd data for all persisted objects.
+// It is exported so that it can be reused across multiple tests.
+// It returns a new map on every invocation to prevent different tests from mutating shared state.
+func GetEtcdStorageData() map[schema.GroupVersionResource]StorageData {
+	return map[schema.GroupVersionResource]StorageData{
+		// k8s.io/kubernetes/pkg/api/v1
+		gvr("", "v1", "configmaps"): {
+			Stub:             `{"data": {"foo": "bar"}, "metadata": {"name": "cm1"}}`,
+			ExpectedEtcdPath: "/registry/configmaps/etcdstoragepathtestnamespace/cm1",
+		},
+		gvr("", "v1", "services"): {
+			Stub:             `{"metadata": {"name": "service1"}, "spec": {"externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000}], "selector": {"test": "data"}}}`,
+			ExpectedEtcdPath: "/registry/services/specs/etcdstoragepathtestnamespace/service1",
+		},
+		gvr("", "v1", "podtemplates"): {
+			Stub:             `{"metadata": {"name": "pt1name"}, "template": {"metadata": {"labels": {"pt": "01"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container9"}]}}}`,
+			ExpectedEtcdPath: "/registry/podtemplates/etcdstoragepathtestnamespace/pt1name",
+		},
+		gvr("", "v1", "pods"): {
+			Stub:             `{"metadata": {"name": "pod1"}, "spec": {"containers": [{"image": "fedora:latest", "name": "container7", "resources": {"limits": {"cpu": "1M"}, "requests": {"cpu": "1M"}}}]}}`,
+			ExpectedEtcdPath: "/registry/pods/etcdstoragepathtestnamespace/pod1",
+		},
+		gvr("", "v1", "endpoints"): {
+			Stub:             `{"metadata": {"name": "ep1name"}, "subsets": [{"addresses": [{"hostname": "bar-001", "ip": "192.168.3.1"}], "ports": [{"port": 8000}]}]}`,
+			ExpectedEtcdPath: "/registry/services/endpoints/etcdstoragepathtestnamespace/ep1name",
+		},
+		gvr("", "v1", "resourcequotas"): {
+			Stub:             `{"metadata": {"name": "rq1name"}, "spec": {"hard": {"cpu": "5M"}}}`,
+			ExpectedEtcdPath: "/registry/resourcequotas/etcdstoragepathtestnamespace/rq1name",
+		},
+		gvr("", "v1", "limitranges"): {
+			Stub:             `{"metadata": {"name": "lr1name"}, "spec": {"limits": [{"type": "Pod"}]}}`,
+			ExpectedEtcdPath: "/registry/limitranges/etcdstoragepathtestnamespace/lr1name",
+		},
+		gvr("", "v1", "namespaces"): {
+			Stub:             `{"metadata": {"name": "namespace1"}, "spec": {"finalizers": ["kubernetes"]}}`,
+			ExpectedEtcdPath: "/registry/namespaces/namespace1",
+		},
+		gvr("", "v1", "nodes"): {
+			Stub:             `{"metadata": {"name": "node1"}, "spec": {"unschedulable": true}}`,
+			ExpectedEtcdPath: "/registry/minions/node1",
+		},
+		gvr("", "v1", "persistentvolumes"): {
+			Stub:             `{"metadata": {"name": "pv1name"}, "spec": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "3M"}, "hostPath": {"path": "/tmp/test/"}}}`,
+			ExpectedEtcdPath: "/registry/persistentvolumes/pv1name",
+		},
+		gvr("", "v1", "events"): {
+			Stub:             `{"involvedObject": {"namespace": "etcdstoragepathtestnamespace"}, "message": "some data here", "metadata": {"name": "event1"}}`,
+			ExpectedEtcdPath: "/registry/events/etcdstoragepathtestnamespace/event1",
+		},
+		gvr("", "v1", "persistentvolumeclaims"): {
+			Stub:             `{"metadata": {"name": "pvc1"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"limits": {"storage": "1M"}, "requests": {"storage": "2M"}}, "selector": {"matchLabels": {"pvc": "stuff"}}}}`,
+			ExpectedEtcdPath: "/registry/persistentvolumeclaims/etcdstoragepathtestnamespace/pvc1",
+		},
+		gvr("", "v1", "serviceaccounts"): {
+			Stub:             `{"metadata": {"name": "sa1name"}, "secrets": [{"name": "secret00"}]}`,
+			ExpectedEtcdPath: "/registry/serviceaccounts/etcdstoragepathtestnamespace/sa1name",
+		},
+		gvr("", "v1", "secrets"): {
+			Stub:             `{"data": {"key": "ZGF0YSBmaWxl"}, "metadata": {"name": "secret1"}}`,
+			ExpectedEtcdPath: "/registry/secrets/etcdstoragepathtestnamespace/secret1",
+		},
+		gvr("", "v1", "replicationcontrollers"): {
+			Stub:             `{"metadata": {"name": "rc1"}, "spec": {"selector": {"new": "stuff"}, "template": {"metadata": {"labels": {"new": "stuff"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container8"}]}}}}`,
+			ExpectedEtcdPath: "/registry/controllers/etcdstoragepathtestnamespace/rc1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/apps/v1beta1
+		gvr("apps", "v1beta1", "statefulsets"): {
+			Stub:             `{"metadata": {"name": "ss1"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
+			ExpectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss1",
+			ExpectedGVK:      gvkP("apps", "v1", "StatefulSet"),
+		},
+		gvr("apps", "v1beta1", "deployments"): {
+			Stub:             `{"metadata": {"name": "deployment2"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+			ExpectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment2",
+			ExpectedGVK:      gvkP("apps", "v1", "Deployment"),
+		},
+		gvr("apps", "v1beta1", "controllerrevisions"): {
+			Stub:             `{"metadata":{"name":"crs1"},"data":{"name":"abc","namespace":"default","creationTimestamp":null,"Spec":{"Replicas":0,"Selector":{"matchLabels":{"foo":"bar"}},"Template":{"creationTimestamp":null,"labels":{"foo":"bar"},"Spec":{"Volumes":null,"InitContainers":null,"Containers":null,"RestartPolicy":"Always","TerminationGracePeriodSeconds":null,"ActiveDeadlineSeconds":null,"DNSPolicy":"ClusterFirst","NodeSelector":null,"ServiceAccountName":"","AutomountServiceAccountToken":null,"NodeName":"","SecurityContext":null,"ImagePullSecrets":null,"Hostname":"","Subdomain":"","Affinity":null,"SchedulerName":"","Tolerations":null,"HostAliases":null}},"VolumeClaimTemplates":null,"ServiceName":""},"Status":{"ObservedGeneration":null,"Replicas":0}},"revision":0}`,
+			ExpectedEtcdPath: "/registry/controllerrevisions/etcdstoragepathtestnamespace/crs1",
+			ExpectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/apps/v1beta2
+		gvr("apps", "v1beta2", "statefulsets"): {
+			Stub:             `{"metadata": {"name": "ss2"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
+			ExpectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss2",
+			ExpectedGVK:      gvkP("apps", "v1", "StatefulSet"),
+		},
+		gvr("apps", "v1beta2", "deployments"): {
+			Stub:             `{"metadata": {"name": "deployment3"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+			ExpectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment3",
+			ExpectedGVK:      gvkP("apps", "v1", "Deployment"),
+		},
+		gvr("apps", "v1beta2", "daemonsets"): {
+			Stub:             `{"metadata": {"name": "ds5"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+			ExpectedEtcdPath: "/registry/daemonsets/etcdstoragepathtestnamespace/ds5",
+			ExpectedGVK:      gvkP("apps", "v1", "DaemonSet"),
+		},
+		gvr("apps", "v1beta2", "replicasets"): {
+			Stub:             `{"metadata": {"name": "rs2"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
+			ExpectedEtcdPath: "/registry/replicasets/etcdstoragepathtestnamespace/rs2",
+			ExpectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
+		},
+		gvr("apps", "v1beta2", "controllerrevisions"): {
+			Stub:             `{"metadata":{"name":"crs2"},"data":{"name":"abc","namespace":"default","creationTimestamp":null,"Spec":{"Replicas":0,"Selector":{"matchLabels":{"foo":"bar"}},"Template":{"creationTimestamp":null,"labels":{"foo":"bar"},"Spec":{"Volumes":null,"InitContainers":null,"Containers":null,"RestartPolicy":"Always","TerminationGracePeriodSeconds":null,"ActiveDeadlineSeconds":null,"DNSPolicy":"ClusterFirst","NodeSelector":null,"ServiceAccountName":"","AutomountServiceAccountToken":null,"NodeName":"","SecurityContext":null,"ImagePullSecrets":null,"Hostname":"","Subdomain":"","Affinity":null,"SchedulerName":"","Tolerations":null,"HostAliases":null}},"VolumeClaimTemplates":null,"ServiceName":""},"Status":{"ObservedGeneration":null,"Replicas":0}},"revision":0}`,
+			ExpectedEtcdPath: "/registry/controllerrevisions/etcdstoragepathtestnamespace/crs2",
+			ExpectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/apps/v1
+		gvr("apps", "v1", "daemonsets"): {
+			Stub:             `{"metadata": {"name": "ds6"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+			ExpectedEtcdPath: "/registry/daemonsets/etcdstoragepathtestnamespace/ds6",
+		},
+		gvr("apps", "v1", "deployments"): {
+			Stub:             `{"metadata": {"name": "deployment4"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+			ExpectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment4",
+		},
+		gvr("apps", "v1", "statefulsets"): {
+			Stub:             `{"metadata": {"name": "ss3"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
+			ExpectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss3",
+		},
+		gvr("apps", "v1", "replicasets"): {
+			Stub:             `{"metadata": {"name": "rs3"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
+			ExpectedEtcdPath: "/registry/replicasets/etcdstoragepathtestnamespace/rs3",
+		},
+		gvr("apps", "v1", "controllerrevisions"): {
+			Stub:             `{"metadata":{"name":"crs3"},"data":{"name":"abc","namespace":"default","creationTimestamp":null,"Spec":{"Replicas":0,"Selector":{"matchLabels":{"foo":"bar"}},"Template":{"creationTimestamp":null,"labels":{"foo":"bar"},"Spec":{"Volumes":null,"InitContainers":null,"Containers":null,"RestartPolicy":"Always","TerminationGracePeriodSeconds":null,"ActiveDeadlineSeconds":null,"DNSPolicy":"ClusterFirst","NodeSelector":null,"ServiceAccountName":"","AutomountServiceAccountToken":null,"NodeName":"","SecurityContext":null,"ImagePullSecrets":null,"Hostname":"","Subdomain":"","Affinity":null,"SchedulerName":"","Tolerations":null,"HostAliases":null}},"VolumeClaimTemplates":null,"ServiceName":""},"Status":{"ObservedGeneration":null,"Replicas":0}},"revision":0}`,
+			ExpectedEtcdPath: "/registry/controllerrevisions/etcdstoragepathtestnamespace/crs3",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/autoscaling/v1
+		gvr("autoscaling", "v1", "horizontalpodautoscalers"): {
+			Stub:             `{"metadata": {"name": "hpa2"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+			ExpectedEtcdPath: "/registry/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa2",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1
+		gvr("autoscaling", "v2beta1", "horizontalpodautoscalers"): {
+			Stub:             `{"metadata": {"name": "hpa1"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+			ExpectedEtcdPath: "/registry/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa1",
+			ExpectedGVK:      gvkP("autoscaling", "v1", "HorizontalPodAutoscaler"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/autoscaling/v2beta2
+		gvr("autoscaling", "v2beta2", "horizontalpodautoscalers"): {
+			Stub:             `{"metadata": {"name": "hpa3"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
+			ExpectedEtcdPath: "/registry/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa3",
+			ExpectedGVK:      gvkP("autoscaling", "v1", "HorizontalPodAutoscaler"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/batch/v1
+		gvr("batch", "v1", "jobs"): {
+			Stub:             `{"metadata": {"name": "job1"}, "spec": {"manualSelector": true, "selector": {"matchLabels": {"controller-uid": "uid1"}}, "template": {"metadata": {"labels": {"controller-uid": "uid1"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container1"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}`,
+			ExpectedEtcdPath: "/registry/jobs/etcdstoragepathtestnamespace/job1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/batch/v1beta1
+		gvr("batch", "v1beta1", "cronjobs"): {
+			Stub:             `{"metadata": {"name": "cjv1beta1"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
+			ExpectedEtcdPath: "/registry/cronjobs/etcdstoragepathtestnamespace/cjv1beta1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/batch/v2alpha1
+		gvr("batch", "v2alpha1", "cronjobs"): {
+			Stub:             `{"metadata": {"name": "cjv2alpha1"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
+			ExpectedEtcdPath: "/registry/cronjobs/etcdstoragepathtestnamespace/cjv2alpha1",
+			ExpectedGVK:      gvkP("batch", "v1beta1", "CronJob"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/certificates/v1beta1
+		gvr("certificates.k8s.io", "v1beta1", "certificatesigningrequests"): {
+			Stub:             `{"metadata": {"name": "csr1"}, "spec": {"request": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQnlqQ0NBVE1DQVFBd2dZa3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJRXdwRFlXeHBabTl5Ym1saApNUll3RkFZRFZRUUhFdzFOYjNWdWRHRnBiaUJXYVdWM01STXdFUVlEVlFRS0V3cEhiMjluYkdVZ1NXNWpNUjh3CkhRWURWUVFMRXhaSmJtWnZjbTFoZEdsdmJpQlVaV05vYm05c2IyZDVNUmN3RlFZRFZRUURFdzUzZDNjdVoyOXYKWjJ4bExtTnZiVENCbnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZa0NnWUVBcFp0WUpDSEo0VnBWWEhmVgpJbHN0UVRsTzRxQzAzaGpYK1prUHl2ZFlkMVE0K3FiQWVUd1htQ1VLWUhUaFZSZDVhWFNxbFB6eUlCd2llTVpyCldGbFJRZGRaMUl6WEFsVlJEV3dBbzYwS2VjcWVBWG5uVUsrNWZYb1RJL1VnV3NocmU4dEoreC9UTUhhUUtSL0oKY0lXUGhxYVFoc0p1elpidkFkR0E4MEJMeGRNQ0F3RUFBYUFBTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUlobAo0UHZGcStlN2lwQVJnSTVaTStHWng2bXBDejQ0RFRvMEprd2ZSRGYrQnRyc2FDMHE2OGVUZjJYaFlPc3E0ZmtIClEwdUEwYVZvZzNmNWlKeENhM0hwNWd4YkpRNnpWNmtKMFRFc3VhYU9oRWtvOXNkcENvUE9uUkJtMmkvWFJEMkQKNmlOaDhmOHowU2hHc0ZxakRnRkh5RjNvK2xVeWorVUM2SDFRVzdibgotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0="}}`,
+			ExpectedEtcdPath: "/registry/certificatesigningrequests/csr1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/coordination/v1beta1
+		gvr("coordination.k8s.io", "v1beta1", "leases"): {
+			Stub:             `{"metadata": {"name": "lease1"}, "spec": {"holderIdentity": "holder", "leaseDurationSeconds": 5}}`,
+			ExpectedEtcdPath: "/registry/leases/etcdstoragepathtestnamespace/lease1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/events/v1beta1
+		gvr("events.k8s.io", "v1beta1", "events"): {
+			Stub:             `{"metadata": {"name": "event2"}, "regarding": {"namespace": "etcdstoragepathtestnamespace"}, "note": "some data here", "eventTime": "2017-08-09T15:04:05.000000Z", "reportingInstance": "node-xyz", "reportingController": "k8s.io/my-controller", "action": "DidNothing", "reason": "Laziness"}`,
+			ExpectedEtcdPath: "/registry/events/etcdstoragepathtestnamespace/event2",
+			ExpectedGVK:      gvkP("", "v1", "Event"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/extensions/v1beta1
+		gvr("extensions", "v1beta1", "daemonsets"): {
+			Stub:             `{"metadata": {"name": "ds1"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
+			ExpectedEtcdPath: "/registry/daemonsets/etcdstoragepathtestnamespace/ds1",
+			ExpectedGVK:      gvkP("apps", "v1", "DaemonSet"),
+		},
+		gvr("extensions", "v1beta1", "podsecuritypolicies"): {
+			Stub:             `{"metadata": {"name": "psp1"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
+			ExpectedEtcdPath: "/registry/podsecuritypolicy/psp1",
+			ExpectedGVK:      gvkP("policy", "v1beta1", "PodSecurityPolicy"),
+		},
+		gvr("extensions", "v1beta1", "ingresses"): {
+			Stub:             `{"metadata": {"name": "ingress1"}, "spec": {"backend": {"serviceName": "service", "servicePort": 5000}}}`,
+			ExpectedEtcdPath: "/registry/ingress/etcdstoragepathtestnamespace/ingress1",
+		},
+		gvr("extensions", "v1beta1", "networkpolicies"): {
+			Stub:             `{"metadata": {"name": "np1"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
+			ExpectedEtcdPath: "/registry/networkpolicies/etcdstoragepathtestnamespace/np1",
+			ExpectedGVK:      gvkP("networking.k8s.io", "v1", "NetworkPolicy"),
+		},
+		gvr("extensions", "v1beta1", "deployments"): {
+			Stub:             `{"metadata": {"name": "deployment1"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
+			ExpectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment1",
+			ExpectedGVK:      gvkP("apps", "v1", "Deployment"),
+		},
+		gvr("extensions", "v1beta1", "replicasets"): {
+			Stub:             `{"metadata": {"name": "rs1"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
+			ExpectedEtcdPath: "/registry/replicasets/etcdstoragepathtestnamespace/rs1",
+			ExpectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/networking/v1
+		gvr("networking.k8s.io", "v1", "networkpolicies"): {
+			Stub:             `{"metadata": {"name": "np2"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
+			ExpectedEtcdPath: "/registry/networkpolicies/etcdstoragepathtestnamespace/np2",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/policy/v1beta1
+		gvr("policy", "v1beta1", "poddisruptionbudgets"): {
+			Stub:             `{"metadata": {"name": "pdb1"}, "spec": {"selector": {"matchLabels": {"anokkey": "anokvalue"}}}}`,
+			ExpectedEtcdPath: "/registry/poddisruptionbudgets/etcdstoragepathtestnamespace/pdb1",
+		},
+		gvr("policy", "v1beta1", "podsecuritypolicies"): {
+			Stub:             `{"metadata": {"name": "psp2"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
+			ExpectedEtcdPath: "/registry/podsecuritypolicy/psp2",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/storage/v1alpha1
+		gvr("storage.k8s.io", "v1alpha1", "volumeattachments"): {
+			Stub:             `{"metadata": {"name": "va1"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv1"}}}`,
+			ExpectedEtcdPath: "/registry/volumeattachments/va1",
+			ExpectedGVK:      gvkP("storage.k8s.io", "v1beta1", "VolumeAttachment"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/storage/v1beta1
+		gvr("storage.k8s.io", "v1beta1", "volumeattachments"): {
+			Stub:             `{"metadata": {"name": "va2"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv2"}}}`,
+			ExpectedEtcdPath: "/registry/volumeattachments/va2",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/storage/v1beta1
+		gvr("storage.k8s.io", "v1beta1", "storageclasses"): {
+			Stub:             `{"metadata": {"name": "sc1"}, "provisioner": "aws"}`,
+			ExpectedEtcdPath: "/registry/storageclasses/sc1",
+			ExpectedGVK:      gvkP("storage.k8s.io", "v1", "StorageClass"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/storage/v1
+		gvr("storage.k8s.io", "v1", "storageclasses"): {
+			Stub:             `{"metadata": {"name": "sc2"}, "provisioner": "aws"}`,
+			ExpectedEtcdPath: "/registry/storageclasses/sc2",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/settings/v1alpha1
+		gvr("settings.k8s.io", "v1alpha1", "podpresets"): {
+			Stub:             `{"metadata": {"name": "podpre1"}, "spec": {"env": [{"name": "FOO"}]}}`,
+			ExpectedEtcdPath: "/registry/podpresets/etcdstoragepathtestnamespace/podpre1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/rbac/v1alpha1
+		gvr("rbac.authorization.k8s.io", "v1alpha1", "roles"): {
+			Stub:             `{"metadata": {"name": "role1"}, "rules": [{"apiGroups": ["v1"], "resources": ["events"], "verbs": ["watch"]}]}`,
+			ExpectedEtcdPath: "/registry/roles/etcdstoragepathtestnamespace/role1",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
+		},
+		gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterroles"): {
+			Stub:             `{"metadata": {"name": "crole1"}, "rules": [{"nonResourceURLs": ["/version"], "verbs": ["get"]}]}`,
+			ExpectedEtcdPath: "/registry/clusterroles/crole1",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
+		},
+		gvr("rbac.authorization.k8s.io", "v1alpha1", "rolebindings"): {
+			Stub:             `{"metadata": {"name": "roleb1"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
+			ExpectedEtcdPath: "/registry/rolebindings/etcdstoragepathtestnamespace/roleb1",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
+		},
+		gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterrolebindings"): {
+			Stub:             `{"metadata": {"name": "croleb1"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
+			ExpectedEtcdPath: "/registry/clusterrolebindings/croleb1",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/rbac/v1beta1
+		gvr("rbac.authorization.k8s.io", "v1beta1", "roles"): {
+			Stub:             `{"metadata": {"name": "role2"}, "rules": [{"apiGroups": ["v1"], "resources": ["events"], "verbs": ["watch"]}]}`,
+			ExpectedEtcdPath: "/registry/roles/etcdstoragepathtestnamespace/role2",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
+		},
+		gvr("rbac.authorization.k8s.io", "v1beta1", "clusterroles"): {
+			Stub:             `{"metadata": {"name": "crole2"}, "rules": [{"nonResourceURLs": ["/version"], "verbs": ["get"]}]}`,
+			ExpectedEtcdPath: "/registry/clusterroles/crole2",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
+		},
+		gvr("rbac.authorization.k8s.io", "v1beta1", "rolebindings"): {
+			Stub:             `{"metadata": {"name": "roleb2"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
+			ExpectedEtcdPath: "/registry/rolebindings/etcdstoragepathtestnamespace/roleb2",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
+		},
+		gvr("rbac.authorization.k8s.io", "v1beta1", "clusterrolebindings"): {
+			Stub:             `{"metadata": {"name": "croleb2"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
+			ExpectedEtcdPath: "/registry/clusterrolebindings/croleb2",
+			ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/rbac/v1
+		gvr("rbac.authorization.k8s.io", "v1", "roles"): {
+			Stub:             `{"metadata": {"name": "role3"}, "rules": [{"apiGroups": ["v1"], "resources": ["events"], "verbs": ["watch"]}]}`,
+			ExpectedEtcdPath: "/registry/roles/etcdstoragepathtestnamespace/role3",
+		},
+		gvr("rbac.authorization.k8s.io", "v1", "clusterroles"): {
+			Stub:             `{"metadata": {"name": "crole3"}, "rules": [{"nonResourceURLs": ["/version"], "verbs": ["get"]}]}`,
+			ExpectedEtcdPath: "/registry/clusterroles/crole3",
+		},
+		gvr("rbac.authorization.k8s.io", "v1", "rolebindings"): {
+			Stub:             `{"metadata": {"name": "roleb3"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
+			ExpectedEtcdPath: "/registry/rolebindings/etcdstoragepathtestnamespace/roleb3",
+		},
+		gvr("rbac.authorization.k8s.io", "v1", "clusterrolebindings"): {
+			Stub:             `{"metadata": {"name": "croleb3"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
+			ExpectedEtcdPath: "/registry/clusterrolebindings/croleb3",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1
+		gvr("admissionregistration.k8s.io", "v1alpha1", "initializerconfigurations"): {
+			Stub:             `{"metadata":{"name":"ic1"},"initializers":[{"name":"initializer.k8s.io","rules":[{"apiGroups":["group"],"apiVersions":["version"],"resources":["resource"]}],"failurePolicy":"Ignore"}]}`,
+			ExpectedEtcdPath: "/registry/initializerconfigurations/ic1",
+		},
+		// k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1
+		gvr("admissionregistration.k8s.io", "v1beta1", "validatingwebhookconfigurations"): {
+			Stub:             `{"metadata":{"name":"hook1","creationTimestamp":null},"webhooks":[{"name":"externaladmissionhook.k8s.io","clientConfig":{"service":{"namespace":"ns","name":"n"},"caBundle":null},"rules":[{"operations":["CREATE"],"apiGroups":["group"],"apiVersions":["version"],"resources":["resource"]}],"failurePolicy":"Ignore"}]}`,
+			ExpectedEtcdPath: "/registry/validatingwebhookconfigurations/hook1",
+		},
+		gvr("admissionregistration.k8s.io", "v1beta1", "mutatingwebhookconfigurations"): {
+			Stub:             `{"metadata":{"name":"hook1","creationTimestamp":null},"webhooks":[{"name":"externaladmissionhook.k8s.io","clientConfig":{"service":{"namespace":"ns","name":"n"},"caBundle":null},"rules":[{"operations":["CREATE"],"apiGroups":["group"],"apiVersions":["version"],"resources":["resource"]}],"failurePolicy":"Ignore"}]}`,
+			ExpectedEtcdPath: "/registry/mutatingwebhookconfigurations/hook1",
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1
+		gvr("scheduling.k8s.io", "v1alpha1", "priorityclasses"): {
+			Stub:             `{"metadata":{"name":"pc1"},"Value":1000}`,
+			ExpectedEtcdPath: "/registry/priorityclasses/pc1",
+			ExpectedGVK:      gvkP("scheduling.k8s.io", "v1beta1", "PriorityClass"),
+		},
+		// --
+
+		// k8s.io/kubernetes/pkg/apis/scheduling/v1beta1
+		gvr("scheduling.k8s.io", "v1beta1", "priorityclasses"): {
+			Stub:             `{"metadata":{"name":"pc2"},"Value":1000}`,
+			ExpectedEtcdPath: "/registry/priorityclasses/pc2",
+		},
+		// --
+
+		// k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
+		// depends on aggregator using the same ungrouped RESTOptionsGetter as the kube apiserver, not SimpleRestOptionsFactory in aggregator.go
+		gvr("apiregistration.k8s.io", "v1beta1", "apiservices"): {
+			Stub:             `{"metadata": {"name": "as1.foo.com"}, "spec": {"group": "foo.com", "version": "as1", "groupPriorityMinimum":100, "versionPriority":10}}`,
+			ExpectedEtcdPath: "/registry/apiregistration.k8s.io/apiservices/as1.foo.com",
+		},
+		// --
+
+		// k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
+		// depends on aggregator using the same ungrouped RESTOptionsGetter as the kube apiserver, not SimpleRestOptionsFactory in aggregator.go
+		gvr("apiregistration.k8s.io", "v1", "apiservices"): {
+			Stub:             `{"metadata": {"name": "as2.foo.com"}, "spec": {"group": "foo.com", "version": "as2", "groupPriorityMinimum":100, "versionPriority":10}}`,
+			ExpectedEtcdPath: "/registry/apiregistration.k8s.io/apiservices/as2.foo.com",
+			ExpectedGVK:      gvkP("apiregistration.k8s.io", "v1beta1", "APIService"),
+		},
+		// --
+
+		// k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
+		gvr("apiextensions.k8s.io", "v1beta1", "customresourcedefinitions"): {
+			Stub:             `{"metadata": {"name": "openshiftwebconsoleconfigs.webconsole.operator.openshift.io"},"spec": {"scope": "Cluster","group": "webconsole.operator.openshift.io","version": "v1alpha1","names": {"kind": "OpenShiftWebConsoleConfig","plural": "openshiftwebconsoleconfigs","singular": "openshiftwebconsoleconfig"}}}`,
+			ExpectedEtcdPath: "/registry/apiextensions.k8s.io/customresourcedefinitions/openshiftwebconsoleconfigs.webconsole.operator.openshift.io",
+		},
+		// --
+	}
+}
+
+// StorageData contains information required to create an object and verify its storage in etcd
+// It must be paired with a specific resource
+type StorageData struct {
+	Stub             string                   // Valid JSON stub to use during create
+	Prerequisites    []Prerequisite           // Optional, ordered list of JSON objects to create before stub
+	ExpectedEtcdPath string                   // Expected location of object in etcd, do not use any variables, constants, etc to derive this value - always supply the full raw string
+	ExpectedGVK      *schema.GroupVersionKind // The GVK that we expect this object to be stored as - leave this nil to use the default
+}
+
+// Prerequisite contains information required to create a resource (but not verify it)
+type Prerequisite struct {
+	GvrData schema.GroupVersionResource
+	Stub    string
+}
+
+func gvr(g, v, r string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: g, Version: v, Resource: r}
+}
+
+func gvkP(g, v, k string) *schema.GroupVersionKind {
+	return &schema.GroupVersionKind{Group: g, Version: v, Kind: k}
+}

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/data.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/data.go
@@ -170,14 +170,6 @@ func GetEtcdStorageData() map[schema.GroupVersionResource]StorageData {
 		},
 		// --
 
-		// k8s.io/kubernetes/pkg/apis/autoscaling/v2beta2
-		gvr("autoscaling", "v2beta2", "horizontalpodautoscalers"): {
-			Stub:             `{"metadata": {"name": "hpa3"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
-			ExpectedEtcdPath: "/registry/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa3",
-			ExpectedGVK:      gvkP("autoscaling", "v1", "HorizontalPodAutoscaler"),
-		},
-		// --
-
 		// k8s.io/kubernetes/pkg/apis/batch/v1
 		gvr("batch", "v1", "jobs"): {
 			Stub:             `{"metadata": {"name": "job1"}, "spec": {"manualSelector": true, "selector": {"matchLabels": {"controller-uid": "uid1"}}, "template": {"metadata": {"labels": {"controller-uid": "uid1"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container1"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}`,
@@ -204,13 +196,6 @@ func GetEtcdStorageData() map[schema.GroupVersionResource]StorageData {
 		gvr("certificates.k8s.io", "v1beta1", "certificatesigningrequests"): {
 			Stub:             `{"metadata": {"name": "csr1"}, "spec": {"request": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQnlqQ0NBVE1DQVFBd2dZa3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJRXdwRFlXeHBabTl5Ym1saApNUll3RkFZRFZRUUhFdzFOYjNWdWRHRnBiaUJXYVdWM01STXdFUVlEVlFRS0V3cEhiMjluYkdVZ1NXNWpNUjh3CkhRWURWUVFMRXhaSmJtWnZjbTFoZEdsdmJpQlVaV05vYm05c2IyZDVNUmN3RlFZRFZRUURFdzUzZDNjdVoyOXYKWjJ4bExtTnZiVENCbnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZa0NnWUVBcFp0WUpDSEo0VnBWWEhmVgpJbHN0UVRsTzRxQzAzaGpYK1prUHl2ZFlkMVE0K3FiQWVUd1htQ1VLWUhUaFZSZDVhWFNxbFB6eUlCd2llTVpyCldGbFJRZGRaMUl6WEFsVlJEV3dBbzYwS2VjcWVBWG5uVUsrNWZYb1RJL1VnV3NocmU4dEoreC9UTUhhUUtSL0oKY0lXUGhxYVFoc0p1elpidkFkR0E4MEJMeGRNQ0F3RUFBYUFBTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUlobAo0UHZGcStlN2lwQVJnSTVaTStHWng2bXBDejQ0RFRvMEprd2ZSRGYrQnRyc2FDMHE2OGVUZjJYaFlPc3E0ZmtIClEwdUEwYVZvZzNmNWlKeENhM0hwNWd4YkpRNnpWNmtKMFRFc3VhYU9oRWtvOXNkcENvUE9uUkJtMmkvWFJEMkQKNmlOaDhmOHowU2hHc0ZxakRnRkh5RjNvK2xVeWorVUM2SDFRVzdibgotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0="}}`,
 			ExpectedEtcdPath: "/registry/certificatesigningrequests/csr1",
-		},
-		// --
-
-		// k8s.io/kubernetes/pkg/apis/coordination/v1beta1
-		gvr("coordination.k8s.io", "v1beta1", "leases"): {
-			Stub:             `{"metadata": {"name": "lease1"}, "spec": {"holderIdentity": "holder", "leaseDurationSeconds": 5}}`,
-			ExpectedEtcdPath: "/registry/leases/etcdstoragepathtestnamespace/lease1",
 		},
 		// --
 

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/data.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/data.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package etcd
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 // GetEtcdStorageData returns etcd data for all persisted objects.
 // It is exported so that it can be reused across multiple tests.
@@ -412,6 +416,23 @@ func GetEtcdStorageData() map[schema.GroupVersionResource]StorageData {
 			Stub:             `{"metadata": {"name": "openshiftwebconsoleconfigs.webconsole.operator.openshift.io"},"spec": {"scope": "Cluster","group": "webconsole.operator.openshift.io","version": "v1alpha1","names": {"kind": "OpenShiftWebConsoleConfig","plural": "openshiftwebconsoleconfigs","singular": "openshiftwebconsoleconfig"}}}`,
 			ExpectedEtcdPath: "/registry/apiextensions.k8s.io/customresourcedefinitions/openshiftwebconsoleconfigs.webconsole.operator.openshift.io",
 		},
+		gvr("cr.bar.com", "v1", "foos"): {
+			Stub:             `{"kind": "Foo", "apiVersion": "cr.bar.com/v1", "metadata": {"name": "cr1foo"}, "color": "blue"}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+			ExpectedEtcdPath: "/registry/cr.bar.com/foos/etcdstoragepathtestnamespace/cr1foo",
+		},
+		gvr("custom.fancy.com", "v2", "pants"): {
+			Stub:             `{"kind": "Pant", "apiVersion": "custom.fancy.com/v2", "metadata": {"name": "cr2pant"}, "isFancy": true}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+			ExpectedEtcdPath: "/registry/custom.fancy.com/pants/cr2pant",
+		},
+		gvr("awesome.bears.com", "v1", "pandas"): {
+			Stub:             `{"kind": "Panda", "apiVersion": "awesome.bears.com/v1", "metadata": {"name": "cr3panda"}, "weight": 100}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+			ExpectedEtcdPath: "/registry/awesome.bears.com/pandas/cr3panda",
+		},
+		gvr("awesome.bears.com", "v3", "pandas"): {
+			Stub:             `{"kind": "Panda", "apiVersion": "awesome.bears.com/v3", "metadata": {"name": "cr4panda"}, "weight": 300}`, // requires TypeMeta due to CRD scheme's UnstructuredObjectTyper
+			ExpectedEtcdPath: "/registry/awesome.bears.com/pandas/cr4panda",
+			ExpectedGVK:      gvkP("awesome.bears.com", "v1", "Panda"),
+		},
 		// --
 	}
 }
@@ -429,6 +450,74 @@ type StorageData struct {
 type Prerequisite struct {
 	GvrData schema.GroupVersionResource
 	Stub    string
+}
+
+// GetCustomResourceDefinitionData returns the resource definitions that back the custom resources
+// included in GetEtcdStorageData.  They should be created using CreateTestCRDs before running any tests.
+func GetCustomResourceDefinitionData() []*apiextensionsv1beta1.CustomResourceDefinition {
+	return []*apiextensionsv1beta1.CustomResourceDefinition{
+		// namespaced with legacy version field
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foos.cr.bar.com",
+			},
+			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+				Group:   "cr.bar.com",
+				Version: "v1",
+				Scope:   apiextensionsv1beta1.NamespaceScoped,
+				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+					Plural: "foos",
+					Kind:   "Foo",
+				},
+			},
+		},
+		// cluster scoped with legacy version field
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pants.custom.fancy.com",
+			},
+			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+				Group:   "custom.fancy.com",
+				Version: "v2",
+				Scope:   apiextensionsv1beta1.ClusterScoped,
+				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+					Plural: "pants",
+					Kind:   "Pant",
+				},
+			},
+		},
+		// cluster scoped with versions field
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pandas.awesome.bears.com",
+			},
+			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+				Group: "awesome.bears.com",
+				Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1",
+						Served:  true,
+						Storage: true,
+					},
+					{
+						Name:    "v2",
+						Served:  false,
+						Storage: false,
+					},
+					{
+						Name:    "v3",
+						Served:  true,
+						Storage: false,
+					},
+				},
+				Scope: apiextensionsv1beta1.ClusterScoped,
+				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+					Plural: "pandas",
+					Kind:   "Panda",
+				},
+			},
+		},
+	}
 }
 
 func gvr(g, v, r string) schema.GroupVersionResource {

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/etcd_storage_path_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/etcd_storage_path_test.go
@@ -20,533 +20,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"mime"
-	"net"
-	"net/http"
-	"os"
 	"reflect"
 	"strings"
-	"sync/atomic"
 	"testing"
-	"time"
+
+	"github.com/coreos/etcd/clientv3"
 
 	"k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
-	genericapiserver "k8s.io/apiserver/pkg/server"
-	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
-	"k8s.io/apiserver/pkg/storage/storagebackend"
-	cacheddiscovery "k8s.io/client-go/discovery/cached"
-	clientset "k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/test/integration"
-	"k8s.io/kubernetes/test/integration/framework"
-
-	// install all APIs
-	_ "k8s.io/kubernetes/pkg/master" // TODO what else is needed
-
-	"github.com/coreos/etcd/clientv3"
-	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/dynamic"
 )
 
-// Etcd data for all persisted objects.
-var etcdStorageData = map[schema.GroupVersionResource]struct {
-	stub             string                   // Valid JSON stub to use during create
-	prerequisites    []prerequisite           // Optional, ordered list of JSON objects to create before stub
-	expectedEtcdPath string                   // Expected location of object in etcd, do not use any variables, constants, etc to derive this value - always supply the full raw string
-	expectedGVK      *schema.GroupVersionKind // The GVK that we expect this object to be stored as - leave this nil to use the default
-}{
-	// k8s.io/kubernetes/pkg/api/v1
-	gvr("", "v1", "configmaps"): {
-		stub:             `{"data": {"foo": "bar"}, "metadata": {"name": "cm1"}}`,
-		expectedEtcdPath: "/registry/configmaps/etcdstoragepathtestnamespace/cm1",
-	},
-	gvr("", "v1", "services"): {
-		stub:             `{"metadata": {"name": "service1"}, "spec": {"externalName": "service1name", "ports": [{"port": 10000, "targetPort": 11000}], "selector": {"test": "data"}}}`,
-		expectedEtcdPath: "/registry/services/specs/etcdstoragepathtestnamespace/service1",
-	},
-	gvr("", "v1", "podtemplates"): {
-		stub:             `{"metadata": {"name": "pt1name"}, "template": {"metadata": {"labels": {"pt": "01"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container9"}]}}}`,
-		expectedEtcdPath: "/registry/podtemplates/etcdstoragepathtestnamespace/pt1name",
-	},
-	gvr("", "v1", "pods"): {
-		stub:             `{"metadata": {"name": "pod1"}, "spec": {"containers": [{"image": "fedora:latest", "name": "container7", "resources": {"limits": {"cpu": "1M"}, "requests": {"cpu": "1M"}}}]}}`,
-		expectedEtcdPath: "/registry/pods/etcdstoragepathtestnamespace/pod1",
-	},
-	gvr("", "v1", "endpoints"): {
-		stub:             `{"metadata": {"name": "ep1name"}, "subsets": [{"addresses": [{"hostname": "bar-001", "ip": "192.168.3.1"}], "ports": [{"port": 8000}]}]}`,
-		expectedEtcdPath: "/registry/services/endpoints/etcdstoragepathtestnamespace/ep1name",
-	},
-	gvr("", "v1", "resourcequotas"): {
-		stub:             `{"metadata": {"name": "rq1name"}, "spec": {"hard": {"cpu": "5M"}}}`,
-		expectedEtcdPath: "/registry/resourcequotas/etcdstoragepathtestnamespace/rq1name",
-	},
-	gvr("", "v1", "limitranges"): {
-		stub:             `{"metadata": {"name": "lr1name"}, "spec": {"limits": [{"type": "Pod"}]}}`,
-		expectedEtcdPath: "/registry/limitranges/etcdstoragepathtestnamespace/lr1name",
-	},
-	gvr("", "v1", "namespaces"): {
-		stub:             `{"metadata": {"name": "namespace1"}, "spec": {"finalizers": ["kubernetes"]}}`,
-		expectedEtcdPath: "/registry/namespaces/namespace1",
-	},
-	gvr("", "v1", "nodes"): {
-		stub:             `{"metadata": {"name": "node1"}, "spec": {"unschedulable": true}}`,
-		expectedEtcdPath: "/registry/minions/node1",
-	},
-	gvr("", "v1", "persistentvolumes"): {
-		stub:             `{"metadata": {"name": "pv1name"}, "spec": {"accessModes": ["ReadWriteOnce"], "capacity": {"storage": "3M"}, "hostPath": {"path": "/tmp/test/"}}}`,
-		expectedEtcdPath: "/registry/persistentvolumes/pv1name",
-	},
-	gvr("", "v1", "events"): {
-		stub:             `{"involvedObject": {"namespace": "etcdstoragepathtestnamespace"}, "message": "some data here", "metadata": {"name": "event1"}}`,
-		expectedEtcdPath: "/registry/events/etcdstoragepathtestnamespace/event1",
-	},
-	gvr("", "v1", "persistentvolumeclaims"): {
-		stub:             `{"metadata": {"name": "pvc1"}, "spec": {"accessModes": ["ReadWriteOnce"], "resources": {"limits": {"storage": "1M"}, "requests": {"storage": "2M"}}, "selector": {"matchLabels": {"pvc": "stuff"}}}}`,
-		expectedEtcdPath: "/registry/persistentvolumeclaims/etcdstoragepathtestnamespace/pvc1",
-	},
-	gvr("", "v1", "serviceaccounts"): {
-		stub:             `{"metadata": {"name": "sa1name"}, "secrets": [{"name": "secret00"}]}`,
-		expectedEtcdPath: "/registry/serviceaccounts/etcdstoragepathtestnamespace/sa1name",
-	},
-	gvr("", "v1", "secrets"): {
-		stub:             `{"data": {"key": "ZGF0YSBmaWxl"}, "metadata": {"name": "secret1"}}`,
-		expectedEtcdPath: "/registry/secrets/etcdstoragepathtestnamespace/secret1",
-	},
-	gvr("", "v1", "replicationcontrollers"): {
-		stub:             `{"metadata": {"name": "rc1"}, "spec": {"selector": {"new": "stuff"}, "template": {"metadata": {"labels": {"new": "stuff"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container8"}]}}}}`,
-		expectedEtcdPath: "/registry/controllers/etcdstoragepathtestnamespace/rc1",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/apps/v1beta1
-	gvr("apps", "v1beta1", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss1"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss1",
-		expectedGVK:      gvkP("apps", "v1", "StatefulSet"),
-	},
-	gvr("apps", "v1beta1", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment2"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment2",
-		expectedGVK:      gvkP("apps", "v1", "Deployment"),
-	},
-	gvr("apps", "v1beta1", "controllerrevisions"): {
-		stub:             `{"metadata":{"name":"crs1"},"data":{"name":"abc","namespace":"default","creationTimestamp":null,"Spec":{"Replicas":0,"Selector":{"matchLabels":{"foo":"bar"}},"Template":{"creationTimestamp":null,"labels":{"foo":"bar"},"Spec":{"Volumes":null,"InitContainers":null,"Containers":null,"RestartPolicy":"Always","TerminationGracePeriodSeconds":null,"ActiveDeadlineSeconds":null,"DNSPolicy":"ClusterFirst","NodeSelector":null,"ServiceAccountName":"","AutomountServiceAccountToken":null,"NodeName":"","SecurityContext":null,"ImagePullSecrets":null,"Hostname":"","Subdomain":"","Affinity":null,"SchedulerName":"","Tolerations":null,"HostAliases":null}},"VolumeClaimTemplates":null,"ServiceName":""},"Status":{"ObservedGeneration":null,"Replicas":0}},"revision":0}`,
-		expectedEtcdPath: "/registry/controllerrevisions/etcdstoragepathtestnamespace/crs1",
-		expectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/apps/v1beta2
-	gvr("apps", "v1beta2", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss2"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss2",
-		expectedGVK:      gvkP("apps", "v1", "StatefulSet"),
-	},
-	gvr("apps", "v1beta2", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment3"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment3",
-		expectedGVK:      gvkP("apps", "v1", "Deployment"),
-	},
-	gvr("apps", "v1beta2", "daemonsets"): {
-		stub:             `{"metadata": {"name": "ds5"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "/registry/daemonsets/etcdstoragepathtestnamespace/ds5",
-		expectedGVK:      gvkP("apps", "v1", "DaemonSet"),
-	},
-	gvr("apps", "v1beta2", "replicasets"): {
-		stub:             `{"metadata": {"name": "rs2"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
-		expectedEtcdPath: "/registry/replicasets/etcdstoragepathtestnamespace/rs2",
-		expectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
-	},
-	gvr("apps", "v1beta2", "controllerrevisions"): {
-		stub:             `{"metadata":{"name":"crs2"},"data":{"name":"abc","namespace":"default","creationTimestamp":null,"Spec":{"Replicas":0,"Selector":{"matchLabels":{"foo":"bar"}},"Template":{"creationTimestamp":null,"labels":{"foo":"bar"},"Spec":{"Volumes":null,"InitContainers":null,"Containers":null,"RestartPolicy":"Always","TerminationGracePeriodSeconds":null,"ActiveDeadlineSeconds":null,"DNSPolicy":"ClusterFirst","NodeSelector":null,"ServiceAccountName":"","AutomountServiceAccountToken":null,"NodeName":"","SecurityContext":null,"ImagePullSecrets":null,"Hostname":"","Subdomain":"","Affinity":null,"SchedulerName":"","Tolerations":null,"HostAliases":null}},"VolumeClaimTemplates":null,"ServiceName":""},"Status":{"ObservedGeneration":null,"Replicas":0}},"revision":0}`,
-		expectedEtcdPath: "/registry/controllerrevisions/etcdstoragepathtestnamespace/crs2",
-		expectedGVK:      gvkP("apps", "v1", "ControllerRevision"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/apps/v1
-	gvr("apps", "v1", "daemonsets"): {
-		stub:             `{"metadata": {"name": "ds6"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "/registry/daemonsets/etcdstoragepathtestnamespace/ds6",
-	},
-	gvr("apps", "v1", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment4"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment4",
-	},
-	gvr("apps", "v1", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss3"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
-		expectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss3",
-	},
-	gvr("apps", "v1", "replicasets"): {
-		stub:             `{"metadata": {"name": "rs3"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
-		expectedEtcdPath: "/registry/replicasets/etcdstoragepathtestnamespace/rs3",
-	},
-	gvr("apps", "v1", "controllerrevisions"): {
-		stub:             `{"metadata":{"name":"crs3"},"data":{"name":"abc","namespace":"default","creationTimestamp":null,"Spec":{"Replicas":0,"Selector":{"matchLabels":{"foo":"bar"}},"Template":{"creationTimestamp":null,"labels":{"foo":"bar"},"Spec":{"Volumes":null,"InitContainers":null,"Containers":null,"RestartPolicy":"Always","TerminationGracePeriodSeconds":null,"ActiveDeadlineSeconds":null,"DNSPolicy":"ClusterFirst","NodeSelector":null,"ServiceAccountName":"","AutomountServiceAccountToken":null,"NodeName":"","SecurityContext":null,"ImagePullSecrets":null,"Hostname":"","Subdomain":"","Affinity":null,"SchedulerName":"","Tolerations":null,"HostAliases":null}},"VolumeClaimTemplates":null,"ServiceName":""},"Status":{"ObservedGeneration":null,"Replicas":0}},"revision":0}`,
-		expectedEtcdPath: "/registry/controllerrevisions/etcdstoragepathtestnamespace/crs3",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/autoscaling/v1
-	gvr("autoscaling", "v1", "horizontalpodautoscalers"): {
-		stub:             `{"metadata": {"name": "hpa2"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
-		expectedEtcdPath: "/registry/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa2",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1
-	gvr("autoscaling", "v2beta1", "horizontalpodautoscalers"): {
-		stub:             `{"metadata": {"name": "hpa1"}, "spec": {"maxReplicas": 3, "scaleTargetRef": {"kind": "something", "name": "cross"}}}`,
-		expectedEtcdPath: "/registry/horizontalpodautoscalers/etcdstoragepathtestnamespace/hpa1",
-		expectedGVK:      gvkP("autoscaling", "v1", "HorizontalPodAutoscaler"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/batch/v1
-	gvr("batch", "v1", "jobs"): {
-		stub:             `{"metadata": {"name": "job1"}, "spec": {"manualSelector": true, "selector": {"matchLabels": {"controller-uid": "uid1"}}, "template": {"metadata": {"labels": {"controller-uid": "uid1"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container1"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}`,
-		expectedEtcdPath: "/registry/jobs/etcdstoragepathtestnamespace/job1",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/batch/v1beta1
-	gvr("batch", "v1beta1", "cronjobs"): {
-		stub:             `{"metadata": {"name": "cjv1beta1"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
-		expectedEtcdPath: "/registry/cronjobs/etcdstoragepathtestnamespace/cjv1beta1",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/batch/v2alpha1
-	gvr("batch", "v2alpha1", "cronjobs"): {
-		stub:             `{"metadata": {"name": "cjv2alpha1"}, "spec": {"jobTemplate": {"spec": {"template": {"metadata": {"labels": {"controller-uid": "uid0"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container0"}], "dnsPolicy": "ClusterFirst", "restartPolicy": "Never"}}}}, "schedule": "* * * * *"}}`,
-		expectedEtcdPath: "/registry/cronjobs/etcdstoragepathtestnamespace/cjv2alpha1",
-		expectedGVK:      gvkP("batch", "v1beta1", "CronJob"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/certificates/v1beta1
-	gvr("certificates.k8s.io", "v1beta1", "certificatesigningrequests"): {
-		stub:             `{"metadata": {"name": "csr1"}, "spec": {"request": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJQnlqQ0NBVE1DQVFBd2dZa3hDekFKQmdOVkJBWVRBbFZUTVJNd0VRWURWUVFJRXdwRFlXeHBabTl5Ym1saApNUll3RkFZRFZRUUhFdzFOYjNWdWRHRnBiaUJXYVdWM01STXdFUVlEVlFRS0V3cEhiMjluYkdVZ1NXNWpNUjh3CkhRWURWUVFMRXhaSmJtWnZjbTFoZEdsdmJpQlVaV05vYm05c2IyZDVNUmN3RlFZRFZRUURFdzUzZDNjdVoyOXYKWjJ4bExtTnZiVENCbnpBTkJna3Foa2lHOXcwQkFRRUZBQU9CalFBd2dZa0NnWUVBcFp0WUpDSEo0VnBWWEhmVgpJbHN0UVRsTzRxQzAzaGpYK1prUHl2ZFlkMVE0K3FiQWVUd1htQ1VLWUhUaFZSZDVhWFNxbFB6eUlCd2llTVpyCldGbFJRZGRaMUl6WEFsVlJEV3dBbzYwS2VjcWVBWG5uVUsrNWZYb1RJL1VnV3NocmU4dEoreC9UTUhhUUtSL0oKY0lXUGhxYVFoc0p1elpidkFkR0E4MEJMeGRNQ0F3RUFBYUFBTUEwR0NTcUdTSWIzRFFFQkJRVUFBNEdCQUlobAo0UHZGcStlN2lwQVJnSTVaTStHWng2bXBDejQ0RFRvMEprd2ZSRGYrQnRyc2FDMHE2OGVUZjJYaFlPc3E0ZmtIClEwdUEwYVZvZzNmNWlKeENhM0hwNWd4YkpRNnpWNmtKMFRFc3VhYU9oRWtvOXNkcENvUE9uUkJtMmkvWFJEMkQKNmlOaDhmOHowU2hHc0ZxakRnRkh5RjNvK2xVeWorVUM2SDFRVzdibgotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0="}}`,
-		expectedEtcdPath: "/registry/certificatesigningrequests/csr1",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/events/v1beta1
-	gvr("events.k8s.io", "v1beta1", "events"): {
-		stub:             `{"metadata": {"name": "event2"}, "regarding": {"namespace": "etcdstoragepathtestnamespace"}, "note": "some data here", "eventTime": "2017-08-09T15:04:05.000000Z", "reportingInstance": "node-xyz", "reportingController": "k8s.io/my-controller", "action": "DidNothing", "reason": "Laziness"}`,
-		expectedEtcdPath: "/registry/events/etcdstoragepathtestnamespace/event2",
-		expectedGVK:      gvkP("", "v1", "Event"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/extensions/v1beta1
-	gvr("extensions", "v1beta1", "daemonsets"): {
-		stub:             `{"metadata": {"name": "ds1"}, "spec": {"selector": {"matchLabels": {"u": "t"}}, "template": {"metadata": {"labels": {"u": "t"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container5"}]}}}}`,
-		expectedEtcdPath: "/registry/daemonsets/etcdstoragepathtestnamespace/ds1",
-		expectedGVK:      gvkP("apps", "v1", "DaemonSet"),
-	},
-	gvr("extensions", "v1beta1", "podsecuritypolicies"): {
-		stub:             `{"metadata": {"name": "psp1"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
-		expectedEtcdPath: "/registry/podsecuritypolicy/psp1",
-		expectedGVK:      gvkP("policy", "v1beta1", "PodSecurityPolicy"),
-	},
-	gvr("extensions", "v1beta1", "ingresses"): {
-		stub:             `{"metadata": {"name": "ingress1"}, "spec": {"backend": {"serviceName": "service", "servicePort": 5000}}}`,
-		expectedEtcdPath: "/registry/ingress/etcdstoragepathtestnamespace/ingress1",
-	},
-	gvr("extensions", "v1beta1", "networkpolicies"): {
-		stub:             `{"metadata": {"name": "np1"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
-		expectedEtcdPath: "/registry/networkpolicies/etcdstoragepathtestnamespace/np1",
-		expectedGVK:      gvkP("networking.k8s.io", "v1", "NetworkPolicy"),
-	},
-	gvr("extensions", "v1beta1", "deployments"): {
-		stub:             `{"metadata": {"name": "deployment1"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
-		expectedEtcdPath: "/registry/deployments/etcdstoragepathtestnamespace/deployment1",
-		expectedGVK:      gvkP("apps", "v1", "Deployment"),
-	},
-	gvr("extensions", "v1beta1", "replicasets"): {
-		stub:             `{"metadata": {"name": "rs1"}, "spec": {"selector": {"matchLabels": {"g": "h"}}, "template": {"metadata": {"labels": {"g": "h"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container4"}]}}}}`,
-		expectedEtcdPath: "/registry/replicasets/etcdstoragepathtestnamespace/rs1",
-		expectedGVK:      gvkP("apps", "v1", "ReplicaSet"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/networking/v1
-	gvr("networking.k8s.io", "v1", "networkpolicies"): {
-		stub:             `{"metadata": {"name": "np2"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
-		expectedEtcdPath: "/registry/networkpolicies/etcdstoragepathtestnamespace/np2",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/policy/v1beta1
-	gvr("policy", "v1beta1", "poddisruptionbudgets"): {
-		stub:             `{"metadata": {"name": "pdb1"}, "spec": {"selector": {"matchLabels": {"anokkey": "anokvalue"}}}}`,
-		expectedEtcdPath: "/registry/poddisruptionbudgets/etcdstoragepathtestnamespace/pdb1",
-	},
-	gvr("policy", "v1beta1", "podsecuritypolicies"): {
-		stub:             `{"metadata": {"name": "psp2"}, "spec": {"fsGroup": {"rule": "RunAsAny"}, "privileged": true, "runAsUser": {"rule": "RunAsAny"}, "seLinux": {"rule": "MustRunAs"}, "supplementalGroups": {"rule": "RunAsAny"}}}`,
-		expectedEtcdPath: "/registry/podsecuritypolicy/psp2",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/storage/v1alpha1
-	gvr("storage.k8s.io", "v1alpha1", "volumeattachments"): {
-		stub:             `{"metadata": {"name": "va1"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv1"}}}`,
-		expectedEtcdPath: "/registry/volumeattachments/va1",
-		expectedGVK:      gvkP("storage.k8s.io", "v1beta1", "VolumeAttachment"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/storage/v1beta1
-	gvr("storage.k8s.io", "v1beta1", "volumeattachments"): {
-		stub:             `{"metadata": {"name": "va2"}, "spec": {"attacher": "gce", "nodeName": "localhost", "source": {"persistentVolumeName": "pv2"}}}`,
-		expectedEtcdPath: "/registry/volumeattachments/va2",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/storage/v1beta1
-	gvr("storage.k8s.io", "v1beta1", "storageclasses"): {
-		stub:             `{"metadata": {"name": "sc1"}, "provisioner": "aws"}`,
-		expectedEtcdPath: "/registry/storageclasses/sc1",
-		expectedGVK:      gvkP("storage.k8s.io", "v1", "StorageClass"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/storage/v1
-	gvr("storage.k8s.io", "v1", "storageclasses"): {
-		stub:             `{"metadata": {"name": "sc2"}, "provisioner": "aws"}`,
-		expectedEtcdPath: "/registry/storageclasses/sc2",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/settings/v1alpha1
-	gvr("settings.k8s.io", "v1alpha1", "podpresets"): {
-		stub:             `{"metadata": {"name": "podpre1"}, "spec": {"env": [{"name": "FOO"}]}}`,
-		expectedEtcdPath: "/registry/podpresets/etcdstoragepathtestnamespace/podpre1",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/rbac/v1alpha1
-	gvr("rbac.authorization.k8s.io", "v1alpha1", "roles"): {
-		stub:             `{"metadata": {"name": "role1"}, "rules": [{"apiGroups": ["v1"], "resources": ["events"], "verbs": ["watch"]}]}`,
-		expectedEtcdPath: "/registry/roles/etcdstoragepathtestnamespace/role1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
-	},
-	gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "crole1"}, "rules": [{"nonResourceURLs": ["/version"], "verbs": ["get"]}]}`,
-		expectedEtcdPath: "/registry/clusterroles/crole1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
-	},
-	gvr("rbac.authorization.k8s.io", "v1alpha1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "roleb1"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
-		expectedEtcdPath: "/registry/rolebindings/etcdstoragepathtestnamespace/roleb1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
-	},
-	gvr("rbac.authorization.k8s.io", "v1alpha1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "croleb1"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
-		expectedEtcdPath: "/registry/clusterrolebindings/croleb1",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/rbac/v1beta1
-	gvr("rbac.authorization.k8s.io", "v1beta1", "roles"): {
-		stub:             `{"metadata": {"name": "role2"}, "rules": [{"apiGroups": ["v1"], "resources": ["events"], "verbs": ["watch"]}]}`,
-		expectedEtcdPath: "/registry/roles/etcdstoragepathtestnamespace/role2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "Role"),
-	},
-	gvr("rbac.authorization.k8s.io", "v1beta1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "crole2"}, "rules": [{"nonResourceURLs": ["/version"], "verbs": ["get"]}]}`,
-		expectedEtcdPath: "/registry/clusterroles/crole2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRole"),
-	},
-	gvr("rbac.authorization.k8s.io", "v1beta1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "roleb2"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
-		expectedEtcdPath: "/registry/rolebindings/etcdstoragepathtestnamespace/roleb2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "RoleBinding"),
-	},
-	gvr("rbac.authorization.k8s.io", "v1beta1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "croleb2"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
-		expectedEtcdPath: "/registry/clusterrolebindings/croleb2",
-		expectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/rbac/v1
-	gvr("rbac.authorization.k8s.io", "v1", "roles"): {
-		stub:             `{"metadata": {"name": "role3"}, "rules": [{"apiGroups": ["v1"], "resources": ["events"], "verbs": ["watch"]}]}`,
-		expectedEtcdPath: "/registry/roles/etcdstoragepathtestnamespace/role3",
-	},
-	gvr("rbac.authorization.k8s.io", "v1", "clusterroles"): {
-		stub:             `{"metadata": {"name": "crole3"}, "rules": [{"nonResourceURLs": ["/version"], "verbs": ["get"]}]}`,
-		expectedEtcdPath: "/registry/clusterroles/crole3",
-	},
-	gvr("rbac.authorization.k8s.io", "v1", "rolebindings"): {
-		stub:             `{"metadata": {"name": "roleb3"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
-		expectedEtcdPath: "/registry/rolebindings/etcdstoragepathtestnamespace/roleb3",
-	},
-	gvr("rbac.authorization.k8s.io", "v1", "clusterrolebindings"): {
-		stub:             `{"metadata": {"name": "croleb3"}, "roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": "somecr"}, "subjects": [{"apiVersion": "rbac.authorization.k8s.io/v1alpha1", "kind": "Group", "name": "system:authenticated"}]}`,
-		expectedEtcdPath: "/registry/clusterrolebindings/croleb3",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1
-	gvr("admissionregistration.k8s.io", "v1alpha1", "initializerconfigurations"): {
-		stub:             `{"metadata":{"name":"ic1"},"initializers":[{"name":"initializer.k8s.io","rules":[{"apiGroups":["group"],"apiVersions":["version"],"resources":["resource"]}],"failurePolicy":"Ignore"}]}`,
-		expectedEtcdPath: "/registry/initializerconfigurations/ic1",
-	},
-	// k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1
-	gvr("admissionregistration.k8s.io", "v1beta1", "validatingwebhookconfigurations"): {
-		stub:             `{"metadata":{"name":"hook1","creationTimestamp":null},"webhooks":[{"name":"externaladmissionhook.k8s.io","clientConfig":{"service":{"namespace":"ns","name":"n"},"caBundle":null},"rules":[{"operations":["CREATE"],"apiGroups":["group"],"apiVersions":["version"],"resources":["resource"]}],"failurePolicy":"Ignore"}]}`,
-		expectedEtcdPath: "/registry/validatingwebhookconfigurations/hook1",
-	},
-	gvr("admissionregistration.k8s.io", "v1beta1", "mutatingwebhookconfigurations"): {
-		stub:             `{"metadata":{"name":"hook1","creationTimestamp":null},"webhooks":[{"name":"externaladmissionhook.k8s.io","clientConfig":{"service":{"namespace":"ns","name":"n"},"caBundle":null},"rules":[{"operations":["CREATE"],"apiGroups":["group"],"apiVersions":["version"],"resources":["resource"]}],"failurePolicy":"Ignore"}]}`,
-		expectedEtcdPath: "/registry/mutatingwebhookconfigurations/hook1",
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/scheduling/v1alpha1
-	gvr("scheduling.k8s.io", "v1alpha1", "priorityclasses"): {
-		stub:             `{"metadata":{"name":"pc1"},"Value":1000}`,
-		expectedEtcdPath: "/registry/priorityclasses/pc1",
-		expectedGVK:      gvkP("scheduling.k8s.io", "v1beta1", "PriorityClass"),
-	},
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/scheduling/v1beta1
-	gvr("scheduling.k8s.io", "v1beta1", "priorityclasses"): {
-		stub:             `{"metadata":{"name":"pc2"},"Value":1000}`,
-		expectedEtcdPath: "/registry/priorityclasses/pc2",
-	},
-	// --
-}
-
-// Be very careful when whitelisting an object as ephemeral.
-// Doing so removes the safety we gain from this test by skipping that object.
-var ephemeralWhiteList = createEphemeralWhiteList(
-
-	// k8s.io/kubernetes/pkg/api/v1
-	gvk("", "v1", "Binding"),             // annotation on pod, not stored in etcd
-	gvk("", "v1", "RangeAllocation"),     // stored in various places in etcd but cannot be directly created
-	gvk("", "v1", "ComponentStatus"),     // status info not stored in etcd
-	gvk("", "v1", "SerializedReference"), // used for serilization, not stored in etcd
-	gvk("", "v1", "PodStatusResult"),     // wrapper object not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/authentication/v1beta1
-	gvk("authentication.k8s.io", "v1beta1", "TokenReview"), // not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/authentication/v1
-	gvk("authentication.k8s.io", "v1", "TokenReview"),  // not stored in etcd
-	gvk("authentication.k8s.io", "v1", "TokenRequest"), // not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/authorization/v1beta1
-
-	// SRR objects that are not stored in etcd
-	gvk("authorization.k8s.io", "v1beta1", "SelfSubjectRulesReview"),
-	// SAR objects that are not stored in etcd
-	gvk("authorization.k8s.io", "v1beta1", "SelfSubjectAccessReview"),
-	gvk("authorization.k8s.io", "v1beta1", "LocalSubjectAccessReview"),
-	gvk("authorization.k8s.io", "v1beta1", "SubjectAccessReview"),
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/authorization/v1
-
-	// SRR objects that are not stored in etcd
-	gvk("authorization.k8s.io", "v1", "SelfSubjectRulesReview"),
-	// SAR objects that are not stored in etcd
-	gvk("authorization.k8s.io", "v1", "SelfSubjectAccessReview"),
-	gvk("authorization.k8s.io", "v1", "LocalSubjectAccessReview"),
-	gvk("authorization.k8s.io", "v1", "SubjectAccessReview"),
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/autoscaling/v1
-	gvk("autoscaling", "v1", "Scale"), // not stored in etcd, part of kapiv1.ReplicationController
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/apps/v1beta1
-	gvk("apps", "v1beta1", "Scale"),              // not stored in etcd, part of kapiv1.ReplicationController
-	gvk("apps", "v1beta1", "DeploymentRollback"), // used to rollback deployment, not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/apps/v1beta2
-	gvk("apps", "v1beta2", "Scale"), // not stored in etcd, part of kapiv1.ReplicationController
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/batch/v1beta1
-	gvk("batch", "v1beta1", "JobTemplate"), // not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/batch/v2alpha1
-	gvk("batch", "v2alpha1", "JobTemplate"), // not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1
-	gvk("componentconfig", "v1alpha1", "KubeSchedulerConfiguration"), // not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/extensions/v1beta1
-	gvk("extensions", "v1beta1", "DeploymentRollback"),         // used to rollback deployment, not stored in etcd
-	gvk("extensions", "v1beta1", "ReplicationControllerDummy"), // not stored in etcd
-	gvk("extensions", "v1beta1", "Scale"),                      // not stored in etcd, part of kapiv1.ReplicationController
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1
-	gvk("imagepolicy.k8s.io", "v1alpha1", "ImageReview"), // not stored in etcd
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/policy/v1beta1
-	gvk("policy", "v1beta1", "Eviction"), // not stored in etcd, deals with evicting kapiv1.Pod
-	// --
-
-	// k8s.io/kubernetes/pkg/apis/admission/v1beta1
-	gvk("admission.k8s.io", "v1beta1", "AdmissionReview"), // not stored in etcd, call out to webhooks.
-	// --
-)
-
-// Only add kinds to this list when there is no way to create the object
-var kindWhiteList = sets.NewString(
-	// k8s.io/kubernetes/pkg/api/v1
-	"DeleteOptions",
-	"ExportOptions",
-	"ListOptions",
-	"NodeProxyOptions",
-	"PodAttachOptions",
-	"PodExecOptions",
-	"PodLogOptions",
-	"PodProxyOptions",
-	"ServiceProxyOptions",
-	"GetOptions",
-	"APIGroup",
-	"PodPortForwardOptions",
-	"APIVersions",
-	// --
-
-	// k8s.io/kubernetes/pkg/watch/versioned
-	"WatchEvent",
-	// --
-
-	// k8s.io/apimachinery/pkg/apis/meta/v1
-	"Status",
-	// --
-)
+// Only add kinds to this list when this a virtual resource with get and create verbs that doesn't actually
+// store into it's kind.  We've used this downstream for mappings before.
+var kindWhiteList = sets.NewString()
 
 // namespace used for all tests, do not change this
 const testNamespace = "etcdstoragepathtestnamespace"
@@ -556,70 +49,58 @@ const testNamespace = "etcdstoragepathtestnamespace"
 // It will also fail when a type gets moved to a different location. Be very careful in this situation because
 // it essentially means that you will be break old clusters unless you create some migration path for the old data.
 func TestEtcdStoragePath(t *testing.T) {
-	certDir, _ := ioutil.TempDir("", "test-integration-etcd")
-	defer os.RemoveAll(certDir)
+	master := StartRealMasterOrDie(t)
+	defer master.Cleanup()
+	defer dumpEtcdKVOnFailure(t, master.KV)
 
-	client, kvClient, mapper := startRealMasterOrDie(t, certDir)
-	defer func() {
-		dumpEtcdKVOnFailure(t, kvClient)
-	}()
+	client := &allClient{dynamicClient: master.Dynamic}
+
+	if _, err := master.Client.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}); err != nil {
+		t.Fatal(err)
+	}
+
+	etcdStorageData := GetEtcdStorageData()
 
 	kindSeen := sets.NewString()
 	pathSeen := map[string][]schema.GroupVersionResource{}
 	etcdSeen := map[schema.GroupVersionResource]empty{}
-	ephemeralSeen := map[schema.GroupVersionKind]empty{}
 	cohabitatingResources := map[string]map[schema.GroupVersionKind]empty{}
 
-	for gvk, apiType := range legacyscheme.Scheme.AllKnownTypes() {
-		// we do not care about internal objects or lists // TODO make sure this is always true
-		if gvk.Version == runtime.APIVersionInternal || strings.HasSuffix(apiType.Name(), "List") {
-			continue
-		}
+	for _, resourceToPersist := range master.Resources {
+		t.Run(resourceToPersist.Mapping.Resource.String(), func(t *testing.T) {
+			mapping := resourceToPersist.Mapping
+			gvk := resourceToPersist.Mapping.GroupVersionKind
+			gvResource := resourceToPersist.Mapping.Resource
+			kind := gvk.Kind
 
-		kind := gvk.Kind
-		pkgPath := apiType.PkgPath()
-
-		if kindWhiteList.Has(kind) {
-			kindSeen.Insert(kind)
-			continue
-		}
-		_, isEphemeral := ephemeralWhiteList[gvk]
-		if isEphemeral {
-			ephemeralSeen[gvk] = empty{}
-			continue
-		}
-
-		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		if err != nil {
-			t.Errorf("unexpected error getting mapping for %s from %s with GVK %s: %v", kind, pkgPath, gvk, err)
-			continue
-		}
-
-		etcdSeen[mapping.Resource] = empty{}
-
-		testData, hasTest := etcdStorageData[mapping.Resource]
-
-		if !hasTest {
-			t.Errorf("no test data for %s from %s.  Please add a test for your new type to etcdStorageData.", kind, pkgPath)
-			continue
-		}
-
-		if len(testData.expectedEtcdPath) == 0 {
-			t.Errorf("empty test data for %s from %s", kind, pkgPath)
-			continue
-		}
-
-		shouldCreate := len(testData.stub) != 0 // try to create only if we have a stub
-
-		var input *metaObject
-		if shouldCreate {
-			if input, err = jsonToMetaObject([]byte(testData.stub)); err != nil || input.isEmpty() {
-				t.Errorf("invalid test data for %s from %s: %v", kind, pkgPath, err)
-				continue
+			if kindWhiteList.Has(kind) {
+				kindSeen.Insert(kind)
+				t.Skip("whitelisted")
 			}
-		}
 
-		func() { // forces defer to run per iteration of the for loop
+			etcdSeen[gvResource] = empty{}
+			testData, hasTest := etcdStorageData[gvResource]
+
+			if !hasTest {
+				t.Fatalf("no test data for %s.  Please add a test for your new type to GetEtcdStorageData().", gvResource)
+			}
+
+			if len(testData.ExpectedEtcdPath) == 0 {
+				t.Fatalf("empty test data for %s", gvResource)
+			}
+
+			shouldCreate := len(testData.Stub) != 0 // try to create only if we have a stub
+
+			var (
+				input *metaObject
+				err   error
+			)
+			if shouldCreate {
+				if input, err = jsonToMetaObject([]byte(testData.Stub)); err != nil || input.isEmpty() {
+					t.Fatalf("invalid test data for %s: %v", gvResource, err)
+				}
+			}
+
 			all := &[]cleanupData{}
 			defer func() {
 				if !t.Failed() { // do not cleanup if test has already failed since we may need things in the etcd dump
@@ -629,54 +110,46 @@ func TestEtcdStoragePath(t *testing.T) {
 				}
 			}()
 
-			if err := client.createPrerequisites(mapper, testNamespace, testData.prerequisites, all); err != nil {
-				t.Errorf("failed to create prerequisites for %s from %s: %#v", kind, pkgPath, err)
-				return
+			if err := client.createPrerequisites(master.Mapper, testNamespace, testData.Prerequisites, all); err != nil {
+				t.Fatalf("failed to create prerequisites for %s: %#v", gvResource, err)
 			}
 
 			if shouldCreate { // do not try to create items with no stub
-				if err := client.create(testData.stub, testNamespace, mapping, all); err != nil {
-					t.Errorf("failed to create stub for %s from %s: %#v", kind, pkgPath, err)
-					return
+				if err := client.create(testData.Stub, testNamespace, mapping, all); err != nil {
+					t.Fatalf("failed to create stub for %s: %#v", gvResource, err)
 				}
 			}
 
-			output, err := getFromEtcd(kvClient, testData.expectedEtcdPath)
+			output, err := getFromEtcd(master.KV, testData.ExpectedEtcdPath)
 			if err != nil {
-				t.Errorf("failed to get from etcd for %s from %s: %#v", kind, pkgPath, err)
-				return
+				t.Fatalf("failed to get from etcd for %s: %#v", gvResource, err)
 			}
 
 			expectedGVK := gvk
-			if testData.expectedGVK != nil {
-				if gvk == *testData.expectedGVK {
-					t.Errorf("GVK override %s for %s from %s is unnecessary or something was changed incorrectly", testData.expectedGVK, kind, pkgPath)
+			if testData.ExpectedGVK != nil {
+				if gvk == *testData.ExpectedGVK {
+					t.Errorf("GVK override %s for %s is unnecessary or something was changed incorrectly", testData.ExpectedGVK, gvk)
 				}
-				expectedGVK = *testData.expectedGVK
+				expectedGVK = *testData.ExpectedGVK
 			}
 
 			actualGVK := output.getGVK()
 			if actualGVK != expectedGVK {
-				t.Errorf("GVK for %s from %s does not match, expected %s got %s", kind, pkgPath, expectedGVK, actualGVK)
+				t.Errorf("GVK for %s does not match, expected %s got %s", kind, expectedGVK, actualGVK)
 			}
 
 			if !apiequality.Semantic.DeepDerivative(input, output) {
-				t.Errorf("Test stub for %s from %s does not match: %s", kind, pkgPath, diff.ObjectGoPrintDiff(input, output))
+				t.Errorf("Test stub for %s does not match: %s", kind, diff.ObjectGoPrintDiff(input, output))
 			}
 
-			addGVKToEtcdBucket(cohabitatingResources, actualGVK, getEtcdBucket(testData.expectedEtcdPath))
-			pathSeen[testData.expectedEtcdPath] = append(pathSeen[testData.expectedEtcdPath], mapping.Resource)
-		}()
+			addGVKToEtcdBucket(cohabitatingResources, actualGVK, getEtcdBucket(testData.ExpectedEtcdPath))
+			pathSeen[testData.ExpectedEtcdPath] = append(pathSeen[testData.ExpectedEtcdPath], mapping.Resource)
+		})
 	}
 
 	if inEtcdData, inEtcdSeen := diffMaps(etcdStorageData, etcdSeen); len(inEtcdData) != 0 || len(inEtcdSeen) != 0 {
 		t.Errorf("etcd data does not match the types we saw:\nin etcd data but not seen:\n%s\nseen but not in etcd data:\n%s", inEtcdData, inEtcdSeen)
 	}
-
-	if inEphemeralWhiteList, inEphemeralSeen := diffMaps(ephemeralWhiteList, ephemeralSeen); len(inEphemeralWhiteList) != 0 || len(inEphemeralSeen) != 0 {
-		t.Errorf("ephemeral whitelist does not match the types we saw:\nin ephemeral whitelist but not seen:\n%s\nseen but not in ephemeral whitelist:\n%s", inEphemeralWhiteList, inEphemeralSeen)
-	}
-
 	if inKindData, inKindSeen := diffMaps(kindWhiteList, kindSeen); len(inKindData) != 0 || len(inKindSeen) != 0 {
 		t.Errorf("kind whitelist data does not match the types we saw:\nin kind whitelist but not seen:\n%s\nseen but not in kind whitelist:\n%s", inKindData, inKindSeen)
 	}
@@ -700,119 +173,6 @@ func TestEtcdStoragePath(t *testing.T) {
 			t.Errorf("invalid test data, please ensure all expectedEtcdPath are unique, path %s has duplicate GVRs:\n%s", path, gvrStrings)
 		}
 	}
-}
-
-func startRealMasterOrDie(t *testing.T, certDir string) (*allClient, clientv3.KV, meta.RESTMapper) {
-	_, defaultServiceClusterIPRange, err := net.ParseCIDR("10.0.0.0/24")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	kubeClientConfigValue := atomic.Value{}
-	storageConfigValue := atomic.Value{}
-
-	go func() {
-		// Catch panics that occur in this go routine so we get a comprehensible failure
-		defer func() {
-			if err := recover(); err != nil {
-				t.Errorf("Unexpected panic trying to start API master: %#v", err)
-			}
-		}()
-
-		listener, _, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		kubeAPIServerOptions := options.NewServerRunOptions()
-		kubeAPIServerOptions.SecureServing.Listener = listener
-		kubeAPIServerOptions.SecureServing.ServerCert.CertDirectory = certDir
-		kubeAPIServerOptions.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURL()}
-		kubeAPIServerOptions.Etcd.DefaultStorageMediaType = runtime.ContentTypeJSON // TODO use protobuf?
-		kubeAPIServerOptions.ServiceClusterIPRange = *defaultServiceClusterIPRange
-		kubeAPIServerOptions.Authorization.Modes = []string{"RBAC"}
-		kubeAPIServerOptions.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-		completedOptions, err := app.Complete(kubeAPIServerOptions)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		tunneler, proxyTransport, err := app.CreateNodeDialer(completedOptions)
-		if err != nil {
-			t.Fatal(err)
-		}
-		kubeAPIServerConfig, sharedInformers, versionedInformers, _, _, _, admissionPostStartHook, err := app.CreateKubeAPIServerConfig(completedOptions, tunneler, proxyTransport)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		kubeAPIServerConfig.ExtraConfig.APIResourceConfigSource = &allResourceSource{} // force enable all resources
-
-		kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.NewEmptyDelegate(), sharedInformers, versionedInformers, admissionPostStartHook)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		kubeClientConfigValue.Store(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
-		storageConfigValue.Store(kubeAPIServerOptions.Etcd.StorageConfig)
-
-		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(wait.NeverStop); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	if err := wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
-		obj := kubeClientConfigValue.Load()
-		if obj == nil {
-			return false, nil
-		}
-		kubeClientConfig := kubeClientConfigValue.Load().(*restclient.Config)
-		// make a copy so we can mutate it to set GroupVersion and NegotiatedSerializer
-		cfg := *kubeClientConfig
-		cfg.ContentConfig.GroupVersion = &schema.GroupVersion{}
-		cfg.ContentConfig.NegotiatedSerializer = legacyscheme.Codecs
-		privilegedClient, err := restclient.RESTClientFor(&cfg)
-		if err != nil {
-			// this happens because we race the API server start
-			t.Log(err)
-			return false, nil
-		}
-		// wait for the server to be healthy
-		result := privilegedClient.Get().AbsPath("/healthz").Do()
-		if errResult := result.Error(); errResult != nil {
-			t.Log(errResult)
-			return false, nil
-		}
-		var status int
-		result.StatusCode(&status)
-		return status == http.StatusOK, nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	kubeClientConfig := kubeClientConfigValue.Load().(*restclient.Config)
-	storageConfig := storageConfigValue.Load().(storagebackend.Config)
-
-	kubeClient := clientset.NewForConfigOrDie(kubeClientConfig)
-	if _, err := kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}); err != nil {
-		t.Fatal(err)
-	}
-
-	client, err := newClient(*kubeClientConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	kvClient, err := integration.GetEtcdKVClient(storageConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	discoveryClient := cacheddiscovery.NewMemCacheClient(kubeClient.Discovery())
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
-	restMapper.Reset()
-
-	return client, kvClient, restMapper
 }
 
 func dumpEtcdKVOnFailure(t *testing.T, kvClient clientv3.KV) {
@@ -853,14 +213,14 @@ func getEtcdBucket(path string) string {
 // stable fields to compare as a sanity check
 type metaObject struct {
 	// all of type meta
-	Kind       string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
-	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
 
 	// parts of object meta
 	Metadata struct {
-		Name      string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
-		Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
-	} `json:"metadata,omitempty" protobuf:"bytes,3,opt,name=metadata"`
+		Name      string `json:"name,omitempty"`
+		Namespace string `json:"namespace,omitempty"`
+	} `json:"metadata,omitempty"`
 }
 
 func (obj *metaObject) getGVK() schema.GroupVersionKind {
@@ -871,39 +231,11 @@ func (obj *metaObject) isEmpty() bool {
 	return obj == nil || *obj == metaObject{} // compare to zero value since all fields are strings
 }
 
-type prerequisite struct {
-	gvrData schema.GroupVersionResource
-	stub    string
-}
-
 type empty struct{}
 
 type cleanupData struct {
-	obj     runtime.Object
-	mapping *meta.RESTMapping
-}
-
-func gvr(g, v, r string) schema.GroupVersionResource {
-	return schema.GroupVersionResource{Group: g, Version: v, Resource: r}
-}
-
-func gvk(g, v, k string) schema.GroupVersionKind {
-	return schema.GroupVersionKind{Group: g, Version: v, Kind: k}
-}
-
-func gvkP(g, v, k string) *schema.GroupVersionKind {
-	return &schema.GroupVersionKind{Group: g, Version: v, Kind: k}
-}
-
-func createEphemeralWhiteList(gvks ...schema.GroupVersionKind) map[schema.GroupVersionKind]empty {
-	ephemeral := map[schema.GroupVersionKind]empty{}
-	for _, gvKind := range gvks {
-		if _, ok := ephemeral[gvKind]; ok {
-			panic("invalid ephemeral whitelist contains duplicate keys")
-		}
-		ephemeral[gvKind] = empty{}
-	}
-	return ephemeral
+	obj      *unstructured.Unstructured
+	resource schema.GroupVersionResource
 }
 
 func jsonToMetaObject(stub []byte) (*metaObject, error) {
@@ -929,76 +261,40 @@ func keyStringer(i interface{}) string {
 }
 
 type allClient struct {
-	client  *http.Client
-	config  *restclient.Config
-	backoff restclient.BackoffManager
-}
-
-func (c *allClient) verb(verb string, gvk schema.GroupVersionKind) (*restclient.Request, error) {
-	apiPath := "/apis"
-	if gvk.Group == kapi.GroupName {
-		apiPath = "/api"
-	}
-	baseURL, versionedAPIPath, err := restclient.DefaultServerURL(c.config.Host, apiPath, gvk.GroupVersion(), true)
-	if err != nil {
-		return nil, err
-	}
-	contentConfig := c.config.ContentConfig
-	gv := gvk.GroupVersion()
-	contentConfig.GroupVersion = &gv
-	serializers, err := createSerializers(contentConfig)
-	if err != nil {
-		return nil, err
-	}
-	return restclient.NewRequest(c.client, verb, baseURL, versionedAPIPath, contentConfig, *serializers, c.backoff, c.config.RateLimiter, 0), nil
+	dynamicClient dynamic.Interface
 }
 
 func (c *allClient) create(stub, ns string, mapping *meta.RESTMapping, all *[]cleanupData) error {
-	req, err := c.verb("POST", mapping.GroupVersionKind)
+	resourceClient, obj, err := JSONToUnstructured(stub, ns, mapping, c.dynamicClient)
 	if err != nil {
 		return err
 	}
-	namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
-	output, err := req.NamespaceIfScoped(ns, namespaced).Resource(mapping.Resource.Resource).Body(strings.NewReader(stub)).Do().Get()
-	if err != nil {
-		return err
-	}
-	*all = append(*all, cleanupData{output, mapping})
-	return nil
-}
 
-func (c *allClient) destroy(obj runtime.Object, mapping *meta.RESTMapping) error {
-	req, err := c.verb("DELETE", mapping.GroupVersionKind)
+	actual, err := resourceClient.Create(obj)
 	if err != nil {
 		return err
 	}
-	namespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
-	name, err := meta.NewAccessor().Name(obj)
-	if err != nil {
-		return err
-	}
-	ns, err := meta.NewAccessor().Namespace(obj)
-	if err != nil {
-		return err
-	}
-	return req.NamespaceIfScoped(ns, namespaced).Resource(mapping.Resource.Resource).Name(name).Do().Error()
+
+	*all = append(*all, cleanupData{obj: actual, resource: mapping.Resource})
+
+	return nil
 }
 
 func (c *allClient) cleanup(all *[]cleanupData) error {
 	for i := len(*all) - 1; i >= 0; i-- { // delete in reverse order in case creation order mattered
 		obj := (*all)[i].obj
-		mapping := (*all)[i].mapping
+		gvr := (*all)[i].resource
 
-		if err := c.destroy(obj, mapping); err != nil {
+		if err := c.dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), nil); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prerequisites []prerequisite, all *[]cleanupData) error {
+func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prerequisites []Prerequisite, all *[]cleanupData) error {
 	for _, prerequisite := range prerequisites {
-		gvk, err := mapper.KindFor(prerequisite.gvrData)
+		gvk, err := mapper.KindFor(prerequisite.GvrData)
 		if err != nil {
 			return err
 		}
@@ -1006,86 +302,11 @@ func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prere
 		if err != nil {
 			return err
 		}
-		if err := c.create(prerequisite.stub, ns, mapping, all); err != nil {
+		if err := c.create(prerequisite.Stub, ns, mapping, all); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func newClient(config restclient.Config) (*allClient, error) {
-	config.ContentConfig.NegotiatedSerializer = legacyscheme.Codecs
-	config.ContentConfig.ContentType = "application/json"
-	config.Timeout = 30 * time.Second
-	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(3, 10)
-
-	transport, err := restclient.TransportFor(&config)
-	if err != nil {
-		return nil, err
-	}
-
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   config.Timeout,
-	}
-
-	backoff := &restclient.URLBackoff{
-		Backoff: flowcontrol.NewBackOff(1*time.Second, 10*time.Second),
-	}
-
-	return &allClient{
-		client:  client,
-		config:  &config,
-		backoff: backoff,
-	}, nil
-}
-
-// copied from restclient
-func createSerializers(config restclient.ContentConfig) (*restclient.Serializers, error) {
-	mediaTypes := config.NegotiatedSerializer.SupportedMediaTypes()
-	contentType := config.ContentType
-	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		return nil, fmt.Errorf("the content type specified in the client configuration is not recognized: %v", err)
-	}
-	info, ok := runtime.SerializerInfoForMediaType(mediaTypes, mediaType)
-	if !ok {
-		if len(contentType) != 0 || len(mediaTypes) == 0 {
-			return nil, fmt.Errorf("no serializers registered for %s", contentType)
-		}
-		info = mediaTypes[0]
-	}
-
-	internalGV := schema.GroupVersions{
-		{
-			Group:   config.GroupVersion.Group,
-			Version: runtime.APIVersionInternal,
-		},
-		// always include the legacy group as a decoding target to handle non-error `Status` return types
-		{
-			Group:   "",
-			Version: runtime.APIVersionInternal,
-		},
-	}
-
-	s := &restclient.Serializers{
-		Encoder: config.NegotiatedSerializer.EncoderForVersion(info.Serializer, *config.GroupVersion),
-		Decoder: config.NegotiatedSerializer.DecoderToVersion(info.Serializer, internalGV),
-
-		RenegotiatedDecoder: func(contentType string, params map[string]string) (runtime.Decoder, error) {
-			info, ok := runtime.SerializerInfoForMediaType(mediaTypes, contentType)
-			if !ok {
-				return nil, fmt.Errorf("serializer for %s not registered", contentType)
-			}
-			return config.NegotiatedSerializer.DecoderToVersion(info.Serializer, internalGV), nil
-		},
-	}
-	if info.StreamSerializer != nil {
-		s.StreamingSerializer = info.StreamSerializer.Serializer
-		s.Framer = info.StreamSerializer.Framer
-	}
-
-	return s, nil
 }
 
 func getFromEtcd(keys clientv3.KV, path string) (*metaObject, error) {
@@ -1127,8 +348,3 @@ func diffMapKeys(a, b interface{}, stringer func(interface{}) string) []string {
 
 	return ret
 }
-
-type allResourceSource struct{}
-
-func (*allResourceSource) AnyVersionForGroupEnabled(group string) bool     { return true }
-func (*allResourceSource) VersionEnabled(version schema.GroupVersion) bool { return true }

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/server.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/server.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
+	cacheddiscovery "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/test/integration"
+	"k8s.io/kubernetes/test/integration/framework"
+
+	// install all APIs
+	_ "k8s.io/kubernetes/pkg/master"
+)
+
+// StartRealMasterOrDie starts an API master that is appropriate for use in tests that require one of every resource
+func StartRealMasterOrDie(t *testing.T) *Master {
+	certDir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, defaultServiceClusterIPRange, err := net.ParseCIDR("10.0.0.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listener, _, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubeAPIServerOptions := options.NewServerRunOptions()
+	kubeAPIServerOptions.InsecureServing.BindPort = 0
+	kubeAPIServerOptions.SecureServing.Listener = listener
+	kubeAPIServerOptions.SecureServing.ServerCert.CertDirectory = certDir
+	kubeAPIServerOptions.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURL()}
+	kubeAPIServerOptions.Etcd.DefaultStorageMediaType = runtime.ContentTypeJSON // force json we can easily interpret the result in etcd
+	kubeAPIServerOptions.ServiceClusterIPRange = *defaultServiceClusterIPRange
+	kubeAPIServerOptions.Authorization.Modes = []string{"RBAC"}
+	kubeAPIServerOptions.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+	completedOptions, err := app.Complete(kubeAPIServerOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := completedOptions.APIEnablement.RuntimeConfig.Set("api/all=true"); err != nil {
+		t.Fatal(err)
+	}
+
+	// get etcd client before starting API server
+	rawClient, kvClient, err := integration.GetEtcdClients(completedOptions.Etcd.StorageConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get a leased session
+	session, err := concurrency.NewSession(rawClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// then build and use an etcd lock
+	// this prevents more than one of these masters from running at the same time
+	lock := concurrency.NewLocker(session, "kube_integration_etcd_raw")
+	lock.Lock()
+
+	// make sure we start with a clean slate
+	if _, err := kvClient.Delete(context.Background(), "/registry/", clientv3.WithPrefix()); err != nil {
+		t.Fatal(err)
+	}
+
+	stopCh := make(chan struct{})
+
+	kubeAPIServer, err := app.CreateServerChain(completedOptions, stopCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubeClientConfig := restclient.CopyConfig(kubeAPIServer.LoopbackClientConfig)
+
+	// we make lots of requests, don't be slow
+	kubeClientConfig.QPS = 99999
+	kubeClientConfig.Burst = 9999
+
+	kubeClient := clientset.NewForConfigOrDie(kubeClientConfig)
+
+	go func() {
+		// Catch panics that occur in this go routine so we get a comprehensible failure
+		defer func() {
+			if err := recover(); err != nil {
+				t.Errorf("Unexpected panic trying to start API master: %#v", err)
+			}
+		}()
+
+		if err := kubeAPIServer.PrepareRun().Run(stopCh); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	lastHealth := ""
+	if err := wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
+		// wait for the server to be healthy
+		result := kubeClient.RESTClient().Get().AbsPath("/healthz").Do()
+		content, _ := result.Raw()
+		lastHealth = string(content)
+		if errResult := result.Error(); errResult != nil {
+			t.Log(errResult)
+			return false, nil
+		}
+		var status int
+		result.StatusCode(&status)
+		return status == http.StatusOK, nil
+	}); err != nil {
+		t.Log(lastHealth)
+		t.Fatal(err)
+	}
+
+	// force cached discovery reset
+	discoveryClient := cacheddiscovery.NewMemCacheClient(kubeClient.Discovery())
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	restMapper.Reset()
+
+	serverResources, err := kubeClient.Discovery().ServerResources()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := func() {
+		if err := os.RemoveAll(certDir); err != nil {
+			t.Log(err)
+		}
+		close(stopCh)
+		lock.Unlock()
+	}
+
+	return &Master{
+		Client:    kubeClient,
+		Dynamic:   dynamic_NewForConfigOrDie(kubeClientConfig),
+		Config:    kubeClientConfig,
+		KV:        kvClient,
+		Mapper:    restMapper,
+		Resources: GetResources(t, serverResources),
+		Cleanup:   cleanup,
+	}
+}
+
+func dynamic_NewForConfigOrDie(kubeClientConfig *restclient.Config) dynamic.Interface {
+	d, err := dynamic.NewForConfig(kubeClientConfig)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+// Master represents a running API server that is ready for use
+// The Cleanup func must be deferred to prevent resource leaks
+type Master struct {
+	Client    clientset.Interface
+	Dynamic   dynamic.Interface
+	Config    *restclient.Config
+	KV        clientv3.KV
+	Mapper    meta.RESTMapper
+	Resources []Resource
+	Cleanup   func()
+}
+
+// Resource contains REST mapping information for a specific resource and extra metadata such as delete collection support
+type Resource struct {
+	Mapping             *meta.RESTMapping
+	HasDeleteCollection bool
+}
+
+// GetResources fetches the Resources associated with serverResources that support get and create
+func GetResources(t *testing.T, serverResources []*metav1.APIResourceList) []Resource {
+	var resources []Resource
+
+	for _, discoveryGroup := range serverResources {
+		for _, discoveryResource := range discoveryGroup.APIResources {
+			// this is a subresource, skip it
+			if strings.Contains(discoveryResource.Name, "/") {
+				continue
+			}
+			hasCreate := false
+			hasGet := false
+			hasDeleteCollection := false
+			for _, verb := range discoveryResource.Verbs {
+				if verb == "get" {
+					hasGet = true
+				}
+				if verb == "create" {
+					hasCreate = true
+				}
+				if verb == "deletecollection" {
+					hasDeleteCollection = true
+				}
+			}
+			if !(hasCreate && hasGet) {
+				continue
+			}
+
+			resourceGV, err := schema.ParseGroupVersion(discoveryGroup.GroupVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gvk := resourceGV.WithKind(discoveryResource.Kind)
+			if len(discoveryResource.Group) > 0 || len(discoveryResource.Version) > 0 {
+				gvk = schema.GroupVersionKind{
+					Group:   discoveryResource.Group,
+					Version: discoveryResource.Version,
+					Kind:    discoveryResource.Kind,
+				}
+			}
+			gvr := resourceGV.WithResource(discoveryResource.Name)
+
+			resources = append(resources, Resource{
+				Mapping: &meta.RESTMapping{
+					Resource:         gvr,
+					GroupVersionKind: gvk,
+					Scope:            scope(discoveryResource.Namespaced),
+				},
+				HasDeleteCollection: hasDeleteCollection,
+			})
+		}
+	}
+
+	return resources
+}
+
+func scope(namespaced bool) meta.RESTScope {
+	if namespaced {
+		return meta.RESTScopeNamespace
+	}
+	return meta.RESTScopeRoot
+}
+
+// JSONToUnstructured converts a JSON stub to unstructured.Unstructured and
+// returns a dynamic resource client that can be used to interact with it
+func JSONToUnstructured(stub, namespace string, mapping *meta.RESTMapping, dynamicClient dynamic.Interface) (dynamic.ResourceInterface, *unstructured.Unstructured, error) {
+	typeMetaAdder := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(stub), &typeMetaAdder); err != nil {
+		return nil, nil, err
+	}
+
+	// we don't require GVK on the data we provide, so we fill it in here.  We could, but that seems extraneous.
+	typeMetaAdder["apiVersion"] = mapping.GroupVersionKind.GroupVersion().String()
+	typeMetaAdder["kind"] = mapping.GroupVersionKind.Kind
+
+	if mapping.Scope == meta.RESTScopeRoot {
+		namespace = ""
+	}
+
+	return dynamicClient.Resource(mapping.Resource).Namespace(namespace), &unstructured.Unstructured{Object: typeMetaAdder}, nil
+}

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/server.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/server.go
@@ -30,6 +30,8 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -153,6 +155,9 @@ func StartRealMasterOrDie(t *testing.T) *Master {
 		t.Fatal(err)
 	}
 
+	// create CRDs so we can make sure that custom resources do not get lost
+	CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(kubeClientConfig), false, GetCustomResourceDefinitionData()...)
+
 	// force cached discovery reset
 	discoveryClient := cacheddiscovery.NewMemCacheClient(kubeClient.Discovery())
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
@@ -169,6 +174,9 @@ func StartRealMasterOrDie(t *testing.T) *Master {
 		}
 		close(stopCh)
 		lock.Unlock()
+		if err := session.Close(); err != nil {
+			t.Log(err)
+		}
 	}
 
 	return &Master{
@@ -288,4 +296,80 @@ func JSONToUnstructured(stub, namespace string, mapping *meta.RESTMapping, dynam
 	}
 
 	return dynamicClient.Resource(mapping.Resource).Namespace(namespace), &unstructured.Unstructured{Object: typeMetaAdder}, nil
+}
+
+// CreateTestCRDs creates the given CRDs, any failure causes the test to Fatal.
+// If skipCrdExistsInDiscovery is true, the CRDs are only checked for the Established condition via their Status.
+// If skipCrdExistsInDiscovery is false, the CRDs are checked via discovery, see CrdExistsInDiscovery.
+func CreateTestCRDs(t *testing.T, client apiextensionsclientset.Interface, skipCrdExistsInDiscovery bool, crds ...*apiextensionsv1beta1.CustomResourceDefinition) {
+	for _, crd := range crds {
+		createTestCRD(t, client, skipCrdExistsInDiscovery, crd)
+	}
+}
+
+func createTestCRD(t *testing.T, client apiextensionsclientset.Interface, skipCrdExistsInDiscovery bool, crd *apiextensionsv1beta1.CustomResourceDefinition) {
+	if _, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd); err != nil {
+		t.Fatalf("Failed to create %s CRD; %v", crd.Name, err)
+	}
+	if skipCrdExistsInDiscovery {
+		if err := waitForEstablishedCRD(client, crd.Name); err != nil {
+			t.Fatalf("Failed to establish %s CRD; %v", crd.Name, err)
+		}
+		return
+	}
+	if err := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		return CrdExistsInDiscovery(client, crd), nil
+	}); err != nil {
+		t.Fatalf("Failed to see %s in discovery: %v", crd.Name, err)
+	}
+}
+
+func waitForEstablishedCRD(client apiextensionsclientset.Interface, name string) error {
+	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		crd, err := client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiextensionsv1beta1.Established:
+				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+}
+
+// CrdExistsInDiscovery checks to see if the given CRD exists in discovery at all served versions.
+func CrdExistsInDiscovery(client apiextensionsclientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition) bool {
+	var versions []string
+	if len(crd.Spec.Version) != 0 {
+		versions = append(versions, crd.Spec.Version)
+	}
+	for _, v := range crd.Spec.Versions {
+		if v.Served {
+			versions = append(versions, v.Name)
+		}
+	}
+	for _, v := range versions {
+		if !crdVersionExistsInDiscovery(client, crd, v) {
+			return false
+		}
+	}
+	return true
+}
+
+func crdVersionExistsInDiscovery(client apiextensionsclientset.Interface, crd *apiextensionsv1beta1.CustomResourceDefinition, version string) bool {
+	resourceList, err := client.Discovery().ServerResourcesForGroupVersion(crd.Spec.Group + "/" + version)
+	if err != nil {
+		return false
+	}
+	for _, resource := range resourceList.APIResources {
+		if resource.Name == crd.Spec.Names.Plural {
+			return true
+		}
+	}
+	return false
 }

--- a/vendor/k8s.io/kubernetes/test/integration/master/transformation_testcase.go
+++ b/vendor/k8s.io/kubernetes/test/integration/master/transformation_testcase.go
@@ -228,7 +228,7 @@ func (e *transformTest) createSecret(name, namespace string) (*corev1.Secret, er
 }
 
 func (e *transformTest) readRawRecordFromETCD(path string) (*clientv3.GetResponse, error) {
-	etcdClient, err := integration.GetEtcdKVClient(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig)
+	_, etcdClient, err := integration.GetEtcdClients(e.kubeAPIServer.ServerOpts.Etcd.StorageConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %v", err)
 	}

--- a/vendor/k8s.io/kubernetes/test/integration/utils.go
+++ b/vendor/k8s.io/kubernetes/test/integration/utils.go
@@ -67,7 +67,7 @@ func WaitForPodToDisappear(podClient coreclient.PodInterface, podName string, in
 	})
 }
 
-func GetEtcdKVClient(config storagebackend.Config) (clientv3.KV, error) {
+func GetEtcdClients(config storagebackend.Config) (*clientv3.Client, clientv3.KV, error) {
 	tlsInfo := transport.TLSInfo{
 		CertFile: config.CertFile,
 		KeyFile:  config.KeyFile,
@@ -76,7 +76,7 @@ func GetEtcdKVClient(config storagebackend.Config) (clientv3.KV, error) {
 
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	cfg := clientv3.Config{
@@ -86,8 +86,8 @@ func GetEtcdKVClient(config storagebackend.Config) (clientv3.KV, error) {
 
 	c, err := clientv3.New(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return clientv3.NewKV(c), nil
+	return c, clientv3.NewKV(c), nil
 }


### PR DESCRIPTION
UPSTREAM: 70019: Refactor dry run test to reuse ETCD storage data

This change updates the ETCD storage test so that its data is
exported. Thus it can be used by other tests. The dry run test was
updated to consume this data instead of having a duplicate copy.

The code to start a master that can be used for "one of every
resource" style tests was also factored out. It is reused in the
dry run test as well.

This prevents these tests from drifting in the future and reduces
the long term maintenance burden.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

UPSTREAM: <drop>: 70019: Remove too new ETCD storage data

We do not have the REST storage for these resources yet.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Remove dead code from ETCD storage test

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Use new exported types in ETCD storage test

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Collapse on top of upstream ETCD storage test

This change updates the OpenShift ETCD storage test to reuse the
upstream ETCD storage test's data.  This makes it easy for us to
keep up with upstream changes.  It also makes it clear in which
areas we differ.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Use upstream etcddata.GetResources in ETCD storage test

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @deads2k @soltysh
@openshift/sig-master