### PR TITLE
UPSTREAM: 74244: kube-aggregator: fix typo aggregator_unavailable_api{server -> service}_gauge

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/metrics.go
@@ -30,7 +30,7 @@ var (
 	)
 	unavailableGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "aggregator_unavailable_apiserver_gauge",
+			Name: "aggregator_unavailable_apiservice",
 			Help: "Gauge of APIServices which are marked as unavailable broken down by APIService name.",
 		},
 		[]string{"name"},


### PR DESCRIPTION
We picked the commit introducing these metrics before. And we might have alerts defined (remembering some aos-devel communication with @derekwaynecarr).