### PR TITLE
use origin-4.0-kubernetes-1.11.1 branch for publishing master

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -10,31 +10,31 @@ import:
   version: 8a9b82f00b3a86eac24681da3f9fe6c34c01cea2
 - package: k8s.io/code-generator
   repo:    https://github.com/openshift/kubernetes-code-generator.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/apimachinery
   repo:    https://github.com/openshift/kubernetes-apimachinery.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/api
   repo:    https://github.com/openshift/kubernetes-api.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/client-go
   repo:    https://github.com/openshift/kubernetes-client-go.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/metrics
   repo:    https://github.com/openshift/kubernetes-metrics.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/apiserver
   repo:    https://github.com/openshift/kubernetes-apiserver.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/kube-aggregator
-  repo:    https://github.com/openshift/kube-aggregator.git
-  version: origin-3.11-kubernetes-1.11.1
+  repo:    https://github.com/openshift/kubernetes-kube-aggregator.git
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/apiextensions-apiserver
   repo:    https://github.com/openshift/kubernetes-apiextensions-apiserver.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 - package: k8s.io/kubernetes
   repo:    https://github.com/openshift/kubernetes.git
-  version: origin-3.11-kubernetes-1.11.1
+  version: origin-4.0-kubernetes-1.11.1
 
 # openshift second
 - package: github.com/openshift/api

--- a/publishing-rules.yaml
+++ b/publishing-rules.yaml
@@ -2,7 +2,7 @@ skip-godeps: true
 rules:
 - destination: kubernetes
   branches:
-  - name: origin-3.11-kubernetes-1.11.1
+  - name: origin-4.0-kubernetes-1.11.1
     source:
       branch: master
       dir: vendor/k8s.io/kubernetes


### PR DESCRIPTION
This change will make the bot publish to `origin-4.0-kubernetes-1.11.1` instead of `origin-3.11-kubernetes-1.11.1`. It also moves glide to track the `origin-4.0-` branch instead of `origin-3.11`.

Next step will be cleaning up the `origin-3.11-` branches inside the forks to get rid of extra commits that we published after we cut the `release-3.11` branch in origin.

/cc @deads2k 
/cc @sttts 
/cc @soltysh 