### PR TITLE
UPSTREAM: 70805: Fix a CloudProvider-vs-nodeIP edge case

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/nodestatus/setters.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/nodestatus/setters.go
@@ -90,17 +90,16 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 			if nodeIP != nil {
 				enforcedNodeAddresses := []v1.NodeAddress{}
 
-				var nodeIPType v1.NodeAddressType
+				nodeIPTypes := make(map[v1.NodeAddressType]bool)
 				for _, nodeAddress := range nodeAddresses {
 					if nodeAddress.Address == nodeIP.String() {
 						enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
-						nodeIPType = nodeAddress.Type
-						break
+						nodeIPTypes[nodeAddress.Type] = true
 					}
 				}
 				if len(enforcedNodeAddresses) > 0 {
 					for _, nodeAddress := range nodeAddresses {
-						if nodeAddress.Type != nodeIPType && nodeAddress.Type != v1.NodeHostName {
+						if !nodeIPTypes[nodeAddress.Type] && nodeAddress.Type != v1.NodeHostName {
 							enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
 						}
 					}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/nodestatus/setters_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/nodestatus/setters_test.go
@@ -94,6 +94,8 @@ func TestNodeAddress(t *testing.T) {
 			name:   "InternalIP and ExternalIP are the same",
 			nodeIP: net.ParseIP("55.55.55.55"),
 			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
+				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
 				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},


### PR DESCRIPTION
In 3.11 and later, nodeIP determination breaks under vSphere if you have many IP addresses on a node (eg due to router HA or egress IPs)

Backport of https://github.com/kubernetes/kubernetes/pull/70805
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643348