### PR TITLE
UPSTREAM: 73928: Fix PVC protection e2es when default storage class is WaitForFirstConsumer

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/pvc_protection.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/pvc_protection.go
@@ -36,6 +36,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		err                     error
 		pvc                     *v1.PersistentVolumeClaim
 		pvcCreatedAndNotDeleted bool
+		pod                     *v1.Pod
 	)
 
 	f := framework.NewDefaultFramework("pvc-protection")
@@ -56,6 +57,11 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		Expect(err).NotTo(HaveOccurred(), "Error creating PVC")
 		pvcCreatedAndNotDeleted = true
 
+		By("Creating a Pod that becomes Running and therefore is actively using the PVC")
+		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
+		pod, err = framework.CreatePod(client, nameSpace, nil, pvcClaims, false, "")
+		Expect(err).NotTo(HaveOccurred(), "While creating pod that uses the PVC or waiting for the Pod to become Running")
+
 		By("Waiting for PVC to become Bound")
 		err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, nameSpace, pvc.Name, framework.Poll, framework.ClaimBindingTimeout)
 		Expect(err).NotTo(HaveOccurred(), "Failed waiting for PVC to be bound %v", err)
@@ -73,6 +79,10 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 	})
 
 	It("Verify \"immediate\" deletion of a PVC that is not in active use by a pod", func() {
+		By("Deleting the pod using the PVC")
+		err = framework.DeletePodWithWait(f, client, pod)
+		Expect(err).NotTo(HaveOccurred(), "Error terminating and deleting pod")
+
 		By("Deleting the PVC")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		Expect(err).NotTo(HaveOccurred(), "Error deleting PVC")
@@ -81,11 +91,6 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 	})
 
 	It("Verify that PVC in active use by a pod is not removed immediately", func() {
-		By("Creating a Pod that becomes Running and therefore is actively using the PVC")
-		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
-		pod, err := framework.CreatePod(client, nameSpace, nil, pvcClaims, false, "")
-		Expect(err).NotTo(HaveOccurred(), "While creating pod that uses the PVC or waiting for the Pod to become Running")
-
 		By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		Expect(err).NotTo(HaveOccurred(), "Error deleting PVC")
@@ -105,11 +110,6 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 	})
 
 	It("Verify that scheduling of a pod that uses PVC that is being deleted fails and the pod becomes Unschedulable", func() {
-		By("Creating first Pod that becomes Running and therefore is actively using the PVC")
-		pvcClaims := []*v1.PersistentVolumeClaim{pvc}
-		firstPod, err := framework.CreatePod(client, nameSpace, nil, pvcClaims, false, "")
-		Expect(err).NotTo(HaveOccurred(), "While creating pod that uses the PVC or waiting for the Pod to become Running")
-
 		By("Deleting the PVC, however, the PVC must not be removed from the system as it's in active use by a pod")
 		err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, metav1.NewDeleteOptions(0))
 		Expect(err).NotTo(HaveOccurred(), "Error deleting PVC")
@@ -120,7 +120,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(Equal(nil))
 
 		By("Creating second Pod whose scheduling fails because it uses a PVC that is being deleted")
-		secondPod, err2 := framework.CreateUnschedulablePod(client, nameSpace, nil, pvcClaims, false, "")
+		secondPod, err2 := framework.CreateUnschedulablePod(client, nameSpace, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
 		Expect(err2).NotTo(HaveOccurred(), "While creating second pod that uses a PVC that is being deleted and that is Unschedulable")
 
 		By("Deleting the second pod that uses the PVC that is being deleted")
@@ -133,7 +133,7 @@ var _ = utils.SIGDescribe("PVC Protection", func() {
 		Expect(pvc.ObjectMeta.DeletionTimestamp).NotTo(Equal(nil))
 
 		By("Deleting the first pod that uses the PVC")
-		err = framework.DeletePodWithWait(f, client, firstPod)
+		err = framework.DeletePodWithWait(f, client, pod)
 		Expect(err).NotTo(HaveOccurred(), "Error terminating and deleting pod")
 
 		By("Checking that the PVC is automatically removed from the system because it's no longer in active use by a pod")


### PR DESCRIPTION
we want to switch the default storageclass to WaitForFirstConsumer to avoid unschedulable pods in multizone clusters https://github.com/openshift/cluster-storage-operator/pull/12 https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode . this fix is needed to make the test tolerate such a storageclass
@openshift/storage 