### PR TITLE
oc login: HEAD issuer for x509 cert check

### DIFF
--- a/pkg/oc/lib/tokencmd/request_token_test.go
+++ b/pkg/oc/lib/tokencmd/request_token_test.go
@@ -142,7 +142,7 @@ func TestRequestToken(t *testing.T) {
 		}
 	}
 
-	initialHead := req{"", http.MethodHead, "/oauth/token/implicit"}
+	initialHead := req{"", http.MethodHead, "/"}
 	initialHeadResp := resp{http.StatusInternalServerError, "", nil} // value of status is ignored
 
 	initialRequest := req{}
@@ -489,6 +489,7 @@ func TestRequestToken(t *testing.T) {
 				TokenUrl:     urls.OpenShiftOAuthTokenURL(s.URL),
 				RedirectUrl:  urls.OpenShiftOAuthTokenImplicitURL(s.URL),
 			},
+			Issuer:    s.URL,
 			TokenFlow: true,
 		}
 		token, err := opts.RequestToken()


### PR DESCRIPTION
This is a better check to perform than HEAD /oauth/token/implicit as it does not assume anything about the OAuth server (which could be Keycloak and not Osin).

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: https://github.com/openshift/console/pull/1216