### PR TITLE
UPSTREAM: <carry>: handle pluralization of dnses

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -39,6 +39,7 @@ import (
 func NameSystems() namer.NameSystems {
 	// If you change this, make sure you get the other instances in listers and informers
 	pluralExceptions := map[string]string{
+		"DNS":                        "DNSes",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
 		"SecurityContextConstraints": "SecurityContextConstraints",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
@@ -50,6 +50,7 @@ func (g *genericGenerator) Filter(c *generator.Context, t *types.Type) bool {
 
 func (g *genericGenerator) Namers(c *generator.Context) namer.NameSystems {
 	pluralExceptions := map[string]string{
+		"DNS":                        "DNSes",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
 		"SecurityContextConstraints": "SecurityContextConstraints",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -36,6 +36,7 @@ import (
 // NameSystems returns the name system used by the generators in this package.
 func NameSystems() namer.NameSystems {
 	pluralExceptions := map[string]string{
+		"DNS":                        "DNSes",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
 		"SecurityContextConstraints": "SecurityContextConstraints",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -36,6 +36,7 @@ import (
 // NameSystems returns the name system used by the generators in this package.
 func NameSystems() namer.NameSystems {
 	pluralExceptions := map[string]string{
+		"DNS":                        "DNSes",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
 		"SecurityContextConstraints": "SecurityContextConstraints",


### PR DESCRIPTION
our generated dns client is wrong:

`E0221 21:15:01.517722       1 reflector.go:134] github.com/openshift/client-go/config/informers/externalversions/factory.go:101: Failed to list *v1.DNS: the server could not find the requested resource (get dnss.config.openshift.io)
`

/assign @sttts 