### PR TITLE
Fixing openapi spec

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/generated/openapi/zz_generated.openapi.go
+++ b/vendor/k8s.io/kubernetes/pkg/generated/openapi/zz_generated.openapi.go
@@ -27682,6 +27682,12 @@ func schema_pkg_apis_apiextensions_v1beta1_JSONSchemaProps(ref common.ReferenceC
 							Ref: ref("k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1.JSON"),
 						},
 					},
+					"nullable": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We create the openapi spec in vendor/k8s.io/kubernetes/pkg/generated/openapi/zz_generated.openapi.go manually during rebase. Upstream does not check it in. I.e. any carry patch will never update it.

The one in pkg/openapi/zz_generated.openapi.go plays no role for kube-apiserver.

In https://github.com/openshift/origin/pull/22202, the later was updated, the former was not.