### PR TITLE
turn hyperkube audit logging on by default

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/default_audit_policy.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/default_audit_policy.go
@@ -1,0 +1,32 @@
+package openshiftkubeapiserver
+
+const defaultAuditPolicy = `
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+# Don't generate audit events for all requests in RequestReceived stage.
+omitStages:
+  - "RequestReceived"
+rules:
+  # Don't log requests for events
+  - level: None
+    verbs: ["*"]
+    resources:
+    - group: ""
+      resources: ["events"]
+
+  # Don't log authenticated requests to certain non-resource URL paths.
+  - level: None
+    userGroups: ["system:authenticated", "system:unauthenticated"]
+    nonResourceURLs:
+    - "/api*" # Wildcard matching.
+    - "/version"
+    - "/healthz"
+
+
+  # A catch-all rule to log all other requests at the Metadata level.
+  - level: Metadata
+    # Long-running requests like watches that fall under this rule will not
+    # generate an audit event in RequestReceived.
+    omitStages:
+      - "RequestReceived"
+`

--- a/test/integration/oauth_server_headers_test.go
+++ b/test/integration/oauth_server_headers_test.go
@@ -92,7 +92,7 @@ func checkNewReqHeaders(t *testing.T, rt http.RoundTripper, checkUrl string) {
 
 	// these headers can change per request and are not important to us
 	// only add items to this list if they cannot be statically checked above
-	ignoredHeaders := []string{"Date", "Content-Length", "Location"}
+	ignoredHeaders := []string{"Audit-Id", "Date", "Content-Length", "Location"}
 	for _, h := range ignoredHeaders {
 		resp.Header.Del(h)
 	}

--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -442,6 +442,7 @@ func startKubernetesAPIServer(masterConfig *configapi.MasterConfig, clientConfig
 	}
 	// we need to set enable-aggregator-routing so that APIServices are resolved from Endpoints
 	kubeAPIServerConfig.APIServerArguments["enable-aggregator-routing"] = kubecontrolplanev1.Arguments{"true"}
+	kubeAPIServerConfig.APIServerArguments["audit-log-format"] = kubecontrolplanev1.Arguments{"json"}
 	go openshift_kube_apiserver.RunOpenShiftKubeAPIServerServer(kubeAPIServerConfig)
 
 	url, err := url.Parse(fmt.Sprintf("https://%s", masterConfig.ServingInfo.BindAddress))


### PR DESCRIPTION
Turns on the audit log by default so that we don't have to deal with "who did that!?" questions from customers.  We probably need to expose knobs to turn it off and set the retention policy (I chose one day).  How far we between now and when dynamic auditing arrives (1.14 probably) is an open question.

@cuppett @derekwaynecarr as discussed
/assign @mfojtik @soltysh 