### PR TITLE
UPSTREAM: 00000: wait for apiservices on startup

### DIFF
--- a/test/integration/master_routes_test.go
+++ b/test/integration/master_routes_test.go
@@ -107,6 +107,7 @@ var expectedIndex = []string{
 	"/healthz/poststarthook/apiservice-openapi-controller",
 	"/healthz/poststarthook/apiservice-registration-controller",
 	"/healthz/poststarthook/apiservice-status-available-controller",
+	"/healthz/poststarthook/apiservice-wait-for-first-sync",
 	"/healthz/poststarthook/bootstrap-controller",
 	"/healthz/poststarthook/ca-registration",
 	"/healthz/poststarthook/generic-apiserver-start-informers",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -18,16 +18,25 @@ package apiserver
 
 import (
 	"net/http"
+	"strings"
 	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/client-go/pkg/version"
 
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	apiregistrationapi "k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
@@ -203,6 +212,33 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		go availableController.Run(5, context.StopCh)
 		return nil
 	})
+	s.GenericAPIServer.AddPostStartHook("apiservice-wait-for-first-sync", func(context genericapiserver.PostStartHookContext) error {
+		// when the aggregator first starts, it should make sure that it has proxy handlers for all the known good API services at this time
+		// we only need to do this once.
+		err := wait.PollImmediateUntil(100*time.Millisecond, func() (bool, error) {
+			// fix race
+			handledAPIServices := sets.StringKeySet(s.proxyHandlers)
+			apiservices, err := s.lister.List(labels.Everything())
+			if err != nil {
+				return false, err
+			}
+			expectedAPIServices := sets.NewString()
+			for _, apiservice := range apiservices {
+				if apiregistrationapi.IsAPIServiceConditionTrue(apiservice, apiregistrationapi.Available) {
+					expectedAPIServices.Insert(apiservice.Name)
+				}
+			}
+
+			notYetHandledAPIServices := expectedAPIServices.Difference(handledAPIServices)
+			if len(notYetHandledAPIServices) == 0 {
+				return true, nil
+			}
+			glog.Infof("still waiting on handling APIServices: %v", strings.Join(notYetHandledAPIServices.List(), ","))
+
+			return false, nil
+		}, context.StopCh)
+		return err
+	})
 
 	if openApiConfig != nil {
 		specDownloader := openapicontroller.NewDownloader()
@@ -255,9 +291,16 @@ func (s *APIAggregator) AddAPIService(apiService *apiregistration.APIService) er
 	}
 	proxyHandler.updateAPIService(apiService)
 	if s.openAPIAggregationController != nil {
-		s.openAPIAggregationController.AddAPIService(proxyHandler, apiService)
+		// this is calling a controller.  It should already handle being async.
+		go func() {
+			defer utilruntime.HandleCrash()
+			s.openAPIAggregationController.AddAPIService(proxyHandler, apiService)
+		}()
 	}
-	s.proxyHandlers[apiService.Name] = proxyHandler
+	// we want to update the registration bit last after all the pieces are wired together
+	defer func() {
+		s.proxyHandlers[apiService.Name] = proxyHandler
+	}()
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle(proxyPath, proxyHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandlePrefix(proxyPath+"/", proxyHandler)
 


### PR DESCRIPTION
A stab at https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_cluster-kube-controller-manager-operator/148/pull-ci-openshift-cluster-kube-controller-manager-operator-master-e2e-aws/636

Let's imagine this sad story.  You have an automanaged system that is trying to come up.

1. kube-apiserver completes installation, the first time, and goes available
2. openshift-apiserver installs and is not available because openapi needs aggregating
3. @sttts vastly improves openapi aggregation performance
4. openshift's openapi is aggregated really fast now so it finishes before....
5. networking completes and an cidr somewhere is updated, which feeds into a kube-apiserver admission plugin
6. CVO updates and realizes it is "done"
7. kube-apiserver goes into progressing state (but is still available)
8. e2e tests start
9. under heavy load, the kubeapiserver operator doesn't flake, but it takes three minutes to roll out
10. new kube-apiservers come up, but the aggregation layer is proxying yet (it's async), so some requests for discovery and resources work and some do not
11. kube e2e tests don't restablish watches, but the kube-apiserver drops them when it shuts down
12. @deads2k needs a drink

This pull tries to prevent readiness until *after* the kube-apiserver can proxy to the expected aggregated APIs.  It does not address problem 11.

@smarterclayton @sttts 