### PR TITLE
Remove open from details tag

### DIFF
--- a/tools/genapidocs/apidocs/templates/objectschema.adoc
+++ b/tools/genapidocs/apidocs/templates/objectschema.adoc
@@ -1,5 +1,5 @@
 {{- range . -}}
-{{- if .Lines}}<details{{if .Open}} open{{end}}><summary>{{else}}<div style="margin-left:13px;">{{end -}}
+{{- if .Lines}}<details><summary>{{else}}<div style="margin-left:13px;">{{end -}}
 {{.Prefix}}<span title="{{.Tooltip | html}}">{{.Name | html}}</span>:
 {{if .Lines}}</summary>{{end -}}
 {{template "objectschema.adoc" .Lines}}


### PR DESCRIPTION
With the conditional, invalid markup is produced of the form. When using `ccutil` the build fails with:

```
transforming the AsciiDoc content to DocBook XML...
Specification mandates value for attribute open, line 3162, column 20 (line 3162)
Unable to parse the AsciiDoc built DocBook XML
```
