### PR TITLE
Remove the smoke-4 suite and add new suites for scalability

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -31,7 +31,8 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return strings.Contains(name, "[Suite:openshift/conformance/parallel")
 		},
-		Parallelism: 30,
+		Parallelism:          30,
+		MaximumAllowedFlakes: 5,
 	},
 	{
 		Name: "openshift/conformance/serial",
@@ -61,6 +62,8 @@ var staticSuites = []*ginkgo.TestSuite{
 			return strings.Contains(name, "[Feature:Builds]")
 		},
 		Parallelism: 7,
+		// TODO: Builds are really flaky right now, remove when we land perf updates and fix io on workers
+		MaximumAllowedFlakes: 3,
 		// Jenkins tests can take a really long time
 		TestTimeout: 60 * time.Minute,
 	},
@@ -87,7 +90,7 @@ var staticSuites = []*ginkgo.TestSuite{
 	{
 		Name: "openshift/jenkins-e2e",
 		Description: templates.LongDesc(`
-		Tests that exercise the OpensShift / Jenkins integrations provided by the OpenShift Jenkins image/plugins and the Pipeline Build Strategy.
+		Tests that exercise the OpenShift / Jenkins integrations provided by the OpenShift Jenkins image/plugins and the Pipeline Build Strategy.
 		`),
 		Matches: func(name string) bool {
 			return strings.Contains(name, "openshift pipeline")
@@ -96,44 +99,28 @@ var staticSuites = []*ginkgo.TestSuite{
 		TestTimeout: 20 * time.Minute,
 	},
 	{
-		Name: "openshift/smoke-4",
+		Name: "openshift/scalability",
 		Description: templates.LongDesc(`
-		Tests that verify a 4.X cluster (using the new operator based core) is ready. This
-		suite will be removed in favor of openshift/conformance once all functionality is
-		available.
+		Tests that verify the scalability characteristics of the cluster. Currently this is focused on core performance behaviors and preventing regressions.
 		`),
 		Matches: func(name string) bool {
-			if !strings.Contains(name, "[Suite:openshift/conformance/parallel") {
-				return false
-			}
-			_, skip := map[string]struct{}{
-				"[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should remove all the taints with the same key off a node [Suite:openshift/conformance/serial] [Suite:k8s]": {},
-				"[sig-cli] Kubectl client [k8s.io] Kubectl taint [Serial] should update the taint on a node [Suite:openshift/conformance/serial] [Suite:k8s]":                         {},
-				"[sig-network] Services should be able to create a functioning NodePort service [Suite:openshift/conformance/parallel] [Suite:k8s]":                                   {},
-				"[sig-network] Services should be able to switch session affinity for NodePort service [Suite:openshift/conformance/parallel] [Suite:k8s]":                            {},
-				"[sig-network] Services should have session affinity work for NodePort service [Suite:openshift/conformance/parallel] [Suite:k8s]":                                    {},
-				"[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if matching [Suite:openshift/conformance/serial] [Suite:k8s]":           {},
-				"[sig-scheduling] SchedulerPredicates [Serial] validates that taints-tolerations is respected if not matching [Suite:openshift/conformance/serial] [Suite:k8s]":       {},
-				"[sig-scheduling] SchedulerPriorities [Serial] Pod should perfer to scheduled to nodes pod can tolerate [Suite:openshift/conformance/serial] [Suite:k8s]":             {},
-				"[sig-storage] Dynamic Provisioning DynamicProvisioner deletion should be idempotent [Suite:openshift/conformance/parallel] [Suite:k8s]":                              {},
-			}[name]
-			return !skip
+			return strings.Contains(name, "[Suite:openshift/scalability]")
 		},
-		AllowPassWithFlakes: true,
-		Parallelism:         30,
+		Parallelism: 1,
+		TestTimeout: 20 * time.Minute,
 	},
 	{
-		Name: "openshift/all",
+		Name: "openshift/conformance-excluded",
+		Description: templates.LongDesc(`
+		Run only tests that are excluded from conformance. Makes identifying omitted tests easier.
+		`),
+		Matches: func(name string) bool { return !strings.Contains(name, "[Suite:openshift/conformance/") },
+	},
+	{
+		Name: "all",
 		Description: templates.LongDesc(`
 		Run all tests.
 		`),
 		Matches: func(name string) bool { return true },
-	},
-	{
-		Name: "kubernetes/all",
-		Description: templates.LongDesc(`
-		Run all Kubernetes tests.
-		`),
-		Matches: func(name string) bool { return strings.Contains(name, "[k8s.io]") },
 	},
 }

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -46,8 +46,7 @@ func main() {
 	suites := staticSuites
 
 	suiteOpt := &testginkgo.Options{
-		DetectFlakes: 6,
-		Suites:       suites,
+		Suites: suites,
 	}
 	cmd := &cobra.Command{
 		Use:   "run SUITE",

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -22,12 +22,11 @@ import (
 // Options is used to run a suite of tests by invoking each test
 // as a call to a child worker (the run-tests command).
 type Options struct {
-	Parallelism  int
-	Timeout      time.Duration
-	JUnitDir     string
-	TestFile     string
-	OutFile      string
-	DetectFlakes int
+	Parallelism int
+	Timeout     time.Duration
+	JUnitDir    string
+	TestFile    string
+	OutFile     string
 
 	IncludeSuccessOutput bool
 
@@ -267,11 +266,11 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	// attempt to retry failures to do flake detection
-	if fail > 0 && fail <= opt.DetectFlakes {
+	if fail > 0 && fail <= suite.MaximumAllowedFlakes {
 		var retries []*testCase
 		for _, test := range failing {
 			retries = append(retries, test.Retry())
-			if len(retries) > opt.DetectFlakes {
+			if len(retries) > suite.MaximumAllowedFlakes {
 				break
 			}
 		}
@@ -308,7 +307,7 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	if fail > 0 {
-		if len(failing) > 0 || !suite.AllowPassWithFlakes {
+		if len(failing) > 0 || suite.MaximumAllowedFlakes == 0 {
 			return fmt.Errorf("%d fail, %d pass, %d skip (%s)", fail, pass, skip, duration)
 		}
 		fmt.Fprintf(opt.Out, "%d flakes detected, suite allows passing with only flakes\n\n", fail)

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -62,9 +62,8 @@ type TestSuite struct {
 	Matches func(name string) bool
 
 	Parallelism int
-	// If true, the test will pass when the only failures have been proven to be
-	// flakes.
-	AllowPassWithFlakes bool
+	// The number of flakes that may occur before this test is marked as a failure.
+	MaximumAllowedFlakes int
 
 	TestTimeout time.Duration
 }

--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -15,7 +15,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[Feature:Platform][Suite:openshift/smoke-4] Managed cluster should", func() {
+var _ = g.Describe("[Feature:Platform] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have no crashlooping pods in core namespaces over two minutes", func() {

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -401,70 +401,15 @@ var (
 
 			`Should be able to support the 1.7 Sample API Server using the current Aggregator`, // down apiservices break other clients today https://bugzilla.redhat.com/show_bug.cgi?id=1623195
 		},
-		// tests that will pass in 4.0
-		// TODO: this will be removed once 4.0 passes all conformance tests
-		"[Suite:openshift/smoke-4]": {
-			`Managed cluster should start all core operators`,
-
-			regexp.QuoteMeta("[sig-storage] Subpath [Volume type"),
-			regexp.QuoteMeta("[sig-storage] Volume Placement"),
-			regexp.QuoteMeta("[sig-storage] Subpath Atomic writer volumes should support subpaths with"),
-			regexp.QuoteMeta("[sig-storage] Secrets should be consumable from pods in volume"),
-			regexp.QuoteMeta("[sig-storage] Projected should be consumable"),
-			regexp.QuoteMeta("[sig-storage] HostPath should give a volume the correct mode"),
-			regexp.QuoteMeta("[sig-storage] HostPath should support r/w"),
-			regexp.QuoteMeta("[sig-storage] Dynamic Provisioning DynamicProvisioner"),
-			regexp.QuoteMeta("[sig-storage] ConfigMap should be consumable from pods"),
-			regexp.QuoteMeta("[sig-storage] ConfigMap should be consumable from pods"),
-			regexp.QuoteMeta("[sig-storage] Downward API volume should"),
-			regexp.QuoteMeta("[sig-storage] CSI Volumes CSI plugin test using CSI driver: hostPath should provision storage"),
-			regexp.QuoteMeta("[sig-scheduling] ResourceQuota should"),
-			regexp.QuoteMeta("[sig-scheduling] LimitRange should create a LimitRange with defaults"),
-			regexp.QuoteMeta("[sig-network] Services should"),
-			regexp.QuoteMeta("[sig-network] Networking Granular Checks: Pods should function for"),
-			regexp.QuoteMeta("[sig-network] DNS"),
-			regexp.QuoteMeta("[sig-cli] Kubectl client [k8s.io]"),
-			regexp.QuoteMeta("[sig-auth] [Feature:NodeAuthorizer]"),
-			regexp.QuoteMeta("[sig-auth] PodSecurityPolicy should"),
-			regexp.QuoteMeta("[sig-apps] ReplicaSet should"),
-			regexp.QuoteMeta("[sig-apps] Job should"),
-			regexp.QuoteMeta("[sig-apps] DisruptionController"),
-			regexp.QuoteMeta("[sig-apps] Deployment deployment"),
-			regexp.QuoteMeta("[sig-apps] CronJob should"),
-			regexp.QuoteMeta("[sig-api-machinery]"),
-			regexp.QuoteMeta("[k8s.io] [sig-node] Security Context [Feature:SecurityContext]"),
-			regexp.QuoteMeta("[k8s.io] [sig-node] Events should be sent by kubelets"),
-			regexp.QuoteMeta("[k8s.io] Pods should"),
-			regexp.QuoteMeta("[k8s.io] Docker Containers should"),
-			regexp.QuoteMeta("[Feature:DeploymentConfig] deploymentconfigs with multiple image change triggers"),
-			regexp.QuoteMeta("[Conformance][templates] templateinstance object kinds test should create and delete objects from varying API groups"),
-			regexp.QuoteMeta("[Conformance][Area:Networking][Feature:Router]"),
-			regexp.QuoteMeta("[Area:Networking] NetworkPolicy"),
-			regexp.QuoteMeta("[Area:Networking] network isolation"),
-			regexp.QuoteMeta("[Area:Networking] services when using a plugin"),
-			regexp.QuoteMeta("[Feature:Builds] result image should have proper labels set"),
-			regexp.QuoteMeta("[Feature:Builds][Conformance] oc new-app"),
+		"[Suite:openshift/scalability]": {
+			`Density .* should allow starting 30 pods per node .*Deployment.* with 0 secrets, 2 configmaps and 0 daemons`,
+			`Density .* should allow starting 100 pods per node .*ReplicationController.* with 0 secrets, 0 configmaps and 0 daemons`,
+			`Load capacity .* should be able to handle 30 pods per node .*Job.* with 0 secrets, 0 configmaps and 0 daemons`,
 		},
 	}
 
 	// labelExcludes temporarily block tests out of a specific suite
-	labelExcludes = map[string][]string{
-		"[Suite:openshift/smoke-4]": {
-			`\[sig-network\] Services .* NodePort`,
-			`DynamicProvisioner deletion should be idempotent`,
-			`Kubectl taint \[Serial\]`,
-			// flaking, very slow
-			`100 namespaces in 150 seconds`,
-
-			// appear to be flaking
-			`should run a successful deployment with multiple triggers`,
-			`should run a successful deployment with a trigger used by different containers`,
-
-			// flaking left and right
-			// Dec  1 01:23:01.913: INFO: resource secrets, expected 6, actual 7
-			`should create a ResourceQuota and capture the life of a secret`,
-		},
-	}
+	labelExcludes = map[string][]string{}
 
 	excludedTests = []string{
 		`\[Disabled:.+\]`,


### PR DESCRIPTION
* smoke-4 is not needed anymore
* make conformance/parallel tolerate some flakes for now
* rename `openshift/all` to `all` for easier typing
* add `openshift/conformance-excluded` to better review excluded
* add `openshift/scalability` to test repeatable performance numbers
* make flake detection per suite, not per run

Will add openshift/scalability to a release blocking job.