### PR TITLE
remove internal types from projectrequest

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -177,7 +177,7 @@ func (c *OpenshiftAPIConfig) Complete() completedConfig {
 
 func (c *completedConfig) withAppsAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &oappsapiserver.AppsServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: oappsapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			Codecs: legacyscheme.Codecs,
@@ -196,7 +196,7 @@ func (c *completedConfig) withAppsAPIServer(delegateAPIServer genericapiserver.D
 
 func (c *completedConfig) withAuthorizationAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &authorizationapiserver.AuthorizationAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: authorizationapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			KubeInformers:             c.ExtraConfig.KubeInformers,
@@ -219,7 +219,7 @@ func (c *completedConfig) withAuthorizationAPIServer(delegateAPIServer genericap
 func (c *completedConfig) withBuildAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 
 	cfg := &buildapiserver.BuildServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: buildapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			Codecs: legacyscheme.Codecs,
@@ -238,7 +238,7 @@ func (c *completedConfig) withBuildAPIServer(delegateAPIServer genericapiserver.
 
 func (c *completedConfig) withImageAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &imageapiserver.ImageAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: imageapiserver.ExtraConfig{
 			KubeAPIServerClientConfig:          c.ExtraConfig.KubeAPIServerClientConfig,
 			LimitVerifier:                      c.ExtraConfig.LimitVerifier,
@@ -262,7 +262,7 @@ func (c *completedConfig) withImageAPIServer(delegateAPIServer genericapiserver.
 
 func (c *completedConfig) withNetworkAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &networkapiserver.NetworkAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: networkapiserver.ExtraConfig{
 			Codecs: legacyscheme.Codecs,
 			Scheme: legacyscheme.Scheme,
@@ -280,7 +280,7 @@ func (c *completedConfig) withNetworkAPIServer(delegateAPIServer genericapiserve
 
 func (c *completedConfig) withOAuthAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &oauthapiserver.OAuthAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: oauthapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			ServiceAccountMethod:      c.ExtraConfig.ServiceAccountMethod,
@@ -300,10 +300,9 @@ func (c *completedConfig) withOAuthAPIServer(delegateAPIServer genericapiserver.
 
 func (c *completedConfig) withProjectAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &projectapiserver.ProjectAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: projectapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
-			KubeInternalInformers:     c.ExtraConfig.KubeInternalInformers,
 			ProjectAuthorizationCache: c.ExtraConfig.ProjectAuthorizationCache,
 			ProjectCache:              c.ExtraConfig.ProjectCache,
 			ProjectRequestTemplate:    c.ExtraConfig.ProjectRequestTemplate,
@@ -325,7 +324,7 @@ func (c *completedConfig) withProjectAPIServer(delegateAPIServer genericapiserve
 
 func (c *completedConfig) withQuotaAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &quotaapiserver.QuotaAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: quotaapiserver.ExtraConfig{
 			ClusterQuotaMappingController: c.ExtraConfig.ClusterQuotaMappingController,
 			QuotaInformers:                c.ExtraConfig.QuotaInformers,
@@ -346,7 +345,7 @@ func (c *completedConfig) withQuotaAPIServer(delegateAPIServer genericapiserver.
 
 func (c *completedConfig) withRouteAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &routeapiserver.RouteAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: routeapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			RouteAllocator:            c.ExtraConfig.RouteAllocator,
@@ -366,7 +365,7 @@ func (c *completedConfig) withRouteAPIServer(delegateAPIServer genericapiserver.
 
 func (c *completedConfig) withSecurityAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &securityapiserver.SecurityAPIServerConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: securityapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			SecurityInformers:         c.ExtraConfig.SecurityInformers,
@@ -388,7 +387,7 @@ func (c *completedConfig) withSecurityAPIServer(delegateAPIServer genericapiserv
 
 func (c *completedConfig) withTemplateAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &templateapiserver.TemplateConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: templateapiserver.ExtraConfig{
 			KubeAPIServerClientConfig: c.ExtraConfig.KubeAPIServerClientConfig,
 			Codecs: legacyscheme.Codecs,
@@ -407,7 +406,7 @@ func (c *completedConfig) withTemplateAPIServer(delegateAPIServer genericapiserv
 
 func (c *completedConfig) withUserAPIServer(delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	cfg := &userapiserver.UserConfig{
-		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config},
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *c.GenericConfig.Config, SharedInformerFactory: c.GenericConfig.SharedInformerFactory},
 		ExtraConfig: userapiserver.ExtraConfig{
 			Codecs: legacyscheme.Codecs,
 			Scheme: legacyscheme.Scheme,

--- a/pkg/project/apiserver/apiserver.go
+++ b/pkg/project/apiserver/apiserver.go
@@ -4,18 +4,17 @@ import (
 	"sync"
 
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	restclient "k8s.io/client-go/rest"
-	kinternalinformers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 
 	projectapiv1 "github.com/openshift/api/project/v1"
 	templateclient "github.com/openshift/client-go/template/clientset/versioned"
@@ -29,7 +28,6 @@ import (
 
 type ExtraConfig struct {
 	KubeAPIServerClientConfig *restclient.Config
-	KubeInternalInformers     kinternalinformers.SharedInformerFactory
 	ProjectAuthorizationCache *projectauth.AuthorizationCache
 	ProjectCache              *projectcache.ProjectCache
 	ProjectRequestTemplate    string
@@ -146,7 +144,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 		authorizationClient.SubjectAccessReviews(),
 		dynamicClient,
 		c.ExtraConfig.RESTMapper,
-		c.ExtraConfig.KubeInternalInformers.Rbac().InternalVersion().RoleBindings().Lister(),
+		c.GenericConfig.SharedInformerFactory.Rbac().V1().RoleBindings().Lister(),
 	)
 
 	v1Storage := map[string]rest.Storage{}

--- a/pkg/project/apiserver/registry/projectrequest/delegated/delegated_test.go
+++ b/pkg/project/apiserver/registry/projectrequest/delegated/delegated_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/kubernetes/pkg/apis/rbac"
-	rbaclisters "k8s.io/kubernetes/pkg/client/listers/rbac/internalversion"
+	rbacv1listers "k8s.io/client-go/listers/rbac/v1"
 
 	"github.com/go-openapi/errors"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
@@ -19,7 +19,7 @@ func TestDelegatedWait(t *testing.T) {
 	storage := &REST{roleBindings: cache}
 
 	cache.namespacelister = &testRoleBindingNamespaceLister{}
-	cache.namespacelister.bindings = map[string]*rbac.RoleBinding{}
+	cache.namespacelister.bindings = map[string]*rbacv1.RoleBinding{}
 	cache.namespacelister.bindings["anything"] = nil
 
 	waitReturnedCh := waitForResultChannel(storage)
@@ -51,15 +51,15 @@ func waitForResultChannel(storage *REST) chan struct{} {
 }
 
 type testRoleBindingNamespaceLister struct {
-	bindings map[string]*rbac.RoleBinding
+	bindings map[string]*rbacv1.RoleBinding
 	lock     sync.Mutex
 }
 
-func (t *testRoleBindingNamespaceLister) List(selector labels.Selector) (ret []*rbac.RoleBinding, err error) {
+func (t *testRoleBindingNamespaceLister) List(selector labels.Selector) (ret []*rbacv1.RoleBinding, err error) {
 	return ret, nil
 }
 
-func (t *testRoleBindingNamespaceLister) Get(name string) (*rbac.RoleBinding, error) {
+func (t *testRoleBindingNamespaceLister) Get(name string) (*rbacv1.RoleBinding, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	if t.bindings[bootstrappolicy.AdminRoleName] != nil {
@@ -72,18 +72,18 @@ type testRoleBindingLister struct {
 	namespacelister *testRoleBindingNamespaceLister
 }
 
-func (t *testRoleBindingLister) RoleBindings(namespace string) rbaclisters.RoleBindingNamespaceLister {
+func (t *testRoleBindingLister) RoleBindings(namespace string) rbacv1listers.RoleBindingNamespaceLister {
 	return t.namespacelister
 }
 
-func (t *testRoleBindingLister) List(selector labels.Selector) ([]*rbac.RoleBinding, error) {
+func (t *testRoleBindingLister) List(selector labels.Selector) ([]*rbacv1.RoleBinding, error) {
 	return nil, nil
 }
 
 func (t *testRoleBindingLister) addAdminRolebinding() {
 	t.namespacelister.lock.Lock()
 	defer t.namespacelister.lock.Unlock()
-	t.namespacelister.bindings[bootstrappolicy.AdminRoleName] = &rbac.RoleBinding{
+	t.namespacelister.bindings[bootstrappolicy.AdminRoleName] = &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{Name: bootstrappolicy.AdminRoleName},
 	}
 }


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @enj 
@openshift/sig-auth 