### PR TITLE
Optimize annotating tests with labels, make test suite debuggable

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -22,7 +22,6 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 		"installplans", "operatorgroups", "subscriptions",
 	}
 
-	g.By("list OLM resources which are necessary for OLM to run properly")
 	for i := range olmResources {
 		g.It("list "+olmResources[i], func() {
 			var resourceList map[string]interface{}


### PR DESCRIPTION
Using regexp for non-regexp matches was overkill, so we can do Contains()
matches more efficiently for the vast majority of labels.

Ensure the test suite is properly profiling cmd_runtest (calling os.Exit()
prevents trace results from being captured on failing or skipped tests).

Reduces total CPU significantly to where it's a small fraction of an
overall run.

@soltysh this is one half of the change