### PR TITLE
properly delete NetworkPolicies when deleting their namespace

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -186,7 +186,15 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkapi.NetNamespace
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	delete(np.namespaces, netns.NetID)
+	if npns, exists := np.namespaces[netns.NetID]; exists {
+		if npns.inUse {
+			npns.inUse = false
+			// We call syncNamespaceFlows() not syncNamespace() because it
+			// needs to happen before we forget about the namespace.
+			np.syncNamespaceFlows(npns)
+		}
+		delete(np.namespaces, netns.NetID)
+	}
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,6 +121,15 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
+	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
+	if err != nil {
+		return err
+	}
+	inUseNamespaces := sets.NewString()
+	for _, pod := range pods {
+		inUseNamespaces.Insert(pod.Namespace)
+	}
+
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -132,7 +141,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    false,
+				inUse:    inUseNamespaces.Has(ns.Name),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}


### PR DESCRIPTION
So there were three bugs here:

1. In most cases, deleting a namespace that had previously been in use on the node would leave behind a single flow (`table=80, priority=50, reg1=XXXX, actions=output:NXM_NX_REG2[]`), because that's what would have been left after all of the NetworkPolicies were auto-deleted before the Namespace was fully deleted, and we weren't doing any further cleanup when the Namespace/NetNamespace itself was deleted.
2. Post-#22106 there might also be additional flows left behind because the processing of the NetworkPolicy deletions would end up being delayed, but the `np.namespaces` entry would have been deleted before `np.syncFlows()` got a chance to run the last time, so it would no longer know to finish cleaning up that namespace. (Because of this we should probably backport this change as far back as we backported #22106.)
3. Additionally, it turns out that the `inUse` flags in the NetworkPolicy namespace tracking were not being reinitialized correctly on restart, so if you restarted the node process and then deleted a namespace (without first creating/modifying any pods or services in that namespace), then it wouldn't even try to clean up the NetworkPolicies, because it mistakenly believed that it didn't need to.

(These stale flows would not have any actual effect on traffic, because they only exist when the VNID is not actually in use. But they use up memory, force pointless checks on packets, etc.)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1682955