### PR TITLE
UPSTREAM: 71440: Fix for race condition caused by concurrent fsnotify (CREATE and REMOVE) in kubelet/plugin_watcher.go

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/util/pluginwatcher/plugin_watcher.go
@@ -106,7 +106,7 @@ func (w *Watcher) Start() error {
 				//TODO: Handle errors by taking corrective measures
 
 				w.wg.Add(1)
-				go func() {
+				func() {
 					defer w.wg.Done()
 
 					if event.Op&fsnotify.Create == fsnotify.Create {


### PR DESCRIPTION
upstream https://github.com/kubernetes/kubernetes/pull/71440

xref https://github.com/openshift/origin/pull/22021#issuecomment-463274704

@derekwaynecarr @rphillips 