### PR TITLE
UPSTREAM: <drop>: Temporarily ignore metrics during namespace cleanup

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -1275,6 +1275,10 @@ func hasRemainingContent(c clientset.Interface, dynamicClient dynamic.Interface,
 			Logf("namespace: %s, resource: %s, ignored listing per whitelist", namespace, apiResource.Name)
 			continue
 		}
+		// TODO: temporary hack for https://github.com/openshift/cluster-monitoring-operator/pull/182
+		if gvr.Group == "metrics.k8s.io" {
+			continue
+		}
 		unstructuredList, err := dynamicClient.List(metav1.ListOptions{})
 		if err != nil {
 			// not all resources support list, so we ignore those


### PR DESCRIPTION
The new metrics adapter is periodically failing, causing e2e tests to
fail because they get a 500 trying to list podmetrics/nodemetrics.

Ignore those resources for now.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_cluster-monitoring-operator/174/pull-ci-openshift-cluster-monitoring-operator-master-e2e-aws/21/