### PR TITLE
[3.11] properly delete NetworkPolicies when deleting their namespace

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -186,7 +186,15 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkapi.NetNamespace
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	delete(np.namespaces, netns.NetID)
+	if npns, exists := np.namespaces[netns.NetID]; exists {
+		if npns.inUse {
+			npns.inUse = false
+			// We call syncNamespaceFlows() not syncNamespace() because it
+			// needs to happen before we forget about the namespace.
+			np.syncNamespaceFlows(npns)
+		}
+		delete(np.namespaces, netns.NetID)
+	}
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,6 +121,15 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
+	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
+	if err != nil {
+		return err
+	}
+	inUseNamespaces := sets.NewString()
+	for _, pod := range pods {
+		inUseNamespaces.Insert(pod.Namespace)
+	}
+
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -132,7 +141,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    false,
+				inUse:    inUseNamespaces.Has(ns.Name),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}


### PR DESCRIPTION
Backport of #22158; since #22106 makes this problem worse, we should backport the fix to all of the releases we backported #22106 to.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686025