### PR TITLE
fix reflect.DeepEqual(x, x) bug

### DIFF
--- a/pkg/apps/controller/deployer/deployer_controller_test.go
+++ b/pkg/apps/controller/deployer/deployer_controller_test.go
@@ -579,7 +579,7 @@ func TestHandle_cleanupPodOk(t *testing.T) {
 
 	sort.Strings(hookPods)
 	sort.Strings(deletedPodNames)
-	if !reflect.DeepEqual(deletedPodNames, deletedPodNames) {
+	if !reflect.DeepEqual(hookPods, deletedPodNames) {
 		t.Fatalf("pod deletions - expected: %v, actual: %v", hookPods, deletedPodNames)
 	}
 
@@ -626,7 +626,7 @@ func TestHandle_cleanupPodOkTest(t *testing.T) {
 
 	sort.Strings(hookPods)
 	sort.Strings(deletedPodNames)
-	if !reflect.DeepEqual(deletedPodNames, deletedPodNames) {
+	if !reflect.DeepEqual(hookPods, deletedPodNames) {
 		t.Fatalf("pod deletions - expected: %v, actual: %v", hookPods, deletedPodNames)
 	}
 	if updatedDeployment == nil {


### PR DESCRIPTION
Probably a copy/paste kind of error.
Found using gocritic linter, `dupArg` checker.