### PR TITLE
Add default proxy env vars to whitelist and update tests

### DIFF
--- a/pkg/build/util/consts.go
+++ b/pkg/build/util/consts.go
@@ -3,7 +3,7 @@ package util
 // TODO: This list needs triage and move to openshift/api and library-go:
 
 var (
-	WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY"}
+	WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
 
 	// DefaultSuccessfulBuildsHistoryLimit is the default number of successful builds to retain
 	DefaultSuccessfulBuildsHistoryLimit = int32(5)


### PR DESCRIPTION
Add the following default proxy env vars to the whitelist:

 - HTTP_PROXY
 - HTTPS_PROXY
 - NO_PROXY

Also updates tests for the application of the default proxy env vars
to the source, docker, and custom build strategies.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1677585