### PR TITLE
tests/extended: narrow the focus of ingress wildcard dns test

### DIFF
--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -22,7 +22,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-func createDNSPod(namespace, probeCmd string) *kapiv1.Pod {
+func CreateDNSPod(namespace, probeCmd string) *kapiv1.Pod {
 	pod := &kapiv1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -376,7 +376,7 @@ var _ = Describe("DNS", func() {
 
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		By("creating a pod to probe DNS")
-		pod := createDNSPod(f.Namespace.Name, cmd)
+		pod := CreateDNSPod(f.Namespace.Name, cmd)
 		validateDNSResults(f, pod, expect, times)
 	})
 })


### PR DESCRIPTION
Refactor the ingress wildcard DNS test to assert only that DNS for a route can be
resolved. Before this change, the test was also asserting that the route pod
endpoint was reachable, which took long enough to set up (over 2 minutes) that
the test was often flaking against timeouts.

Because the test is only concerned with exercising DNS, rather than increasing
timeouts, narrowing the focus to only test DNS should be faster and more stable.

/cc @openshift/sig-network-edge 