### PR TITLE
Reject delete for all top level config

### DIFF
--- a/pkg/admission/customresourcevalidation/customresourcevalidator.go
+++ b/pkg/admission/customresourcevalidation/customresourcevalidator.go
@@ -27,7 +27,7 @@ type validateCustomResource struct {
 
 func NewValidator(resources map[schema.GroupResource]bool, validators map[schema.GroupVersionKind]ObjectValidator) (admission.Interface, error) {
 	return &validateCustomResource{
-		Handler:    admission.NewHandler(admission.Create, admission.Update),
+		Handler:    admission.NewHandler(admission.Create, admission.Update, admission.Delete),
 		resources:  resources,
 		validators: validators,
 	}, nil
@@ -78,6 +78,9 @@ func (a *validateCustomResource) Validate(uncastAttributes admission.Attributes)
 		default:
 			return admission.NewForbidden(attributes, fmt.Errorf("unhandled subresource: %v", attributes.GetSubresource()))
 		}
+
+	case admission.Delete:
+		return apierrors.NewMethodNotSupported(attributes.GetResource().GroupResource(), "delete")
 
 	default:
 		return admission.NewForbidden(attributes, fmt.Errorf("unhandled operation: %v", attributes.GetOperation()))


### PR DESCRIPTION
This change updates the custom resource validator to disallow delete operations.  This makes it impossible to delete top level configs that have registered a custom validator.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/hold

This is a straw man to start discussion around if it makes sense to allow or disallow deleting these singleton resources.

@openshift/sig-auth @openshift/sig-master @openshift/api-reviewers 