### PR TITLE
Return decoding errors of non-legacy config types

### DIFF
--- a/pkg/cmd/openshift-apiserver/cmd.go
+++ b/pkg/cmd/openshift-apiserver/cmd.go
@@ -106,7 +106,13 @@ func (o *OpenShiftAPIServer) RunAPIServer(stopCh <-chan struct{}) error {
 	utilruntime.Must(openshiftcontrolplanev1.Install(scheme))
 	codecs := serializer.NewCodecFactory(scheme)
 	obj, err := runtime.Decode(codecs.UniversalDecoder(openshiftcontrolplanev1.GroupVersion, configv1.GroupVersion), configContent)
-	if err == nil {
+	switch {
+	case runtime.IsMissingVersion(err): // fall through to legacy master config
+	case runtime.IsMissingKind(err): // fall through to legacy master config
+	case runtime.IsNotRegisteredError(err): // fall through to legacy master config
+	case err != nil:
+		return err
+	case err == nil:
 		// Resolve relative to CWD
 		absoluteConfigFile, err := api.MakeAbs(o.ConfigFile, "")
 		if err != nil {


### PR DESCRIPTION
Only fall through in case of missing kind, missing version or unknown gvk.