### PR TITLE
Deployment test is too aggressive on start timing

### DIFF
--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -205,7 +205,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By(fmt.Sprintf("by checking that the deployment config has the correct version"))
-			err = wait.PollImmediate(500*time.Millisecond, 5*time.Second, func() (bool, error) {
+			err = wait.PollImmediate(500*time.Millisecond, time.Minute, func() (bool, error) {
 				dc, _, _, err := deploymentInfo(oc, dc.Name)
 				if err != nil {
 					return false, nil
@@ -215,7 +215,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By(fmt.Sprintf("by checking that the second deployment exists"))
-			err = wait.PollImmediate(500*time.Millisecond, 50*time.Second, func() (bool, error) {
+			err = wait.PollImmediate(500*time.Millisecond, time.Minute, func() (bool, error) {
 				_, rcs, _, err := deploymentInfo(oc, dcName)
 				if err != nil {
 					return false, nil
@@ -234,7 +234,7 @@ var _ = g.Describe("[Feature:DeploymentConfig] deploymentconfigs", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By(fmt.Sprintf("by checking that the first deployer was deleted and the second deployer exists"))
-			err = wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+			err = wait.PollImmediate(500*time.Millisecond, time.Minute, func() (bool, error) {
 				_, _, pods, err := deploymentInfo(oc, dcName)
 				if err != nil {
 					return false, nil


### PR DESCRIPTION
We waited 5s, but lots of things can prevent this from happening
in under 10s. Set a longer timeout consistently through the test.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_telemeter/118/pull-ci-openshift-telemeter-master-e2e-aws/41#openshift-tests-featuredeploymentconfig-deploymentconfigs-when-run-iteratively-conformance-should-immediately-start-a-new-deployment-suiteopenshiftconformanceparallelminimal