### PR TITLE
Wait at end of deployer tests to catch log output

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4934,11 +4934,11 @@ spec:
       - -c
       - |
         set -e
-        sleep 15  # give tests time to set up
         openshift-deploy --until=50%
         echo Halfway
         openshift-deploy
         echo Finished
+        sleep 15  # give tests time to observe logs
   template:
     metadata:
       labels:
@@ -5754,8 +5754,8 @@ spec:
           - /bin/bash
           - -c
           - |
-            sleep 15  # give tests time to setup
             echo 'test pre hook executed'
+            sleep 15  # give tests time to record logs
   template:
     metadata:
       labels:

--- a/test/extended/testdata/deployments/custom-deployment.yaml
+++ b/test/extended/testdata/deployments/custom-deployment.yaml
@@ -22,11 +22,11 @@ spec:
       - -c
       - |
         set -e
-        sleep 15  # give tests time to set up
         openshift-deploy --until=50%
         echo Halfway
         openshift-deploy
         echo Finished
+        sleep 15  # give tests time to observe logs
   template:
     metadata:
       labels:

--- a/test/extended/testdata/deployments/test-deployment-test.yaml
+++ b/test/extended/testdata/deployments/test-deployment-test.yaml
@@ -17,8 +17,8 @@ spec:
           - /bin/bash
           - -c
           - |
-            sleep 15  # give tests time to setup
             echo 'test pre hook executed'
+            sleep 15  # give tests time to record logs
   template:
     metadata:
       labels:


### PR DESCRIPTION
Ensure that log output has a chance to make it to disk.