### PR TITLE
Increase test/extended build timeout to 15m

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -707,7 +707,7 @@ func WaitForABuild(c buildv1clienttyped.BuildInterface, name string, isOK, isFai
 		return err
 	}
 	// wait longer for the build to run to completion
-	err = wait.Poll(5*time.Second, 10*time.Minute, func() (bool, error) {
+	err = wait.Poll(5*time.Second, 15*time.Minute, func() (bool, error) {
 		list, err := c.List(metav1.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
 		if err != nil {
 			e2e.Logf("error listing builds: %v", err)


### PR DESCRIPTION
Addresses image pull flakes in image_ecosystem and build tests.

/assign @bparees 
/cc @gabemontero @coreydaley 