### PR TITLE
Add build-all target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ all build:
 	hack/build-go.sh $(WHAT) $(GOFLAGS)
 .PHONY: all build
 
+# Build all binaries.
+#
+# Example:
+#   make build-all
+build-all:
+	hack/build-go.sh cmd/hypershift vendor/k8s.io/kubernetes/cmd/hyperkube cmd/oc cmd/openshift-sdn cmd/openshift-tests
+.PHONY: build-all
+
 # Build the test binaries.
 #
 # Example:


### PR DESCRIPTION
This is a followup from https://github.com/openshift/origin/pull/22218. @smarterclayton we need to build `hypershift` command, I wonder how your PR merged since it's required for test-cmd. This brings back only the `hypershift` portion back, ptal.

/assign @smarterclayton 