### PR TITLE
Autoassign the 0000_70_ run level in release payloads

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -947,7 +947,7 @@ func writePayload(w io.Writer, now time.Time, is *imageapi.ImageStream, cm *Cinc
 			// get put in a scoped bucket at the end. Only a few components should need to
 			// be in the global order.
 			if !strings.HasPrefix(filename, "0000_") {
-				filename = fmt.Sprintf("99_%s_%s", name, filename)
+				filename = fmt.Sprintf("0000_70_%s_%s", name, filename)
 			}
 			if count, ok := files[filename]; ok {
 				count++


### PR DESCRIPTION
This leaves open the door for resources that should be applied last.

Discussed as part of having service monitor definitions be created in `/manifests`
by individual operators. They need to be declared after CMO is installed. Therefore,
to define a service monitor CR, a team creates it in:

```
0000_99_cluster-kube-scheduler-operator_monitoring.yaml
```

which ensures that it runs after other operators are created. If the CRD isn't created,
then the person defining what is in the release payload needs to sort that out.