### PR TITLE
UPSTREAM: 69755: Use fsync instead of sync for test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/apps/statefulset.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/statefulset.go
@@ -113,7 +113,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			By("Verifying statefulset set proper service name")
 			framework.ExpectNoError(sst.CheckServiceName(ss, headlessSvcName))
 
-			cmd := "echo $(hostname) > /data/hostname; sync;"
+			cmd := "echo $(hostname) | dd of=/data/hostname conv=fsync"
 			By("Running " + cmd + " in all stateful pods")
 			framework.ExpectNoError(sst.ExecInStatefulPods(ss, cmd))
 

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/statefulset_utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/statefulset_utils.go
@@ -599,7 +599,7 @@ func (s *StatefulSetTester) ResumeNextPod(ss *apps.StatefulSet) {
 		if resumedPod != "" {
 			Failf("Found multiple paused stateful pods: %v and %v", pod.Name, resumedPod)
 		}
-		_, err := RunHostCmdWithRetries(pod.Namespace, pod.Name, "touch /data/statefulset-continue; sync", StatefulSetPoll, StatefulPodTimeout)
+		_, err := RunHostCmdWithRetries(pod.Namespace, pod.Name, "dd if=/dev/zero of=/data/statefulset-continue bs=1 count=1 conv=fsync", StatefulSetPoll, StatefulPodTimeout)
 		ExpectNoError(err)
 		Logf("Resumed pod %v", pod.Name)
 		resumedPod = pod.Name


### PR DESCRIPTION
sync sometimes hangs with misbehaving NFS during the tests

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

cc: @gnufied @smarterclayton 