### PR TITLE
UPSTREAM: 68663: Ignore kubelet proxy settings in http probe

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/probe/http/http.go
+++ b/vendor/k8s.io/kubernetes/pkg/probe/http/http.go
@@ -38,7 +38,12 @@ func New() HTTPProber {
 
 // NewWithTLSConfig takes tls config as parameter.
 func NewWithTLSConfig(config *tls.Config) HTTPProber {
-	transport := utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: config, DisableKeepAlives: true})
+	// We do not want the probe use node's local proxy set.
+	transport := utilnet.SetTransportDefaults(&http.Transport{
+		TLSClientConfig:   config,
+		DisableKeepAlives: true,
+		Proxy:             http.ProxyURL(nil),
+	})
 	return httpProber{transport}
 }
 


### PR DESCRIPTION
Picks: https://github.com/kubernetes/kubernetes/pull/68663
Prevents kubelet proxy settings from being used by liveness / readiness probes.

cc @soltysh 