### PR TITLE
Allow redirects to assetPublicURL from logout

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -461,7 +461,6 @@
       "github.com/openshift/origin/pkg/cmd/server/apis/config",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/install",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/latest",
-      "github.com/openshift/origin/pkg/configconversion",
       "github.com/openshift/origin/pkg/serviceaccounts/oauthclient",
       "github.com/openshift/origin/pkg/util/http/links",
       "github.com/openshift/origin/pkg/util/httprequest"

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_oauthserver.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_oauthserver.go
@@ -21,9 +21,6 @@ func NewOAuthServerConfigFromMasterConfig(genericConfig *genericapiserver.Config
 	oauthServerConfig.GenericConfig.AuditBackend = genericConfig.AuditBackend
 	oauthServerConfig.GenericConfig.AuditPolicyChecker = genericConfig.AuditPolicyChecker
 
-	// Build the list of valid redirect_uri prefixes for a login using the openshift-web-console client to redirect to
-	oauthServerConfig.ExtraOAuthConfig.AssetPublicAddresses = []string{oauthConfig.AssetPublicURL}
-
 	return oauthServerConfig, nil
 }
 

--- a/pkg/cmd/openshift-osinserver/server.go
+++ b/pkg/cmd/openshift-osinserver/server.go
@@ -63,8 +63,5 @@ func newOAuthServerConfig(osinConfig *kubecontrolplanev1.KubeAPIServerConfig) (*
 	//oauthServerConfig.GenericConfig.AuditBackend = genericConfig.AuditBackend
 	//oauthServerConfig.GenericConfig.AuditPolicyChecker = genericConfig.AuditPolicyChecker
 
-	// Build the list of valid redirect_uri prefixes for a login using the openshift-web-console client to redirect to
-	oauthServerConfig.ExtraOAuthConfig.AssetPublicAddresses = []string{osinConfig.OAuthConfig.AssetPublicURL}
-
 	return oauthServerConfig, nil
 }

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -147,7 +147,7 @@ func (c *OAuthServerConfig) WithOAuth(handler http.Handler) (http.Handler, error
 	tokenRequestEndpoints.Install(mux, urls.OpenShiftOAuthAPIPrefix)
 
 	if session := c.ExtraOAuthConfig.SessionAuth; session != nil {
-		logoutHandler := logout.NewLogout(session)
+		logoutHandler := logout.NewLogout(session, c.ExtraOAuthConfig.Options.AssetPublicURL)
 		logoutHandler.Install(mux, openShiftLogoutPrefix)
 	}
 

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -70,7 +70,6 @@ const (
 	openShiftLogoutPrefix        = "/logout"
 	openShiftApproveSubpath      = "approve"
 	openShiftOAuthCallbackPrefix = "/oauth2callback"
-	openShiftWebConsoleClientID  = "openshift-web-console"
 	openShiftBrowserClientID     = "openshift-browser-client"
 	openShiftCLIClientID         = "openshift-challenging-client"
 )

--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -191,9 +191,6 @@ func isHTTPS(u string) bool {
 type ExtraOAuthConfig struct {
 	Options osinv1.OAuthConfig
 
-	// AssetPublicAddresses contains valid redirectURI prefixes to direct browsers to the web console
-	AssetPublicAddresses []string
-
 	// KubeClient is kubeclient with enough permission for the auth API
 	KubeClient kclientset.Interface
 
@@ -290,18 +287,6 @@ func (c *OAuthServerConfig) StartOAuthClientsBootstrapping(context genericapiser
 	go func() {
 		// error is guaranteed to be nil
 		_ = wait.PollUntil(1*time.Second, func() (done bool, err error) {
-			webConsoleClient := oauthv1.OAuthClient{
-				ObjectMeta:            metav1.ObjectMeta{Name: openShiftWebConsoleClientID},
-				Secret:                "",
-				RespondWithChallenges: false,
-				RedirectURIs:          c.ExtraOAuthConfig.AssetPublicAddresses,
-				GrantMethod:           oauthv1.GrantHandlerAuto,
-			}
-			if err := ensureOAuthClient(webConsoleClient, c.ExtraOAuthConfig.OAuthClientClient, true, false); err != nil {
-				utilruntime.HandleError(err)
-				return false, nil
-			}
-
 			browserClient := oauthv1.OAuthClient{
 				ObjectMeta:            metav1.ObjectMeta{Name: openShiftBrowserClientID},
 				Secret:                crypto.Random256BitsString(),

--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -1,7 +1,6 @@
 package oauthserver
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -22,15 +21,12 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 
-	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	userclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
-	"github.com/openshift/origin/pkg/configconversion"
 	"github.com/openshift/origin/pkg/oauth/urls"
 	"github.com/openshift/origin/pkg/oauthserver/authenticator/password/bootstrap"
 	"github.com/openshift/origin/pkg/oauthserver/config"
@@ -50,27 +46,6 @@ func init() {
 
 // TODO we need to switch the oauth server to an external type, but that can be done after we get our externally facing flag values fixed
 // TODO remaining bits involve the session file, LDAP util code, validation, ...
-func NewOAuthServerConfigFromInternal(oauthConfig configapi.OAuthConfig, userClientConfig *rest.Config) (*OAuthServerConfig, error) {
-	osinConfig, err := internalOAuthConfigToExternal(oauthConfig)
-	if err != nil {
-		return nil, err
-	}
-	return NewOAuthServerConfig(*osinConfig, userClientConfig)
-}
-
-func internalOAuthConfigToExternal(oauthConfig configapi.OAuthConfig) (*osinv1.OAuthConfig, error) {
-	buf := &bytes.Buffer{}
-	internalConfig := &configapi.MasterConfig{OAuthConfig: &oauthConfig}
-	if err := latest.Codec.Encode(internalConfig, buf); err != nil {
-		return nil, err
-	}
-	legacyConfig := &legacyconfigv1.MasterConfig{}
-	if _, _, err := latest.Codec.Decode(buf.Bytes(), nil, legacyConfig); err != nil {
-		return nil, err
-	}
-	return configconversion.ToOAuthConfig(legacyConfig.OAuthConfig)
-}
-
 func NewOAuthServerConfig(oauthConfig osinv1.OAuthConfig, userClientConfig *rest.Config) (*OAuthServerConfig, error) {
 	// TODO: there is probably some better way to do this
 	decoder := codecs.UniversalDecoder(osinv1.GroupVersion)

--- a/test/integration/web_console_access_test.go
+++ b/test/integration/web_console_access_test.go
@@ -16,6 +16,7 @@ import (
 	knet "k8s.io/apimachinery/pkg/util/net"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	"github.com/openshift/origin/pkg/oauth/urls"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
@@ -131,8 +132,8 @@ func TestAccessOriginWebConsoleMultipleIdentityProviders(t *testing.T) {
 	urlMap["/login"] = urlResults{http.StatusNotFound, ""}
 
 	// Create the common base URLs
-	escapedPublicURL := url.QueryEscape(masterOptions.OAuthConfig.AssetPublicURL)
-	loginSelectorBase := "/oauth/authorize?client_id=openshift-web-console&response_type=token&state=%2F&redirect_uri=" + escapedPublicURL
+	escapedPublicURL := url.QueryEscape(urls.OpenShiftOAuthTokenDisplayURL(masterOptions.OAuthConfig.MasterPublicURL))
+	loginSelectorBase := "/oauth/authorize?client_id=openshift-browser-client&response_type=token&state=%2F&redirect_uri=" + escapedPublicURL
 
 	// Iterate through each of the providers and verify that they redirect to
 	// the appropriate login page and that the login page exists.


### PR DESCRIPTION
Remove dead code in OAuth server

This code path is no longer required after the 1.12 rebase.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Remove openshift-web-console OAuth client

This OAuth client is no longer used.  Currently the console operator
manages its own OAuth client.  AUTH-234 is tracking moving that
responsibility to the authentication operator.

Bug 1666623

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Allow redirects to assetPublicURL from logout

This change allows the console to redirect back to itself after
logging out the kube:admin user.

AUTH-170

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

@openshift/sig-auth 

/assign @stlaz 