### PR TITLE
remove admission dependencies on project cache

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -43,7 +43,6 @@ var (
 	// these are admission plugins that cannot be applied until after the openshiftapiserver apiserver starts.
 	SkipRunLevelOnePlugins = sets.NewString(
 		"authorization.openshift.io/RestrictSubjectBindings",
-		"autoscaling.openshift.io/RunOnceDuration",
 		imagepolicyapiv1.PluginName, // "image.openshift.io/ImagePolicy"
 		"project.openshift.io/ProjectRequestLimit",
 		"quota.openshift.io/ClusterResourceQuota",

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -43,7 +43,6 @@ var (
 	// these are admission plugins that cannot be applied until after the openshiftapiserver apiserver starts.
 	SkipRunLevelOnePlugins = sets.NewString(
 		"authorization.openshift.io/RestrictSubjectBindings",
-		"autoscaling.openshift.io/ClusterResourceOverride",
 		"autoscaling.openshift.io/RunOnceDuration",
 		imagepolicyapiv1.PluginName, // "image.openshift.io/ImagePolicy"
 		"project.openshift.io/ProjectRequestLimit",

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -46,7 +46,6 @@ var (
 		imagepolicyapiv1.PluginName, // "image.openshift.io/ImagePolicy"
 		"project.openshift.io/ProjectRequestLimit",
 		"quota.openshift.io/ClusterResourceQuota",
-		"scheduling.openshift.io/OriginPodNodeEnvironment",
 		"security.openshift.io/SecurityContextConstraint",
 		"security.openshift.io/SCCExecRestrictions",
 	)

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -81,10 +81,6 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 		genericConfig.LongRunningFunc = configprocessing.IsLongRunningRequest
 
 		// ADMISSION
-		projectCache, err := openshiftapiserver.NewProjectCache(kubeAPIServerInformers.KubernetesInformers.Core().V1().Namespaces(), genericConfig.LoopbackClientConfig, kubeAPIServerConfig.ProjectConfig.DefaultNodeSelector)
-		if err != nil {
-			return nil, err
-		}
 		clusterQuotaMappingController := openshiftapiserver.NewClusterQuotaMappingController(kubeAPIServerInformers.KubernetesInformers.Core().V1().Namespaces(), kubeAPIServerInformers.InternalOpenshiftQuotaInformers.Quota().InternalVersion().ClusterResourceQuotas())
 		patchContext.postStartHooks["quota.openshift.io-clusterquotamapping"] = func(context genericapiserver.PostStartHookContext) error {
 			go clusterQuotaMappingController.Run(5, context.StopCh)
@@ -106,7 +102,7 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 		// TODO make a union registry
 		quotaRegistry := generic.NewRegistry(install.NewQuotaConfigurationForAdmission().Evaluators())
 		openshiftPluginInitializer := &oadmission.PluginInitializer{
-			ProjectCache:                 projectCache,
+			DefaultNodeSelector:          kubeAPIServerConfig.ProjectConfig.DefaultNodeSelector,
 			OriginQuotaRegistry:          quotaRegistry,
 			RESTClientConfig:             *genericConfig.LoopbackClientConfig,
 			ClusterResourceQuotaInformer: kubeAPIServerInformers.GetInternalOpenshiftQuotaInformers().Quota().InternalVersion().ClusterResourceQuotas(),

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -15,6 +15,7 @@ import (
 
 type PluginInitializer struct {
 	ProjectCache                 *cache.ProjectCache
+	DefaultNodeSelector          string
 	OriginQuotaRegistry          quota.Registry
 	RESTClientConfig             restclient.Config
 	ClusterResourceQuotaInformer quotainformer.ClusterResourceQuotaInformer
@@ -29,6 +30,9 @@ type PluginInitializer struct {
 func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	if wantsProjectCache, ok := plugin.(WantsProjectCache); ok {
 		wantsProjectCache.SetProjectCache(i.ProjectCache)
+	}
+	if castObj, ok := plugin.(WantsDefaultNodeSelector); ok {
+		castObj.SetDefaultNodeSelector(i.DefaultNodeSelector)
 	}
 	if wantsOriginQuotaRegistry, ok := plugin.(WantsOriginQuotaRegistry); ok {
 		wantsOriginQuotaRegistry.SetOriginQuotaRegistry(i.OriginQuotaRegistry)

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -19,6 +19,11 @@ type WantsProjectCache interface {
 	admission.InitializationValidator
 }
 
+type WantsDefaultNodeSelector interface {
+	SetDefaultNodeSelector(string)
+	admission.InitializationValidator
+}
+
 // WantsQuotaRegistry should be implemented by admission plugins that need a quota registry
 type WantsOriginQuotaRegistry interface {
 	SetOriginQuotaRegistry(quota.Registry)

--- a/pkg/project/cache/cache.go
+++ b/pkg/project/cache/cache.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
-	"github.com/openshift/origin/pkg/util/labelselector"
 )
 
 // NewProjectCache returns a non-initialized ProjectCache. The cache needs to be run to begin functioning
@@ -72,30 +71,6 @@ func (p *ProjectCache) GetNamespace(name string) (*corev1.Namespace, error) {
 		glog.V(4).Infof("found %s via storage lookup", name)
 	}
 	return namespace, nil
-}
-
-func (p *ProjectCache) GetNodeSelector(namespace *corev1.Namespace) string {
-	selector := ""
-	found := false
-	if len(namespace.ObjectMeta.Annotations) > 0 {
-		if ns, ok := namespace.ObjectMeta.Annotations[projectapi.ProjectNodeSelector]; ok {
-			selector = ns
-			found = true
-		}
-	}
-	if !found {
-		selector = p.DefaultNodeSelector
-	}
-	return selector
-}
-
-func (p *ProjectCache) GetNodeSelectorMap(namespace *corev1.Namespace) (map[string]string, error) {
-	selector := p.GetNodeSelector(namespace)
-	labelsMap, err := labelselector.Parse(selector)
-	if err != nil {
-		return map[string]string{}, err
-	}
-	return labelsMap, nil
 }
 
 // Run waits until the cache has synced.


### PR DESCRIPTION
The kube-apiserver should avoid deps on openshift resources as much as possible.  This removes usage of the project cache from kube admission plugins.

/assign @mfojtik 