### PR TITLE
Use a more portable shell invocation

### DIFF
--- a/hack/build-base-images.sh
+++ b/hack/build-base-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script builds the base and release images for use by the release build and image builds.
 

--- a/hack/build-cross.sh
+++ b/hack/build-cross.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Build all cross compile targets and the base binaries
 STARTTIME=$(date +%s)

--- a/hack/build-dind-images.sh
+++ b/hack/build-dind-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script builds the dind images so they can be baked into the ami
 # to reduce minimize the potential for dnf flakes in ci.

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script sets up a go workspace locally and builds all go components.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script builds all images locally except the base and release images,
 # which are handled by hack/build-base-images.sh.

--- a/hack/build-in-docker.sh
+++ b/hack/build-in-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script build the sources in openshift/origin-release image using
 # the Fedora environment and Go compiler.

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script generates release zips into _output/releases. It requires the openshift/origin-release
 # image to be built prior to executing this command via hack/build-base-images.sh.

--- a/hack/build-rpms.sh
+++ b/hack/build-rpms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script generates release zips and RPMs into _output/releases.
 # tito and other build dependencies are required on the host. We will

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # See HACKING.md for usage
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/convert-samples.sh
+++ b/hack/convert-samples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/dind-cluster.sh
+++ b/hack/dind-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # WARNING: The script modifies the host that docker is running on.  It
 # attempts to load the overlay and openvswitch modules. If this modification

--- a/hack/extract-release.sh
+++ b/hack/extract-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script extracts a valid release tar into _output/releases. It requires hack/build-release.sh
 # to have been executed

--- a/hack/generate-docs.sh
+++ b/hack/generate-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is not intended to be run automatically. It is meant to be run
 # immediately before exporting docs. We do not want to check these documents in

--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 etcd_version=$(go run ${OS_ROOT}/tools/godepversion/godepversion.go ${OS_ROOT}/Godeps/Godeps.json github.com/coreos/etcd/etcdserver)

--- a/hack/install-std-race.sh
+++ b/hack/install-std-race.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script installs std -race on Travis (see https://code.google.com/p/go/issues/detail?id=6479)
 

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/lib/build/archive.sh
+++ b/hack/lib/build/archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds utility functions for archiving
 # built binaries and releases.

--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds utility functions for building
 # and placing Golang binaries for multiple arches.

--- a/hack/lib/build/environment.sh
+++ b/hack/lib/build/environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script holds library functions for setting up the Docker container build environment
 

--- a/hack/lib/build/images.sh
+++ b/hack/lib/build/images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds utility functions for building container images.
 

--- a/hack/lib/build/release.sh
+++ b/hack/lib/build/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds utility functions for building releases.
 

--- a/hack/lib/build/rpm.sh
+++ b/hack/lib/build/rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds utilities for building RPMs from Origin.
 

--- a/hack/lib/build/version.sh
+++ b/hack/lib/build/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds utility functions for determining
 # product versions from Git repository state.

--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This library holds functions that are used to clean up local
 # system state after other scripts have run.

--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This utility file contains functions that wrap commands to be tested. All wrapper functions run commands
 # in a sub-shell and redirect all output. Tests in test-cmd *must* use these functions for testing.
 

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script provides constants for the Golang binary build process
 

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is meant to be the entrypoint for OpenShift Bash scripts to import all of the support
 # libraries at once in order to make Bash script preambles as minimal as possible. This script recur-

--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file contains functions used for writing log messages
 # to stdout and stderr from scripts while they run.

--- a/hack/lib/log/stacktrace.sh
+++ b/hack/lib/log/stacktrace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library contains an implementation of a stack trace for Bash scripts.
 

--- a/hack/lib/log/system.sh
+++ b/hack/lib/log/system.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library holds all of the system logging functions for OpenShift bash scripts.
 

--- a/hack/lib/start.sh
+++ b/hack/lib/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library holds functions for configuring and starting an OpenShift server
 

--- a/hack/lib/test/junit.sh
+++ b/hack/lib/test/junit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This utility file contains functions that format test output to be parsed into jUnit XML
 
 # os::test::junit::declare_suite_start prints a message declaring the start of a test suite

--- a/hack/lib/util/docs.sh
+++ b/hack/lib/util/docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library holds utility functions related to the generation
 # of manpages and docs.

--- a/hack/lib/util/ensure.sh
+++ b/hack/lib/util/ensure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script contains helper functions for ensuring that dependencies
 # exist on a host system that are required to run Origin scripts.

--- a/hack/lib/util/environment.sh
+++ b/hack/lib/util/environment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script holds library functions for setting up the shell environment for OpenShift scripts
 

--- a/hack/lib/util/find.sh
+++ b/hack/lib/util/find.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script contains helper functions for finding components
 # in the Origin repository or on the host machine running scripts.

--- a/hack/lib/util/golang.sh
+++ b/hack/lib/util/golang.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library holds golang related utility functions.
 

--- a/hack/lib/util/misc.sh
+++ b/hack/lib/util/misc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library holds miscellaneous utility functions. If there begin to be groups of functions in this
 # file that share intent or are thematically similar, they should be split into their own files.

--- a/hack/lib/util/text.sh
+++ b/hack/lib/util/text.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file contains helpful aliases for manipulating the output text to the terminal as
 # well as functions for one-command augmented printing.

--- a/hack/lib/util/trap.sh
+++ b/hack/lib/util/trap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This library defines the trap handlers for the ERR and EXIT signals. Any new handler for these signals
 # must be added to these handlers and activated by the environment variable mechanism that the rest use.

--- a/hack/load-etcd-dump.sh
+++ b/hack/load-etcd-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env

--- a/hack/make-p12-cert.sh
+++ b/hack/make-p12-cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CERT=${1:-}
 KEY=${2:-}

--- a/hack/move-api-packages.sh
+++ b/hack/move-api-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/move-upstream.sh
+++ b/hack/move-upstream.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # See HACKING.md for usage
 # To apply all the kube UPSTREAM patches to a kubernetes git directory, you can

--- a/hack/push-release.sh
+++ b/hack/push-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script pushes all of the built images to a registry.
 #

--- a/hack/pythia.sh
+++ b/hack/pythia.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script sets up a go workspace locally and invokes pythia to introspect code
 # see: https://github.com/fzipp/pythia

--- a/hack/rebase-describe-bumps.sh
+++ b/hack/rebase-describe-bumps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::util::ensure::built_binary_exists 'godepchecker'

--- a/hack/rebase-kube.sh
+++ b/hack/rebase-kube.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/release-components.sh
+++ b/hack/release-components.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script builds and pushes a release to DockerHub.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script builds and pushes a release to DockerHub.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This command checks that the built commands can function together for
 # simple scenarios.  It does not require Docker so it can run in travis.

--- a/hack/test-end-to-end-docker.sh
+++ b/hack/test-end-to-end-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app

--- a/hack/test-end-to-end.sh
+++ b/hack/test-end-to-end.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script tests the high level end-to-end functionality demonstrated
 # as part of the examples/sample-app

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script runs Go language unit tests for the repository. Arguments to this script
 # are parsed as a list of packages to test until the first argument starting with '-' or '--' is

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 # build the test executable and make sure it's on the path

--- a/hack/test-lib.sh
+++ b/hack/test-lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script runs all of the test written for our Bash libraries.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/test-lib/test/junit.sh
+++ b/hack/test-lib/test/junit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script tests os::test::junit functionality.
 

--- a/hack/test-rpm.sh
+++ b/hack/test-rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script ensures RPM's build properly and can
 # be installed as expected

--- a/hack/test-tools.sh
+++ b/hack/test-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This command runs any exposed integration tests for the developer tools
 STARTTIME=$(date +%s)

--- a/hack/test-util.sh
+++ b/hack/test-util.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file ensures that the helper functions in util.sh behave as expected
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/hack/update-external-examples.sh
+++ b/hack/update-external-examples.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script pulls down example files (eg templates) from external repositories
 # so they can be included directly in our repository.

--- a/hack/update-generated-bindata.sh
+++ b/hack/update-generated-bindata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 STARTTIME=$(date +%s)
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-generated-clientsets.sh
+++ b/hack/update-generated-clientsets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env

--- a/hack/update-generated-completions.sh
+++ b/hack/update-generated-completions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script sets up a go workspace locally and generates shell auto-completion scripts.
 

--- a/hack/update-generated-conversions.sh
+++ b/hack/update-generated-conversions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..

--- a/hack/update-generated-deep-copies.sh
+++ b/hack/update-generated-deep-copies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..

--- a/hack/update-generated-defaulters.sh
+++ b/hack/update-generated-defaulters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..

--- a/hack/update-generated-informers.sh
+++ b/hack/update-generated-informers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env

--- a/hack/update-generated-listers.sh
+++ b/hack/update-generated-listers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::build::setup_env

--- a/hack/update-generated-openapi.sh
+++ b/hack/update-generated-openapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..

--- a/hack/update-generated-swagger-spec.sh
+++ b/hack/update-generated-swagger-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to create latest swagger spec.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/vendor-console.sh
+++ b/hack/vendor-console.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 #  This script vendors the Web Console source files into bindata.go files that can be built into the openshift binary.
 #

--- a/hack/verify-cli-conventions.sh
+++ b/hack/verify-cli-conventions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-bindata.sh
+++ b/hack/verify-generated-bindata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-clientsets.sh
+++ b/hack/verify-generated-clientsets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-completions.sh
+++ b/hack/verify-generated-completions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-conversions.sh
+++ b/hack/verify-generated-conversions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-deep-copies.sh
+++ b/hack/verify-generated-deep-copies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-defaulters.sh
+++ b/hack/verify-generated-defaulters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-informers.sh
+++ b/hack/verify-generated-informers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-json-codecs.sh
+++ b/hack/verify-generated-json-codecs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-listers.sh
+++ b/hack/verify-generated-listers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-openapi.sh
+++ b/hack/verify-generated-openapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-generated-swagger-spec.sh
+++ b/hack/verify-generated-swagger-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::log::info "===== Verifying API Swagger Spec ====="

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 os::golang::verify_go_version

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script verifies that package trees
 # conform to our import restrictions

--- a/hack/verify-jsonformat.sh
+++ b/hack/verify-jsonformat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage:
 #

--- a/hack/verify-open-ports.sh
+++ b/hack/verify-open-ports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to create latest swagger spec.
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"

--- a/hack/verify-upstream-commits.sh
+++ b/hack/verify-upstream-commits.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 function cleanup() {


### PR DESCRIPTION
Not all users have bash installed in `/bin`. `/usr/bin/env` is a more
portable method.