### PR TITLE
SDN test image for QE testing with ovs-2.11.0

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -14,7 +14,7 @@ COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/loopback /opt/cni/bin/
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/host-local /opt/cni/bin/
 RUN INSTALL_PKGS=" \
-      openvswitch socat ethtool iptables nmap-ncat \
+      openvswitch2.11 container-selinux socat ethtool iptables nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute bridge-utils procps-ng openssl \
       binutils xz sysvinit-tools dbus \


### PR DESCRIPTION
QE needs to test openvswitch 2.11.0 for possible inclusion in OpenShift 4.0

Signed-off-by: Phil Cameron <pcameron@redhat.com>