### PR TITLE
Add stubs for Authentication and OAuth validation

### DIFF
--- a/pkg/admission/customresourcevalidation/authentication/OWNERS
+++ b/pkg/admission/customresourcevalidation/authentication/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - enj
+  - ericavonb
+  - mrogers950
+  - sallyom
+  - stlaz
+approvers:
+  - enj

--- a/pkg/admission/customresourcevalidation/authentication/validate_authentication.go
+++ b/pkg/admission/customresourcevalidation/authentication/validate_authentication.go
@@ -1,0 +1,110 @@
+package authentication
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation"
+)
+
+const PluginName = "config.openshift.io/ValidateAuthentication"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return customresourcevalidation.NewValidator(
+			map[schema.GroupResource]bool{
+				configv1.GroupVersion.WithResource("authentications").GroupResource(): true,
+			},
+			map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+				configv1.GroupVersion.WithKind("Authentication"): authenticationV1{},
+			})
+	})
+}
+
+func toAuthenticationV1(uncastObj runtime.Object) (*configv1.Authentication, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	errs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*configv1.Authentication)
+	if !ok {
+		return nil, append(errs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"Authentication"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{"config.openshift.io/v1"}))
+	}
+
+	return obj, nil
+}
+
+type authenticationV1 struct{}
+
+func (authenticationV1) ValidateCreate(uncastObj runtime.Object) field.ErrorList {
+	obj, errs := toAuthenticationV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, customresourcevalidation.RequireNameCluster, field.NewPath("metadata"))...)
+	errs = append(errs, validateAuthenticationSpec(obj.Spec)...)
+
+	return errs
+}
+
+func (authenticationV1) ValidateUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toAuthenticationV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toAuthenticationV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	errs = append(errs, validateAuthenticationSpec(obj.Spec)...)
+
+	return errs
+}
+
+func (authenticationV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toAuthenticationV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toAuthenticationV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// TODO validate the obj.  remember that status validation should *never* fail on spec validation errors.
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	errs = append(errs, validateAuthenticationStatus(obj.Status)...)
+
+	return errs
+}
+
+func validateAuthenticationSpec(spec configv1.AuthenticationSpec) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// TODO
+
+	return errs
+}
+
+func validateAuthenticationStatus(status configv1.AuthenticationStatus) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// TODO
+
+	return errs
+}

--- a/pkg/admission/customresourcevalidation/customresourcevalidationregistration/OWNERS
+++ b/pkg/admission/customresourcevalidation/customresourcevalidationregistration/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - deads2k
+  - enj
+  - mfojtik
+approvers:
+  - deads2k
+  - mfojtik

--- a/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -8,8 +8,8 @@ import (
 
 // AllCustomResourceValidators are the names of all custom resource validators that should be registered
 var AllCustomResourceValidators = []string{
-	"config.openshift.io/ValidateImage",
-	"config.openshift.io/ValidateProject",
+	image.PluginName,
+	project.PluginName,
 }
 
 func RegisterCustomResourceValidation(plugins *admission.Plugins) {

--- a/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -5,18 +5,21 @@ import (
 
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/authentication"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/image"
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation/oauth"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/project"
 )
 
 // AllCustomResourceValidators are the names of all custom resource validators that should be registered
 var AllCustomResourceValidators = []string{
-	image.PluginName,
-	project.PluginName,
 	authentication.PluginName,
+	image.PluginName,
+	oauth.PluginName,
+	project.PluginName,
 }
 
 func RegisterCustomResourceValidation(plugins *admission.Plugins) {
-	image.Register(plugins)
-	project.Register(plugins)
 	authentication.Register(plugins)
+	image.Register(plugins)
+	oauth.Register(plugins)
+	project.Register(plugins)
 }

--- a/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -1,18 +1,22 @@
 package customresourcevalidationregistration
 
 import (
+	"k8s.io/apiserver/pkg/admission"
+
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation/authentication"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/image"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/project"
-	"k8s.io/apiserver/pkg/admission"
 )
 
 // AllCustomResourceValidators are the names of all custom resource validators that should be registered
 var AllCustomResourceValidators = []string{
 	image.PluginName,
 	project.PluginName,
+	authentication.PluginName,
 }
 
 func RegisterCustomResourceValidation(plugins *admission.Plugins) {
 	image.Register(plugins)
 	project.Register(plugins)
+	authentication.Register(plugins)
 }

--- a/pkg/admission/customresourcevalidation/image/OWNERS
+++ b/pkg/admission/customresourcevalidation/image/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - bparees
+  - legionus
+  - dmage
+  - coreydaley
+approvers:
+  - bparees

--- a/pkg/admission/customresourcevalidation/image/validate_image.go
+++ b/pkg/admission/customresourcevalidation/image/validate_image.go
@@ -14,9 +14,11 @@ import (
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation"
 )
 
+const PluginName = "config.openshift.io/ValidateImage"
+
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
-	plugins.Register("config.openshift.io/ValidateImage", func(config io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		return customresourcevalidation.NewValidator(
 			map[schema.GroupResource]bool{
 				configv1.Resource("images"): true,

--- a/pkg/admission/customresourcevalidation/oauth/OWNERS
+++ b/pkg/admission/customresourcevalidation/oauth/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - enj
+  - ericavonb
+  - mrogers950
+  - sallyom
+  - stlaz
+approvers:
+  - enj

--- a/pkg/admission/customresourcevalidation/oauth/validate_oauth.go
+++ b/pkg/admission/customresourcevalidation/oauth/validate_oauth.go
@@ -1,0 +1,110 @@
+package oauth
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation"
+)
+
+const PluginName = "config.openshift.io/ValidateOAuth"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return customresourcevalidation.NewValidator(
+			map[schema.GroupResource]bool{
+				configv1.GroupVersion.WithResource("oauths").GroupResource(): true,
+			},
+			map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+				configv1.GroupVersion.WithKind("OAuth"): oauthV1{},
+			})
+	})
+}
+
+func toOAuthV1(uncastObj runtime.Object) (*configv1.OAuth, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	errs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*configv1.OAuth)
+	if !ok {
+		return nil, append(errs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"OAuth"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{"config.openshift.io/v1"}))
+	}
+
+	return obj, nil
+}
+
+type oauthV1 struct{}
+
+func (oauthV1) ValidateCreate(uncastObj runtime.Object) field.ErrorList {
+	obj, errs := toOAuthV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, customresourcevalidation.RequireNameCluster, field.NewPath("metadata"))...)
+	errs = append(errs, validateOAuthSpec(obj.Spec)...)
+
+	return errs
+}
+
+func (oauthV1) ValidateUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toOAuthV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toOAuthV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	errs = append(errs, validateOAuthSpec(obj.Spec)...)
+
+	return errs
+}
+
+func (oauthV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toOAuthV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toOAuthV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// TODO validate the obj.  remember that status validation should *never* fail on spec validation errors.
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	errs = append(errs, validateOAuthStatus(obj.Status)...)
+
+	return errs
+}
+
+func validateOAuthSpec(spec configv1.OAuthSpec) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// TODO
+
+	return errs
+}
+
+func validateOAuthStatus(status configv1.OAuthStatus) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// TODO
+
+	return errs
+}

--- a/pkg/admission/customresourcevalidation/project/OWNERS
+++ b/pkg/admission/customresourcevalidation/project/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - enj
+  - ericavonb
+  - mrogers950
+  - sallyom
+  - stlaz
+approvers:
+  - enj

--- a/pkg/admission/customresourcevalidation/project/validate_project.go
+++ b/pkg/admission/customresourcevalidation/project/validate_project.go
@@ -15,9 +15,11 @@ import (
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation"
 )
 
+const PluginName = "config.openshift.io/ValidateProject"
+
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
-	plugins.Register("config.openshift.io/ValidateProject", func(config io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		return customresourcevalidation.NewValidator(
 			map[schema.GroupResource]bool{
 				configv1.Resource("projects"): true,


### PR DESCRIPTION
Use consts for custom resource validators plugin names

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add boilerplate for Authentication validation

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Add boilerplate for OAuth validation

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

@openshift/sig-auth @openshift/sig-master 

This is a no-op change to get the validation scaffolding in place.