### PR TITLE
Unblock openshift.io-restmapperupdater post start hook

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -591,7 +591,6 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget,
 		return nil
 	})
 	s.GenericAPIServer.AddPostStartHookOrDie("openshift.io-restmapperupdater", func(context genericapiserver.PostStartHookContext) error {
-		c.ExtraConfig.RESTMapper.Reset()
 		go func() {
 			wait.Until(func() {
 				c.ExtraConfig.RESTMapper.Reset()


### PR DESCRIPTION
The first `restMapper.Reset()` call might block if some other code has accessed the rest mapper before and is still holding the lock. In that case the whole apiserver boostrapping will block, and in the case of discovery issues in the cluster this might lead to a dead lock.

Note, that `wait.Until` immediately calls the func, i.e. `f(); wait.Until(f, 10*time.Seconds)` is even worse than `wait.Until(f, 10*time.Seconds)` for our purposes because the former calls `f` twice immediately without waiting the 10 seconds.