### PR TITLE
Escape newlines in monitor events for all code paths

### DIFF
--- a/pkg/monitor/cmd.go
+++ b/pkg/monitor/cmd.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -61,8 +60,7 @@ func (opt *Options) Run() error {
 					if !event.From.Equal(event.To) {
 						continue
 					}
-					// make sure the message ends up on a single line.  Something about the way we collect logs wants this.
-					fmt.Fprintln(opt.Out, strings.Replace(event.String(), "\n", "\\n", -1))
+					fmt.Fprintln(opt.Out, event.String())
 				}
 				last = events[len(events)-1].From
 			}

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -8,6 +8,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
+func TestMonitor_Newlines(t *testing.T) {
+	evt := &Event{Condition: Condition{Message: "a\nb\n"}}
+	expected := "Jan 01 00:00:00.000 I  a\\nb\\n"
+	if evt.String() != expected {
+		t.Fatalf("unexpected:\n%s\n%s", expected, evt.String())
+	}
+}
+
 func TestMonitor_Events(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -40,7 +41,7 @@ type Event struct {
 }
 
 func (e *Event) String() string {
-	return fmt.Sprintf("%s.%03d %s %s %s", e.At.Format("Jan 02 15:04:05"), e.At.Nanosecond()/1000000, eventString[e.Level], e.Locator, e.Message)
+	return fmt.Sprintf("%s.%03d %s %s %s", e.At.Format("Jan 02 15:04:05"), e.At.Nanosecond()/1000000, eventString[e.Level], e.Locator, strings.Replace(e.Message, "\n", "\\n", -1))
 }
 
 type sample struct {
@@ -64,9 +65,9 @@ type EventInterval struct {
 
 func (i *EventInterval) String() string {
 	if i.From.Equal(i.To) {
-		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), eventString[i.Level], i.Locator, i.Message)
+		return fmt.Sprintf("%s.%03d %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 	}
-	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(i.To.Sub(i.From)/time.Second))+"s", eventString[i.Level], i.Locator, i.Message)
+	return fmt.Sprintf("%s.%03d - %-5s %s %s %s", i.From.Format("Jan 02 15:04:05"), i.From.Nanosecond()/int(time.Millisecond), strconv.Itoa(int(i.To.Sub(i.From)/time.Second))+"s", eventString[i.Level], i.Locator, strings.Replace(i.Message, "\n", "\\n", -1))
 }
 
 type EventIntervals []*EventInterval


### PR DESCRIPTION
The previous code wasn't all the places where events are output.