### PR TITLE
Fix an incorrect error message on SDN restart

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -357,7 +357,7 @@ func (oc *ovsController) getPodDetailsBySandboxID(sandboxID string) (int, net.IP
 	}
 
 	if len(strports) == 0 || len(strIDs) == 0 {
-		return 0, nil, fmt.Errorf("failed to find pod details from OVS flows")
+		return 0, nil, fmt.Errorf("failed to find pod details in OVS database")
 	} else if len(strports) > 1 || len(strIDs) > 1 {
 		return 0, nil, fmt.Errorf("found multiple pods for sandbox ID %q: %#v / %#v", sandboxID, strports, strIDs)
 	}

--- a/pkg/util/ovs/fake_ovs_test.go
+++ b/pkg/util/ovs/fake_ovs_test.go
@@ -123,7 +123,7 @@ func TestTransaction(t *testing.T) {
 	}
 }
 
-func TestFind(t *testing.T) {
+func TestFakeFind(t *testing.T) {
 	ovsif := NewFake("br0")
 	if err := ovsif.AddBridge(); err != nil {
 		t.Fatalf("unexpected error adding bridge: %v", err)

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -282,6 +282,10 @@ func (ovsif *ovsExec) Find(table, column, condition string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	output = strings.TrimSuffix(output, "\n")
+	if output == "" {
+		return nil, err
+	}
 	values := strings.Split(output, "\n\n")
 	// We want "bare" values for strings, but we can't pass --bare to ovs-vsctl because
 	// it breaks more complicated types. So try passing each value through Unquote();


### PR DESCRIPTION
When the SDN has to restart pods on restart, it ends up logging:

    will restart pod 'openshift-apiserver/apiserver-4shs9' due to update failure on restart: could not parse ofport "": strconv.Atoi: parsing "": invalid syntax

This fixes it to be:

    will restart pod 'openshift-apiserver/apiserver-4shs9' due to update failure on restart: failed to find pod details in OVS database

The actual fix is the bit in pkg/util/ovs/ovs.go, although that also fixes a second bug found while adding the test case, which is that if Find returned multiple rows, the last value would have a trailing `"\n"`. (But we aren't using Find anywhere where we wanted to get back multiple rows so it didn't matter.)

(Mentioned in #18924 which I let get auto-closed because we're probably not going to fix it at this point, but let's at least fix the error message...)