### PR TITLE
openshift-apiserver: set openshift apiserver config defaults for legacy config

### DIFF
--- a/pkg/cmd/openshift-apiserver/cmd.go
+++ b/pkg/cmd/openshift-apiserver/cmd.go
@@ -160,5 +160,7 @@ func (o *OpenShiftAPIServer) RunAPIServer(stopCh <-chan struct{}) error {
 		return err
 	}
 
+	configdefault.SetRecommendedOpenShiftAPIServerConfigDefaults(openshiftAPIServerConfig)
+
 	return RunOpenShiftAPIServer(openshiftAPIServerConfig, stopCh)
 }


### PR DESCRIPTION
I tracked the rouge openshift apiserver storage that makes 50k+ SAR requests using JSON client instead of protobuf.

The only case I found that does not apply the override with protobuf seems to be legacy config.