### PR TITLE
allow the kube-apiserver sa token public keys to be a directory

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/cmd.go
+++ b/pkg/cmd/openshift-kube-apiserver/cmd.go
@@ -118,6 +118,7 @@ func (o *OpenShiftKubeAPIServerServer) RunAPIServer(stopCh <-chan struct{}) erro
 			return err
 		}
 		configdefault.SetRecommendedKubeAPIServerConfigDefaults(config)
+		configdefault.ResolveDirectoriesForSATokenVerification(config)
 
 		return RunOpenShiftKubeAPIServerServer(config, stopCh)
 	}


### PR DESCRIPTION
SA token verification iterates through a list of files.  This pull allows us to specify a directory as one of the files.  This means we don't have to track individual certs which will make unioning for rotation easier.

/assign @sttts 