### PR TITLE
[WIP] - Fix build cluster config tests

### DIFF
--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -22,6 +22,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 	)
 
 	g.Context("", func() {
+		g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 
 		g.BeforeEach(func() {
 			exutil.PreTestDump()

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -1,6 +1,8 @@
 package builds
 
 import (
+	"time"
+
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
@@ -42,7 +44,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				exutil.DumpConfigMapStates(oc)
 			}
 			oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
-			exutil.WaitForClusterProgression(oc.AdminConfigClient().Config())
+			exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
 		})
 
 		g.Context("registries config context", func() {
@@ -52,8 +54,8 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("apply default cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				g.By("waiting up to 10m for cluster image configuration to propagate")
-				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config())
+				g.By("waiting up to 30m for cluster image configuration to propagate")
+				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By("starting build sample-build and waiting for success")
 				// Image used by sample-build (centos/ruby-22-centos7) is only available on docker.io
@@ -71,8 +73,8 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("apply blacklist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", blacklistConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				g.By("waiting up to 10m for cluster image configuration to propagate")
-				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config())
+				g.By("waiting up to 30m for cluster image configuration to propagate")
+				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By("starting build sample-build-docker-args-preset and waiting for failure")
 				br, err := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
@@ -89,8 +91,8 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("apply whitelist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", whitelistConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				g.By("waiting up to 10m for cluster image configuration to propagate")
-				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config())
+				g.By("waiting up to 30m for cluster image configuration to propagate")
+				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By("starting build sample-build-docker-args-preset and waiting for failure")
 				br, err := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 		g.Context("registries config context", func() {
 
 			g.It("should default registry search to docker.io for image pulls", func() {
-				g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
+				// g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 				g.By("apply default cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -67,7 +67,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 			})
 
 			g.It("should allow registries to be blacklisted", func() {
-				g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
+				// g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 				g.By("apply blacklist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", blacklistConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -85,7 +85,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 			})
 
 			g.It("should allow registries to be whitelisted", func() {
-				g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
+				// g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 				g.By("apply whitelist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", whitelistConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -22,7 +22,6 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 	)
 
 	g.Context("", func() {
-		g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 
 		g.BeforeEach(func() {
 			exutil.PreTestDump()

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				exutil.DumpConfigMapStates(oc)
 			}
 			oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
-			exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
+			exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 15*time.Minute)
 		})
 
 		g.Context("registries config context", func() {
@@ -54,8 +54,8 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("apply default cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				g.By("waiting up to 30m for cluster image configuration to propagate")
-				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
+				g.By("waiting up to 15m for cluster image configuration to propagate")
+				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 15*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By("starting build sample-build and waiting for success")
 				// Image used by sample-build (centos/ruby-22-centos7) is only available on docker.io
@@ -73,8 +73,8 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("apply blacklist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", blacklistConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				g.By("waiting up to 30m for cluster image configuration to propagate")
-				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
+				g.By("waiting up to 15m for cluster image configuration to propagate")
+				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 15*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By("starting build sample-build-docker-args-preset and waiting for failure")
 				br, err := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
@@ -91,8 +91,8 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				g.By("apply whitelist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", whitelistConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				g.By("waiting up to 30m for cluster image configuration to propagate")
-				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 30*time.Minute)
+				g.By("waiting up to 15m for cluster image configuration to propagate")
+				err = exutil.WaitForClusterProgression(oc.AdminConfigClient().Config(), 15*time.Minute)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				g.By("starting build sample-build-docker-args-preset and waiting for failure")
 				br, err := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -40,6 +40,7 @@
 // test/extended/testdata/builds/build-timing/test-docker-build.json
 // test/extended/testdata/builds/build-timing/test-is.json
 // test/extended/testdata/builds/build-timing/test-s2i-build.json
+// test/extended/testdata/builds/cluster-config/blacklist-build.yaml
 // test/extended/testdata/builds/cluster-config/registry-blacklist.yaml
 // test/extended/testdata/builds/cluster-config/registry-whitelist.yaml
 // test/extended/testdata/builds/cluster-config.yaml
@@ -1788,6 +1789,40 @@ func testExtendedTestdataBuildsBuildTimingTestS2iBuildJson() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataBuildsClusterConfigBlacklistBuildYaml = []byte(`
+kind: BuildConfig
+apiVersion: v1
+metadata:
+  name: blacklist-build
+spec:
+  source:
+    type: Dockerfile
+    dockerfile: |-
+      FROM busybox:latest
+      RUN echo "Hello world!"
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: docker.io/busybox:latest
+  `)
+
+func testExtendedTestdataBuildsClusterConfigBlacklistBuildYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataBuildsClusterConfigBlacklistBuildYaml, nil
+}
+
+func testExtendedTestdataBuildsClusterConfigBlacklistBuildYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataBuildsClusterConfigBlacklistBuildYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/builds/cluster-config/blacklist-build.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml = []byte(`kind: Image
 apiVersion: config.openshift.io/v1
 metadata:
@@ -1796,7 +1831,6 @@ spec:
   registrySources:
       blockedRegistries:
       - docker.io
-      - quay.io
 `)
 
 func testExtendedTestdataBuildsClusterConfigRegistryBlacklistYamlBytes() ([]byte, error) {
@@ -1822,6 +1856,8 @@ spec:
   registrySources:
       allowedRegistries:
       - quay.io
+      - registry.redhat.io
+      - registry.access.redhat.com
 `)
 
 func testExtendedTestdataBuildsClusterConfigRegistryWhitelistYamlBytes() ([]byte, error) {
@@ -32642,6 +32678,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/builds/build-timing/test-docker-build.json": testExtendedTestdataBuildsBuildTimingTestDockerBuildJson,
 	"test/extended/testdata/builds/build-timing/test-is.json": testExtendedTestdataBuildsBuildTimingTestIsJson,
 	"test/extended/testdata/builds/build-timing/test-s2i-build.json": testExtendedTestdataBuildsBuildTimingTestS2iBuildJson,
+	"test/extended/testdata/builds/cluster-config/blacklist-build.yaml": testExtendedTestdataBuildsClusterConfigBlacklistBuildYaml,
 	"test/extended/testdata/builds/cluster-config/registry-blacklist.yaml": testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml,
 	"test/extended/testdata/builds/cluster-config/registry-whitelist.yaml": testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml,
 	"test/extended/testdata/builds/cluster-config.yaml": testExtendedTestdataBuildsClusterConfigYaml,
@@ -33060,6 +33097,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"test-s2i-build.json": &bintree{testExtendedTestdataBuildsBuildTimingTestS2iBuildJson, map[string]*bintree{}},
 					}},
 					"cluster-config": &bintree{nil, map[string]*bintree{
+						"blacklist-build.yaml": &bintree{testExtendedTestdataBuildsClusterConfigBlacklistBuildYaml, map[string]*bintree{}},
 						"registry-blacklist.yaml": &bintree{testExtendedTestdataBuildsClusterConfigRegistryBlacklistYaml, map[string]*bintree{}},
 						"registry-whitelist.yaml": &bintree{testExtendedTestdataBuildsClusterConfigRegistryWhitelistYaml, map[string]*bintree{}},
 					}},

--- a/test/extended/testdata/builds/cluster-config/blacklist-build.yaml
+++ b/test/extended/testdata/builds/cluster-config/blacklist-build.yaml
@@ -1,0 +1,18 @@
+
+kind: BuildConfig
+apiVersion: v1
+metadata:
+  name: blacklist-build
+spec:
+  source:
+    type: Dockerfile
+    dockerfile: |-
+      FROM busybox:latest
+      RUN echo "Hello world!"
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: docker.io/busybox:latest
+  

--- a/test/extended/testdata/builds/cluster-config/registry-blacklist.yaml
+++ b/test/extended/testdata/builds/cluster-config/registry-blacklist.yaml
@@ -6,4 +6,3 @@ spec:
   registrySources:
       blockedRegistries:
       - docker.io
-      - quay.io

--- a/test/extended/testdata/builds/cluster-config/registry-whitelist.yaml
+++ b/test/extended/testdata/builds/cluster-config/registry-whitelist.yaml
@@ -6,3 +6,5 @@ spec:
   registrySources:
       allowedRegistries:
       - quay.io
+      - registry.redhat.io
+      - registry.access.redhat.com

--- a/test/extended/util/cvo.go
+++ b/test/extended/util/cvo.go
@@ -1,12 +1,12 @@
 package util
 
 import (
-	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -28,10 +28,12 @@ func WaitForClusterProgression(cv configclientv1.ClusterOperatorsGetter) error {
 			success = 0
 			// Transient client-side timeout
 			if errors.IsTimeout(err) {
+				e2e.Logf("Timeout listing cluster operators")
 				return false, nil
 			}
 			// Wait if underlying service is unavailable or times out on server side - indicates apiserver churn
 			if errors.IsServiceUnavailable(err) || errors.IsServerTimeout(err) {
+				e2e.Logf("API servers are unavailable or timing out.")
 				return false, nil
 			}
 			return false, err
@@ -41,20 +43,23 @@ func WaitForClusterProgression(cv configclientv1.ClusterOperatorsGetter) error {
 				switch status.Type {
 				case configv1.OperatorFailing:
 					if status.Status == configv1.ConditionTrue {
-						// Operator is failing - abort with error
+						// Operator is failing - can happen if API servers crash on MCO rollout
 						success = 0
-						return false, fmt.Errorf("operator %s is failing due to %s: %s", op.Name, status.Reason, status.Message)
+						e2e.Logf("Operator %s is failing due to %s: %s", op.Name, status.Reason, status.Message)
+						return false, nil
 					}
 				case configv1.OperatorAvailable:
 					if status.Status == configv1.ConditionFalse {
 						// Operator is not available - not ready
 						success = 0
+						e2e.Logf("Waiting for operator %s to become available", op.Name)
 						return false, nil
 					}
 				case configv1.OperatorProgressing:
 					if status.Status == configv1.ConditionTrue {
 						// Operator is progressing - not ready
 						success = 0
+						e2e.Logf("Waiting for operator %s to finish progress on %s: %s", op.Name, status.Reason, status.Message)
 						return false, nil
 					}
 				}

--- a/test/extended/util/cvo.go
+++ b/test/extended/util/cvo.go
@@ -13,16 +13,14 @@ import (
 )
 
 // WaitForClusterProgression waits for a cluster-level configuration change to propagate across all operators.
-// This polls all ClusterVersion objects and waits until the following states are stable:
+// This polls all ClusterOperator objects and waits until the following states are stable:
 //
 // 1. Available = true
 // 2. Progressing = false
 // 3. Failing = false
-//
-// If a ClusterVersion reports it is failing, this will abort with an error.
-func WaitForClusterProgression(cv configclientv1.ClusterOperatorsGetter) error {
+func WaitForClusterProgression(cv configclientv1.ClusterOperatorsGetter, timeout time.Duration) error {
 	success := 0
-	return wait.Poll(10*time.Second, 10*time.Minute, func() (bool, error) {
+	return wait.Poll(10*time.Second, timeout, func() (bool, error) {
 		clusterOperators, err := cv.ClusterOperators().List(metav1.ListOptions{})
 		if err != nil {
 			success = 0

--- a/test/extended/util/cvo.go
+++ b/test/extended/util/cvo.go
@@ -26,8 +26,12 @@ func WaitForClusterProgression(cv configclientv1.ClusterOperatorsGetter) error {
 		clusterOperators, err := cv.ClusterOperators().List(metav1.ListOptions{})
 		if err != nil {
 			success = 0
-			// Wait if underlying service is unavailable - indicates apiserver churn
-			if errors.IsServiceUnavailable(err) {
+			// Transient client-side timeout
+			if errors.IsTimeout(err) {
+				return false, nil
+			}
+			// Wait if underlying service is unavailable or times out on server side - indicates apiserver churn
+			if errors.IsServiceUnavailable(err) || errors.IsServerTimeout(err) {
 				return false, nil
 			}
 			return false, err

--- a/test/extended/util/cvo.go
+++ b/test/extended/util/cvo.go
@@ -20,9 +20,9 @@ import (
 // 3. Failing = false
 //
 // If a ClusterVersion reports it is failing, this will abort with an error.
-func WaitForClusterProgression(cv configclientv1.ClusterVersionsGetter) error {
+func WaitForClusterProgression(cv configclientv1.ClusterOperatorsGetter) error {
 	return wait.Poll(6*time.Second, 10*time.Minute, func() (bool, error) {
-		clusterVersions, err := cv.ClusterVersions().List(metav1.ListOptions{})
+		clusterOperators, err := cv.ClusterOperators().List(metav1.ListOptions{})
 		if err != nil {
 			// Wait if underlying service is unavailable - indicates apiserver churn
 			if errors.IsServiceUnavailable(err) {
@@ -30,7 +30,7 @@ func WaitForClusterProgression(cv configclientv1.ClusterVersionsGetter) error {
 			}
 			return false, err
 		}
-		for _, op := range clusterVersions.Items {
+		for _, op := range clusterOperators.Items {
 			for _, status := range op.Status.Conditions {
 				switch status.Type {
 				case configv1.OperatorFailing:

--- a/test/extended/util/cvo.go
+++ b/test/extended/util/cvo.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+)
+
+// WaitForClusterProgression waits for a cluster-level configuration change to propagate across all operators.
+// This polls all ClusterVersion objects and waits until the following states are stable:
+//
+// 1. Available = true
+// 2. Progressing = false
+// 3. Failing = false
+//
+// If a ClusterVersion reports it is failing, this will abort with an error.
+func WaitForClusterProgression(cv configclientv1.ClusterVersionsGetter) error {
+	return wait.Poll(6*time.Second, 10*time.Minute, func() (bool, error) {
+		clusterVersions, err := cv.ClusterVersions().List(metav1.ListOptions{})
+		if err != nil {
+			// Wait if underlying service is unavailable - indicates apiserver churn
+			if errors.IsServiceUnavailable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		for _, op := range clusterVersions.Items {
+			for _, status := range op.Status.Conditions {
+				switch status.Type {
+				case configv1.OperatorFailing:
+					if status.Status == configv1.ConditionTrue {
+						// Operator is failing - abort with error
+						return false, fmt.Errorf("operator %s is failing due to %s: %s", op.Name, status.Reason, status.Message)
+					}
+				case configv1.OperatorAvailable:
+					if status.Status == configv1.ConditionFalse {
+						// Operator is not available - not ready
+						return false, nil
+					}
+				case configv1.OperatorProgressing:
+					if status.Status == configv1.ConditionTrue {
+						// Operator is progressing - not ready
+						return false, nil
+					}
+				}
+			}
+		}
+		return true, nil
+	})
+
+}


### PR DESCRIPTION
This fixes the wait condition on the build cluster config test. It checks the entire cluster to ensure that it has reached a stable state before running the build tests.