### PR TITLE
allow openshift-apiserver to avoid SAR for certain paths and groups

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -129,7 +129,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	if err := authenticationOptions.ApplyTo(&genericConfig.Authentication, genericConfig.SecureServing, genericConfig.OpenAPIConfig); err != nil {
 		return nil, err
 	}
-	authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions()
+	authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/healthz/").WithAlwaysAllowGroups("system:masters")
 	authorizationOptions.RemoteKubeConfigFile = config.KubeClientConfig.KubeConfig
 	if err := authorizationOptions.ApplyTo(&genericConfig.Authorization); err != nil {
 		return nil, err

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/path/doc.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/path/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package path contains an authorizer that allows certain paths and path prefixes.
+package path

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/path/path.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// NewAuthorizer returns an authorizer which accepts a given set of paths.
+// Each path is either a fully matching path or it ends in * in case a prefix match is done. A leading / is optional.
+func NewAuthorizer(alwaysAllowPaths []string) (authorizer.Authorizer, error) {
+	var prefixes []string
+	paths := sets.NewString()
+	for _, p := range alwaysAllowPaths {
+		p = strings.TrimPrefix(p, "/")
+		if len(p) == 0 {
+			// matches "/"
+			paths.Insert(p)
+			continue
+		}
+		if strings.ContainsRune(p[:len(p)-1], '*') {
+			return nil, fmt.Errorf("only trailing * allowed in %q", p)
+		}
+		if strings.HasSuffix(p, "*") {
+			prefixes = append(prefixes, p[:len(p)-1])
+		} else {
+			paths.Insert(p)
+		}
+	}
+
+	return authorizer.AuthorizerFunc(func(a authorizer.Attributes) (authorizer.Decision, string, error) {
+		if a.IsResourceRequest() {
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+
+		pth := strings.TrimPrefix(a.GetPath(), "/")
+		if paths.Has(pth) {
+			return authorizer.DecisionAllow, "", nil
+		}
+
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(pth, prefix) {
+				return authorizer.DecisionAllow, "", nil
+			}
+		}
+
+		return authorizer.DecisionNoOpinion, "", nil
+	}), nil
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/path/path_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authorization/path/path_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import (
+	"testing"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestNewAuthorizer(t *testing.T) {
+	tests := []struct {
+		name                       string
+		excludedPaths              []string
+		allowed, denied, noOpinion []string
+		wantErr                    bool
+	}{
+		{"inner star", []string{"/foo*bar"}, nil, nil, nil, true},
+		{"double star", []string{"/foo**"}, nil, nil, nil, true},
+		{"empty", nil, nil, nil, []string{"/"}, false},
+		{"slash", []string{"/"}, []string{"/"}, nil, []string{"/foo", "//"}, false},
+		{"foo", []string{"/foo"}, []string{"/foo", "foo"}, nil, []string{"/", "", "/bar", "/foo/", "/fooooo", "//foo"}, false},
+		{"foo slash", []string{"/foo/"}, []string{"/foo/"}, nil, []string{"/", "", "/bar", "/foo", "/fooooo"}, false},
+		{"foo slash star", []string{"/foo/*"}, []string{"/foo/", "/foo/bar/bla"}, nil, []string{"/", "", "/foo", "/bar", "/fooooo"}, false},
+		{"foo bar", []string{"/foo", "/bar"}, []string{"/foo", "/bar"}, nil, []string{"/", "", "/foo/", "/bar/", "/fooooo"}, false},
+		{"foo star", []string{"/foo*"}, []string{"/foo", "/foooo"}, nil, []string{"/", "", "/fo", "/bar"}, false},
+		{"star", []string{"/*"}, []string{"/", "", "/foo", "/foooo"}, nil, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := NewAuthorizer(tt.excludedPaths)
+			if err != nil && !tt.wantErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tt.wantErr {
+				t.Fatalf("expected error, didn't get any")
+			}
+			if err != nil {
+				return
+			}
+
+			for _, cases := range []struct {
+				paths []string
+				want  authorizer.Decision
+			}{
+				{tt.allowed, authorizer.DecisionAllow},
+				{tt.denied, authorizer.DecisionDeny},
+				{tt.noOpinion, authorizer.DecisionNoOpinion},
+			} {
+				for _, pth := range cases.paths {
+					info := authorizer.AttributesRecord{
+						Path: pth,
+					}
+					if got, _, err := a.Authorize(info); err != nil {
+						t.Errorf("NewAuthorizer(%v).Authorize(%q) return unexpected error: %v", tt.excludedPaths, pth, err)
+					} else if got != cases.want {
+						t.Errorf("NewAuthorizer(%v).Authorize(%q) = %v, want %v", tt.excludedPaths, pth, got, cases.want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -19,6 +19,10 @@ package options
 import (
 	"time"
 
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/path"
+	"k8s.io/apiserver/pkg/authorization/union"
+
 	"github.com/spf13/pflag"
 
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
@@ -44,6 +48,13 @@ type DelegatingAuthorizationOptions struct {
 	// DenyCacheTTL is the length of time that an unsuccessful authorization response will be cached.
 	// You generally want more responsive, "deny, try again" flows.
 	DenyCacheTTL time.Duration
+
+	// AlwaysAllowPaths are HTTP paths which are excluded from authorization. They can be plain
+	// paths or end in * in which case prefix-match is applied. A leading / is optional.
+	AlwaysAllowPaths []string
+
+	// AlwaysAllowGroups are groups which are allowed to take any actions.  In kube, this is system:masters.
+	AlwaysAllowGroups []string
 }
 
 func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
@@ -52,6 +63,12 @@ func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
 		AllowCacheTTL: 10 * time.Second,
 		DenyCacheTTL:  10 * time.Second,
 	}
+}
+
+// WithAlwaysAllowGroups appends the list of paths to AlwaysAllowGroups
+func (s *DelegatingAuthorizationOptions) WithAlwaysAllowGroups(groups ...string) *DelegatingAuthorizationOptions {
+	s.AlwaysAllowGroups = append(s.AlwaysAllowGroups, groups...)
+	return s
 }
 
 func (s *DelegatingAuthorizationOptions) Validate() []error {
@@ -83,16 +100,29 @@ func (s *DelegatingAuthorizationOptions) ApplyTo(c *server.AuthorizationInfo) er
 		return nil
 	}
 
+	var authorizers []authorizer.Authorizer
+	if len(s.AlwaysAllowGroups) > 0 {
+		authorizers = append(authorizers, authorizerfactory.NewPrivilegedGroups(s.AlwaysAllowGroups...))
+	}
+	if len(s.AlwaysAllowPaths) > 0 {
+		a, err := path.NewAuthorizer(s.AlwaysAllowPaths)
+		if err != nil {
+			return err
+		}
+		authorizers = append(authorizers, a)
+	}
+
 	cfg, err := s.ToAuthorizationConfig()
 	if err != nil {
 		return err
 	}
-	authorizer, err := cfg.New()
+	delegatedAuthorizer, err := cfg.New()
 	if err != nil {
 		return err
 	}
+	authorizers = append(authorizers, delegatedAuthorizer)
 
-	c.Authorizer = authorizer
+	c.Authorizer = union.New(authorizers...)
 	return nil
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -71,6 +71,12 @@ func (s *DelegatingAuthorizationOptions) WithAlwaysAllowGroups(groups ...string)
 	return s
 }
 
+// WithAlwaysAllowPaths appends the list of paths to AlwaysAllowPaths
+func (s *DelegatingAuthorizationOptions) WithAlwaysAllowPaths(paths ...string) *DelegatingAuthorizationOptions {
+	s.AlwaysAllowPaths = append(s.AlwaysAllowPaths, paths...)
+	return s
+}
+
 func (s *DelegatingAuthorizationOptions) Validate() []error {
 	allErrors := []error{}
 	return allErrors


### PR DESCRIPTION
/heathz is not confidential and system:masters can do anything, so exclude those in the delegated authorizer to improve reliability

@openshift/sig-auth @openshift/sig-master 
/assign @sttts @mfojtik 
@smarterclayton to avoid 403s during health checks.