### PR TITLE
Set --cert-dir for kube-controller-manager in test-cmd

### DIFF
--- a/hack/local-up-master/lib.sh
+++ b/hack/local-up-master/lib.sh
@@ -228,6 +228,7 @@ function localup::start_kubecontrollermanager() {
     hyperkube controller-manager \
       --v=${LOG_LEVEL} \
       --vmodule="${LOG_SPEC}" \
+      --cert-dir="${CERT_DIR}" \
       --service-account-private-key-file="${LOCALUP_CONFIG}/kube-controller-manager/etcd-serving-ca.crt" \
       --root-ca-file="${ROOT_CA_FILE}" \
       --kubeconfig  ${LOCALUP_CONFIG}/kube-controller-manager/controller.kubeconfig \


### PR DESCRIPTION
We need to explicitly set the `--cert-dir` for kube-controller-manager, otherwise it'll get defaulted to `/var/run/kubernetes` which CI does not have access to write to. 

/assign @juanvallejo 

