### PR TITLE
fix go-git problem with some vendored fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ origin.iml
 *.go~
 tags
 .envrc
+# To workaround go-git problem in publishing bots
+vendor/github.com/prometheus/procfs/fixtures/26231/exe

--- a/vendor/github.com/prometheus/procfs/fixtures/26231/exe
+++ b/vendor/github.com/prometheus/procfs/fixtures/26231/exe
@@ -1,1 +1,0 @@
-/usr/bin/vim


### PR DESCRIPTION
An issue (https://github.com/src-d/go-git/issues/1017) was found in go-git library that the publishing bot is using that leads to a dirty checkout which will block progress of publishing bot for the origin repo. It seems like the go-git can't handle the symlinks properly (along with other problem that we fixed in publishing bot).

