### PR TITLE
skip openshift admission on default namespace

### DIFF
--- a/pkg/admission/namespaceconditions/decorator.go
+++ b/pkg/admission/namespaceconditions/decorator.go
@@ -9,7 +9,7 @@ import (
 
 // this is a list of namespaces with special meaning.  The kube ones are here in particular because
 // we don't control their creation or labeling on their creation
-var runLevelZeroNamespaces = sets.NewString("kube-system", "kube-public")
+var runLevelZeroNamespaces = sets.NewString("default", "kube-system", "kube-public")
 var runLevelOneNamespaces = sets.NewString("openshift-node", "openshift-infra", "openshift")
 
 func init() {

--- a/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
@@ -87,11 +87,6 @@ func (q *clusterQuotaAdmission) Validate(a admission.Attributes) (err error) {
 	if len(a.GetNamespace()) == 0 {
 		return nil
 	}
-	// skip default namespace until we no longer require SCC in that namespace and we can simply exclude all openshift admission
-	// from that namespace
-	if a.GetNamespace() == "default" {
-		return nil
-	}
 
 	if !q.waitForSyncedStore(time.After(timeToWaitForCacheSync)) {
 		return admission.NewForbidden(a, errors.New("caches not synchronized"))


### PR DESCRIPTION
We respected admission in `default` because we had legacy components relying on it, but no pods should be created in there now that require SCC values set.

See https://github.com/openshift/origin/pull/19457

/assign @enj 