### PR TITLE
code-generator: add FeaturesList and DNSList to pluralExceptions

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -40,8 +40,10 @@ func NameSystems() namer.NameSystems {
 	// If you change this, make sure you get the other instances in listers and informers
 	pluralExceptions := map[string]string{
 		"DNS":                        "DNSes",
+		"DNSList":                    "DNSList",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
+		"FeaturesList":               "FeaturesList",
 		"SecurityContextConstraints": "SecurityContextConstraints",
 	}
 	lowercaseNamer := namer.NewAllLowercasePluralNamer(pluralExceptions)
@@ -96,10 +98,10 @@ func NameSystems() namer.NameSystems {
 	}
 	publicPluralNamer := &ExceptionNamer{
 		Exceptions: map[string]string{
-		// these exceptions are used to deconflict the generated code
-		// you can put your fully qualified package like
-		// to generate a name that doesn't conflict with your group.
-		// "k8s.io/apis/events/v1beta1.Event": "EventResource"
+			// these exceptions are used to deconflict the generated code
+			// you can put your fully qualified package like
+			// to generate a name that doesn't conflict with your group.
+			// "k8s.io/apis/events/v1beta1.Event": "EventResource"
 		},
 		KeyFunc: func(t *types.Type) string {
 			return t.Name.Package + "." + t.Name.Name

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
@@ -51,8 +51,10 @@ func (g *genericGenerator) Filter(c *generator.Context, t *types.Type) bool {
 func (g *genericGenerator) Namers(c *generator.Context) namer.NameSystems {
 	pluralExceptions := map[string]string{
 		"DNS":                        "DNSes",
+		"DNSList":                    "DNSList",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
+		"FeaturesList":               "FeaturesList",
 		"SecurityContextConstraints": "SecurityContextConstraints",
 	}
 	return namer.NameSystems{

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -37,8 +37,10 @@ import (
 func NameSystems() namer.NameSystems {
 	pluralExceptions := map[string]string{
 		"DNS":                        "DNSes",
+		"DNSList":                    "DNSList",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
+		"FeaturesList":               "FeaturesList",
 		"SecurityContextConstraints": "SecurityContextConstraints",
 	}
 	return namer.NameSystems{
@@ -323,9 +325,9 @@ func versionPackage(basePackage string, groupPkgName string, gv clientgentypes.G
 				DefaultGen: generator.DefaultGen{
 					OptionalName: "interface",
 				},
-				outputPackage: packagePath,
-				imports:       generator.NewImportTracker(),
-				types:         typesToGenerate,
+				outputPackage:             packagePath,
+				imports:                   generator.NewImportTracker(),
+				types:                     typesToGenerate,
 				internalInterfacesPackage: packageForInternalInterfaces(basePackage),
 			})
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -37,8 +37,10 @@ import (
 func NameSystems() namer.NameSystems {
 	pluralExceptions := map[string]string{
 		"DNS":                        "DNSes",
+		"DNSList":                    "DNSList",
 		"Endpoints":                  "Endpoints",
 		"Features":                   "Features",
+		"FeaturesList":               "FeaturesList",
 		"SecurityContextConstraints": "SecurityContextConstraints",
 	}
 	return namer.NameSystems{


### PR DESCRIPTION
FeaturesList and DNSList are not being pluralized correctly within the code generator. This patch adds the two objects to the pluralExceptions.

/cc @deads2k @sjenning 