### PR TITLE
[WIP] - Bring back a way to run ginkgo directly

### DIFF
--- a/test/extended/run_test.go
+++ b/test/extended/run_test.go
@@ -1,0 +1,23 @@
+/*
+ * This is a file allowing you to run ginkgo manually.
+ */
+
+package extended
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// init initialize the extended testing suite.
+func init() {
+	exutil.InitTest()
+}
+
+func TestExtended(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	exutil.ExecuteTest(t, "Extended")
+}


### PR DESCRIPTION
TODO:
 - [ ] - Add verify path so it at least compiles on PRs
 - [ ] - Investigate if some functions need to be extracted from openshift-tests to share initialization

Comes back from https://github.com/openshift/origin/blob/release-3.11/test/extended/extended_test.go#L49-L55

/cc @smarterclayton 