### PR TITLE
e2e: Omit a slow test from smoke-4, clean up error output

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -102,7 +102,10 @@ func main() {
 	cmd.Flags().DurationVar(&suiteOpt.Timeout, "timeout", suiteOpt.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
 	root.AddCommand(cmd)
 
-	testOpt := &testginkgo.TestOptions{}
+	testOpt := &testginkgo.TestOptions{
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}
 	cmd = &cobra.Command{
 		Use:   "run-test NAME",
 		Short: "Run a single test by name",

--- a/pkg/test/ginkgo/cmd_runtest.go
+++ b/pkg/test/ginkgo/cmd_runtest.go
@@ -40,7 +40,7 @@ func (opt *TestOptions) Run(args []string) error {
 	}
 
 	if opt.DryRun {
-		fmt.Printf("Running test (dry-run)\n")
+		fmt.Fprintf(opt.Out, "Running test (dry-run)\n")
 		return nil
 	}
 
@@ -65,21 +65,21 @@ func (opt *TestOptions) Run(args []string) error {
 	case summary.Passed():
 	case summary.Skipped():
 		if len(summary.Failure.Message) > 0 {
-			fmt.Fprintf(os.Stderr, "skip [%s:%d]: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message)
+			fmt.Fprintf(opt.ErrOut, "skip [%s:%d]: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message)
 		}
 		if len(summary.Failure.ForwardedPanic) > 0 {
-			fmt.Fprintf(os.Stderr, "skip [%s:%d]: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.ForwardedPanic)
+			fmt.Fprintf(opt.ErrOut, "skip [%s:%d]: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.ForwardedPanic)
 		}
 		os.Exit(3)
 	case summary.Failed(), summary.Panicked():
 		if len(summary.Failure.ForwardedPanic) > 0 {
 			if len(summary.Failure.Location.FullStackTrace) > 0 {
-				fmt.Fprintf(os.Stderr, "\n%s\n", summary.Failure.Location.FullStackTrace)
+				fmt.Fprintf(opt.ErrOut, "\n%s\n", summary.Failure.Location.FullStackTrace)
 			}
-			fmt.Fprintf(os.Stderr, "fail [%s:%d]: Test Panicked: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.ForwardedPanic)
+			fmt.Fprintf(opt.ErrOut, "fail [%s:%d]: Test Panicked: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.ForwardedPanic)
 			os.Exit(1)
 		}
-		fmt.Fprintf(os.Stderr, "fail [%s:%d]: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message)
+		fmt.Fprintf(opt.ErrOut, "fail [%s:%d]: %s\n", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message)
 		os.Exit(1)
 	default:
 		return fmt.Errorf("unrecognized test case outcome: %#v", summary)

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -447,6 +447,8 @@ var (
 			`\[sig-network\] Services .* NodePort`,
 			`DynamicProvisioner deletion should be idempotent`,
 			`Kubectl taint \[Serial\]`,
+			// flaking, very slow
+			`100 namespaces in 150 seconds`,
 		},
 	}
 


### PR DESCRIPTION
The namespaces serial tests are too slow right now, until we figure out
why openshift-apiserver is dogging it. Disable them for smoke-4.

Fix the output so that we can't overlap stderr or stdout by always writing
summary info to stdout.