### PR TITLE
keep events for three hours

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/flags.go
@@ -120,6 +120,7 @@ func ConfigToFlags(kubeAPIServerConfig *kubecontrolplanev1.KubeAPIServerConfig) 
 	configflags.SetIfUnset(args, "etcd-keyfile", kubeAPIServerConfig.StorageConfig.KeyFile)
 	configflags.SetIfUnset(args, "etcd-prefix", kubeAPIServerConfig.StorageConfig.StoragePrefix)
 	configflags.SetIfUnset(args, "etcd-servers", kubeAPIServerConfig.StorageConfig.URLs...)
+	configflags.SetIfUnset(args, "event-ttl", "3h") // set a TTL long enough to last for our CI tests so we see the first set of events.
 	configflags.SetIfUnset(args, "insecure-port", "0")
 	configflags.SetIfUnset(args, "kubelet-certificate-authority", kubeAPIServerConfig.KubeletClientInfo.CA)
 	configflags.SetIfUnset(args, "kubelet-client-certificate", kubeAPIServerConfig.KubeletClientInfo.CertFile)


### PR DESCRIPTION
Since we're installing the platform on the platform, the ability to keep events for the duration of a CI run to figure out why we're in the state we're in is important.  This updates the event ttl.

/assign @sttts 