### PR TITLE
Revert "Temporarily disable tests requiring kubelet 1.12"

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -407,16 +407,6 @@ var (
 			`should idle the service and DeploymentConfig properly`, // idling with a single service and DeploymentConfig [Conformance]
 
 			`\[Feature:Volumes\]`, // storage team to investigate it post-rebase
-
-			// TODO: the following list of tests is disabled temporarily due to the fact
-			// that we're running kubelet 1.11 and these require 1.12. We will remove them
-			// post-rebase
-			`\[Feature:NodeAuthenticator\]`,
-			`PreemptionExecutionPath`,
-			`\[Volume type: blockfswithoutformat\]`,
-			`CSI Volumes CSI attach test using HostPath driver`,
-			`CSI Volumes CSI plugin test using CSI driver: hostPath`,
-			`Volume metrics should create volume metrics in Volume Manager`,
 		},
 		// tests too slow to be part of conformance
 		"[Slow]": {


### PR DESCRIPTION
This reverts commit c27ddecb0f6b770c67f06fb5185b991843b08824, which disabled a set of tests that required 1.12 kubelet. Now that we run our tests with it they need to be verified which are needed.

For overall tests:
/assign @smarterclayton 

For storage related tests:
/assign @gnufied @jsafrane 

For node test:
/assign @sjenning 