### PR TITLE
e2e monitor tweaks

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -143,21 +143,21 @@ func findNodeCondition(status []corev1.NodeCondition, name corev1.NodeConditionT
 
 func locateEvent(event *corev1.Event) string {
 	if len(event.InvolvedObject.Namespace) > 0 {
-		return fmt.Sprintf("ns=%s %s=%s", event.InvolvedObject.Namespace, strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name)
+		return fmt.Sprintf("ns/%s %s/%s", event.InvolvedObject.Namespace, strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name)
 	}
-	return fmt.Sprintf("%s=%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name)
+	return fmt.Sprintf("%s/%s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name)
 }
 
 func locatePod(pod *corev1.Pod) string {
-	return fmt.Sprintf("ns=%s pod=%s node=%s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	return fmt.Sprintf("ns=%s pod/%s node/%s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 }
 
 func locateNode(node *corev1.Node) string {
-	return fmt.Sprintf("node=%s", node.Name)
+	return fmt.Sprintf("node/%s", node.Name)
 }
 
 func locatePodContainer(pod *corev1.Pod, containerName string) string {
-	return fmt.Sprintf("ns=%s pod=%s node=%s container=%s", pod.Namespace, pod.Name, pod.Spec.NodeName, containerName)
+	return fmt.Sprintf("ns/%s pod/%s node/%s container=%s", pod.Namespace, pod.Name, pod.Spec.NodeName, containerName)
 }
 
 func filterToSystemNamespaces(obj runtime.Object) bool {

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +48,8 @@ func startEventMonitoring(ctx context.Context, m Recorder, client kubernetes.Int
 							condition := Condition{
 								Level:   Info,
 								Locator: locateEvent(obj),
-								Message: obj.Message,
+								// make sure the message ends up on a single line.  Something about the way we collect logs wants this.
+								Message: strings.Replace(obj.Message, "\n", "\\n", -1) + fmt.Sprintf(" count(%d)", +obj.Count),
 							}
 							if obj.Type == corev1.EventTypeWarning {
 								condition.Level = Warning


### PR DESCRIPTION
1.  makes the resource strings match standard resource strings
2. make sure event messages end up on one line and include counts
3. add a per-kube-apiserver healthz sampler

@smarterclayton 2 and 3 are information that I need/want in the sampler output to try to understand why random apiservers drop.

/assign @smarterclayton 

