### PR TITLE
Explain which image short name is missing from the input

### DIFF
--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -171,7 +171,7 @@ func NewImageMapperFromImageStreamFile(path string, input *imageapi.ImageStream,
 				glog.V(2).Infof("Image file %q referenced an image %q that is not part of the input images, skipping", path, tag.From.Name)
 				continue
 			}
-			return nil, fmt.Errorf("requested mapping for %q, but no input image could be located", tag.From.Name)
+			return nil, fmt.Errorf("image file %q referenced image %q that is not part of the input images", path, tag.Name)
 		}
 		references[tag.Name] = ref
 	}


### PR DESCRIPTION
The other messages in this function show path and tag.Name, this message
should too. Makes debugging which tag hasn't been cloned much easier.