### PR TITLE
build/strategy: wire in blob mount-from functionality

### DIFF
--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -81,12 +81,22 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, includeAddit
 							Name:      "buildworkdir",
 							MountPath: buildutil.BuildWorkDirMount,
 						},
+						{
+							Name:      "buildcachedir",
+							MountPath: buildutil.BuildBlobsMetaCache,
+						},
 					},
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Resources:       build.Spec.Resources,
 				},
 			},
 			Volumes: []v1.Volume{
+				{
+					Name: "buildcachedir",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: buildutil.BuildBlobsMetaCache},
+					},
+				},
 				{
 					Name: "buildworkdir",
 					VolumeSource: v1.VolumeSource{
@@ -140,6 +150,10 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, includeAddit
 				{
 					Name:      "buildworkdir",
 					MountPath: buildutil.BuildWorkDirMount,
+				},
+				{
+					Name:      "buildcachedir",
+					MountPath: buildutil.BuildBlobsMetaCache,
 				},
 			},
 			ImagePullPolicy: v1.PullIfNotPresent,

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -71,13 +71,15 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	// build-system-config
 	// certificate authorities
 	// container storage
-	if len(container.VolumeMounts) != 8 {
-		t.Fatalf("Expected 8 volumes in container, got %d", len(container.VolumeMounts))
+	// blobs cache
+	if len(container.VolumeMounts) != 9 {
+		t.Fatalf("Expected 9 volumes in container, got %d", len(container.VolumeMounts))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
 	}
 	expectedMounts := []string{buildutil.BuildWorkDirMount,
+		buildutil.BuildBlobsMetaCache,
 		DockerPushSecretMountPath,
 		DockerPullSecretMountPath,
 		filepath.Join(SecretBuildSourceBaseMountPath, "super-secret"),
@@ -92,8 +94,8 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 9 {
-		t.Fatalf("Expected 9 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 10 {
+		t.Fatalf("Expected 10 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if !kapihelper.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -89,12 +89,22 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, includeAddit
 							Name:      "buildworkdir",
 							MountPath: buildutil.BuildWorkDirMount,
 						},
+						{
+							Name:      "buildcachedir",
+							MountPath: buildutil.BuildBlobsMetaCache,
+						},
 					},
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Resources:       build.Spec.Resources,
 				},
 			},
 			Volumes: []corev1.Volume{
+				{
+					Name: "buildcachedir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Path: buildutil.BuildBlobsMetaCache},
+					},
+				},
 				{
 					Name: "buildworkdir",
 					VolumeSource: corev1.VolumeSource{
@@ -145,6 +155,10 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, includeAddit
 				{
 					Name:      "buildworkdir",
 					MountPath: buildutil.BuildWorkDirMount,
+				},
+				{
+					Name:      "buildcachedir",
+					MountPath: buildutil.BuildBlobsMetaCache,
 				},
 			},
 			ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/build/controller/strategy/sti_test.go
+++ b/pkg/build/controller/strategy/sti_test.go
@@ -111,10 +111,12 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 	// build-system-configmap
 	// certificate authorities
 	// container storage
-	if len(container.VolumeMounts) != 8 {
-		t.Fatalf("Expected 8 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
+	// blobs cache
+	if len(container.VolumeMounts) != 9 {
+		t.Fatalf("Expected 9 volumes in container, got %d %v", len(container.VolumeMounts), container.VolumeMounts)
 	}
 	expectedMounts := []string{buildutil.BuildWorkDirMount,
+		buildutil.BuildBlobsMetaCache,
 		DockerPushSecretMountPath,
 		DockerPullSecretMountPath,
 		filepath.Join(SecretBuildSourceBaseMountPath, "secret"),
@@ -129,8 +131,8 @@ func testSTICreateBuildPod(t *testing.T, rootAllowed bool) {
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 9 {
-		t.Fatalf("Expected 9 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 10 {
+		t.Fatalf("Expected 10 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -32,6 +32,10 @@ const (
 
 	// buildPodSuffix is the suffix used to append to a build pod name given a build name
 	buildPodSuffix = "build"
+
+	// BuildBlobsMetaCache is the directory used to store a cache for the blobs to be
+	// reused across builds.
+	BuildBlobsMetaCache = "/var/lib/containers/cache"
 )
 
 // GeneratorFatalError represents a fatal error while generating a build.


### PR DESCRIPTION
@mrunalp @mtrmac @bparees @smarterclayton 

This is just a wip to test things out as we need the resulting hypershift image from this PR to substitute the original one in a cluster and test this workflow, so, do not merge

Signed-off-by: Antonio Murdaca <runcom@linux.com>