### PR TITLE
cli: Add an `oc adm release info` command that views and diffs releases

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -4980,6 +4980,54 @@ _oc_adm_release_extract()
     noun_aliases=()
 }
 
+_oc_adm_release_info()
+{
+    last_command="oc_adm_release_info"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--changes-from=")
+    local_nonpersistent_flags+=("--changes-from=")
+    flags+=("--commits")
+    local_nonpersistent_flags+=("--commits")
+    flags+=("--pullspecs")
+    local_nonpersistent_flags+=("--pullspecs")
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--cache-dir=")
+    flags+=("--certificate-authority=")
+    flags+=("--client-certificate=")
+    flags+=("--client-key=")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--kubeconfig=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    flags_with_completion+=("--namespace")
+    flags_completion+=("__oc_get_namespaces")
+    two_word_flags+=("-n")
+    flags_with_completion+=("-n")
+    flags_completion+=("__oc_get_namespaces")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    two_word_flags+=("-s")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_adm_release_mirror()
 {
     last_command="oc_adm_release_mirror"
@@ -5121,6 +5169,7 @@ _oc_adm_release()
     last_command="oc_adm_release"
     commands=()
     commands+=("extract")
+    commands+=("info")
     commands+=("mirror")
     commands+=("new")
 

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -5122,6 +5122,54 @@ _oc_adm_release_extract()
     noun_aliases=()
 }
 
+_oc_adm_release_info()
+{
+    last_command="oc_adm_release_info"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--changes-from=")
+    local_nonpersistent_flags+=("--changes-from=")
+    flags+=("--commits")
+    local_nonpersistent_flags+=("--commits")
+    flags+=("--pullspecs")
+    local_nonpersistent_flags+=("--pullspecs")
+    flags+=("--as=")
+    flags+=("--as-group=")
+    flags+=("--cache-dir=")
+    flags+=("--certificate-authority=")
+    flags+=("--client-certificate=")
+    flags+=("--client-key=")
+    flags+=("--cluster=")
+    flags+=("--config=")
+    flags+=("--context=")
+    flags+=("--insecure-skip-tls-verify")
+    flags+=("--kubeconfig=")
+    flags+=("--loglevel=")
+    flags+=("--logspec=")
+    flags+=("--match-server-version")
+    flags+=("--namespace=")
+    flags_with_completion+=("--namespace")
+    flags_completion+=("__oc_get_namespaces")
+    two_word_flags+=("-n")
+    flags_with_completion+=("-n")
+    flags_completion+=("__oc_get_namespaces")
+    flags+=("--request-timeout=")
+    flags+=("--server=")
+    two_word_flags+=("-s")
+    flags+=("--token=")
+    flags+=("--user=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _oc_adm_release_mirror()
 {
     last_command="oc_adm_release_mirror"
@@ -5263,6 +5311,7 @@ _oc_adm_release()
     last_command="oc_adm_release"
     commands=()
     commands+=("extract")
+    commands+=("info")
     commands+=("mirror")
     commands+=("new")
 

--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -129,9 +129,13 @@ func parseImageStream(path string) (*imageapi.ImageStream, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to read release image info from release contents: %v", err)
 	}
+	return readReleaseImageReferences(data)
+}
+
+func readReleaseImageReferences(data []byte) (*imageapi.ImageStream, error) {
 	is := &imageapi.ImageStream{}
 	if err := yaml.Unmarshal(data, &is); err != nil {
-		return nil, fmt.Errorf("unable to load image-references from release payload at %s: %v", path, err)
+		return nil, fmt.Errorf("unable to load release image-references: %v", err)
 	}
 	if is.Kind != "ImageStream" || is.APIVersion != "image.openshift.io/v1" {
 		return nil, fmt.Errorf("unrecognized image-references in release payload")

--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -1,0 +1,566 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/blang/semver"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	digest "github.com/opencontainers/go-digest"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
+
+	imageapi "github.com/openshift/api/image/v1"
+	"github.com/openshift/origin/pkg/image/apis/image/docker10"
+	imagereference "github.com/openshift/origin/pkg/image/apis/image/reference"
+	"github.com/openshift/origin/pkg/oc/cli/image/extract"
+)
+
+func NewInfoOptions(streams genericclioptions.IOStreams) *InfoOptions {
+	return &InfoOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewInfo(f kcmdutil.Factory, parentName string, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewInfoOptions(streams)
+	cmd := &cobra.Command{
+		Use:   "info IMAGE [--changes-from=IMAGE]",
+		Short: "Display information about a release",
+		Long: templates.LongDesc(`
+			Show information about an OpenShift release
+
+			Experimental: This command is under active development and may change without notice.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(cmd, args))
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&o.From, "changes-from", o.From, "Show changes from this image to the requested image.")
+	flags.BoolVar(&o.ShowCommit, "commits", o.ShowCommit, "Display information about the source an image was created with.")
+	flags.BoolVar(&o.ShowPullSpec, "pullspecs", o.ShowCommit, "Display the pull spec of the image instead of the digest.")
+	// flags.BoolVar(&o.Verify, "verify", o.Verify, "Verify the payload is consistent by checking the referenced images.")
+	return cmd
+}
+
+type InfoOptions struct {
+	genericclioptions.IOStreams
+
+	Images []string
+	From   string
+
+	ShowCommit   bool
+	ShowPullSpec bool
+	Verify       bool
+}
+
+func (o *InfoOptions) Complete(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("info expects at least one argument, a release image pull spec")
+	}
+	o.Images = args
+	return nil
+}
+
+func (o *InfoOptions) Run() error {
+	if len(o.Images) == 0 {
+		return fmt.Errorf("must specify a release image as an argument")
+	}
+	if len(o.From) > 0 && len(o.Images) != 1 {
+		return fmt.Errorf("must specify a release image as argument when comparing to another release image")
+	}
+
+	if len(o.From) > 0 {
+		var baseRelease *ReleaseInfo
+		var baseErr error
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			baseRelease, baseErr = o.LoadReleaseInfo(o.From)
+		}()
+
+		release, err := o.LoadReleaseInfo(o.Images[0])
+		if err != nil {
+			return err
+		}
+
+		<-done
+		if baseErr != nil {
+			return baseErr
+		}
+		diff, err := calculateDiff(baseRelease, release)
+		if err != nil {
+			return err
+		}
+		return describeReleaseDiff(o.Out, diff, o.ShowCommit)
+	}
+
+	for _, image := range o.Images {
+		release, err := o.LoadReleaseInfo(image)
+		if err != nil {
+			return err
+		}
+		if err := describeReleaseInfo(o.Out, release, o.ShowCommit, o.ShowPullSpec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func calculateDiff(from, to *ReleaseInfo) (*ReleaseDiff, error) {
+	diff := &ReleaseDiff{
+		From:             from,
+		To:               to,
+		ChangedImages:    make(map[string]*ImageReferenceDiff),
+		ChangedManifests: make(map[string]*ReleaseManifestDiff),
+	}
+	for i := range from.References.Spec.Tags {
+		tag := &from.References.Spec.Tags[i]
+		if tag.From == nil || tag.From.Kind != "DockerImage" {
+			continue
+		}
+		diff.ChangedImages[tag.Name] = &ImageReferenceDiff{
+			Name: tag.Name,
+			From: tag,
+		}
+	}
+	for i := range to.References.Spec.Tags {
+		tag := &to.References.Spec.Tags[i]
+		if tag.From == nil || tag.From.Kind != "DockerImage" {
+			continue
+		}
+		if exists, ok := diff.ChangedImages[tag.Name]; ok {
+			exists.To = tag
+			continue
+		}
+		diff.ChangedImages[tag.Name] = &ImageReferenceDiff{
+			Name: tag.Name,
+			To:   tag,
+		}
+	}
+	for k, v := range diff.ChangedImages {
+		if v.From != nil && v.To != nil && v.From.From.Name == v.To.From.Name {
+			delete(diff.ChangedImages, k)
+		}
+	}
+	for name, manifest := range from.ManifestFiles {
+		diff.ChangedManifests[name] = &ReleaseManifestDiff{
+			Filename: name,
+			From:     manifest,
+		}
+	}
+	for name, manifest := range to.ManifestFiles {
+		if exists, ok := diff.ChangedManifests[name]; ok {
+			exists.To = manifest
+			continue
+		}
+		diff.ChangedManifests[name] = &ReleaseManifestDiff{
+			Filename: name,
+			From:     manifest,
+		}
+	}
+	for k, v := range diff.ChangedManifests {
+		if bytes.Equal(v.From, v.To) {
+			delete(diff.ChangedManifests, k)
+		}
+	}
+
+	return diff, nil
+}
+
+type ReleaseDiff struct {
+	From, To *ReleaseInfo
+
+	ChangedImages    map[string]*ImageReferenceDiff
+	ChangedManifests map[string]*ReleaseManifestDiff
+}
+
+type ImageReferenceDiff struct {
+	Name string
+
+	From, To *imageapi.TagReference
+}
+
+type ReleaseManifestDiff struct {
+	Filename string
+
+	From, To []byte
+}
+
+type ReleaseInfo struct {
+	Image      imagereference.DockerImageReference
+	Digest     digest.Digest
+	Config     *docker10.DockerImageConfig
+	Metadata   *CincinnatiMetadata
+	References *imageapi.ImageStream
+
+	ManifestFiles map[string][]byte
+	UnknownFiles  []string
+}
+
+func (i *ReleaseInfo) PreferredName() string {
+	if i.Metadata != nil {
+		return i.Metadata.Version
+	}
+	return i.References.Name
+}
+
+func (i *ReleaseInfo) Platform() string {
+	os := i.Config.OS
+	if len(os) > 0 {
+		os = "unknown"
+	}
+	arch := i.Config.Architecture
+	if len(arch) == 0 {
+		arch = "unknown"
+	}
+	return fmt.Sprintf("%s/%s", os, arch)
+}
+
+func (o *InfoOptions) LoadReleaseInfo(image string) (*ReleaseInfo, error) {
+	ref, err := imagereference.Parse(image)
+	if err != nil {
+		return nil, err
+	}
+	opts := extract.NewOptions(genericclioptions.IOStreams{Out: o.Out, ErrOut: o.ErrOut})
+
+	release := &ReleaseInfo{}
+
+	opts.ImageMetadataCallback = func(m *extract.Mapping, dgst digest.Digest, config *docker10.DockerImageConfig) {
+		release.Digest = dgst
+		release.Config = config
+	}
+	opts.OnlyFiles = true
+	opts.RemovePermissions = true
+	opts.Mappings = []extract.Mapping{
+		{
+			ImageRef: ref,
+
+			From:        "release-manifests/",
+			To:          ".",
+			LayerFilter: extract.NewPositionLayerFilter(-1),
+		},
+	}
+	var errs []error
+	opts.TarEntryCallback = func(hdr *tar.Header, _ extract.LayerInfo, r io.Reader) (bool, error) {
+		switch hdr.Name {
+		case "image-references":
+			data, err := ioutil.ReadAll(r)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("unable to read release image-references: %v", err))
+				return true, nil
+			}
+			is, err := readReleaseImageReferences(data)
+			if err != nil {
+				errs = append(errs, err)
+				return true, nil
+			}
+			release.References = is
+		case "cincinnati":
+			data, err := ioutil.ReadAll(r)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("unable to read release metadata: %v", err))
+				return true, nil
+			}
+			m := &CincinnatiMetadata{}
+			if err := json.Unmarshal(data, m); err != nil {
+				errs = append(errs, fmt.Errorf("invalid release metadata: %v", err))
+				return true, nil
+			}
+			release.Metadata = m
+		default:
+			if ext := path.Ext(hdr.Name); len(ext) > 0 && (ext == ".yaml" || ext == ".yml" || ext == ".json") {
+				glog.V(4).Infof("Found manifest %s", hdr.Name)
+				data, err := ioutil.ReadAll(r)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("unable to read release manifest %q: %v", hdr.Name, err))
+					return true, nil
+				}
+				if release.ManifestFiles == nil {
+					release.ManifestFiles = make(map[string][]byte)
+				}
+				release.ManifestFiles[hdr.Name] = data
+			} else {
+				release.UnknownFiles = append(release.UnknownFiles, hdr.Name)
+			}
+		}
+		return true, nil
+	}
+	if err := opts.Run(); err != nil {
+		return nil, err
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("release image could not be read: %s", errorList(errs))
+	}
+	if release.References == nil {
+		return nil, fmt.Errorf("release image did not contain an image-references file")
+	}
+	return release, nil
+}
+
+func errorList(errs []error) string {
+	if len(errs) == 1 {
+		return errs[0].Error()
+	}
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, "\n\n")
+	for _, err := range errs {
+		fmt.Fprintf(buf, "* %v\n", err)
+	}
+	return buf.String()
+}
+
+func stringArrContains(arr []string, s string) bool {
+	for _, item := range arr {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func describeReleaseDiff(out io.Writer, diff *ReleaseDiff, showCommit bool) error {
+	if diff.To.Digest == diff.From.Digest {
+		fmt.Fprintf(out, "Releases are identical\n")
+		return nil
+	}
+	w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	defer w.Flush()
+	now := time.Now()
+	fmt.Fprintf(w, "\tFROM\tTO\n")
+	fmt.Fprintf(w, "Name:\t%s\t%s\n", diff.From.PreferredName(), diff.To.PreferredName())
+	fmt.Fprintf(w, "Created:\t%s\t%s\n", duration.ShortHumanDuration(now.Sub(diff.From.Config.Created)), duration.ShortHumanDuration(now.Sub(diff.To.Config.Created)))
+	if from, to := diff.From.Platform(), diff.To.Platform(); from != to {
+		fmt.Fprintf(w, "OS/Arch:\t%s\t%s\n", from, to)
+	}
+
+	switch {
+	case diff.From.Metadata != nil && diff.To.Metadata != nil:
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Version:\t%s\t%s\n", diff.From.Metadata.Version, diff.To.Metadata.Version)
+		canUpgrade := "No"
+		if stringArrContains(diff.To.Metadata.Previous, diff.From.Metadata.Version) {
+			canUpgrade = "Yes"
+		}
+		fmt.Fprintf(w, "Upgrade From:\t\t%s\n", canUpgrade)
+	case diff.From.Metadata != nil && diff.To.Metadata == nil:
+		fmt.Fprintf(w, "Has Release Metadata:\tYes\t\n")
+	case diff.From.Metadata == nil && diff.To.Metadata != nil:
+		fmt.Fprintf(w, "Has Release Metadata:\t\tYes\n")
+	}
+
+	if len(diff.ChangedImages) > 0 {
+		var keys []string
+		for k := range diff.ChangedImages {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		writeTabSection(w, func(w io.Writer) {
+			count := 0
+			for _, k := range keys {
+				if image := diff.ChangedImages[k]; image.To != nil && image.From != nil {
+					if count == 0 {
+						fmt.Fprintln(w)
+						fmt.Fprintf(w, "Images Changed:\n")
+					}
+					count++
+					old, new := digestOrRef(image.From.From.Name), digestOrRef(image.To.From.Name)
+					if old != new {
+						if showCommit {
+							fmt.Fprintf(w, "  %s\t%s\n", image.Name, gitDiffOrCommit(image.From, image.To))
+						} else {
+							fmt.Fprintf(w, "  %s\t%s\t%s\n", image.Name, old, new)
+						}
+					}
+				}
+			}
+		})
+
+		writeTabSection(w, func(w io.Writer) {
+			count := 0
+			for _, k := range keys {
+				if image := diff.ChangedImages[k]; image.From == nil {
+					if count == 0 {
+						fmt.Fprintln(w)
+						fmt.Fprintf(w, "Images Added:\n")
+					}
+					count++
+					if showCommit {
+						fmt.Fprintf(w, "  %s\t%s\n", image.Name, repoAndCommit(image.To))
+					} else {
+						fmt.Fprintf(w, "  %s\t%s\n", image.Name, digestOrRef(image.To.From.Name))
+					}
+				}
+			}
+		})
+
+		writeTabSection(w, func(w io.Writer) {
+			count := 0
+			for _, k := range keys {
+				if image := diff.ChangedImages[k]; image.To == nil {
+					if count == 0 {
+						fmt.Fprintln(w)
+						fmt.Fprintf(w, "Images Removed:\n")
+					}
+					count++
+					fmt.Fprintf(w, "  %s\n", image.Name)
+				}
+			}
+		})
+	}
+	fmt.Fprintln(w)
+	return nil
+}
+
+func repoAndCommit(ref *imageapi.TagReference) string {
+	repo := ref.Annotations["io.openshift.build.source-location"]
+	commit := ref.Annotations["io.openshift.build.commit.id"]
+	if len(repo) == 0 || len(commit) == 0 {
+		return "<unknown>"
+	}
+	return fmt.Sprintf("%s %s", repo, commit)
+}
+
+func gitDiffOrCommit(from, to *imageapi.TagReference) string {
+	oldRepo, newRepo := from.Annotations["io.openshift.build.source-location"], to.Annotations["io.openshift.build.source-location"]
+	oldCommit, newCommit := from.Annotations["io.openshift.build.commit.id"], to.Annotations["io.openshift.build.commit.id"]
+	if len(newRepo) == 0 || len(newCommit) == 0 {
+		return "<unknown>"
+	}
+	if oldRepo == newRepo {
+		if oldCommit == newCommit {
+			return fmt.Sprintf("%s %s", newRepo, newCommit)
+		}
+		if strings.HasPrefix(newRepo, "https://github.com/") {
+			if u, err := url.Parse(newRepo); err == nil {
+				u.Path = path.Join(u.Path, "compare", fmt.Sprintf("%s...%s", oldCommit, newCommit))
+				return u.String()
+			}
+		}
+		return fmt.Sprintf("%s %s %s", newRepo, oldCommit, newCommit)
+	}
+	if len(oldCommit) == 0 {
+		return fmt.Sprintf("%s <unknown> %s", newRepo, newCommit)
+	}
+	return fmt.Sprintf("%s %s %s", newRepo, oldCommit, newCommit)
+}
+
+func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, pullSpec bool) error {
+	w := tabwriter.NewWriter(out, 0, 4, 1, ' ', 0)
+	defer w.Flush()
+	fmt.Fprintf(w, "Name:\t%s\n", release.PreferredName())
+	fmt.Fprintf(w, "Digest:\t%s\n", release.Digest)
+	fmt.Fprintf(w, "Created:\t%s\n", release.Config.Created.Local().Truncate(time.Second))
+	fmt.Fprintf(w, "OS/Arch:\t%s/%s\n", release.Config.OS, release.Config.Architecture)
+	fmt.Fprintf(w, "Manifests:\t%d\n", len(release.ManifestFiles))
+	if len(release.UnknownFiles) > 0 {
+		fmt.Fprintf(w, "Unknown files:\t%d\n", len(release.UnknownFiles))
+	}
+	if m := release.Metadata; m != nil {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Release Metadata:\n")
+		fmt.Fprintf(w, "  Version:\t%s\n", m.Version)
+		if len(m.Previous) > 0 {
+			fmt.Fprintf(w, "  Upgrades:\t%s\n", strings.Join(sortSemanticVersions(m.Previous), ", "))
+		} else {
+			fmt.Fprintf(w, "  Upgrades:\t<none>\n")
+		}
+		var keys []string
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		writeTabSection(w, func(w io.Writer) {
+			for _, k := range keys {
+				fmt.Fprintf(w, "  Metadata:\n")
+				fmt.Fprintf(w, "    %s:\t%s\n", k, m.Metadata[k])
+			}
+		})
+	}
+	writeTabSection(w, func(w io.Writer) {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Images:\n")
+		switch {
+		case showCommit:
+			fmt.Fprintf(w, "  NAME\tREPO\tCOMMIT\t\n")
+			for _, tag := range release.References.Spec.Tags {
+				if tag.From == nil || tag.From.Kind != "DockerImage" {
+					continue
+				}
+				fmt.Fprintf(w, "  %s\t%s\t%s\n", tag.Name, tag.Annotations["io.openshift.build.source-location"], tag.Annotations["io.openshift.build.commit.id"])
+			}
+		case pullSpec:
+			fmt.Fprintf(w, "  NAME\tPULL SPEC\n")
+			for _, tag := range release.References.Spec.Tags {
+				if tag.From == nil || tag.From.Kind != "DockerImage" {
+					continue
+				}
+				fmt.Fprintf(w, "  %s\t%s\n", tag.Name, tag.From.Name)
+			}
+		default:
+			fmt.Fprintf(w, "  NAME\tDIGEST\n")
+			for _, tag := range release.References.Spec.Tags {
+				if tag.From == nil || tag.From.Kind != "DockerImage" {
+					continue
+				}
+				var id string
+				if ref, err := imagereference.Parse(tag.From.Name); err == nil {
+					id = ref.ID
+				}
+				if len(id) == 0 {
+					id = tag.From.Name
+				}
+				fmt.Fprintf(w, "  %s\t%s\n", tag.Name, id)
+			}
+		}
+	})
+	fmt.Fprintln(w)
+	return nil
+}
+
+func writeTabSection(out io.Writer, fn func(w io.Writer)) {
+	w := tabwriter.NewWriter(out, 0, 4, 1, ' ', 0)
+	fn(w)
+	w.Flush()
+}
+
+func sortSemanticVersions(versionStrings []string) []string {
+	var versions []semver.Version
+	for _, version := range versionStrings {
+		v, err := semver.Parse(version)
+		if err != nil {
+			return versionStrings
+		}
+		versions = append(versions, v)
+	}
+	semver.Sort(versions)
+	versionStrings = make([]string, 0, len(versions))
+	for _, v := range versions {
+		versionStrings = append(versionStrings, v.String())
+	}
+	return versionStrings
+}
+
+func digestOrRef(ref string) string {
+	if ref, err := imagereference.Parse(ref); err == nil && len(ref.ID) > 0 {
+		return ref.ID
+	}
+	return ref
+}

--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -230,7 +230,7 @@ func findSpecTag(tags []imageapi.TagReference, name string) *imageapi.TagReferen
 	return nil
 }
 
-type cincinnatiMetadata struct {
+type CincinnatiMetadata struct {
 	Kind string `json:"kind"`
 
 	Version  string   `json:"version"`
@@ -264,9 +264,9 @@ func (o *NewOptions) Run() error {
 		name = "0.0.1-" + now.Format("2006-01-02T150405Z")
 	}
 
-	var cm *cincinnatiMetadata
+	var cm *CincinnatiMetadata
 	if len(o.PreviousVersions) > 0 || len(o.ReleaseMetadata) > 0 || o.ForceManifest {
-		cm = &cincinnatiMetadata{Kind: "cincinnati-metadata-v0"}
+		cm = &CincinnatiMetadata{Kind: "cincinnati-metadata-v0"}
 		semverName, err := semver.Parse(name)
 		if err != nil {
 			return fmt.Errorf("when release metadata is added, the --name must be a semantic version")
@@ -866,7 +866,7 @@ func writeNestedTarHeader(tw *tar.Writer, parts []string, existing map[string]st
 	return nil
 }
 
-func writePayload(w io.Writer, now time.Time, is *imageapi.ImageStream, cm *cincinnatiMetadata, ordered []string, metadata map[string]imageData, allowMissingImages bool, verifiers []PayloadVerifier) ([]string, error) {
+func writePayload(w io.Writer, now time.Time, is *imageapi.ImageStream, cm *CincinnatiMetadata, ordered []string, metadata map[string]imageData, allowMissingImages bool, verifiers []PayloadVerifier) ([]string, error) {
 	var operators []string
 	directories := make(map[string]struct{})
 	files := make(map[string]int)
@@ -993,7 +993,7 @@ func writePayload(w io.Writer, now time.Time, is *imageapi.ImageStream, cm *cinc
 	return operators, nil
 }
 
-func copyPayload(w io.Writer, now time.Time, is *imageapi.ImageStream, cm *cincinnatiMetadata, directory string, verifiers []PayloadVerifier) error {
+func copyPayload(w io.Writer, now time.Time, is *imageapi.ImageStream, cm *CincinnatiMetadata, directory string, verifiers []PayloadVerifier) error {
 	directories := make(map[string]struct{})
 
 	gw := gzip.NewWriter(w)

--- a/pkg/oc/cli/admin/release/release.go
+++ b/pkg/oc/cli/admin/release/release.go
@@ -21,6 +21,7 @@ func NewCmd(f kcmdutil.Factory, parentName string, streams genericclioptions.IOS
 			return cmd.Help()
 		},
 	}
+	cmd.AddCommand(NewInfo(f, parentName+" release", streams))
 	cmd.AddCommand(NewRelease(f, parentName+" release", streams))
 	cmd.AddCommand(NewExtract(f, parentName+" release", streams))
 	cmd.AddCommand(NewMirror(f, parentName+" release", streams))


### PR DESCRIPTION
By default will print high level info about a release image. With the
`--changes-from=IMAGE` option shows you the delta between that image and
the one you specified. Support `--commits` to display source info for
both diffs and normal output.