### PR TITLE
Support tunneling to masters over SSH for e2e tests

### DIFF
--- a/images/cli/Dockerfile
+++ b/images/cli/Dockerfile
@@ -10,7 +10,9 @@ RUN INSTALL_PKGS="origin-clients" && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all
+COPY manifests /manifests
 
 LABEL io.k8s.display-name="OpenShift Client" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
-      io.openshift.tags="openshift,cli"
+      io.openshift.tags="openshift,cli" \
+      io.openshift.release.operator="true"

--- a/images/cli/manifests/01_imagestream.yaml
+++ b/images/cli/manifests/01_imagestream.yaml
@@ -1,0 +1,11 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  namespace: openshift
+  name: cli
+spec:
+  tags:
+  - name: latest
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-cli:v4.0

--- a/images/cli/manifests/image-references
+++ b/images/cli/manifests/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cli
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-cli:v4.0

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -22,8 +22,7 @@ func cliPodWithPullSecret(cli *exutil.CLI, shell string) *kapiv1.Pod {
 	o.Expect(sa.ImagePullSecrets).NotTo(o.BeEmpty())
 	pullSecretName := sa.ImagePullSecrets[0].Name
 
-	format, _ := exutil.FindImageFormatString(cli)
-	cliImage := strings.Replace(format, "${component}", "cli", -1)
+	cliImage, _ := exutil.FindCLIImage(cli)
 
 	return &kapiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -43,7 +43,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ := exutil.FindImageFormatString(oc)
+		routerImage, _ := exutil.FindRouterImage(oc)
 		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 
 		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ = exutil.FindImageFormatString(oc)
+		routerImage, _ = exutil.FindRouterImage(oc)
 		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 
 		configPath := exutil.FixturePath("testdata", "router-common.yaml")

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ = exutil.FindImageFormatString(oc)
+		routerImage, _ = exutil.FindRouterImage(oc)
 		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 
 		_, err := oc.AdminKubeClient().Rbac().RoleBindings(ns).Create(&rbacv1.RoleBinding{

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ = exutil.FindImageFormatString(oc)
+		routerImage, _ = exutil.FindRouterImage(oc)
 		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 
 		configPath := exutil.FixturePath("testdata", "router-common.yaml")

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	)
 
 	g.BeforeEach(func() {
-		routerImage, _ := exutil.FindImageFormatString(oc)
+		routerImage, _ := exutil.FindRouterImage(oc)
 		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
 		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
Workers are now private, which means we can't directly connect to
them. For now, make the e2e tests tolerate a bastion hop by
proxying the SSH connection from a given instance.

TODO:

* [x] needs to go upstream in some form kubernetes/kubernetes#72286
* [x] need to revert openshift/installer#927 because we can't access the external IP anyway in openshift/installer#970
* [x] should probably autodetect the bastion if we can, or just change release to set it 
https://github.com/openshift/release/pull/2469

Blocks moving away from e2e-gcp because some tests still depend on SSH https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-all-4.0/18/