### PR TITLE
switch unidling to external API

### DIFF
--- a/pkg/cmd/openshift-controller-manager/controller/unidling.go
+++ b/pkg/cmd/openshift-controller-manager/controller/unidling.go
@@ -22,7 +22,7 @@ func RunUnidlingController(ctx *ControllerContext) (bool, error) {
 	scaleNamespacer := appsv1client.NewDelegatingScaleNamespacer(appsClient,
 		ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraUnidlingControllerServiceAccountName).ExtensionsV1beta1())
 
-	coreClient := ctx.ClientBuilder.KubeInternalClientOrDie(bootstrappolicy.InfraUnidlingControllerServiceAccountName).Core()
+	coreClient := ctx.ClientBuilder.ClientOrDie(bootstrappolicy.InfraUnidlingControllerServiceAccountName).Core()
 	controller := unidlingcontroller.NewUnidlingController(
 		scaleNamespacer,
 		coreClient,

--- a/pkg/unidling/controller/unidling_controller_test.go
+++ b/pkg/unidling/controller/unidling_controller_test.go
@@ -6,31 +6,30 @@ import (
 	"testing"
 	"time"
 
-	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	kexternalfake "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	appsfake "github.com/openshift/client-go/apps/clientset/versioned/fake"
+	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	kexternalfake "k8s.io/client-go/kubernetes/fake"
-	clientgotesting "k8s.io/client-go/testing"
-	"k8s.io/kubernetes/pkg/apis/autoscaling"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kinternalfake "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	// install the APIs we need for the codecs to run correctly in order to build patches
 	_ "github.com/openshift/origin/pkg/api/install"
 )
 
 type fakeResults struct {
-	resMap       map[unidlingapi.CrossGroupObjectReference]autoscaling.Scale
-	resEndpoints *kapi.Endpoints
+	resMap       map[unidlingapi.CrossGroupObjectReference]autoscalingv1.Scale
+	resEndpoints *corev1.Endpoints
 }
 
-func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale) (*kinternalfake.Clientset, *appsfake.Clientset, *fakeResults) {
-	fakeClient := &kinternalfake.Clientset{}
+func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscalingv1.Scale) (*kexternalfake.Clientset, *appsfake.Clientset, *fakeResults) {
+	fakeClient := &kexternalfake.Clientset{}
 	fakeDeployClient := &appsfake.Clientset{}
 
 	nowTimeStr := nowTime.Format(time.RFC3339)
@@ -50,7 +49,7 @@ func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	endpointsObj := kapi.Endpoints{
+	endpointsObj := corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "somesvc",
 			Annotations: map[string]string{
@@ -89,12 +88,12 @@ func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale
 		objName := action.(clientgotesting.GetAction).GetName()
 		for _, scale := range scales {
 			if scale.Kind == "ReplicationController" && objName == scale.Name {
-				return true, &kapi.ReplicationController{
+				return true, &corev1.ReplicationController{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: objName,
 					},
-					Spec: kapi.ReplicationControllerSpec{
-						Replicas: scale.Spec.Replicas,
+					Spec: corev1.ReplicationControllerSpec{
+						Replicas: &scale.Spec.Replicas,
 					},
 				}, nil
 			}
@@ -104,7 +103,7 @@ func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale
 	})
 
 	res := &fakeResults{
-		resMap: make(map[unidlingapi.CrossGroupObjectReference]autoscaling.Scale),
+		resMap: make(map[unidlingapi.CrossGroupObjectReference]autoscalingv1.Scale),
 	}
 
 	fakeDeployClient.PrependReactor("update", "deploymentconfigs", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -122,13 +121,13 @@ func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale
 	})
 
 	fakeClient.PrependReactor("update", "replicationcontrollers", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		obj := action.(clientgotesting.UpdateAction).GetObject().(*kapi.ReplicationController)
+		obj := action.(clientgotesting.UpdateAction).GetObject().(*corev1.ReplicationController)
 		for _, scale := range scales {
 			if scale.Kind == "ReplicationController" && obj.Name == scale.Name {
 				newScale := scale
-				newScale.Spec.Replicas = obj.Spec.Replicas
+				newScale.Spec.Replicas = *obj.Spec.Replicas
 				res.resMap[unidlingapi.CrossGroupObjectReference{Name: obj.Name, Kind: "ReplicationController"}] = newScale
-				return true, &kapi.ReplicationController{}, nil
+				return true, &corev1.ReplicationController{}, nil
 			}
 		}
 
@@ -154,15 +153,15 @@ func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale
 
 	fakeClient.PrependReactor("patch", "replicationcontrollers", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 		patchAction := action.(clientgotesting.PatchActionImpl)
-		var patch kapi.ReplicationController
+		var patch corev1.ReplicationController
 		json.Unmarshal(patchAction.GetPatch(), &patch)
 
 		for _, scale := range scales {
 			if scale.Kind == "ReplicationController" && patchAction.GetName() == scale.Name {
 				newScale := scale
-				newScale.Spec.Replicas = patch.Spec.Replicas
+				newScale.Spec.Replicas = *patch.Spec.Replicas
 				res.resMap[unidlingapi.CrossGroupObjectReference{Name: patchAction.GetName(), Kind: "ReplicationController"}] = newScale
-				return true, &kapi.ReplicationController{}, nil
+				return true, &corev1.ReplicationController{}, nil
 			}
 		}
 
@@ -170,7 +169,7 @@ func prepFakeClient(t *testing.T, nowTime time.Time, scales ...autoscaling.Scale
 	})
 
 	fakeClient.AddReactor("*", "endpoints", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		obj := action.(clientgotesting.UpdateAction).GetObject().(*kapi.Endpoints)
+		obj := action.(clientgotesting.UpdateAction).GetObject().(*corev1.Endpoints)
 		if obj.Name != endpointsObj.Name {
 			return false, nil, nil
 		}
@@ -215,7 +214,7 @@ func TestControllerHandlesStaleEvents(t *testing.T) {
 func TestControllerIgnoresAlreadyScaledObjects(t *testing.T) {
 	// truncate to avoid conversion comparison issues
 	nowTime := time.Now().Truncate(time.Second)
-	baseScales := []autoscaling.Scale{
+	baseScales := []autoscalingv1.Scale{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "somerc",
@@ -223,7 +222,7 @@ func TestControllerIgnoresAlreadyScaledObjects(t *testing.T) {
 			TypeMeta: metav1.TypeMeta{
 				Kind: "ReplicationController",
 			},
-			Spec: autoscaling.ScaleSpec{
+			Spec: autoscalingv1.ScaleSpec{
 				Replicas: 0,
 			},
 		},
@@ -234,7 +233,7 @@ func TestControllerIgnoresAlreadyScaledObjects(t *testing.T) {
 			TypeMeta: metav1.TypeMeta{
 				Kind: "DeploymentConfig",
 			},
-			Spec: autoscaling.ScaleSpec{
+			Spec: autoscalingv1.ScaleSpec{
 				Replicas: 5,
 			},
 		},
@@ -328,7 +327,7 @@ func TestControllerIgnoresAlreadyScaledObjects(t *testing.T) {
 
 func TestControllerUnidlesProperly(t *testing.T) {
 	nowTime := time.Now().Truncate(time.Second)
-	baseScales := []autoscaling.Scale{
+	baseScales := []autoscalingv1.Scale{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "somerc",
@@ -336,7 +335,7 @@ func TestControllerUnidlesProperly(t *testing.T) {
 			TypeMeta: metav1.TypeMeta{
 				Kind: "ReplicationController",
 			},
-			Spec: autoscaling.ScaleSpec{
+			Spec: autoscalingv1.ScaleSpec{
 				Replicas: 0,
 			},
 		},
@@ -348,7 +347,7 @@ func TestControllerUnidlesProperly(t *testing.T) {
 				Kind:       "DeploymentConfig",
 				APIVersion: "apps.openshift.io/v1",
 			},
-			Spec: autoscaling.ScaleSpec{
+			Spec: autoscalingv1.ScaleSpec{
 				Replicas: 0,
 			},
 		},
@@ -411,8 +410,8 @@ func TestControllerUnidlesProperly(t *testing.T) {
 
 type failureTestInfo struct {
 	name                   string
-	endpointsGet           *kapi.Endpoints
-	scaleGets              []autoscaling.Scale
+	endpointsGet           *corev1.Endpoints
+	scaleGets              []autoscalingv1.Scale
 	scaleUpdatesNotFound   []bool
 	preventEndpointsUpdate bool
 
@@ -421,8 +420,8 @@ type failureTestInfo struct {
 	annotationsExpected map[string]string
 }
 
-func prepareFakeClientForFailureTest(test failureTestInfo) (*kinternalfake.Clientset, *appsfake.Clientset) {
-	fakeClient := &kinternalfake.Clientset{}
+func prepareFakeClientForFailureTest(test failureTestInfo) (*kexternalfake.Clientset, *appsfake.Clientset) {
+	fakeClient := &kexternalfake.Clientset{}
 	fakeDeployClient := &appsfake.Clientset{}
 
 	fakeClient.PrependReactor("get", "endpoints", func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -456,12 +455,12 @@ func prepareFakeClientForFailureTest(test failureTestInfo) (*kinternalfake.Clien
 		objName := action.(clientgotesting.GetAction).GetName()
 		for _, scale := range test.scaleGets {
 			if scale.Kind == "ReplicationController" && objName == scale.Name {
-				return true, &kapi.ReplicationController{
+				return true, &corev1.ReplicationController{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: objName,
 					},
-					Spec: kapi.ReplicationControllerSpec{
-						Replicas: scale.Spec.Replicas,
+					Spec: corev1.ReplicationControllerSpec{
+						Replicas: &scale.Spec.Replicas,
 					},
 				}, nil
 			}
@@ -486,13 +485,13 @@ func prepareFakeClientForFailureTest(test failureTestInfo) (*kinternalfake.Clien
 	})
 
 	fakeClient.PrependReactor("update", "replicationcontrollers", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		obj := action.(clientgotesting.UpdateAction).GetObject().(*kapi.ReplicationController)
+		obj := action.(clientgotesting.UpdateAction).GetObject().(*corev1.ReplicationController)
 		for i, scale := range test.scaleGets {
 			if scale.Kind == "ReplicationController" && obj.Name == scale.Name {
 				if test.scaleUpdatesNotFound != nil && test.scaleUpdatesNotFound[i] {
 					return false, nil, nil
 				}
-				return true, &kapi.ReplicationController{}, nil
+				return true, &corev1.ReplicationController{}, nil
 			}
 		}
 
@@ -500,7 +499,7 @@ func prepareFakeClientForFailureTest(test failureTestInfo) (*kinternalfake.Clien
 	})
 
 	fakeClient.PrependReactor("update", "endpoints", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		obj := action.(clientgotesting.UpdateAction).GetObject().(*kapi.Endpoints)
+		obj := action.(clientgotesting.UpdateAction).GetObject().(*corev1.Endpoints)
 		if obj.Name != test.endpointsGet.Name {
 			return false, nil, nil
 		}
@@ -564,7 +563,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 		},
 		{
 			name: "not retry on failure to parse time",
-			endpointsGet: &kapi.Endpoints{
+			endpointsGet: &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somesvc",
 					Annotations: map[string]string{
@@ -577,7 +576,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 		},
 		{
 			name: "not retry on failure to unmarshal target scalables",
-			endpointsGet: &kapi.Endpoints{
+			endpointsGet: &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somesvc",
 					Annotations: map[string]string{
@@ -591,7 +590,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 		},
 		{
 			name: "remove a scalable from the list if it cannot be found (while getting)",
-			endpointsGet: &kapi.Endpoints{
+			endpointsGet: &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somesvc",
 					Annotations: map[string]string{
@@ -600,7 +599,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					},
 				},
 			},
-			scaleGets: []autoscaling.Scale{
+			scaleGets: []autoscalingv1.Scale{
 				{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "DeploymentConfig",
@@ -609,7 +608,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "somedc",
 					},
-					Spec: autoscaling.ScaleSpec{Replicas: 0},
+					Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 				},
 			},
 			errorExpected: false,
@@ -620,7 +619,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 		},
 		{
 			name: "should remove a scalable from the list if it cannot be found (while updating)",
-			endpointsGet: &kapi.Endpoints{
+			endpointsGet: &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somesvc",
 					Annotations: map[string]string{
@@ -629,7 +628,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					},
 				},
 			},
-			scaleGets: []autoscaling.Scale{
+			scaleGets: []autoscalingv1.Scale{
 				{
 					TypeMeta: metav1.TypeMeta{
 						Kind: "ReplicationController",
@@ -637,7 +636,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "somerc",
 					},
-					Spec: autoscaling.ScaleSpec{Replicas: 0},
+					Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 				},
 				{
 					TypeMeta: metav1.TypeMeta{
@@ -647,7 +646,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "somedc",
 					},
-					Spec: autoscaling.ScaleSpec{Replicas: 0},
+					Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 				},
 			},
 			scaleUpdatesNotFound: []bool{false, true},
@@ -659,7 +658,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 		},
 		{
 			name: "retry on failed endpoints update",
-			endpointsGet: &kapi.Endpoints{
+			endpointsGet: &corev1.Endpoints{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "somesvc",
 					Annotations: map[string]string{
@@ -668,7 +667,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					},
 				},
 			},
-			scaleGets: []autoscaling.Scale{
+			scaleGets: []autoscalingv1.Scale{
 				{
 					TypeMeta: metav1.TypeMeta{
 						Kind: "ReplicationController",
@@ -676,7 +675,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "somerc",
 					},
-					Spec: autoscaling.ScaleSpec{Replicas: 0},
+					Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 				},
 				{
 					TypeMeta: metav1.TypeMeta{
@@ -686,7 +685,7 @@ func TestControllerPerformsCorrectlyOnFailures(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "somedc",
 					},
-					Spec: autoscaling.ScaleSpec{Replicas: 0},
+					Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 				},
 			},
 			preventEndpointsUpdate: true,


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @derekwaynecarr 

@derekwaynecarr we need an owner.