### PR TITLE
no longer validate existence of wildfly imagestream as part of switch…

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -53,7 +53,7 @@ const nfsPrefix = "nfs-"
 
 // WaitForOpenShiftNamespaceImageStreams waits for the standard set of imagestreams to be imported
 func WaitForOpenShiftNamespaceImageStreams(oc *CLI) error {
-	langs := []string{"ruby", "nodejs", "perl", "php", "python", "wildfly", "mysql", "postgresql", "mongodb", "jenkins"}
+	langs := []string{"ruby", "nodejs", "perl", "php", "python", "mysql", "postgresql", "mongodb", "jenkins"}
 	scan := func() bool {
 		for _, lang := range langs {
 			e2e.Logf("Checking language %v \n", lang)
@@ -96,7 +96,7 @@ func WaitForOpenShiftNamespaceImageStreams(oc *CLI) error {
 // imagestreams from the OpenShift namespace
 func CheckOpenShiftNamespaceImageStreams(oc *CLI) {
 	missing := false
-	langs := []string{"ruby", "nodejs", "perl", "php", "python", "wildfly", "mysql", "postgresql", "mongodb", "jenkins"}
+	langs := []string{"ruby", "nodejs", "perl", "php", "python", "mysql", "postgresql", "mongodb", "jenkins"}
 	for _, lang := range langs {
 		_, err := oc.ImageClient().Image().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
/assign @bparees 

image_ecosystem passed locally for me with this change and https://github.com/openshift/cluster-samples-operator/pull/81 deployed of my AWS cluster