### PR TITLE
UPSTREAM: <carry>: prioritize some CRD groups over others

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -213,8 +213,8 @@ func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.Grou
 				Spec: apiregistration.APIServiceSpec{
 					Group:                groupVersion.Group,
 					Version:              groupVersion.Version,
-					GroupPriorityMinimum: 1000, // CRDs should have relatively low priority
-					VersionPriority:      100,  // CRDs will be sorted by kube-like versions like any other APIService with the same VersionPriority
+					GroupPriorityMinimum: getGroupPriorityMin(groupVersion.Group), // CRDs should have relatively low priority
+					VersionPriority:      100,                                     // CRDs will be sorted by kube-like versions like any other APIService with the same VersionPriority
 				},
 			})
 			return nil

--- a/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/patch.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/patch.go
@@ -1,0 +1,12 @@
+package crdregistration
+
+func getGroupPriorityMin(group string) int32 {
+	switch group {
+	case "config.openshift.io":
+		return 1100
+	case "operator.openshift.io":
+		return 1080
+	default:
+		return 1000
+	}
+}


### PR DESCRIPTION
This coerces our "special" groups above the unwashed masses of CRs.  This makes sure that `oc edit authentication` will edit the `authentication.config.openshift.io`, not `authentication.operator.openshift.io`

/assign @sttts 
@enj @benjaminapetersen fyi