### PR TITLE
DO NOT MERGE: Enable all e2e tests in smoke

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -92,7 +92,9 @@ var staticSuites = []*ginkgo.TestSuite{
 		available.
 		`),
 		Matches: func(name string) bool {
-			return strings.Contains(name, "[Suite:openshift/smoke-4]")
+			// TODO: temporarily run all
+			// return strings.Contains(name, "[Suite:openshift/smoke-4]")
+			return strings.Contains(name, "[Suite:openshift/conformance/")
 		},
 		Parallelism: 10,
 	},


### PR DESCRIPTION
This PR will report all e2e tests on aws on the new installer that pass, which
we will use to fill a list of known passing tests.