### PR TITLE
oc adm release new doesn't replace correctly for leading characters

### DIFF
--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -190,7 +190,7 @@ func NopManifestMapper(data []byte) ([]byte, error) {
 // patternImageFormat attempts to match a docker pull spec by prefix (%s) and capture the
 // prefix and either a tag or digest. It requires leading and trailing whitespace, quotes, or
 // end of file.
-const patternImageFormat = `([\s\"\']|^)(%s)(:[\w][\w.-]{0,127}|@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{2,})?([\s"']|$)`
+const patternImageFormat = `([\W]|^)(%s)(:[\w][\w.-]{0,127}|@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{2,})?([\s"']|$)`
 
 func NewImageMapper(images map[string]ImageReference) (ManifestMapper, error) {
 	repositories := make([]string, 0, len(images))

--- a/pkg/oc/cli/admin/release/image_mapper_test.go
+++ b/pkg/oc/cli/admin/release/image_mapper_test.go
@@ -97,6 +97,42 @@ func TestNewImageMapper(t *testing.T) {
 			output: "image: quay.io/openshift/origin-etcd@sha256:1234",
 		},
 		{
+			name: "replace with digest on a multi-line file with quotes and newlines",
+			args: args{
+				images: map[string]ImageReference{
+					"etcd": {
+						SourceRepository: "quay.io/openshift/origin-prometheus:latest",
+						TargetPullSpec:   "quay.io/openshift/origin-prometheus@sha256:1234",
+					},
+				},
+			},
+			input: `
+	- "-images=prometheus=quay.io/openshift/origin-prometheus:latest"
+	- "-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest"
+`,
+			output: `
+	- "-images=prometheus=quay.io/openshift/origin-prometheus@sha256:1234"
+	- "-images=alertmanager=quay.io/openshift/origin-prometheus-alertmanager:latest"
+`,
+		},
+		{
+			name: "replace with digest on a multi-line file with quotes and newlines",
+			args: args{
+				images: map[string]ImageReference{
+					"etcd": {
+						SourceRepository: "quay.io/openshift/origin-prometheus:latest",
+						TargetPullSpec:   "quay.io/openshift/origin-prometheus@sha256:1234",
+					},
+				},
+			},
+			input: `
+	- "quay.io/openshift/origin-prometheus:latest"
+`,
+			output: `
+	- "quay.io/openshift/origin-prometheus@sha256:1234"
+`,
+		},
+		{
 			name: "replace bare repository when told to do so",
 			args: args{
 				images: map[string]ImageReference{


### PR DESCRIPTION
cluster monitoring operator was using an equals sign as the preceeding
character for an image which the regex didn't grab. Use `\W` to identify
the leading char instead.