### PR TITLE
pkg/oc/cli/admin/release: Issues from commit-body trailers

### DIFF
--- a/pkg/oc/cli/admin/release/git.go
+++ b/pkg/oc/cli/admin/release/git.go
@@ -158,15 +158,9 @@ func (cmt *commit) process(body string) error {
 		})
 	}
 
-	cmd := exec.Command("git", "interpret-trailers", "--parse")
-	cmd.Stdin = bytes.NewBufferString(body)
-	glog.V(5).Infof("Executing git: %v (on %s)\n", cmd.Args, cmt.Hash)
-	output, err := cmd.Output()
-	if err != nil {
-		return err
-	}
-
-	for _, line := range strings.Split(string(output), "\n") {
+	paragraphs := strings.Split(body, "\n\n")
+	trailerBlock := paragraphs[len(paragraphs)-1] // TODO: ugly assumption
+	for _, line := range strings.Split(trailerBlock, "\n") {
 		if len(line) == 0 {
 			continue
 		}

--- a/pkg/oc/cli/admin/release/git_test.go
+++ b/pkg/oc/cli/admin/release/git_test.go
@@ -1,0 +1,106 @@
+package release
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCommitProcess(t *testing.T) {
+	for _, testCase := range []struct {
+		initial  commit
+		body     string
+		expected commit
+	}{
+		{
+			body:     "no trailers",
+			initial:  commit{},
+			expected: commit{},
+		},
+		{
+			body: "pull request subject",
+			initial: commit{
+				Parents: []string{"hash1", "hash2"},
+				Subject: "Merge pull request #123 from example",
+			},
+			expected: commit{
+				Parents:     []string{"hash1", "hash2"},
+				Subject:     "pull request subject",
+				PullRequest: 123,
+			},
+		},
+		{
+			body: "subject bug reference",
+			initial: commit{
+				Subject: "Bug 123: example commit",
+			},
+			expected: commit{
+				Subject: "example commit",
+				Issues: []*issue{
+					{
+						Store: "rhbz",
+						ID:    123,
+						URI:   "https://bugzilla.redhat.com/show_bug.cgi?id=123",
+					},
+				},
+			},
+		},
+		{
+			body:    "trailer bug references\n\nIssue: https://github.com/openshift/origin/issues/123\nIssue: https://github.com/example/repo/pull/456\n",
+			initial: commit{},
+			expected: commit{
+				Issues: []*issue{
+					{
+						Store: "origin",
+						ID:    123,
+						URI:   "https://github.com/openshift/origin/issues/123",
+					},
+					{
+						Store: "example/repo",
+						ID:    456,
+						URI:   "https://github.com/example/repo/pull/456",
+					},
+				},
+			},
+		},
+		{
+			body: "subject and trailer bug references\n\nIssue: https://github.com/openshift/origin/issues/123\nIssue: https://github.com/example/repo/pull/456\n",
+			initial: commit{
+				Subject: "Bug 123: example commit",
+			},
+			expected: commit{
+				Subject: "example commit",
+				Issues: []*issue{
+					{
+						Store: "rhbz",
+						ID:    123,
+						URI:   "https://bugzilla.redhat.com/show_bug.cgi?id=123",
+					},
+					{
+						Store: "origin",
+						ID:    123,
+						URI:   "https://github.com/openshift/origin/issues/123",
+					},
+					{
+						Store: "example/repo",
+						ID:    456,
+						URI:   "https://github.com/example/repo/pull/456",
+					},
+				},
+			},
+		},
+	} {
+		name := strings.SplitN(testCase.body, "\n", 2)[0]
+		t.Run(name, func(t *testing.T) {
+			cmt := &testCase.initial
+			err := cmt.process(testCase.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(cmt, &testCase.expected) {
+				t.Fatalf("unexpected result: %#+v (expected %#+v)", *cmt, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -1039,7 +1039,7 @@ func describeChangelog(out, errOut io.Writer, diff *ReleaseDiff, dir string) err
 	}
 
 	for _, change := range codeChanges {
-		u, commits, err := commitsForRepo(dir, change, out, errOut)
+		u, commits, err := firstParentCommitsForRepo(dir, change, out, errOut)
 		if err != nil {
 			fmt.Fprintf(errOut, "error: %v\n", err)
 			hasError = true
@@ -1052,32 +1052,30 @@ func describeChangelog(out, errOut io.Writer, diff *ReleaseDiff, dir string) err
 				fmt.Fprintf(out, "### %s\n\n", strings.Join(change.ImagesAffected, ", "))
 			}
 			for _, commit := range commits {
-				var suffix string
+				entries := []string{}
+
+				if len(commit.Subject) > 0 {
+					entries = append(entries, commit.Subject)
+				}
+
 				switch {
 				case commit.PullRequest > 0:
-					suffix = fmt.Sprintf("[#%d](%s)", commit.PullRequest, fmt.Sprintf("https://%s%s/pull/%d", u.Host, u.Path, commit.PullRequest))
+					entries = append(entries, fmt.Sprintf("[#%d](%s)", commit.PullRequest, fmt.Sprintf("https://%s%s/pull/%d", u.Host, u.Path, commit.PullRequest)))
 				case u.Host == "github.com":
-					commit := commit.Commit[:8]
-					suffix = fmt.Sprintf("[%s](%s)", commit, fmt.Sprintf("https://%s%s/commit/%s", u.Host, u.Path, commit))
+					commit := commit.Hash[:8]
+					entries = append(entries, fmt.Sprintf("[%s](%s)", commit, fmt.Sprintf("https://%s%s/commit/%s", u.Host, u.Path, commit)))
 				default:
-					suffix = commit.Commit[:8]
+					entries = append(entries, commit.Hash[:8])
 				}
-				switch {
-				case commit.Bug > 0:
-					fmt.Fprintf(out,
-						"* [Bug %d](%s): %s %s\n",
-						commit.Bug,
-						fmt.Sprintf("https://bugzilla.redhat.com/show_bug.cgi?id=%d", commit.Bug),
-						commit.Subject,
-						suffix,
-					)
-				default:
-					fmt.Fprintf(out,
-						"* %s %s\n",
-						commit.Subject,
-						suffix,
-					)
+
+				for _, issue := range commit.Issues {
+					entries = append(entries, issue.Markdown())
 				}
+
+				fmt.Fprintf(out,
+					"* %s\n",
+					strings.Join(entries, " "),
+				)
 			}
 			if u.Host == "github.com" {
 				fmt.Fprintf(out, "* [Full changelog](%s)\n\n", fmt.Sprintf("https://%s%s/compare/%s...%s", u.Host, u.Path, change.From, change.To))
@@ -1103,17 +1101,18 @@ func describeBugs(out, errOut io.Writer, diff *ReleaseDiff, dir string, format s
 
 	bugIDs := sets.NewInt()
 	for _, change := range codeChanges {
-		_, commits, err := commitsForRepo(dir, change, out, errOut)
+		_, commits, err := firstParentCommitsForRepo(dir, change, out, errOut)
 		if err != nil {
 			fmt.Fprintf(errOut, "error: %v\n", err)
 			hasError = true
 			continue
 		}
 		for _, commit := range commits {
-			if commit.Bug == 0 {
-				continue
+			for _, issue := range commit.Issues {
+				if issue.Store == "rhbz" {
+					bugIDs.Insert(issue.ID)
+				}
 			}
-			bugIDs.Insert(commit.Bug)
 		}
 	}
 
@@ -1249,7 +1248,7 @@ func (c CodeChange) ToShort() string {
 	return c.To
 }
 
-func commitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.URL, []MergeCommit, error) {
+func firstParentCommitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.URL, []*commit, error) {
 	u, err := sourceLocationAsURL(change.Repo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("The source repository cannot be parsed %s: %v", change.Repo, err)
@@ -1258,7 +1257,7 @@ func commitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.
 	if err != nil {
 		return nil, nil, err
 	}
-	commits, err := mergeLogForRepo(g, change.From, change.To)
+	commits, err := firstParentLogForRepo(g, change.From, change.To)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Could not load commits for %s: %v", change.Repo, err)
 	}

--- a/pkg/oc/cli/admin/release/issue.go
+++ b/pkg/oc/cli/admin/release/issue.go
@@ -2,6 +2,14 @@ package release
 
 import (
 	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+)
+
+var (
+	reBugzilla    = regexp.MustCompile(`^https://bugzilla.redhat.com/(show_bug.cgi[?]id=)?(\d+)$`)
+	reGitHubIssue = regexp.MustCompile(`^https://github.com/([^/]*)/([^/]*)/(issues|pull)/(\d+)$`)
 )
 
 type issue struct {
@@ -17,4 +25,48 @@ type issue struct {
 
 func (i *issue) Markdown() string {
 	return fmt.Sprintf("[%s#%d](%s)", i.Store, i.ID, i.URI) // TODO: proper escaping
+}
+
+func issueFromURI(uri string) (*issue, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	issue := &issue{URI: uri}
+	var id string
+
+	switch parsed.Host {
+	case "bugzilla.redhat.com":
+		issue.Store = "rhbz"
+		matches := reBugzilla.FindStringSubmatch(uri)
+		if matches == nil {
+			return nil, fmt.Errorf("could not extract Bugzilla bug ID from %q", uri)
+		}
+
+		id = matches[2]
+	case "github.com":
+		matches := reGitHubIssue.FindStringSubmatch(uri)
+		if matches == nil {
+			return nil, fmt.Errorf("could not extract GitHub issue ID from %q", uri)
+		}
+
+		org, repo := matches[1], matches[2]
+		if org == "openshift" {
+			issue.Store = repo
+		} else {
+			issue.Store = fmt.Sprintf("%s/%s", org, repo)
+		}
+
+		id = matches[4]
+	default:
+		return nil, fmt.Errorf("unrecognized issue host %q", parsed.Host)
+	}
+
+	issue.ID, err = strconv.Atoi(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not issue ID from %q: %v", uri, err)
+	}
+
+	return issue, nil
 }

--- a/pkg/oc/cli/admin/release/issue.go
+++ b/pkg/oc/cli/admin/release/issue.go
@@ -1,0 +1,20 @@
+package release
+
+import (
+	"fmt"
+)
+
+type issue struct {
+	// Store for the issue, e.g. "rhbz" for https://bugzilla.redhat.com, or "origin" for https://github.com/openshift/origin/issues.
+	Store string
+
+	// ID for the issue, e.g. 123.
+	ID int
+
+	// URI for the issue, e.g. https://bugzilla.redhat.com/show_bug.cgi?id=123.
+	URI string
+}
+
+func (i *issue) Markdown() string {
+	return fmt.Sprintf("[%s#%d](%s)", i.Store, i.ID, i.URI) // TODO: proper escaping
+}

--- a/pkg/oc/cli/admin/release/issue_test.go
+++ b/pkg/oc/cli/admin/release/issue_test.go
@@ -1,0 +1,72 @@
+package release
+
+import (
+	"testing"
+)
+
+func TestIssueFromURI(t *testing.T) {
+	for _, testCase := range []struct {
+		uri      string
+		expected issue
+	}{
+		{
+			uri: "https://bugzilla.redhat.com/123",
+			expected: issue{
+				Store: "rhbz",
+				ID:    123,
+				URI:   "https://bugzilla.redhat.com/123",
+			},
+		},
+		{
+			uri: "https://bugzilla.redhat.com/show_bug.cgi?id=123",
+			expected: issue{
+				Store: "rhbz",
+				ID:    123,
+				URI:   "https://bugzilla.redhat.com/show_bug.cgi?id=123",
+			},
+		},
+		{
+			uri: "https://github.com/openshift/origin/issues/123",
+			expected: issue{
+				Store: "origin",
+				ID:    123,
+				URI:   "https://github.com/openshift/origin/issues/123",
+			},
+		},
+		{
+			uri: "https://github.com/openshift/origin/pull/123",
+			expected: issue{
+				Store: "origin",
+				ID:    123,
+				URI:   "https://github.com/openshift/origin/pull/123",
+			},
+		},
+		{
+			uri: "https://github.com/example/repo/issues/123",
+			expected: issue{
+				Store: "example/repo",
+				ID:    123,
+				URI:   "https://github.com/example/repo/issues/123",
+			},
+		},
+		{
+			uri: "https://github.com/example/repo/pull/123",
+			expected: issue{
+				Store: "example/repo",
+				ID:    123,
+				URI:   "https://github.com/example/repo/pull/123",
+			},
+		},
+	} {
+		t.Run(testCase.uri, func(t *testing.T) {
+			actual, err := issueFromURI(testCase.uri)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if *actual != testCase.expected {
+				t.Fatalf("unexpected result: %#+v (expected %#+v)", *actual, testCase.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Builds on #22185; review that first.

This allows devs to link to issues in GitHub or Bugzilla without cluttering up their commit subjects.

[`interpret-trailers` is from 2.2.0][1].  We could re-implement it in Go (maybe someone else already has?), but there are a number of upstream quirks around trailers (preceeding blank lines.  Something about unfolding?  Maybe more?), so I'd rather lean on existing code if possible.

[1]: https://github.com/git/git/blob/v2.2.0/Documentation/RelNotes/2.2.0.txt#L89-L90