### PR TITLE
openshift-tests will skip printing info about nodes and pods

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -172,6 +172,7 @@ func initProvider(provider string) error {
 		return err
 	}
 	exutil.TestContext.AllowedNotReadyNodes = 100
+	exutil.TestContext.MaxNodesToGather = 0
 
 	exutil.AnnotateTestSuite()
 	exutil.InitTest()

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -37,12 +37,15 @@ os::build::require_clean_tree
 remote="${UPSTREAM_REMOTE:-origin}"
 git fetch ${remote}
 
-if [[ -n "${APPLY_PR_COMMITS-}" ]]; then
-    selector="$(os::build::commit_range $pr ${remote}/${UPSTREAM_BRANCH:-master})"
+if [[ "${1}" == *".."* ]]; then
+  selector=$1
+  pr="TODO"
+elif [[ -n "${APPLY_PR_COMMITS-}" ]]; then
+  selector="$(os::build::commit_range $pr ${remote}/${UPSTREAM_BRANCH:-master})"
 else
-    pr_commit="$(git rev-parse ${remote}/pr/$1)"
-    echo "++ PR merge commit on branch ${UPSTREAM_BRANCH:-master}: ${pr_commit}"
-    selector="${pr_commit}^1..${pr_commit}"
+  pr_commit="$(git rev-parse ${remote}/pr/$1)"
+  echo "++ PR merge commit on branch ${UPSTREAM_BRANCH:-master}: ${pr_commit}"
+  selector="${pr_commit}^1..${pr_commit}"
 fi
 
 if [[ -z "${NO_REBASE-}" ]]; then

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/test_context.go
@@ -92,6 +92,7 @@ type TestContextType struct {
 	GatherLogsSizes                   bool
 	GatherMetricsAfterTest            string
 	GatherSuiteMetricsAfterTest       bool
+	MaxNodesToGather                  int
 	AllowGatheringProfiles            bool
 	// If set to 'true' framework will gather ClusterAutoscaler metrics when gathering them for other components.
 	IncludeClusterAutoscalerMetrics bool
@@ -209,6 +210,7 @@ func RegisterCommonFlags() {
 
 	flag.StringVar(&TestContext.GatherKubeSystemResourceUsageData, "gather-resource-usage", "false", "If set to 'true' or 'all' framework will be monitoring resource usage of system all add-ons in (some) e2e tests, if set to 'master' framework will be monitoring master node only, if set to 'none' of 'false' monitoring will be turned off.")
 	flag.BoolVar(&TestContext.GatherLogsSizes, "gather-logs-sizes", false, "If set to true framework will be monitoring logs sizes on all machines running e2e tests.")
+	flag.IntVar(&TestContext.MaxNodesToGather, "max-nodes-to-gather-from", 20, "The maximum number of nodes to gather extended info from on test failure.")
 	flag.StringVar(&TestContext.GatherMetricsAfterTest, "gather-metrics-at-teardown", "false", "If set to 'true' framework will gather metrics from all components after each test. If set to 'master' only master component metrics would be gathered.")
 	flag.BoolVar(&TestContext.GatherSuiteMetricsAfterTest, "gather-suite-metrics-at-teardown", false, "If set to true framwork will gather metrics from all components after the whole test suite completes.")
 	flag.BoolVar(&TestContext.AllowGatheringProfiles, "allow-gathering-profiles", true, "If set to true framework will allow to gather CPU/memory allocation pprof profiles from the master.")

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -2476,7 +2476,7 @@ func DumpAllNamespaceInfo(c clientset.Interface, namespace string) {
 	// 1. it takes tens of minutes or hours to grab all of them
 	// 2. there are so many of them that working with them are mostly impossible
 	// So we dump them only if the cluster is relatively small.
-	maxNodesForDump := 20
+	maxNodesForDump := TestContext.MaxNodesToGather
 	if nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{}); err == nil {
 		if len(nodes.Items) <= maxNodesForDump {
 			dumpAllPodInfo(c)


### PR DESCRIPTION
This info was rarely useful and made debugging what actually failed harder
most of the time. The monitor can be used to triage the info as necessary.