### PR TITLE
UPSTREAM: 74617: make audit metadata work for custom resources

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/pborman/uuid"
 
-	"reflect"
-
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -117,8 +117,8 @@ func LogRequestObject(ae *auditinternal.Event, obj runtime.Object, gvr schema.Gr
 	if ae.ObjectRef == nil {
 		ae.ObjectRef = &auditinternal.ObjectReference{}
 	}
-	if acc, ok := obj.(metav1.ObjectMetaAccessor); ok {
-		meta := acc.GetObjectMeta()
+	// meta.Accessor is more general than ObjectMetaAccessor, but if it fails, we can just skip setting these bits
+	if meta, err := meta.Accessor(obj); err == nil {
 		if len(ae.ObjectRef.Namespace) == 0 {
 			ae.ObjectRef.Namespace = meta.GetNamespace()
 		}


### PR DESCRIPTION
this fixes metadata gathering for audit for custom resources

@openshift/sig-master 