### PR TITLE
switch scheduling.openshift.io/OriginPodNodeEnvironment to external client

### DIFF
--- a/pkg/scheduler/admission/nodeenv/admission_test.go
+++ b/pkg/scheduler/admission/nodeenv/admission_test.go
@@ -10,7 +10,6 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	"github.com/openshift/origin/pkg/util/labelselector"
 )
@@ -24,8 +23,7 @@ func TestPodAdmission(t *testing.T) {
 		},
 	}
 
-	mockClientset := fake.NewSimpleClientset()
-	handler := &podNodeEnvironment{client: mockClientset}
+	handler := &podNodeEnvironment{}
 	pod := &kapi.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "testPod"},
 	}


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @ravisantoshgudimetla 
@openshift/sig-pod 