### PR TITLE
UPSTREAM: 73345: discovery: speedup kubectl restmapper cache misses

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -934,8 +934,13 @@ func (_ *fakeServerResources) ServerResourcesForGroupVersion(groupVersion string
 	return nil, nil
 }
 
+// Deprecated: use ServerGroupsAndResources instead.
 func (_ *fakeServerResources) ServerResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
+}
+
+func (_ *fakeServerResources) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, nil
 }
 
 func (f *fakeServerResources) ServerPreferredResources() ([]*metav1.APIResourceList, error) {

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_pod_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/top_pod_test.go
@@ -387,6 +387,10 @@ func (d *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 	return nil, nil
 }
 
+func (d *fakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, nil
+}
+
 // ServerResourcesForGroupVersion returns the supported resources for a group and version.
 func (d *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	return nil, nil

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/cached/memcache.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/cached/memcache.go
@@ -66,8 +66,14 @@ func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*m
 }
 
 // ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
 func (d *memCacheClient) ServerResources() ([]*metav1.APIResourceList, error) {
 	return discovery.ServerResources(d)
+}
+
+// ServerGroupsAndResources returns the groups and supported resources for all groups and versions.
+func (d *memCacheClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return discovery.ServerGroupsAndResources(d)
 }
 
 func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/cached_discovery.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/cached_discovery.go
@@ -90,8 +90,15 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 }
 
 // ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
 func (d *CachedDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	return ServerResources(d)
+	_, rs, err := ServerGroupsAndResources(d)
+	return rs, err
+}
+
+// ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
+func (d *CachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return ServerGroupsAndResources(d)
 }
 
 func (d *CachedDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -84,12 +84,28 @@ type ServerResourcesInterface interface {
 	// ServerResourcesForGroupVersion returns the supported resources for a group and version.
 	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
 	// ServerResources returns the supported resources for all groups and versions.
+	//
+	// The returned resource list might be non-nil with partial results even in the case of
+	// non-nil error.
+	//
+	// Deprecated: use ServerGroupsAndResources instead.
 	ServerResources() ([]*metav1.APIResourceList, error)
+	// ServerResources returns the supported groups and resources for all groups and versions.
+	//
+	// The returned group and resource lists might be non-nil with partial results even in the
+	// case of non-nil error.
+	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
 	// ServerPreferredResources returns the supported resources with the version preferred by the
 	// server.
+	//
+	// The returned group and resource lists might be non-nil with partial results even in the
+	// case of non-nil error.
 	ServerPreferredResources() ([]*metav1.APIResourceList, error)
 	// ServerPreferredNamespacedResources returns the supported namespaced resources with the
 	// version preferred by the server.
+	//
+	// The returned resource list might be non-nil with partial results even in the case of
+	// non-nil error.
 	ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error)
 }
 
@@ -187,14 +203,18 @@ func (d *DiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (r
 	return resources, nil
 }
 
-// serverResources returns the supported resources for all groups and versions.
-func (d *DiscoveryClient) serverResources() ([]*metav1.APIResourceList, error) {
-	return ServerResources(d)
+// ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
+func (d *DiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	_, rs, err := d.ServerGroupsAndResources()
+	return rs, err
 }
 
-// ServerResources returns the supported resources for all groups and versions.
-func (d *DiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	return withRetries(defaultRetries, d.serverResources)
+// ServerGroupsAndResources returns the supported resources for all groups and versions.
+func (d *DiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return withRetries(defaultRetries, func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+		return ServerGroupsAndResources(d)
+	})
 }
 
 // ErrGroupDiscoveryFailed is returned if one or more API groups fail to load.
@@ -220,23 +240,28 @@ func IsGroupDiscoveryFailedError(err error) bool {
 	return err != nil && ok
 }
 
-// serverPreferredResources returns the supported resources with the version preferred by the server.
-func (d *DiscoveryClient) serverPreferredResources() ([]*metav1.APIResourceList, error) {
-	return ServerPreferredResources(d)
+// ServerResources uses the provided discovery interface to look up supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
+func ServerResources(d DiscoveryInterface) ([]*metav1.APIResourceList, error) {
+	_, rs, err := ServerGroupsAndResources(d)
+	return rs, err
 }
 
-// ServerResources uses the provided discovery interface to look up supported resources for all groups and versions.
-func ServerResources(d DiscoveryInterface) ([]*metav1.APIResourceList, error) {
-	apiGroups, err := d.ServerGroups()
-	if err != nil {
-		return nil, err
+func ServerGroupsAndResources(d DiscoveryInterface) ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	sgs, err := d.ServerGroups()
+	if sgs == nil {
+		return nil, nil, err
+	}
+	resultGroups := []*metav1.APIGroup{}
+	for i := range sgs.Groups {
+		resultGroups = append(resultGroups, &sgs.Groups[i])
 	}
 
-	groupVersionResources, failedGroups := fetchGroupVersionResources(d, apiGroups)
+	groupVersionResources, failedGroups := fetchGroupVersionResources(d, sgs)
 
 	// order results by group/version discovery order
 	result := []*metav1.APIResourceList{}
-	for _, apiGroup := range apiGroups.Groups {
+	for _, apiGroup := range sgs.Groups {
 		for _, version := range apiGroup.Versions {
 			gv := schema.GroupVersion{Group: apiGroup.Name, Version: version.Version}
 			if resources, ok := groupVersionResources[gv]; ok {
@@ -246,10 +271,10 @@ func ServerResources(d DiscoveryInterface) ([]*metav1.APIResourceList, error) {
 	}
 
 	if len(failedGroups) == 0 {
-		return result, nil
+		return resultGroups, result, nil
 	}
 
-	return result, &ErrGroupDiscoveryFailed{Groups: failedGroups}
+	return resultGroups, result, &ErrGroupDiscoveryFailed{Groups: failedGroups}
 }
 
 // ServerPreferredResources uses the provided discovery interface to look up preferred resources
@@ -313,7 +338,7 @@ func ServerPreferredResources(d DiscoveryInterface) ([]*metav1.APIResourceList, 
 	return result, &ErrGroupDiscoveryFailed{Groups: failedGroups}
 }
 
-// fetchServerResourcesForGroupVersions uses the discovery client to fetch the resources for the specified groups in parallel
+// fetchServerResourcesForGroupVersions uses the discovery client to fetch the resources for the specified groups in parallel.
 func fetchGroupVersionResources(d DiscoveryInterface, apiGroups *metav1.APIGroupList) (map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error) {
 	groupVersionResources := make(map[schema.GroupVersion]*metav1.APIResourceList)
 	failedGroups := make(map[schema.GroupVersion]error)
@@ -337,7 +362,9 @@ func fetchGroupVersionResources(d DiscoveryInterface, apiGroups *metav1.APIGroup
 				if err != nil {
 					// TODO: maybe restrict this to NotFound errors
 					failedGroups[groupVersion] = err
-				} else {
+				}
+				if apiResourceList != nil {
+					// even in case of error, some fallback might have been returned
 					groupVersionResources[groupVersion] = apiResourceList
 				}
 			}()
@@ -351,7 +378,11 @@ func fetchGroupVersionResources(d DiscoveryInterface, apiGroups *metav1.APIGroup
 // ServerPreferredResources returns the supported resources with the version preferred by the
 // server.
 func (d *DiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	return withRetries(defaultRetries, d.serverPreferredResources)
+	_, rs, err := withRetries(defaultRetries, func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+		rs, err := ServerPreferredResources(d)
+		return nil, rs, err
+	})
+	return rs, err
 }
 
 // ServerPreferredNamespacedResources returns the supported namespaced resources with the
@@ -406,19 +437,20 @@ func (d *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 }
 
 // withRetries retries the given recovery function in case the groups supported by the server change after ServerGroup() returns.
-func withRetries(maxRetries int, f func() ([]*metav1.APIResourceList, error)) ([]*metav1.APIResourceList, error) {
+func withRetries(maxRetries int, f func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)) ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	var result []*metav1.APIResourceList
+	var resultGroups []*metav1.APIGroup
 	var err error
 	for i := 0; i < maxRetries; i++ {
-		result, err = f()
+		resultGroups, result, err = f()
 		if err == nil {
-			return result, nil
+			return resultGroups, result, nil
 		}
 		if _, ok := err.(*ErrGroupDiscoveryFailed); !ok {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return result, err
+	return resultGroups, result, err
 }
 
 func setDiscoveryDefaults(config *restclient.Config) error {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -50,13 +50,30 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 	return nil, fmt.Errorf("GroupVersion %q not found", groupVersion)
 }
 
+// ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
 func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	_, rs, err := c.ServerGroupsAndResources()
+	return rs, err
+}
+
+// ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
+func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	sgs, err := c.ServerGroups()
+	if err != nil {
+		return nil, nil, err
+	}
+	resultGroups := []*metav1.APIGroup{}
+	for i := range sgs.Groups {
+		resultGroups = append(resultGroups, &sgs.Groups[i])
+	}
+
 	action := testing.ActionImpl{
 		Verb:     "get",
 		Resource: schema.GroupVersionResource{Resource: "resource"},
 	}
 	c.Invokes(action, nil)
-	return c.Resources, nil
+	return resultGroups, c.Resources, nil
 }
 
 func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/restmapper/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/restmapper/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
+        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
@@ -265,11 +265,26 @@ func (c *fakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string
 	return nil, errors.NewNotFound(schema.GroupResource{}, "")
 }
 
+// Deprecated: use ServerGroupsAndResources instead.
 func (c *fakeDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	if c.serverResourcesHandler != nil {
-		return c.serverResourcesHandler()
+	_, rs, err := c.ServerGroupsAndResources()
+	return rs, err
+}
+
+func (c *fakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	sgs, err := c.ServerGroups()
+	if err != nil {
+		return nil, nil, err
 	}
-	return []*metav1.APIResourceList{}, nil
+	resultGroups := []*metav1.APIGroup{}
+	for i := range sgs.Groups {
+		resultGroups = append(resultGroups, &sgs.Groups[i])
+	}
+	if c.serverResourcesHandler != nil {
+		rs, err := c.serverResourcesHandler()
+		return resultGroups, rs, err
+	}
+	return resultGroups, []*metav1.APIResourceList{}, nil
 }
 
 func (c *fakeDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {


### PR DESCRIPTION
Mostly clean cherry-pick.