### PR TITLE
oc: update oc admin top to conform to K8S 1.12

### DIFF
--- a/pkg/oc/cli/admin/top/top.go
+++ b/pkg/oc/cli/admin/top/top.go
@@ -11,10 +11,6 @@ import (
 
 const (
 	TopRecommendedName = "top"
-
-	DefaultHeapsterNamespace = "openshift-infra"
-	DefaultHeapsterScheme    = "https"
-	DefaultHeapsterService   = "heapster"
 )
 
 var topLong = templates.LongDesc(`
@@ -32,21 +28,8 @@ func NewCommandTop(name, fullName string, f cmdutil.Factory, streams genericclio
 		Run:   cmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 
-	ocHeapsterTopOpts := kcmd.HeapsterTopOptions{
-		Namespace: DefaultHeapsterNamespace,
-		Scheme:    DefaultHeapsterScheme,
-		Service:   DefaultHeapsterService,
-	}
-
-	cmdTopNodeOpts := &kcmd.TopNodeOptions{
-		HeapsterOptions: ocHeapsterTopOpts,
-	}
-	cmdTopNode := kcmd.NewCmdTopNode(f, cmdTopNodeOpts, streams)
-
-	cmdTopPodOpts := &kcmd.TopPodOptions{
-		HeapsterOptions: ocHeapsterTopOpts,
-	}
-	cmdTopPod := kcmd.NewCmdTopPod(f, cmdTopPodOpts, streams)
+	cmdTopNode := kcmd.NewCmdTopNode(f, nil, streams)
+	cmdTopPod := kcmd.NewCmdTopPod(f, nil, streams)
 
 	cmds.AddCommand(NewCmdTopImages(f, fullName, TopImagesRecommendedName, streams))
 	cmds.AddCommand(NewCmdTopImageStreams(f, fullName, TopImageStreamsRecommendedName, streams))


### PR DESCRIPTION
Heapster is not used in OSE 4.0. Remove the heapster config. Fixes a crash within oc using 4.0:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]      
        panic: tabwriter: panic during Flush                                             
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x100cc8d]                 
                                                                                         
goroutine 1 [running]: 
text/tabwriter.handlePanic(0xc0017aae30, 0x28944cc, 0x5)
        /usr/lib/go/src/text/tabwriter/tabwriter.go:482 +0x112                           
panic(0x2514700, 0x49b9920)                                                              
        /usr/lib/go/src/runtime/panic.go:513 +0x1b9                          
text/tabwriter.(*Writer).write0(0xc001151130, 0xc00005d000, 0x4, 0x80)          
        /usr/lib/go/src/text/tabwriter/tabwriter.go:254 +0x2d                    
text/tabwriter.(*Writer).writeLines(0xc001151130, 0x0, 0x0, 0x3, 0x20)        
        /usr/lib/go/src/text/tabwriter/tabwriter.go:321 +0x283                     
text/tabwriter.(*Writer).format(0xc001151130, 0x0, 0x0, 0x3, 0x5)                   
        /usr/lib/go/src/text/tabwriter/tabwriter.go:409 +0x28a                 
text/tabwriter.(*Writer).format(0xc001151130, 0x0, 0x3, 0x3, 0x0)                        
        /usr/lib/go/src/text/tabwriter/tabwriter.go:403 +0x19a                                                                                                                                                                                                                   
text/tabwriter.(*Writer).format(0xc001151130, 0x0, 0x3, 0x3, 0x3)
        /usr/lib/go/src/text/tabwriter/tabwriter.go:403 +0x19a                           
text/tabwriter.(*Writer).format(0xc001151130, 0x0, 0x3, 0x3, 0x2)             
        /usr/lib/go/src/text/tabwriter/tabwriter.go:403 +0x19a                  
text/tabwriter.(*Writer).format(0xc001151130, 0x0, 0x3, 0x3, 0x1)
        /usr/lib/go/src/text/tabwriter/tabwriter.go:403 +0x19a
text/tabwriter.(*Writer).format(0xc001151130, 0x0, 0x3, 0x4, 0x5)                        
        /usr/lib/go/src/text/tabwriter/tabwriter.go:403 +0x19a
text/tabwriter.(*Writer).flush(0xc001151130, 0x0, 0x0)
        /usr/lib/go/src/text/tabwriter/tabwriter.go:508 +0x13a                           
text/tabwriter.(*Writer).Flush(0xc001151130, 0xc00066e850, 0xc0013b3b60)
        /usr/lib/go/src/text/tabwriter/tabwriter.go:491 +0x2b
github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/metricsutil.(*TopCmdPrinter).PrintNodeMetrics(0xc000b74b20, 0xc00099e280, 0x2, 0x2, 0xc0017ab1b8, 0x0, 0x0)
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/metricsutil/metrics_printer.go:86 +0x42b
github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/cmd.TopNodeOptions.RunTopNode(0x0, 0x0, 0x0, 0x0, 0x2f67f20, 0xc00057ffb0, 0x28aa9e7, 0xf, 0x289a975, 0x8, ...)
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_node.go:219 +0x472
github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/cmd.NewCmdTopNode.func1(0xc001651b80, 0x4bafae8, 0x0, 0x0)
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_node.go:114 +0x161
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc001651b80, 0x4bafae8, 0x0, 0x0, 0xc001651b80, 0x4bafae8)
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:760 +0x2cc
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc001523900, 0xc001523900, 0x13eb8f9, 0xc0004fe770)
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:846 +0x2fd
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(0xc001523900, 0x2, 0xc001523900)
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
        /home/rphillips/work/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/oc/oc.go:68 +0x541


```

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1670618