### PR TITLE
release: Fetch the target repo instead of '--all'

### DIFF
--- a/pkg/oc/cli/admin/release/git.go
+++ b/pkg/oc/cli/admin/release/git.go
@@ -139,7 +139,7 @@ func gitOutputToError(err error, out string) error {
 	return fmt.Errorf(out)
 }
 
-func mergeLogForRepo(g *git, from, to string) ([]MergeCommit, error) {
+func mergeLogForRepo(g *git, repo, from, to string) ([]MergeCommit, error) {
 	if from == to {
 		return nil, nil
 	}
@@ -160,9 +160,11 @@ func mergeLogForRepo(g *git, from, to string) ([]MergeCommit, error) {
 		if !strings.Contains(out, "Invalid revision range") {
 			return nil, gitOutputToError(err, out)
 		}
-		if _, err := g.exec("fetch", "--all"); err != nil {
+		// fetch by repo so we at least guarantee we get our target
+		if _, err := g.exec("fetch", repo); err != nil {
 			return nil, gitOutputToError(err, out)
 		}
+		// TODO: fetch other remotes as well?
 		if _, err := g.exec("cat-file", "-e", from+"^{commit}"); err != nil {
 			return nil, fmt.Errorf("from commit %s does not exist", from)
 		}

--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -1260,7 +1260,7 @@ func commitsForRepo(dir string, change CodeChange, out, errOut io.Writer) (*url.
 	if err != nil {
 		return nil, nil, err
 	}
-	commits, err := mergeLogForRepo(g, change.From, change.To)
+	commits, err := mergeLogForRepo(g, change.Repo, change.From, change.To)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Could not load commits for %s: %v", change.Repo, err)
 	}


### PR DESCRIPTION
It's possible the repo isn't in the list of remotes, so do a direct
fetch instead.