### PR TITLE
Update e2e test to check for 'openshift-cluster-dns-operator' instead of 'openshift-cluster-dns-operator/openshift-dns'

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -148,7 +148,7 @@ var _ = g.Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 				e2e.Logf("Some cluster operators never became available %s", strings.Join(unavailable, ", "))
 			}
 		}
-		if _, ok := available["openshift-cluster-dns-operator/openshift-dns"]; !ok {
+		if _, ok := available["openshift-cluster-dns-operator"]; !ok {
 			e2e.Failf("A required operator was not available")
 		}
 	})


### PR DESCRIPTION
- Need this change for https://github.com/openshift/cluster-dns-operator/pull/58