### PR TITLE
quickstart/rails - Use standard 'rails db:migrate' command in pre hook

### DIFF
--- a/examples/quickstarts/rails-postgresql-persistent.json
+++ b/examples/quickstarts/rails-postgresql-persistent.json
@@ -162,7 +162,9 @@
                         "pre": {
                             "execNewPod": {
                                 "command": [
-                                    "./migrate-database.sh"
+                                    "bash",
+                                    "-c",
+                                    "bundle exec rails db:migrate"
                                 ],
                                 "containerName": "${NAME}"
                             },

--- a/examples/quickstarts/rails-postgresql.json
+++ b/examples/quickstarts/rails-postgresql.json
@@ -162,7 +162,9 @@
                         "pre": {
                             "execNewPod": {
                                 "command": [
-                                    "./migrate-database.sh"
+                                    "bash",
+                                    "-c",
+                                    "bundle exec rails db:migrate"
                                 ],
                                 "containerName": "${NAME}"
                             },


### PR DESCRIPTION
The current template requires a non-standard script to be added to a
rails project in order to run db migrations.  This change removes that
undocumented requirement so that the template will work out of the box
with more rails applications.