### PR TITLE
test-cmd logs

### DIFF
--- a/hack/local-up-master/lib.sh
+++ b/hack/local-up-master/lib.sh
@@ -285,10 +285,8 @@ function localup::start_openshiftcontrollermanager() {
 function localup::init_master() {
     export LOCALUP_ROOT=${LOCALUP_ROOT:-$(pwd)}
     export LOCALUP_CONFIG=${LOCALUP_ROOT}/openshift.local.masterup
-    mkdir -p ${LOCALUP_CONFIG}/logs
     ETCD_DIR=${LOCALUP_CONFIG}/etcd
     CERT_DIR=${LOCALUP_CONFIG}/kube-apiserver
-    LOG_DIR=${LOCALUP_CONFIG}/logs
     ROOT_CA_FILE=${CERT_DIR}/server-ca.crt
 
     # ensure necessary ports are free

--- a/hack/local-up-master/lib.sh
+++ b/hack/local-up-master/lib.sh
@@ -298,8 +298,6 @@ function localup::init_master() {
     ! ${USE_SUDO:+sudo} fuser -s 8445/tcp || { os::log::error "port 8445 already in use"; exit 1 ; }
     ! ${USE_SUDO:+sudo} fuser -s 10252/tcp || { os::log::error "port 10252 already in use"; exit 1 ; }
 
-    os::log::debug "Logging to ${LOG_DIR}..."
-
     kube::util::test_openssl_installed
     kube::util::ensure-cfssl
 

--- a/hack/local-up-master/master.sh
+++ b/hack/local-up-master/master.sh
@@ -7,6 +7,14 @@ source "$(dirname "${BASH_SOURCE}")/../local-up-master/lib.sh"
 
 trap "clusterup::cleanup" EXIT
 
+os::cleanup::tmpdir
+os::util::environment::setup_all_server_vars
+os::util::ensure_tmpfs "${ETCD_DATA_DIR}"
+
+echo "Logging to ${LOG_DIR}..."
+
+os::log::system::start
+
 LOCALUP_ROOT=${LOCALUP_ROOT:-$(pwd)}
 LOCALUP_CONFIG=${LOCALUP_ROOT}/openshift.local.masterup
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -49,6 +49,8 @@ os::cleanup::tmpdir
 os::util::environment::setup_all_server_vars
 os::util::ensure_tmpfs "${ETCD_DATA_DIR}"
 
+echo "Logging to ${LOG_DIR}..."
+
 os::log::system::start
 
 # Prevent user environment from colliding with the test setup


### PR DESCRIPTION
/assign @juanvallejo 

We can't move server logs from `test-cmd.sh` to a temporary directory b/c they won't be available in our CI. Those need to stay in `_output/scripts/test-cmd/`.