### PR TITLE
Set readiness checks on test routers

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -10976,6 +10976,11 @@ objects:
       - containerPort: 1936
         name: stats
         protocol: TCP
+      readinessProbe:
+        initialDelaySeconds: 10
+        httpGet:
+          path: /healthz/ready
+          port: 1936
     serviceAccountName: default
 `)
 
@@ -11029,6 +11034,11 @@ objects:
       - containerPort: 1936
         name: stats
         protocol: TCP
+      readinessProbe:
+        initialDelaySeconds: 10
+        httpGet:
+          path: /healthz/ready
+          port: 1936
     serviceAccountName: default
 `)
 
@@ -11081,6 +11091,11 @@ objects:
       - containerPort: 1936
         name: stats
         protocol: TCP
+      readinessProbe:
+        initialDelaySeconds: 10
+        httpGet:
+          path: /healthz/ready
+          port: 1936
     serviceAccountName: default
 `)
 

--- a/test/extended/testdata/router-override-domains.yaml
+++ b/test/extended/testdata/router-override-domains.yaml
@@ -33,4 +33,9 @@ objects:
       - containerPort: 1936
         name: stats
         protocol: TCP
+      readinessProbe:
+        initialDelaySeconds: 10
+        httpGet:
+          path: /healthz/ready
+          port: 1936
     serviceAccountName: default

--- a/test/extended/testdata/router-override.yaml
+++ b/test/extended/testdata/router-override.yaml
@@ -33,4 +33,9 @@ objects:
       - containerPort: 1936
         name: stats
         protocol: TCP
+      readinessProbe:
+        initialDelaySeconds: 10
+        httpGet:
+          path: /healthz/ready
+          port: 1936
     serviceAccountName: default

--- a/test/extended/testdata/router-scoped.yaml
+++ b/test/extended/testdata/router-scoped.yaml
@@ -32,4 +32,9 @@ objects:
       - containerPort: 1936
         name: stats
         protocol: TCP
+      readinessProbe:
+        initialDelaySeconds: 10
+        httpGet:
+          path: /healthz/ready
+          port: 1936
     serviceAccountName: default


### PR DESCRIPTION
Eliminate an unready backend as a potential source of e2e flakes.