### PR TITLE
Increase the upgrade suite timeout longer

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 
@@ -24,7 +25,8 @@ var upgradeSuites = []*ginkgo.TestSuite{
 		`),
 		Matches: func(name string) bool { return strings.Contains(name, "[Feature:ClusterUpgrade]") },
 
-		Init: func() error { return filterUpgrade(upgrade.AllTests(), func(name string) bool { return true }) },
+		Init:        func() error { return filterUpgrade(upgrade.AllTests(), func(name string) bool { return true }) },
+		TestTimeout: 60 * time.Minute,
 	},
 }
 

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -338,7 +338,7 @@ func clusterUpgrade(c configv1client.Interface, version upgrades.VersionContext)
 
 	framework.Logf("Cluster version operator acknowledged upgrade request")
 
-	if err := wait.PollImmediate(5*time.Second, 30*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(5*time.Second, 50*time.Minute, func() (bool, error) {
 		cv, err := c.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("unable to retrieve cluster version during upgrade: %v", err)


### PR DESCRIPTION
https://openshift-gce-devel.appspot.com/builds/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.0/

The suite defaults to 15m