### PR TITLE
fix image error signature

### DIFF
--- a/pkg/image/apiserver/admission/limitrange/usage.go
+++ b/pkg/image/apiserver/admission/limitrange/usage.go
@@ -30,7 +30,7 @@ import (
 //
 // The docker image reference will always be normalized such that registry url is always specified while a
 // default docker namespace and tag are stripped.
-type InternalImageReferenceHandler func(imageReference string, inSpec, inStatus bool) error
+type InternalImageReferenceHandler func(imageReference string, inSpec, inStatus bool)
 
 // GetImageStreamUsage counts number of unique internally managed images occupying given image stream. It
 // returns a number of unique image references found in the image stream spec not contained in
@@ -40,14 +40,13 @@ func GetImageStreamUsage(is *imageapi.ImageStream) kapi.ResourceList {
 	specRefs := resource.NewQuantity(0, resource.DecimalSI)
 	statusRefs := resource.NewQuantity(0, resource.DecimalSI)
 
-	ProcessImageStreamImages(is, false, func(ref string, inSpec, inStatus bool) error {
+	processImageStreamImages(is, false, func(ref string, inSpec, inStatus bool) {
 		if inSpec {
 			specRefs.Set(specRefs.Value() + 1)
 		}
 		if inStatus {
 			statusRefs.Set(statusRefs.Value() + 1)
 		}
-		return nil
 	})
 
 	return kapi.ResourceList{
@@ -56,10 +55,10 @@ func GetImageStreamUsage(is *imageapi.ImageStream) kapi.ResourceList {
 	}
 }
 
-// ProcessImageStreamImages is a utility method that calls a given handler on every image reference found in
+// processImageStreamImages is a utility method that calls a given handler on every image reference found in
 // the given image stream. If specOnly is true, only image references found in is spec will be processed. The
 // handler will be called just once for each unique image reference.
-func ProcessImageStreamImages(is *imageapi.ImageStream, specOnly bool, handler InternalImageReferenceHandler) error {
+func processImageStreamImages(is *imageapi.ImageStream, specOnly bool, handler InternalImageReferenceHandler) {
 	type sources struct{ inSpec, inStatus bool }
 	var statusReferences sets.String
 	imageReferences := make(map[string]*sources)
@@ -81,11 +80,8 @@ func ProcessImageStreamImages(is *imageapi.ImageStream, specOnly bool, handler I
 	}
 
 	for ref, s := range imageReferences {
-		if err := handler(ref, s.inSpec, s.inStatus); err != nil {
-			return err
-		}
+		handler(ref, s.inSpec, s.inStatus)
 	}
-	return nil
 }
 
 // gatherImagesFromImageStreamStatus is a utility method that collects all image references found in a status
@@ -117,7 +113,7 @@ func gatherImagesFromImageStreamSpec(is *imageapi.ImageStream) sets.String {
 			continue
 		}
 
-		ref, err := GetImageReferenceForObjectReference(is.Namespace, tagRef.From)
+		ref, err := getImageReferenceForObjectReference(is.Namespace, tagRef.From)
 		if err != nil {
 			glog.V(4).Infof("could not process object reference: %v", err)
 			continue
@@ -129,9 +125,9 @@ func gatherImagesFromImageStreamSpec(is *imageapi.ImageStream) sets.String {
 	return res
 }
 
-// GetImageReferenceForObjectReference returns corresponding image reference for the given object
+// getImageReferenceForObjectReference returns corresponding image reference for the given object
 // reference representing either an image stream image or image stream tag or docker image.
-func GetImageReferenceForObjectReference(namespace string, objRef *kapi.ObjectReference) (string, error) {
+func getImageReferenceForObjectReference(namespace string, objRef *kapi.ObjectReference) (string, error) {
 	switch objRef.Kind {
 	case "ImageStreamImage", "DockerImage":
 		res, err := imageapi.ParseDockerImageReference(objRef.Name)

--- a/pkg/image/apiserver/admission/limitrange/usage_test.go
+++ b/pkg/image/apiserver/admission/limitrange/usage_test.go
@@ -183,7 +183,7 @@ func TestGetImageReferenceForObjectReference(t *testing.T) {
 		},
 	} {
 
-		res, err := GetImageReferenceForObjectReference(tc.namespace, &tc.objRef)
+		res, err := getImageReferenceForObjectReference(tc.namespace, &tc.objRef)
 		if tc.expectedError && err == nil {
 			t.Errorf("[%s] got unexpected non-error", tc.name)
 		}


### PR DESCRIPTION
While trying to handle changes during the rebase related to clients and limitrangers, I wasted time inspecting dead error handling code and reasoning about unexposed methods.  This scrubs the related code.

/assign @adambkaplan 
@openshift/sig-developer-experience 