### PR TITLE
properly prefix all admission plugins

### DIFF
--- a/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("openshift.io/RestrictSubjectBindings",
+	plugins.Register("authorization.openshift.io/RestrictSubjectBindings",
 		func(config io.Reader) (admission.Interface, error) {
 			return NewRestrictUsersAdmission()
 		})

--- a/pkg/build/apiserver/admission/secretinjector/admission.go
+++ b/pkg/build/apiserver/admission/secretinjector/admission.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("openshift.io/BuildConfigSecretInjector",
+	plugins.Register("build.openshift.io/BuildConfigSecretInjector",
 		func(config io.Reader) (admission.Interface, error) {
 			return &secretInjector{
 				Handler: admission.NewHandler(admission.Create),

--- a/pkg/build/apiserver/admission/strategyrestrictions/admission.go
+++ b/pkg/build/apiserver/admission/strategyrestrictions/admission.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("BuildByStrategy",
+	plugins.Register("build.openshift.io/BuildByStrategy",
 		func(config io.Reader) (admission.Interface, error) {
 			return NewBuildByStrategy(), nil
 		})
@@ -102,10 +102,10 @@ func (a *buildByStrategy) SetRESTClientConfig(restClientConfig rest.Config) {
 
 func (a *buildByStrategy) ValidateInitialization() error {
 	if a.buildClient == nil {
-		return fmt.Errorf("BuildByStrategy needs an Openshift buildClient")
+		return fmt.Errorf("build.openshift.io/BuildByStrategy needs an Openshift buildClient")
 	}
 	if a.sarClient == nil {
-		return fmt.Errorf("BuildByStrategy needs an Openshift sarClient")
+		return fmt.Errorf("build.openshift.io/BuildByStrategy needs an Openshift sarClient")
 	}
 	return nil
 }

--- a/pkg/cmd/openshift-apiserver/openshiftadmission/chain_builder.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/chain_builder.go
@@ -18,13 +18,6 @@ import (
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 )
 
-// fixupAdmissionPlugins fixes the input plugins to handle deprecation and duplicates.
-func fixupAdmissionPlugins(plugins []string) []string {
-	result := replace(plugins, "openshift.io/OriginResourceQuota", "ResourceQuota")
-	result = dedupe(result)
-	return result
-}
-
 func NewAdmissionChains(
 	admissionConfigFiles []string,
 	explicitOn, explicitOff []string,
@@ -68,7 +61,7 @@ func NewAdmissionChains(
 			orderedPlugins = append(orderedPlugins, plugin)
 		}
 	}
-	admissionChain, err := newAdmissionChainFunc(fixupAdmissionPlugins(orderedPlugins), admissionPluginConfigFilename, admissionInitializer, admissionDecorator)
+	admissionChain, err := newAdmissionChainFunc(orderedPlugins, admissionPluginConfigFilename, admissionInitializer, admissionDecorator)
 	if err != nil {
 		return nil, err
 	}
@@ -110,34 +103,6 @@ func newAdmissionChain(pluginNames []string, admissionConfigFilename string, adm
 	}
 
 	return admission.NewChainHandler(plugins...), nil
-}
-
-// replace returns a slice where each instance of the input that is x is replaced with y
-func replace(input []string, x, y string) []string {
-	result := []string{}
-	for i := range input {
-		if input[i] == x {
-			result = append(result, y)
-		} else {
-			result = append(result, input[i])
-		}
-	}
-	return result
-}
-
-// dedupe removes duplicate items from the input list.
-// the last instance of a duplicate is kept in the input list.
-func dedupe(input []string) []string {
-	items := sets.NewString()
-	result := []string{}
-	for i := len(input) - 1; i >= 0; i-- {
-		if items.Has(input[i]) {
-			continue
-		}
-		items.Insert(input[i])
-		result = append([]string{input[i]}, result...)
-	}
-	return result
 }
 
 func init() {

--- a/pkg/cmd/openshift-apiserver/openshiftadmission/config_test.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/config_test.go
@@ -1,31 +1,10 @@
 package openshiftadmission
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
-
-	overrideapi "github.com/openshift/origin/pkg/quota/apiserver/admission/apis/clusterresourceoverride"
-	"github.com/openshift/origin/pkg/security/apiserver/admission/sccadmission"
-	"github.com/openshift/origin/pkg/service/admission/externalipranger"
-)
-
-// legacyOpenshiftAdmissionPlugins holds names that already existed without a prefix.  We should come up with a migration
-// plan (double register for a few releases?), but for now just make sure we don't get worse.
-var legacyOpenshiftAdmissionPlugins = sets.NewString(
-	"ProjectRequestLimit",
-	"PodNodeConstraints",
-	"BuildByStrategy",
-	"RunOnceDuration",
-	"OriginPodNodeEnvironment",
-	overrideapi.PluginName,
-	externalipranger.ExternalIPPluginName,
-	sccadmission.PluginName,
-	"SCCExecRestrictions",
-	"ResourceQuota",
 )
 
 // TestAdmissionPluginNames makes sure that openshift admission plugins are prefixed with `openshift.io/`.
@@ -34,31 +13,8 @@ func TestAdmissionPluginNames(t *testing.T) {
 	RegisterOpenshiftAdmissionPlugins(originAdmissionPlugins)
 
 	for _, plugin := range originAdmissionPlugins.Registered() {
-		if !strings.HasPrefix(plugin, "openshift.io/") && !legacyOpenshiftAdmissionPlugins.Has(plugin) {
+		if !strings.Contains(plugin, "openshift.io/") {
 			t.Errorf("openshift admission plugins must be prefixed with openshift.io/ %v", plugin)
 		}
-	}
-}
-func TestQuotaAdmissionPluginsAreLast(t *testing.T) {
-	kubeLen := len(OpenShiftAdmissionPlugins)
-	if kubeLen < 2 {
-		t.Fatalf("must have at least the 2 quota plugins")
-	}
-
-	if OpenShiftAdmissionPlugins[kubeLen-2] != "ResourceQuota" {
-		t.Errorf("kubeAdmissionPlugins must have %s as the next to last plugin", "ResourceQuota")
-	}
-
-	if OpenShiftAdmissionPlugins[kubeLen-1] != "openshift.io/ClusterResourceQuota" {
-		t.Errorf("kubeAdmissionPlugins must have ClusterResourceQuota as the last plugin")
-	}
-}
-
-func TestFixupAdmissionPlugins(t *testing.T) {
-	inputList := []string{"DefaultTolerationSeconds", "openshift.io/OriginResourceQuota", "OwnerReferencesPermissionEnforcement", "ResourceQuota", "openshift.io/ClusterResourceQuota"}
-	expectedList := []string{"DefaultTolerationSeconds", "OwnerReferencesPermissionEnforcement", "ResourceQuota", "openshift.io/ClusterResourceQuota"}
-	actualList := fixupAdmissionPlugins(inputList)
-	if !reflect.DeepEqual(expectedList, actualList) {
-		t.Errorf("Expected: %v, but got: %v", expectedList, actualList)
 	}
 }

--- a/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
@@ -52,35 +52,35 @@ var (
 	OpenShiftAdmissionPlugins = []string{
 		lifecycle.PluginName,
 		"OwnerReferencesPermissionEnforcement",
-		"ProjectRequestLimit",
-		"openshift.io/BuildConfigSecretInjector",
-		"BuildByStrategy",
+		"project.openshift.io/ProjectRequestLimit",
+		"build.openshift.io/BuildConfigSecretInjector",
+		"build.openshift.io/BuildByStrategy",
 		imageadmission.PluginName,
-		"PodNodeConstraints",
+		"scheduling.openshift.io/PodNodeConstraints",
 		imagepolicyapi.PluginName,
+		"quota.openshift.io/ClusterResourceQuota",
 		mutatingwebhook.PluginName,
 		validatingwebhook.PluginName,
 		"ResourceQuota",
-		"openshift.io/ClusterResourceQuota",
 	}
 
 	DefaultOnPlugins = sets.NewString(
 		lifecycle.PluginName,
-		"openshift.io/BuildConfigSecretInjector",
-		"BuildByStrategy",
+		"build.openshift.io/BuildConfigSecretInjector",
+		"build.openshift.io/BuildByStrategy",
 		imageadmission.PluginName,
 		"OwnerReferencesPermissionEnforcement",
 		imagepolicyapi.PluginName,
 		mutatingwebhook.PluginName,
 		validatingwebhook.PluginName,
 		"ResourceQuota",
-		"openshift.io/ClusterResourceQuota",
+		"quota.openshift.io/ClusterResourceQuota",
 	)
 
 	// DefaultOffPlugins includes plugins which require explicit configuration to run
 	// if you wire them incorrectly, they may prevent the server from starting
 	DefaultOffPlugins = sets.NewString(
-		"ProjectRequestLimit",
+		"project.openshift.io/ProjectRequestLimit",
 		"PodNodeConstraints",
 	)
 )

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -36,7 +36,9 @@ func RegisterOpenshiftKubeAdmissionPlugins(plugins *admission.Plugins) {
 	securityadmission.Register(plugins)
 	securityadmission.RegisterSCCExecRestrictions(plugins)
 	externalipranger.RegisterExternalIP(plugins)
+	externalipranger.DeprecatedRegisterExternalIP(plugins)
 	restrictedendpoints.RegisterRestrictedEndpoints(plugins)
+	restrictedendpoints.DeprecatedRegisterRestrictedEndpoints(plugins)
 }
 
 var (
@@ -65,7 +67,9 @@ var (
 		"scheduling.openshift.io/PodNodeConstraints",
 		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		externalipranger.ExternalIPPluginName,
+		"ExternalIPRanger",
 		restrictedendpoints.RestrictedEndpointsPluginName,
+		"openshift.io/RestrictedEndpointsAdmission",
 		"image.openshift.io/ImagePolicy",
 		sccadmission.PluginName,
 		"security.openshift.io/SCCExecRestrictions",
@@ -80,7 +84,9 @@ var (
 		"PodNodeSelector",
 		"Priority",
 		externalipranger.ExternalIPPluginName,
+		"ExternalIPRanger",
 		restrictedendpoints.RestrictedEndpointsPluginName,
+		"openshift.io/RestrictedEndpointsAdmission",
 		noderestriction.PluginName,
 		securityadmission.PluginName,
 		"StorageObjectInUseProtection",
@@ -89,7 +95,7 @@ var (
 		"OwnerReferencesPermissionEnforcement",
 		"PodTolerationRestriction",
 		"quota.openshift.io/ClusterResourceQuota",
-		"network.openshift.io/IngressAdmission",
+		"route.openshift.io/IngressAdmission",
 	)
 
 	// additionalDefaultOffPlugins are admission plugins we choose not to enable by default in openshift

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -46,46 +46,37 @@ var (
 	SkipRunLevelZeroPlugins = sets.NewString()
 	// these are admission plugins that cannot be applied until after the openshiftapiserver apiserver starts.
 	SkipRunLevelOnePlugins = sets.NewString(
-		"ProjectRequestLimit",
-		"openshift.io/RestrictSubjectBindings",
-		"openshift.io/ClusterResourceQuota",
-		"openshift.io/ImagePolicy",
-		overrideapi.PluginName,
-		"OriginPodNodeEnvironment",
-		"RunOnceDuration",
-		sccadmission.PluginName,
-		"SCCExecRestrictions",
+		"project.openshift.io/ProjectRequestLimit",
+		"authorization.openshift.io/RestrictSubjectBindings",
+		"quota.openshift.io/ClusterResourceQuota",
+		"image.openshift.io/ImagePolicy",
+		overrideapi.PluginName, // "autoscaling.openshift.io/ClusterResourceOverride"
+		"scheduling.openshift.io/OriginPodNodeEnvironment",
+		"autoscaling.openshift.io/RunOnceDuration",
+		sccadmission.PluginName, // "security.openshift.io/SecurityContextConstraint"
+		"security.openshift.io/SCCExecRestrictions",
 	)
 
-	// BeforeKubeAdmissionPlugins is the list of plugins to add before kube admission, so we run before limit ranges
-	// TODO this cannot be done on today's mutation
-	beforeKubeAdmissionPlugins = []string{
-		"ClusterResourceOverride",
-	}
-
 	// AfterKubeAdmissionPlugins are the admission plugins to add after kube admission, before mutating webhooks
-	afterKubeAdmissionPlugins = []string{
-		"openshift.io/RestrictSubjectBindings",
-		"RunOnceDuration",
-		"PodNodeConstraints",
-		"OriginPodNodeEnvironment",
+	openshiftAdmissionPluginsForKube = []string{
+		"autoscaling.openshift.io/ClusterResourceOverride",
+		"authorization.openshift.io/RestrictSubjectBindings",
+		"autoscaling.openshift.io/RunOnceDuration",
+		"scheduling.openshift.io/PodNodeConstraints",
+		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		externalipranger.ExternalIPPluginName,
 		restrictedendpoints.RestrictedEndpointsPluginName,
-		"openshift.io/ImagePolicy",
+		"image.openshift.io/ImagePolicy",
 		sccadmission.PluginName,
-		"SCCExecRestrictions",
+		"security.openshift.io/SCCExecRestrictions",
 		ingressadmission.IngressAdmission,
-	}
-
-	// FinalKubeAdmissionPlugins are the admission plugins to add after quota.  You shouldn't ever add this.
-	finalKubeAdmissionPlugins = []string{
-		"openshift.io/ClusterResourceQuota",
+		"quota.openshift.io/ClusterResourceQuota",
 	}
 
 	// additionalDefaultOnPlugins is a list of plugins we turn on by default that core kube does not.
 	additionalDefaultOnPlugins = sets.NewString(
-		imageadmission.PluginName, // "openshift.io/ImageLimitRange"
-		"OriginPodNodeEnvironment",
+		imageadmission.PluginName, // "image.openshift.io/ImageLimitRange"
+		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		"PodNodeSelector",
 		"Priority",
 		externalipranger.ExternalIPPluginName,
@@ -93,36 +84,35 @@ var (
 		noderestriction.PluginName,
 		securityadmission.PluginName,
 		"StorageObjectInUseProtection",
-		"SCCExecRestrictions",
+		"security.openshift.io/SCCExecRestrictions",
 		"PersistentVolumeLabel",
 		"OwnerReferencesPermissionEnforcement",
 		"PodTolerationRestriction",
-		"openshift.io/ClusterResourceQuota",
-		"openshift.io/IngressAdmission",
+		"quota.openshift.io/ClusterResourceQuota",
+		"network.openshift.io/IngressAdmission",
 	)
 
 	// additionalDefaultOffPlugins are admission plugins we choose not to enable by default in openshift
 	// you shouldn't put anything from kube in this list without api-approvers signing off on it.
 	additionalDefaultOffPlugins = sets.NewString(
-		"ProjectRequestLimit",
-		"RunOnceDuration",
-		"PodNodeConstraints",
+		"project.openshift.io/ProjectRequestLimit",
+		"autoscaling.openshift.io/RunOnceDuration",
+		"scheduling.openshift.io/PodNodeConstraints",
 		overrideapi.PluginName,
 		imagepolicyapi.PluginName,
-		"openshift.io/RestrictSubjectBindings",
+		"authorization.openshift.io/RestrictSubjectBindings",
 	)
 )
 
 func NewOrderedKubeAdmissionPlugins(kubeAdmissionOrder []string) []string {
-	ret := append([]string{}, beforeKubeAdmissionPlugins...)
+	ret := []string{}
 	for _, curr := range kubeAdmissionOrder {
 		if curr == mutatingwebhook.PluginName {
-			ret = append(ret, afterKubeAdmissionPlugins...)
+			ret = append(ret, openshiftAdmissionPluginsForKube...)
 			ret = append(ret, customresourcevalidationregistration.AllCustomResourceValidators...)
 		}
 		ret = append(ret, curr)
 	}
-	ret = append(ret, finalKubeAdmissionPlugins...)
 	return ret
 }
 

--- a/pkg/configconversion/legacyconfig_conversion.go
+++ b/pkg/configconversion/legacyconfig_conversion.go
@@ -40,7 +40,7 @@ func convertNetworkConfigToAdmissionConfig(masterConfig *legacyconfigv1.MasterCo
 	if err != nil {
 		return err
 	}
-	masterConfig.AdmissionConfig.PluginConfig["openshift.io/RestrictedEndpointsAdmission"] = &legacyconfigv1.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig["network.openshift.io/RestrictedEndpointsAdmission"] = &legacyconfigv1.AdmissionPluginConfig{
 		Configuration: runtime.RawExtension{Raw: restrictedEndpointConfigContent},
 	}
 
@@ -56,7 +56,7 @@ func convertNetworkConfigToAdmissionConfig(masterConfig *legacyconfigv1.MasterCo
 	if err != nil {
 		return err
 	}
-	masterConfig.AdmissionConfig.PluginConfig["ExternalIPRanger"] = &legacyconfigv1.AdmissionPluginConfig{
+	masterConfig.AdmissionConfig.PluginConfig["network.openshift.io/ExternalIPRanger"] = &legacyconfigv1.AdmissionPluginConfig{
 		Configuration: runtime.RawExtension{Raw: externalIPRangerAdmissionConfigContent},
 	}
 

--- a/pkg/image/apiserver/admission/apis/imagepolicy/name.go
+++ b/pkg/image/apiserver/admission/apis/imagepolicy/name.go
@@ -1,4 +1,4 @@
 package imagepolicy
 
-const PluginName = "openshift.io/ImagePolicy"
+const PluginName = "image.openshift.io/ImagePolicy"
 const ConfigKind = "ImagePolicyConfig"

--- a/pkg/image/apiserver/admission/limitrange/admission.go
+++ b/pkg/image/apiserver/admission/limitrange/admission.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	PluginName = "openshift.io/ImageLimitRange"
+	PluginName = "image.openshift.io/ImageLimitRange"
 )
 
 func newLimitExceededError(limitType kapi.LimitType, resourceName kapi.ResourceName, requested, limit *resource.Quantity) error {

--- a/pkg/project/apiserver/admission/nodeenv/admission.go
+++ b/pkg/project/apiserver/admission/nodeenv/admission.go
@@ -16,7 +16,7 @@ import (
 )
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("OriginPodNodeEnvironment",
+	plugins.Register("scheduling.openshift.io/OriginPodNodeEnvironment",
 		func(config io.Reader) (admission.Interface, error) {
 			return NewPodNodeEnvironment()
 		})

--- a/pkg/project/apiserver/admission/requestlimit/admission.go
+++ b/pkg/project/apiserver/admission/requestlimit/admission.go
@@ -31,14 +31,14 @@ import (
 const allowedTerminatingProjects = 2
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("ProjectRequestLimit",
+	plugins.Register("project.openshift.io/ProjectRequestLimit",
 		func(config io.Reader) (admission.Interface, error) {
 			pluginConfig, err := readConfig(config)
 			if err != nil {
 				return nil, err
 			}
 			if pluginConfig == nil {
-				glog.Infof("Admission plugin %q is not configured so it will be disabled.", "ProjectRequestLimit")
+				glog.Infof("Admission plugin %q is not configured so it will be disabled.", "project.openshift.io/ProjectRequestLimit")
 				return nil, nil
 			}
 			return NewProjectRequestLimit(pluginConfig)
@@ -188,10 +188,10 @@ func (o *projectRequestLimit) SetProjectCache(cache *projectcache.ProjectCache) 
 
 func (o *projectRequestLimit) ValidateInitialization() error {
 	if o.userClient == nil {
-		return fmt.Errorf("ProjectRequestLimit plugin requires an Openshift client")
+		return fmt.Errorf("project.openshift.io/ProjectRequestLimit plugin requires an Openshift client")
 	}
 	if o.cache == nil {
-		return fmt.Errorf("ProjectRequestLimit plugin requires a project cache")
+		return fmt.Errorf("project.openshift.io/ProjectRequestLimit plugin requires a project cache")
 	}
 	return nil
 }

--- a/pkg/quota/apiserver/admission/apis/clusterresourceoverride/name.go
+++ b/pkg/quota/apiserver/admission/apis/clusterresourceoverride/name.go
@@ -1,4 +1,4 @@
 package clusterresourceoverride
 
-const PluginName = "ClusterResourceOverride"
+const PluginName = "autoscaling.openshift.io/ClusterResourceOverride"
 const ConfigKind = "ClusterResourceOverrideConfig"

--- a/pkg/quota/apiserver/admission/clusterresourceoverride/admission.go
+++ b/pkg/quota/apiserver/admission/clusterresourceoverride/admission.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	clusterResourceOverrideAnnotation = "quota.openshift.io/cluster-resource-override-enabled"
+	clusterResourceOverrideAnnotation = "autoscaling.openshift.io/cluster-resource-override-enabled"
 	cpuBaseScaleFactor                = 1000.0 / (1024.0 * 1024.0 * 1024.0) // 1000 milliCores per 1GiB
 )
 

--- a/pkg/quota/apiserver/admission/clusterresourceoverride/doc.go
+++ b/pkg/quota/apiserver/admission/clusterresourceoverride/doc.go
@@ -4,5 +4,5 @@ package clusterresourceoverride
 // The plugin allows administrators to override user-provided container request/limit values
 // in order to control overcommit and optionally pin CPU to memory.
 // The plugin's actions can be disabled per-project with the project annotation
-// quota.openshift.io/cluster-resource-override-enabled="false", so cluster admins
+// autoscaling.openshift.io/cluster-resource-override-enabled="false", so cluster admins
 // can exempt infrastructure projects and such from the overrides.

--- a/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("openshift.io/ClusterResourceQuota",
+	plugins.Register("quota.openshift.io/ClusterResourceQuota",
 		func(config io.Reader) (admission.Interface, error) {
 			return NewClusterResourceQuota()
 		})

--- a/pkg/quota/apiserver/admission/runonceduration/admission.go
+++ b/pkg/quota/apiserver/admission/runonceduration/admission.go
@@ -20,14 +20,14 @@ import (
 )
 
 func Register(plugins *admission.Plugins) {
-	plugins.Register("RunOnceDuration",
+	plugins.Register("autoscaling.openshift.io/RunOnceDuration",
 		func(config io.Reader) (admission.Interface, error) {
 			pluginConfig, err := readConfig(config)
 			if err != nil {
 				return nil, err
 			}
 			if pluginConfig == nil {
-				glog.Infof("Admission plugin %q is not configured so it will be disabled.", "RunOnceDuration")
+				glog.Infof("Admission plugin %q is not configured so it will be disabled.", "autoscaling.openshift.io/RunOnceDuration")
 				return nil, nil
 			}
 			return NewRunOnceDuration(pluginConfig), nil
@@ -107,7 +107,7 @@ func (a *runOnceDuration) SetProjectCache(cache *projectcache.ProjectCache) {
 
 func (a *runOnceDuration) ValidateInitialization() error {
 	if a.cache == nil {
-		return errors.New("RunOnceDuration plugin requires a project cache")
+		return errors.New("autoscaling.openshift.io/RunOnceDuration plugin requires a project cache")
 	}
 	return nil
 }

--- a/pkg/route/apiserver/admission/ingress_admission.go
+++ b/pkg/route/apiserver/admission/ingress_admission.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	IngressAdmission = "network.openshift.io/IngressAdmission"
+	IngressAdmission = "route.openshift.io/IngressAdmission"
 )
 
 func Register(plugins *admission.Plugins) {

--- a/pkg/route/apiserver/admission/ingress_admission.go
+++ b/pkg/route/apiserver/admission/ingress_admission.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	IngressAdmission = "openshift.io/IngressAdmission"
+	IngressAdmission = "network.openshift.io/IngressAdmission"
 )
 
 func Register(plugins *admission.Plugins) {

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints"
 )
 
-const PluginName = "PodNodeConstraints"
+const PluginName = "scheduling.openshift.io/PodNodeConstraints"
 
 // kindsToIgnore is a list of kinds that contain a PodSpec that
 // we choose not to handle in this plugin

--- a/pkg/security/apiserver/admission/sccadmission/admission.go
+++ b/pkg/security/apiserver/admission/sccadmission/admission.go
@@ -28,7 +28,7 @@ import (
 	kadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 )
 
-const PluginName = "SecurityContextConstraint"
+const PluginName = "security.openshift.io/SecurityContextConstraint"
 
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName,

--- a/pkg/security/apiserver/admission/sccadmission/scc_exec.go
+++ b/pkg/security/apiserver/admission/sccadmission/scc_exec.go
@@ -17,7 +17,7 @@ import (
 )
 
 func RegisterSCCExecRestrictions(plugins *admission.Plugins) {
-	plugins.Register("SCCExecRestrictions",
+	plugins.Register("security.openshift.io/SCCExecRestrictions",
 		func(config io.Reader) (admission.Interface, error) {
 			execAdmitter := NewSCCExecRestrictions()
 			return execAdmitter, nil

--- a/pkg/service/admission/externalipranger/deprecated_register.go
+++ b/pkg/service/admission/externalipranger/deprecated_register.go
@@ -1,0 +1,32 @@
+package externalipranger
+
+import (
+	"io"
+
+	"github.com/golang/glog"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// Deprecated  we need this to ratchet a rename across our operator
+func DeprecatedRegisterExternalIP(plugins *admission.Plugins) {
+	plugins.Register("ExternalIPRanger",
+		func(config io.Reader) (admission.Interface, error) {
+			pluginConfig, err := readConfig(config)
+			if err != nil {
+				return nil, err
+			}
+			if pluginConfig == nil {
+				glog.Infof("Admission plugin %q is not configured so it will be disabled.", ExternalIPPluginName)
+				return nil, nil
+			}
+
+			// this needs to be moved upstream to be part of core config
+			reject, admit, err := ParseRejectAdmitCIDRRules(pluginConfig.ExternalIPNetworkCIDRs)
+			if err != nil {
+				// should have been caught with validation
+				return nil, err
+			}
+
+			return NewExternalIPRanger(reject, admit, pluginConfig.AllowIngressIP), nil
+		})
+}

--- a/pkg/service/admission/externalipranger/externalip_admission.go
+++ b/pkg/service/admission/externalipranger/externalip_admission.go
@@ -18,10 +18,10 @@ import (
 	"github.com/openshift/origin/pkg/service/admission/apis/externalipranger"
 )
 
-const ExternalIPPluginName = "ExternalIPRanger"
+const ExternalIPPluginName = "network.openshift.io/ExternalIPRanger"
 
 func RegisterExternalIP(plugins *admission.Plugins) {
-	plugins.Register("ExternalIPRanger",
+	plugins.Register("network.openshift.io/ExternalIPRanger",
 		func(config io.Reader) (admission.Interface, error) {
 			pluginConfig, err := readConfig(config)
 			if err != nil {

--- a/pkg/service/admission/restrictedendpoints/deprecated_register.go
+++ b/pkg/service/admission/restrictedendpoints/deprecated_register.go
@@ -1,0 +1,30 @@
+package restrictedendpoints
+
+import (
+	"io"
+
+	"github.com/golang/glog"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// Deprecated  we need this to ratchet a rename across our operator
+func DeprecatedRegisterRestrictedEndpoints(plugins *admission.Plugins) {
+	plugins.Register("openshift.io/RestrictedEndpointsAdmission",
+		func(config io.Reader) (admission.Interface, error) {
+			pluginConfig, err := readConfig(config)
+			if err != nil {
+				return nil, err
+			}
+			if pluginConfig == nil {
+				glog.Infof("Admission plugin %q is not configured so it will be disabled.", RestrictedEndpointsPluginName)
+				return nil, nil
+			}
+			restrictedNetworks, err := ParseSimpleCIDRRules(pluginConfig.RestrictedCIDRs)
+			if err != nil {
+				// should have been caught with validation
+				return nil, err
+			}
+
+			return NewRestrictedEndpointsAdmission(restrictedNetworks), nil
+		})
+}

--- a/pkg/service/admission/restrictedendpoints/endpoint_admission.go
+++ b/pkg/service/admission/restrictedendpoints/endpoint_admission.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openshift/origin/pkg/service/admission/apis/restrictedendpoints"
 )
 
-const RestrictedEndpointsPluginName = "openshift.io/RestrictedEndpointsAdmission"
+const RestrictedEndpointsPluginName = "network.openshift.io/RestrictedEndpointsAdmission"
 
 func RegisterRestrictedEndpoints(plugins *admission.Plugins) {
 	plugins.Register(RestrictedEndpointsPluginName,

--- a/test/integration/pod_node_constraints_test.go
+++ b/test/integration/pod_node_constraints_test.go
@@ -61,7 +61,7 @@ func setupClusterAdminPodNodeConstraintsTest(t *testing.T, pluginConfig *plugina
 		t.Fatalf("error creating config: %v", err)
 	}
 	cfg := map[string]*configapi.AdmissionPluginConfig{
-		"PodNodeConstraints": {
+		"scheduling.openshift.io/PodNodeConstraints": {
 			Configuration: pluginConfig,
 		},
 	}
@@ -99,7 +99,7 @@ func setupUserPodNodeConstraintsTest(t *testing.T, pluginConfig *pluginapi.PodNo
 		t.Fatalf("error creating config: %v", err)
 	}
 	cfg := map[string]*configapi.AdmissionPluginConfig{
-		"PodNodeConstraints": {
+		"scheduling.openshift.io/PodNodeConstraints": {
 			Configuration: pluginConfig,
 		},
 	}

--- a/test/integration/project_reqlimit_test.go
+++ b/test/integration/project_reqlimit_test.go
@@ -27,7 +27,7 @@ func setupProjectRequestLimitTest(t *testing.T, pluginConfig *requestlimit.Proje
 		t.Fatalf("error creating config: %v", err)
 	}
 	masterConfig.AdmissionConfig.PluginConfig = map[string]*configapi.AdmissionPluginConfig{
-		"ProjectRequestLimit": {
+		"project.openshift.io/ProjectRequestLimit": {
 			Configuration: pluginConfig,
 		},
 	}

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -24,7 +24,7 @@ func TestRestrictUsers(t *testing.T) {
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
 
 	masterConfig.AdmissionConfig.PluginConfig = map[string]*configapi.AdmissionPluginConfig{
-		"openshift.io/RestrictSubjectBindings": {
+		"authorization.openshift.io/RestrictSubjectBindings": {
 			Configuration: &configapi.DefaultAdmissionConfig{},
 		},
 	}

--- a/test/integration/runonce_duration_test.go
+++ b/test/integration/runonce_duration_test.go
@@ -77,7 +77,7 @@ func setupRunOnceDurationTest(t *testing.T, pluginConfig *pluginapi.RunOnceDurat
 		t.Fatalf("error creating config: %v", err)
 	}
 	masterConfig.AdmissionConfig.PluginConfig = map[string]*configapi.AdmissionPluginConfig{
-		"RunOnceDuration": {
+		"autoscaling.openshift.io/RunOnceDuration": {
 			Configuration: pluginConfig,
 		},
 	}


### PR DESCRIPTION
All openshift admission plugins should be namespaced. Since we aren't config-compatible from 3.11 to 4.0, this is a legal change.

/assign @mfojtik @sttts 