### PR TITLE
UPSTREAM: 73962: Fix glusterfs e2e not using correct storageclass 

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
@@ -72,6 +72,7 @@ const (
 func testDynamicProvisioning(t storageClassTest, client clientset.Interface, claim *v1.PersistentVolumeClaim, class *storage.StorageClass) *v1.PersistentVolume {
 	var err error
 	if class != nil {
+		Expect(*claim.Spec.StorageClassName).To(Equal(class.Name))
 		By("creating a StorageClass " + class.Name)
 		class, err = client.StorageV1().StorageClasses().Create(class)
 		Expect(err).NotTo(HaveOccurred())
@@ -933,6 +934,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 
 			By("creating a claim object with a suffix for gluster dynamic provisioner")
 			claim := newClaim(test, ns, suffix)
+			claim.Spec.StorageClassName = &class.Name
 
 			testDynamicProvisioning(test, c, claim, class)
 		})

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/volume_provisioning.go
@@ -919,7 +919,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 		It("should create and delete persistent volumes [fast]", func() {
 			By("creating a Gluster DP server Pod")
 			pod := startGlusterDpServerPod(c, ns)
-			serverUrl := "https://" + pod.Status.PodIP + ":8081"
+			serverUrl := "http://" + pod.Status.PodIP + ":8081"
 			By("creating a StorageClass")
 			test := storageClassTest{
 				name:               "Gluster Dynamic provisioner test",


### PR DESCRIPTION
Currently, the glusterfs e2e test is using the default storageclass (aws) instead of the glusterfs one it's supposed to be testing. This patch fixes that & unblocks https://github.com/openshift/cluster-storage-operator/pull/12 because the test in its current state can't tolerate a storageclass with WaitForFirstConsumer

see also https://github.com/openshift/origin/pull/22048

@openshift/storage