### PR TITLE
Fix example flake

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -30,8 +31,8 @@ import (
 
 // TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
 func TestFakeClient(t *testing.T) {
-	// Use a timeout to keep the test from hanging.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Create the fake client.
 	client := fake.NewSimpleClientset()
@@ -45,7 +46,6 @@ func TestFakeClient(t *testing.T) {
 			pod := obj.(*v1.Pod)
 			t.Logf("pod added: %s/%s", pod.Namespace, pod.Name)
 			pods <- pod
-			cancel()
 		},
 	})
 
@@ -55,23 +55,19 @@ func TestFakeClient(t *testing.T) {
 	// This is not required in tests, but it serves as a proof-of-concept by
 	// ensuring that the informer goroutine have warmed up and called List before
 	// we send any events to it.
-	for !podInformer.HasSynced() {
-		time.Sleep(10 * time.Millisecond)
-	}
+	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
 
 	// Inject an event into the fake client.
 	p := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}
 	_, err := client.CoreV1().Pods("test-ns").Create(p)
 	if err != nil {
-		t.Errorf("error injecting pod add: %v", err)
+		t.Fatalf("error injecting pod add: %v", err)
 	}
 
-	// Wait and check result.
-	<-ctx.Done()
 	select {
 	case pod := <-pods:
 		t.Logf("Got pod from channel: %s/%s", pod.Namespace, pod.Name)
-	default:
+	case <-time.After(wait.ForeverTestTimeout):
 		t.Error("Informer did not get the added pod")
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -61,7 +61,7 @@ func TestFakeClient(t *testing.T) {
 
 	// Inject an event into the fake client.
 	p := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "my-pod"}}
-	_, err := client.Core().Pods("test-ns").Create(p)
+	_, err := client.CoreV1().Pods("test-ns").Create(p)
 	if err != nil {
 		t.Errorf("error injecting pod add: %v", err)
 	}


### PR DESCRIPTION
backport of https://github.com/kubernetes/kubernetes/pull/74969

Fixes: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/batch/pull-ci-openshift-origin-master-unit/3803#githubcomopenshiftoriginvendork8sioclient-goexamplesfake-client-testfakeclient

/cc @sttts @mfojtik 