### PR TITLE
switch quota to external clients

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -329,7 +329,6 @@ func (c *completedConfig) withQuotaAPIServer(delegateAPIServer genericapiserver.
 		ExtraConfig: quotaapiserver.ExtraConfig{
 			ClusterQuotaMappingController: c.ExtraConfig.ClusterQuotaMappingController,
 			QuotaInformers:                c.ExtraConfig.QuotaInformers,
-			KubeInternalInformers:         c.ExtraConfig.KubeInternalInformers,
 			Codecs:                        legacyscheme.Codecs,
 			Scheme:                        legacyscheme.Scheme,
 		},

--- a/pkg/quota/apiserver/admission/clusterresourcequota/accessor.go
+++ b/pkg/quota/apiserver/admission/clusterresourcequota/accessor.go
@@ -9,8 +9,8 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	etcd "k8s.io/apiserver/pkg/storage/etcd"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 	utilquota "k8s.io/kubernetes/pkg/quota"
 
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
@@ -21,7 +21,7 @@ import (
 
 type clusterQuotaAccessor struct {
 	clusterQuotaLister quotalister.ClusterResourceQuotaLister
-	namespaceLister    kcorelisters.NamespaceLister
+	namespaceLister    corev1listers.NamespaceLister
 	clusterQuotaClient quotatypedclient.ClusterResourceQuotasGetter
 
 	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper
@@ -35,7 +35,7 @@ type clusterQuotaAccessor struct {
 // newQuotaAccessor creates an object that conforms to the QuotaAccessor interface to be used to retrieve quota objects.
 func newQuotaAccessor(
 	clusterQuotaLister quotalister.ClusterResourceQuotaLister,
-	namespaceLister kcorelisters.NamespaceLister,
+	namespaceLister corev1listers.NamespaceLister,
 	clusterQuotaClient quotatypedclient.ClusterResourceQuotasGetter,
 	clusterQuotaMapper clusterquotamapping.ClusterQuotaMapper,
 ) *clusterQuotaAccessor {

--- a/pkg/quota/apiserver/apiserver.go
+++ b/pkg/quota/apiserver/apiserver.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	quotaapiv1 "github.com/openshift/api/quota/v1"
 	appliedclusterresourcequotaregistry "github.com/openshift/origin/pkg/quota/apiserver/registry/appliedclusterresourcequota"
@@ -21,7 +20,6 @@ import (
 type ExtraConfig struct {
 	ClusterQuotaMappingController *clusterquotamapping.ClusterQuotaMappingController
 	QuotaInformers                quotainformer.SharedInformerFactory
-	KubeInternalInformers         kinternalinformers.SharedInformerFactory
 
 	// TODO these should all become local eventually
 	Scheme *runtime.Scheme
@@ -106,7 +104,6 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	v1Storage["appliedClusterResourceQuotas"] = appliedclusterresourcequotaregistry.NewREST(
 		c.ExtraConfig.ClusterQuotaMappingController.GetClusterQuotaMapper(),
 		c.ExtraConfig.QuotaInformers.Quota().InternalVersion().ClusterResourceQuotas().Lister(),
-		c.ExtraConfig.KubeInternalInformers.Core().InternalVersion().Namespaces().Lister(),
 	)
 	return v1Storage, nil
 }

--- a/pkg/quota/apiserver/registry/appliedclusterresourcequota/filter.go
+++ b/pkg/quota/apiserver/registry/appliedclusterresourcequota/filter.go
@@ -13,7 +13,6 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
-	kcorelisters "k8s.io/kubernetes/pkg/client/listers/core/internalversion"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -26,18 +25,16 @@ import (
 )
 
 type AppliedClusterResourceQuotaREST struct {
-	quotaMapper     clusterquotamapping.ClusterQuotaMapper
-	quotaLister     quotalister.ClusterResourceQuotaLister
-	namespaceLister kcorelisters.NamespaceLister
+	quotaMapper clusterquotamapping.ClusterQuotaMapper
+	quotaLister quotalister.ClusterResourceQuotaLister
 	rest.TableConvertor
 }
 
-func NewREST(quotaMapper clusterquotamapping.ClusterQuotaMapper, quotaLister quotalister.ClusterResourceQuotaLister, namespaceLister kcorelisters.NamespaceLister) *AppliedClusterResourceQuotaREST {
+func NewREST(quotaMapper clusterquotamapping.ClusterQuotaMapper, quotaLister quotalister.ClusterResourceQuotaLister) *AppliedClusterResourceQuotaREST {
 	return &AppliedClusterResourceQuotaREST{
-		quotaMapper:     quotaMapper,
-		quotaLister:     quotaLister,
-		namespaceLister: namespaceLister,
-		TableConvertor:  printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+		quotaMapper:    quotaMapper,
+		quotaLister:    quotaLister,
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
 	}
 }
 


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @soltysh @mfojtik 
@openshift/sig-master 