### PR TITLE
Fix completion for __oc_get_containers

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -302,7 +302,7 @@ __oc_get_containers()
 {
     local template
     template="{{ range .spec.containers  }}{{ .name }} {{ end }}"
-    __debug ${FUNCNAME} "nouns are ${nouns[@]}"
+    __oc_debug "${FUNCNAME} nouns are ${nouns[@]}"
 
     local len="${#nouns[@]}"
     if [[ ${len} -ne 1 ]]; then

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -444,7 +444,7 @@ __oc_get_containers()
 {
     local template
     template="{{ range .spec.containers  }}{{ .name }} {{ end }}"
-    __debug ${FUNCNAME} "nouns are ${nouns[@]}"
+    __oc_debug "${FUNCNAME} nouns are ${nouns[@]}"
 
     local len="${#nouns[@]}"
     if [[ ${len} -ne 1 ]]; then

--- a/pkg/oc/cli/cli_bashcomp_func.go
+++ b/pkg/oc/cli/cli_bashcomp_func.go
@@ -67,7 +67,7 @@ __oc_get_containers()
 {
     local template
     template="{{ range .spec.containers  }}{{ .name }} {{ end }}"
-    __debug ${FUNCNAME} "nouns are ${nouns[@]}"
+    __oc_debug "${FUNCNAME} nouns are ${nouns[@]}"
 
     local len="${#nouns[@]}"
     if [[ ${len} -ne 1 ]]; then


### PR DESCRIPTION
`__debug` is already replaced with `__oc_debug`. This patch makes
completion use `__oc_debug` instead of `__debug`.

Fixes https://github.com/openshift/origin/issues/21705