### PR TITLE
UPSTREAM: 0000: retry on discovery errors in crd-discovery-available post-start hook

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -38,6 +38,7 @@ import (
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
+	clientdiscovery "k8s.io/client-go/discovery"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
@@ -221,7 +222,10 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			}
 
 			_, serverGroupsAndResources, err := crdClient.Discovery().ServerGroupsAndResources()
-			if err != nil {
+			switch {
+			case clientdiscovery.IsGroupDiscoveryFailedError(err):
+				return false, nil
+			case err != nil:
 				return false, err
 			}
 			


### PR DESCRIPTION
Retrying should prevent these errors and API server start failures:

`
F0227 10:32:31.605070       1 hooks.go:188] PostStartHook "crd-discovery-available" failed: unable to retrieve the complete list of server APIs: autoscaling.openshift.io/v1alpha1: the server could not find the requested resource, cloudcredential.openshift.io/v1beta1: the server could not find the requested resource,....
`

Fixes: https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.0/4888/

/cc @deads2k 