### PR TITLE
Fix the router tests host name to use the external load balancer service

### DIFF
--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -7,6 +7,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -130,6 +131,12 @@ func waitForNamedRouterServiceIP(oc *exutil.CLI, name string) (string, error) {
 		}
 		o.Expect(err).NotTo(o.HaveOccurred())
 		host = svc.Spec.ClusterIP
+		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			if len(svc.Status.LoadBalancer.Ingress) == 0 || len(svc.Status.LoadBalancer.Ingress[0].Hostname) == 0 {
+				return false, nil
+			}
+			host = svc.Status.LoadBalancer.Ingress[0].Hostname
+		}
 		return true, nil
 	})
 	return host, err


### PR DESCRIPTION
host name if it is available.
On aws when the proxy protocol is enabled, the cluster ip would talk the
"proxy" protocol, so we have to use the external load balancer host name to
talk http[s].

This is blocking https://github.com/openshift/cluster-ingress-operator/pull/84 tests.

@ironcladlou  PTAL thx 
