### PR TITLE
UPSTREAM: 73603: TestCreatePodSandbox_RuntimeClass should not expect RunPodSandbox when runtime class is not found

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
@@ -79,13 +79,13 @@ func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			fakeRuntime.Called = []string{}
 			pod := newTestPod()
 			pod.Spec.RuntimeClassName = test.rcn
 
 			id, _, err := m.createPodSandbox(pod, 1)
 			if test.expectError {
 				assert.Error(t, err)
-				assert.Contains(t, fakeRuntime.Called, "RunPodSandbox")
 			} else {
 				assert.NoError(t, err)
 				assert.Contains(t, fakeRuntime.Called, "RunPodSandbox")


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/73603

@smarterclayton 