### PR TITLE
release: Allow version strings to be replaced during release creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ check: | build verify
 verify: build
 	# build-tests task has been disabled until we can determine why memory usage is so high
 	{ \
+	hack/verify-generated-versions.sh ||r=1;\
 	hack/verify-gofmt.sh ||r=1;\
 	hack/verify-govet.sh ||r=1;\
 	hack/verify-imports.sh ||r=1;\
@@ -118,6 +119,7 @@ verify-commits:
 # Example:
 #   make update
 update:
+	hack/update-generated-versions.sh
 	hack/update-generated-bindata.sh
 	hack/update-generated-conversions.sh
 	hack/update-generated-clientsets.sh

--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -4756,6 +4756,8 @@ _oc_adm_release_new()
 
     flags+=("--allow-missing-images")
     local_nonpersistent_flags+=("--allow-missing-images")
+    flags+=("--component-versions=")
+    local_nonpersistent_flags+=("--component-versions=")
     flags+=("--dir=")
     local_nonpersistent_flags+=("--dir=")
     flags+=("--dry-run")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -4898,6 +4898,8 @@ _oc_adm_release_new()
 
     flags+=("--allow-missing-images")
     local_nonpersistent_flags+=("--allow-missing-images")
+    flags+=("--component-versions=")
+    local_nonpersistent_flags+=("--component-versions=")
     flags+=("--dir=")
     local_nonpersistent_flags+=("--dir=")
     flags+=("--dry-run")

--- a/hack/update-generated-versions.sh
+++ b/hack/update-generated-versions.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+os::build::setup_env
+
+verify="${VERIFY:-}"
+
+os::build::version::kubernetes_vars
+if [[ "${KUBE_GIT_VERSION}" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+	version_kubernetes=${BASH_REMATCH[1]}
+else
+  os::log::fatal "Unable to find kubernetes version from ${KUBE_GIT_VERSION}"
+fi
+
+for i in ${OS_ROOT}/images/hyperkube/Dockerfile*; do
+  if ! grep -q "io.openshift.build.versions=" "${i}"; then
+    os::log::fatal "$i does not contain an io.openshift.build.versions tag"
+  fi
+  if [[ -n "${verify}" ]]; then
+    diff "${i}" <(sed -Ee "s|(io.openshift.build.versions=).*|\\1\"kubernetes=${version_kubernetes}\"|g" "${i}")
+  else
+    sed -i'' -Ee "s|(io.openshift.build.versions=).*|\\1\"kubernetes=${version_kubernetes}\"|g" "${i}"
+  fi
+done

--- a/hack/verify-generated-versions.sh
+++ b/hack/verify-generated-versions.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+function cleanup() {
+    return_code=$?
+    os::test::junit::generate_report
+    os::util::describe_return_code "${return_code}"
+    exit "${return_code}"
+}
+trap "cleanup" EXIT
+
+os::test::junit::declare_suite_start "verify/versions"
+os::cmd::expect_success "VERIFY=1 ${OS_ROOT}/hack/update-generated-versions.sh"
+os::test::junit::declare_suite_end

--- a/images/hyperkube/Dockerfile
+++ b/images/hyperkube/Dockerfile
@@ -13,4 +13,5 @@ RUN INSTALL_PKGS="origin-hyperkube" && \
 
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
-      io.openshift.tags="openshift,hyperkube"
+      io.openshift.tags="openshift,hyperkube" \
+      io.openshift.build.versions="kubernetes=1.12.4"


### PR DESCRIPTION
Many components need to track important versions in the release payload,
such as the kubernetes version they offer. This change to release
creation from image streams allows images to declare standard versions
that can then be substituted into the release payload at creation time.

Images define the versions they export via a LABEL in their dockerfile

    LABEL io.openshift.build.versions=kubernetes=1.12.4,prometheus=1.3.5

Each key must be alphanumeric with interior dashes, and the value must
be a semantic version. A manifest inside an operator that references
the above image in their image-references can have the following strings
in their manifest substituted:

    0.0.1-snapshot-kubernetes -> 1.12.4
    0.0.1-snapshot-prometheus -> 1.3.5

An additional global reference is supported for the payload version (if
the release image is given a semantic name):

    0.0.1-snapshot -> (value of --name)

An error is returned if the operator image references two different
images with conflicting versions, or if the image label is invalid,
or if no such snapshot version can be found.

The semantic version has any build section (everything after '+')
stripped which should make it safe to use as a manifest name:

    kind: ConfigMap
    apiVersion: v1
    metadata:
      name: input-0.0.1-snapshot-kubernetes

would get the name `input-1.12.4` from the example above.

@deads2k, @crawford, @derekwaynecarr

TODO: still need to add the components to the release metadata