### PR TITLE
WIP: kube-aggregator: become unhealthy when causing flapping

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -203,6 +203,9 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		go availableController.Run(5, context.StopCh)
 		return nil
 	})
+	if err := s.GenericAPIServer.AddHealthzChecks(availableController); err != nil {
+		return err
+	}
 
 	if openApiConfig != nil {
 		specDownloader := openapicontroller.NewDownloader()

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
@@ -35,9 +35,17 @@ var (
 		},
 		[]string{"name"},
 	)
+	unavailableFlapping = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aggregator_unavailable_flapping_apiservice_count",
+			Help: "Counter of flapping events broken down by APIService name.",
+		},
+		[]string{"name"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(unavailableCounter)
 	prometheus.MustRegister(unavailableGauge)
+	prometheus.MustRegister(unavailableFlapping)
 }


### PR DESCRIPTION
This PR marks the kube-apiserver as unhealthy when it realized that itself causes flapping availability of APIServices.

It is unclear whether we need a higher barrier before marking ourself unhealthy. Also if multiple APIServices flap caused by different instances, all kube-apiservers could become unhealthy at once.

This is some kind of circuit breaker.