### PR TITLE
[release 3.11] UPSTREAM: 66617: Do not set cgroup parent when --cgroups-per-qos is disabled

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -299,7 +299,7 @@ func (m *podContainerManagerNoop) EnsureExists(_ *v1.Pod) error {
 }
 
 func (m *podContainerManagerNoop) GetPodContainerName(_ *v1.Pod) (CgroupName, string) {
-	return m.cgroupRoot, m.cgroupRoot.ToCgroupfs()
+	return m.cgroupRoot, ""
 }
 
 func (m *podContainerManagerNoop) GetPodContainerNameForDriver(_ *v1.Pod) string {


### PR DESCRIPTION

backport of https://github.com/openshift/origin/pull/20596

fix pods launching in a dind cluster