### PR TITLE
UPSTREAM: 73758: kubelet: set low oom_score_adj for containers in critical pods

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/qos/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/qos/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["policy_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/scheduling:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
@@ -25,6 +26,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubelet/qos",
     deps = [
         "//pkg/apis/core/v1/helper/qos:go_default_library",
+        "//pkg/kubelet/types:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/qos/policy.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/qos/policy.go
@@ -17,8 +17,9 @@ limitations under the License.
 package qos
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -41,6 +42,11 @@ const (
 // and 1000. Containers with higher OOM scores are killed if the system runs out of memory.
 // See https://lwn.net/Articles/391222/ for more information.
 func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapacity int64) int {
+	if types.IsCriticalPod(pod) {
+		// Critical pods should be the last to get killed.
+		return guaranteedOOMScoreAdj
+	}
+
 	switch v1qos.GetPodQOS(pod) {
 	case v1.PodQOSGuaranteed:
 		// Guaranteed containers should be the last to get killed.

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/qos/policy_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/qos/policy_test.go
@@ -20,8 +20,9 @@ import (
 	"strconv"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
 const (
@@ -135,6 +136,19 @@ var (
 			},
 		},
 	}
+
+	systemCritical = scheduling.SystemCriticalPriority
+
+	critical = v1.Pod{
+		Spec: v1.PodSpec{
+			Priority: &systemCritical,
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{},
+				},
+			},
+		},
+	}
 )
 
 type oomTest struct {
@@ -187,6 +201,12 @@ func TestGetContainerOOMScoreAdjust(t *testing.T) {
 			memoryCapacity:  standardMemoryAmount,
 			lowOOMScoreAdj:  2,
 			highOOMScoreAdj: 2,
+		},
+		{
+			pod:             &critical,
+			memoryCapacity:  4000000000,
+			lowOOMScoreAdj:  -998,
+			highOOMScoreAdj: -998,
 		},
 	}
 	for _, test := range oomTests {


### PR DESCRIPTION
@derekwaynecarr 

To help with https://github.com/openshift/cluster-network-operator/pull/80 by allowing containers in a pod that has system-critical priority to get the same `oom_score_adj` that Guaranteed pods do without having to specify memory limits.