### PR TITLE
pkg/oc/cli/admin/release/info: Support OCI repo/commit annotations

### DIFF
--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -510,9 +510,17 @@ func describeReleaseDiff(out io.Writer, diff *ReleaseDiff, showCommit bool) erro
 }
 
 func repoAndCommit(ref *imageapi.TagReference) string {
-	repo := ref.Annotations["io.openshift.build.source-location"]
-	commit := ref.Annotations["io.openshift.build.commit.id"]
-	if len(repo) == 0 || len(commit) == 0 {
+	repo := ref.Annotations["org.opencontainers.image.source"]
+	if repo == "" {
+		repo = ref.Annotations["io.openshift.build.source-location"]
+	}
+
+	commit := ref.Annotations["org.opencontainers.image.revision"]
+	if commit == "" {
+		commit = ref.Annotations["io.openshift.build.commit.id"]
+	}
+
+	if repo == "" || commit == "" {
 		return "<unknown>"
 	}
 	return fmt.Sprintf("%s %s", repo, commit)


### PR DESCRIPTION
These are [standardized][1], and folks consuming our images are more likely to recognize the standard names than our local labels.  With this commit, we'll pull the metadata from the standard locations, and only fall back to the OpenShift-specific locations when the standard annotations are unset.

From [the OCI image spec][2], `org.opencontainers.image.source` is equivalent to `org.label-schema.vcs-url` and `org.opencontainers.image.revision` is equivalent to `org.label-schema.vcs-ref`.  And from [the label schema][3], `https://github.com/nginx/nginx` is an example value for `org.label-schema.vcs-url` and `org.label-schema.vcs-ref` is the commit hash for Git repositories.

Previous related discussion [here][4] and in openshift/ci-operator#188.

CC @smarterclayton, @tbielawa, and @adammhaile.

[1]: https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md#pre-defined-annotation-keys
[2]: https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md#back-compatibility-with-label-schema
[3]: https://label-schema.org/rc1/#build-time-labels
[4]: https://github.com/openshift/origin/pull/21432#discussion_r247595715