### PR TITLE
UPSTREAM: <carry>: protect key openshift namespaces

### DIFF
--- a/test/integration/namespace_lifecycle_admission_test.go
+++ b/test/integration/namespace_lifecycle_admission_test.go
@@ -35,7 +35,7 @@ func TestNamespaceLifecycleAdmission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, ns := range []string{"default", "openshift", "openshift-infra"} {
+	for _, ns := range []string{"default", "openshift-config", "openshift-cluster-version"} {
 		if err := clusterAdminKubeClientset.Core().Namespaces().Delete(ns, nil); err == nil {
 			t.Fatalf("expected error deleting %q namespace, got none", ns)
 		}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -53,7 +53,14 @@ const (
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
-		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic, "openshift", "openshift-infra"))
+		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic,
+			// user specified configuration that cannot be rebuilt
+			"openshift-config",
+			// the CVO which is the root we use to rebuild all the rest
+			"openshift-cluster-version",
+			// contains a namespaced list of all nodes in the cluster (yeah, weird.  they do it for multi-tenant management I think?)
+			"openshift-cluster-api",
+		))
 	})
 }
 


### PR DESCRIPTION
Given an operator based installation, the only two namespaces that need to be protected are `openshift-config` (user defined information that we cannot recreate) and `openshift-cluster-version` (the CVO which is responsible for recreating all the rest).

/assign @derekwaynecarr @smarterclayton 