### PR TITLE
UPSTREAM: <carry>: allow a kube-apiserver to skip registering an API …

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/master/controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/controller.go
@@ -208,6 +208,11 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 	if err := c.CreateOrUpdateMasterServiceIfNeeded(kubernetesServiceName, c.ServiceIP, servicePorts, serviceType, reconcile); err != nil {
 		return err
 	}
+
+	if disableEndpointRegistration {
+		return nil
+	}
+
 	endpointPorts := createEndpointPortSpec(c.PublicServicePort, "https", c.ExtraEndpointPorts)
 	if err := c.EndpointReconciler.ReconcileEndpoints(kubernetesServiceName, c.PublicIP, endpointPorts, reconcile); err != nil {
 		return err

--- a/vendor/k8s.io/kubernetes/pkg/master/patch_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/patch_controller.go
@@ -1,0 +1,8 @@
+package master
+
+import (
+	"os"
+	"strings"
+)
+
+var disableEndpointRegistration = strings.EqualFold(os.Getenv("DISABLE_KUBE_ENDPOINT_REGISTRATION"), "true")


### PR DESCRIPTION
…endpoint

This allows us to skip creating the endpoint for the boostrap kube-apiserver

/assign @smarterclayton 