### PR TITLE
switch oc to external clients where possible

### DIFF
--- a/pkg/oc/cli/rollout/latest.go
+++ b/pkg/oc/cli/rollout/latest.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
@@ -55,7 +55,7 @@ type RolloutLatestOptions struct {
 	again  bool
 
 	appsClient appsclient.DeploymentConfigsGetter
-	kubeClient kclientset.Interface
+	kubeClient kubernetes.Interface
 
 	Printer printers.ResourcePrinter
 
@@ -124,7 +124,7 @@ func (o *RolloutLatestOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, 
 	if err != nil {
 		return err
 	}
-	o.kubeClient, err = kclientset.NewForConfig(clientConfig)
+	o.kubeClient, err = kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (o *RolloutLatestOptions) RunRolloutLatest() error {
 	}
 
 	deploymentName := appsutil.LatestDeploymentNameForConfigAndVersion(config.Name, config.Status.LatestVersion)
-	deployment, err := o.kubeClient.Core().ReplicationControllers(config.Namespace).Get(deploymentName, metav1.GetOptions{})
+	deployment, err := o.kubeClient.CoreV1().ReplicationControllers(config.Namespace).Get(deploymentName, metav1.GetOptions{})
 	switch {
 	case err == nil:
 		// Reject attempts to start a concurrent deployment.

--- a/pkg/oc/cli/rsh/rsh.go
+++ b/pkg/oc/cli/rsh/rsh.go
@@ -7,16 +7,16 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/api/core/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/batch"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/controller"
 	kubecmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 
 	oapps "github.com/openshift/api/apps"
-	appstypedclient "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
+	appsv1client "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	appsutil "github.com/openshift/origin/pkg/apps/util"
 	"github.com/openshift/origin/pkg/cmd/util"
 )
@@ -189,7 +189,7 @@ func (o *RshOptions) Run() error {
 }
 
 func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) (string, error) {
-	sortBy := func(pods []*v1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }
+	sortBy := func(pods []*corev1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }
 	namespace, _, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return "", err
@@ -198,7 +198,7 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 	if err != nil {
 		return "", err
 	}
-	resourceType, name, err := util.ResolveResource(kapi.Resource("pods"), resource, mapper)
+	resourceType, name, err := util.ResolveResource(corev1.Resource("pods"), resource, mapper)
 	if err != nil {
 		return "", err
 	}
@@ -208,9 +208,9 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 	}
 
 	switch resourceType {
-	case kapi.Resource("pods"):
+	case corev1.Resource("pods"):
 		return name, nil
-	case kapi.Resource("replicationcontrollers"):
+	case corev1.Resource("replicationcontrollers"):
 		kc, err := corev1client.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
@@ -226,7 +226,7 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 		}
 		return pod.Name, nil
 	case oapps.Resource("deploymentconfigs"):
-		appsClient, err := appstypedclient.NewForConfig(clientConfig)
+		appsClient, err := appsv1client.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
 		}
@@ -236,11 +236,11 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 		}
 		return podForResource(f, fmt.Sprintf("rc/%s", appsutil.LatestDeploymentNameForConfig(dc)), timeout)
 	case extensions.Resource("daemonsets"):
-		kc, err := kclientset.NewForConfig(clientConfig)
+		kc, err := kubernetes.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
 		}
-		ds, err := kc.Extensions().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+		ds, err := kc.ExtensionsV1beta1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
@@ -259,11 +259,11 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 		}
 		return pod.Name, nil
 	case extensions.Resource("deployments"):
-		kc, err := kclientset.NewForConfig(clientConfig)
+		kc, err := kubernetes.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
 		}
-		d, err := kc.Extensions().Deployments(namespace).Get(name, metav1.GetOptions{})
+		d, err := kc.ExtensionsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
@@ -281,11 +281,11 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 		}
 		return pod.Name, nil
 	case apps.Resource("statefulsets"):
-		kc, err := kclientset.NewForConfig(clientConfig)
+		kc, err := kubernetes.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
 		}
-		s, err := kc.Apps().StatefulSets(namespace).Get(name, metav1.GetOptions{})
+		s, err := kc.AppsV1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
@@ -303,11 +303,11 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 		}
 		return pod.Name, nil
 	case extensions.Resource("replicasets"):
-		kc, err := kclientset.NewForConfig(clientConfig)
+		kc, err := kubernetes.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
 		}
-		rs, err := kc.Extensions().ReplicaSets(namespace).Get(name, metav1.GetOptions{})
+		rs, err := kc.ExtensionsV1beta1().ReplicaSets(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
@@ -325,11 +325,11 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 		}
 		return pod.Name, nil
 	case batch.Resource("jobs"):
-		kc, err := kclientset.NewForConfig(clientConfig)
+		kc, err := kubernetes.NewForConfig(clientConfig)
 		if err != nil {
 			return "", err
 		}
-		job, err := kc.Batch().Jobs(namespace).Get(name, metav1.GetOptions{})
+		job, err := kc.BatchV1().Jobs(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
@@ -344,7 +344,7 @@ func podForResource(f kcmdutil.Factory, resource string, timeout time.Duration) 
 	}
 }
 
-func podNameForJob(job *batch.Job, kc corev1client.CoreV1Interface, timeout time.Duration, sortBy func(pods []*v1.Pod) sort.Interface) (string, error) {
+func podNameForJob(job *batchv1.Job, kc corev1client.CoreV1Interface, timeout time.Duration, sortBy func(pods []*corev1.Pod) sort.Interface) (string, error) {
 	selector, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
 	if err != nil {
 		return "", err

--- a/pkg/oc/cli/rsync/forwarder.go
+++ b/pkg/oc/cli/rsync/forwarder.go
@@ -4,10 +4,10 @@ import (
 	"io"
 	"net/http"
 
+	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
@@ -15,7 +15,7 @@ import (
 type portForwarder struct {
 	Namespace string
 	PodName   string
-	Client    kclientset.Interface
+	Client    kubernetes.Interface
 	Config    *restclient.Config
 	Out       io.Writer
 	ErrOut    io.Writer
@@ -27,7 +27,7 @@ var _ forwarder = &portForwarder{}
 // ForwardPorts will forward a set of ports from a pod, the stopChan will stop the forwarding
 // when it's closed or receives a struct{}
 func (f *portForwarder) ForwardPorts(ports []string, stopChan <-chan struct{}) error {
-	req := f.Client.Core().RESTClient().Post().
+	req := f.Client.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Namespace(f.Namespace).
 		Name(f.PodName).
@@ -58,7 +58,7 @@ func newPortForwarder(f kcmdutil.Factory, o *RsyncOptions) (forwarder, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := kclientset.NewForConfig(config)
+	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oc/cli/set/volume_test.go
+++ b/pkg/oc/cli/set/volume_test.go
@@ -4,29 +4,29 @@ import (
 	"errors"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions/resource"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/kubectl/polymorphichelpers"
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 
 	"github.com/openshift/origin/pkg/oc/originpolymorphichelpers"
 )
 
-func fakePodWithVol() *api.Pod {
-	fakePod := &api.Pod{
+func fakePodWithVol() *corev1.Pod {
+	fakePod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "fakepod",
 		},
-		Spec: api.PodSpec{
-			Containers: []api.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name: "fake-container",
-					VolumeMounts: []api.VolumeMount{
+					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "fake-mount",
 							MountPath: "/var/www/html",
@@ -34,11 +34,11 @@ func fakePodWithVol() *api.Pod {
 					},
 				},
 			},
-			Volumes: []api.Volume{
+			Volumes: []corev1.Volume{
 				{
 					Name: "fake-mount",
-					VolumeSource: api.VolumeSource{
-						HostPath: &api.HostPathVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
 							Path: "/var/www/html",
 						},
 					},
@@ -49,17 +49,17 @@ func fakePodWithVol() *api.Pod {
 	return fakePod
 }
 
-func fakePodWithVolumeClaim() *api.Pod {
-	fakePod := &api.Pod{
+func fakePodWithVolumeClaim() *corev1.Pod {
+	fakePod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "fakepod",
 		},
-		Spec: api.PodSpec{
-			Containers: []api.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name: "fake-container",
-					VolumeMounts: []api.VolumeMount{
+					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "fake-mount",
 							MountPath: "/var/www/html",
@@ -67,11 +67,11 @@ func fakePodWithVolumeClaim() *api.Pod {
 					},
 				},
 			},
-			Volumes: []api.Volume{
+			Volumes: []corev1.Volume{
 				{
 					Name: "fake-mount",
-					VolumeSource: api.VolumeSource{
-						PersistentVolumeClaim: &api.PersistentVolumeClaimVolumeSource{
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "fake-claim",
 						},
 					},
@@ -82,14 +82,14 @@ func fakePodWithVolumeClaim() *api.Pod {
 	return fakePod
 }
 
-func makeFakePod() *api.Pod {
-	fakePod := &api.Pod{
+func makeFakePod() *corev1.Pod {
+	fakePod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "fakepod",
 		},
-		Spec: api.PodSpec{
-			Containers: []api.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name: "fake-container",
 				},
@@ -110,7 +110,7 @@ func getFakeMapping() *meta.RESTMapping {
 	return fakeMapping
 }
 
-func getFakeInfo(podInfo *api.Pod) ([]*resource.Info, *VolumeOptions) {
+func getFakeInfo(podInfo *corev1.Pod) ([]*resource.Info, *VolumeOptions) {
 	fakeMapping := getFakeMapping()
 	info := &resource.Info{
 		Client:    fake.NewSimpleClientset().Core().RESTClient(),
@@ -142,7 +142,7 @@ func TestRemoveVolume(t *testing.T) {
 		t.Errorf("Expected at least 1 patch object")
 	}
 	updatedInfo := patches[0].Info
-	podObject, ok := updatedInfo.Object.(*api.Pod)
+	podObject, ok := updatedInfo.Object.(*corev1.Pod)
 
 	if !ok {
 		t.Errorf("Expected pod info to be updated")
@@ -173,7 +173,7 @@ func TestAddVolume(t *testing.T) {
 		t.Errorf("Expected at least 1 patch object")
 	}
 	updatedInfo := patches[0].Info
-	podObject, ok := updatedInfo.Object.(*api.Pod)
+	podObject, ok := updatedInfo.Object.(*corev1.Pod)
 
 	if !ok {
 		t.Errorf("Expected pod info to be updated")
@@ -211,7 +211,7 @@ func TestAddRemoveVolumeWithExistingClaim(t *testing.T) {
 	}
 
 	updatedInfo := patches[0].Info
-	podObject, ok := updatedInfo.Object.(*api.Pod)
+	podObject, ok := updatedInfo.Object.(*corev1.Pod)
 
 	if !ok {
 		t.Errorf("Expected pod info to be updated")
@@ -244,7 +244,7 @@ func TestAddRemoveVolumeWithExistingClaim(t *testing.T) {
 	}
 
 	updatedInfo2 := removePatches[0].Info
-	podObject2, ok := updatedInfo2.Object.(*api.Pod)
+	podObject2, ok := updatedInfo2.Object.(*corev1.Pod)
 
 	if !ok {
 		t.Errorf("Expected pod info to be updated")


### PR DESCRIPTION
kube 1.13 removed all internal clients. this must be fixed to even be able to get vendoring tools to load the code in.

/assign @soltysh 