### PR TITLE
Allow kube:admin to be scoped

### DIFF
--- a/pkg/apiserver/authentication/oauth/bootstrapauthenticator.go
+++ b/pkg/apiserver/authentication/oauth/bootstrapauthenticator.go
@@ -8,6 +8,8 @@ import (
 
 	userapi "github.com/openshift/api/user/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	"github.com/openshift/origin/pkg/oauthserver/authenticator/password/bootstrap"
 )
 
@@ -55,7 +57,25 @@ func (a *bootstrapAuthenticator) AuthenticateToken(name string) (kuser.Info, boo
 
 	// we explicitly do not set UID as we do not want to leak any derivative of the password
 	return &kuser.DefaultInfo{
-		Name:   bootstrap.BootstrapUser,
-		Groups: []string{kuser.SystemPrivilegedGroup}, // authorized to do everything
+		Name: bootstrap.BootstrapUser,
+		// we cannot use SystemPrivilegedGroup because it cannot be properly scoped.
+		// see openshift/origin#18922 and how loopback connections are handled upstream via AuthorizeClientBearerToken.
+		// api aggregation with delegated authorization makes this impossible to control, see WithAlwaysAllowGroups.
+		// an openshift specific cluster role binding binds ClusterAdminGroup to the cluster role cluster-admin.
+		// thus this group is authorized to do everything via RBAC.
+		// this does make the bootstrap user susceptible to anything that causes the RBAC authorizer to fail.
+		// this is a safe trade-off because scopes must always be evaluated before RBAC for them to work at all.
+		// a failure in that logic means scopes are broken instead of a specific failure related to the bootstrap user.
+		// if this becomes a problem in the future, we could generate a custom extra value based on the secret content
+		// and store it in BootstrapUserData, similar to how UID is calculated.  this extra value would then be wired
+		// to a custom authorizer that allows all actions.  the problem with such an approach is that since we do not
+		// allow remote authorizers in OpenShift, the BootstrapUserDataGetter logic would have to be shared between the
+		// the kube api server and osin instead of being an implementation detail hidden inside of osin.  currently the
+		// only shared code is the value of the BootstrapUser constant (since it is special cased in validation).
+		Groups: []string{bootstrappolicy.ClusterAdminGroup},
+		Extra: map[string][]string{
+			// this user still needs scopes because it can be used in OAuth flows (unlike cert based users)
+			authorizationapi.ScopesKey: token.Scopes,
+		},
 	}, true, nil
 }

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -463,7 +463,7 @@ func (c *OAuthServerConfig) getAuthenticationHandler(mux oauthserver.Mux, errorH
 
 	// the bootstrap user IDP is always set as the first one when sessions are enabled
 	if c.ExtraOAuthConfig.Options.SessionConfig != nil {
-		selectProvider = selectprovider.NewBootstrapSelectProvider(selectProvider, c.ExtraOAuthConfig.KubeClient.CoreV1(), c.ExtraOAuthConfig.KubeClient.CoreV1())
+		selectProvider = selectprovider.NewBootstrapSelectProvider(selectProvider, c.ExtraOAuthConfig.BootstrapUserDataGetter)
 	}
 
 	authHandler := handlers.NewUnionAuthenticationHandler(challengers, redirectors, errorHandler, selectProvider)
@@ -616,7 +616,7 @@ func (c *OAuthServerConfig) getPasswordAuthenticator(identityProvider osinv1.Ide
 		return keystonepassword.New(identityProvider.Name, connectionInfo.URL, transport, provider.DomainName, identityMapper, provider.UseKeystoneIdentity), nil
 
 	case *config.BootstrapIdentityProvider:
-		return bootstrap.New(c.ExtraOAuthConfig.KubeClient.CoreV1(), c.ExtraOAuthConfig.KubeClient.CoreV1()), nil
+		return bootstrap.New(c.ExtraOAuthConfig.BootstrapUserDataGetter), nil
 
 	default:
 		return nil, fmt.Errorf("No password auth found that matches %v.  The OAuth server cannot start!", identityProvider)


### PR DESCRIPTION
Move bootstrap user data to BootstrapUserData struct

This change moves the bootstrap OAuth user behind an interface to
isolate the logic.  The data needed to validate flows for this user
are now stored in a BootstrapUserData struct to make it easier to
extend the associated flows.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Allow kube:admin to be scoped

When I originally wrote the authenticator for the bootstrap user, I
was thinking of a user that could always perform any action, similar
to an x509 cert based user.  However, unlike a cert based user, the
bootstrap user can go through OAuth flows, meaning that untrusted
clients can get scoped tokens for it.  We need those tokens to not
be all powerful, otherwise we break the safety guarantees of those
flows.

This change removes the use of the system:masters group and instead
uses the system:cluster-admins group.  The former does not honor
scopes or any other deny authorizer due to how it is wired.  The
latter is authorized via RBAC and thus interacts correctly with deny
authorizers.

This change also passes the token scopes via the standard extra
field scopes.authorization.openshift.io (this was originally omitted
due to my incorrect thought process around the bootstrap user).

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

xrefs:
#18922
#18966
#21530
https://github.com/kubernetes/kubernetes/pull/70670
https://github.com/kubernetes/kubernetes/pull/70671

@openshift/sig-auth 
/assign @mrogers950 