### PR TITLE
pkg/oc/cli/admin/release/new: Always include kube-etcd-signer-server

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -46,7 +46,7 @@ func NewNewOptions(streams genericclioptions.IOStreams) *NewOptions {
 		// TODO: only cluster-version-operator and maybe CLI should be in this list,
 		//   the others should always be referenced by the cluster-bootstrap or
 		//   another operator.
-		AlwaysInclude:  []string{"cluster-version-operator", "cli", "installer"},
+		AlwaysInclude:  []string{"cluster-version-operator", "cli", "installer", "kube-etcd-signer-server"},
 		ToImageBaseTag: "cluster-version-operator",
 		// We strongly control the set of allowed component versions to prevent confusion
 		// about what component versions may be used for. Changing this list requires


### PR DESCRIPTION
Taking advantage of openshift/release@e43e260f59 (openshift/release#3021) to get this installer dependency into the release image.

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1684670

CC @hexfusion