### PR TITLE
don't allow the fake admission plugin object for enablement

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -80,7 +80,9 @@ var (
 	// additionalDefaultOnPlugins is a list of plugins we turn on by default that core kube does not.
 	additionalDefaultOnPlugins = sets.NewString(
 		"authorization.openshift.io/RestrictSubjectBindings",
+		overrideapi.PluginName,
 		imageadmission.PluginName, // "image.openshift.io/ImageLimitRange"
+		imagepolicyapi.PluginName,
 		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		"PodNodeSelector",
 		"Priority",
@@ -90,23 +92,16 @@ var (
 		"openshift.io/RestrictedEndpointsAdmission",
 		noderestriction.PluginName,
 		securityadmission.PluginName,
+		"autoscaling.openshift.io/RunOnceDuration",
+		"scheduling.openshift.io/PodNodeConstraints",
 		"StorageObjectInUseProtection",
 		"security.openshift.io/SCCExecRestrictions",
+		"project.openshift.io/ProjectRequestLimit",
 		"PersistentVolumeLabel",
 		"OwnerReferencesPermissionEnforcement",
 		"PodTolerationRestriction",
 		"quota.openshift.io/ClusterResourceQuota",
 		"route.openshift.io/IngressAdmission",
-	)
-
-	// additionalDefaultOffPlugins are admission plugins we choose not to enable by default in openshift
-	// you shouldn't put anything from kube in this list without api-approvers signing off on it.
-	additionalDefaultOffPlugins = sets.NewString(
-		"project.openshift.io/ProjectRequestLimit",
-		"autoscaling.openshift.io/RunOnceDuration",
-		"scheduling.openshift.io/PodNodeConstraints",
-		overrideapi.PluginName,
-		imagepolicyapi.PluginName,
 	)
 )
 
@@ -125,7 +120,6 @@ func NewOrderedKubeAdmissionPlugins(kubeAdmissionOrder []string) []string {
 func NewDefaultOffPluginsFunc(kubeDefaultOffAdmission sets.String) func() sets.String {
 	return func() sets.String {
 		kubeOff := sets.NewString(kubeDefaultOffAdmission.UnsortedList()...)
-		kubeOff.Insert(additionalDefaultOffPlugins.List()...)
 		kubeOff.Delete(additionalDefaultOnPlugins.List()...)
 		return kubeOff
 	}

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -79,6 +79,7 @@ var (
 
 	// additionalDefaultOnPlugins is a list of plugins we turn on by default that core kube does not.
 	additionalDefaultOnPlugins = sets.NewString(
+		"authorization.openshift.io/RestrictSubjectBindings",
 		imageadmission.PluginName, // "image.openshift.io/ImageLimitRange"
 		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		"PodNodeSelector",
@@ -106,7 +107,6 @@ var (
 		"scheduling.openshift.io/PodNodeConstraints",
 		overrideapi.PluginName,
 		imagepolicyapi.PluginName,
-		"authorization.openshift.io/RestrictSubjectBindings",
 	)
 )
 

--- a/pkg/cmd/server/apis/config/latest/helpers.go
+++ b/pkg/cmd/server/apis/config/latest/helpers.go
@@ -182,24 +182,3 @@ func captureSurroundingJSONForError(prefix string, data []byte, err error) error
 	}
 	return err
 }
-
-// IsAdmissionPluginActivated returns true if the admission plugin is activated using configapi.DefaultAdmissionConfig
-// otherwise it returns a default value
-func IsAdmissionPluginActivated(reader io.Reader, defaultValue bool) (bool, error) {
-	obj, err := ReadYAML(reader)
-	if err != nil {
-		return false, err
-	}
-	if obj == nil {
-		return defaultValue, nil
-	}
-	activationConfig, ok := obj.(*configapi.DefaultAdmissionConfig)
-	if !ok {
-		// if we failed the cast, then we've got a config object specified for this admission plugin
-		// that means that this must be enabled and all additional validation is up to the
-		// admission plugin itself
-		return true, nil
-	}
-
-	return !activationConfig.Disable, nil
-}

--- a/pkg/quota/apiserver/admission/apis/clusterresourceoverride/name.go
+++ b/pkg/quota/apiserver/admission/apis/clusterresourceoverride/name.go
@@ -1,4 +1,3 @@
 package clusterresourceoverride
 
 const PluginName = "autoscaling.openshift.io/ClusterResourceOverride"
-const ConfigKind = "ClusterResourceOverrideConfig"

--- a/test/integration/admissionconfig_test.go
+++ b/test/integration/admissionconfig_test.go
@@ -5,7 +5,6 @@ import (
 
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -16,11 +15,8 @@ func TestAlwaysPullImagesOn(t *testing.T) {
 		t.Fatalf("error creating config: %v", err)
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
-	masterConfig.AdmissionConfig.PluginConfig = map[string]*configapi.AdmissionPluginConfig{
-		"AlwaysPullImages": {
-			Configuration: &configapi.DefaultAdmissionConfig{},
-		},
-	}
+	masterConfig.AdmissionConfig.PluginOrderOverride = []string{"AlwaysPullImages"}
+
 	kubeConfigFile, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {
 		t.Fatalf("error starting server: %v", err)

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -29,7 +29,6 @@ import (
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	etcddata "k8s.io/kubernetes/test/integration/etcd"
 
-	serverapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/etcd"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
@@ -237,9 +236,6 @@ func TestEtcd3StoragePath(t *testing.T) {
 			"batch/v2alpha1=true",
 		},
 		"storage-media-type": {"application/json"},
-	}
-	masterConfig.AdmissionConfig.PluginConfig["ServiceAccount"] = &serverapi.AdmissionPluginConfig{
-		Configuration: &serverapi.DefaultAdmissionConfig{Disable: true},
 	}
 
 	_, err = testserver.StartConfiguredMasterAPI(masterConfig)

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -11,7 +11,6 @@ import (
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
 	authorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -22,12 +21,6 @@ func TestRestrictUsers(t *testing.T) {
 		t.Fatalf("error creating config: %v", err)
 	}
 	defer testserver.CleanupMasterEtcd(t, masterConfig)
-
-	masterConfig.AdmissionConfig.PluginConfig = map[string]*configapi.AdmissionPluginConfig{
-		"authorization.openshift.io/RestrictSubjectBindings": {
-			Configuration: &configapi.DefaultAdmissionConfig{},
-		},
-	}
 
 	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterConfig)
 	if err != nil {


### PR DESCRIPTION
openshift 3.x has a fake admission configuration object we use for allowign enablement.  It's causing issues with config parsing and isn't really supported in kube. We will switch to an expliciton/off mechanism in 4.0 to match kube.

/assign @bparees 

@bparees when in doubt, remove! :)