### PR TITLE
make the network admission plugins tolerate groupified config

### DIFF
--- a/pkg/service/admission/apis/externalipranger/install/install.go
+++ b/pkg/service/admission/apis/externalipranger/install/install.go
@@ -9,6 +9,8 @@ import (
 )
 
 func InstallLegacyInternal(scheme *runtime.Scheme) {
-	utilruntime.Must(externalipranger.InstallLegacy(scheme))
+	utilruntime.Must(externalipranger.Install(scheme))
+	utilruntime.Must(v1.Install(scheme))
+	utilruntime.Must(externalipranger.DeprecatedInstallLegacy(scheme))
 	utilruntime.Must(v1.DeprecatedInstall(scheme))
 }

--- a/pkg/service/admission/apis/externalipranger/register.go
+++ b/pkg/service/admission/apis/externalipranger/register.go
@@ -5,15 +5,29 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var SchemeGroupVersion = schema.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
+var DeprecatedGroupVersion = schema.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	InstallLegacy = SchemeBuilder.AddToScheme
+	deprecatedSchemeBuilder = runtime.NewSchemeBuilder(addDeprecatedKnownTypes)
+	DeprecatedInstallLegacy = deprecatedSchemeBuilder.AddToScheme
+)
+
+func addDeprecatedKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(DeprecatedGroupVersion,
+		&ExternalIPRangerAdmissionConfig{},
+	)
+	return nil
+}
+
+var GroupVersion = schema.GroupVersion{Group: "network.openshift.io", Version: runtime.APIVersionInternal}
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	Install       = deprecatedSchemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(GroupVersion,
 		&ExternalIPRangerAdmissionConfig{},
 	)
 	return nil

--- a/pkg/service/admission/apis/externalipranger/v1/register.go
+++ b/pkg/service/admission/apis/externalipranger/v1/register.go
@@ -12,7 +12,7 @@ var DeprecatedSchemeGroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
 var (
 	DeprecatedSchemeBuilder = runtime.NewSchemeBuilder(
 		deprecatedAddKnownTypes,
-		restrictedendpoints.InstallLegacy,
+		restrictedendpoints.DeprecatedInstall,
 	)
 	DeprecatedInstall = DeprecatedSchemeBuilder.AddToScheme
 )
@@ -20,6 +20,23 @@ var (
 // Adds the list of known types to api.Scheme.
 func deprecatedAddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(DeprecatedSchemeGroupVersion,
+		&ExternalIPRangerAdmissionConfig{},
+	)
+	return nil
+}
+
+var GroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(
+		addKnownTypes,
+		restrictedendpoints.DeprecatedInstall,
+	)
+	Install = schemeBuilder.AddToScheme
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
 		&ExternalIPRangerAdmissionConfig{},
 	)
 	return nil

--- a/pkg/service/admission/apis/restrictedendpoints/install/install.go
+++ b/pkg/service/admission/apis/restrictedendpoints/install/install.go
@@ -9,6 +9,8 @@ import (
 )
 
 func InstallLegacyInternal(scheme *runtime.Scheme) {
-	utilruntime.Must(restrictedendpoints.InstallLegacy(scheme))
+	utilruntime.Must(restrictedendpoints.Install(scheme))
+	utilruntime.Must(v1.Install(scheme))
+	utilruntime.Must(restrictedendpoints.DeprecatedInstall(scheme))
 	utilruntime.Must(v1.DeprecatedInstall(scheme))
 }

--- a/pkg/service/admission/apis/restrictedendpoints/register.go
+++ b/pkg/service/admission/apis/restrictedendpoints/register.go
@@ -5,15 +5,29 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var SchemeGroupVersion = schema.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
+var DeprecatedSchemeGroupVersion = schema.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	InstallLegacy = SchemeBuilder.AddToScheme
+	deprecatedSchemeBuilder = runtime.NewSchemeBuilder(addDeprecatedKnownTypes)
+	DeprecatedInstall       = deprecatedSchemeBuilder.AddToScheme
+)
+
+func addDeprecatedKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(DeprecatedSchemeGroupVersion,
+		&RestrictedEndpointsAdmissionConfig{},
+	)
+	return nil
+}
+
+var GroupVersion = schema.GroupVersion{Group: "network.openshift.io", Version: runtime.APIVersionInternal}
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	Install       = schemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(GroupVersion,
 		&RestrictedEndpointsAdmissionConfig{},
 	)
 	return nil

--- a/pkg/service/admission/apis/restrictedendpoints/v1/register.go
+++ b/pkg/service/admission/apis/restrictedendpoints/v1/register.go
@@ -12,7 +12,7 @@ var DeprecatedSchemeGroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
 var (
 	DeprecatedSchemeBuilder = runtime.NewSchemeBuilder(
 		deprecatedAddKnownTypes,
-		restrictedendpoints.InstallLegacy,
+		restrictedendpoints.DeprecatedInstall,
 	)
 	DeprecatedInstall = DeprecatedSchemeBuilder.AddToScheme
 )
@@ -20,6 +20,23 @@ var (
 // Adds the list of known types to api.Scheme.
 func deprecatedAddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(DeprecatedSchemeGroupVersion,
+		&RestrictedEndpointsAdmissionConfig{},
+	)
+	return nil
+}
+
+var GroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(
+		addKnownTypes,
+		restrictedendpoints.DeprecatedInstall,
+	)
+	Install = schemeBuilder.AddToScheme
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
 		&RestrictedEndpointsAdmissionConfig{},
 	)
 	return nil


### PR DESCRIPTION
Once this merges, we'll be able to fix the operator and then remove the non-groupified version.

/assign @mfojtik @sttts 