### PR TITLE
UPSTREAM: 00000: prevent GC discovery from pulling partial lists on r…

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/controllermanager.go
@@ -264,7 +264,7 @@ func startControllers(c *cloudcontrollerconfig.CompletedConfig, stop <-chan stru
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.
-	err = genericcontrollermanager.WaitForAPIServer(c.VersionedClient, 10*time.Second)
+	err = genericcontrollermanager.WaitForAPIServer(c.VersionedClient.Discovery().RESTClient(), 10*time.Second)
 	if err != nil {
 		glog.Fatalf("Failed to wait for apiserver being healthy: %v", err)
 	}

--- a/vendor/k8s.io/kubernetes/cmd/controller-manager/app/helper.go
+++ b/vendor/k8s.io/kubernetes/cmd/controller-manager/app/helper.go
@@ -22,17 +22,18 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // WaitForAPIServer waits for the API Server's /healthz endpoint to report "ok" with timeout.
-func WaitForAPIServer(client clientset.Interface, timeout time.Duration) error {
+func WaitForAPIServer(client rest.Interface, timeout time.Duration) error {
 	var lastErr error
 
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		healthStatus := 0
-		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		result := client.Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
 		if result.Error() != nil {
 			lastErr = fmt.Errorf("failed to get apiserver /healthz status: %v", result.Error())
 			return false, nil

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -449,7 +449,7 @@ func CreateControllerContext(s *config.CompletedConfig, rootClientBuilder, clien
 
 	// If apiserver is not running we should wait for some time and fail only then. This is particularly
 	// important when we start apiserver and controller manager at the same time.
-	if err := genericcontrollermanager.WaitForAPIServer(versionedClient, 10*time.Second); err != nil {
+	if err := genericcontrollermanager.WaitForAPIServer(versionedClient.Discovery().RESTClient(), 10*time.Second); err != nil {
 		return ControllerContext{}, fmt.Errorf("failed to wait for apiserver being healthy: %v", err)
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/util/workqueue"
+	genericcontrollermanager "k8s.io/kubernetes/cmd/controller-manager/app"
 	"k8s.io/kubernetes/pkg/controller"
 	_ "k8s.io/kubernetes/pkg/util/reflector/prometheus" // for reflector metric registration
 	// install the prometheus plugin
@@ -164,7 +165,7 @@ type resettableRESTMapper interface {
 // Note that discoveryClient should NOT be shared with gc.restMapper, otherwise
 // the mapper's underlying discovery client will be unnecessarily reset during
 // the course of detecting new resources.
-func (gc *GarbageCollector) Sync(discoveryClient discovery.ServerResourcesInterface, period time.Duration, stopCh <-chan struct{}) {
+func (gc *GarbageCollector) Sync(discoveryClient discovery.DiscoveryInterface, period time.Duration, stopCh <-chan struct{}) {
 	oldResources := make(map[schema.GroupVersionResource]struct{})
 	wait.Until(func() {
 		// Get the current resource list from discovery.
@@ -640,7 +641,7 @@ func (gc *GarbageCollector) GraphHasUID(UIDs []types.UID) bool {
 // All discovery errors are considered temporary. Upon encountering any error,
 // GetDeletableResources will log and return any discovered resources it was
 // able to process (which may be none).
-func GetDeletableResources(discoveryClient discovery.ServerResourcesInterface) map[schema.GroupVersionResource]struct{} {
+func getDeletableResources(discoveryClient discovery.ServerResourcesInterface) map[schema.GroupVersionResource]struct{} {
 	preferredResources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		if discovery.IsGroupDiscoveryFailedError(err) {
@@ -669,4 +670,22 @@ func GetDeletableResources(discoveryClient discovery.ServerResourcesInterface) m
 	}
 
 	return deletableGroupVersionResources
+}
+
+func GetDeletableResources(discoveryClient discovery.DiscoveryInterface) map[schema.GroupVersionResource]struct{} {
+	// What if the kube-apiserver goes down and comes back up.  We then run this call, but the kube-apiserver isn't healthy.
+	// Since we wire against localhost, we can connect *before* we're healthy and the kube-apiserver can be bounced independently.
+	// In such a case, the kube-apiserver health check is false because not all APIServices are available, so some resources
+	// appear to disappear.
+
+	// If apiserver is not running we should wait for some time and fail only then. This is particularly
+	// important when we start apiserver and controller manager at the same time.
+	if discoveryClient.RESTClient() != nil {
+		if err := genericcontrollermanager.WaitForAPIServer(discoveryClient.RESTClient(), 10*time.Second); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to discover preferred resources: %v", err))
+			return map[schema.GroupVersionResource]struct{}{}
+		}
+	}
+
+	return getDeletableResources(discoveryClient)
 }

--- a/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googleapis/gnostic/OpenAPIv2"
+
 	"github.com/stretchr/testify/assert"
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
@@ -39,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
@@ -782,7 +785,7 @@ func TestGetDeletableResources(t *testing.T) {
 			PreferredResources: test.serverResources,
 			Error:              test.err,
 		}
-		actual := GetDeletableResources(client)
+		actual := getDeletableResources(client)
 		if !reflect.DeepEqual(test.deletableResources, actual) {
 			t.Errorf("expected resources:\n%v\ngot:\n%v", test.deletableResources, actual)
 		}
@@ -930,6 +933,8 @@ type fakeServerResources struct {
 	InterfaceUsedCount int
 }
 
+var _ discovery.DiscoveryInterface = &fakeServerResources{}
+
 func (_ *fakeServerResources) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	return nil, nil
 }
@@ -970,4 +975,20 @@ func (f *fakeServerResources) getInterfaceUsedCount() int {
 
 func (_ *fakeServerResources) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
+}
+
+func (_ *fakeServerResources) RESTClient() restclient.Interface {
+	return nil
+}
+
+func (_ *fakeServerResources) ServerGroups() (*metav1.APIGroupList, error) {
+	panic("unsupported")
+}
+
+func (_ *fakeServerResources) ServerVersion() (*version.Info, error) {
+	panic("unsupported")
+}
+
+func (_ *fakeServerResources) OpenAPISchema() (*openapi_v2.Document, error) {
+	panic("unsupported")
 }


### PR DESCRIPTION
…estarting apiservers


What if the kube-apiserver goes down and comes back up.  We then run this call, but the kube-apiserver isn't healthy.Since we wire against localhost, we can connect *before* we're healthy and the kube-apiserver can be bounced independently. In such a case, the kube-apiserver health check is false because not all APIServices are available, so some resourcesappear to disappear.  If apiserver is not running we should wait for some time and fail only then. This is particularly important when we start apiserver and controller manager at the same time.

@ecordell @ironcladlou @mfojtik @tnozicka maybe?