### PR TITLE
use external clients for authorization admission

### DIFF
--- a/pkg/authorization/apiserver/admission/restrictusers/restrictusers_test.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/restrictusers_test.go
@@ -5,18 +5,19 @@ import (
 	"strings"
 	"testing"
 
-	authorizationapi "github.com/openshift/api/authorization/v1"
-	userapi "github.com/openshift/api/user/v1"
-	fakeauthorizationclient "github.com/openshift/client-go/authorization/clientset/versioned/fake"
-	fakeuserclient "github.com/openshift/client-go/user/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+
+	authorizationapi "github.com/openshift/api/authorization/v1"
+	userapi "github.com/openshift/api/user/v1"
+	fakeauthorizationclient "github.com/openshift/client-go/authorization/clientset/versioned/fake"
+	fakeuserclient "github.com/openshift/client-go/user/clientset/versioned/fake"
 )
 
 func TestAdmission(t *testing.T) {
@@ -53,7 +54,7 @@ func TestAdmission(t *testing.T) {
 			Name: "group",
 		}
 
-		serviceaccount = kapi.ServiceAccount{
+		serviceaccount = corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "namespace",
 				Name:      "serviceaccount",
@@ -102,7 +103,7 @@ func TestAdmission(t *testing.T) {
 			namespace:   "namespace",
 			subresource: "subresource",
 			kubeObjects: []runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "namespace",
 					},
@@ -131,7 +132,7 @@ func TestAdmission(t *testing.T) {
 			namespace:   "",
 			subresource: "",
 			kubeObjects: []runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "namespace",
 					},
@@ -166,7 +167,7 @@ func TestAdmission(t *testing.T) {
 			namespace:   "namespace",
 			subresource: "",
 			kubeObjects: []runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "namespace",
 					},
@@ -204,7 +205,7 @@ func TestAdmission(t *testing.T) {
 			namespace:   "namespace",
 			subresource: "",
 			kubeObjects: []runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "namespace",
 					},
@@ -249,7 +250,7 @@ func TestAdmission(t *testing.T) {
 			namespace:   "namespace",
 			subresource: "",
 			kubeObjects: []runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "namespace",
 					},
@@ -323,7 +324,7 @@ func TestAdmission(t *testing.T) {
 			namespace:   "namespace",
 			subresource: "",
 			kubeObjects: []runtime.Object{
-				&kapi.Namespace{
+				&corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "namespace",
 					},
@@ -362,7 +363,7 @@ func TestAdmission(t *testing.T) {
 			t.Errorf("unexpected error initializing admission plugin: %v", err)
 		}
 
-		plugin.(*restrictUsersAdmission).kclient = kclientset
+		plugin.(*restrictUsersAdmission).kubeClient = kclientset
 		plugin.(*restrictUsersAdmission).roleBindingRestrictionsGetter = fakeAuthorizationClient.AuthorizationV1()
 		plugin.(*restrictUsersAdmission).userClient = fakeUserClient
 		plugin.(*restrictUsersAdmission).groupCache = fakeGroupCache{}

--- a/pkg/authorization/apiserver/admission/restrictusers/subjectchecker.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/subjectchecker.go
@@ -6,8 +6,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
 	authorizationapi "github.com/openshift/api/authorization/v1"
 	userapi "github.com/openshift/api/user/v1"
@@ -48,7 +48,7 @@ func (checkers UnionSubjectChecker) Allowed(subject rbac.Subject, ctx *RoleBindi
 // whether a RoleBindingRestriction allows rolebindings on a particular subject.
 type RoleBindingRestrictionContext struct {
 	userClient userclient.UserV1Interface
-	kclient    kclientset.Interface
+	kclient    kubernetes.Interface
 
 	// groupCache maps user name to groups.
 	groupCache GroupCache
@@ -66,7 +66,7 @@ type RoleBindingRestrictionContext struct {
 
 // NewRoleBindingRestrictionContext returns a new RoleBindingRestrictionContext
 // object.
-func NewRoleBindingRestrictionContext(ns string, kc kclientset.Interface, userClient userclient.UserV1Interface, groupCache GroupCache) (*RoleBindingRestrictionContext, error) {
+func newRoleBindingRestrictionContext(ns string, kc kubernetes.Interface, userClient userclient.UserV1Interface, groupCache GroupCache) (*RoleBindingRestrictionContext, error) {
 	return &RoleBindingRestrictionContext{
 		namespace:       ns,
 		kclient:         kc,

--- a/pkg/authorization/apiserver/admission/restrictusers/subjectchecker_test.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/subjectchecker_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 
 	authorizationapi "github.com/openshift/api/authorization/v1"
 	userapi "github.com/openshift/api/user/v1"
@@ -64,7 +64,7 @@ func TestSubjectCheckers(t *testing.T) {
 			&group,
 		}
 		kubeObjects = []runtime.Object{
-			&kapi.ServiceAccount{
+			&corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "namespace",
 					Name:      "serviceaccount",
@@ -328,7 +328,7 @@ func TestSubjectCheckers(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	ctx, err := NewRoleBindingRestrictionContext("namespace",
+	ctx, err := newRoleBindingRestrictionContext("namespace",
 		kclient, fakeUserClient.User(), groupCache)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

@openshift/sig-auth 