### PR TITLE
Prevent internal OAuth server from running when using external

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -128,7 +128,7 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 		// END ADMISSION
 
 		// HANDLER CHAIN (with oauth server and web console)
-		genericConfig.BuildHandlerChainFunc, postStartHooks, err = BuildHandlerChain(genericConfig, kubeAPIServerConfig.OAuthConfig, kubeAPIServerConfig.UserAgentMatchingConfig, kubeAPIServerConfig.ConsolePublicURL)
+		genericConfig.BuildHandlerChainFunc, postStartHooks, err = BuildHandlerChain(genericConfig, kubeAPIServerConfig.OAuthConfig, kubeAPIServerConfig.AuthConfig, kubeAPIServerConfig.UserAgentMatchingConfig, kubeAPIServerConfig.ConsolePublicURL)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When a valid authConfig.OAuthMetadataFile is set, we should not run the internal OAuth server.  This roughly equates to the master config validation from 3.x which required these to be mutually
exclusive.

Signed-off-by: Monis Khan <mkhan@redhat.com>