### PR TITLE
Hostname lookup IP can be default IP on the hosts having multiple NICs

### DIFF
--- a/pkg/cmd/util/ip.go
+++ b/pkg/cmd/util/ip.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"net"
+	"os"
 )
 
 // ErrorNoDefaultIP is returned when no suitable non-loopback address can be found.
@@ -11,9 +12,17 @@ var ErrorNoDefaultIP = errors.New("no suitable IP address")
 // DefaultLocalIP4 returns an IPv4 address that this host can be reached
 // on. Will return NoDefaultIP if no suitable address can be found.
 func DefaultLocalIP4() (net.IP, error) {
+	var firstIP net.IP = nil
+	var hostIP = ""
 	devices, err := net.Interfaces()
 	if err != nil {
 		return nil, err
+	}
+	// Get an IP as hostname lookup.
+	if hostname, err := os.Hostname(); err == nil && len(hostname) > 0 {
+		if ip, err := net.LookupHost(hostname); err == nil && len(ip) == 1 {
+			hostIP = ip[0]
+		}
 	}
 	for _, dev := range devices {
 		if (dev.Flags&net.FlagUp != 0) && (dev.Flags&net.FlagLoopback == 0) {
@@ -24,11 +33,22 @@ func DefaultLocalIP4() (net.IP, error) {
 			for i := range addrs {
 				if ip, ok := addrs[i].(*net.IPNet); ok {
 					if ip.IP.To4() != nil {
-						return ip.IP, nil
+						// Save first IP that this host can be reached on.
+						if firstIP == nil {
+							firstIP = ip.IP
+						}
+						// When host IP is existing on this host, return the IP.
+						if ip.IP.String() == hostIP {
+							return ip.IP, nil
+						}
 					}
 				}
 			}
 		}
+	}
+	// When the host IP is not matched, first interface's IP would return.
+	if firstIP != nil {
+		return firstIP, nil
 	}
 	return nil, ErrorNoDefaultIP
 }


### PR DESCRIPTION
`Hostname lookup` is required to install `OCP` as a [prerequisite](https://docs.openshift.com/container-platform/3.11/install/prerequisites.html#node-hostnames-prereq). When the `node hosts` have multiple `network interfaces`, `hostname lookup IP` can be more reasonable `default local IP`.

This fix is helpful for the following issues to resolve:
 - [Cannot set '--cluster-dns' value by dnsIP](https://bugzilla.redhat.com/show_bug.cgi?id=1662253)
 - [Nameserver value in /etc/resolv.conf file inside pods are inconsistent](https://github.com/openshift/origin/issues/21696)

I've verified the following patterns:
* **Base Env conditions**:
  - hostname: `node.example.com (192.168.100.10)`
  - `eth0`: `192.168.100.10`
  - `eth1`: `192.168.200.50`
~~~
  # openshift-node-config --config=/etc/origin/node/node-config.yaml
  ... --cluster-dns=192.168.100.10 ...
~~~

**1. hostname can not resolved as IP: first IP that the host can be reached on.**
  * Env conditions:
    - hostname: `node.example.com (NXDOMAIN, the hostname not found)`
    - `eth0`: `192.168.100.10`
    - `eth1`: `192.168.200.50`
  * Result: `eth0's IP`
~~~
    # openshift-node-config --config=/etc/origin/node/node-config.yaml
    ... --cluster-dns=192.168.100.10 ...
~~~

**2. Not existing IP on the host can be resolved: first IP that the host can be reached on.**
  * Env conditions:
    - hostname: `node.example.com (10.10.1.10)`
    - `eth0`: `192.168.100.10`
    - `eth1`: `192.168.200.50`
  * Result:  `eth0's IP`
~~~
    # openshift-node-config --config=/etc/origin/node/node-config.yaml
    ... --cluster-dns=192.168.100.10 ...
~~~

**3. hostname can be resolved second interface's IP: host IP that can be solved and reached on**
  * Env conditions:
    - hostname: `node.example.com (192.168.200.50)`
    - `eth0`: `192.168.100.10`
    - `eth1`: `192.168.200.50`
    * Result:  `eth1's IP`
~~~
      # openshift-node-config --config=/etc/origin/node/node-config.yaml
      ... --cluster-dns=192.168.200.50 ...
~~~