### PR TITLE
UPSTREAM: 68655: Allow cordon and drain of multiple nodes

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain.go
@@ -114,11 +114,11 @@ func NewCmdCordon(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	}
 
 	cmd := &cobra.Command{
-		Use: "cordon NODE",
+		Use:                   "cordon NODE",
 		DisableFlagsInUseLine: true,
-		Short:   i18n.T("Mark node as unschedulable"),
-		Long:    cordon_long,
-		Example: cordon_example,
+		Short:                 i18n.T("Mark node as unschedulable"),
+		Long:                  cordon_long,
+		Example:               cordon_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.RunCordonOrUncordon(true))
@@ -145,11 +145,11 @@ func NewCmdUncordon(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *c
 	}
 
 	cmd := &cobra.Command{
-		Use: "uncordon NODE",
+		Use:                   "uncordon NODE",
 		DisableFlagsInUseLine: true,
-		Short:   i18n.T("Mark node as schedulable"),
-		Long:    uncordon_long,
-		Example: uncordon_example,
+		Short:                 i18n.T("Mark node as schedulable"),
+		Long:                  uncordon_long,
+		Example:               uncordon_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.RunCordonOrUncordon(false))
@@ -208,11 +208,11 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	options := NewDrainOptions(f, ioStreams)
 
 	cmd := &cobra.Command{
-		Use: "drain NODE",
+		Use:                   "drain NODE",
 		DisableFlagsInUseLine: true,
-		Short:   i18n.T("Drain node in preparation for maintenance"),
-		Long:    drain_long,
-		Example: drain_example,
+		Short:                 i18n.T("Drain node in preparation for maintenance"),
+		Long:                  drain_long,
+		Example:               drain_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.RunDrain())
@@ -240,9 +240,6 @@ func (o *DrainOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	}
 	if len(args) > 0 && len(o.Selector) > 0 {
 		return cmdutil.UsageErrorf(cmd, "error: cannot specify both a node name and a --selector option")
-	}
-	if len(args) > 0 && len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, fmt.Sprintf("USAGE: %s [flags]", cmd.Use))
 	}
 
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/drain_test.go
@@ -144,6 +144,22 @@ func TestCordon(t *testing.T) {
 			arg:         "bar",
 			expectFatal: true,
 		},
+		{
+			description: "cordon for multiple nodes",
+			node:        node,
+			expected:    cordoned_node,
+			cmd:         NewCmdCordon,
+			arg:         "node node1 node2",
+			expectFatal: false,
+		},
+		{
+			description: "uncordon for multiple nodes",
+			node:        cordoned_node,
+			expected:    node,
+			cmd:         NewCmdUncordon,
+			arg:         "node node1 node2",
+			expectFatal: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -162,10 +178,18 @@ func TestCordon(t *testing.T) {
 				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 					m := &MyReq{req}
 					switch {
+					case m.isFor("GET", "/nodes/node1"):
+						fallthrough
+					case m.isFor("GET", "/nodes/node2"):
+						fallthrough
 					case m.isFor("GET", "/nodes/node"):
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, test.node)}, nil
 					case m.isFor("GET", "/nodes/bar"):
 						return &http.Response{StatusCode: 404, Header: defaultHeader(), Body: stringBody("nope")}, nil
+					case m.isFor("PATCH", "/nodes/node1"):
+						fallthrough
+					case m.isFor("PATCH", "/nodes/node2"):
+						fallthrough
 					case m.isFor("PATCH", "/nodes/node"):
 						data, err := ioutil.ReadAll(req.Body)
 						if err != nil {
@@ -211,7 +235,7 @@ func TestCordon(t *testing.T) {
 					saw_fatal = true
 					panic(e)
 				})
-				cmd.SetArgs([]string{test.arg})
+				cmd.SetArgs(strings.Split(test.arg, " "))
 				cmd.Execute()
 			}()
 


### PR DESCRIPTION
The command already supports multiple args - allow it by removing the
singleton check.