### PR TITLE
Fix an example script in `oc observe -h`

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/observe/observe.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/observe/observe.go
@@ -97,7 +97,7 @@ var (
 
 		    $ cat set_owner.sh
 		    #!/bin/sh
-		    if [[ "$(%[1]s get namespace "$1" --template='{{ .metadata.annotations.owner }}')" == "" ]]; then
+		    if [[ "$(%[1]s get namespace "$1" -o 'jsonpath={ .metadata.annotations.owner }')" == "" ]]; then
 		      %[1]s annotate namespace "$1" owner=bob
 		    fi
 


### PR DESCRIPTION
This PR fixes the script to use jsonpath instead go-template. jsonpath prints nothing if the field does not exist.

`--template` option (go-template) of `oc get` command prints `<no value>` if the field does not exist. So `set_owner.sh` in `oc observe -h` does not work correctly.

```
$ oc get namespace default --template='{{ .metadata.annotations.owner }}'
<no value>
$ oc get namespace default -o 'jsonpath={ .metadata.annotations.owner }'

```