### PR TITLE
re-enable image-lookup test-cmd test suite

### DIFF
--- a/pkg/apiserver/admission/register.go
+++ b/pkg/apiserver/admission/register.go
@@ -106,6 +106,7 @@ var (
 		"openshift.io/IngressAdmission",
 		mutatingwebhook.PluginName,
 		validatingwebhook.PluginName,
+		imagepolicyapi.PluginName,
 	)
 
 	// DefaultOffPlugins includes plugins which require explicit configuration to run
@@ -115,7 +116,6 @@ var (
 		"RunOnceDuration",
 		"PodNodeConstraints",
 		overrideapi.PluginName,
-		imagepolicyapi.PluginName,
 		"AlwaysPullImages",
 		"ImagePolicyWebhook",
 		"openshift.io/RestrictSubjectBindings",

--- a/pkg/image/apiserver/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/apiserver/admission/imagepolicy/imagepolicy.go
@@ -39,12 +39,15 @@ func Register(plugins *admission.Plugins) {
 			if err != nil {
 				return nil, err
 			}
+			var config *imagepolicy.ImagePolicyConfig
 			if obj == nil {
-				return nil, nil
-			}
-			config, ok := obj.(*imagepolicy.ImagePolicyConfig)
-			if !ok {
-				return nil, fmt.Errorf("unexpected config object: %#v", obj)
+				config = &imagepolicy.ImagePolicyConfig{}
+			} else {
+				var ok bool
+				config, ok = obj.(*imagepolicy.ImagePolicyConfig)
+				if !ok {
+					return nil, fmt.Errorf("unexpected config object: %#v", obj)
+				}
 			}
 			if errs := validation.Validate(config); len(errs) > 0 {
 				return nil, errs.ToAggregate()

--- a/test/cmd/image-lookup.sh
+++ b/test/cmd/image-lookup.sh
@@ -20,21 +20,17 @@ os::cmd::expect_success_and_text "oc import-image --confirm --from=nginx:latest 
 os::cmd::expect_success_and_text "oc set image-lookup is/nginx" "updated"
 # Image lookup works for pods
 os::cmd::expect_success          "oc run --generator=run-pod/v1 --restart=Never --image=nginx:latest nginx"
-# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
-#os::cmd::expect_success_and_text "oc get pod/nginx -o jsonpath='{.spec.containers[0].image}'" "nginx@sha256:"
+os::cmd::expect_success_and_text "oc get pod/nginx -o jsonpath='{.spec.containers[0].image}'" "nginx@sha256:"
 # Image lookup works for jobs
 os::cmd::expect_success          "oc run --generator=job/v1 --restart=Never --image=nginx:latest nginx"
-# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
-#os::cmd::expect_success_and_text "oc get job/nginx -o jsonpath='{.spec.template.spec.containers[0].image}'" "nginx@sha256:"
+os::cmd::expect_success_and_text "oc get job/nginx -o jsonpath='{.spec.template.spec.containers[0].image}'" "nginx@sha256:"
 # Image lookup works for replica sets
 os::cmd::expect_success          "oc create deployment --image=nginx:latest nginx"
-# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
-#os::cmd::expect_success_and_text "oc get rs -o jsonpath='{..spec.template.spec.containers[0].image}'" "nginx@sha256:"
+os::cmd::expect_success_and_text "oc get rs -o jsonpath='{..spec.template.spec.containers[0].image}'" "nginx@sha256:"
 # Image lookup works for replication controllers
 rc='{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"nginx"},"spec":{"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"name":"main","image":"nginx:latest"}]}}}}'
 os::cmd::expect_success          "echo '${rc}' | oc create -f -"
-# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
-#os::cmd::expect_success_and_text "oc get rc/nginx -o jsonpath='{.spec.template.spec.containers[0].image}'" "nginx@sha256:"
+os::cmd::expect_success_and_text "oc get rc/nginx -o jsonpath='{.spec.template.spec.containers[0].image}'" "nginx@sha256:"
 
 # Verify swapping settings on image stream
 os::cmd::expect_success_and_text "oc set image-lookup is/nginx --v=1" "was not changed"
@@ -54,7 +50,6 @@ rc='{"kind":"Deployment","apiVersion":"apps/v1beta1","metadata":{"name":"alterna
 os::cmd::expect_success          "echo '${rc}' | oc set image-lookup --local -f - -o json | oc create -f -"
 os::cmd::expect_success          "oc run --generator=run-pod/v1 --restart=Never --image=alternate:latest alternate"
 os::cmd::expect_success_and_text "oc get pod/alternate -o jsonpath='{.spec.containers[0].image}'" "alternate:latest"
-# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
-#os::cmd::expect_success_and_text "oc get rs -o jsonpath='{..spec.template.spec.containers[0].image}'" "nginx@sha256:"
+os::cmd::expect_success_and_text "oc get rs -o jsonpath='{..spec.template.spec.containers[0].image}'" "nginx@sha256:"
 
 os::test::junit::declare_suite_end

--- a/test/cmd/image-lookup.sh
+++ b/test/cmd/image-lookup.sh
@@ -13,45 +13,48 @@ trap os::test::junit::reconcile_output EXIT
 project="$( oc project -q )"
 
 os::test::junit::declare_suite_start "cmd/image-lookup"
-## This test validates image lookup resolution
-#
-## TODO: fix and re-enable these tests before 4.0 release
-#
-## Verify image resolution on default resource types
-#os::cmd::expect_success_and_text "oc import-image --confirm --from=nginx:latest nginx:latest" "sha256:"
-#os::cmd::expect_success_and_text "oc set image-lookup is/nginx" "updated"
-## Image lookup works for pods
-#os::cmd::expect_success          "oc run --generator=run-pod/v1 --restart=Never --image=nginx:latest nginx"
+# This test validates image lookup resolution
+
+# Verify image resolution on default resource types
+os::cmd::expect_success_and_text "oc import-image --confirm --from=nginx:latest nginx:latest" "sha256:"
+os::cmd::expect_success_and_text "oc set image-lookup is/nginx" "updated"
+# Image lookup works for pods
+os::cmd::expect_success          "oc run --generator=run-pod/v1 --restart=Never --image=nginx:latest nginx"
+# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
 #os::cmd::expect_success_and_text "oc get pod/nginx -o jsonpath='{.spec.containers[0].image}'" "nginx@sha256:"
-## Image lookup works for jobs
-#os::cmd::expect_success          "oc run --generator=job/v1 --restart=Never --image=nginx:latest nginx"
+# Image lookup works for jobs
+os::cmd::expect_success          "oc run --generator=job/v1 --restart=Never --image=nginx:latest nginx"
+# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
 #os::cmd::expect_success_and_text "oc get job/nginx -o jsonpath='{.spec.template.spec.containers[0].image}'" "nginx@sha256:"
-## Image lookup works for replica sets
-#os::cmd::expect_success          "oc create deployment --image=nginx:latest nginx"
+# Image lookup works for replica sets
+os::cmd::expect_success          "oc create deployment --image=nginx:latest nginx"
+# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
 #os::cmd::expect_success_and_text "oc get rs -o jsonpath='{..spec.template.spec.containers[0].image}'" "nginx@sha256:"
-## Image lookup works for replication controllers
-#rc='{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"nginx"},"spec":{"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"name":"main","image":"nginx:latest"}]}}}}'
-#os::cmd::expect_success          "echo '${rc}' | oc create -f -"
+# Image lookup works for replication controllers
+rc='{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"nginx"},"spec":{"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"name":"main","image":"nginx:latest"}]}}}}'
+os::cmd::expect_success          "echo '${rc}' | oc create -f -"
+# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
 #os::cmd::expect_success_and_text "oc get rc/nginx -o jsonpath='{.spec.template.spec.containers[0].image}'" "nginx@sha256:"
-#
-## Verify swapping settings on image stream
-#os::cmd::expect_success_and_text "oc set image-lookup is/nginx --v=1" "was not changed"
-#os::cmd::expect_success_and_text "oc set image-lookup nginx --v=1" "was not changed"
-#os::cmd::expect_success_and_text "oc set image-lookup is --list" "nginx.*true"
-#os::cmd::expect_success_and_text "oc set image-lookup nginx --enabled=false" "updated"
-#os::cmd::expect_success_and_text "oc set image-lookup is --list" "nginx.*false"
-#os::cmd::expect_failure_and_text "oc set image-lookup unknown --list" "the server doesn't have a resource type"
-#os::cmd::expect_success_and_text "oc set image-lookup secrets --list" "false"
-#
-## Clear resources
-#os::cmd::expect_success "oc delete deploy,dc,rs,rc,pods --all"
-#
-## Resource annotated with image lookup will create pods that resolve
-#os::cmd::expect_success          "oc tag nginx:latest alternate:latest"
-#rc='{"kind":"Deployment","apiVersion":"apps/v1beta1","metadata":{"name":"alternate"},"spec":{"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"name":"main","image":"alternate:latest"}]}}}}'
-#os::cmd::expect_success          "echo '${rc}' | oc set image-lookup --local -f - -o json | oc create -f -"
-#os::cmd::expect_success          "oc run --generator=run-pod/v1 --restart=Never --image=alternate:latest alternate"
-#os::cmd::expect_success_and_text "oc get pod/alternate -o jsonpath='{.spec.containers[0].image}'" "alternate:latest"
+
+# Verify swapping settings on image stream
+os::cmd::expect_success_and_text "oc set image-lookup is/nginx --v=1" "was not changed"
+os::cmd::expect_success_and_text "oc set image-lookup nginx --v=1" "was not changed"
+os::cmd::expect_success_and_text "oc set image-lookup is --list" "nginx.*true"
+os::cmd::expect_success_and_text "oc set image-lookup nginx --enabled=false" "updated"
+os::cmd::expect_success_and_text "oc set image-lookup is --list" "nginx.*false"
+os::cmd::expect_failure_and_text "oc set image-lookup unknown --list" "the server doesn't have a resource type"
+os::cmd::expect_success_and_text "oc set image-lookup secrets --list" "false"
+
+# Clear resources
+os::cmd::expect_success "oc delete deploy,dc,rs,rc,pods --all"
+
+# Resource annotated with image lookup will create pods that resolve
+os::cmd::expect_success          "oc tag nginx:latest alternate:latest"
+rc='{"kind":"Deployment","apiVersion":"apps/v1beta1","metadata":{"name":"alternate"},"spec":{"template":{"metadata":{"labels":{"app":"test"}},"spec":{"containers":[{"name":"main","image":"alternate:latest"}]}}}}'
+os::cmd::expect_success          "echo '${rc}' | oc set image-lookup --local -f - -o json | oc create -f -"
+os::cmd::expect_success          "oc run --generator=run-pod/v1 --restart=Never --image=alternate:latest alternate"
+os::cmd::expect_success_and_text "oc get pod/alternate -o jsonpath='{.spec.containers[0].image}'" "alternate:latest"
+# TODO: the container image resolves to "nginx:latest", not the actual image ref. Why?
 #os::cmd::expect_success_and_text "oc get rs -o jsonpath='{..spec.template.spec.containers[0].image}'" "nginx@sha256:"
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
cc @soltysh @deads2k 

Depends on https://github.com/openshift/origin/pull/21458

Part of efforts to restore disabled functionality as a result of https://github.com/openshift/origin/pull/21221