### PR TITLE
Prefer oauthMetadataFile as OAuth metadata source

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/nonapiserver.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/nonapiserver.go
@@ -3,12 +3,15 @@ package openshiftkubeapiserver
 import (
 	"net/http"
 
-	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
-	osinv1 "github.com/openshift/api/osin/v1"
-	oauthutil "github.com/openshift/origin/pkg/oauth/util"
+	"github.com/golang/glog"
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericmux "k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/client-go/informers"
+
+	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
+	osinv1 "github.com/openshift/api/osin/v1"
+	oauthutil "github.com/openshift/origin/pkg/oauth/util"
 )
 
 func NewOpenshiftNonAPIConfig(generiConfig *genericapiserver.Config, kubeInformers informers.SharedInformerFactory, oauthConfig *osinv1.OAuthConfig, authConfig kubecontrolplanev1.MasterAuthConfig) (*OpenshiftNonAPIConfig, error) {
@@ -21,7 +24,8 @@ func NewOpenshiftNonAPIConfig(generiConfig *genericapiserver.Config, kubeInforme
 	}
 	ret.ExtraConfig.OAuthMetadata, _, err = oauthutil.PrepOauthMetadata(oauthConfig, authConfig.OAuthMetadataFile)
 	if err != nil {
-		return nil, err
+		// invalid metadata must not prevent the kube api server from starting
+		glog.Errorf("Unable to initialize OAuth authorization server metadata: %v", err)
 	}
 
 	return ret, nil

--- a/pkg/oauth/util/discovery.go
+++ b/pkg/oauth/util/discovery.go
@@ -104,6 +104,9 @@ func LoadOAuthMetadataFile(metadataFile string) ([]byte, *OauthAuthorizationServ
 }
 
 func PrepOauthMetadata(oauthConfig *osinv1.OAuthConfig, oauthMetadataFile string) ([]byte, *OauthAuthorizationServerMetadata, error) {
+	if len(oauthMetadataFile) > 0 {
+		return LoadOAuthMetadataFile(oauthMetadataFile)
+	}
 	if oauthConfig != nil && len(oauthConfig.MasterPublicURL) != 0 {
 		metadataStruct := getOauthMetadata(oauthConfig.MasterPublicURL)
 		metadata, err := json.MarshalIndent(metadataStruct, "", "  ")
@@ -112,9 +115,6 @@ func PrepOauthMetadata(oauthConfig *osinv1.OAuthConfig, oauthMetadataFile string
 			return nil, nil, err
 		}
 		return metadata, &metadataStruct, nil
-	}
-	if len(oauthMetadataFile) > 0 {
-		return LoadOAuthMetadataFile(oauthMetadataFile)
 	}
 	return nil, nil, nil
 }


### PR DESCRIPTION
This change makes kubeAPIServerConfig.authConfig.oauthMetadataFile
the preferred source for the OAuth authorization server metadata
instead of the data from the OAuth config.  This serves as a
starting point for breaking out osin from the kube apiserver.
Soon this code path will have no reliance on OAuth config.

Also makes failure to initialize OAuth metadata not fatal for the
kube apiserver.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth @openshift/sig-master 