### PR TITLE
skip timestamps in build log output check

### DIFF
--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -61,7 +61,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func(
 				o.Expect(br.Build.Status.Duration).To(o.Equal(duration), "Build duration should be computed correctly")
 
 				g.By("expecting the build logs to contain the correct cgroups values")
-				buildLog, err := br.Logs()
+				buildLog, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(buildLog).To(o.ContainSubstring("MEMORY=209715200"))
 				o.Expect(buildLog).To(o.ContainSubstring("MEMORYSWAP=209715200"))

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -557,6 +557,24 @@ func (t *BuildResult) Logs() (string, error) {
 	return buildOuput, nil
 }
 
+// LogsNoTimestamp returns the logs associated with this build.
+func (t *BuildResult) LogsNoTimestamp() (string, error) {
+	if t == nil || t.BuildPath == "" {
+		return "", fmt.Errorf("Not enough information to retrieve logs for %#v", *t)
+	}
+
+	if t.LogDumper != nil {
+		return t.LogDumper(t.Oc, t)
+	}
+
+	buildOuput, err := t.Oc.Run("logs").Args("-f", t.BuildPath).Output()
+	if err != nil {
+		return "", fmt.Errorf("Error retrieving logs for %#v: %v", *t, err)
+	}
+
+	return buildOuput, nil
+}
+
 // Dumps logs and triggers a Ginkgo assertion if the build did NOT succeed.
 func (t *BuildResult) AssertSuccess() *BuildResult {
 	if !t.BuildSuccess {


### PR DESCRIPTION
Seeing weird build log output when `--timestamps` is passed which breaks the output checking this test does.  The log output looks like:

```
2018-12-02T13:27:11.370755435Z MEMORY=2018-12-02T13:27:11.466193503Z 209715200
```
when we are looking for
`MEMORY=209715200`

somehow a timestamp got dumped in the middle of the output.

Note that the pod logs printed later show the correct/expected output:

```
time="2018-12-02T13:27:11Z" level=debug msg="Running &exec.Cmd{Path:\"/bin/sh\", Args:[]string{\"/bin/sh\", \"-c\", \"/tmp/scripts/assemble\"}, Env:[]string{\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\", \"BUILD_LOGLEVEL=6\", \"OPENSHIFT_BUILD_NAMESPACE=e2e-test-s2i-build-quota-7d49h\", \"OPENSHIFT_BUILD_NAME=s2i-build-quota-1\"}, Dir:\"/\", Stdin:(*os.File)(0xc4200bc000), Stdout:(*os.File)(0xc4200bc008), Stderr:(*os.File)(0xc4200bc010), ExtraFiles:[]*os.File(nil), SysProcAttr:(*syscall.SysProcAttr)(nil), Process:(*os.Process)(nil), ProcessState:(*os.ProcessState)(nil), ctx:context.Context(nil), lookPathErr:error(nil), finished:false, childFiles:[]*os.File(nil), closeAfterStart:[]io.Closer(nil), closeAfterWait:[]io.Closer(nil), goroutine:[]func() error(nil), errch:(chan error)(nil), waitDone:(chan struct {})(nil)} (PATH = \"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\")"
MEMORY=209715200
MEMORYSWAP=9223372036854771712
QUOTA=6000
SHARES=61
PERIOD=100000
```

so it's possible this is somehow specific to the build logs endpoint, but this also appears to be a flake, so who knows.

/cc @smarterclayton 

The run that flaked is here: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/21574/pull-ci-openshift-origin-master-e2e-gcp-crio/300
