### PR TITLE
Git 1.8.1 (default in el7) does not support `-C`

### DIFF
--- a/pkg/oc/cli/admin/release/git.go
+++ b/pkg/oc/cli/admin/release/git.go
@@ -41,7 +41,7 @@ func (g *git) exec(command ...string) (string, error) {
 }
 
 func (g *git) streamExec(out, errOut io.Writer, command ...string) error {
-	cmd := exec.Command("git", append([]string{"-C", g.path}, command...)...)
+	cmd := exec.Command("git", append([]string{"--git-dir", filepath.Join(g.path, ".git")}, command...)...)
 	cmd.Stdout = out
 	cmd.Stderr = errOut
 	return cmd.Run()


### PR DESCRIPTION
Found this when I actually started adding tests and trying to use it.
`--git-dir=PATH/.git` is the replacement.