### PR TITLE
test, deployments: do not use logs -f

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -329,9 +329,9 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(dc.Name).To(o.Equal(dcName))
 			e2e.Logf("created DC, creationTimestamp: %v", dc.CreationTimestamp)
 
-			o.Expect(waitForLatestCondition(oc, "deployment-test", deploymentRunTimeout, deploymentRunning)).NotTo(o.HaveOccurred())
+			o.Expect(waitForLatestCondition(oc, "deployment-test", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 
-			out, err := oc.Run("logs").Args("-f", "dc/deployment-test").Output()
+			out, err := oc.Run("logs").Args("pod/deployment-test-1-deploy").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			e2e.Logf("oc logs finished")
 
@@ -370,7 +370,10 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 					defer g.GinkgoRecover()
 					defer close(rolloutCompleteWithLogs)
 					var err error
-					out, err = waitForDeployerToComplete(oc, fmt.Sprintf("deployment-test-%d", rolloutNumber), deploymentRunTimeout)
+					dcName := fmt.Sprintf("deployment-test-%d", rolloutNumber)
+					_, err = waitForDeployerToComplete(oc, dcName, deploymentRunTimeout)
+					o.Expect(err).NotTo(o.HaveOccurred())
+					out, err = oc.Run("logs").Args(fmt.Sprintf("pod/%s-deploy", dcName)).Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
 				}(i + 2) // we already did 2 rollouts previously.
 
@@ -594,9 +597,9 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(dc.Name).To(o.Equal(dcName))
 			e2e.Logf("created DC, creationTimestamp: %v", dc.CreationTimestamp)
 
-			o.Expect(waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentRunning)).NotTo(o.HaveOccurred())
+			o.Expect(waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 
-			out, err := oc.Run("logs").Args("--follow", "dc/custom-deployment").Output()
+			out, err := oc.Run("logs").Args("pod/custom-deployment-1-deploy").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			e2e.Logf("oc logs finished")
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -4937,11 +4937,11 @@ spec:
       - -c
       - |
         set -e
+        sleep 15  # give tests time to set up
         openshift-deploy --until=50%
         echo Halfway
         openshift-deploy
         echo Finished
-        sleep 15  # give tests time to observe logs
   template:
     metadata:
       labels:
@@ -5757,8 +5757,8 @@ spec:
           - /bin/bash
           - -c
           - |
+            sleep 15  # give tests time to setup
             echo 'test pre hook executed'
-            sleep 15  # give tests time to record logs
   template:
     metadata:
       labels:

--- a/test/extended/testdata/deployments/custom-deployment.yaml
+++ b/test/extended/testdata/deployments/custom-deployment.yaml
@@ -22,11 +22,11 @@ spec:
       - -c
       - |
         set -e
+        sleep 15  # give tests time to set up
         openshift-deploy --until=50%
         echo Halfway
         openshift-deploy
         echo Finished
-        sleep 15  # give tests time to observe logs
   template:
     metadata:
       labels:

--- a/test/extended/testdata/deployments/test-deployment-test.yaml
+++ b/test/extended/testdata/deployments/test-deployment-test.yaml
@@ -17,8 +17,8 @@ spec:
           - /bin/bash
           - -c
           - |
+            sleep 15  # give tests time to setup
             echo 'test pre hook executed'
-            sleep 15  # give tests time to record logs
   template:
     metadata:
       labels:


### PR DESCRIPTION
this might address some flakes we are seeing when using logs -f and
excessive iops.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>