### PR TITLE
Bug 1682978: Verify builder version is reported

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -138,6 +138,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("verifying the build output is verbose"))
 					o.Expect(buildLog).To(o.ContainSubstring("Creating a new S2I builder"))
+					o.Expect(buildLog).To(o.ContainSubstring("openshift-builder v"))
 				})
 
 				g.It("BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel", func() {
@@ -148,6 +149,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("verifying the build output is not verbose"))
 					o.Expect(buildLog).NotTo(o.ContainSubstring("Creating a new S2I builder"))
+					o.Expect(buildLog).NotTo(o.ContainSubstring("openshift-builder v"))
 				})
 
 			})


### PR DESCRIPTION
Ensure the openshift-builder version is reported when verbose build logs are enabled.