### PR TITLE
Wrap IDP transports with DebugWrappers

### DIFF
--- a/pkg/oauthserver/oauth/external/google/google.go
+++ b/pkg/oauthserver/oauth/external/google/google.go
@@ -3,6 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/openshift/origin/pkg/oauthserver/oauth/external"
 	"github.com/openshift/origin/pkg/oauthserver/oauth/external/openid"
@@ -19,7 +20,7 @@ const (
 
 var googleOAuthScopes = []string{"openid", "email", "profile"}
 
-func NewProvider(providerName, clientID, clientSecret, hostedDomain string) (external.Provider, error) {
+func NewProvider(providerName, clientID, clientSecret, hostedDomain string, transport http.RoundTripper) (external.Provider, error) {
 	config := openid.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -55,5 +56,5 @@ func NewProvider(providerName, clientID, clientSecret, hostedDomain string) (ext
 		}
 	}
 
-	return openid.NewProvider(providerName, nil, config)
+	return openid.NewProvider(providerName, transport, config)
 }

--- a/pkg/oauthserver/oauth/external/google/google_test.go
+++ b/pkg/oauthserver/oauth/external/google/google_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGoogle(t *testing.T) {
-	p, err := NewProvider("google", "clientid", "clientsecret", "")
+	p, err := NewProvider("google", "clientid", "clientsecret", "", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
This change adds glog level based request and response logging to all HTTP communication performed by IDPs.  This will greatly aid in debugging failures related to IDPs.

Note that this does not cover the LDAP and RequestHeader IDPs.  LDAP will require inspection at the net.Conn level.  RequestHeader will require upstream changes (primarily to add logging around x509
errors).

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 

AUTH-167