### PR TITLE
`oc adm upgrade` should allow a user to clear their requested version

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -5296,6 +5296,8 @@ _oc_adm_upgrade()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--clear")
+    local_nonpersistent_flags+=("--clear")
     flags+=("--force")
     local_nonpersistent_flags+=("--force")
     flags+=("--to=")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -5438,6 +5438,8 @@ _oc_adm_upgrade()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--clear")
+    local_nonpersistent_flags+=("--clear")
     flags+=("--force")
     local_nonpersistent_flags+=("--force")
     flags+=("--to=")


### PR DESCRIPTION
The current CV object allows you to cancel your upgrade if the payload
has not yet been downloaded and the new CVO image applied (at that point
you're committed to moving to that new version). Add a flag on the
upgrade command that gives a user a way to do this if for instance they
request a version that doesn't exist (payload can't be downloaded) but
don't call it cancel because it's not really going to abort an inprogress
update. Instead, call it `clear` to indicate you are clearing your
desired status.