### PR TITLE
cmd: set user-agent for openshift apiserver and controller manager

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -39,6 +40,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	if err != nil {
 		return nil, err
 	}
+	kubeClientConfig.UserAgent = strings.Replace(kubeClientConfig.UserAgent, "hypershift", "openshift-apiserver", 1)
 	kubeClient, err := kubernetes.NewForConfig(kubeClientConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/openshift-controller-manager/cmd.go
+++ b/pkg/cmd/openshift-controller-manager/cmd.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/golang/glog"
@@ -137,6 +138,7 @@ func (o *OpenShiftControllerManager) RunControllerManager() error {
 		if err != nil {
 			return err
 		}
+		clientConfig.UserAgent = strings.Replace(clientConfig.UserAgent, "hypershift", "openshift-controller-manager", 1)
 		return RunOpenShiftControllerManager(config, clientConfig)
 	}
 
@@ -165,6 +167,7 @@ func (o *OpenShiftControllerManager) RunControllerManager() error {
 	if err != nil {
 		return err
 	}
+	clientConfig.UserAgent = strings.Replace(clientConfig.UserAgent, "hypershift", "openshift-controller-manager", 1)
 
 	return RunOpenShiftControllerManager(config, clientConfig)
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -550,7 +550,12 @@ func buildGenericConfig(
 				if server == "kubernetes.default.svc" {
 					return genericConfig.LoopbackClientConfig, nil
 				}
-				return delegate.ClientConfigFor(server)
+				clientConfig, err := delegate.ClientConfigFor(server)
+				if err != nil {
+					return nil, err
+				}
+				clientConfig.UserAgent = strings.Replace(clientConfig.UserAgent, "hypershift", "webhook-auth-resolver", 1)
+				return clientConfig, nil
 			},
 			ClientConfigForServiceFunc: func(serviceName, serviceNamespace string) (*rest.Config, error) {
 				if serviceName == "kubernetes" && serviceNamespace == "default" {
@@ -560,6 +565,7 @@ func buildGenericConfig(
 				if err != nil {
 					return nil, err
 				}
+				ret.UserAgent = strings.Replace(ret.UserAgent, "hypershift", "webhook-auth-resolver", 1)
 				if proxyTransport != nil && proxyTransport.DialContext != nil {
 					ret.Dial = proxyTransport.DialContext
 				}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options/options.go
@@ -21,6 +21,7 @@ package options
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -417,6 +418,7 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 	kubeconfig.ContentConfig.ContentType = s.Generic.ClientConnection.ContentType
 	kubeconfig.QPS = s.Generic.ClientConnection.QPS
 	kubeconfig.Burst = int(s.Generic.ClientConnection.Burst)
+	kubeconfig.UserAgent = strings.Replace(kubeconfig.UserAgent, "hypershift", "kube-controller-manager", 1)
 
 	client, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, KubeControllerManagerUserAgent))
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -150,6 +151,7 @@ func (s *DeprecatedInsecureServingOptionsWithLoopback) ApplyTo(insecureServingIn
 	}
 
 	secureLoopbackClientConfig, err := (*insecureServingInfo).NewLoopbackClientConfig()
+	secureLoopbackClientConfig.UserAgent = strings.Replace(secureLoopbackClientConfig.UserAgent, "hypershift", "kube-apiserver", 1)
 	switch {
 	// if we failed and there's no fallback loopback client config, we need to fail
 	case err != nil && secureLoopbackClientConfig == nil:

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
@@ -19,6 +19,7 @@ package options
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/pborman/uuid"
 
@@ -61,6 +62,7 @@ func (s *SecureServingOptionsWithLoopback) ApplyTo(secureServingInfo **server.Se
 	}
 
 	secureLoopbackClientConfig, err := (*secureServingInfo).NewLoopbackClientConfig(uuid.NewRandom().String(), certPem)
+	secureLoopbackClientConfig.UserAgent = strings.Replace(secureLoopbackClientConfig.UserAgent, "hypershift", "kube-apiserver", 1)
 	switch {
 	// if we failed and there's no fallback loopback client config, we need to fail
 	case err != nil && secureLoopbackClientConfig == nil:


### PR DESCRIPTION
The goal is to distinguish between openshift-apiserver and openshift-controller from other components that are today reported in prometheus as `hypershift`.