### PR TITLE
network: add runtime-changeable log levels

### DIFF
--- a/pkg/network/common/logging_linux.go
+++ b/pkg/network/common/logging_linux.go
@@ -1,0 +1,42 @@
+// +build linux
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/golang/glog"
+)
+
+func InitVariableLogging() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		// The first time logging is changed, jump to V(6)
+		var newLevel int32 = 5
+
+		wg.Done()
+		for {
+			<-c
+			newLevel++
+			// Loop between V(6) and V(1)
+			if newLevel >= 7 {
+				newLevel = 1
+			}
+
+			var level glog.Level
+			if err := level.Set(fmt.Sprintf("%d", newLevel)); err != nil {
+				glog.Errorf("failed set glog.logging.verbosity %d: %v", newLevel, err)
+			} else {
+				glog.Infof("set glog.logging.verbosity to %d", newLevel)
+			}
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/network/common/logging_other.go
+++ b/pkg/network/common/logging_other.go
@@ -1,0 +1,6 @@
+// +build !linux
+
+package common
+
+func InitVariableLogging() {
+}

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -55,6 +55,7 @@ func Start(networkConfig openshiftcontrolplanev1.NetworkControllerConfig, networ
 	kClient kclientset.Interface, kubeInformers informers.SharedInformerFactory,
 	networkInformers networkinternalinformers.SharedInformerFactory) error {
 	glog.Infof("Initializing SDN master of type %q", networkConfig.NetworkPluginName)
+	common.InitVariableLogging()
 
 	master := &OsdnMaster{
 		kClient:       kClient,

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -146,6 +146,8 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 	}
 	glog.Infof("Initializing SDN node of type %q with configured hostname %q (IP %q), iptables sync period %q", c.PluginName, c.Hostname, c.SelfIP, c.IPTablesSyncPeriod.String())
 
+	common.InitVariableLogging()
+
 	if useConnTrack && c.ProxyMode != kubeproxyconfig.ProxyModeIPTables {
 		return nil, fmt.Errorf("%q plugin is not compatible with proxy-mode %q", c.PluginName, c.ProxyMode)
 	}


### PR DESCRIPTION
Via SIGUSR1, looping between 1 and 6, but starting at 6 the first
time you USR1 either master or node.

@openshift/networking @openshift/sig-networking @squeed @knobunc @danwinship 