### PR TITLE
UPSTREAM: 64675 : Fixes data races for pkg/kubelet/config/file_linux_test.go

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/config/file_linux_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/config/file_linux_test.go
@@ -131,6 +131,7 @@ func TestWatchFileChanged(t *testing.T) {
 }
 
 type testCase struct {
+	lock       *sync.Mutex
 	desc       string
 	linkedFile string
 	pod        runtime.Object
@@ -141,6 +142,7 @@ func getTestCases(hostname types.NodeName) []*testCase {
 	grace := int64(30)
 	return []*testCase{
 		{
+			lock: &sync.Mutex{},
 			desc: "Simple pod",
 			pod: &v1.Pod{
 				TypeMeta: metav1.TypeMeta{
@@ -304,11 +306,10 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			}
 
 			var file string
-			lock := &sync.Mutex{}
 			ch := make(chan interface{})
 			func() {
-				lock.Lock()
-				defer lock.Unlock()
+				testCase.lock.Lock()
+				defer testCase.lock.Unlock()
 
 				if symlink {
 					file = testCase.writeToFile(linkedDirName, fileName, t)
@@ -320,10 +321,6 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 
 			if watchDir {
 				NewSourceFile(dirName, hostname, 100*time.Millisecond, ch)
-				defer func() {
-					// Remove the file
-					deleteFile(dirName, fileName, ch, t)
-				}()
 			} else {
 				NewSourceFile(file, hostname, 100*time.Millisecond, ch)
 			}
@@ -332,8 +329,8 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 
 			changeFile := func() {
 				// Edit the file content
-				lock.Lock()
-				defer lock.Unlock()
+				testCase.lock.Lock()
+				testCase.lock.Unlock()
 
 				pod := testCase.pod.(*v1.Pod)
 				pod.Spec.Containers[0].Name = "image2"
@@ -352,9 +349,7 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			expectUpdate(t, ch, testCase)
 
 			if watchDir {
-				from := fileName
-				fileName = fileName + "_ch"
-				go changeFileName(dirName, from, fileName, t)
+				go changeFileName(dirName, fileName, fileName+"_ch", t)
 				// expect an update by MOVED_FROM inotify event cause changing file name
 				expectEmptyUpdate(t, ch)
 				// expect an update by MOVED_TO inotify event cause changing file name
@@ -362,18 +357,6 @@ func watchFileChanged(watchDir bool, symlink bool, t *testing.T) {
 			}
 		}()
 	}
-}
-
-func deleteFile(dir, file string, ch chan interface{}, t *testing.T) {
-	go func() {
-		path := filepath.Join(dir, file)
-		err := os.Remove(path)
-		if err != nil {
-			t.Errorf("unable to remove test file %s: %s", path, err)
-		}
-	}()
-
-	expectEmptyUpdate(t, ch)
 }
 
 func expectUpdate(t *testing.T, ch chan interface{}, testCase *testCase) {
@@ -396,7 +379,8 @@ func expectUpdate(t *testing.T, ch chan interface{}, testCase *testCase) {
 					t.Fatalf("%s: Invalid pod %#v, %#v", testCase.desc, internalPod, errs)
 				}
 			}
-
+			testCase.lock.Lock()
+			defer testCase.lock.Unlock()
 			if !apiequality.Semantic.DeepEqual(testCase.expected, update) {
 				t.Fatalf("%s: Expected: %#v, Got: %#v", testCase.desc, testCase.expected, update)
 			}


### PR DESCRIPTION
Pick of https://github.com/kubernetes/kubernetes/pull/64675/files

/cc @sjenning @smarterclayton 