### PR TITLE
switch image rest API to external client

### DIFF
--- a/pkg/image/apiserver/registry/imagesecret/rest.go
+++ b/pkg/image/apiserver/registry/imagesecret/rest.go
@@ -4,30 +4,32 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kcoreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	coreapi "k8s.io/kubernetes/pkg/apis/core"
+	corev1conversion "k8s.io/kubernetes/pkg/apis/core/v1"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
 // REST implements the RESTStorage interface for ImageStreamImport
 type REST struct {
-	secrets kcoreclient.SecretsGetter
+	secrets corev1client.SecretsGetter
 }
 
 var _ rest.GetterWithOptions = &REST{}
 
 // NewREST returns a new REST.
-func NewREST(secrets kcoreclient.SecretsGetter) *REST {
+func NewREST(secrets corev1client.SecretsGetter) *REST {
 	return &REST{secrets: secrets}
 }
 
 func (r *REST) New() runtime.Object {
-	return &kapi.SecretList{}
+	return &coreapi.SecretList{}
 }
 
 func (r *REST) NewGetOptions() (runtime.Object, bool, string) {
@@ -53,16 +55,26 @@ func (r *REST) Get(ctx context.Context, _ string, options runtime.Object) (runti
 	if err != nil {
 		return nil, err
 	}
-	filtered := make([]kapi.Secret, 0, len(secrets.Items))
+	filtered := make([]coreapi.Secret, 0, len(secrets.Items))
 	for i := range secrets.Items {
 		if secrets.Items[i].Annotations[imageapi.ExcludeImageSecretAnnotation] == "true" {
 			continue
 		}
 		switch secrets.Items[i].Type {
-		case kapi.SecretTypeDockercfg, kapi.SecretTypeDockerConfigJson:
-			filtered = append(filtered, secrets.Items[i])
+		case corev1.SecretTypeDockercfg, corev1.SecretTypeDockerConfigJson:
+			internalSecret := &coreapi.Secret{}
+			if err := corev1conversion.Convert_v1_Secret_To_core_Secret(&secrets.Items[i], internalSecret, nil); err != nil {
+				return nil, err
+			}
+			filtered = append(filtered, *internalSecret)
 		}
 	}
-	secrets.Items = filtered
-	return secrets, nil
+	// clear the external content and convert
+	secrets.Items = nil
+	internalSecretList := &coreapi.SecretList{}
+	if err := corev1conversion.Convert_v1_SecretList_To_core_SecretList(secrets, internalSecretList, nil); err != nil {
+		return nil, err
+	}
+	internalSecretList.Items = filtered
+	return internalSecretList, nil
 }

--- a/pkg/image/apiserver/registry/imagesecret/rest_test.go
+++ b/pkg/image/apiserver/registry/imagesecret/rest_test.go
@@ -3,36 +3,37 @@ package imagesecret
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	coreapi "k8s.io/kubernetes/pkg/apis/core"
 
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 )
 
 func TestGetSecrets(t *testing.T) {
-	fake := fake.NewSimpleClientset(&kapi.SecretList{
-		Items: []kapi.Secret{
+	fake := fake.NewSimpleClientset(&corev1.SecretList{
+		Items: []corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret-1", Namespace: "default"},
-				Type:       kapi.SecretTypeDockercfg,
+				Type:       corev1.SecretTypeDockercfg,
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret-2", Annotations: map[string]string{imageapi.ExcludeImageSecretAnnotation: "true"}, Namespace: "default"},
-				Type:       kapi.SecretTypeDockercfg,
+				Type:       corev1.SecretTypeDockercfg,
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret-3", Namespace: "default"},
-				Type:       kapi.SecretTypeOpaque,
+				Type:       corev1.SecretTypeOpaque,
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret-4", Namespace: "default"},
-				Type:       kapi.SecretTypeServiceAccountToken,
+				Type:       corev1.SecretTypeServiceAccountToken,
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret-5", Namespace: "default"},
-				Type:       kapi.SecretTypeDockerConfigJson,
+				Type:       corev1.SecretTypeDockerConfigJson,
 			},
 		},
 	})
@@ -42,7 +43,7 @@ func TestGetSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	list := obj.(*kapi.SecretList)
+	list := obj.(*coreapi.SecretList)
 	if len(list.Items) != 2 {
 		t.Fatal(list)
 	}


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @adambkaplan 
@openshift/sig-developer-experience 