### PR TITLE
UPSTREAM: <carry>: require good status on discovery check

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -184,6 +184,8 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		c.GenericConfig.SharedInformerFactory.Core().V1().Endpoints(),
 		apiregistrationClient.Apiregistration(),
 		c.ExtraConfig.ProxyTransport,
+		c.ExtraConfig.ProxyClientCert,
+		c.ExtraConfig.ProxyClientKey,
 		s.serviceResolver,
 	)
 


### PR DESCRIPTION
The aggregator shouldn't report the status on an endpoint to be good unless it gets back a 200-ish return code.  This builds the correct transport so that a unauthorized *should* pop out if the backing apiserver would return one.

/assign @sttts

I'm actually not sure how to wire this upstream since the proxy transport is created in an odd way and we couldn't/shouldn't modify it here. We already customized this to hit many in parallel, what's one more :(

@mfojtik checking at the other end.