### PR TITLE
UPSTREAM: 74806: src/k8s.io/apiserver: Increase cert expiration histo…

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -40,6 +40,9 @@ var clientCertificateExpirationHistogram = prometheus.NewHistogram(
 		Help:      "Distribution of the remaining lifetime on the certificate used to authenticate a request.",
 		Buckets: []float64{
 			0,
+			(30 * time.Minute).Seconds(),
+			(1 * time.Hour).Seconds(),
+			(2 * time.Hour).Seconds(),
 			(6 * time.Hour).Seconds(),
 			(12 * time.Hour).Seconds(),
 			(24 * time.Hour).Seconds(),


### PR DESCRIPTION
…gram resolution

The `certificate_expiration_seconds` histogram measures the remaining
time of client certificates used to authenticate to the API server. It
records the lifetime of received client request certificates in buckets
of 6h, 12h, ..., 1y.

In environments with automated certificate rotation it is not uncommen
to have issued certificates expire in less than the above mentioned
minimum bucket of 6h. In such environments the above histogram is
useless given that every request will be recorded in the first bucket.

This patch increases the histogram resolution by adding a 30m, 1h and 2h
bucket. Prometheus histogram buckets are cummulative, e.g. the 12h
bucket is counting _all_ records with an expiration date lower or equal
to 12h including _all_ requests of the 6h bucket. Thereby this patch
does not break existing monitoring setups.  This histogram is exposed
once per API server, thereby the 3 additional time series do not cause a
cardinality issue.

---

As advised on Slack I followed https://github.com/openshift/origin/pull/22188/ as an example. Let me know if editing the `vendor` directory is not the right way to go. This has not yet landed in the master brach upstream (https://github.com/kubernetes/kubernetes/pull/74806). Should we wait for that to happen first?