### PR TITLE
Use ruby 2.5 image in extended tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -1457,7 +1457,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/ruby-22-centos7"
+          "name": "docker.io/centos/ruby-25-centos7"
         },
         "env": [
           {
@@ -1553,7 +1553,7 @@ func testExtendedTestdataBuildsBuildSecretsTestSecretJson() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsBuildTimingDockerfile = []byte(`FROM centos/ruby-22-centos7
+var _testExtendedTestdataBuildsBuildTimingDockerfile = []byte(`FROM centos/ruby-25-centos7
 
 USER root
 `)
@@ -1866,7 +1866,7 @@ var _testExtendedTestdataBuildsIncrementalAuthBuildJson = []byte(`{
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7:latest"
+              "name": "centos/ruby-25-centos7:latest"
             }
           }
         },
@@ -2445,7 +2445,7 @@ func testExtendedTestdataBuildsTestBcWithPrRefYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataBuildsTestBuildAppDockerfile = []byte(`FROM centos/ruby-22-centos7
+var _testExtendedTestdataBuildsTestBuildAppDockerfile = []byte(`FROM centos/ruby-25-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production
@@ -2669,7 +2669,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/centos/ruby-22-centos7
+          name: docker.io/centos/ruby-25-centos7
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -2795,7 +2795,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -2824,7 +2824,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -2852,7 +2852,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -2881,7 +2881,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -2909,7 +2909,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -2927,7 +2927,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-22-centos7
+        FROM centos/ruby-25-centos7
         ARG foo
         RUN echo $foo
     strategy:
@@ -2953,7 +2953,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-22-centos7
+        FROM centos/ruby-25-centos7
         ARG foo
         RUN echo $foo
     strategy:
@@ -3603,7 +3603,7 @@ var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
+          "name":"centos/ruby-25-centos7"
         }
       }
     },
@@ -4884,7 +4884,7 @@ run Proc.new { |env|
 EOF
 
 cat > Dockerfile <<- EOF
-FROM centos/ruby-22-centos7
+FROM centos/ruby-25-centos7
 ENV SECRET_FILE /opt/openshift/src/dockercfg
 COPY dockercfg ./
 COPY config.ru ./
@@ -8722,7 +8722,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7"
+              "name": "centos/ruby-25-centos7"
             }
           }
         ]
@@ -8740,7 +8740,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7"
+              "name": "centos/ruby-25-centos7"
             }
           }
         ]
@@ -8758,7 +8758,7 @@ var _testExtendedTestdataJenkinsPluginMultitagTemplateJson = []byte(`{
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7"
+              "name": "centos/ruby-25-centos7"
             }
           }
         ]
@@ -9464,7 +9464,7 @@ func testExtendedTestdataLdapLdapserverServiceJson() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataLong_namesDockerfile = []byte(`FROM centos/ruby-22-centos7
+var _testExtendedTestdataLong_namesDockerfile = []byte(`FROM centos/ruby-25-centos7
 
 CMD ["/bin/sh", "-c", "echo", "hello"]
 `)
@@ -9512,7 +9512,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-22-centos7"
+                            "name": "centos/ruby-25-centos7"
                         }
                     }
                 }
@@ -9541,7 +9541,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-22-centos7"
+                            "name": "centos/ruby-25-centos7"
                         }
                     }
                 }
@@ -11134,7 +11134,7 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
         resources: {}
       status: 
         lastVersion: 0
@@ -11181,7 +11181,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
     - 
       kind: "BuildConfig"
       apiVersion: "v1"
@@ -11202,7 +11202,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {
@@ -11245,7 +11245,7 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
         resources: {}
       status: 
         lastVersion: 0
@@ -11320,7 +11320,7 @@ func testExtendedTestdataS2iDropcapsRootAccessBuildYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM centos/ruby-22-centos7:latest
+var _testExtendedTestdataS2iDropcapsRootableRubyDockerfile = []byte(`FROM centos/ruby-25-centos7:latest
 USER root
 RUN yum -y install expect
 RUN echo "root:redhat" | chpasswd

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -2451,8 +2451,8 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby22 "bundle install"
-CMD ["scl", "enable", "rh-ruby22", "./run.sh"]
+RUN scl enable rh-ruby25 "bundle install"
+CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
 
 USER default
 `)

--- a/test/extended/testdata/builds/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-s2i-build.json
@@ -45,7 +45,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/ruby-22-centos7"
+          "name": "docker.io/centos/ruby-25-centos7"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/build-timing/Dockerfile
+++ b/test/extended/testdata/builds/build-timing/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos/ruby-22-centos7
+FROM centos/ruby-25-centos7
 
 USER root

--- a/test/extended/testdata/builds/incremental-auth-build.json
+++ b/test/extended/testdata/builds/incremental-auth-build.json
@@ -48,7 +48,7 @@
             ],
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7:latest"
+              "name": "centos/ruby-25-centos7:latest"
             }
           }
         },

--- a/test/extended/testdata/builds/test-build-app/Dockerfile
+++ b/test/extended/testdata/builds/test-build-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-22-centos7
+FROM centos/ruby-25-centos7
 USER default
 EXPOSE 8080
 ENV RACK_ENV production

--- a/test/extended/testdata/builds/test-build-app/Dockerfile
+++ b/test/extended/testdata/builds/test-build-app/Dockerfile
@@ -4,7 +4,7 @@ EXPOSE 8080
 ENV RACK_ENV production
 ENV RAILS_ENV production
 COPY . /opt/app-root/src/
-RUN scl enable rh-ruby22 "bundle install"
-CMD ["scl", "enable", "rh-ruby22", "./run.sh"]
+RUN scl enable rh-ruby25 "bundle install"
+CMD ["scl", "enable", "rh-ruby25", "./run.sh"]
 
 USER default

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -84,7 +84,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: docker.io/centos/ruby-22-centos7
+          name: docker.io/centos/ruby-25-centos7
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -48,7 +48,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -77,7 +77,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -105,7 +105,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -134,7 +134,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
   status:
     lastVersion: 0
@@ -162,7 +162,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: centos/ruby-22-centos7
+          name: centos/ruby-25-centos7
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -180,7 +180,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-22-centos7
+        FROM centos/ruby-25-centos7
         ARG foo
         RUN echo $foo
     strategy:
@@ -206,7 +206,7 @@ items:
     source:
       type: Dockerfile
       dockerfile: |-
-        FROM centos/ruby-22-centos7
+        FROM centos/ruby-25-centos7
         ARG foo
         RUN echo $foo
     strategy:

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -17,7 +17,7 @@
       "sourceStrategy":{
         "from":{
           "kind":"DockerImage",
-          "name":"centos/ruby-22-centos7"
+          "name":"centos/ruby-25-centos7"
         }
       }
     },

--- a/test/extended/testdata/custom-secret-builder/build.sh
+++ b/test/extended/testdata/custom-secret-builder/build.sh
@@ -35,7 +35,7 @@ run Proc.new { |env|
 EOF
 
 cat > Dockerfile <<- EOF
-FROM centos/ruby-22-centos7
+FROM centos/ruby-25-centos7
 ENV SECRET_FILE /opt/openshift/src/dockercfg
 COPY dockercfg ./
 COPY config.ru ./

--- a/test/extended/testdata/jenkins-plugin/multitag-template.json
+++ b/test/extended/testdata/jenkins-plugin/multitag-template.json
@@ -18,7 +18,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7"
+              "name": "centos/ruby-25-centos7"
             }
           }
         ]
@@ -36,7 +36,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7"
+              "name": "centos/ruby-25-centos7"
             }
           }
         ]
@@ -54,7 +54,7 @@
             "name": "orig",
             "from": {
               "kind": "DockerImage",
-              "name": "centos/ruby-22-centos7"
+              "name": "centos/ruby-25-centos7"
             }
           }
         ]

--- a/test/extended/testdata/long_names/Dockerfile
+++ b/test/extended/testdata/long_names/Dockerfile
@@ -1,3 +1,3 @@
-FROM centos/ruby-22-centos7
+FROM centos/ruby-25-centos7
 
 CMD ["/bin/sh", "-c", "echo", "hello"]

--- a/test/extended/testdata/long_names/fixture.json
+++ b/test/extended/testdata/long_names/fixture.json
@@ -26,7 +26,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-22-centos7"
+                            "name": "centos/ruby-25-centos7"
                         }
                     }
                 }
@@ -55,7 +55,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "centos/ruby-22-centos7"
+                            "name": "centos/ruby-25-centos7"
                         }
                     }
                 }

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -32,7 +32,7 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
         resources: {}
       status: 
         lastVersion: 0

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
     - 
       kind: "BuildConfig"
       apiVersion: "v1"
@@ -44,4 +44,4 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy: 
             from: 
               kind: "DockerImage"
-              name: "centos/ruby-22-centos7"
+              name: "centos/ruby-25-centos7"
         resources: {}
       status: 
         lastVersion: 0

--- a/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
+++ b/test/extended/testdata/s2i-dropcaps/rootable-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-22-centos7:latest
+FROM centos/ruby-25-centos7:latest
 USER root
 RUN yum -y install expect
 RUN echo "root:redhat" | chpasswd


### PR DESCRIPTION
Attempt to address build test errors from Gemfile dependency failure:

```
2019-01-16T08:28:42.127100663Z Gem::InstallError: i18n requires Ruby version >= 2.3.0.
```