### PR TITLE
oc adm release new should prefer openshift scoped git labels

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -682,14 +682,12 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 					labels = imageConfig.Config.Labels
 				}
 
-				if len(labels["vcs-ref"]) > 0 {
-					if tag.Annotations == nil {
-						tag.Annotations = make(map[string]string)
-					}
-					tag.Annotations["io.openshift.build.commit.id"] = labels["vcs-ref"]
-					tag.Annotations["io.openshift.build.commit.ref"] = labels["io.openshift.build.commit.ref"]
-					tag.Annotations["io.openshift.build.source-location"] = labels["vcs-url"]
+				if tag.Annotations == nil {
+					tag.Annotations = make(map[string]string)
 				}
+				tag.Annotations["io.openshift.build.commit.id"] = labels["io.openshift.build.commit.id"]
+				tag.Annotations["io.openshift.build.commit.ref"] = labels["io.openshift.build.commit.ref"]
+				tag.Annotations["io.openshift.build.source-location"] = labels["io.openshift.build.source-location"]
 
 				if len(labels["io.openshift.release.operator"]) == 0 {
 					glog.V(2).Infof("Image %s has no io.openshift.release.operator label, skipping", m.ImageRef)


### PR DESCRIPTION
For now we consistently set these throughout our automation. In the
future we can consider adding support for other labels.

OCP releases were showing no version info.