### PR TITLE
UPSTREAM: 72970: apiserver: sync with http server shutdown to flush existing connections

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/controllermanager.go
@@ -123,7 +123,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig) error {
 	if c.SecureServing != nil {
 		handler := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Debugging)
 		handler = genericcontrollermanager.BuildHandlerChain(handler, &c.Authorization, &c.Authentication)
-		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			return err
 		}
 	}

--- a/vendor/k8s.io/kubernetes/cmd/controller-manager/app/insecure_serving.go
+++ b/vendor/k8s.io/kubernetes/cmd/controller-manager/app/insecure_serving.go
@@ -48,5 +48,6 @@ func (s *InsecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.D
 	} else {
 		glog.Infof("Serving insecurely on %s", s.Listener.Addr())
 	}
-	return server.RunServer(insecureServer, s.Listener, shutdownTimeout, stopCh)
+	_, err := server.RunServer(insecureServer, s.Listener, shutdownTimeout, stopCh)
+	return err
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -142,7 +142,7 @@ func Run(c *config.CompletedConfig) error {
 	if c.SecureServing != nil {
 		handler := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Debugging)
 		handler = genericcontrollermanager.BuildHandlerChain(handler, &c.Authorization, &c.Authentication)
-		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			return err
 		}
 	}

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
@@ -166,7 +166,7 @@ func Run(c schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error 
 	}
 	if c.SecureServing != nil {
 		handler := buildHandlerChain(newHealthzHandler(&c.ComponentConfig, false), c.Authentication.Authenticator, c.Authorization.Authorizer)
-		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			// fail early for secure handlers, removing the old error loop from above
 			return fmt.Errorf("failed to start healthz server: %v", err)
 		}

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/server/insecure_handler.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/server/insecure_handler.go
@@ -121,7 +121,7 @@ func serveInsecurely(insecureServingInfo *InsecureServingInfo, insecureHandler h
 	if err != nil {
 		return err
 	}
-	err = server.RunServer(insecureServer, ln, shutDownTimeout, stopCh)
+	_, err = server.RunServer(insecureServer, ln, shutDownTimeout, stopCh)
 	return err
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -309,8 +309,11 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 	// Use an internal stop channel to allow cleanup of the listeners on error.
 	internalStopCh := make(chan struct{})
 
+	var stoppedCh <-chan struct{}
 	if s.SecureServingInfo != nil && s.Handler != nil {
-		if err := s.SecureServingInfo.Serve(s.Handler, s.ShutdownTimeout, internalStopCh); err != nil {
+		var err error
+		stoppedCh, err = s.SecureServingInfo.Serve(s.Handler, s.ShutdownTimeout, internalStopCh)
+		if err != nil {
 			close(internalStopCh)
 			return err
 		}
@@ -322,6 +325,9 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 	go func() {
 		<-stopCh
 		close(internalStopCh)
+		if stoppedCh != nil {
+			<-stoppedCh
+		}
 		s.HandlerChainWaitGroup.Wait()
 		close(auditStopCh)
 	}()

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -542,7 +542,7 @@ func TestGracefulShutdown(t *testing.T) {
 
 	// get port
 	serverPort := ln.Addr().(*net.TCPAddr).Port
-	err = RunServer(insecureServer, ln, 10*time.Second, stopCh)
+	stoppedCh, err := RunServer(insecureServer, ln, 10*time.Second, stopCh)
 	if err != nil {
 		t.Errorf("RunServer err: %v", err)
 	}
@@ -565,6 +565,7 @@ func TestGracefulShutdown(t *testing.T) {
 	close(stopCh)
 	// wait for wait group handler finish
 	s.HandlerChainWaitGroup.Wait()
+	<-stoppedCh
 
 	// check server all handlers finished.
 	if !graceShutdown {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/serve.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/serve.go
@@ -37,12 +37,12 @@ const (
 	defaultKeepAlivePeriod = 3 * time.Minute
 )
 
-// serveSecurely runs the secure http server. It fails only if certificates cannot
-// be loaded or the initial listen call fails. The actual server loop (stoppable by closing
-// stopCh) runs in a go routine, i.e. serveSecurely does not block.
-func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Duration, stopCh <-chan struct{}) error {
+// Serve runs the secure http server. It fails only if certificates cannot be loaded or the initial listen call fails.
+// The actual server loop (stoppable by closing stopCh) runs in a go routine, i.e. Serve does not block.
+// It returns a stoppedCh that is closed when all non-hijacked active requests have been processed.
+func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Duration, stopCh <-chan struct{}) (<-chan struct{}, error) {
 	if s.Listener == nil {
-		return fmt.Errorf("listener must not be nil")
+		return nil, fmt.Errorf("listener must not be nil")
 	}
 
 	secureServer := &http.Server{
@@ -110,29 +110,32 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 
 	// apply settings to the server
 	if err := http2.ConfigureServer(secureServer, http2Options); err != nil {
-		return fmt.Errorf("error configuring http2: %v", err)
+		return nil, fmt.Errorf("error configuring http2: %v", err)
 	}
 
 	glog.Infof("Serving securely on %s", secureServer.Addr)
 	return RunServer(secureServer, s.Listener, shutdownTimeout, stopCh)
 }
 
-// RunServer listens on the given port if listener is not given,
-// then spawns a go-routine continuously serving
-// until the stopCh is closed. This function does not block.
+// then spawns a go-routine continuously serving until the stopCh is closed.
+// It returns a stoppedCh that is closed when all non-hijacked active requests
+// have been processed.
+// This function does not block.
 // TODO: make private when insecure serving is gone from the kube-apiserver
 func RunServer(
 	server *http.Server,
 	ln net.Listener,
 	shutDownTimeout time.Duration,
 	stopCh <-chan struct{},
-) error {
+) (<-chan struct{}, error) {
 	if ln == nil {
-		return fmt.Errorf("listener must not be nil")
+		return nil, fmt.Errorf("listener must not be nil")
 	}
 
 	// Shutdown server gracefully.
+	stoppedCh := make(chan struct{})
 	go func() {
+		defer close(stoppedCh)
 		<-stopCh
 		ctx, cancel := context.WithTimeout(context.Background(), shutDownTimeout)
 		server.Shutdown(ctx)
@@ -159,7 +162,7 @@ func RunServer(
 		}
 	}()
 
-	return nil
+	return stoppedCh, nil
 }
 
 type NamedTLSCert struct {


### PR DESCRIPTION
We did not wait for the http server to shut down completely. In the http/2 case this seems to lead to early closing of connections, without sending all bytes to the client. Credits to @xingxingxia for finding that.

```release-note
Fix graceful apiserver shutdown to not drop outgoing bytes before the process terminates.
```

Here is the go doc of the http server shutdown method:
```golang
// Shutdown gracefully shuts down the server without interrupting any
// active connections. Shutdown works by first closing all open
// listeners, then closing all idle connections, and then waiting
// indefinitely for connections to return to idle and then shut down.
// If the provided context expires before the shutdown is complete,
// Shutdown returns the context's error, otherwise it returns any
// error returned from closing the Server's underlying Listener(s).
//
// When Shutdown is called, Serve, ListenAndServe, and
// ListenAndServeTLS immediately return ErrServerClosed. Make sure the
// program doesn't exit and waits instead for Shutdown to return.
//
// Shutdown does not attempt to close nor wait for hijacked
// connections such as WebSockets. The caller of Shutdown should
// separately notify such long-lived connections of shutdown and wait
// for them to close, if desired. See RegisterOnShutdown for a way to
// register shutdown notification functions.
//
// Once Shutdown has been called on a server, it may not be reused;
// future calls to methods such as Serve will return ErrServerClosed.
func (srv *Server) Shutdown(ctx context.Context) error {
...
}
```