### PR TITLE
UPSTREAM: 73888: Use higher precision duration in server side print

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/meta/table/table.go
@@ -67,5 +67,5 @@ func ConvertToHumanReadableDateType(timestamp metav1.Time) string {
 	if timestamp.IsZero() {
 		return "<unknown>"
 	}
-	return duration.ShortHumanDuration(time.Now().Sub(timestamp.Time))
+	return duration.HumanDuration(time.Now().Sub(timestamp.Time))
 }


### PR DESCRIPTION
Most other printers use the new 2-3 digit precision duration, and
the generic one should also.