### PR TITLE
builds - Generate Registry Configurations

### DIFF
--- a/pkg/build/controller/strategy/util.go
+++ b/pkg/build/controller/strategy/util.go
@@ -385,10 +385,10 @@ func updateConfigsForContainer(c corev1.Container, volumeName string, configDir 
 		},
 	)
 	// registries.conf is the primary registry config file mounted in by OpenShift
-	registriesConfPath := filepath.Join(configDir, "registries.conf")
+	registriesConfPath := filepath.Join(configDir, buildutil.RegistryConfKey)
 
 	// policy.json sets image policies for buildah (allowed repositories for image pull/push, etc.)
-	signaturePolicyPath := filepath.Join(configDir, "policy.json")
+	signaturePolicyPath := filepath.Join(configDir, buildutil.SignaturePolicyKey)
 
 	// registries.d is a directory used by buildah to support multiple registries.conf files
 	// currently not created/managed by OpenShift

--- a/pkg/build/controller/strategy/util_test.go
+++ b/pkg/build/controller/strategy/util_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"unsafe"
@@ -402,6 +403,30 @@ func TestSetupBuildSystem(t *testing.T) {
 		}
 		if !foundMount {
 			t.Errorf("registry config was not mounted into container %s", c.Name)
+		}
+		foundRegistriesConf := false
+		foundSignaturePolicy := false
+		for _, env := range c.Env {
+			if env.Name == "BUILD_REGISTRIES_CONF_PATH" {
+				foundRegistriesConf = true
+				expectedMountPath := filepath.Join(ConfigMapBuildSystemConfigsMountPath, util.RegistryConfKey)
+				if env.Value != expectedMountPath {
+					t.Errorf("expected BUILD_REGISTRIES_CONF_PATH %s, got %s", expectedMountPath, env.Value)
+				}
+			}
+			if env.Name == "BUILD_SIGNATURE_POLICY_PATH" {
+				foundSignaturePolicy = true
+				expectedMountMapth := filepath.Join(ConfigMapBuildSystemConfigsMountPath, util.SignaturePolicyKey)
+				if env.Value != expectedMountMapth {
+					t.Errorf("expected BUILD_SIGNATURE_POLICY_PATH %s, got %s", expectedMountMapth, env.Value)
+				}
+			}
+		}
+		if !foundRegistriesConf {
+			t.Errorf("env var %s was not present in container %s", "BUILD_REGISTRIES_CONF_PATH", c.Name)
+		}
+		if !foundSignaturePolicy {
+			t.Errorf("env var %s was not present in container %s", "BUILD_SIGNATURE_POLICY_PATH", c.Name)
 		}
 	}
 }

--- a/pkg/build/util/consts.go
+++ b/pkg/build/util/consts.go
@@ -115,7 +115,7 @@ const (
 	CustomBuildStrategyBaseImageKey = "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE"
 
 	// RegistryConfKey is the ConfigMap key for the build pod's registry configuration file.
-	RegistryConfKey = "registry.conf"
+	RegistryConfKey = "registries.conf"
 
 	// SignaturePolicyKey is the ConfigMap key for the build pod's image signature policy file.
 	SignaturePolicyKey = "policy.json"

--- a/pkg/cmd/openshift-controller-manager/controller/interfaces.go
+++ b/pkg/cmd/openshift-controller-manager/controller/interfaces.go
@@ -78,7 +78,7 @@ func NewControllerContext(
 	if err != nil {
 		return nil, err
 	}
-	configClient, err := configclient.NewForConfig(clientConfig)
+	configClient, err := configclient.NewForConfig(nonProtobufConfig(clientConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (b OpenshiftControllerClientBuilder) OpenshiftConfigClient(name string) (co
 	if err != nil {
 		return nil, err
 	}
-	return configclient.NewForConfig(clientConfig)
+	return configclient.NewForConfig(nonProtobufConfig(clientConfig))
 }
 
 // OpenshiftConfigClientOrDie provides a REST client for the build API.

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -1,0 +1,119 @@
+package builds
+
+import (
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// e2e tests of the build controller configuration.
+// These are tagged [Serial] because each test modifies the cluster-wide build controller config.
+var _ = g.Describe("[Feature:Builds][Serial][Slow] alter builds via cluster configuration", func() {
+	defer g.GinkgoRecover()
+	var (
+		buildFixture           = exutil.FixturePath("testdata", "builds", "test-build.yaml")
+		defaultConfigFixture   = exutil.FixturePath("testdata", "builds", "cluster-config.yaml")
+		blacklistConfigFixture = exutil.FixturePath("testdata", "builds", "cluster-config", "registry-blacklist.yaml")
+		searchConfigFixture    = exutil.FixturePath("testdata", "builds", "cluster-config", "registry-search.yaml")
+		whitelistConfigFixture = exutil.FixturePath("testdata", "builds", "cluster-config", "registry-whitelist.yaml")
+		oc                     = exutil.NewCLI("build-cluster-config", exutil.KubeConfigPath())
+	)
+
+	g.Context("", func() {
+
+		g.BeforeEach(func() {
+			exutil.PreTestDump()
+		})
+
+		g.JustBeforeEach(func() {
+			g.By("waiting for default service account")
+			err := exutil.WaitForServiceAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()), "default")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By("waiting for builder service account")
+			err = exutil.WaitForServiceAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()), "builder")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			oc.Run("create").Args("-f", buildFixture).Execute()
+		})
+
+		g.AfterEach(func() {
+			if g.CurrentGinkgoTestDescription().Failed {
+				exutil.DumpPodStates(oc)
+				exutil.DumpPodLogsStartingWith("", oc)
+				exutil.DumpConfigMapStates(oc)
+			}
+			oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
+		})
+
+		g.Context("registries config context", func() {
+
+			g.It("should default registry search to docker.io for image pulls", func() {
+				g.By("apply default cluster configuration")
+				err := oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				g.By("waiting 1s for build controller configuration to propagate")
+				time.Sleep(1 * time.Second)
+				g.By("starting build sample-build and waiting for success")
+				// Image used by sample-build (centos/ruby-22-centos7) is only available on docker.io
+				br, err := exutil.StartBuildAndWait(oc, "sample-build")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				br.AssertSuccess()
+				g.By("expecting the build logs to indicate docker.io was the default registry")
+				buildLog, err := br.LogsNoTimestamp()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(buildLog).To(o.ContainSubstring("defaulting registry to docker.io"))
+			})
+
+			g.It("can override registry search for image pulls", func() {
+				g.By("apply image search cluster configuration")
+				err := oc.AsAdmin().Run("apply").Args("-f", searchConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				g.By("waiting 1s for build controller configuration to propagate")
+				time.Sleep(1 * time.Second)
+				g.By("starting build sample-build and waiting for failure")
+				br, err := exutil.StartBuildAndWait(oc, "sample-build")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				br.AssertFailure()
+				g.By("expecting the build logs to indicate the image was not found")
+				buildLog, err := br.LogsNoTimestamp()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(buildLog).To(o.ContainSubstring("build error: no such image"))
+			})
+
+			g.It("should allow registries to be blacklisted", func() {
+				g.By("apply blacklist cluster configuration")
+				err := oc.AsAdmin().Run("apply").Args("-f", blacklistConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				g.By("waiting 1s for build controller configuration to propagate")
+				time.Sleep(1 * time.Second)
+				g.By("starting build sample-build-docker-args-preset and waiting for failure")
+				br, err := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				br.AssertFailure()
+				g.By("expecting the build logs to indicate the image was rejected")
+				buildLog, err := br.LogsNoTimestamp()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(buildLog).To(o.ContainSubstring("Source image rejected"))
+			})
+
+			g.It("should allow registries to be whitelisted", func() {
+				g.By("apply whitelist cluster configuration")
+				err := oc.AsAdmin().Run("apply").Args("-f", whitelistConfigFixture).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				g.By("waiting 1s for build controller configuration to propagate")
+				time.Sleep(1 * time.Second)
+				g.By("starting build sample-build-docker-args-preset and waiting for failure")
+				br, err := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				br.AssertFailure()
+				g.By("expecting the build logs to indicate the image was rejected")
+				buildLog, err := br.LogsNoTimestamp()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(buildLog).To(o.ContainSubstring("Source image rejected"))
+			})
+
+		})
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -40,6 +40,10 @@
 // test/extended/testdata/builds/build-timing/test-docker-build.json
 // test/extended/testdata/builds/build-timing/test-is.json
 // test/extended/testdata/builds/build-timing/test-s2i-build.json
+// test/extended/testdata/builds/cluster-config/registry-blacklist.yaml
+// test/extended/testdata/builds/cluster-config/registry-search.yaml
+// test/extended/testdata/builds/cluster-config/registry-whitelist.yaml
+// test/extended/testdata/builds/cluster-config.yaml
 // test/extended/testdata/builds/gradle-pipeline.yaml
 // test/extended/testdata/builds/incremental-auth-build.json
 // test/extended/testdata/builds/s2i-environment-build-app/.s2i/environment
@@ -1783,6 +1787,107 @@ func testExtendedTestdataBuildsBuildTimingTestS2iBuildJson() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/builds/build-timing/test-s2i-build.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml = []byte(`kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  buildDefaults:
+    registriesConfig:
+      blockedRegistries:
+      - docker.io
+      - quay.io
+`)
+
+func testExtendedTestdataBuildsClusterConfigRegistryBlacklistYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml, nil
+}
+
+func testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsClusterConfigRegistryBlacklistYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/cluster-config/registry-blacklist.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsClusterConfigRegistrySearchYaml = []byte(`kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  buildDefaults:
+    registriesConfig:
+      searchRegistries:
+      - badregistry.foo
+`)
+
+func testExtendedTestdataBuildsClusterConfigRegistrySearchYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsClusterConfigRegistrySearchYaml, nil
+}
+
+func testExtendedTestdataBuildsClusterConfigRegistrySearchYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsClusterConfigRegistrySearchYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/cluster-config/registry-search.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml = []byte(`kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  buildDefaults:
+    registriesConfig:
+      allowedRegistries:
+      - quay.io
+`)
+
+func testExtendedTestdataBuildsClusterConfigRegistryWhitelistYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml, nil
+}
+
+func testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsClusterConfigRegistryWhitelistYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/cluster-config/registry-whitelist.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataBuildsClusterConfigYaml = []byte(`kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec: {}
+`)
+
+func testExtendedTestdataBuildsClusterConfigYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsClusterConfigYaml, nil
+}
+
+func testExtendedTestdataBuildsClusterConfigYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsClusterConfigYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/cluster-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -32773,6 +32878,10 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/build-timing/test-docker-build.json": testExtendedTestdataBuildsBuildTimingTestDockerBuildJson,
 	"test/extended/testdata/builds/build-timing/test-is.json": testExtendedTestdataBuildsBuildTimingTestIsJson,
 	"test/extended/testdata/builds/build-timing/test-s2i-build.json": testExtendedTestdataBuildsBuildTimingTestS2iBuildJson,
+	"test/extended/testdata/builds/cluster-config/registry-blacklist.yaml": testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml,
+	"test/extended/testdata/builds/cluster-config/registry-search.yaml": testExtendedTestdataBuildsClusterConfigRegistrySearchYaml,
+	"test/extended/testdata/builds/cluster-config/registry-whitelist.yaml": testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml,
+	"test/extended/testdata/builds/cluster-config.yaml": testExtendedTestdataBuildsClusterConfigYaml,
 	"test/extended/testdata/builds/gradle-pipeline.yaml": testExtendedTestdataBuildsGradlePipelineYaml,
 	"test/extended/testdata/builds/incremental-auth-build.json": testExtendedTestdataBuildsIncrementalAuthBuildJson,
 	"test/extended/testdata/builds/s2i-environment-build-app/.s2i/environment": testExtendedTestdataBuildsS2iEnvironmentBuildAppS2iEnvironment,
@@ -33190,6 +33299,12 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"test-is.json": &bintree{testExtendedTestdataBuildsBuildTimingTestIsJson, map[string]*bintree{}},
 						"test-s2i-build.json": &bintree{testExtendedTestdataBuildsBuildTimingTestS2iBuildJson, map[string]*bintree{}},
 					}},
+					"cluster-config": &bintree{nil, map[string]*bintree{
+						"registry-blacklist.yaml": &bintree{testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml, map[string]*bintree{}},
+						"registry-search.yaml": &bintree{testExtendedTestdataBuildsClusterConfigRegistrySearchYaml, map[string]*bintree{}},
+						"registry-whitelist.yaml": &bintree{testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml, map[string]*bintree{}},
+					}},
+					"cluster-config.yaml": &bintree{testExtendedTestdataBuildsClusterConfigYaml, map[string]*bintree{}},
 					"gradle-pipeline.yaml": &bintree{testExtendedTestdataBuildsGradlePipelineYaml, map[string]*bintree{}},
 					"incremental-auth-build.json": &bintree{testExtendedTestdataBuildsIncrementalAuthBuildJson, map[string]*bintree{}},
 					"s2i-environment-build-app": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/builds/cluster-config.yaml
+++ b/test/extended/testdata/builds/cluster-config.yaml
@@ -1,0 +1,5 @@
+kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec: {}

--- a/test/extended/testdata/builds/cluster-config/registry-blacklist.yaml
+++ b/test/extended/testdata/builds/cluster-config/registry-blacklist.yaml
@@ -1,0 +1,10 @@
+kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  buildDefaults:
+    registriesConfig:
+      blockedRegistries:
+      - docker.io
+      - quay.io

--- a/test/extended/testdata/builds/cluster-config/registry-search.yaml
+++ b/test/extended/testdata/builds/cluster-config/registry-search.yaml
@@ -1,0 +1,9 @@
+kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  buildDefaults:
+    registriesConfig:
+      searchRegistries:
+      - badregistry.foo

--- a/test/extended/testdata/builds/cluster-config/registry-whitelist.yaml
+++ b/test/extended/testdata/builds/cluster-config/registry-whitelist.yaml
@@ -1,0 +1,9 @@
+kind: Build
+apiVersion: config.openshift.io/v1
+metadata:
+  name: cluster
+spec:
+  buildDefaults:
+    registriesConfig:
+      allowedRegistries:
+      - quay.io


### PR DESCRIPTION
Generate `registries.conf` and `policy.json` for builds from the cluster-wide config.