### PR TITLE
Don't restart pods on SDN restart/upgrade

### DIFF
--- a/pkg/network/node/cniserver/cniserver.go
+++ b/pkg/network/node/cniserver/cniserver.go
@@ -94,6 +94,8 @@ type PodRequest struct {
 	Netns string
 	// for an ADD request, the host side of the created veth
 	HostVeth string
+	// for an ADD request, the (optional) already-assigned IP
+	AssignedIP string
 	// Channel for returning the operation result to the CNIServer
 	Result chan *PodResult
 }

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	kubeutilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -262,29 +263,6 @@ func GetLinkDetails(ip string) (netlink.Link, *net.IPNet, error) {
 	return nil, nil, ErrorNetworkInterfaceNotFound
 }
 
-func (node *OsdnNode) killUpdateFailedPods(pods []kapi.Pod) error {
-	for _, pod := range pods {
-		// Get the sandbox ID for this pod from the runtime
-		filter := &kruntimeapi.PodSandboxFilter{
-			LabelSelector: map[string]string{ktypes.KubernetesPodUIDLabel: string(pod.UID)},
-		}
-		sandboxID, err := node.getPodSandboxID(filter)
-		if err != nil {
-			return err
-		}
-
-		// Make an event that the pod is going to be killed
-		podRef := &v1.ObjectReference{Kind: "Pod", Name: pod.Name, Namespace: pod.Namespace, UID: pod.UID}
-		node.recorder.Eventf(podRef, v1.EventTypeWarning, "NetworkFailed", "The pod's network interface has been lost and the pod will be stopped.")
-
-		glog.V(5).Infof("Killing pod '%s/%s' sandbox due to failed restart", pod.Namespace, pod.Name)
-		if err := node.runtimeService.StopPodSandbox(sandboxID); err != nil {
-			glog.Warningf("Failed to kill pod '%s/%s' sandbox: %v", pod.Namespace, pod.Name, err)
-		}
-	}
-	return nil
-}
-
 func (node *OsdnNode) Start() error {
 	glog.V(2).Infof("Starting openshift-sdn network plugin")
 
@@ -322,7 +300,7 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("failed to set up iptables: %v", err)
 	}
 
-	networkChanged, err := node.SetupSDN()
+	networkChanged, existingPods, err := node.SetupSDN()
 	if err != nil {
 		return fmt.Errorf("node SDN setup failed: %v", err)
 	}
@@ -347,36 +325,16 @@ func (node *OsdnNode) Start() error {
 
 	glog.V(2).Infof("Starting openshift-sdn pod manager")
 	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR,
-		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String()); err != nil {
+		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String(),
+		networkChanged); err != nil {
 		return err
 	}
 
-	if networkChanged {
-		var pods, podsToKill []kapi.Pod
-
-		pods, err = node.GetLocalPods(metav1.NamespaceAll)
+	if networkChanged && len(existingPods) > 0 {
+		glog.Infof("OVS bridge has been recreated. Will reattach %d existing pods...", len(existingPods))
+		err := node.reattachPods(existingPods)
 		if err != nil {
 			return err
-		}
-		for _, p := range pods {
-			// Ignore HostNetwork pods since they don't go through OVS
-			if p.Spec.SecurityContext != nil && p.Spec.SecurityContext.HostNetwork {
-				continue
-			}
-			if err := node.UpdatePod(p); err != nil {
-				glog.Warningf("will restart pod '%s/%s' due to update failure on restart: %s", p.Namespace, p.Name, err)
-				podsToKill = append(podsToKill, p)
-			} else if vnid, err := node.policy.GetVNID(p.Namespace); err == nil {
-				node.policy.EnsureVNIDRules(vnid)
-			}
-		}
-
-		// Kill pods we couldn't recover; they will get restarted and then
-		// we'll be able to set them up correctly
-		if len(podsToKill) > 0 {
-			if err := node.killUpdateFailedPods(podsToKill); err != nil {
-				glog.Warningf("failed to restart pods that failed to update at startup: %v", err)
-			}
 		}
 	}
 
@@ -403,6 +361,53 @@ func (node *OsdnNode) Start() error {
   "type": "openshift-sdn"
 }
 `), 0644)
+}
+
+// reattachPods takes an array containing the information about pods that had been
+// attached to the OVS bridge before restart, and either reattaches or kills each of the
+// corresponding pods.
+func (node *OsdnNode) reattachPods(existingPods map[string]podNetworkInfo) error {
+	sandboxes, err := node.getPodSandboxes()
+	if err != nil {
+		return err
+	}
+
+	failed := []*kruntimeapi.PodSandbox{}
+	for sandboxID, podInfo := range existingPods {
+		sandbox, ok := sandboxes[sandboxID]
+		if !ok {
+			glog.Warningf("Could not find sandbox for existing pod with IP %s; it may be in an inconsistent state", podInfo.ip)
+			continue
+		}
+
+		req := &cniserver.PodRequest{
+			Command:      cniserver.CNI_ADD,
+			PodNamespace: sandbox.Metadata.Namespace,
+			PodName:      sandbox.Metadata.Name,
+			SandboxID:    sandboxID,
+			HostVeth:     podInfo.vethName,
+			AssignedIP:   podInfo.ip,
+			Result:       make(chan *cniserver.PodResult),
+		}
+		if _, err := node.podManager.handleCNIRequest(req); err != nil {
+			glog.Warningf("Could not reattach pod '%s/%s' to SDN: %v", req.PodNamespace, req.PodName, err)
+			failed = append(failed, sandbox)
+		}
+	}
+
+	// Kill pods we couldn't recover; they will get restarted and then
+	// we'll be able to set them up correctly
+	for _, sandbox := range failed {
+		podRef := &v1.ObjectReference{Kind: "Pod", Name: sandbox.Metadata.Name, Namespace: sandbox.Metadata.Namespace, UID: types.UID(sandbox.Metadata.Uid)}
+		node.recorder.Eventf(podRef, v1.EventTypeWarning, "NetworkFailed", "The pod's network interface has been lost and the pod will be stopped.")
+
+		glog.V(5).Infof("Killing pod '%s/%s' sandbox due to failed restart", podRef.Namespace, podRef.Name)
+		if err := node.runtimeService.StopPodSandbox(sandbox.Id); err != nil {
+			glog.Warningf("Failed to kill pod '%s/%s' sandbox: %v", podRef.Namespace, podRef.Name, err)
+		}
+	}
+
+	return nil
 }
 
 // FIXME: this should eventually go into kubelet via a CNI UPDATE/CHANGE action

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -288,7 +288,7 @@ func (oc *ovsController) SetUpPod(sandboxID, hostVeth string, podIP net.IP, vnid
 
 // Returned list can also be used for port names
 func (oc *ovsController) getInterfacesForSandbox(sandboxID string) ([]string, error) {
-	return oc.ovs.Find("interface", "name", "external-ids:sandbox="+sandboxID)
+	return oc.ovs.FindOne("interface", "name", "external-ids:sandbox="+sandboxID)
 }
 
 func (oc *ovsController) ClearPodBandwidth(portList []string, sandboxID string) error {
@@ -300,7 +300,7 @@ func (oc *ovsController) ClearPodBandwidth(portList []string, sandboxID string) 
 	}
 
 	// Now that the QoS is unused remove it
-	qosList, err := oc.ovs.Find("qos", "_uuid", "external-ids:sandbox="+sandboxID)
+	qosList, err := oc.ovs.FindOne("qos", "_uuid", "external-ids:sandbox="+sandboxID)
 	if err != nil {
 		return err
 	}
@@ -347,31 +347,27 @@ func (oc *ovsController) SetPodBandwidth(hostVeth, sandboxID string, ingressBPS,
 }
 
 func (oc *ovsController) getPodDetailsBySandboxID(sandboxID string) (int, net.IP, error) {
-	strports, err := oc.ovs.Find("interface", "ofport", "external-ids:sandbox="+sandboxID)
-	if err != nil {
-		return 0, nil, err
-	}
-	strIDs, err := oc.ovs.Find("interface", "external-ids", "external-ids:sandbox="+sandboxID)
+	rows, err := oc.ovs.Find("interface", []string{"ofport", "external-ids"}, "external-ids:sandbox="+sandboxID)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	if len(strports) == 0 || len(strIDs) == 0 {
+	if len(rows) == 0 {
 		return 0, nil, fmt.Errorf("failed to find pod details in OVS database")
-	} else if len(strports) > 1 || len(strIDs) > 1 {
-		return 0, nil, fmt.Errorf("found multiple pods for sandbox ID %q: %#v / %#v", sandboxID, strports, strIDs)
+	} else if len(rows) > 1 {
+		return 0, nil, fmt.Errorf("found multiple pods for sandbox ID %q: %#v", sandboxID, rows)
 	}
 
-	ofport, err := strconv.Atoi(strports[0])
+	ofport, err := strconv.Atoi(rows[0]["ofport"])
 	if err != nil {
-		return 0, nil, fmt.Errorf("could not parse ofport %q: %v", strports[0], err)
+		return 0, nil, fmt.Errorf("could not parse ofport %q: %v", rows[0]["ofport"], err)
 	}
 
-	ids, err := ovs.ParseExternalIDs(strIDs[0])
+	ids, err := ovs.ParseExternalIDs(rows[0]["external-ids"])
 	if err != nil {
-		return 0, nil, fmt.Errorf("could not parse external-ids %q: %v", strIDs[0], err)
+		return 0, nil, fmt.Errorf("could not parse external-ids %q: %v", rows[0]["external-ids"], err)
 	} else if ids["ip"] == "" {
-		return 0, nil, fmt.Errorf("external-ids %q does not contain IP", strIDs[0])
+		return 0, nil, fmt.Errorf("external-ids %#v does not contain IP", ids)
 	}
 	podIP := net.ParseIP(ids["ip"])
 	if podIP == nil {

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -171,10 +171,13 @@ func getIPAMConfig(clusterNetworks []common.ClusterNetwork, localSubnet string) 
 }
 
 // Start the CNI server and start processing requests from it
-func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string) error {
+func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string, clearHostPorts bool) error {
 	if m.enableHostports {
 		iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
 		m.hostportSyncer = kubehostport.NewHostportSyncer(iptInterface)
+		if clearHostPorts {
+			_ = m.hostportSyncer.SyncHostports(Tun0, nil)
+		}
 	}
 
 	var err error
@@ -500,16 +503,6 @@ func podIsExited(p *kcontainer.Pod) bool {
 func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *runningPod, error) {
 	defer PodOperationsLatency.WithLabelValues(PodOperationSetup).Observe(sinceInMicroseconds(time.Now()))
 
-	pod, err := m.kClient.Core().Pods(req.PodNamespace).Get(req.PodName, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ipamResult, podIP, err := m.ipamAdd(req.Netns, req.SandboxID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to run IPAM for %v: %v", req.SandboxID, err)
-	}
-
 	// Release any IPAM allocations and hostports if the setup failed
 	var success bool
 	defer func() {
@@ -522,6 +515,23 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 			}
 		}
 	}()
+
+	pod, err := m.kClient.Core().Pods(req.PodNamespace).Get(req.PodName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ipamResult cnitypes.Result
+	podIP := net.ParseIP(req.AssignedIP)
+	if podIP == nil {
+		ipamResult, podIP, err = m.ipamAdd(req.Netns, req.SandboxID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to run IPAM for %v: %v", req.SandboxID, err)
+		}
+		if err := maybeAddMacvlan(pod, req.Netns); err != nil {
+			return nil, nil, err
+		}
+	}
 
 	// Open any hostports the pod wants
 	var v1Pod v1.Pod
@@ -537,10 +547,6 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 
 	vnid, err := m.policy.GetVNID(req.PodNamespace)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := maybeAddMacvlan(pod, req.Netns); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/network/node/pod_test.go
+++ b/pkg/network/node/pod_test.go
@@ -318,7 +318,7 @@ func TestPodManager(t *testing.T) {
 		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
 		_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
+		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
 		if err != nil {
 			t.Fatalf("could not start PodManager: %v", err)
 		}
@@ -417,7 +417,7 @@ func TestDirectPodUpdate(t *testing.T) {
 	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
 	_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
+	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
 	if err != nil {
 		t.Fatalf("could not start PodManager: %v", err)
 	}

--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -63,3 +63,21 @@ func (node *OsdnNode) getPodSandboxID(filter *kruntimeapi.PodSandboxFilter) (str
 	}
 	return podSandboxList[0].Id, nil
 }
+
+func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, error) {
+	runtimeService, err := node.getRuntimeService()
+	if err != nil {
+		return nil, err
+	}
+
+	podSandboxList, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pod sandboxes: %v", err)
+	}
+
+	podSandboxMap := make(map[string]*kruntimeapi.PodSandbox)
+	for _, sandbox := range podSandboxList {
+		podSandboxMap[sandbox.Id] = sandbox
+	}
+	return podSandboxMap, nil
+}

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -100,15 +100,15 @@ func deleteLocalSubnetRoute(device, localSubnetCIDR string) {
 	}
 }
 
-func (plugin *OsdnNode) SetupSDN() (bool, error) {
+func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 	// Make sure IPv4 forwarding state is 1
 	sysctl := sysctl.New()
 	val, err := sysctl.GetSysctl("net/ipv4/ip_forward")
 	if err != nil {
-		return false, fmt.Errorf("could not get IPv4 forwarding state: %s", err)
+		return false, nil, fmt.Errorf("could not get IPv4 forwarding state: %s", err)
 	}
 	if val != 1 {
-		return false, fmt.Errorf("net/ipv4/ip_forward=0, it must be set to 1")
+		return false, nil, fmt.Errorf("net/ipv4/ip_forward=0, it must be set to 1")
 	}
 
 	var clusterNetworkCIDRs []string
@@ -119,7 +119,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	localSubnetCIDR := plugin.localSubnetCIDR
 	_, ipnet, err := net.ParseCIDR(localSubnetCIDR)
 	if err != nil {
-		return false, fmt.Errorf("invalid local subnet CIDR: %v", err)
+		return false, nil, fmt.Errorf("invalid local subnet CIDR: %v", err)
 	}
 	localSubnetMaskLength, _ := ipnet.Mask.Size()
 	localSubnetGateway := netutils.GenerateDefaultGateway(ipnet).String()
@@ -129,16 +129,21 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	gwCIDR := fmt.Sprintf("%s/%d", localSubnetGateway, localSubnetMaskLength)
 
 	if err := waitForOVS(ovsDialDefaultNetwork, ovsDialDefaultAddress); err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	var changed bool
+	var existingPods map[string]podNetworkInfo
 	if err := plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs); err == nil {
 		glog.V(5).Infof("[SDN setup] no SDN setup required")
 	} else {
 		glog.Infof("[SDN setup] full SDN setup required (%v)", err)
+		existingPods, err = plugin.oc.GetPodNetworkInfo()
+		if err != nil {
+			glog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
+		}
 		if err := plugin.setup(clusterNetworkCIDRs, localSubnetCIDR, localSubnetGateway, gwCIDR); err != nil {
-			return false, err
+			return false, nil, err
 		}
 		changed = true
 	}
@@ -148,7 +153,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	healthFn := func() error { return plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs) }
 	runOVSHealthCheck(ovsDialDefaultNetwork, ovsDialDefaultAddress, healthFn)
 
-	return changed, nil
+	return changed, existingPods, nil
 }
 
 func (plugin *OsdnNode) setup(clusterNetworkCIDRs []string, localSubnetCIDR, localSubnetGateway, gwCIDR string) error {

--- a/pkg/util/ovs/fake_ovs_test.go
+++ b/pkg/util/ovs/fake_ovs_test.go
@@ -145,7 +145,7 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("port numbers are reused: %d, %d, %d", vethA, vethB, vethC)
 	}
 
-	ports, err := ovsif.Find("interface", "name", "external-ids:sandboxID=ALPHA")
+	ports, err := ovsif.FindOne("interface", "name", "external-ids:sandboxID=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("unexpected result finding port ALPHA's name: %#v", ports)
 	}
 
-	ports, err = ovsif.Find("interface", "ofport", "external-ids:sandboxID=BETA")
+	ports, err = ovsif.FindOne("interface", "ofport", "external-ids:sandboxID=BETA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("unexpected result finding port BETA's ofport: %#v", ports)
 	}
 
-	ports, err = ovsif.Find("interface", "name", "external-ids:notSandbox=ALPHA")
+	ports, err = ovsif.FindOne("interface", "name", "external-ids:notSandbox=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("unexpected result finding notSandbox=ALPHA ports: %#v", ports)
 	}
 
-	ports, err = ovsif.Find("interface", "name", "external-ids:sandboxID=DELTA")
+	ports, err = ovsif.FindOne("interface", "name", "external-ids:sandboxID=DELTA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -66,8 +66,11 @@ type Interface interface {
 	Clear(table, record string, columns ...string) error
 
 	// Find finds records in the OVS database that match the given condition.
-	// It returns the value of the given column of matching records.
-	Find(table, column, condition string) ([]string, error)
+	// It returns the value of the given columns of matching records.
+	Find(table string, column []string, condition string) ([]map[string]string, error)
+
+	// FindOne is like Find but returns only a single column
+	FindOne(table, column, condition string) ([]string, error)
 
 	// DumpFlows dumps the flow table for the bridge and returns it as an array of
 	// strings, one per flow. If flow is not "" then it describes the flows to dump.
@@ -276,9 +279,8 @@ func (ovsif *ovsExec) Set(table, record string, values ...string) error {
 	return err
 }
 
-// Returns the given column of records that match the condition
-func (ovsif *ovsExec) Find(table, column, condition string) ([]string, error) {
-	output, err := ovsif.exec(OVS_VSCTL, "--no-heading", "--columns="+column, "find", table, condition)
+func (ovsif *ovsExec) Find(table string, columns []string, condition string) ([]map[string]string, error) {
+	output, err := ovsif.exec(OVS_VSCTL, "--columns="+strings.Join(columns, ","), "find", table, condition)
 	if err != nil {
 		return nil, err
 	}
@@ -286,16 +288,43 @@ func (ovsif *ovsExec) Find(table, column, condition string) ([]string, error) {
 	if output == "" {
 		return nil, err
 	}
-	values := strings.Split(output, "\n\n")
-	// We want "bare" values for strings, but we can't pass --bare to ovs-vsctl because
-	// it breaks more complicated types. So try passing each value through Unquote();
-	// if it fails, that means the value wasn't a quoted string, so use it as-is.
-	for i, val := range values {
-		if unquoted, err := strconv.Unquote(val); err == nil {
-			values[i] = unquoted
+
+	rows := strings.Split(output, "\n\n")
+	result := make([]map[string]string, len(rows))
+	for i, row := range rows {
+		cols := make(map[string]string)
+		for _, col := range strings.Split(row, "\n") {
+			data := strings.SplitN(col, ":", 2)
+			if len(data) != 2 {
+				return nil, fmt.Errorf("bad 'ovs-vsctl find' line %q", col)
+			}
+			name := strings.TrimSpace(data[0])
+			val := strings.TrimSpace(data[1])
+			// We want "bare" values for strings, but we can't pass --bare to
+			// ovs-vsctl because it breaks more complicated types. So try
+			// passing each value through Unquote(); if it fails, that means
+			// the value wasn't a quoted string, so use it as-is.
+			if unquoted, err := strconv.Unquote(val); err == nil {
+				val = unquoted
+			}
+			cols[name] = val
 		}
+		result[i] = cols
 	}
-	return values, nil
+
+	return result, nil
+}
+
+func (ovsif *ovsExec) FindOne(table, column, condition string) ([]string, error) {
+	fullResult, err := ovsif.Find(table, []string{column}, condition)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(fullResult))
+	for _, row := range fullResult {
+		result = append(result, row[column])
+	}
+	return result, nil
 }
 
 func (ovsif *ovsExec) Clear(table, record string, columns ...string) error {

--- a/pkg/util/ovs/ovs_test.go
+++ b/pkg/util/ovs/ovs_test.go
@@ -3,6 +3,7 @@ package ovs
 import (
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -267,8 +268,8 @@ func TestFind(t *testing.T) {
 		t.Fatalf("Unexpected error from ovs.New(): %v", err)
 	}
 
-	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --no-heading --columns=name find interface type=vxlan", "\"vxlan0\"\n", nil)
-	values, err := ovsif.Find("interface", "name", "type=vxlan")
+	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --columns=name find interface type=vxlan", "name : \"vxlan0\"\n", nil)
+	values, err := ovsif.FindOne("interface", "name", "type=vxlan")
 	if err != nil {
 		t.Fatalf("Unexpected error from command: %v", err)
 	}
@@ -277,8 +278,8 @@ func TestFind(t *testing.T) {
 	}
 	ensureTestResults(t, fexec)
 
-	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --no-heading --columns=name find interface type=internal", "\"tun0\"\n\n\"br0\"\n", nil)
-	values, err = ovsif.Find("interface", "name", "type=internal")
+	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --columns=name find interface type=internal", "name : \"tun0\"\n\nname : \"br0\"\n", nil)
+	values, err = ovsif.FindOne("interface", "name", "type=internal")
 	if err != nil {
 		t.Fatalf("Unexpected error from command: %v", err)
 	}
@@ -287,13 +288,41 @@ func TestFind(t *testing.T) {
 	}
 	ensureTestResults(t, fexec)
 
-	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --no-heading --columns=name find interface type=bob", "", nil)
-	values, err = ovsif.Find("interface", "name", "type=bob")
+	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --columns=name find interface type=bob", "", nil)
+	values, err = ovsif.FindOne("interface", "name", "type=bob")
 	if err != nil {
 		t.Fatalf("Unexpected error from command: %v", err)
 	}
 	if len(values) != 0 {
 		t.Fatalf("Unexpected response: %#v", values)
+	}
+	ensureTestResults(t, fexec)
+
+	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --columns=name,external_ids,ofport find interface external_ids:sandbox!=\"\"", `name                : "veth143e4c68"
+external_ids        : {ip="10.129.0.3", sandbox="7eb618c7b95e2855f13b1508fa33655c83f6ed9e7bd6812037624dc3b8da590e"}
+ofport              : 4
+
+name                : "veth8a018953"
+external_ids        : {ip="10.129.0.2", sandbox="cfd0762622523c17f306aab20192e305c4b0811f0f64a317f3fe1288329a795e"}
+ofport              : 3
+`, nil)
+	valuesMap, err := ovsif.Find("interface", []string{"name", "external_ids", "ofport"}, "external_ids:sandbox!=\"\"")
+	if err != nil {
+		t.Fatalf("Unexpected error from command: %v", err)
+	}
+	if !reflect.DeepEqual(valuesMap, []map[string]string{
+		{
+			"name":         "veth143e4c68",
+			"external_ids": `{ip="10.129.0.3", sandbox="7eb618c7b95e2855f13b1508fa33655c83f6ed9e7bd6812037624dc3b8da590e"}`,
+			"ofport":       "4",
+		},
+		{
+			"name":         "veth8a018953",
+			"external_ids": `{ip="10.129.0.2", sandbox="cfd0762622523c17f306aab20192e305c4b0811f0f64a317f3fe1288329a795e"}`,
+			"ofport":       "3",
+		},
+	}) {
+		t.Fatalf("Unexpected response: %#v", valuesMap)
 	}
 	ensureTestResults(t, fexec)
 }

--- a/pkg/util/ovs/parse.go
+++ b/pkg/util/ovs/parse.go
@@ -372,7 +372,7 @@ func fieldMatches(val, match string, ptype ParseType) bool {
 func ParseExternalIDs(externalIDs string) (map[string]string, error) {
 	ids := make(map[string]string, 1)
 	// Output from "find" and "list" will have braces, but input to "set" won't
-	if externalIDs[0] == '{' && externalIDs[len(externalIDs)-1] == '}' {
+	if strings.HasPrefix(externalIDs, "{") && strings.HasSuffix(externalIDs, "}") {
 		externalIDs = externalIDs[1 : len(externalIDs)-1]
 	}
 	for _, id := range strings.Split(externalIDs, ",") {


### PR DESCRIPTION
This fixes the SDN to be able to preserve existing pod networking after a restart, and specifically in the case of an upgrade to a new version of the SDN/OVS pods.

The problem with the current code is that while the OVS vsdb is persisted to disk and preserved across a restart/upgrade of the OVS pod, the OVS *flow* database is apparently kept only in memory. This means that when openshift-sdn is restarted, it will find that `br0` exists and has pods attached to it, but it has no flows. There was code that was intended to deal with this case, but it had bit-rotted (#18924).

This PR fixes it to save the information about the previously-attached pods before destroying and recreating the bridge, and then use that information later to reattach them. (Leaving the existing bridge in place rather than recreating+reattaching is not noticeably less disruptive [the pods would still be unreachable in between when the ovs pod was restarted and when the sdn pod fixed things] and would require more code restructuring. Also, recreating the bridge from scratch means we avoid needing a reconciliation loop to catch up with events that occurred while the SDN process wasn't running.)

Fixes https://jira.coreos.com/browse/SDN-254