### PR TITLE
[4.0] UPSTREAM: 74524: Don't fail if iface is being used by iSCSI session

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/iscsi/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/volume/iscsi/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/pkg/volume/iscsi/iscsi_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/iscsi/iscsi_util.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
+	utilexec "k8s.io/utils/exec"
 )
 
 const (
@@ -52,6 +53,10 @@ const (
 
 	// How many seconds to wait for a multipath device if at least two paths are available.
 	multipathDeviceTimeout = 10
+
+	// 'iscsiadm' error code stating that a session is logged in
+	// See https://github.com/open-iscsi/open-iscsi/blob/7d121d12ad6ba7783308c25ffd338a9fa0cc402b/include/iscsi_err.h#L37-L38
+	iscsiadmErrorSessExists = 15
 )
 
 var (
@@ -894,8 +899,13 @@ func cloneIface(b iscsiDiskMounter, newIface string) error {
 	// create new iface
 	out, err = b.exec.Run("iscsiadm", "-m", "iface", "-I", newIface, "-o", "new")
 	if err != nil {
-		lastErr = fmt.Errorf("iscsi: failed to create new iface: %s (%v)", string(out), err)
-		return lastErr
+		exit, ok := err.(utilexec.ExitError)
+		if ok && exit.ExitStatus() == iscsiadmErrorSessExists {
+			glog.Infof("iscsi: there is a session already logged in with iface %s", newIface)
+		} else {
+			lastErr = fmt.Errorf("iscsi: failed to create new iface: %s (%v)", string(out), err)
+			return lastErr
+		}
 	}
 	// update new iface records
 	for key, val := range params {


### PR DESCRIPTION
Upstream issue: https://github.com/kubernetes/kubernetes/issues/74523
Upstream PR: https://github.com/kubernetes/kubernetes/pull/74524

/sig storage
/assign @jsafrane @wongma7 @gnufied 