### PR TITLE
Preserve release metadata when mirroring

### DIFF
--- a/pkg/oc/cli/image/mirror/mirror.go
+++ b/pkg/oc/cli/image/mirror/mirror.go
@@ -596,13 +596,13 @@ func copyBlob(ctx context.Context, plan *workPlan, c *repositoryBlobCopy, blob d
 			fmt.Fprintf(errOut, "warning: Layer size mismatch for %s: had %d, wrote %d\n", blob.Digest, blob.Size, n)
 		}
 		if _, err := w.Commit(ctx, blob); err != nil {
-			return err
+			return fmt.Errorf("failed to commit blob %s from %s to %s: %v", blob.Digest, c.location, c.toRef, err)
 		}
 		plan.BytesCopied(n)
 		return nil
 	}()
 	if err != nil {
-		return fmt.Errorf("failed to commit blob %s from %s to %s: %v", blob.Digest, c.location, c.toRef, err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
The fix to update image references was too broad and overwrote the
metadata generated by the job. Instead, update only the changed
references.

Fix a misplaced wrapper error in mirror to avoid double printing
on most errors.