### PR TITLE
deploymentconfig: log update conflicts using higher log level in controller

### DIFF
--- a/pkg/apps/controller/deploymentconfig/deploymentconfig_controller.go
+++ b/pkg/apps/controller/deploymentconfig/deploymentconfig_controller.go
@@ -496,8 +496,12 @@ func (c *DeploymentConfigController) handleErr(err error, key interface{}) {
 		return
 	}
 
+	verbosity := glog.Level(2)
 	if c.queue.NumRequeues(key) < maxRetryCount {
-		glog.V(2).Infof("Error syncing deployment config %v: %v", key, err)
+		if kapierrors.IsConflict(err) {
+			verbosity = glog.Level(4)
+		}
+		glog.V(verbosity).Infof("Error syncing deployment config %v: %v", key, err)
 		c.queue.AddRateLimited(key)
 		return
 	}


### PR DESCRIPTION
Seeing couple thousand of: `I0311 07:48:49.801055       1 deploymentconfig_controller.go:500] Error syncing deployment config e2e-test-cli-deployment-tlfw9/deployment-simple: Operation cannot be fulfilled on deploymentconfigs.apps.openshift.io "deployment-simple": the object has been modified; please apply your changes to the latest version and try again` in log.

Since these are always retried, we can mute the glog and move these to loglevel 5.