### PR TITLE
Add VIPERCONFIG env var to openshift-tests

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -173,6 +173,7 @@ func initProvider(provider string) error {
 	}
 	exutil.TestContext.AllowedNotReadyNodes = 100
 	exutil.TestContext.MaxNodesToGather = 0
+	exutil.TestContext.Viper = os.Getenv("VIPERCONFIG")
 
 	exutil.AnnotateTestSuite()
 	exutil.InitTest()


### PR DESCRIPTION
openshift-tests removed the ability to pass command line flags to e2e test, on the perf & scale team Cluster Loader is a key tool/test that exists in extended test. In order for it to be functional we need to be able to pass variable configurations into it.

@smarterclayton can you suggest someone to review/approve this, as well as any other tasks to get this in?