### PR TITLE
sdn: clarify SDN startup log message

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -346,20 +346,26 @@ func (node *OsdnNode) Start() error {
 		gatherPeriodicMetrics(node.oc.ovs)
 	}, time.Minute*2)
 
-	glog.V(2).Infof("openshift-sdn network plugin ready")
+	glog.V(2).Infof("openshift-sdn network plugin registering startup")
 
 	// Make an event that openshift-sdn started
 	node.recorder.Eventf(&v1.ObjectReference{Kind: "Node", Name: node.hostName}, v1.EventTypeNormal, "Starting", "Starting openshift-sdn.")
 
 	// Write our CNI config file out to disk to signal to kubelet that
 	// our network plugin is ready
-	return ioutil.WriteFile(filepath.Join(node.cniDirPath, openshiftCNIFile), []byte(`
+	err = ioutil.WriteFile(filepath.Join(node.cniDirPath, openshiftCNIFile), []byte(`
 {
   "cniVersion": "0.2.0",
   "name": "openshift-sdn",
   "type": "openshift-sdn"
 }
 `), 0644)
+	if err != nil {
+		return err
+	}
+
+	glog.V(2).Infof("openshift-sdn network plugin ready")
+	return nil
 }
 
 // reattachPods takes an array containing the information about pods that had been


### PR DESCRIPTION
Log a message both before and after the CNI config file is written, so
we can be sure of when the plugin notifies kubelet that it is ready.

@pecameron @weliang1 @squeed @JacobTanenbaum @danwinship 