### PR TITLE
kube:admin strong password, logout endpoint

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_handlerchain.go
@@ -16,6 +16,7 @@ import (
 const (
 	openShiftOAuthAPIPrefix      = "/oauth"
 	openShiftLoginPrefix         = "/login"
+	openShiftLogoutPrefix        = "/logout"
 	openShiftOAuthCallbackPrefix = "/oauth2callback"
 )
 
@@ -61,7 +62,7 @@ func withOAuthRedirection(oauthConfig *osinv1.OAuthConfig, handler, oauthServerH
 	}
 
 	glog.Infof("Starting OAuth2 API at %s", urls.OpenShiftOAuthAPIPrefix)
-	return WithPatternPrefixHandler(handler, oauthServerHandler, openShiftOAuthAPIPrefix, openShiftLoginPrefix, openShiftOAuthCallbackPrefix)
+	return WithPatternPrefixHandler(handler, oauthServerHandler, openShiftOAuthAPIPrefix, openShiftLoginPrefix, openShiftLogoutPrefix, openShiftOAuthCallbackPrefix)
 }
 
 func WithPatternPrefixHandler(handler http.Handler, patternHandler http.Handler, prefixes ...string) http.Handler {

--- a/pkg/oauthserver/server/login/login.go
+++ b/pkg/oauthserver/server/login/login.go
@@ -101,9 +101,9 @@ func (l *Login) Install(mux oauthserver.Mux, paths ...string) {
 func (l *Login) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	headers.SetStandardHeaders(w)
 	switch req.Method {
-	case "GET":
+	case http.MethodGet:
 		l.handleLoginForm(w, req)
-	case "POST":
+	case http.MethodPost:
 		l.handleLogin(w, req)
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/pkg/oauthserver/server/logout/logout.go
+++ b/pkg/oauthserver/server/logout/logout.go
@@ -1,0 +1,56 @@
+package logout
+
+import (
+	"net/http"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/openshift/origin/pkg/oauthserver"
+	"github.com/openshift/origin/pkg/oauthserver/server/headers"
+	"github.com/openshift/origin/pkg/oauthserver/server/redirect"
+	"github.com/openshift/origin/pkg/oauthserver/server/session"
+	"github.com/openshift/origin/pkg/oauthserver/server/tokenrequest"
+)
+
+const thenParam = "then"
+
+func NewLogout(invalidator session.SessionInvalidator) tokenrequest.Endpoints {
+	return &logout{
+		invalidator: invalidator,
+	}
+}
+
+type logout struct {
+	invalidator session.SessionInvalidator
+}
+
+func (l *logout) Install(mux oauthserver.Mux, paths ...string) {
+	for _, path := range paths {
+		mux.Handle(path, l)
+	}
+}
+
+func (l *logout) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// TODO this seems like something that should happen automatically at a higher level
+	// we also do not set these headers on the OAuth endpoints or the token request endpoint...
+	headers.SetStandardHeaders(w)
+
+	if req.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// invalidate with empty user to force session removal
+	if err := l.invalidator.InvalidateAuthentication(w, &user.DefaultInfo{}); err != nil {
+		glog.V(5).Infof("error logging out: %v", err)
+		http.Error(w, "failed to log out", http.StatusInternalServerError)
+		return
+	}
+
+	if then := req.FormValue(thenParam); redirect.IsServerRelativeURL(then) {
+		http.Redirect(w, req, then, http.StatusFound)
+		return
+	}
+}

--- a/pkg/oauthserver/server/selectprovider/bootstrapselectprovider.go
+++ b/pkg/oauthserver/server/selectprovider/bootstrapselectprovider.go
@@ -25,7 +25,8 @@ type bootstrapSelectProvider struct {
 
 func (b *bootstrapSelectProvider) SelectAuthentication(providers []api.ProviderInfo, w http.ResponseWriter, req *http.Request) (*api.ProviderInfo, bool, error) {
 	// this should never happen but let us not panic the server in case we screwed up
-	if len(providers) == 0 || providers[0].Name != bootstrap.BootstrapUser {
+	// also avoids checking the secret when there is only one provider
+	if len(providers) <= 1 || providers[0].Name != bootstrap.BootstrapUser {
 		return b.delegate.SelectAuthentication(providers, w, req)
 	}
 

--- a/pkg/oauthserver/server/session/authenticator.go
+++ b/pkg/oauthserver/server/session/authenticator.go
@@ -4,11 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"github.com/openshift/origin/pkg/oauthserver/authenticator/password/bootstrap"
 )
 
 const (
@@ -19,21 +15,19 @@ const (
 	expKey = "exp"
 )
 
-type Authenticator struct {
-	store   Store
-	maxAge  time.Duration
-	secrets v1.SecretInterface
+type sessionAuthenticator struct {
+	store  Store
+	maxAge time.Duration
 }
 
-func NewAuthenticator(store Store, maxAge time.Duration, secrets v1.SecretsGetter) *Authenticator {
-	return &Authenticator{
-		store:   store,
-		maxAge:  maxAge,
-		secrets: secrets.Secrets(metav1.NamespaceSystem),
+func NewAuthenticator(store Store, maxAge time.Duration) SessionAuthenticator {
+	return &sessionAuthenticator{
+		store:  store,
+		maxAge: maxAge,
 	}
 }
 
-func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *sessionAuthenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
 	values := a.store.Get(req)
 
 	expires, ok := values.GetInt64(expKey)
@@ -55,62 +49,17 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 		return nil, false, nil
 	}
 
-	// make sure that the password has not changed since this cookie was issued
-	// note that this is not really for security - it is so that we do not annoy the user
-	// by letting them log in successfully only to have a token that does not work
-	if name == bootstrap.BootstrapUser {
-		_, currentUID, ok, err := bootstrap.HashAndUID(a.secrets)
-		if err != nil || !ok {
-			return nil, ok, err
-		}
-		if currentUID != uid {
-			return nil, false, nil
-		}
-	}
-
 	return &user.DefaultInfo{
 		Name: name,
 		UID:  uid,
 	}, true, nil
 }
 
-func (a *Authenticator) AuthenticationSucceeded(user user.Info, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
-	return false, a.put(w, user.GetName(), user.GetUID(), time.Now().Add(a.getMaxAge(user)).Unix())
+func (a *sessionAuthenticator) AuthenticationSucceeded(user user.Info, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
+	return false, putUser(a.store, w, user, a.maxAge)
 }
 
-// TODO figure out how to extract the BootstrapUser logic from this function
-// as that is the only thing that prevents us from layering the BootstrapUser
-// bits as a separate unit on top of the standard session logic
-func (a *Authenticator) getMaxAge(user user.Info) time.Duration {
-	// since osin is the IDP for this user, we increase the length
-	// of the session to allow for transitions between components
-	if user.GetName() == bootstrap.BootstrapUser {
-		// this means the user could stay authenticated for one hour + OAuth access token lifetime
-		return time.Hour
-	}
-
-	return a.maxAge
-}
-
-func (a *Authenticator) InvalidateAuthentication(w http.ResponseWriter, user user.Info) error {
-	// the IDP is responsible for maintaining the user's session
-	// since osin is the IDP for this user, we do not invalidate its session
-	// this is safe to do because we tie the cookie to the password hash
-	if user.GetName() == bootstrap.BootstrapUser {
-		return nil
-	}
-
+func (a *sessionAuthenticator) InvalidateAuthentication(w http.ResponseWriter, _ user.Info) error {
 	// zero out all fields
-	return a.put(w, "", "", 0)
-}
-
-func (a *Authenticator) put(w http.ResponseWriter, name, uid string, expires int64) error {
-	values := Values{}
-
-	values[userNameKey] = name
-	values[userUIDKey] = uid
-
-	values[expKey] = expires
-
-	return a.store.Put(w, values)
+	return putUser(a.store, w, &user.DefaultInfo{}, 0)
 }

--- a/pkg/oauthserver/server/session/bootstrapauthenticator.go
+++ b/pkg/oauthserver/server/session/bootstrapauthenticator.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/origin/pkg/oauthserver/authenticator/password/bootstrap"
+)
+
+func NewBootstrapAuthenticator(delegate SessionAuthenticator, secrets v1.SecretsGetter, store Store) SessionAuthenticator {
+	return &bootstrapAuthenticator{
+		delegate: delegate,
+		secrets:  secrets.Secrets(metav1.NamespaceSystem),
+		store:    store,
+	}
+}
+
+type bootstrapAuthenticator struct {
+	delegate SessionAuthenticator
+	secrets  v1.SecretInterface
+	store    Store
+}
+
+func (b *bootstrapAuthenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	u, ok, err := b.delegate.AuthenticateRequest(req)
+	if err != nil || !ok || u.GetName() != bootstrap.BootstrapUser {
+		return u, ok, err
+	}
+
+	// make sure that the password has not changed since this cookie was issued
+	// note that this is not really for security - it is so that we do not annoy the user
+	// by letting them log in successfully only to have a token that does not work
+	_, uid, ok, err := bootstrap.HashAndUID(b.secrets)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	if uid != u.GetUID() {
+		return nil, false, nil
+	}
+
+	return u, true, nil
+}
+
+func (b *bootstrapAuthenticator) AuthenticationSucceeded(user user.Info, state string, w http.ResponseWriter, req *http.Request) (bool, error) {
+	if user.GetName() != bootstrap.BootstrapUser {
+		return b.delegate.AuthenticationSucceeded(user, state, w, req)
+	}
+
+	// since osin is the IDP for this user, we increase the length
+	// of the session to allow for transitions between components
+	// this means the user could stay authenticated for one hour + OAuth access token lifetime
+	return false, putUser(b.store, w, user, time.Hour)
+}
+
+func (b *bootstrapAuthenticator) InvalidateAuthentication(w http.ResponseWriter, user user.Info) error {
+	if user.GetName() != bootstrap.BootstrapUser {
+		return b.delegate.InvalidateAuthentication(w, user)
+	}
+
+	// the IDP is responsible for maintaining the user's session
+	// since osin is the IDP for the bootstrap user, we do not invalidate its session
+	// this is safe to do because we tie the cookie and token to the password hash
+	return nil
+}

--- a/pkg/oauthserver/server/session/put.go
+++ b/pkg/oauthserver/server/session/put.go
@@ -1,0 +1,23 @@
+package session
+
+import (
+	"net/http"
+	"time"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func putUser(store Store, w http.ResponseWriter, user user.Info, expiresIn time.Duration) error {
+	values := Values{}
+
+	values[userNameKey] = user.GetName()
+	values[userUIDKey] = user.GetUID()
+
+	var expires int64
+	if expiresIn > 0 {
+		expires = time.Now().Add(expiresIn).Unix()
+	}
+	values[expKey] = expires
+
+	return store.Put(w, values)
+}

--- a/pkg/oauthserver/server/session/types.go
+++ b/pkg/oauthserver/server/session/types.go
@@ -2,6 +2,11 @@ package session
 
 import (
 	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/openshift/origin/pkg/oauthserver/oauth/handlers"
 )
 
 // Store abstracts HTTP session storage of Values
@@ -22,4 +27,14 @@ func (v Values) GetString(key string) (string, bool) {
 func (v Values) GetInt64(key string) (int64, bool) {
 	i, _ := v[key].(int64)
 	return i, i != 0
+}
+
+type SessionInvalidator interface {
+	InvalidateAuthentication(w http.ResponseWriter, user user.Info) error
+}
+
+type SessionAuthenticator interface {
+	authenticator.Request
+	handlers.AuthenticationSuccessHandler
+	SessionInvalidator
 }


### PR DESCRIPTION
Enforce strong password for kube:admin

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Refactor out bootstrap session logic

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add logout endpoint to force session invalidation

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

@openshift/sig-auth @smarterclayton @derekwaynecarr 