### PR TITLE
[3.11] UPSTREAM: 70805: Fix a CloudProvider-vs-nodeIP edge case

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_node_status.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_node_status.go
@@ -473,17 +473,16 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		if kl.nodeIP != nil {
 			enforcedNodeAddresses := []v1.NodeAddress{}
 
-			var nodeIPType v1.NodeAddressType
+			nodeIPTypes := make(map[v1.NodeAddressType]bool)
 			for _, nodeAddress := range nodeAddresses {
 				if nodeAddress.Address == kl.nodeIP.String() {
 					enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
-					nodeIPType = nodeAddress.Type
-					break
+					nodeIPTypes[nodeAddress.Type] = true
 				}
 			}
 			if len(enforcedNodeAddresses) > 0 {
 				for _, nodeAddress := range nodeAddresses {
-					if nodeAddress.Type != nodeIPType && nodeAddress.Type != v1.NodeHostName {
+					if !nodeIPTypes[nodeAddress.Type] && nodeAddress.Type != v1.NodeHostName {
 						enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
 					}
 				}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_node_status_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_node_status_test.go
@@ -187,6 +187,8 @@ func TestNodeStatusWithCloudProviderNodeIP(t *testing.T) {
 			name:   "InternalIP and ExternalIP are the same",
 			nodeIP: net.ParseIP("55.55.55.55"),
 			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
+				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
 				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
 				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},


### PR DESCRIPTION
In 3.11 and later, nodeIP determination breaks under vSphere if you have many IP addresses on a node (eg due to router HA or egress IPs)

Backport of #21807, however that is blocked waiting for the 1.12 rebase, so this could potentially be committed now...
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1666820
