### PR TITLE
handle named certificates with no explicit names

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags.go
@@ -326,7 +326,11 @@ func admissionFlags(admissionPluginConfig map[string]configv1.AdmissionPluginCon
 func sniCertKeys(namedCertificates []configv1.NamedCertificate) []string {
 	args := []string{}
 	for _, nc := range namedCertificates {
-		args = append(args, fmt.Sprintf("%s,%s:%s", nc.CertFile, nc.KeyFile, strings.Join(nc.Names, ",")))
+		names := ""
+		if len(nc.Names) > 0 {
+			names = ":" + strings.Join(nc.Names, ",")
+		}
+		args = append(args, fmt.Sprintf("%s,%s%s", nc.CertFile, nc.KeyFile, names))
 	}
 	return args
 }

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags_test.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags_test.go
@@ -1,0 +1,25 @@
+package openshiftkubeapiserver
+
+import (
+	"github.com/openshift/api/config/v1"
+	"testing"
+)
+
+func TestSNICertKeys(t *testing.T) {
+	testCases := []struct {
+		names    []string
+		expected string
+	}{
+		{names: []string{"foo"}, expected: "secret.crt,secret.key:foo"},
+		{names: []string{"foo", "bar"}, expected: "secret.crt,secret.key:foo,bar"},
+		{expected: "secret.crt,secret.key"},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			result := sniCertKeys([]v1.NamedCertificate{{Names: tc.names, CertInfo: v1.CertInfo{CertFile: "secret.crt", KeyFile: "secret.key"}}})
+			if len(result) != 1 || result[0] != tc.expected {
+				t.Errorf("expected: %v, actual: %v", []string{tc.expected}, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When building the command line for kube-apiserver, named certificates without explicit names defined (names are optional) result in a malformed `--tls-sni-cert-key` command line option.