### PR TITLE
Fix broken update handling of path-based routes

### DIFF
--- a/pkg/router/controller/hostindex/hostindex.go
+++ b/pkg/router/controller/hostindex/hostindex.go
@@ -101,7 +101,10 @@ func (hi *hostIndex) add(route *routev1.Route, changes *routeChanges) bool {
 			hi.remove(existing, false, changes)
 			// uid changed, which means this is
 		case existing.Spec.Path != route.Spec.Path:
-			// path changed, must check to see if we displace / are displaced by another route
+			// path changed, must check to see if we displace / are displaced by
+			// another route. Remove the existing state to avoid maintaining a
+			// duplicate claim in the index.
+			hi.remove(existing, false, changes)
 		default:
 			// if no changes have been made, we don't need to note a change
 			if existing.ResourceVersion == route.ResourceVersion {

--- a/pkg/router/controller/hostindex/hostindex_test.go
+++ b/pkg/router/controller/hostindex/hostindex_test.go
@@ -233,6 +233,64 @@ func Test_hostIndex(t *testing.T) {
 			},
 			active: map[string][]string{"test.com": {"001"}},
 		},
+		{
+			name:       "multiple changes to same path-based route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{route: newRoute("test", "1", 1, 2, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+				{route: newRoute("test", "1", 1, 3, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{route: newRoute("test", "1", 1, 4, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+				{route: newRoute("test", "1", 1, 5, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+			},
+			active:    map[string][]string{"test.com": {"001"}},
+			activates: map[string]struct{}{"001": {}},
+		},
+		{
+			name:       "remove unchanged path-based route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{remove: true, route: newRoute("test", "1", 0, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+			},
+		},
+		{
+			name:       "remove updated path-based route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{route: newRoute("test", "1", 1, 2, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+				{route: newRoute("test", "1", 1, 3, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{route: newRoute("test", "1", 1, 4, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+				{remove: true, route: newRoute("test", "1", 1, 4, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+			},
+		},
+		{
+			name:       "missed delete of path-based route",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 2, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{route: newRoute("test", "2", 1, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+			},
+			newRoute:  true,
+			active:    map[string][]string{"test.com": {"001"}},
+			activates: map[string]struct{}{"001": {}},
+			displaces: map[string]struct{}{"002": {}},
+			inactive:  map[string][]string{"test.com": {"002"}},
+		},
+		{
+			name:       "path-based route rejection",
+			activateFn: SameNamespace,
+			steps: []step{
+				{route: newRoute("test", "1", 1, 1, routev1.RouteSpec{Host: "test.com", Path: "/x/y/z"})},
+				{route: newRoute("test", "2", 2, 1, routev1.RouteSpec{Host: "test.com", Path: "/foo"})},
+				{route: newRoute("test", "2", 2, 2, routev1.RouteSpec{Host: "test.com", Path: "/bar"})},
+				{route: newRoute("test", "2", 2, 3, routev1.RouteSpec{Host: "test.com", Path: "/x/y/z"})},
+			},
+			active:    map[string][]string{"test.com": {"001"}},
+			displaces: map[string]struct{}{"002": {}},
+			inactive:  map[string][]string{"test.com": {"002"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When an existing route's path is updated to a new value not previously observed,
the new route state is correctly activated, but the previous route is not
replaced in the `hostRules` internal active list. Instead, the updated route
state (with a different path but duplicate UID) is appended to the active list.
A `hostRules` active list with more than one route instance sharing a UID and
host is an invalid internal state. The net effect is some unintended confusing
behavior which manifests when updating the route's path, including:

  * Updating from path A->B->A preventing future transitions to B

  * Updating from path A->B->A->B leaves an orphaned claim on the host in the
namespace, preventing the recreation of the route with either of the previously
observed paths until the router is restarted (causing the internal state to be
rebuilt)

Routes updates which are affected by this bug will be rejected with a status
like:

    message: route foo already exposes foo-ns.os.example.com and is older
    reason: HostAlreadyClaimed

Where `foo` refers to itself. This indicates the route update was rejected due
to a claim made by the same route being updated.

To fix the problem, ensure that when a path change is detected on the same route
the prior existing state is removed from the index, eliminating the possibility
of keeping an orphaned claim. Then add the new route as usual, which handles
acceptance/rejection normally.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1660598