### PR TITLE
UPSTREAM: <carry>: log a warning with verbose output if healthz fails

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -158,6 +158,7 @@ func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
 		}
 		// always be verbose on failure
 		if failed {
+			glog.Warningf("%vhealthz check failed", verboseOut.String())
 			http.Error(w, fmt.Sprintf("%vhealthz check failed", verboseOut.String()), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
For easier debugging of readiness errors.