### PR TITLE
revert running prune test builds in parallel

### DIFF
--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -72,19 +72,9 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting four test builds")
-
-			done := make(chan struct{})
 			for i := 0; i < 4; i++ {
-				go func() {
-					br, _ := exutil.StartBuildAndWait(oc, "myphp")
-					br.AssertSuccess()
-					done <- struct{}{}
-				}()
-				// avoid conflicts that may occur when launching multiple builds in parallel.
-				time.Sleep(5 * time.Second)
-			}
-			for i := 0; i < 4; i++ {
-				<-done
+				br, _ := exutil.StartBuildAndWait(oc, "myphp")
+				br.AssertSuccess()
 			}
 
 			buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
@@ -127,18 +117,9 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting four test builds")
-			done := make(chan struct{})
 			for i := 0; i < 4; i++ {
-				go func() {
-					br, _ := exutil.StartBuildAndWait(oc, "myphp")
-					br.AssertFailure()
-					done <- struct{}{}
-				}()
-				// avoid conflicts that may occur when launching multiple builds in parallel.
-				time.Sleep(5 * time.Second)
-			}
-			for i := 0; i < 4; i++ {
-				<-done
+				br, _ := exutil.StartBuildAndWait(oc, "myphp")
+				br.AssertFailure()
 			}
 
 			buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
@@ -226,18 +207,9 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("starting four test builds")
-			done := make(chan struct{})
 			for i := 0; i < 4; i++ {
-				go func() {
-					br, _ := exutil.StartBuildAndWait(oc, "myphp")
-					br.AssertFailure()
-					done <- struct{}{}
-				}()
-				// avoid conflicts that may occur when launching multiple builds in parallel.
-				time.Sleep(5 * time.Second)
-			}
-			for i := 0; i < 4; i++ {
-				<-done
+				br, _ := exutil.StartBuildAndWait(oc, "myphp")
+				br.AssertFailure()
 			}
 
 			buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -74,14 +74,10 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			g.By("starting four test builds")
 
 			done := make(chan struct{})
-			buildResults := [4]*exutil.BuildResult{}
 			for i := 0; i < 4; i++ {
 				go func() {
-					count := i
-					var err error
-					buildResults[count], err = exutil.StartBuildAndWait(oc, "myphp")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(buildResults[count]).NotTo(o.BeNil())
+					br, _ := exutil.StartBuildAndWait(oc, "myphp")
+					br.AssertSuccess()
 					done <- struct{}{}
 				}()
 				// avoid conflicts that may occur when launching multiple builds in parallel.
@@ -89,9 +85,6 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			}
 			for i := 0; i < 4; i++ {
 				<-done
-			}
-			for i := 0; i < 4; i++ {
-				buildResults[i].AssertSuccess()
 			}
 
 			buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
@@ -135,14 +128,10 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 
 			g.By("starting four test builds")
 			done := make(chan struct{})
-			buildResults := [4]*exutil.BuildResult{}
 			for i := 0; i < 4; i++ {
 				go func() {
-					count := i
-					var err error
-					buildResults[count], err = exutil.StartBuildAndWait(oc, "myphp")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(buildResults[count]).NotTo(o.BeNil())
+					br, _ := exutil.StartBuildAndWait(oc, "myphp")
+					br.AssertFailure()
 					done <- struct{}{}
 				}()
 				// avoid conflicts that may occur when launching multiple builds in parallel.
@@ -150,9 +139,6 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			}
 			for i := 0; i < 4; i++ {
 				<-done
-			}
-			for i := 0; i < 4; i++ {
-				buildResults[i].AssertFailure()
 			}
 
 			buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})
@@ -241,14 +227,10 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 
 			g.By("starting four test builds")
 			done := make(chan struct{})
-			buildResults := [4]*exutil.BuildResult{}
 			for i := 0; i < 4; i++ {
 				go func() {
-					count := i
-					var err error
-					buildResults[count], err = exutil.StartBuildAndWait(oc, "myphp")
-					o.Expect(err).NotTo(o.HaveOccurred())
-					o.Expect(buildResults[count]).NotTo(o.BeNil())
+					br, _ := exutil.StartBuildAndWait(oc, "myphp")
+					br.AssertFailure()
 					done <- struct{}{}
 				}()
 				// avoid conflicts that may occur when launching multiple builds in parallel.
@@ -256,9 +238,6 @@ var _ = g.Describe("[Feature:Builds][pruning] prune builds based on settings in 
 			}
 			for i := 0; i < 4; i++ {
 				<-done
-			}
-			for i := 0; i < 4; i++ {
-				buildResults[i].AssertFailure()
 			}
 
 			buildConfig, err := oc.BuildClient().Build().BuildConfigs(oc.Namespace()).Get("myphp", metav1.GetOptions{})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -814,7 +814,6 @@ metadata:
   name: myphp
 spec:
   failedBuildsHistoryLimit: 2
-  runPolicy: Parallel
   source:
     type: Git
     git:
@@ -859,7 +858,6 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   failedBuildsHistoryLimit: 2
-  runPolicy: Parallel
   source:
     type: Git
     git:
@@ -949,7 +947,6 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   successfulBuildsHistoryLimit: 2
-  runPolicy: Parallel
   source:
     dockerfile: |
       FROM busybox

--- a/test/extended/testdata/builds/build-pruning/errored-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/errored-build-config.yaml
@@ -4,7 +4,6 @@ metadata:
   name: myphp
 spec:
   failedBuildsHistoryLimit: 2
-  runPolicy: Parallel
   source:
     type: Git
     git:

--- a/test/extended/testdata/builds/build-pruning/failed-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/failed-build-config.yaml
@@ -8,7 +8,6 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   failedBuildsHistoryLimit: 2
-  runPolicy: Parallel
   source:
     type: Git
     git:

--- a/test/extended/testdata/builds/build-pruning/successful-build-config.yaml
+++ b/test/extended/testdata/builds/build-pruning/successful-build-config.yaml
@@ -8,7 +8,6 @@ metadata:
     openshift.io/generated-by: OpenShiftWebConsole
 spec:
   successfulBuildsHistoryLimit: 2
-  runPolicy: Parallel
   source:
     dockerfile: |
       FROM busybox


### PR DESCRIPTION
this introduced flakes because when all 4 builds run in parallel, the one we're waiting for can get pruned before waitforabuild actually sees that it is complete.

since Clayton sped up the build this test uses, i'm going back to running them in serial.
