### PR TITLE
Use simple builder for --from-file build test

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -163,7 +163,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 
 				g.It("should accept --from-file as input", func() {
 					g.By("starting the build with a Dockerfile")
-					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfile))
+					br, err := exutil.StartBuildAndWait(oc, "simple-build", fmt.Sprintf("--from-file=%s", exampleGemfile))
 					br.AssertSuccess()
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -171,7 +171,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("Uploading file"))
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("as binary input for the build ..."))
-					o.Expect(buildLog).To(o.ContainSubstring("Your bundle is complete"))
+					o.Expect(buildLog).To(o.ContainSubstring("assembled!"))
 				})
 
 				g.It("should accept --from-dir as input", func() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -2970,7 +2970,40 @@ items:
     nodeSelector: 
   status:
     lastVersion: 0
-`)
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: simple-build
+    creationTimestamp: 
+  spec:
+    triggers:
+    - type: ImageChange
+      imageChange: {}
+    - type: Generic
+      generic:
+        secret: "mysecret"
+        secretReference: 
+          name: "webhooksecret"
+    source:
+      type: Git
+      git:
+        uri: git://github.com/openshift/ruby-hello-world.git
+    strategy:
+      type: Source
+      sourceStrategy:
+        env:
+        - name: FOO
+          value: test
+        - name: BAR
+          value: test
+        - name: BUILD_LOGLEVEL
+          value: '5'
+        from:
+          kind: DockerImage
+          name: docker.io/openshift/test-build-simples2i:latest
+    resources: {}
+  status:
+    lastVersion: 0`)
 
 func testExtendedTestdataBuildsTestBuildYamlBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsTestBuildYaml, nil

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -223,3 +223,37 @@ items:
     nodeSelector: 
   status:
     lastVersion: 0
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: simple-build
+    creationTimestamp: 
+  spec:
+    triggers:
+    - type: ImageChange
+      imageChange: {}
+    - type: Generic
+      generic:
+        secret: "mysecret"
+        secretReference: 
+          name: "webhooksecret"
+    source:
+      type: Git
+      git:
+        uri: git://github.com/openshift/ruby-hello-world.git
+    strategy:
+      type: Source
+      sourceStrategy:
+        env:
+        - name: FOO
+          value: test
+        - name: BAR
+          value: test
+        - name: BUILD_LOGLEVEL
+          value: '5'
+        from:
+          kind: DockerImage
+          name: docker.io/openshift/test-build-simples2i:latest
+    resources: {}
+  status:
+    lastVersion: 0


### PR DESCRIPTION
As an alternative to https://github.com/openshift/ruby-hello-world/pull/78, so we un-break build tests.