### PR TITLE
test/extended/README openshift/all->all suite

### DIFF
--- a/test/extended/README.md
+++ b/test/extended/README.md
@@ -31,7 +31,7 @@ See the description on the test for more info about what prerequites may exist f
 To run a subset of tests using a regexp, run:
 
 ```console
-$ openshift-tests run openshift/all --dry-run | grep -E "<REGEX>" | openshift-tests run -f -
+$ openshift-tests run all --dry-run | grep -E "<REGEX>" | openshift-tests run -f -
 ```
 
 


### PR DESCRIPTION
test/extended/README.md fix, how to run a subset of tests using regexp

change `openshift-tests run openshift/all` to `openshift-tests run all`