### PR TITLE
release: Only referenced images are included in the payload

### DIFF
--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -122,6 +123,9 @@ func (p *Payload) References() (*imageapi.ImageStream, error) {
 
 func parseImageStream(path string) (*imageapi.ImageStream, error) {
 	data, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, err
+	}
 	if err != nil {
 		return nil, fmt.Errorf("unable to read release image info from release contents: %v", err)
 	}

--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -555,6 +555,12 @@ func (o *NewOptions) Run() error {
 		})
 	}
 
+	if payload == nil {
+		if err := pruneUnreferencedImageStreams(o.ErrOut, is, metadata); err != nil {
+			return err
+		}
+	}
+
 	var operators []string
 	pr, pw := io.Pipe()
 	go func() {
@@ -583,7 +589,7 @@ func (o *NewOptions) Run() error {
 	case len(operators) == 0:
 		fmt.Fprintf(o.ErrOut, "warning: No operator metadata was found, no operators will be part of the release.\n")
 	default:
-		fmt.Fprintf(o.Out, "Built update image content from %d operators\n", len(operators))
+		fmt.Fprintf(o.Out, "Built release image from %d operators\n", len(operators))
 	}
 
 	return nil
@@ -635,6 +641,9 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 	for i := range is.Spec.Tags {
 		tag := is.Spec.Tags[i]
 		dstDir := filepath.Join(dir, tag.Name)
+		if tag.From.Kind != "DockerImage" {
+			continue
+		}
 		src := tag.From.Name
 		ref, err := imagereference.Parse(src)
 		if err != nil {
@@ -657,7 +666,7 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 				if err := os.MkdirAll(dstDir, 0770); err != nil {
 					return false, err
 				}
-				fmt.Fprintf(o.Out, "Loading manifests from %s: %s ...\n", tag.Name, src)
+				fmt.Fprintf(o.Out, "Loading manifests from %s: %s ...\n", tag.Name, m.ImageRef.ID)
 				return true, nil
 			},
 		})
@@ -1154,3 +1163,33 @@ func takeFileByName(files *[]os.FileInfo, name string) os.FileInfo {
 }
 
 type PayloadVerifier func(filename string, data []byte) error
+
+func pruneUnreferencedImageStreams(out io.Writer, is *imageapi.ImageStream, metadata map[string]imageData) error {
+	referenced := make(map[string]struct{})
+	for _, v := range metadata {
+		is, err := parseImageStream(filepath.Join(v.Directory, "image-references"))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, tag := range is.Spec.Tags {
+			referenced[tag.Name] = struct{}{}
+		}
+	}
+	var updated []imageapi.TagReference
+	for _, tag := range is.Spec.Tags {
+		_, ok := referenced[tag.Name]
+		if !ok {
+			glog.V(3).Infof("Excluding tag %s which is not referenced by an operator", tag.Name)
+			continue
+		}
+		updated = append(updated, tag)
+	}
+	if len(updated) != len(is.Spec.Tags) {
+		fmt.Fprintf(out, "info: Included %d referenced images into the payload\n", len(updated))
+		is.Spec.Tags = updated
+	}
+	return nil
+}


### PR DESCRIPTION
Prune the set of input images down to only images referenced by the operator.
To get in the release image, an operator has to reference you.