### PR TITLE
UPSTREAM: <carry>: proxy/userspace: respect minSyncInterval

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/proxy/userspace/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/userspace/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//pkg/apis/core/helper:go_default_library",
         "//pkg/proxy:go_default_library",
         "//pkg/proxy/util:go_default_library",
+        "//pkg/util/async:go_default_library",
         "//pkg/util/conntrack:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/slice:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/proxy/userspace/loadbalancer.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/userspace/loadbalancer.go
@@ -31,4 +31,5 @@ type LoadBalancer interface {
 	DeleteService(service proxy.ServicePortName)
 	CleanupStaleStickySessions(service proxy.ServicePortName)
 	ServiceHasEndpoints(service proxy.ServicePortName) bool
+	EndpointsSyncedChan() chan bool
 }


### PR DESCRIPTION
The userspace proxy has no ratelimiting. Fix that.

https://bugzilla.redhat.com/show_bug.cgi?id=1590589

@squeed @knobunc @mcurry-rh @danwinship @openshift/sig-networking @openshift/networking 

There's a low chance upstream would take this because (a) it doesn't use the ServiceChangeTracker that was pulled out of the iptables proxy a while back, which isn't yet suitable for the userspace proxy, and (b) upstream doesn't care about the userspace proxy at all. I can certainly try to push it upstream though...

Upstream attempt: https://github.com/kubernetes/kubernetes/pull/71735