### PR TITLE
only check for exceeding of ServerThreshold if the current row is a server

### DIFF
--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -429,9 +429,9 @@ loop:
 		// displaying only backends and frontends.
 		if row[32] == serverType {
 			servers++
-		}
-		if servers > e.opts.ServerThreshold {
-			continue
+			if servers > e.opts.ServerThreshold {
+				continue
+			}
 		}
 
 		rows++


### PR DESCRIPTION
Running into this issue on our clusters:
We have around 1040 servers/backend reported in haproxy metrics and the `ServerThreshold` is the default on `500`.
As expected `haproxy_server_*` are not existing in prometheus as we exceed the threshold. But unfortunately the `backend` and `frontend` are not fully exported, they stop at around ~400.

Reason is that as soon as the rowparser reaches the 500th server it runs `continue` but it does that also for `backends` and `frontends`, leading into the situation that not all `backend` and `frontend` are reported.

Fixes https://github.com/openshift/origin/issues/21545