### PR TITLE
fix(kubeadmission): turn RestrictSubjectBindings admission plugin on by default

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -99,7 +99,6 @@ func NewDefaultOffPluginsFunc(kubeDefaultOffAdmission sets.String) func() sets.S
 		kubeOff := sets.NewString(kubeDefaultOffAdmission.UnsortedList()...)
 		kubeOff.Delete(additionalDefaultOnPlugins.List()...)
 		kubeOff.Delete(openshiftAdmissionPluginsForKube...)
-		kubeOff.Insert("authorization.openshift.io/RestrictSubjectBindings")
 		return kubeOff
 	}
 }


### PR DESCRIPTION
Bug 1684344: rolebindingrestriction for 4.x

Cause: 4.x did not support configuring the rolebindingrestriction admission plugin

Consequence: No way to turn on RestrictSubjectBindings admission plugin

Fix: Turn on the RestrictSubjectBindings admission plugin by default

Result: No change in behavior for those not utilizing the plugin. Ability to create SubjectBindingRestrictions for those who do in 4.x.