### PR TITLE
Add possibility for HAProxy router custom configuration templates

### DIFF
--- a/pkg/router/template/configmanager/haproxy/manager.go
+++ b/pkg/router/template/configmanager/haproxy/manager.go
@@ -147,6 +147,9 @@ type haproxyConfigManager struct {
 
 	// commitTimer indicates if a router config commit is pending.
 	commitTimer *time.Timer
+
+	// listExtraAnnotations is a list of all extra annotations needed for HAProxy blueprint
+	listExtraAnnotations []string
 }
 
 // NewHAProxyConfigManager returns a new haproxyConfigManager.
@@ -154,6 +157,16 @@ func NewHAProxyConfigManager(options templaterouter.ConfigManagerOptions) *hapro
 	client := NewClient(options.ConnectionInfo, haproxyConnectionTimeout)
 
 	glog.V(4).Infof("%s: options = %+v\n", haproxyManagerName, options)
+
+	listExtraAnnotations := []string{}
+	extraAnnotations := os.Getenv("ROUTER_BLUEPRINT_CUSTOM_ANNOTATIONS")
+	// allow adding list of extra annotations for HAProxy blueprint
+	for _, entry := range strings.Split(extraAnnotations, ",") {
+		if v := strings.Trim(entry, " "); len(v) > 0 {
+			glog.V(6).Infof("ROUTER_BLUEPRINT_CUSTOM_ANNOTATIONS has anotation %s", entry)
+			listExtraAnnotations = append(listExtraAnnotations, v)
+		}
+	}
 
 	return &haproxyConfigManager{
 		connectionInfo:         options.ConnectionInfo,
@@ -165,10 +178,11 @@ func NewHAProxyConfigManager(options templaterouter.ConfigManagerOptions) *hapro
 		extendedValidation:     options.ExtendedValidation,
 		defaultCertificate:     "",
 
-		client:           client,
-		reloadInProgress: false,
-		backendEntries:   make(map[string]*routeBackendEntry),
-		poolUsage:        make(map[string]string),
+		client:               client,
+		reloadInProgress:     false,
+		backendEntries:       make(map[string]*routeBackendEntry),
+		poolUsage:            make(map[string]string),
+		listExtraAnnotations: listExtraAnnotations,
 	}
 }
 
@@ -811,7 +825,18 @@ func (cm *haproxyConfigManager) reset() {
 // as a "surrogate" for the route.
 func (cm *haproxyConfigManager) findMatchingBlueprint(route *routev1.Route) *routev1.Route {
 	termination := routeTerminationType(route)
-	routeModifiers := backendModAnnotations(route)
+	routeModifiers := backendModAnnotations(route, cm)
+
+	// when route matches the annotation the configuration will be reloaded
+	if _, ok := route.Annotations["haproxy.router.openshift.io/skip-route-blueprint-match"]; ok {
+		return nil
+	}
+
+	// when route matches the annotation the configuration will be reloaded
+	if _, ok := route.Annotations["haproxy.router.openshift.io/skip-route-blueprint-match"]; ok {
+		return nil
+	}
+
 	for _, candidate := range cm.blueprintRoutes {
 		t2 := routeTerminationType(candidate)
 		if termination != t2 {
@@ -825,7 +850,7 @@ func (cm *haproxyConfigManager) findMatchingBlueprint(route *routev1.Route) *rou
 				continue
 			}
 
-			candidateModifiers := backendModAnnotations(candidate)
+			candidateModifiers := backendModAnnotations(candidate, cm)
 			if !reflect.DeepEqual(routeModifiers, candidateModifiers) {
 				continue
 			}
@@ -1076,9 +1101,9 @@ func applyMapAssociations(m *HAProxyMap, associations map[string]string, add boo
 
 // backendModAnnotations return the annotations in a route that will
 // require custom (or modified) backend configuration in haproxy.
-func backendModAnnotations(route *routev1.Route) map[string]string {
+func backendModAnnotations(route *routev1.Route, cm *haproxyConfigManager) map[string]string {
 	termination := routeTerminationType(route)
-	backendModifiers := modAnnotationsList(termination)
+	backendModifiers := modAnnotationsList(termination, cm.listExtraAnnotations)
 
 	annotations := make(map[string]string)
 	for _, name := range backendModifiers {
@@ -1092,7 +1117,7 @@ func backendModAnnotations(route *routev1.Route) map[string]string {
 
 // modAnnotationsList returns a list of annotations that can modify the
 // haproxy config for a backend.
-func modAnnotationsList(termination routev1.TLSTerminationType) []string {
+func modAnnotationsList(termination routev1.TLSTerminationType, listExtraAnnotations []string) []string {
 	annotations := []string{
 		"haproxy.router.openshift.io/balance",
 		"haproxy.router.openshift.io/ip_whitelist",
@@ -1103,6 +1128,20 @@ func modAnnotationsList(termination routev1.TLSTerminationType) []string {
 		"haproxy.router.openshift.io/rate-limit-connections.rate-http",
 		"haproxy.router.openshift.io/pod-concurrent-connections",
 		"router.openshift.io/haproxy.health.check.interval",
+	}
+
+	// allow adding list of extra annotations for HAProxy blueprint
+	listExtraAnnotations := os.Getenv("ROUTER_BLUEPRINT_CUSTOM_ANNOTATIONS")
+	for _, entry := range strings.Split(listExtraAnnotations, ",") {
+		if v := strings.Trim(entry, " "); len(v) > 0 {
+			glog.V(6).Infof("ROUTER_BLUEPRINT_CUSTOM_ANNOTATIONS has anotation %s", entry)
+			annotations = append(annotations, v)
+		}
+	}
+
+	// allow adding list of extra annotations for HAProxy blueprint
+	if len(listExtraAnnotations) > 0 {
+		annotations = append(annotations, listExtraAnnotations...)
 	}
 
 	if termination == routev1.TLSTerminationPassthrough {


### PR DESCRIPTION
Adds a possibility to configure a list of annotations that need to vary
the HAProxy configuration, and adds a route annotation that disables
matching routes to existing "blueprints" 

This fixes #21170 

cc @ramr @gnufied @ncdc 