### PR TITLE
Revert NetworkPolicy cleanup

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -195,15 +195,7 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkapi.NetNamespace
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	if npns, exists := np.namespaces[netns.NetID]; exists {
-		if npns.inUse {
-			npns.inUse = false
-			// We call syncNamespaceFlows() not syncNamespace() because it
-			// needs to happen before we forget about the namespace.
-			np.syncNamespaceFlows(npns)
-		}
-		delete(np.namespaces, netns.NetID)
-	}
+	delete(np.namespaces, netns.NetID)
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,15 +121,6 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
-	if err != nil {
-		return err
-	}
-	inUseNamespaces := sets.NewString()
-	for _, pod := range pods {
-		inUseNamespaces.Insert(pod.Namespace)
-	}
-
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -141,7 +132,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    inUseNamespaces.Has(ns.Name),
+				inUse:    false,
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}


### PR DESCRIPTION
This reverts #22251:
- The code has needed at least one fixup in master (#22302)
- The corresponding 3.10 PR (#22252) never passed CI. While I wasn't able to figure out why due to lack of logs in the 3.10 CI artifacts, it seemed to pretty reliably fail with this patch and pass without it.
- Although it's nice to clean things up properly right away, the hourly `SyncVNIDRules` run will clean things up eventually anyway, so the problem is merely that "at any given time there are some unused OVS flows", not "unused OVS flows keep piling up forever" like I'd originally though.

(Note that this is reverting a change that never made it into an errata release.)