### PR TITLE
[3.11] Test that a pod in the cluster can reach Router on its default domain

### DIFF
--- a/test/extended/extended_test.go
+++ b/test/extended/extended_test.go
@@ -42,11 +42,16 @@ import (
 	_ "github.com/openshift/origin/test/extended/security"
 	_ "github.com/openshift/origin/test/extended/templates"
 
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
+
+	routev1 "github.com/openshift/api/route/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 // init initialize the extended testing suite.
 func init() {
+	routev1.Install(scheme.Scheme)
+
 	exutil.InitTest()
 }
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -186,6 +186,9 @@
 // test/extended/testdata/roles/empty-role.yaml
 // test/extended/testdata/roles/policy-clusterroles.yaml
 // test/extended/testdata/roles/policy-roles.yaml
+// test/extended/testdata/router/hello-openshift-replicaset.yaml
+// test/extended/testdata/router/hello-openshift-route.yaml
+// test/extended/testdata/router/hello-openshift-service.yaml
 // test/extended/testdata/router-config-manager.yaml
 // test/extended/testdata/router-http-echo-server.yaml
 // test/extended/testdata/router-metrics.yaml
@@ -10319,6 +10322,102 @@ func testExtendedTestdataRolesPolicyRolesYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/roles/policy-roles.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataRouterHelloOpenshiftReplicasetYaml = []byte(`apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: hello-openshift
+  labels:
+    app: hello-openshift
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-openshift
+  template:
+    metadata:
+      labels:
+        app: hello-openshift
+    spec:
+      containers:
+      - name: server
+        image: "openshift/hello-openshift"
+        ports:
+          - containerPort: 8080
+            name: http
+
+`)
+
+func testExtendedTestdataRouterHelloOpenshiftReplicasetYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterHelloOpenshiftReplicasetYaml, nil
+}
+
+func testExtendedTestdataRouterHelloOpenshiftReplicasetYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterHelloOpenshiftReplicasetYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/hello-openshift-replicaset.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataRouterHelloOpenshiftRouteYaml = []byte(`apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: test
+spec:
+  host: ""
+  to:
+    kind: Service
+    name: hello-openshift
+  ports:
+    - targetPort: 8080
+`)
+
+func testExtendedTestdataRouterHelloOpenshiftRouteYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterHelloOpenshiftRouteYaml, nil
+}
+
+func testExtendedTestdataRouterHelloOpenshiftRouteYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterHelloOpenshiftRouteYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/hello-openshift-route.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataRouterHelloOpenshiftServiceYaml = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: hello-openshift
+  labels:
+    app: hello-openshift
+spec:
+  selector:
+    app: hello-openshift
+  ports:
+    - port: 8080
+`)
+
+func testExtendedTestdataRouterHelloOpenshiftServiceYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterHelloOpenshiftServiceYaml, nil
+}
+
+func testExtendedTestdataRouterHelloOpenshiftServiceYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterHelloOpenshiftServiceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/hello-openshift-service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -34517,6 +34616,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/roles/empty-role.yaml": testExtendedTestdataRolesEmptyRoleYaml,
 	"test/extended/testdata/roles/policy-clusterroles.yaml": testExtendedTestdataRolesPolicyClusterrolesYaml,
 	"test/extended/testdata/roles/policy-roles.yaml": testExtendedTestdataRolesPolicyRolesYaml,
+	"test/extended/testdata/router/hello-openshift-replicaset.yaml": testExtendedTestdataRouterHelloOpenshiftReplicasetYaml,
+	"test/extended/testdata/router/hello-openshift-route.yaml": testExtendedTestdataRouterHelloOpenshiftRouteYaml,
+	"test/extended/testdata/router/hello-openshift-service.yaml": testExtendedTestdataRouterHelloOpenshiftServiceYaml,
 	"test/extended/testdata/router-config-manager.yaml": testExtendedTestdataRouterConfigManagerYaml,
 	"test/extended/testdata/router-http-echo-server.yaml": testExtendedTestdataRouterHttpEchoServerYaml,
 	"test/extended/testdata/router-metrics.yaml": testExtendedTestdataRouterMetricsYaml,
@@ -35076,6 +35178,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"empty-role.yaml": &bintree{testExtendedTestdataRolesEmptyRoleYaml, map[string]*bintree{}},
 					"policy-clusterroles.yaml": &bintree{testExtendedTestdataRolesPolicyClusterrolesYaml, map[string]*bintree{}},
 					"policy-roles.yaml": &bintree{testExtendedTestdataRolesPolicyRolesYaml, map[string]*bintree{}},
+				}},
+				"router": &bintree{nil, map[string]*bintree{
+					"hello-openshift-replicaset.yaml": &bintree{testExtendedTestdataRouterHelloOpenshiftReplicasetYaml, map[string]*bintree{}},
+					"hello-openshift-route.yaml": &bintree{testExtendedTestdataRouterHelloOpenshiftRouteYaml, map[string]*bintree{}},
+					"hello-openshift-service.yaml": &bintree{testExtendedTestdataRouterHelloOpenshiftServiceYaml, map[string]*bintree{}},
 				}},
 				"router-config-manager.yaml": &bintree{testExtendedTestdataRouterConfigManagerYaml, map[string]*bintree{}},
 				"router-http-echo-server.yaml": &bintree{testExtendedTestdataRouterHttpEchoServerYaml, map[string]*bintree{}},

--- a/test/extended/testdata/router/hello-openshift-replicaset.yaml
+++ b/test/extended/testdata/router/hello-openshift-replicaset.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: hello-openshift
+  labels:
+    app: hello-openshift
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello-openshift
+  template:
+    metadata:
+      labels:
+        app: hello-openshift
+    spec:
+      containers:
+      - name: server
+        image: "openshift/hello-openshift"
+        ports:
+          - containerPort: 8080
+            name: http
+

--- a/test/extended/testdata/router/hello-openshift-route.yaml
+++ b/test/extended/testdata/router/hello-openshift-route.yaml
@@ -1,0 +1,11 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: test
+spec:
+  host: ""
+  to:
+    kind: Service
+    name: hello-openshift
+  ports:
+    - targetPort: 8080

--- a/test/extended/testdata/router/hello-openshift-service.yaml
+++ b/test/extended/testdata/router/hello-openshift-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-openshift
+  labels:
+    app: hello-openshift
+spec:
+  selector:
+    app: hello-openshift
+  ports:
+    - port: 8080

--- a/test/extended/util/manifest_test.go
+++ b/test/extended/util/manifest_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+)
+
+func init() {
+	appsv1.Install(scheme.Scheme)
+}
+
+func TestReadFixture(t *testing.T) {
+	tt := []struct {
+		name     string
+		path     string
+		expected runtime.Object
+	}{
+		{
+			name:     "dc V1",
+			path:     FixturePath("testdata", "deployments", "deployment-simple.yaml"),
+			expected: &appsv1.DeploymentConfig{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := ReadFixture(tc.path)
+			if err != nil {
+				t.Error(err)
+			}
+
+			expected := reflect.TypeOf(tc.expected)
+			got := reflect.TypeOf(obj)
+			if expected != got {
+				t.Errorf("expected %v, got %v", expected, got)
+			}
+		})
+	}
+}

--- a/test/extended/util/manifests.go
+++ b/test/extended/util/manifests.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	o "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
+)
+
+func ReadFixture(path string) (runtime.Object, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %v", path, err)
+	}
+
+	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
+func ReadFixtureOrFail(path string) runtime.Object {
+	obj, err := ReadFixture(path)
+
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return obj
+}


### PR DESCRIPTION
Router is mandatory part of OpenShift setup. The default domain should be setup correctly and if networking and firewalls/loadbalancers work correctly a Pod in the cluster should be able to reach router's default domain.

Tested manually with latest 4.0, hope it shows the issue I was seeing few weeks back with 3.11 cluster setup.

/cc @smarterclayton @ironcladlou @openshift/sig-network-edge 