### PR TITLE
images/tests/Dockerfile*: Install gzip for compressing logs

### DIFF
--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -9,6 +9,7 @@ FROM openshift/origin-cli
 RUN INSTALL_PKGS=" \
       origin-tests \
       git \
+      gzip \
       " && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \

--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=cmd/openshift-tests
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:cli
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/openshift-tests /usr/bin/
-RUN yum install --setopt=tsflags=nodocs -y git util-linux && yum clean all && rm -rf /var/cache/yum/* && \
+RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \


### PR DESCRIPTION
This image is primarily intended for running the test suite against an external cluster, but it's also a convenient place to collect the tools needed to retrieve and store logs extracted from those tested clusters.  If the inspection dependencies become too onerous, we might want to split them out into their own image, but for now it seems easier to overload tests.

It's not clear to me why only the RHEL Dockerfile lists `util-linux`, which it has since 228e3f56 (#22065), but I've left that part alone.

This is a pre-req for openshift/release#2911.