### PR TITLE
UPSTREAM: 73404: Kubelet: Fix volumemanager test race

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1233,8 +1233,16 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabledRace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
 	}
-	runReconciler(reconciler)
+	// Start the reconciler to fill ASW.
+	stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
+	go func() {
+		reconciler.Run(stopChan)
+		close(stoppedChan)
+	}()
 	waitForMount(t, fakePlugin, generatedVolumeName, asw)
+	// Stop the reconciler.
+	close(stopChan)
+	<-stoppedChan
 
 	finished := make(chan interface{})
 	fakePlugin.UnmountDeviceHook = func(mountPath string) error {
@@ -1258,6 +1266,9 @@ func Test_Run_Positive_VolumeMountControllerAttachEnabledRace(t *testing.T) {
 		close(finished)
 		return devicePath, nil
 	}
+
+	// Start the reconciler again.
+	go reconciler.Run(wait.NeverStop)
 
 	// 2. Delete the volume from DSW (and wait for callbacks)
 	dsw.DeletePodFromVolume(podName, generatedVolumeName)


### PR DESCRIPTION
this will fix flakes like https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/batch/pull-ci-openshift-origin-master-unit/2571#githubcomopenshiftoriginvendork8siokubernetespkgkubeletvolumemanagerreconciler-test_run_positive_volumemountcontrollerattachenabledrace

@tsmetana 