### PR TITLE
conformance-k8s.sh should work against AWS kube

### DIFF
--- a/test/extended/conformance-k8s.sh
+++ b/test/extended/conformance-k8s.sh
@@ -67,8 +67,8 @@ oc adm policy add-scc-to-group privileged system:authenticated system:serviceacc
 oc adm policy remove-scc-from-group restricted system:authenticated
 oc adm policy remove-scc-from-group anyuid system:cluster-admins
 # Mark the master nodes as unschedulable so tests ignore them
-oc get nodes -o name -l 'node-role.kubernetes.io/master=true' | xargs -L1 oc adm cordon
-unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master=true'; ) | wc -l )"
+oc get nodes -o name -l 'node-role.kubernetes.io/master' | xargs -L1 oc adm cordon
+unschedulable="$( ( oc get nodes -o name -l 'node-role.kubernetes.io/master'; ) | wc -l )"
 # TODO: undo these operations
 
 # Execute Kubernetes prerequisites


### PR DESCRIPTION
We changed from node-role.kubernetes.io/master=true to an empty string
like tectonic. Update to a mode both can use.