### PR TITLE
pkg/oc/cli/admin/release: Support 'Bug X, Y, Z: ...' pull-request subjects

### DIFF
--- a/pkg/oc/cli/admin/release/issue.go
+++ b/pkg/oc/cli/admin/release/issue.go
@@ -1,0 +1,17 @@
+package release
+
+import (
+	"fmt"
+)
+
+type issue struct {
+	// ID for the issue, e.g. 123.
+	ID int
+
+	// URI for the issue, e.g. https://bugzilla.redhat.com/show_bug.cgi?id=123.
+	URI string
+}
+
+func (i *issue) Markdown() string {
+	return fmt.Sprintf("[rhbz#%d](%s)", i.ID, i.URI)
+}


### PR DESCRIPTION
For pulls that fix multiple bugs.

The rename from `MergeCommit` -> `commit` is because:

* There is no need for a public structure that is part of this package's API, and
* Consumers don't need to care if the commit is a merge or not.

The new `issue` structure sets the stage for future work to also support references to GitHub and other issue stores, although I haven't added extractors for those yet.  At the moment, it just provides separation between the issue-extracting logic (which knows `Bug ###` means "Red Hat's Bugzilla") and the formatting logic (which just needs to know "there's an issue with a Markdown link").

CC @smarterclayton, @ironcladlou