### PR TITLE
Don't override kubelet volume path

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -70,9 +70,6 @@ func InitTest() {
 	TestContext.VerifyServiceAccount = true
 	TestContext.RepoRoot = os.Getenv("KUBE_REPO_ROOT")
 	TestContext.KubeVolumeDir = os.Getenv("VOLUME_DIR")
-	if len(TestContext.KubeVolumeDir) == 0 {
-		TestContext.KubeVolumeDir = "/var/lib/origin/volumes"
-	}
 	TestContext.KubectlPath = "kubectl"
 	TestContext.KubeConfig = KubeConfigPath()
 	os.Setenv("KUBECONFIG", TestContext.KubeConfig)


### PR DESCRIPTION
OpenShift uses /var/lib/kubelet now. This should fix SELinux test failures like [this](https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/22143/pull-ci-openshift-origin-master-e2e-aws/4962#openshift-tests-k8sio-sig-node-security-context-featuresecuritycontext-should-support-volume-selinux-relabeling-suiteopenshiftconformanceparallel-suitek8s):

```
openshift-tests [k8s.io] [sig-node] Security Context [Feature:SecurityContext] should support volume SELinux relabeling [Suite:openshift/conformance/parallel] [Suite:k8s]

...
STEP: Creating a pod to test Pod with same MCS label reading test file
Feb 26 06:15:12.138: INFO: Waiting up to 5m0s for pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523" in namespace "e2e-tests-security-context-nfscc" to be "success or failure"
Feb 26 06:15:12.162: INFO: Pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523": Phase="Pending", Reason="", readiness=false. Elapsed: 24.148709ms
Feb 26 06:15:14.183: INFO: Pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523": Phase="Pending", Reason="", readiness=false. Elapsed: 2.045399959s
Feb 26 06:15:16.224: INFO: Pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523": Phase="Pending", Reason="", readiness=false. Elapsed: 4.086254985s
Feb 26 06:15:18.246: INFO: Pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523": Phase="Pending", Reason="", readiness=false. Elapsed: 6.107644537s
Feb 26 06:15:20.269: INFO: Pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523": Phase="Pending", Reason="", readiness=false. Elapsed: 8.131160246s
Feb 26 06:15:22.301: INFO: Pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523": Phase="Failed", Reason="", readiness=false. Elapsed: 10.162553986s
Feb 26 06:15:22.357: INFO: Output of node "ip-10-0-169-220.ec2.internal" pod "security-context-dfe4d89b-398d-11e9-ab76-0a58ac10f523" container "test-container": cat: can't open '/mounted_volume/TEST': No such file or directory

```

cc @smarterclayton @openshift/sig-storage 