### PR TITLE
OVS flows go missing during upgrade

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,14 +121,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
-	if err != nil {
-		return err
-	}
-	inUseNamespaces := sets.NewString()
-	for _, pod := range pods {
-		inUseNamespaces.Insert(pod.Namespace)
-	}
+	inUseVNIDs := np.node.oc.FindPolicyVNIDs()
 
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
@@ -141,7 +134,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    inUseNamespaces.Has(ns.Name),
+				inUse:    inUseVNIDs.Has(int(vnid)),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -651,28 +651,39 @@ func (oc *ovsController) UpdateVXLANMulticastFlows(remoteIPs []string) error {
 	return otx.Commit()
 }
 
-// FindUnusedVNIDs returns a list of VNIDs for which there are table 80 "check" rules,
+// FindPolicyVNIDs returns the set of VNIDs for which there are currently "policy" rules
+// in OVS. (This is used to reinitialize the osdnPolicy after a restart.)
+func (oc *ovsController) FindPolicyVNIDs() sets.Int {
+	_, policyVNIDs := oc.findInUseAndPolicyVNIDs()
+	return policyVNIDs
+}
+
+// FindUnusedVNIDs returns a list of VNIDs for which there are table 80 "policy" rules,
 // but no table 60/70 "load" rules (meaning that there are no longer any pods or services
 // on this node with that VNID). There is no locking with respect to other ovsController
 // actions, but as long the "add a pod" and "add a service" codepaths add the
 // pod/service-specific rules before they call policy.EnsureVNIDRules(), then there is no
 // race condition.
 func (oc *ovsController) FindUnusedVNIDs() []int {
+	inUseVNIDs, policyVNIDs := oc.findInUseAndPolicyVNIDs()
+	return policyVNIDs.Difference(inUseVNIDs).UnsortedList()
+}
+
+func (oc *ovsController) findInUseAndPolicyVNIDs() (sets.Int, sets.Int) {
+	// VNID 0 is always in use, even if there aren't any explicit flows for it
+	inUseVNIDs := sets.NewInt(0)
+	policyVNIDs := sets.NewInt()
+
 	flows, err := oc.ovs.DumpFlows("")
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("FindUnusedVNIDs: could not DumpFlows: %v", err))
-		return nil
+		utilruntime.HandleError(fmt.Errorf("findInUseAndPolicyVNIDs: could not DumpFlows: %v", err))
+		return inUseVNIDs, policyVNIDs
 	}
 
-	// inUseVNIDs is the set of VNIDs in use by pods or services on this node.
-	// policyVNIDs is the set of VNIDs that we have rules for delivering to.
-	// VNID 0 is always assumed to be in both sets.
-	inUseVNIDs := sets.NewInt(0)
-	policyVNIDs := sets.NewInt(0)
 	for _, flow := range flows {
 		parsed, err := ovs.ParseFlow(ovs.ParseForDump, flow)
 		if err != nil {
-			glog.Warningf("FindUnusedVNIDs: could not parse flow %q: %v", flow, err)
+			glog.Warningf("findInUseAndPolicyVNIDs: could not parse flow %q: %v", flow, err)
 			continue
 		}
 
@@ -690,7 +701,7 @@ func (oc *ovsController) FindUnusedVNIDs() []int {
 				}
 				vnid, err := strconv.ParseInt(action.Value[:vnidEnd], 0, 32)
 				if err != nil {
-					glog.Warningf("FindUnusedVNIDs: could not parse VNID in 'load:%s': %v", action.Value, err)
+					glog.Warningf("findInUseAndPolicyVNIDs: could not parse VNID in 'load:%s': %v", action.Value, err)
 					continue
 				}
 				inUseVNIDs.Insert(int(vnid))
@@ -703,7 +714,7 @@ func (oc *ovsController) FindUnusedVNIDs() []int {
 			if field, exists := parsed.FindField("reg1"); exists {
 				vnid, err := strconv.ParseInt(field.Value, 0, 32)
 				if err != nil {
-					glog.Warningf("FindUnusedVNIDs: could not parse VNID in 'reg1=%s': %v", field.Value, err)
+					glog.Warningf("findInUseAndPolicyVNIDs: could not parse VNID in 'reg1=%s': %v", field.Value, err)
 					continue
 				}
 				policyVNIDs.Insert(int(vnid))
@@ -711,7 +722,7 @@ func (oc *ovsController) FindUnusedVNIDs() []int {
 		}
 	}
 
-	return policyVNIDs.Difference(inUseVNIDs).UnsortedList()
+	return inUseVNIDs, policyVNIDs
 }
 
 func (oc *ovsController) ensureTunMAC() error {


### PR DESCRIPTION
In the case where we have to recreate the OVS bridge and then reattach pods to it, the NetworkPolicy initialization code was initializing its namespace `inUse` fields based on what the state of the *old* OVS bridge would have been rather than the state of the *new* OVS bridge (which would have no policy-related rules yet). As a result, when the pods were reattached, it would think that it had already created the policy rules for their namespaces, even though it hadn't, and so there would never end up being rules for those namespaces, and so traffic to the reattached pods would get dropped.

This fixes it by initializing the `inUse` fields based on what's actually in OVS (which means it will work correctly in both the recreating-the-bridge case and the not-recreating-the-bridge case).

(It also fixes the multitenant code to properly initialize its in-use map at startup; this has no real effect other than preventing it from later running some "ovs-ofctl add-flows" commands that would be no-ops anyway.)

I haven't yet been able to verify that this fixes https://bugzilla.redhat.com/show_bug.cgi?id=1687881