### PR TITLE
project admission isn't required on the kube-apiserver

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -46,7 +46,6 @@ var (
 		"autoscaling.openshift.io/ClusterResourceOverride",
 		"autoscaling.openshift.io/RunOnceDuration",
 		imagepolicyapiv1.PluginName, // "image.openshift.io/ImagePolicy"
-		"project.openshift.io/ProjectRequestLimit",
 		"quota.openshift.io/ClusterResourceQuota",
 		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		"security.openshift.io/SecurityContextConstraint",


### PR DESCRIPTION
Looks like an oversight during admission rewiring. There is no project request limit to secure.

/assign @enj @mfojtik 