### PR TITLE
Bug 1558935 - Replace kubectl name in long description of oc commands

### DIFF
--- a/pkg/cmd/util/cmd.go
+++ b/pkg/cmd/util/cmd.go
@@ -20,6 +20,7 @@ var commaSepVarsPattern = regexp.MustCompile(".*=.*,.*=.*")
 // command name (like 'kubectl' to the appropriate target name). It returns c.
 func ReplaceCommandName(from, to string, c *cobra.Command) *cobra.Command {
 	c.Example = strings.Replace(c.Example, from, to, -1)
+	c.Long = strings.Replace(c.Long, from, to, -1)
 	for _, sub := range c.Commands() {
 		ReplaceCommandName(from, to, sub)
 	}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1558935
/assign @mfojtik 