### PR TITLE
sdn: clarify SDN startup log message

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -389,20 +389,26 @@ func (node *OsdnNode) Start() error {
 		gatherPeriodicMetrics(node.oc.ovs)
 	}, time.Minute*2)
 
-	glog.V(2).Infof("openshift-sdn network plugin ready")
+	glog.V(2).Infof("openshift-sdn network plugin registering startup")
 
 	// Make an event that openshift-sdn started
 	node.recorder.Eventf(&v1.ObjectReference{Kind: "Node", Name: node.hostName}, v1.EventTypeNormal, "Starting", "Starting openshift-sdn.")
 
 	// Write our CNI config file out to disk to signal to kubelet that
 	// our network plugin is ready
-	return ioutil.WriteFile(filepath.Join(node.cniDirPath, openshiftCNIFile), []byte(`
+	err = ioutil.WriteFile(filepath.Join(node.cniDirPath, openshiftCNIFile), []byte(`
 {
   "cniVersion": "0.2.0",
   "name": "openshift-sdn",
   "type": "openshift-sdn"
 }
 `), 0644)
+	if err != nil {
+		return err
+	}
+
+	glog.V(2).Infof("openshift-sdn network plugin ready")
+	return nil
 }
 
 // FIXME: this should eventually go into kubelet via a CNI UPDATE/CHANGE action


### PR DESCRIPTION
Log a message both before and after the CNI config file is written, so
we can be sure of when the plugin notifies kubelet that it is ready.

Cherry pick of https://github.com/openshift/origin/pull/22283

(cherry picked from commit c65802e91878f6d1d53bf0f1021a1b807080ceba)

@sdodson @pecameron @weliang1 