### PR TITLE
UPSTREAM: 73097: Add NotReady taint to new nodes during admission

### DIFF
--- a/pkg/apiserver/admission/chain_builder.go
+++ b/pkg/apiserver/admission/chain_builder.go
@@ -15,6 +15,7 @@ import (
 	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	expandpvcadmission "k8s.io/kubernetes/plugin/pkg/admission/storage/persistentvolume/resize"
 	storageclassdefaultadmission "k8s.io/kubernetes/plugin/pkg/admission/storage/storageclass/setdefault"
 
@@ -85,6 +86,7 @@ var (
 		"LimitRanger",
 		"ServiceAccount",
 		noderestriction.PluginName,
+		nodetaint.PluginName,
 		"SecurityContextDeny",
 		sccadmission.PluginName,
 		"PodSecurityPolicy",

--- a/pkg/apiserver/admission/config_test.go
+++ b/pkg/apiserver/admission/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/origin/pkg/security/apiserver/admission/sccadmission"
 	"github.com/openshift/origin/pkg/service/admission/externalipranger"
 	"github.com/openshift/origin/pkg/service/admission/restrictedendpoints"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 )
 
 // combinedAdmissionControlPlugins gives the in-order default admission chain for all resources resources.
@@ -53,6 +54,7 @@ var combinedAdmissionControlPlugins = []string{
 	"LimitRanger",
 	"ServiceAccount",
 	noderestriction.PluginName,
+	nodetaint.PluginName,
 	"SecurityContextDeny",
 	sccadmission.PluginName,
 	"PodSecurityPolicy",

--- a/pkg/apiserver/admission/register.go
+++ b/pkg/apiserver/admission/register.go
@@ -9,6 +9,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	kubeapiserver "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	expandpvcadmission "k8s.io/kubernetes/plugin/pkg/admission/storage/persistentvolume/resize"
 	storageclassdefaultadmission "k8s.io/kubernetes/plugin/pkg/admission/storage/storageclass/setdefault"
 
@@ -94,6 +95,7 @@ var (
 		"LimitRanger",
 		"ServiceAccount",
 		noderestriction.PluginName,
+		nodetaint.PluginName,
 		securityadmission.PluginName,
 		"StorageObjectInUseProtection",
 		"SCCExecRestrictions",

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/plugins.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/plugins.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
 	"k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
 	"k8s.io/kubernetes/plugin/pkg/admission/podpreset"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
@@ -73,6 +74,7 @@ var AllOrderedPlugins = []string{
 	limitranger.PluginName,                  // LimitRanger
 	serviceaccount.PluginName,               // ServiceAccount
 	noderestriction.PluginName,              // NodeRestriction
+	nodetaint.PluginName,                    // TaintNodesByCondition
 	alwayspullimages.PluginName,             // AlwaysPullImages
 	imagepolicy.PluginName,                  // ImagePolicyWebhook
 	podsecuritypolicy.PluginName,            // PodSecurityPolicy
@@ -113,6 +115,7 @@ func registerAllAdmissionPlugins(plugins *admission.Plugins) {
 	autoprovision.Register(plugins)
 	exists.Register(plugins)
 	noderestriction.Register(plugins)
+	nodetaint.Register(plugins)
 	label.Register(plugins) // DEPRECATED in favor of NewPersistentVolumeLabelController in CCM
 	podnodeselector.Register(plugins)
 	podpreset.Register(plugins)
@@ -143,6 +146,9 @@ func defaultOffAdmissionPlugins() sets.String {
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodPriority) {
 		defaultOnPlugins.Insert(podpriority.PluginName) //PodPriority
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
+		defaultOnPlugins.Insert(nodetaint.PluginName) //TaintNodesByCondition
 	}
 
 	return sets.NewString(AllOrderedPlugins...).Difference(defaultOnPlugins)

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/nodetaint/admission.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/nodetaint/admission.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetaint
+
+import (
+	"fmt"
+	"io"
+	"k8s.io/apiserver/pkg/admission"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+const (
+	// PluginName is the name of the plugin.
+	PluginName = "TaintNodesByCondition"
+	// TaintNodeNotReady is the not-ready label as specified in the API.
+	TaintNodeNotReady = "node.kubernetes.io/not-ready"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewPlugin(), nil
+	})
+}
+
+// NewPlugin creates a new NodeTaint admission plugin.
+// This plugin identifies requests from nodes
+func NewPlugin() *Plugin {
+	return &Plugin{
+		Handler:  admission.NewHandler(admission.Create),
+		features: utilfeature.DefaultFeatureGate,
+	}
+}
+
+// Plugin holds state for and implements the admission plugin.
+type Plugin struct {
+	*admission.Handler
+	// allows overriding for testing
+	features utilfeature.FeatureGate
+}
+
+var (
+	_ = admission.Interface(&Plugin{})
+)
+
+var (
+	nodeResource = api.Resource("nodes")
+)
+
+// Admit is the main function that checks node identity and adds taints as needed.
+func (p *Plugin) Admit(a admission.Attributes) error {
+	// If TaintNodesByCondition is not enabled, we don't need to do anything.
+	if !p.features.Enabled(features.TaintNodesByCondition) {
+		return nil
+	}
+
+	// Our job is just to taint nodes.
+	if a.GetResource().GroupResource() != nodeResource || a.GetSubresource() != "" {
+		return nil
+	}
+
+	node, ok := a.GetObject().(*api.Node)
+	if !ok {
+		return admission.NewForbidden(a, fmt.Errorf("unexpected type %T", a.GetObject()))
+	}
+
+	// Taint node with NotReady taint at creation if TaintNodesByCondition is
+	// enabled. This is needed to make sure that nodes are added to the cluster
+	// with the NotReady taint. Otherwise, a new node may receive the taint with
+	// some delay causing pods to be scheduled on a not-ready node.
+	// Node controller will remove the taint when the node becomes ready.
+	addNotReadyTaint(node)
+	return nil
+}
+
+func addNotReadyTaint(node *api.Node) {
+	notReadyTaint := api.Taint{
+		Key:    TaintNodeNotReady,
+		Effect: api.TaintEffectNoSchedule,
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.MatchTaint(notReadyTaint) {
+			// the taint already exists.
+			return
+		}
+	}
+	node.Spec.Taints = append(node.Spec.Taints, notReadyTaint)
+}

--- a/vendor/k8s.io/kubernetes/plugin/pkg/admission/nodetaint/admission_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/admission/nodetaint/admission_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetaint
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+var (
+	enableTaintNodesByCondition  = utilfeature.NewFeatureGate()
+	disableTaintNodesByCondition = utilfeature.NewFeatureGate()
+)
+
+func init() {
+	if err := enableTaintNodesByCondition.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.TaintNodesByCondition: {Default: true}}); err != nil {
+		panic(err)
+	}
+	if err := disableTaintNodesByCondition.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.TaintNodesByCondition: {Default: false}}); err != nil {
+		panic(err)
+	}
+}
+
+func Test_nodeTaints(t *testing.T) {
+	var (
+		mynode            = &user.DefaultInfo{Name: "system:node:mynode", Groups: []string{"system:nodes"}}
+		resource          = api.Resource("nodes").WithVersion("v1")
+		notReadyTaint     = api.Taint{Key: TaintNodeNotReady, Effect: api.TaintEffectNoSchedule}
+		notReadyCondition = api.NodeCondition{Type: api.NodeReady, Status: api.ConditionFalse}
+		myNodeObjMeta     = metav1.ObjectMeta{Name: "mynode"}
+		myNodeObj         = api.Node{ObjectMeta: myNodeObjMeta}
+		myTaintedNodeObj  = api.Node{ObjectMeta: myNodeObjMeta,
+			Spec: api.NodeSpec{Taints: []api.Taint{notReadyTaint}}}
+		myUnreadyNodeObj = api.Node{ObjectMeta: myNodeObjMeta,
+			Status: api.NodeStatus{Conditions: []api.NodeCondition{notReadyCondition}}}
+		nodeKind = api.Kind("Node").WithVersion("v1")
+	)
+	tests := []struct {
+		name           string
+		node           api.Node
+		oldNode        api.Node
+		features       utilfeature.FeatureGate
+		operation      admission.Operation
+		expectedTaints []api.Taint
+	}{
+		{
+			name:           "notReady taint is added on creation",
+			node:           myNodeObj,
+			features:       enableTaintNodesByCondition,
+			operation:      admission.Create,
+			expectedTaints: []api.Taint{notReadyTaint},
+		},
+		{
+			name:           "NotReady taint is not added when TaintNodesByCondition is disabled",
+			node:           myNodeObj,
+			features:       disableTaintNodesByCondition,
+			operation:      admission.Create,
+			expectedTaints: nil,
+		},
+		{
+			name:           "already tainted node is not tainted again",
+			node:           myTaintedNodeObj,
+			features:       enableTaintNodesByCondition,
+			operation:      admission.Create,
+			expectedTaints: []api.Taint{notReadyTaint},
+		},
+		{
+			name:           "NotReady taint is added to an unready node as well",
+			node:           myUnreadyNodeObj,
+			features:       enableTaintNodesByCondition,
+			operation:      admission.Create,
+			expectedTaints: []api.Taint{notReadyTaint},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := admission.NewAttributesRecord(&tt.node, &tt.oldNode, nodeKind, myNodeObj.Namespace, myNodeObj.Name, resource, "", tt.operation, false, mynode)
+			c := NewPlugin()
+			if tt.features != nil {
+				c.features = tt.features
+			}
+			err := c.Admit(attributes)
+			if err != nil {
+				t.Errorf("nodePlugin.Admit() error = %v", err)
+			}
+			node, _ := attributes.GetObject().(*api.Node)
+			if !reflect.DeepEqual(node.Spec.Taints, tt.expectedTaints) {
+				t.Errorf("Unexpected Node taints. Got %v\nExpected: %v", node.Spec.Taints, tt.expectedTaints)
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/kubernetes/test/e2e_node/services/apiserver.go
+++ b/vendor/k8s.io/kubernetes/test/e2e_node/services/apiserver.go
@@ -52,7 +52,7 @@ func (a *APIServer) Start() error {
 	}
 	o.ServiceClusterIPRange = *ipnet
 	o.AllowPrivileged = true
-	o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+	o.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount", "TaintNodesByCondition"}
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)


### PR DESCRIPTION
Context:

kube 1.12 has taintnodesbyconditions enabled, we wanted to disable it before this PR landed as there is a race condition between scheduler and node controller - https://github.com/kubernetes/kubernetes/pull/73097. The PR should resolve the issues where we have scheduler trying to schedule pods onto nodes which are in `NotReady` state as now scheduler only looks at taints. 

/cc @sjenning @derekwaynecarr 