### PR TITLE
UPSTREAM: 74755: Revert kubelet to default to ttl cache secret/configmap

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/conversion/master/internal.yaml
@@ -87,7 +87,7 @@ ComponentConfigs:
     ClusterDNS:
     - 10.96.0.10
     ClusterDomain: cluster.local
-    ConfigMapAndSecretChangeDetectionStrategy: Watch
+    ConfigMapAndSecretChangeDetectionStrategy: Cache
     ContainerLogMaxFiles: 5
     ContainerLogMaxSize: 10Mi
     ContentType: application/vnd.kubernetes.protobuf

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha2.yaml
@@ -86,7 +86,7 @@ kubeletConfiguration:
     clusterDNS:
     - 10.96.0.10
     clusterDomain: cluster.local
-    configMapAndSecretChangeDetectionStrategy: Watch
+    configMapAndSecretChangeDetectionStrategy: Cache
     containerLogMaxFiles: 5
     containerLogMaxSize: 10Mi
     contentType: application/vnd.kubernetes.protobuf

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/conversion/master/v1alpha3.yaml
@@ -102,7 +102,7 @@ cgroupsPerQOS: true
 clusterDNS:
 - 10.96.0.10
 clusterDomain: cluster.local
-configMapAndSecretChangeDetectionStrategy: Watch
+configMapAndSecretChangeDetectionStrategy: Cache
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi
 contentType: application/vnd.kubernetes.protobuf

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/defaulting/master/defaulted.yaml
@@ -97,7 +97,7 @@ cgroupsPerQOS: true
 clusterDNS:
 - 10.192.0.10
 clusterDomain: cluster.global
-configMapAndSecretChangeDetectionStrategy: Watch
+configMapAndSecretChangeDetectionStrategy: Cache
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi
 contentType: application/vnd.kubernetes.protobuf

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -205,7 +205,7 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 		obj.ContainerLogMaxFiles = utilpointer.Int32Ptr(5)
 	}
 	if obj.ConfigMapAndSecretChangeDetectionStrategy == "" {
-		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.WatchChangeDetectionStrategy
+		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.TTLCacheChangeDetectionStrategy
 	}
 	if obj.EnforceNodeAllocatable == nil {
 		obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement


### PR DESCRIPTION
Reference https://github.com/kubernetes/kubernetes/pull/74842 (Kubernetes 1.12 backport)