### PR TITLE
[3.11] contrib: systemd: fix systemd accounting

### DIFF
--- a/contrib/systemd/origin-accounting.conf
+++ b/contrib/systemd/origin-accounting.conf
@@ -1,7 +1,4 @@
 [Manager]
 DefaultCPUAccounting=yes
 DefaultMemoryAccounting=yes
-# systemd v230 or newer
-DefaultIOAccounting=yes
-# Deprecated, remove in future
 DefaultBlockIOAccounting=yes


### PR DESCRIPTION
master PR (doesn't matter against 4.x really) https://github.com/openshift/origin/pull/21138

https://github.com/openshift/origin/pull/14644 added IO accounting for systemd.

Unfortunately, the systemd version in RHEL doesn't understand `DefaultIOAccounting` (yet) and fails to apply any part of the config file, leading to this issue https://bugzilla.redhat.com/show_bug.cgi?id=1623261

`DefaultBlockIOAccounting` is what RHEL understands.

@derekwaynecarr @smarterclayton @sdodson