### PR TITLE
 Support CNI 0.3.x in openshift-sdn

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -115,11 +115,7 @@ func (p *cniPlugin) testCmdAdd(args *skel.CmdArgs) (types.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	convertedResult, err := convertToRequestedVersion(args.StdinData, result)
-	if err != nil {
-		return nil, err
-	}
-	return convertedResult, nil
+	return convertToRequestedVersion(args.StdinData, result)
 }
 
 func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
@@ -235,10 +231,6 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
-
-	result.Interfaces = nil
-	result.IPs[0].Interface = nil
-	result.IPs[0].Gateway = defaultGW
 
 	convertedResult, err := convertToRequestedVersion(req.Config, result)
 	if err != nil {

--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ip"
@@ -94,7 +93,7 @@ func (p *cniPlugin) doCNI(url string, req *cniserver.CNIRequest) ([]byte, error)
 
 // Send the ADD command environment and config to the CNI server, returning
 // the IPAM result to the caller
-func (p *cniPlugin) doCNIServerAdd(req *cniserver.CNIRequest, hostVeth string) (types.Result, error) {
+func (p *cniPlugin) doCNIServerAdd(req *cniserver.CNIRequest, hostVeth string) (*current.Result, error) {
 	req.HostVeth = hostVeth
 	body, err := p.doCNI("http://dummy/", req)
 	if err != nil {
@@ -108,7 +107,7 @@ func (p *cniPlugin) doCNIServerAdd(req *cniserver.CNIRequest, hostVeth string) (
 		return nil, fmt.Errorf("failed to unmarshal response '%s': %v", string(body), err)
 	}
 
-	return result, nil
+	return result.(*current.Result), nil
 }
 
 func (p *cniPlugin) testCmdAdd(args *skel.CmdArgs) (types.Result, error) {
@@ -116,11 +115,11 @@ func (p *cniPlugin) testCmdAdd(args *skel.CmdArgs) (types.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	result, err = convertToRequestedVersion(args.StdinData, result)
+	convertedResult, err := convertToRequestedVersion(args.StdinData, result)
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return convertedResult, nil
 }
 
 func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
@@ -146,39 +145,34 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	// current.NewResultFromResult and ipam.ConfigureIface both think that
-	// a route with no gateway specified means to pass the default gateway
-	// as the next hop to ip.AddRoute, but that's not what we want; we want
-	// to pass nil as the next hop. So we need to clear the default gateway.
-	result020, err := types020.GetResult(result)
-	if err != nil {
-		return fmt.Errorf("failed to convert IPAM result: %v", err)
+	if err != nil || len(result.IPs) != 1 || result.IPs[0].Version != "4" {
+		return fmt.Errorf("Unexpected IPAM result: %v", err)
 	}
-	defaultGW := result020.IP4.Gateway
-	result020.IP4.Gateway = nil
 
-	result030, err := current.NewResultFromResult(result020)
-	if err != nil || len(result030.IPs) != 1 || result030.IPs[0].Version != "4" {
-		return fmt.Errorf("failed to convert IPAM result: %v", err)
-	}
+	// ipam.ConfigureIface thinks that a route with no gateway specified
+	// means to pass the default gateway as the next hop to ip.AddRoute,
+	// but that's not what we want; we want to pass nil as the next hop.
+	// So we need to clear the default gateway.
+	defaultGW := result.IPs[0].Gateway
+	result.IPs[0].Gateway = nil
 
 	// Add a sandbox interface record which ConfigureInterface expects.
 	// The only interface we report is the pod interface.
-	result030.Interfaces = []*current.Interface{
+	result.Interfaces = []*current.Interface{
 		{
 			Name:    args.IfName,
 			Mac:     contVeth.HardwareAddr.String(),
 			Sandbox: args.Netns,
 		},
 	}
-	result030.IPs[0].Interface = current.Int(0)
+	result.IPs[0].Interface = current.Int(0)
 
 	err = ns.WithNetNSPath(args.Netns, func(hostNS ns.NetNS) error {
 		// Set up eth0
-		if err := ip.SetHWAddrByIP(args.IfName, result030.IPs[0].Address.IP, nil); err != nil {
+		if err := ip.SetHWAddrByIP(args.IfName, result.IPs[0].Address.IP, nil); err != nil {
 			return fmt.Errorf("failed to set pod interface MAC address: %v", err)
 		}
-		if err := ipam.ConfigureIface(args.IfName, result030); err != nil {
+		if err := ipam.ConfigureIface(args.IfName, result); err != nil {
 			return fmt.Errorf("failed to configure container IPAM: %v", err)
 		}
 
@@ -242,14 +236,18 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	result, err = convertToRequestedVersion(req.Config, result)
+	result.Interfaces = nil
+	result.IPs[0].Interface = nil
+	result.IPs[0].Gateway = defaultGW
+
+	convertedResult, err := convertToRequestedVersion(req.Config, result)
 	if err != nil {
 		return err
 	}
-	return result.Print()
+	return convertedResult.Print()
 }
 
-func convertToRequestedVersion(stdinData []byte, result types.Result) (types.Result, error) {
+func convertToRequestedVersion(stdinData []byte, result *current.Result) (types.Result, error) {
 	// Plugin must return result in same version as specified in netconf
 	versionDecoder := &version.ConfigDecoder{}
 	confVersion, err := versionDecoder.Decode(stdinData)

--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -101,18 +101,11 @@ func (p *cniPlugin) doCNIServerAdd(req *cniserver.CNIRequest, hostVeth string) (
 		return nil, err
 	}
 
-	// We currently expect CNI version 0.2.0 results, because that's the
+	// We currently expect CNI version 0.3.1 results, because that's the
 	// CNIVersion we pass in our config JSON
-	result, err := types020.NewResult(body)
+	result, err := current.NewResult(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response '%s': %v", string(body), err)
-	}
-
-	// We'll create the 0.3.x (current) version of the Result, because it will allow us to
-	// properly convert it to any lower version
-	result, err = convertTo03x(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert result to %v: %v", current.ImplementedSpecVersion, err)
 	}
 
 	return result, nil
@@ -285,54 +278,4 @@ func main() {
 	defer hostNS.Close()
 	p := NewCNIPlugin(cniserver.CNIServerSocketPath, hostNS)
 	skel.PluginMain(p.CmdAdd, p.CmdDel, version.All)
-}
-
-// convertTo03x properly converts a 0.2.0 result to a 0.3.x result, without breaking nil gw fields
-// this code is a patched version of convertFrom020() from vendor/github.com/containernetworking/cni/pkg/types/current/types.go
-// TODO: remove when https://github.com/containernetworking/cni/pull/617 is merged
-func convertTo03x(result types.Result) (types.Result, error) {
-	oldResult, err := types020.GetResult(result)
-	if err != nil {
-		return nil, err
-	}
-
-	newResult := &current.Result{
-		CNIVersion: current.ImplementedSpecVersion,
-		DNS:        oldResult.DNS,
-		Routes:     []*types.Route{},
-	}
-
-	if oldResult.IP4 != nil {
-		newResult.IPs = append(newResult.IPs, &current.IPConfig{
-			Version: "4",
-			Address: oldResult.IP4.IP,
-			Gateway: oldResult.IP4.Gateway,
-		})
-		for _, route := range oldResult.IP4.Routes {
-			newResult.Routes = append(newResult.Routes, &types.Route{
-				Dst: route.Dst,
-				GW:  route.GW,
-			})
-		}
-	}
-
-	if oldResult.IP6 != nil {
-		newResult.IPs = append(newResult.IPs, &current.IPConfig{
-			Version: "6",
-			Address: oldResult.IP6.IP,
-			Gateway: oldResult.IP6.Gateway,
-		})
-		for _, route := range oldResult.IP6.Routes {
-			newResult.Routes = append(newResult.Routes, &types.Route{
-				Dst: route.Dst,
-				GW:  route.GW,
-			})
-		}
-	}
-
-	if len(newResult.IPs) == 0 {
-		return nil, fmt.Errorf("cannot convert: no valid IP addresses")
-	}
-
-	return newResult, nil
 }

--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -110,7 +110,7 @@ func (p *cniPlugin) doCNIServerAdd(req *cniserver.CNIRequest, hostVeth string) (
 
 	// We'll create the 0.3.x (current) version of the Result, because it will allow us to
 	// properly convert it to any lower version
-	result, err = current.NewResultFromResult(result)
+	result, err = convertTo03x(result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert result to %v: %v", current.ImplementedSpecVersion, err)
 	}
@@ -285,4 +285,54 @@ func main() {
 	defer hostNS.Close()
 	p := NewCNIPlugin(cniserver.CNIServerSocketPath, hostNS)
 	skel.PluginMain(p.CmdAdd, p.CmdDel, version.All)
+}
+
+// convertTo03x properly converts a 0.2.0 result to a 0.3.x result, without breaking nil gw fields
+// this code is a patched version of convertFrom020() from vendor/github.com/containernetworking/cni/pkg/types/current/types.go
+// TODO: remove when https://github.com/containernetworking/cni/pull/617 is merged
+func convertTo03x(result types.Result) (types.Result, error) {
+	oldResult, err := types020.GetResult(result)
+	if err != nil {
+		return nil, err
+	}
+
+	newResult := &current.Result{
+		CNIVersion: current.ImplementedSpecVersion,
+		DNS:        oldResult.DNS,
+		Routes:     []*types.Route{},
+	}
+
+	if oldResult.IP4 != nil {
+		newResult.IPs = append(newResult.IPs, &current.IPConfig{
+			Version: "4",
+			Address: oldResult.IP4.IP,
+			Gateway: oldResult.IP4.Gateway,
+		})
+		for _, route := range oldResult.IP4.Routes {
+			newResult.Routes = append(newResult.Routes, &types.Route{
+				Dst: route.Dst,
+				GW:  route.GW,
+			})
+		}
+	}
+
+	if oldResult.IP6 != nil {
+		newResult.IPs = append(newResult.IPs, &current.IPConfig{
+			Version: "6",
+			Address: oldResult.IP6.IP,
+			Gateway: oldResult.IP6.Gateway,
+		})
+		for _, route := range oldResult.IP6.Routes {
+			newResult.Routes = append(newResult.Routes, &types.Route{
+				Dst: route.Dst,
+				GW:  route.GW,
+			})
+		}
+	}
+
+	if len(newResult.IPs) == 0 {
+		return nil, fmt.Errorf("cannot convert: no valid IP addresses")
+	}
+
+	return newResult, nil
 }

--- a/cmd/sdn-cni-plugin/sdn_cni_plugin_test.go
+++ b/cmd/sdn-cni-plugin/sdn_cni_plugin_test.go
@@ -152,29 +152,31 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		var result cnitypes.Result
-		var err error
+		t.Run(tc.name, func(t *testing.T) {
+			var result cnitypes.Result
+			var err error
 
-		skelArgsToEnv(tc.reqType, tc.skelArgs)
-		switch tc.reqType {
-		case cniserver.CNI_ADD:
-			result, err = cniPlugin.testCmdAdd(tc.skelArgs)
-		case cniserver.CNI_DEL:
-			err = cniPlugin.CmdDel(tc.skelArgs)
-		default:
-			t.Fatalf("[%s] unhandled CNI command type", tc.name)
-		}
-		clearEnv()
+			skelArgsToEnv(tc.reqType, tc.skelArgs)
+			switch tc.reqType {
+			case cniserver.CNI_ADD:
+				result, err = cniPlugin.testCmdAdd(tc.skelArgs)
+			case cniserver.CNI_DEL:
+				err = cniPlugin.CmdDel(tc.skelArgs)
+			default:
+				t.Fatalf("[%s] unhandled CNI command type", tc.name)
+			}
+			clearEnv()
 
-		if tc.errorPrefix == "" {
-			if err != nil {
-				t.Fatalf("[%s] expected result %v but got error: %v", tc.name, tc.result, err)
+			if tc.errorPrefix == "" {
+				if err != nil {
+					t.Fatalf("[%s] expected result %v but got error: %v", tc.name, tc.result, err)
+				}
+				if tc.result != nil && !reflect.DeepEqual(result, tc.result) {
+					t.Fatalf("[%s] expected result %v but got %v", tc.name, tc.result, result)
+				}
+			} else if !strings.HasPrefix(fmt.Sprintf("%v", err), tc.errorPrefix) {
+				t.Fatalf("[%s] unexpected error message '%v'", tc.name, err)
 			}
-			if tc.result != nil && !reflect.DeepEqual(result, tc.result) {
-				t.Fatalf("[%s] expected result %v but got %v", tc.name, tc.result, result)
-			}
-		} else if !strings.HasPrefix(fmt.Sprintf("%v", err), tc.errorPrefix) {
-			t.Fatalf("[%s] unexpected error message '%v'", tc.name, err)
-		}
+		})
 	}
 }

--- a/cmd/sdn-cni-plugin/sdn_cni_plugin_test.go
+++ b/cmd/sdn-cni-plugin/sdn_cni_plugin_test.go
@@ -92,12 +92,22 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 	cniPlugin := NewCNIPlugin(path, &dummyHostNS{})
 
 	expectedIP, expectedNet, _ := net.ParseCIDR("10.0.0.2/24")
+	expectedGateway := net.ParseIP("10.0.0.1")
 	expectedResult = &cni020.Result{
 		CNIVersion: "0.2.0",
 		IP4: &cni020.IPConfig{
 			IP: net.IPNet{
 				IP:   expectedIP,
 				Mask: expectedNet.Mask,
+			},
+			Gateway: expectedGateway,
+			Routes: []cnitypes.Route{
+				{
+					Dst: net.IPNet{
+						IP:   expectedIP,
+						Mask: expectedNet.Mask,
+					},
+				},
 			},
 		},
 	}
@@ -146,9 +156,18 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 							IP:   expectedIP,
 							Mask: expectedNet.Mask,
 						},
+						Gateway: expectedGateway,
 					},
 				},
-				Routes: []*cnitypes.Route{},
+				Routes: []*cnitypes.Route{
+					{
+						Dst: net.IPNet{
+							IP:   expectedIP,
+							Mask: expectedNet.Mask,
+						},
+						GW: nil,
+					},
+				},
 			},
 		},
 		// ADD request using cniVersion 0.3.1
@@ -172,9 +191,18 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 							IP:   expectedIP,
 							Mask: expectedNet.Mask,
 						},
+						Gateway: expectedGateway,
 					},
 				},
-				Routes: []*cnitypes.Route{},
+				Routes: []*cnitypes.Route{
+					{
+						Dst: net.IPNet{
+							IP:   expectedIP,
+							Mask: expectedNet.Mask,
+						},
+						GW: nil,
+					},
+				},
 			},
 		},
 		// Normal DEL request

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -355,7 +355,7 @@ func (node *OsdnNode) Start() error {
 	// our network plugin is ready
 	return ioutil.WriteFile(filepath.Join(node.cniDirPath, openshiftCNIFile), []byte(`
 {
-  "cniVersion": "0.2.0",
+  "cniVersion": "0.3.1",
   "name": "openshift-sdn",
   "type": "openshift-sdn"
 }

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -5,6 +5,7 @@ package node
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/containernetworking/cni/pkg/types/current"
 	"net"
 	"strconv"
 	"sync"
@@ -421,7 +422,7 @@ func createIPAMArgs(netnsPath, cniBinPath string, action cniserver.CNICommand, i
 }
 
 // Run CNI IPAM allocation for the container and return the allocated IP address
-func (m *podManager) ipamAdd(netnsPath string, id string) (*cni020.Result, net.IP, error) {
+func (m *podManager) ipamAdd(netnsPath string, id string) (*current.Result, net.IP, error) {
 	if netnsPath == "" {
 		return nil, nil, fmt.Errorf("netns required for CNI_ADD")
 	}
@@ -441,7 +442,12 @@ func (m *podManager) ipamAdd(netnsPath string, id string) (*cni020.Result, net.I
 		return nil, nil, fmt.Errorf("failed to obtain IP address from CNI IPAM")
 	}
 
-	return result, result.IP4.IP.IP, nil
+	newResult, err := current.NewResultFromResult(result)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to convert CNI IPAM ADD result from 0.2.0 to current version: %v", err)
+	}
+
+	return newResult, result.IP4.IP.IP, nil
 }
 
 // Run CNI IPAM release for the container


### PR DESCRIPTION
This PR makes openshift-sdn support CNI version 0.3.0 and 0.3.1, which allows openshift-sdn to be used with additional CNI plugins (plugin chaining). 

Fixes https://github.com/openshift/origin/issues/21891
