### PR TITLE
Add openshift-integrated-oauth-server command

### DIFF
--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -8,8 +8,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/openshift/origin/pkg/cmd/openshift-osinserver"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -21,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/openshift-apiserver"
 	"github.com/openshift/origin/pkg/cmd/openshift-controller-manager"
 	"github.com/openshift/origin/pkg/cmd/openshift-etcd"
+	"github.com/openshift/origin/pkg/cmd/openshift-integrated-oauth-server"
 	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver"
 	"github.com/openshift/origin/pkg/cmd/openshift-network-controller"
 	"github.com/openshift/origin/pkg/version"
@@ -77,7 +76,8 @@ func NewHyperShiftCommand(stopCh <-chan struct{}) *cobra.Command {
 	startOpenShiftNetworkController := openshift_network_controller.NewOpenShiftNetworkControllerCommand(openshift_network_controller.RecommendedStartNetworkControllerName, "hypershift", os.Stdout, os.Stderr)
 	cmd.AddCommand(startOpenShiftNetworkController)
 
-	startOsin := openshift_osinserver.NewOpenShiftOsinServer(os.Stdout, os.Stderr, stopCh)
+	startOsin := openshift_integrated_oauth_server.NewOsinServer(os.Stdout, os.Stderr, stopCh)
+	startOsin.Use = "openshift-osinserver"
 	startOsin.Deprecated = "will be removed in 4.0"
 	startOsin.Hidden = true
 	cmd.AddCommand(startOsin)

--- a/cmd/openshift-integrated-oauth-server/OWNERS
+++ b/cmd/openshift-integrated-oauth-server/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - enj
+  - ericavonb
+  - mrogers950
+  - stlaz
+approvers:
+  - enj

--- a/cmd/openshift-integrated-oauth-server/main.go
+++ b/cmd/openshift-integrated-oauth-server/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	goflag "flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
+
+	"github.com/openshift/library-go/pkg/serviceability"
+	"github.com/openshift/origin/pkg/cmd/openshift-integrated-oauth-server"
+	"github.com/openshift/origin/pkg/version"
+)
+
+func main() {
+	stopCh := genericapiserver.SetupSignalHandler()
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), version.Get())()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	command := NewOpenshiftIntegratedOAuthServerCommand(stopCh)
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func NewOpenshiftIntegratedOAuthServerCommand(stopCh <-chan struct{}) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openshift-integrated-oauth-server",
+		Short: "Command for the OpenShift integrated OAuth server",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	startOsin := openshift_integrated_oauth_server.NewOsinServer(os.Stdout, os.Stderr, stopCh)
+	cmd.AddCommand(startOsin)
+
+	return cmd
+}

--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -151,6 +151,7 @@
       "github.com/openshift/origin/pkg/apiserver/authentication/oauth",
       "github.com/openshift/origin/pkg/oauth/apis/oauth/validation",
 
+      "github.com/openshift/origin/pkg/cmd/openshift-integrated-oauth-server",
       "github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver",
       "github.com/openshift/origin/pkg/cmd/server/origin",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/validation",

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -39,6 +39,7 @@ readonly OS_IMAGE_COMPILE_TARGETS_LINUX=(
   cmd/openshift-sdn
   cmd/openshift-tests
   cmd/openshift
+  cmd/openshift-integrated-oauth-server
   vendor/k8s.io/kubernetes/cmd/hyperkube
 )
 readonly OS_SCRATCH_IMAGE_COMPILE_TARGETS_LINUX=(

--- a/pkg/cmd/openshift-integrated-oauth-server/OWNERS
+++ b/pkg/cmd/openshift-integrated-oauth-server/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - enj
+  - ericavonb
+  - mrogers950
+  - stlaz
+approvers:
+  - enj

--- a/pkg/cmd/openshift-integrated-oauth-server/server.go
+++ b/pkg/cmd/openshift-integrated-oauth-server/server.go
@@ -1,4 +1,4 @@
-package openshift_osinserver
+package openshift_integrated_oauth_server
 
 import (
 	"errors"
@@ -6,7 +6,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
-	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
+	osinv1 "github.com/openshift/api/osin/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"github.com/openshift/origin/pkg/cmd/openshift-apiserver/openshiftapiserver/configprocessing"
 	"github.com/openshift/origin/pkg/oauthserver/oauthserver"
@@ -15,8 +15,8 @@ import (
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus"
 )
 
-func RunOpenShiftOsinServer(osinConfig *kubecontrolplanev1.KubeAPIServerConfig, stopCh <-chan struct{}) error {
-	if osinConfig == nil || osinConfig.OAuthConfig == nil {
+func RunOsinServer(osinConfig *osinv1.OsinServerConfig, stopCh <-chan struct{}) error {
+	if osinConfig == nil {
 		return errors.New("osin server requires non-empty oauthConfig")
 	}
 
@@ -35,7 +35,7 @@ func RunOpenShiftOsinServer(osinConfig *kubecontrolplanev1.KubeAPIServerConfig, 
 	return oauthServer.GenericAPIServer.PrepareRun().Run(stopCh)
 }
 
-func newOAuthServerConfig(osinConfig *kubecontrolplanev1.KubeAPIServerConfig) (*oauthserver.OAuthServerConfig, error) {
+func newOAuthServerConfig(osinConfig *osinv1.OsinServerConfig) (*oauthserver.OAuthServerConfig, error) {
 	genericConfig := genericapiserver.NewRecommendedConfig(legacyscheme.Codecs)
 
 	servingOptions, err := configprocessing.ToServingOptions(osinConfig.ServingInfo)
@@ -52,7 +52,7 @@ func newOAuthServerConfig(osinConfig *kubecontrolplanev1.KubeAPIServerConfig) (*
 		return nil, err
 	}
 
-	oauthServerConfig, err := oauthserver.NewOAuthServerConfig(*osinConfig.OAuthConfig, kubeClientConfig)
+	oauthServerConfig, err := oauthserver.NewOAuthServerConfig(osinConfig.OAuthConfig, kubeClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -144,7 +144,12 @@ func (c *OAuthServerConfig) WithOAuth(handler http.Handler) (http.Handler, error
 	)
 	server.Install(mux, urls.OpenShiftOAuthAPIPrefix)
 
-	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.ExtraOAuthConfig.Options.MasterPublicURL, openShiftLogoutPrefix, c.getOsinOAuthClient, c.ExtraOAuthConfig.OAuthAccessTokenClient)
+	loginURL := c.ExtraOAuthConfig.Options.LoginURL
+	if len(loginURL) == 0 {
+		loginURL = c.ExtraOAuthConfig.Options.MasterPublicURL
+	}
+
+	tokenRequestEndpoints := tokenrequest.NewEndpoints(loginURL, openShiftLogoutPrefix, c.getOsinOAuthClient, c.ExtraOAuthConfig.OAuthAccessTokenClient)
 	tokenRequestEndpoints.Install(mux, urls.OpenShiftOAuthAPIPrefix)
 
 	if session := c.ExtraOAuthConfig.SessionAuth; session != nil {


### PR DESCRIPTION
This serves as the official standalone binary run by the cluster-authentication-operator when it is managing the integrated OAuth server.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 
