### PR TITLE
[Backport-3.10] Fix issue where wildcard routes get 503s intermittently.

### DIFF
--- a/pkg/router/controller/host_admitter.go
+++ b/pkg/router/controller/host_admitter.go
@@ -245,7 +245,7 @@ func (p *HostAdmitter) displacedRoutes(newRoute *routeapi.Route) ([]*routeapi.Ro
 	// See if any existing routes block our host, or if we displace their host
 	for i, route := range p.claimedHosts[newRoute.Spec.Host] {
 		if p.disableNamespaceCheck || route.Namespace == newRoute.Namespace {
-			if !p.disableNamespaceCheck && route.Name == newRoute.Name {
+			if route.UID == newRoute.UID {
 				continue
 			}
 
@@ -284,7 +284,7 @@ func (p *HostAdmitter) displacedRoutes(newRoute *routeapi.Route) ([]*routeapi.Ro
 	// See if any existing wildcard routes block our domain, or if we displace them
 	for i, route := range p.claimedWildcards[wildcardKey] {
 		if p.disableNamespaceCheck || route.Namespace == newRoute.Namespace {
-			if !p.disableNamespaceCheck && route.Name == newRoute.Name {
+			if route.UID == newRoute.UID {
 				continue
 			}
 


### PR DESCRIPTION
Couldn't cherrypick from #22087  due to conflicts in the unit test file (import package name changes), so this is a new PR. Code fixes are the same.

As part of the resync processing, wildcard routes get a "HostAlreadyClaimed"
error and then later as part of the same event processing flow, the route
gets re-added. This results in a temporary outage (route returns 503s).

fixes #1660647 (https://bugzilla.redhat.com/show_bug.cgi?id=1660647)

@openshift/sig-network-edge  PTAL Thx