### PR TITLE
UPSTREAM: 73894: Print the involved object in the event table

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/printers/internalversion/printers.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/internalversion/printers.go
@@ -238,10 +238,10 @@ func AddKubeHandlers(h printers.PrintHandler) {
 		{Name: "Last Seen", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["lastTimestamp"]},
 		{Name: "Type", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["type"]},
 		{Name: "Reason", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["reason"]},
-		{Name: "Kind", Type: "string", Description: apiv1.Event{}.InvolvedObject.SwaggerDoc()["kind"]},
+		{Name: "Object", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["involvedObject"]},
+		{Name: "Subobject", Type: "string", Priority: 1, Description: apiv1.Event{}.InvolvedObject.SwaggerDoc()["fieldPath"]},
 		{Name: "Source", Type: "string", Priority: 1, Description: apiv1.Event{}.SwaggerDoc()["source"]},
 		{Name: "Message", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["message"]},
-		{Name: "Subobject", Type: "string", Priority: 1, Description: apiv1.Event{}.InvolvedObject.SwaggerDoc()["fieldPath"]},
 		{Name: "First Seen", Type: "string", Priority: 1, Description: apiv1.Event{}.SwaggerDoc()["firstTimestamp"]},
 		{Name: "Count", Type: "string", Priority: 1, Description: apiv1.Event{}.SwaggerDoc()["count"]},
 		{Name: "Name", Type: "string", Priority: 1, Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -1349,15 +1349,21 @@ func printEvent(obj *api.Event, options printers.PrintOptions) ([]metav1beta1.Ta
 		firstTimestamp = translateTimestampSince(obj.FirstTimestamp)
 		lastTimestamp = translateTimestampSince(obj.LastTimestamp)
 	}
+	var target string
+	if len(obj.InvolvedObject.Name) > 0 {
+		target = fmt.Sprintf("%s/%s", strings.ToLower(obj.InvolvedObject.Kind), obj.InvolvedObject.Name)
+	} else {
+		target = strings.ToLower(obj.InvolvedObject.Kind)
+	}
 	if options.Wide {
 		row.Cells = append(row.Cells,
 			lastTimestamp,
 			obj.Type,
 			obj.Reason,
-			obj.InvolvedObject.Kind,
+			target,
+			obj.InvolvedObject.FieldPath,
 			formatEventSource(obj.Source),
 			strings.TrimSpace(obj.Message),
-			obj.InvolvedObject.FieldPath,
 			firstTimestamp,
 			int64(obj.Count),
 			obj.Name,
@@ -1367,7 +1373,7 @@ func printEvent(obj *api.Event, options printers.PrintOptions) ([]metav1beta1.Ta
 			lastTimestamp,
 			obj.Type,
 			obj.Reason,
-			obj.InvolvedObject.Kind,
+			target,
 			strings.TrimSpace(obj.Message),
 		)
 	}


### PR DESCRIPTION
Makes it much easier to read events.

```
119m   Normal    SuccessfulDelete         cronjob/image-mirror-origin-v3.11-quay                Deleted job image-mirror-origin-v3.11-quay-1550088000
60m    Normal    SuccessfulCreate         cronjob/image-mirror-origin-v3.11-quay                Created job image-mirror-origin-v3.11-quay-1550095200
59m    Normal    SawCompletedJob          cronjob/image-mirror-origin-v3.11-quay                Saw completed job: image-mirror-origin-v3.11-quay-1550095200
59m    Normal    SuccessfulDelete         cronjob/image-mirror-origin-v3.11-quay                Deleted job image-mirror-origin-v3.11-
```