### PR TITLE
Increase the default test timeout to 15m

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -154,7 +154,9 @@ func (opt *Options) Run(args []string) error {
 		timeout = suite.TestTimeout
 	}
 	if timeout == 0 {
-		timeout = 10 * time.Minute
+		// TODO: temporarily increased because some normally fast build tests have become much slower
+		//   reduce back to 10m at some point in the future
+		timeout = 15 * time.Minute
 	}
 
 	ctx, cancelFn := context.WithCancel(context.Background())


### PR DESCRIPTION
Builds are currently taking a lot longer, and while that isn't a shippable
state we need to reduce flakes on a few key tests that hit the boundary.
Devex team will be following up with perf.