### PR TITLE
pkg/oc/cli/admin/release: Issues from non-first-parent commits

### DIFF
--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -1039,7 +1039,7 @@ func describeChangelog(out, errOut io.Writer, diff *ReleaseDiff, dir string) err
 	}
 
 	for _, change := range codeChanges {
-		u, commits, err := commitsForRepo(dir, change, out, errOut)
+		u, commits, err := firstParentCommitsForRepo(dir, change, out, errOut)
 		if err != nil {
 			fmt.Fprintf(errOut, "error: %v\n", err)
 			hasError = true
@@ -1052,32 +1052,30 @@ func describeChangelog(out, errOut io.Writer, diff *ReleaseDiff, dir string) err
 				fmt.Fprintf(out, "### %s\n\n", strings.Join(change.ImagesAffected, ", "))
 			}
 			for _, commit := range commits {
-				var suffix string
+				entries := []string{}
+
+				if len(commit.Subject) > 0 {
+					entries = append(entries, commit.Subject)
+				}
+
 				switch {
 				case commit.PullRequest > 0:
-					suffix = fmt.Sprintf("[#%d](%s)", commit.PullRequest, fmt.Sprintf("https://%s%s/pull/%d", u.Host, u.Path, commit.PullRequest))
+					entries = append(entries, fmt.Sprintf("[#%d](%s)", commit.PullRequest, fmt.Sprintf("https://%s%s/pull/%d", u.Host, u.Path, commit.PullRequest)))
 				case u.Host == "github.com":
-					commit := commit.Commit[:8]
-					suffix = fmt.Sprintf("[%s](%s)", commit, fmt.Sprintf("https://%s%s/commit/%s", u.Host, u.Path, commit))
+					commit := commit.Hash[:8]
+					entries = append(entries, fmt.Sprintf("[%s](%s)", commit, fmt.Sprintf("https://%s%s/commit/%s", u.Host, u.Path, commit)))
 				default:
-					suffix = commit.Commit[:8]
+					entries = append(entries, commit.Hash[:8])
 				}
-				switch {
-				case commit.Bug > 0:
-					fmt.Fprintf(out,
-						"* [Bug %d](%s): %s %s\n",
-						commit.Bug,
-						fmt.Sprintf("https://bugzilla.redhat.com/show_bug.cgi?id=%d", commit.Bug),
-						commit.Subject,
-						suffix,
-					)
-				default:
-					fmt.Fprintf(out,
-						"* %s %s\n",
-						commit.Subject,
-						suffix,
-					)
+
+				for _, issue := range commit.Issues {
+					entries = append(entries, issue.Markdown())
 				}
+
+				fmt.Fprintf(out,
+					"* %s\n",
+					strings.Join(entries, " "),
+				)
 			}
 			if u.Host == "github.com" {
 				fmt.Fprintf(out, "* [Full changelog](%s)\n\n", fmt.Sprintf("https://%s%s/compare/%s...%s", u.Host, u.Path, change.From, change.To))
@@ -1103,17 +1101,18 @@ func describeBugs(out, errOut io.Writer, diff *ReleaseDiff, dir string, format s
 
 	bugIDs := sets.NewInt()
 	for _, change := range codeChanges {
-		_, commits, err := commitsForRepo(dir, change, out, errOut)
+		_, commits, err := firstParentCommitsForRepo(dir, change, out, errOut)
 		if err != nil {
 			fmt.Fprintf(errOut, "error: %v\n", err)
 			hasError = true
 			continue
 		}
 		for _, commit := range commits {
-			if commit.Bug == 0 {
-				continue
+			for _, issue := range commit.Issues {
+				if issue.Store == "rhbz" {
+					bugIDs.Insert(issue.ID)
+				}
 			}
-			bugIDs.Insert(commit.Bug)
 		}
 	}
 
@@ -1249,7 +1248,7 @@ func (c CodeChange) ToShort() string {
 	return c.To
 }
 
-func commitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.URL, []MergeCommit, error) {
+func firstParentCommitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.URL, []*commit, error) {
 	u, err := sourceLocationAsURL(change.Repo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("The source repository cannot be parsed %s: %v", change.Repo, err)
@@ -1258,7 +1257,7 @@ func commitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.
 	if err != nil {
 		return nil, nil, err
 	}
-	commits, err := mergeLogForRepo(g, change.From, change.To)
+	commits, err := firstParentLogForRepo(g, change.From, change.To)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Could not load commits for %s: %v", change.Repo, err)
 	}

--- a/pkg/oc/cli/admin/release/issue.go
+++ b/pkg/oc/cli/admin/release/issue.go
@@ -1,0 +1,20 @@
+package release
+
+import (
+	"fmt"
+)
+
+type issue struct {
+	// Store for the issue, e.g. "rhbz" for https://bugzilla.redhat.com, or "origin" for https://github.com/openshift/origin/issues.
+	Store string
+
+	// ID for the issue, e.g. 123.
+	ID int
+
+	// URI for the issue, e.g. https://bugzilla.redhat.com/show_bug.cgi?id=123.
+	URI string
+}
+
+func (i *issue) Markdown() string {
+	return fmt.Sprintf("[%s#%d](%s)", i.Store, i.ID, i.URI) // TODO: proper escaping
+}


### PR DESCRIPTION
Sometimes a single pull request will address multiple issues, and listing them all in a PR subject is not feasible.  With this commit, I iterate over all commits in the given range (merge or not), but only return a slice for the first-parent chain (which in most cases will be a series of merges to master).  For commits that are part of the retrieved graph but which lie outside the first-parent chain, I find the nearest first-parent ancestor and attach any referenced issues to that ancestor.  The new `issue` structure sets the stage for future work to also support references to GitHub and other issue stores, although I haven't added extractors for those yet (I'm planning on using [`git interpret-trailers`][1]).

CC @smarterclayton, @mfojtik, @soltysh, since this is following up on #22030.

[1]: https://github.com/git/git/blob/v2.2.0/Documentation/RelNotes/2.2.0.txt#L89-L90