### PR TITLE
UPSTREAM: 73583: fix flaky RuntimeClass test in kubelet

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/BUILD
@@ -110,6 +110,7 @@ go_test(
         "//pkg/kubelet/runtimeclass:go_default_library",
         "//pkg/kubelet/runtimeclass/testing:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",


### PR DESCRIPTION
I was not able to reproduce https://github.com/openshift/origin/issues/21890 with this fix.

Fixes: https://github.com/openshift/origin/issues/21890