### PR TITLE
WIP: Support `route.spec.subdomain` which defaults within route domain

### DIFF
--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -27027,9 +27027,16 @@ func schema_openshift_api_route_v1_RouteSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"subdomain": {
+						SchemaProps: spec.SchemaProps{
+							Description: "subdomain is a DNS subdomain that is requested within the ingress controller's domain (as a subdomain). If host is set this field is ignored. An ingress controller may choose to ignore this suggested name, in which case the controller will report the assigned name in the status.ingress array or refuse to admit the route. If this value is set and the server does not support this field host will be populated automatically. Otherwise host is left empty. The field may have multiple parts separated by a dot, but not all ingress controllers may honor the request. This field may not be changed after creation except by a user with the update routes/custom-host permission.\n\nExample: subdomain `frontend` automatically receives the router subdomain `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"path": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Path that the router watches for, to route traffic for to the service. Optional",
+							Description: "path that the router watches for, to route traffic for to the service. Optional",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/route/apis/route/types.go
+++ b/pkg/route/apis/route/types.go
@@ -25,6 +25,18 @@ type RouteSpec struct {
 	// Host is an alias/DNS that points to the service. Optional
 	// Must follow DNS952 subdomain conventions.
 	Host string
+	// Subdomain is a DNS subdomain that is requested within the ingress controller's
+	// domain (as a subdomain). If host is set this field is ignored. An ingress
+	// controller may choose to ignore this suggested name, in which case the controller
+	// will report the assigned name in the status.ingress array or refuse to admit the
+	// route. If this value is set and the server does not support this field host will
+	// be populated automatically. Otherwise host is left empty. The field may have
+	// multiple parts separated by a dot, but not all ingress controllers may honor
+	// the request.
+	//
+	// Example: subdomain `frontend` automatically receives the router subdomain
+	// `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
+	Subdomain string
 	// Path that the router watches for, to route traffic for to the service. Optional
 	Path string
 

--- a/pkg/route/apis/route/v1/conversion.go
+++ b/pkg/route/apis/route/v1/conversion.go
@@ -19,6 +19,7 @@ func routeFieldSelectorKeyConversionFunc(label, value string) (internalLabel, in
 	switch label {
 	case "spec.path",
 		"spec.host",
+		"spec.subdomain",
 		"spec.to.name":
 		return label, value, nil
 	default:

--- a/pkg/route/apis/route/v1/zz_generated.conversion.go
+++ b/pkg/route/apis/route/v1/zz_generated.conversion.go
@@ -258,6 +258,7 @@ func Convert_route_RoutePort_To_v1_RoutePort(in *route.RoutePort, out *v1.RouteP
 
 func autoConvert_v1_RouteSpec_To_route_RouteSpec(in *v1.RouteSpec, out *route.RouteSpec, s conversion.Scope) error {
 	out.Host = in.Host
+	out.Subdomain = in.Subdomain
 	out.Path = in.Path
 	if err := Convert_v1_RouteTargetReference_To_route_RouteTargetReference(&in.To, &out.To, s); err != nil {
 		return err
@@ -276,6 +277,7 @@ func Convert_v1_RouteSpec_To_route_RouteSpec(in *v1.RouteSpec, out *route.RouteS
 
 func autoConvert_route_RouteSpec_To_v1_RouteSpec(in *route.RouteSpec, out *v1.RouteSpec, s conversion.Scope) error {
 	out.Host = in.Host
+	out.Subdomain = in.Subdomain
 	out.Path = in.Path
 	if err := Convert_route_RouteTargetReference_To_v1_RouteTargetReference(&in.To, &out.To, s); err != nil {
 		return err

--- a/pkg/route/apis/route/validation/validation.go
+++ b/pkg/route/apis/route/validation/validation.go
@@ -29,7 +29,7 @@ func ValidateRoute(route *routeapi.Route) field.ErrorList {
 
 	specPath := field.NewPath("spec")
 
-	//host is not required but if it is set ensure it meets DNS requirements
+	//  host is not required but if it is set ensure it meets DNS requirements
 	if len(route.Spec.Host) > 0 {
 		// TODO: Add a better check that the host name matches up to
 		//       DNS requirements. Change to use:
@@ -39,6 +39,19 @@ func ValidateRoute(route *routeapi.Route) field.ErrorList {
 		//       creation time for new routes.
 		if len(kvalidation.IsDNS1123Subdomain(route.Spec.Host)) != 0 {
 			result = append(result, field.Invalid(specPath.Child("host"), route.Spec.Host, "host must conform to DNS 952 subdomain conventions"))
+		}
+	}
+
+	// subdomain is not required but if it is set ensure it meets DNS requirements
+	if len(route.Spec.Subdomain) > 0 {
+		// TODO: Add a better check that the host name matches up to
+		//       DNS requirements. Change to use:
+		//         ValidateHostName(route)
+		//       Need to check the implications of doing it here in
+		//       ValidateRoute - probably needs to be done only on
+		//       creation time for new routes.
+		if len(kvalidation.IsDNS1123Subdomain(route.Spec.Subdomain)) != 0 {
+			result = append(result, field.Invalid(specPath.Child("subdomain"), route.Spec.Subdomain, "subdomain must conform to DNS 952 subdomain conventions"))
 		}
 	}
 

--- a/pkg/route/apis/route/validation/validation_test.go
+++ b/pkg/route/apis/route/validation/validation_test.go
@@ -100,6 +100,34 @@ func TestValidateRoute(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
+			name: "Valid subdomain",
+			route: &routeapi.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routeapi.RouteSpec{
+					Subdomain: "api.ci",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid DNS 952 subdomain",
+			route: &routeapi.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routeapi.RouteSpec{
+					Subdomain: "**",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
 			name: "No service name",
 			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/route/apiserver/registry/route/strategy.go
+++ b/pkg/route/apiserver/registry/route/strategy.go
@@ -113,7 +113,7 @@ func (s routeStrategy) allocateHost(ctx context.Context, route *routeapi.Route) 
 		return nil
 	}
 
-	if len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
+	if len(route.Spec.Subdomain) == 0 && len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
 		// TODO: this does not belong here, and should be removed
 		shard, err := s.RouteAllocator.AllocateRouterShard(route)
 		if err != nil {
@@ -184,8 +184,9 @@ func certificateChangeRequiresAuth(route, older *routeapi.Route) bool {
 
 func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *routeapi.Route) field.ErrorList {
 	hostChanged := route.Spec.Host != older.Spec.Host
+	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
 	certChanged := certificateChangeRequiresAuth(route, older)
-	if !hostChanged && !certChanged {
+	if !hostChanged && !certChanged && !subdomainChanged {
 		return nil
 	}
 	user, ok := apirequest.UserFrom(ctx)
@@ -209,11 +210,17 @@ func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *rou
 		),
 	)
 	if err != nil {
+		if subdomainChanged {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "subdomain"), err)}
+		}
 		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
 	}
 	if !res.Status.Allowed {
 		if hostChanged {
 			return kvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
+		}
+		if subdomainChanged {
+			return kvalidation.ValidateImmutableField(route.Spec.Subdomain, older.Spec.Subdomain, field.NewPath("spec", "subdomain"))
 		}
 
 		// if tls is being updated without host being updated, we check if 'create' permission exists on custom-host subresource

--- a/vendor/github.com/openshift/api/route/v1/types.go
+++ b/vendor/github.com/openshift/api/route/v1/types.go
@@ -70,7 +70,23 @@ type RouteSpec struct {
 	// chosen.
 	// Must follow DNS952 subdomain conventions.
 	Host string `json:"host" protobuf:"bytes,1,opt,name=host"`
-	// Path that the router watches for, to route traffic for to the service. Optional
+	// subdomain is a DNS subdomain that is requested within the ingress controller's
+	// domain (as a subdomain). If host is set this field is ignored. An ingress
+	// controller may choose to ignore this suggested name, in which case the controller
+	// will report the assigned name in the status.ingress array or refuse to admit the
+	// route. If this value is set and the server does not support this field host will
+	// be populated automatically. Otherwise host is left empty. The field may have
+	// multiple parts separated by a dot, but not all ingress controllers may honor
+	// the request. This field may not be changed after creation except by a user with
+	// the update routes/custom-host permission.
+	//
+	// Example: subdomain `frontend` automatically receives the router subdomain
+	// `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
+	//
+	// +optional
+	Subdomain string `json:"subdomain"`
+
+	// path that the router watches for, to route traffic for to the service. Optional
 	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`
 
 	// to is an object the route should use as the primary backend. Only the Service kind


### PR DESCRIPTION
Allow an infrastructure component like `registry`, `console`,
`prometheus` to be defined without having to look up the global name. This
simplifies routes that are consistent across clusters even when the
subdomain is different.  This field is ignored if host is set.

The spec.subdomain field is like host except it is requested within the
router's subdomain rather than instead of it, allowing a route to be
defined generically across all possible route configurations ahead of time
- i.e.:

``` 
kind: Route
apiVersion: route.openshift.io/v1
metadata:
  name: test
  namespace: ns
spec:
  subdomain: console
```

would request a route with hostname `console.<appsdomain>` by default instead of `test-ns.<appsdomain>`.

Related https://github.com/openshift/router/pull/19, 
https://github.com/openshift/api/pull/250