### PR TITLE
Support reloading CA files

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -529,7 +529,7 @@ func buildGenericConfig(
 	}
 	serviceResolver = aggregatorapiserver.NewLoopbackServiceResolver(serviceResolver, localHost)
 
-	genericConfig.Authentication.Authenticator, genericConfig.OpenAPIConfig.SecurityDefinitions, err = BuildAuthenticator(s, clientgoExternalClient, sharedInformers)
+	genericConfig.Authentication.Authenticator, genericConfig.OpenAPIConfig.SecurityDefinitions, genericConfig.Authentication.DynamicReloadFns, err = BuildAuthenticator(s, clientgoExternalClient, sharedInformers)
 	if err != nil {
 		lastErr = fmt.Errorf("invalid authentication config: %v", err)
 		return
@@ -636,7 +636,7 @@ func BuildAdmissionPluginInitializers(
 }
 
 // BuildAuthenticator constructs the authenticator
-func BuildAuthenticator(s *options.ServerRunOptions, extclient clientgoclientset.Interface, sharedInformers informers.SharedInformerFactory) (authenticator.Request, *spec.SecurityDefinitions, error) {
+func BuildAuthenticator(s *options.ServerRunOptions, extclient clientgoclientset.Interface, sharedInformers informers.SharedInformerFactory) (authenticator.Request, *spec.SecurityDefinitions, map[string]genericapiserver.PostStartHookFunc, error) {
 	authenticatorConfig := s.Authentication.ToAuthenticationConfig()
 	if s.Authentication.ServiceAccounts.Lookup {
 		authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromClient(extclient)

--- a/vendor/k8s.io/kubernetes/cmd/kubelet/app/auth.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubelet/app/auth.go
@@ -76,7 +76,8 @@ func BuildAuthn(client authenticationclient.TokenReviewInterface, authn kubeletc
 		authenticatorConfig.TokenAccessReviewClient = client
 	}
 
-	authenticator, _, err := authenticatorConfig.New()
+	// ignore dynamic reload.  We may want this in the future
+	authenticator, _, _, err := authenticatorConfig.New()
 	return authenticator, err
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -71,16 +71,30 @@ func (f UserConversionFunc) User(chain []*x509.Certificate) (user.Info, bool, er
 	return f(chain)
 }
 
+type VerifyOptionFunc func() x509.VerifyOptions
+
+func StaticVerifierFn(opts x509.VerifyOptions) VerifyOptionFunc {
+	return func() x509.VerifyOptions {
+		return opts
+	}
+}
+
 // Authenticator implements request.Authenticator by extracting user info from verified client certificates
 type Authenticator struct {
-	opts x509.VerifyOptions
-	user UserConversion
+	verifyOptionsFn VerifyOptionFunc
+	user            UserConversion
 }
 
 // New returns a request.Authenticator that verifies client certificates using the provided
 // VerifyOptions, and converts valid certificate chains into user.Info using the provided UserConversion
 func New(opts x509.VerifyOptions, user UserConversion) *Authenticator {
-	return &Authenticator{opts, user}
+	return NewDynamic(StaticVerifierFn(opts), user)
+}
+
+// New returns a request.Authenticator that verifies client certificates using the provided
+// VerifyOptions, and converts valid certificate chains into user.Info using the provided UserConversion
+func NewDynamic(verifyOptionsFn VerifyOptionFunc, user UserConversion) *Authenticator {
+	return &Authenticator{verifyOptionsFn, user}
 }
 
 // AuthenticateRequest authenticates the request using presented client certificates
@@ -90,7 +104,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 	}
 
 	// Use intermediates, if provided
-	optsCopy := a.opts
+	optsCopy := a.verifyOptionsFn()
 	if optsCopy.Intermediates == nil && len(req.TLS.PeerCertificates) > 1 {
 		optsCopy.Intermediates = x509.NewCertPool()
 		for _, intermediate := range req.TLS.PeerCertificates[1:] {
@@ -122,8 +136,8 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 
 // Verifier implements request.Authenticator by verifying a client cert on the request, then delegating to the wrapped auth
 type Verifier struct {
-	opts x509.VerifyOptions
-	auth authenticator.Request
+	verifyOptionsFn VerifyOptionFunc
+	auth            authenticator.Request
 
 	// allowedCommonNames contains the common names which a verified certificate is allowed to have.
 	// If empty, all verified certificates are allowed.
@@ -132,7 +146,12 @@ type Verifier struct {
 
 // NewVerifier create a request.Authenticator by verifying a client cert on the request, then delegating to the wrapped auth
 func NewVerifier(opts x509.VerifyOptions, auth authenticator.Request, allowedCommonNames sets.String) authenticator.Request {
-	return &Verifier{opts, auth, allowedCommonNames}
+	return NewDynamicVerifier(StaticVerifierFn(opts), auth, allowedCommonNames)
+}
+
+// NewVerifier create a request.Authenticator by verifying a client cert on the request, then delegating to the wrapped auth
+func NewDynamicVerifier(verifyOptionsFn VerifyOptionFunc, auth authenticator.Request, allowedCommonNames sets.String) authenticator.Request {
+	return &Verifier{verifyOptionsFn, auth, allowedCommonNames}
 }
 
 // AuthenticateRequest verifies the presented client certificate, then delegates to the wrapped auth
@@ -142,7 +161,7 @@ func (a *Verifier) AuthenticateRequest(req *http.Request) (user.Info, bool, erro
 	}
 
 	// Use intermediates, if provided
-	optsCopy := a.opts
+	optsCopy := a.verifyOptionsFn()
 	if optsCopy.Intermediates == nil && len(req.TLS.PeerCertificates) > 1 {
 		optsCopy.Intermediates = x509.NewCertPool()
 		for _, intermediate := range req.TLS.PeerCertificates[1:] {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/certs/clientca.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/certs/clientca.go
@@ -1,0 +1,117 @@
+package certs
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/client-go/util/cert"
+
+	"github.com/golang/glog"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubex509 "k8s.io/apiserver/pkg/authentication/request/x509"
+)
+
+func NewDynamicCA(caBundleFilename string) *DynamicCA {
+	return &DynamicCA{
+		caFile: caFileReference{Cert: caBundleFilename},
+	}
+}
+
+// DynamicCA dynamically loads ca bundle and provides a verifier compatible with kube x509 authentication
+type DynamicCA struct {
+	caFile caFileReference
+
+	currentContent caFileContent
+	currentValue   atomic.Value
+}
+
+type caFileReference struct {
+	Cert string
+}
+
+type caFileContent struct {
+	Cert []byte
+}
+
+type runtimeDynamicCA struct {
+	verifyOptions x509.VerifyOptions
+}
+
+func (c *DynamicCA) GetVerifier() x509.VerifyOptions {
+	uncastObj := c.currentValue.Load()
+	if uncastObj == nil {
+		panic("tls: configuration not ready")
+	}
+	runtimeConfig, ok := uncastObj.(*runtimeDynamicCA)
+	if !ok {
+		panic("tls: unexpected config type")
+	}
+	return runtimeConfig.GetVerifier()
+}
+
+func (c *DynamicCA) Run(stopCh <-chan struct{}) {
+	glog.Infof("Starting DynamicCA: %v", c.caFile.Cert)
+	defer glog.Infof("Shutting down DynamicCA: %v", c.caFile.Cert)
+
+	go wait.Until(func() {
+		err := c.CheckCerts()
+		if err != nil {
+			utilruntime.HandleError(err)
+		}
+	}, 1*time.Minute, stopCh)
+
+	<-stopCh
+}
+
+func (c *DynamicCA) CheckCerts() error {
+	certBytes, err := ioutil.ReadFile(c.caFile.Cert)
+	if err != nil {
+		return err
+	}
+	newContent := caFileContent{Cert: certBytes}
+
+	if newContent.Equals(&c.currentContent) {
+		return nil
+	}
+
+	certs, err := cert.ParseCertsPEM(newContent.Cert)
+	if err != nil {
+		return fmt.Errorf("unable to load client CA file %s: %v", c.caFile.Cert, err)
+	}
+	pool := x509.NewCertPool()
+	for _, cert := range certs {
+		pool.AddCert(cert)
+	}
+
+	verifyOpts := kubex509.DefaultVerifyOptions()
+	verifyOpts.Roots = pool
+	newRuntimeConfig := &runtimeDynamicCA{verifyOptions: verifyOpts}
+
+	c.currentValue.Store(newRuntimeConfig)
+	c.currentContent = newContent // this is single threaded, so we have no locking issue
+
+	return nil
+}
+
+func (c *caFileContent) Equals(rhs *caFileContent) bool {
+	if c == nil && rhs == nil {
+		return true
+	}
+	if c == nil && rhs != nil {
+		return false
+	}
+	if c != nil && rhs == nil {
+		return false
+	}
+	return reflect.DeepEqual(c.Cert, rhs.Cert)
+}
+
+func (c *runtimeDynamicCA) GetVerifier() x509.VerifyOptions {
+	return c.verifyOptions
+}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -31,6 +32,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/golang/glog"
 	"github.com/pborman/uuid"
+	"k8s.io/apiserver/pkg/server/certs"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -208,9 +210,11 @@ type SecureServingInfo struct {
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA *x509.CertPool
 
-	// DynamicCertificates is an alternative to Cert and SNICerts that is limited to files, but those file will
-	// be monitored for changes every minute and allows the certificates to be updated dynamically.
-	DynamicCertificates *DynamicCertificateConfig
+	DefaultCertificate certs.CertKeyFileReference
+	NameToCertificate  map[string]*certs.CertKeyFileReference
+
+	// LoopbackCert holds the special certificate that we create for loopback connections
+	LoopbackCert *tls.Certificate
 
 	// MinTLSVersion optionally overrides the minimum TLS version supported.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
@@ -20,15 +20,13 @@ import (
 	"fmt"
 	"net"
 
+	"k8s.io/apiserver/pkg/server/certs"
+
 	restclient "k8s.io/client-go/rest"
 )
 
-// LoopbackClientServerNameOverride is passed to the apiserver from the loopback client in order to
-// select the loopback certificate via SNI if TLS is used.
-const LoopbackClientServerNameOverride = "apiserver-loopback-client"
-
 func (s *SecureServingInfo) NewClientConfig(caCert []byte) (*restclient.Config, error) {
-	if s == nil || (s.DynamicCertificates == nil) {
+	if s == nil {
 		return nil, nil
 	}
 
@@ -59,7 +57,7 @@ func (s *SecureServingInfo) NewLoopbackClientConfig(token string, loopbackCert [
 	}
 
 	c.BearerToken = token
-	c.TLSClientConfig.ServerName = LoopbackClientServerNameOverride
+	c.TLSClientConfig.ServerName = certs.LoopbackClientServerNameOverride
 
 	return c, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/dynamic_certificate_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/dynamic_certificate_test.go
@@ -1,1 +1,0 @@
-package server

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/golang/glog"
 
@@ -58,6 +59,9 @@ type PostStartHookProvider interface {
 
 type postStartHookEntry struct {
 	hook PostStartHookFunc
+	// originatingStack holds the stack that registered postStartHooks. This allows us to show a more helpful message
+	// for duplicate registration.
+	originatingStack string
 
 	// done will be closed when the postHook is finished
 	done chan struct{}
@@ -85,15 +89,16 @@ func (s *GenericAPIServer) AddPostStartHook(name string, hook PostStartHookFunc)
 	if s.postStartHooksCalled {
 		return fmt.Errorf("unable to add %q because PostStartHooks have already been called", name)
 	}
-	if _, exists := s.postStartHooks[name]; exists {
-		return fmt.Errorf("unable to add %q because it is already registered", name)
+	if postStartHook, exists := s.postStartHooks[name]; exists {
+		// this is programmer error, but it can be hard to debug
+		return fmt.Errorf("unable to add %q because it was already registered by: %s", name, postStartHook.originatingStack)
 	}
 
 	// done is closed when the poststarthook is finished.  This is used by the health check to be able to indicate
 	// that the poststarthook is finished
 	done := make(chan struct{})
 	s.AddHealthzChecks(postStartHookHealthz{name: "poststarthook/" + name, done: done})
-	s.postStartHooks[name] = postStartHookEntry{hook: hook, done: done}
+	s.postStartHooks[name] = postStartHookEntry{hook: hook, originatingStack: string(debug.Stack()), done: done}
 
 	return nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apiserver/pkg/server/certs"
+
 	"k8s.io/apiserver/pkg/server/servingcerttesting"
 
 	"github.com/stretchr/testify/assert"
@@ -347,7 +349,7 @@ func TestServerRunWithSNI(t *testing.T) {
 		},
 		"loopback: LoopbackClientServerNameOverride on server cert": {
 			Cert: servingcerttesting.TestCertSpec{
-				Host: server.LoopbackClientServerNameOverride,
+				Host: certs.LoopbackClientServerNameOverride,
 			},
 			SNICerts: []NamedTestCertSpec{
 				{
@@ -365,7 +367,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			SNICerts: []NamedTestCertSpec{
 				{
 					TestCertSpec: servingcerttesting.TestCertSpec{
-						Host: server.LoopbackClientServerNameOverride,
+						Host: certs.LoopbackClientServerNameOverride,
 					},
 				},
 			},

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -27,10 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apiserver/pkg/server/certs"
-
-	"k8s.io/apiserver/pkg/server/servingcerttesting"
-
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,6 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/server"
 	. "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/certs"
+	servingcerttesting "k8s.io/apiserver/pkg/server/options/testing"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
@@ -552,6 +550,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			if expected := &v; !reflect.DeepEqual(got, expected) {
 				t.Errorf("loopback client didn't get correct version info: expected=%v got=%v", expected, got)
 			}
+
 		})
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/pborman/uuid"
+	"k8s.io/apiserver/pkg/server/certs"
 
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
@@ -51,7 +52,7 @@ func (s *SecureServingOptionsWithLoopback) ApplyTo(secureServingInfo **server.Se
 
 	// create self-signed cert+key with the fake server.LoopbackClientServerNameOverride and
 	// let the server return it when the loopback client connects.
-	certPem, keyPem, err := certutil.GenerateSelfSignedCertKey(server.LoopbackClientServerNameOverride, nil, nil)
+	certPem, keyPem, err := certutil.GenerateSelfSignedCertKey(certs.LoopbackClientServerNameOverride, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to generate self-signed certificate for loopback connection: %v", err)
 	}
@@ -71,9 +72,7 @@ func (s *SecureServingOptionsWithLoopback) ApplyTo(secureServingInfo **server.Se
 
 	default:
 		*loopbackClientConfig = secureLoopbackClientConfig
-		if (*secureServingInfo).DynamicCertificates != nil {
-			(*secureServingInfo).DynamicCertificates.LoopbackCert = &tlsCert
-		}
+		(*secureServingInfo).LoopbackCert = &tlsCert
 	}
 
 	return nil

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/testing/certs.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/options/testing/certs.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package servingcerttesting
+package testing
 
 import (
 	"bytes"


### PR DESCRIPTION
I understand how the configForClient function works now.  I've updated the code to use it and provided a way to have the authenticators reload.

I still need to wire the aggregator for reloading, but I think I can force that based on a value change with another patch.

/assign @sttts @mfojtik 