### PR TITLE
Temporarily force the installer to be part of the payload

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -42,7 +42,10 @@ func NewNewOptions(streams genericclioptions.IOStreams) *NewOptions {
 	return &NewOptions{
 		IOStreams:      streams,
 		MaxPerRegistry: 4,
-		AlwaysInclude:  []string{"cluster-version-operator", "cli"},
+		// TODO: only cluster-version-operator and maybe CLI should be in this list,
+		//   the others should always be referenced by the cluster-bootstrap or
+		//   another operator.
+		AlwaysInclude:  []string{"cluster-version-operator", "cli", "installer"},
 		ToImageBaseTag: "cluster-version-operator",
 	}
 }


### PR DESCRIPTION
It should instead be referenced by another component, but include it here
until we can identify what that is. This gives us installer reproducibility
for hive.