### PR TITLE
[3.9] UPSTREAM: 63977: pkg: kubelet: remote: increase grpc client default size

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_image.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_image.go
@@ -43,7 +43,7 @@ func NewRemoteImageService(endpoint string, connectionTimeout time.Duration) (in
 		return nil, err
 	}
 
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connectionTimeout), grpc.WithDialer(dailer))
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connectionTimeout), grpc.WithDialer(dailer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
 		glog.Errorf("Connect remote image service %s failed: %v", addr, err)
 		return nil, err

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_runtime.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/remote_runtime.go
@@ -45,7 +45,7 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration) (
 	if err != nil {
 		return nil, err
 	}
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connectionTimeout), grpc.WithDialer(dailer))
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connectionTimeout), grpc.WithDialer(dailer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
 		glog.Errorf("Connect remote runtime %s failed: %v", addr, err)
 		return nil, err

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/remote/utils.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/remote/utils.go
@@ -25,6 +25,10 @@ import (
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
+// maxMsgSize use 8MB as the default message size limit.
+// grpc library default is 4MB
+const maxMsgSize = 1024 * 1024 * 8
+
 // getContextWithTimeout returns a context with timeout.
 func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
fyi @mrunalp @nee1esh @derekwaynecarr 

Upstream (1.11): https://github.com/kubernetes/kubernetes/pull/63977
3.10 backport https://github.com/openshift/origin/pull/19774

xref https://bugzilla.redhat.com/show_bug.cgi?id=1666198