### PR TITLE
oc login: use system roots when necessary

### DIFF
--- a/pkg/oc/cli/admin/prune/imageprune/prune.go
+++ b/pkg/oc/cli/admin/prune/imageprune/prune.go
@@ -1659,7 +1659,7 @@ func (p *imageStreamDeleter) NotifyImageStreamPrune(stream *imagev1.ImageStream,
 // provided url. It attempts an https request first; if that fails, it fails
 // back to http.
 func deleteFromRegistry(registryClient *http.Client, url string) error {
-	req, err := http.NewRequest("DELETE", url, nil)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/login/helpers.go
+++ b/pkg/oc/cli/login/helpers.go
@@ -64,7 +64,7 @@ func dialToServer(clientConfig restclient.Config) error {
 	// Do a HEAD request to serverPathToDial to make sure the server is alive.
 	// We don't care about the response, any err != nil is valid for the sake of reachability.
 	serverURLToDial := (&url.URL{Scheme: parsedURL.Scheme, Host: parsedURL.Host, Path: "/"}).String()
-	req, err := http.NewRequest("HEAD", serverURLToDial, nil)
+	req, err := http.NewRequest(http.MethodHead, serverURLToDial, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/login/loginoptions_test.go
+++ b/pkg/oc/cli/login/loginoptions_test.go
@@ -272,12 +272,13 @@ func (r *oauthMetadataResponse) Serialize() ([]byte, error) {
 }
 
 func TestPreserveErrTypeAuthInfo(t *testing.T) {
-	invoked := make(chan struct{}, 2)
+	invoked := make(chan struct{}, 3)
 	oauthResponse := []byte{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case invoked <- struct{}{}:
+			t.Logf("saw %s request for path: %s", r.Method, r.URL.String())
 		default:
 			t.Fatalf("unexpected request handled by test server: %v: %v", r.Method, r.URL)
 		}
@@ -323,7 +324,7 @@ func TestPreserveErrTypeAuthInfo(t *testing.T) {
 	}
 
 	if !kapierrs.IsUnauthorized(err) {
-		t.Fatalf("expecting error of type metav1.StatusReasonUnauthorized, but got %T", err)
+		t.Fatalf("expecting error of type metav1.StatusReasonUnauthorized, but got type %T: %v", err, err)
 	}
 }
 

--- a/pkg/oc/lib/tokencmd/request_token.go
+++ b/pkg/oc/lib/tokencmd/request_token.go
@@ -318,7 +318,7 @@ func oauthTokenFlow(location string) (string, error) {
 // of the challenge flow (an authenticating proxy for example) and not a redirect step in the OAuth flow.
 func oauthCodeFlow(client *osincli.Client, authorizeRequest *osincli.AuthorizeRequest, location string) (string, error) {
 	// Make a request out of the URL since that is what AuthorizeRequest.HandleRequest expects to extract data from
-	req, err := http.NewRequest("GET", location, nil)
+	req, err := http.NewRequest(http.MethodGet, location, nil)
 	if err != nil {
 		return "", err
 	}
@@ -368,7 +368,7 @@ func createOAuthError(errorCode, errorDescription string) error {
 
 func request(rt http.RoundTripper, requestURL string, requestHeaders http.Header) (*http.Response, error) {
 	// Build the request
-	req, err := http.NewRequest("GET", requestURL, nil)
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
oc: http.NewRequest use http.Method* enums

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

oc login: use system roots when necessary

When performing an OAuth flow with an external OAuth server, the use
of system roots may be required (ex: if the OAuth server is using a
route with a valid Let's Encrypt cert).  Combing system roots with
custom CA data only works reliably on Linux style operating systems.
Since oc must work across operating systems, we opt to probe the
OAuth server to determine what CA store to use.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

/assign @mrogers950 