### PR TITLE
Update e2e tests for 4.0 conventions

### DIFF
--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -48,6 +48,11 @@ COPY --from=test /usr/bin/curl /test/
 
 		g.It("should succeed [Conformance]", func() {
 			g.By("creating a build directly")
+			is, err := oc.ImageClient().Image().ImageStreams("openshift").Get("php", metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
+			registry := strings.Split(is.Status.DockerImageRepository, "/")[0]
+
 			build, err := oc.BuildClient().Build().Builds(oc.Namespace()).Create(&buildv1.Build{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "multi-stage",
@@ -66,7 +71,7 @@ COPY --from=test /usr/bin/curl /test/
 						Output: buildv1.BuildOutput{
 							To: &corev1.ObjectReference{
 								Kind: "DockerImage",
-								Name: fmt.Sprintf("docker-registry.default.svc:5000/%s/multi-stage:v1", oc.Namespace()),
+								Name: fmt.Sprintf("%s/%s/multi-stage:v1", registry, oc.Namespace()),
 							},
 						},
 					},
@@ -79,10 +84,6 @@ COPY --from=test /usr/bin/curl /test/
 
 			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(build.Name+"-build", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
-			if !result.BuildSuccess && strings.HasSuffix(pod.Spec.Containers[0].Image, ":v3.10.0-alpha.0") {
-				g.Skip(fmt.Sprintf("The currently selected builder image does not yet support optimized image builds: %s", pod.Spec.Containers[0].Image))
-			}
-
 			o.Expect(result.BuildSuccess).To(o.BeTrue(), "Build did not succeed: %#v", result)
 
 			s, err := result.Logs()
@@ -102,7 +103,7 @@ COPY --from=test /usr/bin/curl /test/
 					Containers: []corev1.Container{
 						{
 							Name:    "run",
-							Image:   fmt.Sprintf("docker-registry.default.svc:5000/%s/multi-stage:v1", oc.Namespace()),
+							Image:   fmt.Sprintf("%s/%s/multi-stage:v1", registry, oc.Namespace()),
 							Command: []string{"/test/curl", "-k", "https://kubernetes.default.svc"},
 						},
 					},

--- a/test/extended/templates/templateservicebroker_bind.go
+++ b/test/extended/templates/templateservicebroker_bind.go
@@ -9,11 +9,12 @@ import (
 	o "github.com/onsi/gomega"
 	"github.com/pborman/uuid"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/test/e2e/framework"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -38,11 +39,11 @@ var _ = g.Describe("[Conformance][templates] templateservicebroker bind test", f
 
 	g.Context("", func() {
 		g.BeforeEach(func() {
-			framework.SkipIfProviderIs("gce")
-
 			var err error
-
 			brokercli, err = TSBClient(cli)
+			if kerrors.IsNotFound(err) {
+				e2e.Skipf("The template service broker is not installed: %v", err)
+			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			cliUser = &user.DefaultInfo{Name: cli.Username(), Groups: []string{"system:authenticated"}}


### PR DESCRIPTION
Make TSB tests skip based on install status. Update other tests to lookup
the correct hostname for the registry rather than hardcode it.