### PR TITLE
Save logs to ARTIFACT_DIR if one was provided

### DIFF
--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -139,7 +139,7 @@ function os::util::environment::setup_tmpdir_vars() {
 
     BASEOUTDIR="${OS_OUTPUT_SCRIPTPATH}/${sub_dir}"
     export BASEOUTDIR
-    LOG_DIR="${LOG_DIR:-${BASEOUTDIR}/logs}"
+    LOG_DIR="${ARTIFACT_DIR:-${BASEOUTDIR}}/logs"
     export LOG_DIR
     ARTIFACT_DIR="${ARTIFACT_DIR:-${BASEOUTDIR}/artifacts}"
     export ARTIFACT_DIR


### PR DESCRIPTION
Currently our CI sets `ARTIFACT_DIR` (https://github.com/openshift/release/blob/0d11e633e49a937036d4bbd7886854b50365dbee/ci-operator/config/openshift/origin/openshift-origin-master.yaml#L170) which is then being copied over to artifacts and available in CI, we need to ensure we save logs to that dir when this value is set.

/assign @juanvallejo 