### PR TITLE
Remove myself from OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - smarterclayton
   - deads2k
   - bparees
-  - stevekuznetsov
   - soltysh
   - tbielawa
 approvers:
@@ -12,6 +11,5 @@ approvers:
   - mfojtik
   - eparis
   - derekwaynecarr
-  - stevekuznetsov # for build and tooling changes
   - tbielawa # also for build and automated release tooling changes
   - pweil-

--- a/examples/data-population/OWNERS
+++ b/examples/data-population/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
   - smarterclayton
   - derekwaynecarr
-  - stevekuznetsov
 approvers:
   - smarterclayton
   - derekwaynecarr
-  - stevekuznetsov

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,6 +1,5 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - bparees
   - soltysh
   - knobunc
@@ -10,7 +9,6 @@ reviewers:
   - marun
 approvers:
   - smarterclayton
-  - stevekuznetsov
   - bparees
   - knobunc
   - dcbw

--- a/hack/lib/OWNERS
+++ b/hack/lib/OWNERS
@@ -1,9 +1,7 @@
 reviewers:
-  - stevekuznetsov
   - smarterclayton
   - soltysh
   - jhadvig
 approvers:
-  - stevekuznetsov
   - smarterclayton
   - soltysh

--- a/hack/test-lib/OWNERS
+++ b/hack/test-lib/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
-  - stevekuznetsov
   - smarterclayton
 approvers:
-  - stevekuznetsov
   - smarterclayton

--- a/images/OWNERS
+++ b/images/OWNERS
@@ -9,4 +9,3 @@ approvers:
   - smarterclayton
   - pweil-
   - sdodson
-  - stevekuznetsov

--- a/images/base/OWNERS
+++ b/images/base/OWNERS
@@ -2,10 +2,8 @@ reviewers:
   - smarterclayton
   - sdodson
   - rootfs
-  - stevekuznetsov
   - sjenning
   - csrwng
 approvers:
   - smarterclayton
   - sdodson
-  - stevekuznetsov

--- a/images/cli/OWNERS
+++ b/images/cli/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - sdodson
 approvers:
   - smarterclayton
   - kargakis
-  - stevekuznetsov

--- a/images/deployer/OWNERS
+++ b/images/deployer/OWNERS
@@ -1,7 +1,5 @@
 reviewers:
-  - stevekuznetsov
   - mfojtik
   - smarterclayton
 approvers:
-  - stevekuznetsov
   - mfojtik

--- a/images/dind/OWNERS
+++ b/images/dind/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - knobunc
   - ironcladlou
   - squeed
-  - stevekuznetsov
   - rajatchopra
   - JacobTanenbaum
   - bparees
@@ -14,4 +13,3 @@ approvers:
   - knobunc
   - ironcladlou
   - squeed
-  - stevekuznetsov

--- a/images/hyperkube/OWNERS
+++ b/images/hyperkube/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - sdodson
 approvers:
   - smarterclayton
   - kargakis
-  - stevekuznetsov

--- a/images/hypershift/OWNERS
+++ b/images/hypershift/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - sdodson
 approvers:
   - smarterclayton
   - kargakis
-  - stevekuznetsov

--- a/images/node/OWNERS
+++ b/images/node/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - giuseppe
   - sdodson
   - smarterclayton
-  - stevekuznetsov
   - dcbw
   - rootfs
   - pravisankar
@@ -10,5 +9,4 @@ reviewers:
 approvers:
   - sdodson
   - smarterclayton
-  - stevekuznetsov
   - dcbw

--- a/images/origin/OWNERS
+++ b/images/origin/OWNERS
@@ -2,8 +2,6 @@ reviewers:
   - smarterclayton
   - giuseppe
   - markturansky
-  - stevekuznetsov
   - sdodson
 approvers:
   - smarterclayton
-  - stevekuznetsov

--- a/images/pod/OWNERS
+++ b/images/pod/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - soltysh
 approvers:
   - smarterclayton
-  - stevekuznetsov
   - soltysh

--- a/images/recycler/OWNERS
+++ b/images/recycler/OWNERS
@@ -1,7 +1,5 @@
 reviewers:
-  - stevekuznetsov
   - markturansky
   - smarterclayton
 approvers:
-  - stevekuznetsov
   - smarterclayton

--- a/images/source/OWNERS
+++ b/images/source/OWNERS
@@ -1,4 +1,2 @@
 reviewers:
-  - stevekuznetsov
 approvers:
-  - stevekuznetsov

--- a/images/tests/OWNERS
+++ b/images/tests/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - sdodson
 approvers:
   - smarterclayton
   - kargakis
-  - stevekuznetsov

--- a/pkg/bulk/OWNERS
+++ b/pkg/bulk/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - mfojtik
   - deads2k
   - bparees
-  - stevekuznetsov
   - juanvallejo
   - soltysh
 approvers:

--- a/pkg/oc/cli/admin/ipfailover/ipfailover/OWNERS
+++ b/pkg/oc/cli/admin/ipfailover/ipfailover/OWNERS
@@ -1,7 +1,5 @@
 reviewers:
   - smarterclayton
   - pecameron
-  - stevekuznetsov
 approvers:
   - smarterclayton
-  - stevekuznetsov

--- a/pkg/openapi/OWNERS
+++ b/pkg/openapi/OWNERS
@@ -3,7 +3,6 @@ reviewers:
   - bparees
   - coreydaley
   - soltysh
-  - stevekuznetsov
 approvers:
   - smarterclayton
   - bparees

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -2,7 +2,6 @@ reviewers:
   - smarterclayton
   - deads2k
   - bparees
-  - stevekuznetsov
   - mfojtik
   - csrwng
   - soltysh
@@ -14,6 +13,5 @@ approvers:
   - smarterclayton
   - deads2k
   - bparees
-  - stevekuznetsov
   - enj
   - tnozicka

--- a/test/cmd/OWNERS
+++ b/test/cmd/OWNERS
@@ -8,7 +8,6 @@ reviewers:
   - danwinship
   - soltysh
 approvers:
-  - stevekuznetsov
   - knobunc
   - ironcladlou
   - squeed

--- a/test/end-to-end/OWNERS
+++ b/test/end-to-end/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-  - stevekuznetsov
   - smarterclayton
   - miminar
   - soltysh
@@ -14,7 +13,6 @@ reviewers:
   - danwinship
   - dmage
 approvers:
-  - stevekuznetsov
   - smarterclayton
   - soltysh
   - knobunc

--- a/test/extended/OWNERS
+++ b/test/extended/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
   - smarterclayton
   - bparees
-  - stevekuznetsov
   - mfojtik
   - gabemontero
   - deads2k
@@ -13,7 +12,6 @@ reviewers:
 approvers:
   - smarterclayton
   - bparees
-  - stevekuznetsov
   - mfojtik
   - knobunc
   - ironcladlou

--- a/test/old-start-configs/OWNERS
+++ b/test/old-start-configs/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
   - deads2k
   - smarterclayton
-  - stevekuznetsov
   - bparees
 approvers:
   - deads2k
   - smarterclayton
-  - stevekuznetsov
   - bparees

--- a/tools/OWNERS
+++ b/tools/OWNERS
@@ -1,11 +1,9 @@
 reviewers:
   - smarterclayton
-  - stevekuznetsov
   - deads2k
   - soltysh
   - juanvallejo
 approvers:
   - smarterclayton
-  - stevekuznetsov
   - deads2k
   - soltysh

--- a/tools/gendocs/OWNERS
+++ b/tools/gendocs/OWNERS
@@ -1,6 +1,4 @@
 reviewers:
-  - stevekuznetsov
   - smarterclayton
 approvers:
-  - stevekuznetsov
   - smarterclayton

--- a/tools/godepversion/OWNERS
+++ b/tools/godepversion/OWNERS
@@ -1,4 +1,2 @@
 reviewers:
-  - stevekuznetsov
 approvers:
-  - stevekuznetsov

--- a/tools/junitreport/OWNERS
+++ b/tools/junitreport/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
-  - stevekuznetsov
   - smarterclayton
   - soltysh
   - danmcp
 approvers:
-  - stevekuznetsov
   - smarterclayton
   - soltysh
   - danmcp

--- a/tools/rebasehelpers/OWNERS
+++ b/tools/rebasehelpers/OWNERS
@@ -1,11 +1,9 @@
 reviewers:
-  - stevekuznetsov
   - soltysh
   - jpeeler
   - deads2k
   - smarterclayton
 approvers:
-  - stevekuznetsov
   - soltysh
   - deads2k
   - smarterclayton


### PR DESCRIPTION
I'm no longer an owner or maintainer for any feature in this repository
and listing myself in the OWNERS files here simply adds to the noise I
get on GitHub.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 