### PR TITLE
Tighten kube:admin provisioning period

### DIFF
--- a/pkg/apiserver/authentication/oauth/bootstrapauthenticator.go
+++ b/pkg/apiserver/authentication/oauth/bootstrapauthenticator.go
@@ -13,16 +13,18 @@ import (
 )
 
 type bootstrapAuthenticator struct {
-	tokens    oauthclient.OAuthAccessTokenInterface
-	secrets   v1.SecretInterface
-	validator OAuthTokenValidator
+	tokens     oauthclient.OAuthAccessTokenInterface
+	secrets    v1.SecretInterface
+	namespaces v1.NamespaceInterface
+	validator  OAuthTokenValidator
 }
 
-func NewBootstrapAuthenticator(tokens oauthclient.OAuthAccessTokenInterface, secrets v1.SecretsGetter, validators ...OAuthTokenValidator) kauthenticator.Token {
+func NewBootstrapAuthenticator(tokens oauthclient.OAuthAccessTokenInterface, secrets v1.SecretsGetter, namespaces v1.NamespacesGetter, validators ...OAuthTokenValidator) kauthenticator.Token {
 	return &bootstrapAuthenticator{
-		tokens:    tokens,
-		secrets:   secrets.Secrets(metav1.NamespaceSystem),
-		validator: OAuthTokenValidators(validators),
+		tokens:     tokens,
+		secrets:    secrets.Secrets(metav1.NamespaceSystem),
+		namespaces: namespaces.Namespaces(),
+		validator:  OAuthTokenValidators(validators),
 	}
 }
 
@@ -36,7 +38,7 @@ func (a *bootstrapAuthenticator) AuthenticateToken(name string) (kuser.Info, boo
 		return nil, false, nil
 	}
 
-	_, uid, ok, err := bootstrap.HashAndUID(a.secrets)
+	_, uid, ok, err := bootstrap.HashAndUID(a.secrets, a.namespaces)
 	if err != nil || !ok {
 		return nil, ok, err
 	}

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_authenticator.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_authenticator.go
@@ -81,6 +81,7 @@ func NewAuthenticator(
 		apiClientCAs,
 		usercache.NewGroupCache(groupInformer),
 		kubeExternalClient.CoreV1(),
+		kubeExternalClient.CoreV1(),
 	)
 }
 
@@ -95,6 +96,7 @@ func newAuthenticator(
 	apiClientCAs *x509.CertPool,
 	groupMapper oauth.UserToGroupMapper,
 	secretsGetter v1.SecretsGetter,
+	namespacesGetter v1.NamespacesGetter,
 ) (authenticator.Request, map[string]genericapiserver.PostStartHookFunc, error) {
 	postStartHooks := map[string]genericapiserver.PostStartHookFunc{}
 	authenticators := []authenticator.Request{}
@@ -138,7 +140,7 @@ func newAuthenticator(
 		if oauthConfig.SessionConfig != nil {
 			tokenAuthenticators = append(tokenAuthenticators,
 				// bootstrap oauth user that can do anything, backed by a secret
-				oauth.NewBootstrapAuthenticator(accessTokenGetter, secretsGetter, validators...))
+				oauth.NewBootstrapAuthenticator(accessTokenGetter, secretsGetter, namespacesGetter, validators...))
 		}
 	}
 

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -462,7 +462,7 @@ func (c *OAuthServerConfig) getAuthenticationHandler(mux oauthserver.Mux, errorH
 
 	// the bootstrap user IDP is always set as the first one when sessions are enabled
 	if c.ExtraOAuthConfig.Options.SessionConfig != nil {
-		selectProvider = selectprovider.NewBootstrapSelectProvider(selectProvider, c.ExtraOAuthConfig.KubeClient.CoreV1())
+		selectProvider = selectprovider.NewBootstrapSelectProvider(selectProvider, c.ExtraOAuthConfig.KubeClient.CoreV1(), c.ExtraOAuthConfig.KubeClient.CoreV1())
 	}
 
 	authHandler := handlers.NewUnionAuthenticationHandler(challengers, redirectors, errorHandler, selectProvider)
@@ -615,7 +615,7 @@ func (c *OAuthServerConfig) getPasswordAuthenticator(identityProvider configapi.
 		return keystonepassword.New(identityProvider.Name, connectionInfo.URL, transport, provider.DomainName, identityMapper, provider.UseKeystoneIdentity), nil
 
 	case *configapi.BootstrapIdentityProvider:
-		return bootstrap.New(c.ExtraOAuthConfig.KubeClient.CoreV1()), nil
+		return bootstrap.New(c.ExtraOAuthConfig.KubeClient.CoreV1(), c.ExtraOAuthConfig.KubeClient.CoreV1()), nil
 
 	default:
 		return nil, fmt.Errorf("No password auth found that matches %v.  The OAuth server cannot start!", identityProvider)


### PR DESCRIPTION
This change makes the secret backing the kube:admin user bounded by
the creation timestamp of kube-system.  Thus once the secret is
deleted, recreating it will not allow kube:admin to be reused.  This
makes write access to the secret far less powerful.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 

@sallyom how is that test coming :smile: ?