### PR TITLE
Move denyAllIdp logic from operator to oauthserver

### DIFF
--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -142,6 +142,20 @@ func NewOAuthServerConfig(oauthConfig osinv1.OAuthConfig, userClientConfig *rest
 		)
 	}
 
+	if len(oauthConfig.IdentityProviders) == 0 {
+		oauthConfig.IdentityProviders = []osinv1.IdentityProvider{
+			{
+				Name:            "defaultDenyAll",
+				UseAsChallenger: true,
+				UseAsLogin:      true,
+				MappingMethod:   string(identitymapper.MappingMethodClaim),
+				Provider: runtime.RawExtension{
+					Object: &osinv1.DenyAllPasswordIdentityProvider{},
+				},
+			},
+		}
+	}
+
 	ret := &OAuthServerConfig{
 		GenericConfig: genericConfig,
 		ExtraOAuthConfig: ExtraOAuthConfig{


### PR DESCRIPTION
This PR adds the denyAllIdentityProvider logic from cluster-authentication-operator to oauthserver.
See this: https://github.com/openshift/cluster-authentication-operator/pull/55

When no identity providers are configured, deny all is implied. This ends up looking weird in the UI due to how `kube:admin` is wired. We need to move the logic out of the operator and directly into the OAuth server.