### PR TITLE
Set command name for user-agent in rest client per component.

### DIFF
--- a/pkg/cmd/openshift-apiserver/cmd.go
+++ b/pkg/cmd/openshift-apiserver/cmd.go
@@ -12,7 +12,11 @@ import (
 	"github.com/spf13/cobra"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -22,15 +26,13 @@ import (
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"github.com/openshift/library-go/pkg/serviceability"
+
 	"github.com/openshift/origin/pkg/api/legacy"
 	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/configdefault"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config/validation"
 	"github.com/openshift/origin/pkg/configconversion"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 const RecommendedStartAPIServerName = "openshift-apiserver"
@@ -51,6 +53,8 @@ func NewOpenShiftAPIServerCommand(name, basename string, out, errout io.Writer, 
 		Short: "Launch OpenShift apiserver",
 		Long:  longDescription,
 		Run: func(c *cobra.Command, args []string) {
+			rest.CommandNameOverride = name
+
 			legacy.InstallInternalLegacyAll(legacyscheme.Scheme)
 
 			kcmdutil.CheckErr(options.Validate())

--- a/pkg/cmd/openshift-controller-manager/cmd.go
+++ b/pkg/cmd/openshift-controller-manager/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,7 @@ func NewOpenShiftControllerManagerCommand(name, basename string, out, errout io.
 		Short: "Start the OpenShift controllers",
 		Long:  longDescription,
 		Run: func(c *cobra.Command, args []string) {
+			rest.CommandNameOverride = name
 			kcmdutil.CheckErr(options.Validate())
 
 			serviceability.StartProfiler()

--- a/pkg/cmd/openshift-kube-apiserver/cmd.go
+++ b/pkg/cmd/openshift-kube-apiserver/cmd.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -23,12 +25,12 @@ import (
 	osinv1 "github.com/openshift/api/osin/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"github.com/openshift/library-go/pkg/serviceability"
+
 	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/configdefault"
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	configapilatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config/validation"
 	"github.com/openshift/origin/pkg/configconversion"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 const RecommendedStartAPIServerName = "openshift-kube-apiserver"
@@ -49,6 +51,7 @@ func NewOpenShiftKubeAPIServerServerCommand(name, basename string, out, errout i
 		Short: "Start the OpenShift kube-apiserver",
 		Long:  longDescription,
 		Run: func(c *cobra.Command, args []string) {
+			rest.CommandNameOverride = name
 			if err := options.Validate(); err != nil {
 				glog.Fatal(err)
 			}

--- a/pkg/cmd/openshift-network-controller/cmd.go
+++ b/pkg/cmd/openshift-network-controller/cmd.go
@@ -9,6 +9,7 @@ import (
 	"path"
 
 	"github.com/openshift/origin/pkg/cmd/openshift-controller-manager/configdefault"
+	"k8s.io/client-go/rest"
 
 	"github.com/coreos/go-systemd/daemon"
 	"github.com/golang/glog"
@@ -47,6 +48,7 @@ func NewOpenShiftNetworkControllerCommand(name, basename string, out, errout io.
 		Short: "Start the OpenShift SDN controller",
 		Long:  longDescription,
 		Run: func(c *cobra.Command, args []string) {
+			rest.CommandNameOverride = name
 			kcmdutil.CheckErr(options.Validate())
 
 			serviceability.StartProfiler()

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/config.go
@@ -282,12 +282,18 @@ func adjustVersion(v string) string {
 	return seg[0]
 }
 
+// CommandNameOverride allows to override the command reported in user-agent.
+var CommandNameOverride = ""
+
 // adjustCommand returns the last component of the
 // OS-specific command path for use in User-Agent.
 func adjustCommand(p string) string {
 	// Unlikely, but better than returning "".
 	if len(p) == 0 {
 		return "unknown"
+	}
+	if len(CommandNameOverride) > 0 {
+		return CommandNameOverride
 	}
 	return filepath.Base(p)
 }


### PR DESCRIPTION
By default, Kubernetes will use the `os.Args[0]` as the source for the command name in `User-Agent` string. This change will allow to override this with custom command name and set this per component name in `hypershift` binary.

That means each component will be uniquely identifiable in prometheus.