### PR TITLE
Fix issue where wildcard routes get 503s intermittently.

### DIFF
--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -233,7 +233,8 @@ func (p *HostAdmitter) displacedRoutes(newRoute *routeapi.Route) ([]*routeapi.Ro
 	// See if any existing routes block our host, or if we displace their host
 	for i, route := range p.claimedHosts[newRoute.Spec.Host] {
 		if p.disableNamespaceCheck || route.Namespace == newRoute.Namespace {
-			if !p.disableNamespaceCheck && route.Name == newRoute.Name {
+			if route.Namespace == newRoute.Namespace && route.Name == newRoute.Name {
+				// Ignore ourself.
 				continue
 			}
 
@@ -272,7 +273,7 @@ func (p *HostAdmitter) displacedRoutes(newRoute *routeapi.Route) ([]*routeapi.Ro
 	// See if any existing wildcard routes block our domain, or if we displace them
 	for i, route := range p.claimedWildcards[wildcardKey] {
 		if p.disableNamespaceCheck || route.Namespace == newRoute.Namespace {
-			if !p.disableNamespaceCheck && route.Name == newRoute.Name {
+			if route.Namespace == newRoute.Namespace && route.Name == newRoute.Name {
 				continue
 			}
 


### PR DESCRIPTION
As part of the resync processing, wildcard routes get a "HostAlreadyClaimed"
error and then later as part of the same event processing flow get re-added.
This results in a temporary outage (route returns 503s).

Associated bugz: https://bugzilla.redhat.com/show_bug.cgi?id=1660647

@openshift/sig-network-edge  PTAL Thx