### PR TITLE
Use BoundedFrequencyRunner to limit the rate of NetworkPolicy updates

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -18,9 +19,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/networking"
+	"k8s.io/kubernetes/pkg/util/async"
 
 	networkapi "github.com/openshift/api/network/v1"
 	"github.com/openshift/origin/pkg/network"
@@ -35,6 +38,8 @@ type networkPolicyPlugin struct {
 	namespaces  map[uint32]*npNamespace
 	kNamespaces map[string]kapi.Namespace
 	pods        map[ktypes.UID]kapi.Pod
+
+	runner *async.BoundedFrequencyRunner
 }
 
 // npNamespace tracks NetworkPolicy-related data for a Namespace
@@ -42,6 +47,7 @@ type npNamespace struct {
 	name  string
 	vnid  uint32
 	inUse bool
+	dirty bool
 
 	policies map[ktypes.UID]*npPolicy
 }
@@ -94,6 +100,12 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 	if err := otx.Commit(); err != nil {
 		return err
 	}
+
+	// Rate-limit calls to np.syncFlows to 1-per-second after the 2nd call within 1
+	// second. The maxInterval (time.Hour) is irrelevant here because we always call
+	// np.runner.Run() if there is syncing to be done.
+	np.runner = async.NewBoundedFrequencyRunner("NetworkPolicy", np.syncFlows, time.Second, time.Hour, 2)
+	go np.runner.Loop(utilwait.NeverStop)
 
 	if err := np.initNamespaces(); err != nil {
 		return err
@@ -190,6 +202,25 @@ func (np *networkPolicyPlugin) GetMulticastEnabled(vnid uint32) bool {
 }
 
 func (np *networkPolicyPlugin) syncNamespace(npns *npNamespace) {
+	if !npns.dirty {
+		npns.dirty = true
+		np.runner.Run()
+	}
+}
+
+func (np *networkPolicyPlugin) syncFlows() {
+	np.lock.Lock()
+	defer np.lock.Unlock()
+
+	for _, npns := range np.namespaces {
+		if npns.dirty {
+			np.syncNamespaceFlows(npns)
+			npns.dirty = false
+		}
+	}
+}
+
+func (np *networkPolicyPlugin) syncNamespaceFlows(npns *npNamespace) {
 	glog.V(5).Infof("syncNamespace %d", npns.vnid)
 	otx := np.node.oc.NewTransaction()
 	otx.DeleteFlows("table=80, reg1=%d", npns.vnid)


### PR DESCRIPTION
In clusters with lots of podSelector-based NetworkPolicies, some changes (like redeploying a Deployment) can result in spamming OVS with flow updates (as we rewrite the entire namespace's worth of flows once for each pod that changes). In some cases this can result in blah blah PLEG blah blah and the Node becoming NotReady.

This changes it to use the same code kube-proxy uses to limit the rate of updates. Further improvements to this are possible, but this is enough to fix the Node NotReady status.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1656805