### PR TITLE
Emptydir blob cache for builds

### DIFF
--- a/pkg/build/controller/strategy/docker.go
+++ b/pkg/build/controller/strategy/docker.go
@@ -3,7 +3,7 @@ package strategy
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -197,5 +197,6 @@ func (bs *DockerBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds
+	setupBlobCache(pod)
 	return pod, nil
 }

--- a/pkg/build/controller/strategy/docker_test.go
+++ b/pkg/build/controller/strategy/docker_test.go
@@ -53,7 +53,23 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	if actual.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("Expected never, got %#v", actual.Spec.RestartPolicy)
 	}
-	expectedKeys := map[string]string{"BUILD": "", "SOURCE_REPOSITORY": "", "SOURCE_URI": "", "SOURCE_CONTEXT_DIR": "", "SOURCE_REF": "", "BUILD_LOGLEVEL": "", "PUSH_DOCKERCFG_PATH": "", "PULL_DOCKERCFG_PATH": "", "BUILD_REGISTRIES_CONF_PATH": "", "BUILD_REGISTRIES_DIR_PATH": "", "BUILD_SIGNATURE_POLICY_PATH": "", "BUILD_STORAGE_CONF_PATH": "", "BUILD_ISOLATION": "", "BUILD_STORAGE_DRIVER": ""}
+	expectedKeys := map[string]string{
+		"BUILD":                       "",
+		"SOURCE_REPOSITORY":           "",
+		"SOURCE_URI":                  "",
+		"SOURCE_CONTEXT_DIR":          "",
+		"SOURCE_REF":                  "",
+		"BUILD_LOGLEVEL":              "",
+		"PUSH_DOCKERCFG_PATH":         "",
+		"PULL_DOCKERCFG_PATH":         "",
+		"BUILD_REGISTRIES_CONF_PATH":  "",
+		"BUILD_REGISTRIES_DIR_PATH":   "",
+		"BUILD_SIGNATURE_POLICY_PATH": "",
+		"BUILD_STORAGE_CONF_PATH":     "",
+		"BUILD_ISOLATION":             "",
+		"BUILD_STORAGE_DRIVER":        "",
+		"BUILD_BLOBCACHE_DIR":         "",
+	}
 	gotKeys := map[string]string{}
 	for _, k := range container.Env {
 		gotKeys[k.Name] = ""
@@ -64,6 +80,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 
 	// expected volumes:
 	// buildworkdir
+	// blobs meta cache
 	// pushsecret
 	// pullsecret
 	// inputsecret
@@ -71,9 +88,9 @@ func TestDockerCreateBuildPod(t *testing.T) {
 	// build-system-config
 	// certificate authorities
 	// container storage
-	// blobs cache
-	if len(container.VolumeMounts) != 9 {
-		t.Fatalf("Expected 9 volumes in container, got %d", len(container.VolumeMounts))
+	// blobs content cache
+	if len(container.VolumeMounts) != 10 {
+		t.Fatalf("Expected 10 volumes in container, got %d", len(container.VolumeMounts))
 	}
 	if *actual.Spec.ActiveDeadlineSeconds != 60 {
 		t.Errorf("Expected ActiveDeadlineSeconds 60, got %d", *actual.Spec.ActiveDeadlineSeconds)
@@ -87,6 +104,7 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		ConfigMapBuildSystemConfigsMountPath,
 		ConfigMapCertsMountPath,
 		"/var/lib/containers/storage",
+		buildutil.BuildBlobsContentCache,
 	}
 	for i, expected := range expectedMounts {
 		if container.VolumeMounts[i].MountPath != expected {
@@ -94,8 +112,8 @@ func TestDockerCreateBuildPod(t *testing.T) {
 		}
 	}
 	// build pod has an extra volume: the git clone source secret
-	if len(actual.Spec.Volumes) != 10 {
-		t.Fatalf("Expected 10 volumes in Build pod, got %d", len(actual.Spec.Volumes))
+	if len(actual.Spec.Volumes) != 11 {
+		t.Fatalf("Expected 11 volumes in Build pod, got %d", len(actual.Spec.Volumes))
 	}
 	if !kapihelper.Semantic.DeepEqual(container.Resources, build.Spec.Resources) {
 		t.Fatalf("Expected actual=expected, %v != %v", container.Resources, build.Spec.Resources)

--- a/pkg/build/controller/strategy/sti.go
+++ b/pkg/build/controller/strategy/sti.go
@@ -202,6 +202,7 @@ func (bs *SourceBuildStrategy) CreateBuildPod(build *buildv1.Build, additionalCA
 	setupBuildCAs(build, pod, additionalCAs, internalRegistryHost)
 	setupContainersStorage(pod, &pod.Spec.Containers[0]) // for unprivileged builds
 	// setupContainersNodeStorage(pod, &pod.Spec.Containers[0]) // for privileged builds
+	setupBlobCache(pod)
 	return pod, nil
 }
 

--- a/pkg/build/util/util.go
+++ b/pkg/build/util/util.go
@@ -33,9 +33,13 @@ const (
 	// buildPodSuffix is the suffix used to append to a build pod name given a build name
 	buildPodSuffix = "build"
 
-	// BuildBlobsMetaCache is the directory used to store a cache for the blobs to be
+	// BuildBlobsMetaCache is the directory used to store a cache for the blobs metadata to be
 	// reused across builds.
 	BuildBlobsMetaCache = "/var/lib/containers/cache"
+
+	// BuildBlobsContentCache is the directory used to store a cache for the blobs content to be
+	// reused within a build pod.
+	BuildBlobsContentCache = "/var/cache/blobs"
 )
 
 // GeneratorFatalError represents a fatal error while generating a build.


### PR DESCRIPTION
Use `EmptyDir` to host the container blob _content_ cache, rather than relying on container storage.