### PR TITLE
apiextensions-apiserver: fix empty APIResource group+version handling in wait logic

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -248,9 +249,10 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			}
 
 			discoveryGroupsAndResources := sets.NewString()
-			for _, resource := range serverGroupsAndResources {
-				for _, apiResource := range resource.APIResources {
-					discoveryGroupsAndResources.Insert(fmt.Sprintf("%s.%s.%s", apiResource.Name, apiResource.Version, apiResource.Group))
+			for _, resourceList := range serverGroupsAndResources {
+				for _, apiResource := range resourceList.APIResources {
+					group, version := splitGroupVersion(resourceList.GroupVersion)
+					discoveryGroupsAndResources.Insert(fmt.Sprintf("%s.%s.%s", apiResource.Name, version, group))
 				}
 			}
 			if !discoveryGroupsAndResources.HasAll(crdGroupsAndResources.List()...) {
@@ -274,6 +276,16 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	return s, nil
+}
+
+func splitGroupVersion(gv string) (group string, version string) {
+	ss := strings.SplitN(gv, "/", 2)
+	if len(ss) == 1 {
+		version = ss[0]
+	} else {
+		group, version = ss[0], ss[1]
+	}
+	return
 }
 
 func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -74,6 +74,7 @@ func NewDiscoveryController(crdInformer informers.CustomResourceDefinitionInform
 }
 
 func (c *DiscoveryController) sync(version schema.GroupVersion) error {
+
 	apiVersionsForDiscovery := []metav1.GroupVersionForDiscovery{}
 	apiResourcesForDiscovery := []metav1.APIResource{}
 	versionsForDiscoveryMap := map[metav1.GroupVersion]bool{}
@@ -129,8 +130,6 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 			Name:         crd.Status.AcceptedNames.Plural,
 			SingularName: crd.Status.AcceptedNames.Singular,
 			Namespaced:   crd.Spec.Scope == apiextensions.NamespaceScoped,
-			Group:        crd.Spec.Group,
-			Version:      version.Version,
 			Kind:         crd.Status.AcceptedNames.Kind,
 			Verbs:        verbs,
 			ShortNames:   crd.Status.AcceptedNames.ShortNames,
@@ -139,29 +138,21 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 
 		if crd.Spec.Subresources != nil && crd.Spec.Subresources.Status != nil {
 			apiResourcesForDiscovery = append(apiResourcesForDiscovery, metav1.APIResource{
-				Name:         crd.Status.AcceptedNames.Plural + "/status",
-				SingularName: "",
-				Namespaced:   crd.Spec.Scope == apiextensions.NamespaceScoped,
-				Group:        crd.Spec.Group,
-				Version:      version.Version,
-				Kind:         crd.Status.AcceptedNames.Kind,
-				Verbs:        metav1.Verbs([]string{"get", "patch", "update"}),
-				ShortNames:   nil,
-				Categories:   nil,
+				Name:       crd.Status.AcceptedNames.Plural + "/status",
+				Namespaced: crd.Spec.Scope == apiextensions.NamespaceScoped,
+				Kind:       crd.Status.AcceptedNames.Kind,
+				Verbs:      metav1.Verbs([]string{"get", "patch", "update"}),
 			})
 		}
 
 		if crd.Spec.Subresources != nil && crd.Spec.Subresources.Scale != nil {
 			apiResourcesForDiscovery = append(apiResourcesForDiscovery, metav1.APIResource{
-				Name:         crd.Status.AcceptedNames.Plural + "/scale",
-				SingularName: "",
-				Namespaced:   crd.Spec.Scope == apiextensions.NamespaceScoped,
-				Group:        autoscaling.GroupName,
-				Version:      "v1",
-				Kind:         "Scale",
-				Verbs:        metav1.Verbs([]string{"get", "patch", "update"}),
-				ShortNames:   nil,
-				Categories:   nil,
+				Group:      autoscaling.GroupName,
+				Version:    "v1",
+				Kind:       "Scale",
+				Name:       crd.Status.AcceptedNames.Plural + "/scale",
+				Namespaced: crd.Spec.Scope == apiextensions.NamespaceScoped,
+				Verbs:      metav1.Verbs([]string{"get", "patch", "update"}),
 			})
 		}
 	}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -377,8 +377,6 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			resourcePath = itemPath
 			resourceParams = nameParams
 		}
-		apiResource.Group = a.group.GroupVersion.Group
-		apiResource.Version = a.group.GroupVersion.Version
 		apiResource.Name = path
 		apiResource.Namespaced = false
 		apiResource.Kind = resourceKind
@@ -429,8 +427,6 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			resourcePath = itemPath
 			resourceParams = nameParams
 		}
-		apiResource.Group = a.group.GroupVersion.Group
-		apiResource.Version = a.group.GroupVersion.Version
 		apiResource.Name = path
 		apiResource.Namespaced = true
 		apiResource.Kind = resourceKind


### PR DESCRIPTION
Also get rid of wrong upstream carry.

Compare https://github.com/kubernetes/kubernetes/pull/74587#issuecomment-468183531.