### PR TITLE
Update completion to use api-resources

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -257,9 +257,6 @@ __oc_override_flags()
                     ;;
             esac
         done
-        if [ "${w}" == "--all-namespaces" ]; then
-            namespace="--all-namespaces"
-        fi
     done
     for of in "${__oc_override_flag_list[@]}"; do
         if eval "test -n \"\$${of}\""; then
@@ -290,9 +287,14 @@ __oc_get_namespaces()
 __oc_get_resource()
 {
     if [[ ${#nouns[@]} -eq 0 ]]; then
-        return 1
+      local oc_out
+      if oc_out=$(oc api-resources $(__oc_override_flags) -o name --cached --request-timeout=5s --verbs=get 2>/dev/null); then
+          COMPREPLY=( $( compgen -W "${oc_out[*]}" -- "$cur" ) )
+          return 0
+      fi
+      return 1
     fi
-    __oc_parse_get ${nouns[${#nouns[@]} -1]}
+    __oc_parse_get "${nouns[${#nouns[@]} -1]}"
 }
 
 # $1 is the name of the pod we want to get the list of containers inside

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -399,9 +399,6 @@ __oc_override_flags()
                     ;;
             esac
         done
-        if [ "${w}" == "--all-namespaces" ]; then
-            namespace="--all-namespaces"
-        fi
     done
     for of in "${__oc_override_flag_list[@]}"; do
         if eval "test -n \"\$${of}\""; then
@@ -432,9 +429,14 @@ __oc_get_namespaces()
 __oc_get_resource()
 {
     if [[ ${#nouns[@]} -eq 0 ]]; then
-        return 1
+      local oc_out
+      if oc_out=$(oc api-resources $(__oc_override_flags) -o name --cached --request-timeout=5s --verbs=get 2>/dev/null); then
+          COMPREPLY=( $( compgen -W "${oc_out[*]}" -- "$cur" ) )
+          return 0
+      fi
+      return 1
     fi
-    __oc_parse_get ${nouns[${#nouns[@]} -1]}
+    __oc_parse_get "${nouns[${#nouns[@]} -1]}"
 }
 
 # $1 is the name of the pod we want to get the list of containers inside

--- a/pkg/oc/cli/cli_bashcomp_func.go
+++ b/pkg/oc/cli/cli_bashcomp_func.go
@@ -55,9 +55,14 @@ __oc_get_namespaces()
 __oc_get_resource()
 {
     if [[ ${#nouns[@]} -eq 0 ]]; then
-        return 1
+      local oc_out
+      if oc_out=$(oc api-resources $(__oc_override_flags) -o name --cached --request-timeout=5s --verbs=get 2>/dev/null); then
+          COMPREPLY=( $( compgen -W "${oc_out[*]}" -- "$cur" ) )
+          return 0
+      fi
+      return 1
     fi
-    __oc_parse_get ${nouns[${#nouns[@]} -1]}
+    __oc_parse_get "${nouns[${#nouns[@]} -1]}"
 }
 
 # $1 is the name of the pod we want to get the list of containers inside

--- a/pkg/oc/cli/cli_bashcomp_func.go
+++ b/pkg/oc/cli/cli_bashcomp_func.go
@@ -22,9 +22,6 @@ __oc_override_flags()
                     ;;
             esac
         done
-        if [ "${w}" == "--all-namespaces" ]; then
-            namespace="--all-namespaces"
-        fi
     done
     for of in "${__oc_override_flag_list[@]}"; do
         if eval "test -n \"\$${of}\""; then


### PR DESCRIPTION
This patch changes:
- to uses `oc api-resources` in bash completion
- to fix a bug in `__oc_override_flags()` based on https://github.com/kubernetes/kubernetes/pull/63421#discussion_r186091439

~~~
# oc get <TAB><TAB>
alertmanagers.monitoring.coreos.com                           horizontalpodautoscalers.autoscaling                          projects.project.openshift.io
apiservices.apiregistration.k8s.io                            hostsubnets.network.openshift.io                              prometheuses.monitoring.coreos.com
appliedclusterresourcequotas.quota.openshift.io               identities.user.openshift.io                                  prometheusrules.monitoring.coreos.com
brokertemplateinstances.template.openshift.io                 images.image.openshift.io                                     rangeallocations.security.openshift.io
buildconfigs.build.openshift.io                               imagestreamimages.image.openshift.io                          replicasets.apps
... snip ...
~~~

Please refer to: https://github.com/kubernetes/kubernetes/pull/63421
Fixes: https://github.com/openshift/origin/issues/21425