### PR TITLE
builds - Handle port numbers in registry CA hosts

### DIFF
--- a/pkg/build/controller/strategy/util_test.go
+++ b/pkg/build/controller/strategy/util_test.go
@@ -251,8 +251,9 @@ func TestMountConfigsAndSecrets(t *testing.T) {
 
 func TestSetupBuildCAs(t *testing.T) {
 	tests := []struct {
-		name  string
-		certs map[string]string
+		name           string
+		certs          map[string]string
+		expectedMounts map[string]string
 	}{
 		{
 			name: "no certs",
@@ -260,9 +261,16 @@ func TestSetupBuildCAs(t *testing.T) {
 		{
 			name: "additional certs",
 			certs: map[string]string{
-				"first":                       dummyCA,
-				"second":                      dummyCA,
-				"internal.svc.localhost:5000": dummyCA,
+				"first":                        dummyCA,
+				"second.domain.com":            dummyCA,
+				"internal.svc.localhost..5000": dummyCA,
+				"myregistry.foo...2345":        dummyCA,
+			},
+			expectedMounts: map[string]string{
+				"first":                        "first",
+				"second.domain.com":            "second.domain.com",
+				"internal.svc.localhost..5000": "internal.svc.localhost:5000",
+				"myregistry.foo...2345":        "myregistry.foo.:2345",
 			},
 		},
 	}
@@ -313,7 +321,7 @@ func TestSetupBuildCAs(t *testing.T) {
 					continue
 				}
 
-				expectedPath := fmt.Sprintf("certs.d/%s/ca.crt", expected)
+				expectedPath := fmt.Sprintf("certs.d/%s/ca.crt", tc.expectedMounts[expected])
 				if foundItem.Path != expectedPath {
 					t.Errorf("expected mount path to be %s; got %s", expectedPath, foundItem.Path)
 				}


### PR DESCRIPTION
* Registry CAs will be stored in a ConfigMap with key format "hostname[..port]"
* hostname[..port] gets mounted in at path "certs.d/hostname[:port]"

Fixes openshift/builder#41

JIRA-ID: DEVEXP-154