### PR TITLE
Mirroring a new payload should rewrite payload image references

### DIFF
--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -35,53 +35,25 @@ func (p *Payload) Path() string {
 // If a new ID appears in the returned reference, it will be used instead of the existing digest.
 // All references in manifest files will be updated and then the image stream will be written to
 // the correct location with any updated metadata.
-func (p *Payload) Rewrite(allowTags bool, fn func(component string) imagereference.DockerImageReference) (map[string]string, error) {
+func (p *Payload) Rewrite(allowTags bool, fn func(component string) imagereference.DockerImageReference) error {
 	is, err := p.References()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	replacements := make(map[string]string)
-	for i := range is.Spec.Tags {
-		tag := &is.Spec.Tags[i]
-		if tag.From == nil || tag.From.Kind != "DockerImage" {
-			continue
-		}
-		oldImage := tag.From.Name
-		oldRef, err := imagereference.Parse(oldImage)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse image reference for tag %q from payload: %v", tag.Name, err)
-		}
-		if len(oldRef.Tag) > 0 || len(oldRef.ID) == 0 {
-			if !allowTags {
-				return nil, fmt.Errorf("image reference tag %q in payload does not point to an image digest - unable to rewrite payload", tag.Name)
-			}
-		}
-		ref := fn(tag.Name)
-		if !allowTags {
-			if len(ref.ID) == 0 {
-				ref.Tag = ""
-				ref.ID = oldRef.ID
-			}
-		}
-		newImage := ref.Exact()
-		replacements[oldImage] = newImage
-		tag.From.Name = newImage
+	replacements, err := ReplacementsForImageStream(is, allowTags, fn)
+	if err != nil {
+		return err
 	}
 
-	if glog.V(5) {
-		for k, v := range replacements {
-			glog.Infof("Mapping %s -> %s", k, v)
-		}
-	}
 	mapper, err := NewExactMapper(replacements)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	files, err := ioutil.ReadDir(p.path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	for _, file := range files {
 		if file.IsDir() {
@@ -93,22 +65,22 @@ func (p *Payload) Rewrite(allowTags bool, fn func(component string) imagereferen
 		path := filepath.Join(p.path, file.Name())
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		out, err := mapper(data)
 		if err != nil {
-			return nil, fmt.Errorf("unable to rewrite the contents of %s: %v", path, err)
+			return fmt.Errorf("unable to rewrite the contents of %s: %v", path, err)
 		}
 		if bytes.Equal(data, out) {
 			continue
 		}
 		glog.V(6).Infof("Rewrote\n%s\n\nto\n\n%s\n", string(data), string(out))
 		if err := ioutil.WriteFile(path, out, file.Mode()); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return replacements, nil
+	return nil
 }
 
 func (p *Payload) References() (*imageapi.ImageStream, error) {
@@ -466,4 +438,41 @@ func parseComponentVersionsLabel(label string) (ComponentVersions, error) {
 		labels[parts[0]] = v.String()
 	}
 	return labels, nil
+}
+
+func ReplacementsForImageStream(is *imageapi.ImageStream, allowTags bool, fn func(component string) imagereference.DockerImageReference) (map[string]string, error) {
+	replacements := make(map[string]string)
+	for i := range is.Spec.Tags {
+		tag := &is.Spec.Tags[i]
+		if tag.From == nil || tag.From.Kind != "DockerImage" {
+			continue
+		}
+		oldImage := tag.From.Name
+		oldRef, err := imagereference.Parse(oldImage)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse image reference for tag %q from payload: %v", tag.Name, err)
+		}
+		if len(oldRef.Tag) > 0 || len(oldRef.ID) == 0 {
+			if !allowTags {
+				return nil, fmt.Errorf("image reference tag %q in payload does not point to an image digest - unable to rewrite payload", tag.Name)
+			}
+		}
+		ref := fn(tag.Name)
+		if !allowTags {
+			if len(ref.ID) == 0 {
+				ref.Tag = ""
+				ref.ID = oldRef.ID
+			}
+		}
+		newImage := ref.Exact()
+		replacements[oldImage] = newImage
+		tag.From.Name = newImage
+	}
+
+	if glog.V(5) {
+		for k, v := range replacements {
+			glog.Infof("Mapping %s -> %s", k, v)
+		}
+	}
+	return replacements, nil
 }

--- a/pkg/oc/cli/image/mirror/mirror.go
+++ b/pkg/oc/cli/image/mirror/mirror.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client"
 
 	units "github.com/docker/go-units"
 	"github.com/golang/glog"
-	digest "github.com/opencontainers/go-digest"
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
@@ -472,6 +472,7 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 								for _, srcManifest := range srcManifests {
 									switch srcManifest.(type) {
 									case *schema2.DeserializedManifest:
+									case *schema1.SignedManifest:
 									case *manifestlist.DeserializedManifestList:
 										// we do not need to upload layers in a manifestlist
 										continue
@@ -623,7 +624,7 @@ func copyBlob(ctx context.Context, plan *workPlan, c *repositoryBlobCopy, blob d
 func copyManifestToTags(
 	ctx context.Context,
 	ref reference.Named,
-	srcDigest digest.Digest,
+	srcDigest godigest.Digest,
 	tags []string,
 	plan *repositoryManifestPlan,
 	out io.Writer,
@@ -656,7 +657,7 @@ func copyManifestToTags(
 func copyManifest(
 	ctx context.Context,
 	ref reference.Named,
-	srcDigest digest.Digest,
+	srcDigest godigest.Digest,
 	plan *repositoryManifestPlan,
 	out io.Writer,
 ) error {


### PR DESCRIPTION
When we clarified reference modes to support OCP preserving quay inputs and
fixed versions, we lost the remapping that ensured the mirror destination
is what is in the payload. Refactor the rewriting so that even without a
payload, we remap the pull locations after mirror.

Fix mirroring schema1 to schema2 images