### PR TITLE
UPSTREAM: docker/distribution: 2384: Fallback to GET for manifest

### DIFF
--- a/vendor/github.com/docker/distribution/registry/client/repository.go
+++ b/vendor/github.com/docker/distribution/registry/client/repository.go
@@ -321,7 +321,8 @@ func (t *tags) Get(ctx context.Context, tag string) (distribution.Descriptor, er
 	defer resp.Body.Close()
 
 	switch {
-	case resp.StatusCode >= 200 && resp.StatusCode < 400:
+	case resp.StatusCode >= 200 && resp.StatusCode < 400 && len(resp.Header.Get("Docker-Content-Digest")) > 0:
+		// if the response is a success AND a Docker-Content-Digest can be retrieved from the headers
 		return descriptorFromResponse(resp)
 	default:
 		// if the response is an error - there will be no body to decode.


### PR DESCRIPTION
When Docker-Content-Digest is not specified on the response, fall back
from HEAD to GET so that we can calculate the digest from the manifest
content.

Alternative to #21533, we can revendor after the bump