### PR TITLE
[3.11] UPSTREAM: 74306: Fix scanning of failed targets

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/util/device_util_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/util/device_util_linux.go
@@ -135,7 +135,8 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 			targetNamePath := sessionPath + "/iscsi_session/" + sessionName + "/targetname"
 			targetName, err := io.ReadFile(targetNamePath)
 			if err != nil {
-				return nil, err
+				glog.Infof("Failed to process session %s, assuming this session is unavailable: %s", sessionName, err)
+				continue
 			}
 
 			// Ignore hosts that don't matchthe target we were looking for.
@@ -147,7 +148,8 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 			// for the iSCSI connection.
 			dirs2, err := io.ReadDir(sessionPath)
 			if err != nil {
-				return nil, err
+				glog.Infof("Failed to process session %s, assuming this session is unavailable: %s", sessionName, err)
+				continue
 			}
 			for _, dir2 := range dirs2 {
 				// Skip over files that aren't the connection
@@ -164,25 +166,29 @@ func (handler *deviceHandler) GetISCSIPortalHostMapForTarget(targetIqn string) (
 				addrPath := connectionPath + "/address"
 				addr, err := io.ReadFile(addrPath)
 				if err != nil {
-					return nil, err
+					glog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				portPath := connectionPath + "/port"
 				port, err := io.ReadFile(portPath)
 				if err != nil {
-					return nil, err
+					glog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				persistentAddrPath := connectionPath + "/persistent_address"
 				persistentAddr, err := io.ReadFile(persistentAddrPath)
 				if err != nil {
-					return nil, err
+					glog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				persistentPortPath := connectionPath + "/persistent_port"
 				persistentPort, err := io.ReadFile(persistentPortPath)
 				if err != nil {
-					return nil, err
+					glog.Infof("Failed to process connection %s, assuming this connection is unavailable: %s", dirName, err)
+					continue
 				}
 
 				// Add entries to the map for both the current and persistent portals


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1669560
https://github.com/kubernetes/kubernetes/pull/74306

@openshift/sig-storage