### PR TITLE
Fix haproxy router reload script to remove iptables rule remanants when

### DIFF
--- a/images/router/haproxy/reload-haproxy
+++ b/images/router/haproxy/reload-haproxy
@@ -10,6 +10,46 @@ readonly max_wait_time=30
 readonly timeout_opts="-m 1 --connect-timeout 1"
 readonly numeric_re='^[0-9]+$'
 
+function syn_eater_rule_exists() {
+  /usr/sbin/iptables -L INPUT 2> /dev/null |   \
+    grep -F '/* Eat SYNs while reloading haproxy */' > /dev/null 2>&1
+}
+
+function remove_syn_eater_rule() {
+  # How many times to retry removal of the iptables rules (if requested at all)
+  # It will sleep for 1/2 a second between attempts, so the time is retries / 2 secs
+  local retries=20
+
+  local ports=$(grep -E -o '^\s*bind\s+:[[:digit:]]+\w' "$config_file" | cut -f2 -d: | paste -d, -s)
+  if [ -z "$ports" ]; then
+    return 0
+  fi
+
+  # We NEVER want to leave the syn eater in place after the reload or haproxy
+  # will never get new connections.  So try to remove it twenty times, and if
+  # that fails, log the error and return failure so the pod logs a fatal error.
+  local i=0
+  while (( i++ < retries )) ; do
+    /usr/sbin/iptables -D INPUT -p tcp -m multiport --dports $ports --syn -j DROP \
+                       -m comment --comment "Eat SYNs while reloading haproxy" || :
+
+    # Test the condition and end the loop if the rule has been removed
+    /usr/sbin/iptables -L INPUT | grep -F '/* Eat SYNs while reloading haproxy */' || break
+
+    >&2 echo "Unable to remove SYN eating rule, attempt $i.  Will retry..."
+
+    # But sleep for a bit before retrying
+    sleep 0.5
+  done
+  if (( i >= retries )); then
+    # We failed to remove the rule... log failure and return failure.
+    >&2 echo "Unable to remove the iptables SYN eating rule - tried $retries times"
+    return 1
+  fi
+
+  return 0
+}
+
 function haproxyHealthCheck() {
   local wait_time=${MAX_RELOAD_WAIT_TIME:-$max_wait_time}
   local port=${ROUTER_SERVICE_HTTP_PORT:-"80"}
@@ -67,15 +107,13 @@ function haproxyHealthCheck() {
 }
 
 
-# How many times to retry removal of the iptables rules (if requested at all)
-# It will sleep for 1/2 a second between attempts, so the time is retries / 2 secs
-retries=20
-
-
 # sort the path based map files for the haproxy map_beg function
 for mapfile in "$haproxy_conf_dir"/*.map; do
   sort -r "$mapfile" -o "$mapfile"
 done
+
+# Remove any syn eater rules remaining from a previous router instance.
+syn_eater_rule_exists && remove_syn_eater_rule || :
 
 old_pids=$(ps -A -opid,args | grep haproxy | egrep -v -e 'grep|reload-haproxy' | awk '{print $1}' | tr '\n' ' ')
 
@@ -109,27 +147,8 @@ if [ -n "$old_pids" ]; then
   reload_status=$?
 
   if [[ "$installed_iptables" == 1 ]]; then
-    # We NEVER want to leave the syn eater in place after the reload or haproxy
-    # will never get new connections.  So try to remove it twenty times, and if
-    # that fails, log the error and return failure so the pod logs a fatal error.
-    i=0
-    while (( i++ < retries )) ; do
-      /usr/sbin/iptables -D INPUT -p tcp -m multiport --dports $ports --syn -j DROP \
-                         -m comment --comment "Eat SYNs while reloading haproxy" || :
-
-      # Test the condition and end the loop if the rule has been removed
-      /usr/sbin/iptables -L INPUT | grep -F '/* Eat SYNs while reloading haproxy */' || break
-
-      >&2 echo "Unable to remove SYN eating rule, attempt $i.  Will retry..."
-
-      # But sleep for a bit before retrying
-      sleep 0.5
-    done
-    if (( i >= retries )); then
-      # We failed to remove the rule... log failure and exit to signal the caller
-      >&2 echo "Unable to remove the iptables SYN eating rule.  Aborting after $retries retries"
-      exit 1
-    fi
+    # If we failed to remove the rule, exit (with error) to signal the invoker.
+    remove_syn_eater_rule || exit 1
   fi
 else
   /usr/sbin/haproxy -f $config_file -p $pid_file


### PR DESCRIPTION
DROP_SYN_DURING_RESTART is removed. This is a specific case where the new
deployment catches the previous router at a point in time when haproxy is
reloading with a syn eater rule added. And so the syn eater iptables rule
is never cleaned up subsequently.
fixes bugz #1644931

 * Reused the existing syn eater code by moving it into a function (with a wee bit change to check for 
    non-zero ports and not call exit 1 on exhausting the retries). And we always call it before we reload. 
    And of course after we reload in the case DROP_SYN_DURING_RESTART is set.
 * Checked this for cases where the router container is privileged/non-privileged.

Cherrypicked from older PR against OSE repo: https://github.com/openshift/ose/pull/1456

@knobunc @openshift/sig-network-edge PTAL Thx