### PR TITLE
switch project auth cache to external types

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -203,7 +203,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	subjectLocator := NewSubjectLocator(informers.GetKubernetesInformers().Rbac().V1())
 	projectAuthorizationCache := NewProjectAuthorizationCache(
 		subjectLocator,
-		informers.GetInternalKubernetesInformers().Core().InternalVersion().Namespaces().Informer(),
+		informers.GetKubernetesInformers().Core().V1().Namespaces(),
 		informers.GetKubernetesInformers().Rbac().V1(),
 	)
 

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/project.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/project.go
@@ -5,7 +5,6 @@ import (
 	rbacinformers "k8s.io/client-go/informers/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	projectauth "github.com/openshift/origin/pkg/project/auth"
@@ -30,9 +29,10 @@ func NewProjectCache(nsInformer corev1informers.NamespaceInformer, privilegedLoo
 		nil
 }
 
-func NewProjectAuthorizationCache(subjectLocator rbacauthorizer.SubjectLocator, namespaces cache.SharedIndexInformer, rbacInformers rbacinformers.Interface) *projectauth.AuthorizationCache {
+func NewProjectAuthorizationCache(subjectLocator rbacauthorizer.SubjectLocator, namespaces corev1informers.NamespaceInformer, rbacInformers rbacinformers.Interface) *projectauth.AuthorizationCache {
 	return projectauth.NewAuthorizationCache(
-		namespaces,
+		namespaces.Lister(),
+		namespaces.Informer(),
 		projectauth.NewAuthorizerReviewer(subjectLocator),
 		rbacInformers,
 	)

--- a/pkg/project/apiserver/apiserver.go
+++ b/pkg/project/apiserver/apiserver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,7 +15,6 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	restclient "k8s.io/client-go/rest"
-	kclientsetinternal "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	projectapiv1 "github.com/openshift/api/project/v1"
@@ -109,7 +109,7 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	kubeInternalClient, err := kclientsetinternal.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
+	kubeClient, err := kubernetes.NewForConfig(c.ExtraConfig.KubeAPIServerClientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 		return nil, err
 	}
 
-	projectStorage := projectproxy.NewREST(kubeInternalClient.Core().Namespaces(), c.ExtraConfig.ProjectAuthorizationCache, c.ExtraConfig.ProjectAuthorizationCache, c.ExtraConfig.ProjectCache)
+	projectStorage := projectproxy.NewREST(kubeClient.CoreV1().Namespaces(), c.ExtraConfig.ProjectAuthorizationCache, c.ExtraConfig.ProjectAuthorizationCache, c.ExtraConfig.ProjectCache)
 
 	namespace, templateName, err := configapi.ParseNamespaceAndName(c.ExtraConfig.ProjectRequestTemplate)
 	if err != nil {

--- a/pkg/project/apiserver/registry/project/proxy/proxy_test.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy_test.go
@@ -4,13 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/client-go/kubernetes/fake"
 
 	oapi "github.com/openshift/origin/pkg/api"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
@@ -18,16 +19,16 @@ import (
 
 // mockLister returns the namespaces in the list
 type mockLister struct {
-	namespaceList *kapi.NamespaceList
+	namespaceList *corev1.NamespaceList
 }
 
-func (ml *mockLister) List(user user.Info) (*kapi.NamespaceList, error) {
+func (ml *mockLister) List(user user.Info, selector labels.Selector) (*corev1.NamespaceList, error) {
 	return ml.namespaceList, nil
 }
 
 func TestListProjects(t *testing.T) {
-	namespaceList := kapi.NamespaceList{
-		Items: []kapi.Namespace{
+	namespaceList := corev1.NamespaceList{
+		Items: []corev1.Namespace{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 			},
@@ -101,7 +102,7 @@ func TestCreateProjectOK(t *testing.T) {
 }
 
 func TestGetProjectOK(t *testing.T) {
-	mockClient := fake.NewSimpleClientset(&kapi.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
+	mockClient := fake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	storage := NewREST(mockClient.Core().Namespaces(), &mockLister{}, nil, nil)
 	project, err := storage.Get(apirequest.NewContext(), "foo", &metav1.GetOptions{})
 	if project == nil {

--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	informersv1 "k8s.io/client-go/informers"
 	fakev1 "k8s.io/client-go/kubernetes/fake"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/controller"
 
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
@@ -46,7 +45,7 @@ func newTestWatcher(username string, groups []string, predicate storage.Selectio
 }
 
 type fakeAuthCache struct {
-	namespaces []*kapi.Namespace
+	namespaces []*corev1.Namespace
 
 	removed []CacheWatcher
 }
@@ -55,8 +54,8 @@ func (w *fakeAuthCache) RemoveWatcher(watcher CacheWatcher) {
 	w.removed = append(w.removed, watcher)
 }
 
-func (w *fakeAuthCache) List(userInfo user.Info) (*kapi.NamespaceList, error) {
-	ret := &kapi.NamespaceList{}
+func (w *fakeAuthCache) List(userInfo user.Info, selector labels.Selector) (*corev1.NamespaceList, error) {
+	ret := &corev1.NamespaceList{}
 	if w.namespaces != nil {
 		for i := range w.namespaces {
 			ret.Items = append(ret.Items, *w.namespaces[i])

--- a/pkg/project/util/util_test.go
+++ b/pkg/project/util/util_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	"github.com/google/gofuzz"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
@@ -19,8 +19,8 @@ func TestProjectFidelity(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		f.Fuzz(p)
 		p.TypeMeta = metav1.TypeMeta{} // Ignore TypeMeta
-		namespace := ConvertProject(p)
-		p2 := ConvertNamespace(namespace)
+		namespace := ConvertProjectToExternal(p)
+		p2 := ConvertNamespaceFromExternal(namespace)
 		if !reflect.DeepEqual(p, p2) {
 			t.Errorf("project data not preserved; the diff is %s", diff.ObjectDiff(p, p2))
 		}
@@ -30,12 +30,12 @@ func TestProjectFidelity(t *testing.T) {
 // TestNamespaceFidelity makes sure that the namespace to project round trip does not lose any data
 func TestNamespaceFidelity(t *testing.T) {
 	f := fuzz.New().NilChance(0)
-	n := &kapi.Namespace{}
+	n := &corev1.Namespace{}
 	for i := 0; i < 100; i++ {
 		f.Fuzz(n)
 		n.TypeMeta = metav1.TypeMeta{} // Ignore TypeMeta
-		project := ConvertNamespace(n)
-		n2 := ConvertProject(project)
+		project := ConvertNamespaceFromExternal(n)
+		n2 := ConvertProjectToExternal(project)
 		if !reflect.DeepEqual(n, n2) {
 			t.Errorf("namespace data not preserved; the diff is %s", diff.ObjectDiff(n, n2))
 		}


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @enj 
@openshift/sig-auth 