### PR TITLE
Write image-references to disk after all metadata is fetched

### DIFF
--- a/pkg/oc/cli/admin/release/extract.go
+++ b/pkg/oc/cli/admin/release/extract.go
@@ -255,6 +255,7 @@ func ensureCloneForRepo(dir string, repo string, out, errOut io.Writer) (*git, e
 	if err != nil {
 		return nil, err
 	}
+	glog.V(4).Infof("Ensure repo is cloned at %s pointing to %s", basePath, repo)
 	fi, err := os.Stat(basePath)
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/pkg/oc/cli/admin/release/git.go
+++ b/pkg/oc/cli/admin/release/git.go
@@ -52,7 +52,7 @@ func (g *git) streamExec(out, errOut io.Writer, command ...string) error {
 func (g *git) ChangeContext(path string) (*git, error) {
 	location := &git{path: path}
 	if errOut, err := location.exec("rev-parse", "--git-dir"); err != nil {
-		if strings.Contains(errOut, "not a git repository") {
+		if strings.Contains(strings.ToLower(errOut), "not a git repository") {
 			return location, noSuchRepo
 		}
 		return location, err

--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -190,7 +190,11 @@ func NewTransformFromImageStreamFile(path string, input *imageapi.ImageStream, a
 		if _, ok := references[tag.Name]; !ok {
 			continue
 		}
-		value := tag.Annotations[annotationBuildVersions]
+		value, ok := tag.Annotations[annotationBuildVersions]
+		if !ok {
+			continue
+		}
+		glog.V(4).Infof("Found build versions from %s: %s", tag.Name, value)
 		items, err := parseComponentVersionsLabel(value)
 		if err != nil {
 			return nil, fmt.Errorf("input image stream has an invalid version annotation for tag %q: %v", tag.Name, value)
@@ -203,6 +207,7 @@ func NewTransformFromImageStreamFile(path string, input *imageapi.ImageStream, a
 				}
 			} else {
 				versions[k] = v
+				glog.V(4).Infof("Found version %s=%s from %s", k, v, tag.Name)
 			}
 			tagsByName[k] = append(tagsByName[k], tag.Name)
 		}


### PR DESCRIPTION
Otherwise we lose image-references data when you try to rebuild from disk