### PR TITLE
UPSTREAM: 74416: apiserver: add --minimal-shutdown-duration to delay until endpoint convergence

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -157,6 +157,9 @@ type Config struct {
 	// If specified, long running requests such as watch will be allocated a random timeout between this value, and
 	// twice this value.  Note that it is up to the request handlers to ignore or honor this timeout. In seconds.
 	MinRequestTimeout int
+	// MinimalShutdownDuration allows to block shutdown for some time, e.g. until endpoints pointing to this API server
+	// have converged on all node. During this time, the API server keeps serving.
+	MinimalShutdownDuration time.Duration
 	// MaxRequestsInFlight is the maximum number of parallel non-long-running requests. Every further
 	// request has to wait. Applies only to non-mutating requests.
 	MaxRequestsInFlight int
@@ -258,6 +261,7 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		MaxMutatingRequestsInFlight:  200,
 		RequestTimeout:               time.Duration(60) * time.Second,
 		MinRequestTimeout:            1800,
+		MinimalShutdownDuration:      0,
 		EnableAPIResponseCompression: utilfeature.DefaultFeatureGate.Enabled(features.APIResponseCompression),
 
 		// Default to treating watch as a long-running operation
@@ -453,8 +457,9 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		delegationTarget:       delegationTarget,
 		HandlerChainWaitGroup:  c.HandlerChainWaitGroup,
 
-		minRequestTimeout: time.Duration(c.MinRequestTimeout) * time.Second,
-		ShutdownTimeout:   c.RequestTimeout,
+		minRequestTimeout:       time.Duration(c.MinRequestTimeout) * time.Second,
+		MinimalShutdownDuration: c.MinimalShutdownDuration,
+		ShutdownTimeout:         c.RequestTimeout,
 
 		SecureServingInfo: c.SecureServing,
 		ExternalAddress:   c.ExternalAddress,

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -42,6 +42,7 @@ type ServerRunOptions struct {
 	MaxMutatingRequestsInFlight int
 	RequestTimeout              time.Duration
 	MinRequestTimeout           int
+	MinimalShutdownDuration     time.Duration
 	TargetRAMMB                 int
 }
 
@@ -52,6 +53,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		MaxMutatingRequestsInFlight: defaults.MaxMutatingRequestsInFlight,
 		RequestTimeout:              defaults.RequestTimeout,
 		MinRequestTimeout:           defaults.MinRequestTimeout,
+		MinimalShutdownDuration:     defaults.MinimalShutdownDuration,
 	}
 }
 
@@ -63,6 +65,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.MaxMutatingRequestsInFlight = s.MaxMutatingRequestsInFlight
 	c.RequestTimeout = s.RequestTimeout
 	c.MinRequestTimeout = s.MinRequestTimeout
+	c.MinimalShutdownDuration = s.MinimalShutdownDuration
 	c.PublicAddress = s.AdvertiseAddress
 
 	return nil
@@ -153,6 +156,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"a request open before timing it out. Currently only honored by the watch request "+
 		"handler, which picks a randomized value above this number as the connection timeout, "+
 		"to spread out load.")
+
+	fs.DurationVar(&s.MinimalShutdownDuration, "minimal-shutdown-duration", s.MinimalShutdownDuration, ""+
+		"Minimal duration of a graceful shutdown, e.g. to guarantee that all endpoints pointing to this API server "+
+		"have converged")
 
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }


### PR DESCRIPTION
This is meant to delay the apiserver shutdown for a defined time duration in order to give the SDN a chance to update changed endpoints.

The reconciler is part of the "master controller", also called "bootstrap controller". It has a pre shutdown hook triggered by the `stopCh`. We delay the `internalStopCh` being closed which triggers to stop serving. So this looks good.