### PR TITLE
Update authorization to RBAC proxy registry to use external clients

### DIFF
--- a/pkg/authorization/apiserver/registry/clusterrole/proxy.go
+++ b/pkg/authorization/apiserver/registry/clusterrole/proxy.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	restclient "k8s.io/client-go/rest"
-	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -167,7 +167,7 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	return role, false, err
 }
 
-func (s *REST) getImpersonatingClient(ctx context.Context) (rbacinternalversion.ClusterRoleInterface, error) {
+func (s *REST) getImpersonatingClient(ctx context.Context) (rbacv1.ClusterRoleInterface, error) {
 	rbacClient, err := authclient.NewImpersonatingRBACFromContext(ctx, s.privilegedClient)
 	if err != nil {
 		return nil, err

--- a/pkg/authorization/apiserver/registry/clusterrolebinding/proxy.go
+++ b/pkg/authorization/apiserver/registry/clusterrolebinding/proxy.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	restclient "k8s.io/client-go/rest"
-	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -167,7 +167,7 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	return role, false, err
 }
 
-func (s *REST) getImpersonatingClient(ctx context.Context) (rbacinternalversion.ClusterRoleBindingInterface, error) {
+func (s *REST) getImpersonatingClient(ctx context.Context) (rbacv1.ClusterRoleBindingInterface, error) {
 	rbacClient, err := authclient.NewImpersonatingRBACFromContext(ctx, s.privilegedClient)
 	if err != nil {
 		return nil, err

--- a/pkg/authorization/apiserver/registry/role/proxy.go
+++ b/pkg/authorization/apiserver/registry/role/proxy.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	restclient "k8s.io/client-go/rest"
-	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -169,7 +169,7 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	return role, false, err
 }
 
-func (s *REST) getImpersonatingClient(ctx context.Context) (rbacinternalversion.RoleInterface, error) {
+func (s *REST) getImpersonatingClient(ctx context.Context) (rbacv1.RoleInterface, error) {
 	namespace, ok := apirequest.NamespaceFrom(ctx)
 	if !ok {
 		return nil, apierrors.NewBadRequest("namespace parameter required")

--- a/pkg/authorization/apiserver/registry/rolebinding/proxy.go
+++ b/pkg/authorization/apiserver/registry/rolebinding/proxy.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	restclient "k8s.io/client-go/rest"
-	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
@@ -179,7 +179,7 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	return role, false, err
 }
 
-func (s *REST) getImpersonatingClient(ctx context.Context) (rbacinternalversion.RoleBindingInterface, error) {
+func (s *REST) getImpersonatingClient(ctx context.Context) (rbacv1.RoleBindingInterface, error) {
 	namespace, ok := apirequest.NamespaceFrom(ctx)
 	if !ok {
 		return nil, apierrors.NewBadRequest("namespace parameter required")

--- a/pkg/authorization/apiserver/registry/util/convert.go
+++ b/pkg/authorization/apiserver/registry/util/convert.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/kubernetes/pkg/apis/rbac"
+	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	"github.com/openshift/origin/pkg/authorization/apis/authorization/rbacconversion"
@@ -9,88 +11,152 @@ import (
 
 // ClusterRoleToRBAC turns an OpenShift ClusterRole into a Kubernetes RBAC
 // ClusterRole, the returned object is safe to mutate
-func ClusterRoleToRBAC(obj *authorizationapi.ClusterRole) (*rbac.ClusterRole, error) {
-	convertedObj := &rbac.ClusterRole{}
-	if err := rbacconversion.Convert_authorization_ClusterRole_To_rbac_ClusterRole(obj, convertedObj, nil); err != nil {
+func ClusterRoleToRBAC(obj *authorizationapi.ClusterRole) (*rbacv1.ClusterRole, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.ClusterRole{}
+	if err := rbacconversion.Convert_authorization_ClusterRole_To_rbac_ClusterRole(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &rbacv1.ClusterRole{}
+	if err := rbacv1helpers.Convert_rbac_ClusterRole_To_v1_ClusterRole(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // ClusterRoleBindingToRBAC turns an OpenShift ClusterRoleBinding into a Kubernetes
 // RBAC ClusterRoleBinding, the returned object is safe to mutate
-func ClusterRoleBindingToRBAC(obj *authorizationapi.ClusterRoleBinding) (*rbac.ClusterRoleBinding, error) {
-	convertedObj := &rbac.ClusterRoleBinding{}
-	if err := rbacconversion.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(obj, convertedObj, nil); err != nil {
+func ClusterRoleBindingToRBAC(obj *authorizationapi.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.ClusterRoleBinding{}
+	if err := rbacconversion.Convert_authorization_ClusterRoleBinding_To_rbac_ClusterRoleBinding(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &rbacv1.ClusterRoleBinding{}
+	if err := rbacv1helpers.Convert_rbac_ClusterRoleBinding_To_v1_ClusterRoleBinding(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // RoleToRBAC turns an OpenShift Role into a Kubernetes RBAC Role,
 // the returned object is safe to mutate
-func RoleToRBAC(obj *authorizationapi.Role) (*rbac.Role, error) {
-	convertedObj := &rbac.Role{}
-	if err := rbacconversion.Convert_authorization_Role_To_rbac_Role(obj, convertedObj, nil); err != nil {
+func RoleToRBAC(obj *authorizationapi.Role) (*rbacv1.Role, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.Role{}
+	if err := rbacconversion.Convert_authorization_Role_To_rbac_Role(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &rbacv1.Role{}
+	if err := rbacv1helpers.Convert_rbac_Role_To_v1_Role(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // RoleBindingToRBAC turns an OpenShift RoleBinding into a Kubernetes RBAC
 // Rolebinding, the returned object is safe to mutate
-func RoleBindingToRBAC(obj *authorizationapi.RoleBinding) (*rbac.RoleBinding, error) {
-	convertedObj := &rbac.RoleBinding{}
-	if err := rbacconversion.Convert_authorization_RoleBinding_To_rbac_RoleBinding(obj, convertedObj, nil); err != nil {
+func RoleBindingToRBAC(obj *authorizationapi.RoleBinding) (*rbacv1.RoleBinding, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.RoleBinding{}
+	if err := rbacconversion.Convert_authorization_RoleBinding_To_rbac_RoleBinding(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &rbacv1.RoleBinding{}
+	if err := rbacv1helpers.Convert_rbac_RoleBinding_To_v1_RoleBinding(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // ClusterRoleFromRBAC turns a Kubernetes RBAC ClusterRole into an Openshift
 // ClusterRole, the returned object is safe to mutate
-func ClusterRoleFromRBAC(obj *rbac.ClusterRole) (*authorizationapi.ClusterRole, error) {
-	convertedObj := &authorizationapi.ClusterRole{}
-	if err := rbacconversion.Convert_rbac_ClusterRole_To_authorization_ClusterRole(obj, convertedObj, nil); err != nil {
+func ClusterRoleFromRBAC(obj *rbacv1.ClusterRole) (*authorizationapi.ClusterRole, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.ClusterRole{}
+	if err := rbacv1helpers.Convert_v1_ClusterRole_To_rbac_ClusterRole(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &authorizationapi.ClusterRole{}
+	if err := rbacconversion.Convert_rbac_ClusterRole_To_authorization_ClusterRole(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // ClusterRoleBindingFromRBAC turns a Kuberenets RBAC ClusterRoleBinding into
 // an Openshift ClusterRoleBinding, the returned object is safe to mutate
-func ClusterRoleBindingFromRBAC(obj *rbac.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error) {
-	convertedObj := &authorizationapi.ClusterRoleBinding{}
-	if err := rbacconversion.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(obj, convertedObj, nil); err != nil {
+func ClusterRoleBindingFromRBAC(obj *rbacv1.ClusterRoleBinding) (*authorizationapi.ClusterRoleBinding, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.ClusterRoleBinding{}
+	if err := rbacv1helpers.Convert_v1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &authorizationapi.ClusterRoleBinding{}
+	if err := rbacconversion.Convert_rbac_ClusterRoleBinding_To_authorization_ClusterRoleBinding(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // RoleFromRBAC turns a Kubernetes RBAC Role into an OpenShift Role,
 // the returned object is safe to mutate
-func RoleFromRBAC(obj *rbac.Role) (*authorizationapi.Role, error) {
-	convertedObj := &authorizationapi.Role{}
-	if err := rbacconversion.Convert_rbac_Role_To_authorization_Role(obj, convertedObj, nil); err != nil {
+func RoleFromRBAC(obj *rbacv1.Role) (*authorizationapi.Role, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.Role{}
+	if err := rbacv1helpers.Convert_v1_Role_To_rbac_Role(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &authorizationapi.Role{}
+	if err := rbacconversion.Convert_rbac_Role_To_authorization_Role(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }
 
 // RoleBindingFromRBAC turns a Kubernetes RBAC RoleBinding into an OpenShift
 // Rolebinding, the returned object is safe to mutate
-func RoleBindingFromRBAC(obj *rbac.RoleBinding) (*authorizationapi.RoleBinding, error) {
-	convertedObj := &authorizationapi.RoleBinding{}
-	if err := rbacconversion.Convert_rbac_RoleBinding_To_authorization_RoleBinding(obj, convertedObj, nil); err != nil {
+func RoleBindingFromRBAC(obj *rbacv1.RoleBinding) (*authorizationapi.RoleBinding, error) {
+	// do a deep copy here since conversion does not guarantee a new object.
+	objCopy := obj.DeepCopy()
+
+	convertedObjInternal := &rbac.RoleBinding{}
+	if err := rbacv1helpers.Convert_v1_RoleBinding_To_rbac_RoleBinding(objCopy, convertedObjInternal, nil); err != nil {
 		return nil, err
 	}
-	// do a deep copy here since conversion does not guarantee a new object.
-	return convertedObj.DeepCopy(), nil
+
+	convertedObj := &authorizationapi.RoleBinding{}
+	if err := rbacconversion.Convert_rbac_RoleBinding_To_authorization_RoleBinding(convertedObjInternal, convertedObj, nil); err != nil {
+		return nil, err
+	}
+
+	return convertedObj, nil
 }

--- a/pkg/build/apiserver/admission/secretinjector/admission.go
+++ b/pkg/build/apiserver/admission/secretinjector/admission.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/glog"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
 	restclient "k8s.io/client-go/rest"
@@ -69,7 +70,7 @@ func (si *secretInjector) admit(attr admission.Attributes, mutationAllowed bool)
 		return nil
 	}
 
-	secrets, err := client.Core().Secrets(namespace).List(metav1.ListOptions{})
+	secrets, err := client.CoreV1().Secrets(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		glog.V(2).Infof("secretinjector: failed to list Secrets: %v", err)
 		return nil
@@ -77,8 +78,8 @@ func (si *secretInjector) admit(attr admission.Attributes, mutationAllowed bool)
 
 	patterns := []*urlpattern.URLPattern{}
 	for _, secret := range secrets.Items {
-		if secret.Type == api.SecretTypeBasicAuth && url.Scheme == "ssh" ||
-			secret.Type == api.SecretTypeSSHAuth && url.Scheme != "ssh" {
+		if secret.Type == corev1.SecretTypeBasicAuth && url.Scheme == "ssh" ||
+			secret.Type == corev1.SecretTypeSSHAuth && url.Scheme != "ssh" {
 			continue
 		}
 

--- a/pkg/client/impersonatingclient/impersonate.go
+++ b/pkg/client/impersonatingclient/impersonate.go
@@ -6,21 +6,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/authentication/user"
+	kclientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/flowcontrol"
-	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 )
 
 // NewImpersonatingConfig wraps the config's transport to impersonate a user, including user, groups, and scopes
 func NewImpersonatingConfig(user user.Info, config restclient.Config) restclient.Config {
 	oldWrapTransport := config.WrapTransport
+	if oldWrapTransport == nil {
+		oldWrapTransport = func(rt http.RoundTripper) http.RoundTripper { return rt }
+	}
+	newConfig := transport.ImpersonationConfig{
+		UserName: user.GetName(),
+		Groups:   user.GetGroups(),
+		Extra:    user.GetExtra(),
+	}
 	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
-		newConfig := transport.ImpersonationConfig{
-			UserName: user.GetName(),
-			Groups:   user.GetGroups(),
-			Extra:    user.GetExtra(),
-		}
 		return transport.NewImpersonatingRoundTripper(newConfig, oldWrapTransport(rt))
 	}
 	return config
@@ -43,7 +46,7 @@ func NewImpersonatingRESTClient(user user.Info, client restclient.Interface) res
 }
 
 // Verb does the impersonation per request by setting the proper headers
-func (c impersonatingRESTClient) impersonate(req *restclient.Request) *restclient.Request {
+func (c *impersonatingRESTClient) impersonate(req *restclient.Request) *restclient.Request {
 	req.SetHeader(transport.ImpersonateUserHeader, c.user.GetName())
 	req.SetHeader(transport.ImpersonateGroupHeader, c.user.GetGroups()...)
 	for k, vv := range c.user.GetExtra() {
@@ -52,34 +55,34 @@ func (c impersonatingRESTClient) impersonate(req *restclient.Request) *restclien
 	return req
 }
 
-func (c impersonatingRESTClient) Verb(verb string) *restclient.Request {
+func (c *impersonatingRESTClient) Verb(verb string) *restclient.Request {
 	return c.impersonate(c.delegate.Verb(verb))
 }
 
-func (c impersonatingRESTClient) Post() *restclient.Request {
+func (c *impersonatingRESTClient) Post() *restclient.Request {
 	return c.impersonate(c.delegate.Post())
 }
 
-func (c impersonatingRESTClient) Put() *restclient.Request {
+func (c *impersonatingRESTClient) Put() *restclient.Request {
 	return c.impersonate(c.delegate.Put())
 }
 
-func (c impersonatingRESTClient) Patch(pt types.PatchType) *restclient.Request {
+func (c *impersonatingRESTClient) Patch(pt types.PatchType) *restclient.Request {
 	return c.impersonate(c.delegate.Patch(pt))
 }
 
-func (c impersonatingRESTClient) Get() *restclient.Request {
+func (c *impersonatingRESTClient) Get() *restclient.Request {
 	return c.impersonate(c.delegate.Get())
 }
 
-func (c impersonatingRESTClient) Delete() *restclient.Request {
+func (c *impersonatingRESTClient) Delete() *restclient.Request {
 	return c.impersonate(c.delegate.Delete())
 }
 
-func (c impersonatingRESTClient) APIVersion() schema.GroupVersion {
+func (c *impersonatingRESTClient) APIVersion() schema.GroupVersion {
 	return c.delegate.APIVersion()
 }
 
-func (c impersonatingRESTClient) GetRateLimiter() flowcontrol.RateLimiter {
+func (c *impersonatingRESTClient) GetRateLimiter() flowcontrol.RateLimiter {
 	return c.delegate.GetRateLimiter()
 }

--- a/pkg/client/impersonatingclient/impersonate_rbac.go
+++ b/pkg/client/impersonatingclient/impersonate_rbac.go
@@ -5,14 +5,14 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
-	rbacinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 )
 
-func NewImpersonatingRBACFromContext(ctx context.Context, restclient rest.Interface) (rbacinternalversion.RbacInterface, error) {
+func NewImpersonatingRBACFromContext(ctx context.Context, restclient rest.Interface) (rbacv1.RbacV1Interface, error) {
 	user, ok := request.UserFrom(ctx)
 	if !ok {
 		return nil, apierrors.NewBadRequest("user missing from context")
 	}
-	return rbacinternalversion.New(NewImpersonatingRESTClient(user, restclient)), nil
+	return rbacv1.New(NewImpersonatingRESTClient(user, restclient)), nil
 }

--- a/test/integration/authorization_rbac_proxy_test.go
+++ b/test/integration/authorization_rbac_proxy_test.go
@@ -1,0 +1,613 @@
+package integration
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kapierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
+
+	authorizationv1 "github.com/openshift/api/authorization/v1"
+	authorizationv1client "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+var authorizationV1Encoder runtime.Encoder
+
+func init() {
+	authorizationV1Scheme := runtime.NewScheme()
+	utilruntime.Must(authorizationv1.Install(authorizationV1Scheme))
+	authorizationV1Codecs := serializer.NewCodecFactory(authorizationV1Scheme)
+	authorizationV1Encoder = authorizationV1Codecs.LegacyCodec(authorizationv1.GroupVersion)
+}
+
+// TestLegacyLocalRoleBindingEndpoint exercises the legacy rolebinding endpoint that is proxied to rbac
+func TestLegacyLocalRoleBindingEndpoint(t *testing.T) {
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := "testproject"
+	testBindingName := "testrole"
+
+	clusterAdminRoleBindingsClient := authorizationv1client.NewForConfigOrDie(clusterAdminClientConfig).RoleBindings(namespace)
+	clusterAdminRBACRoleBindingsClient := rbacv1client.NewForConfigOrDie(clusterAdminClientConfig).RoleBindings(namespace)
+
+	_, _, err = testserver.CreateNewProject(clusterAdminClientConfig, namespace, "testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create rolebinding
+	roleBindingToCreate := &authorizationv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testBindingName,
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind:      "Role",
+			Name:      "edit",
+			Namespace: namespace,
+		},
+	}
+
+	roleBindingCreated, err := clusterAdminRoleBindingsClient.Create(roleBindingToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if roleBindingCreated.Name != roleBindingToCreate.Name {
+		t.Fatalf("expected rolebinding %s, got %s", roleBindingToCreate.Name, roleBindingCreated.Name)
+	}
+
+	// list rolebindings
+	roleBindingList, err := clusterAdminRoleBindingsClient.List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkBindings := sets.String{}
+	for _, rb := range roleBindingList.Items {
+		checkBindings.Insert(rb.Name)
+	}
+
+	// check for the created rolebinding in the list
+	if !checkBindings.HasAll(testBindingName) {
+		t.Fatalf("rolebinding list does not have the expected bindings")
+	}
+
+	// edit rolebinding
+	roleBindingToEdit := &authorizationv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testBindingName,
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser",
+			},
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser2",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind:      "Role",
+			Name:      "edit",
+			Namespace: namespace,
+		},
+	}
+	roleBindingToEditBytes, err := runtime.Encode(authorizationV1Encoder, roleBindingToEdit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	roleBindingEdited, err := clusterAdminRoleBindingsClient.Patch(testBindingName, types.StrategicMergePatchType, roleBindingToEditBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if roleBindingEdited.Name != roleBindingToEdit.Name {
+		t.Fatalf("expected rolebinding %s, got %s", roleBindingToEdit.Name, roleBindingEdited.Name)
+	}
+
+	checkSubjects := sets.String{}
+	for _, subj := range roleBindingEdited.Subjects {
+		checkSubjects.Insert(subj.Name)
+	}
+	if !checkSubjects.HasAll("testuser", "testuser2") {
+		t.Fatalf("rolebinding not edited")
+	}
+
+	// get rolebinding by name
+	getRoleBinding, err := clusterAdminRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRoleBinding.Name != testBindingName {
+		t.Fatalf("expected rolebinding %s, got %s", testBindingName, getRoleBinding.Name)
+	}
+	// get rolebinding by name via RBAC endpoint
+	getRoleBindingRBAC, err := clusterAdminRBACRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRoleBindingRBAC.Name != testBindingName {
+		t.Fatalf("expected rolebinding %s, got %s", testBindingName, getRoleBindingRBAC.Name)
+	}
+
+	// delete rolebinding
+	err = clusterAdminRoleBindingsClient.Delete(testBindingName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm deletion
+	_, err = clusterAdminRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+	// confirm deletion via RBAC endpoint
+	_, err = clusterAdminRBACRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+
+	// create local rolebinding for cluster role
+	localClusterRoleBindingToCreate := &authorizationv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-crb",
+			Namespace: namespace,
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind: "ClusterRole",
+			Name: "edit",
+		},
+	}
+
+	localClusterRoleBindingCreated, err := clusterAdminRoleBindingsClient.Create(localClusterRoleBindingToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if localClusterRoleBindingCreated.Name != localClusterRoleBindingToCreate.Name {
+		t.Fatalf("expected clusterrolebinding %s, got %s", localClusterRoleBindingToCreate.Name, localClusterRoleBindingCreated.Name)
+	}
+}
+
+// TestLegacyClusterRoleBindingEndpoint exercises the legacy clusterrolebinding endpoint that is proxied to rbac
+func TestLegacyClusterRoleBindingEndpoint(t *testing.T) {
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testBindingName := "testbinding"
+
+	clusterAdminClusterRoleBindingsClient := authorizationv1client.NewForConfigOrDie(clusterAdminClientConfig).ClusterRoleBindings()
+	clusterAdminRBACClusterRoleBindingsClient := rbacv1client.NewForConfigOrDie(clusterAdminClientConfig).ClusterRoleBindings()
+
+	// list clusterrole bindings
+	clusterRoleBindingList, err := clusterAdminClusterRoleBindingsClient.List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkBindings := sets.String{}
+	for _, rb := range clusterRoleBindingList.Items {
+		checkBindings.Insert(rb.Name)
+	}
+
+	// ensure there are at least some of the expected bindings in the list
+	if !checkBindings.HasAll("basic-users", "cluster-admin", "cluster-admins", "cluster-readers") {
+		t.Fatalf("clusterrolebinding list does not have the expected bindings")
+	}
+
+	// create clusterrole binding
+	clusterRoleBindingToCreate := &authorizationv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testBindingName,
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind: "ClusterRole",
+			Name: "edit",
+		},
+	}
+
+	clusterRoleBindingCreated, err := clusterAdminClusterRoleBindingsClient.Create(clusterRoleBindingToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clusterRoleBindingCreated.Name != clusterRoleBindingToCreate.Name {
+		t.Fatalf("expected clusterrolebinding %s, got %s", clusterRoleBindingToCreate.Name, clusterRoleBindingCreated.Name)
+	}
+
+	// edit clusterrole binding
+	clusterRoleBindingToEdit := &authorizationv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testBindingName,
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser",
+			},
+			{
+				Kind: rbacv1.UserKind,
+				Name: "testuser2",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Kind: "ClusterRole",
+			Name: "edit",
+		},
+	}
+	clusterRoleBindingToEditBytes, err := runtime.Encode(authorizationV1Encoder, clusterRoleBindingToEdit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterRoleBindingEdited, err := clusterAdminClusterRoleBindingsClient.Patch(testBindingName, types.StrategicMergePatchType, clusterRoleBindingToEditBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clusterRoleBindingEdited.Name != clusterRoleBindingToEdit.Name {
+		t.Fatalf("expected clusterrolebinding %s, got %s", clusterRoleBindingToEdit.Name, clusterRoleBindingEdited.Name)
+	}
+
+	checkSubjects := sets.String{}
+	for _, subj := range clusterRoleBindingEdited.Subjects {
+		checkSubjects.Insert(subj.Name)
+	}
+	if !checkSubjects.HasAll("testuser", "testuser2") {
+		t.Fatalf("clusterrolebinding not edited")
+	}
+
+	// get clusterrolebinding by name
+	getRoleBinding, err := clusterAdminClusterRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRoleBinding.Name != testBindingName {
+		t.Fatalf("expected clusterrolebinding %s, got %s", testBindingName, getRoleBinding.Name)
+	}
+	// get clusterrolebinding by name via RBAC endpoint
+	getRoleBindingRBAC, err := clusterAdminRBACClusterRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRoleBindingRBAC.Name != testBindingName {
+		t.Fatalf("expected clusterrolebinding %s, got %s", testBindingName, getRoleBindingRBAC.Name)
+	}
+
+	// delete clusterrolebinding
+	err = clusterAdminClusterRoleBindingsClient.Delete(testBindingName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm deletion
+	_, err = clusterAdminClusterRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+	// confirm deletion via RBAC endpoint
+	_, err = clusterAdminRBACClusterRoleBindingsClient.Get(testBindingName, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+}
+
+// TestLegacyClusterRoleEndpoint exercises the legacy clusterrole endpoint that is proxied to rbac
+func TestLegacyClusterRoleEndpoint(t *testing.T) {
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testRole := "testrole"
+
+	clusterAdminClusterRoleClient := authorizationv1client.NewForConfigOrDie(clusterAdminClientConfig).ClusterRoles()
+	clusterAdminRBACClusterRoleClient := rbacv1client.NewForConfigOrDie(clusterAdminClientConfig).ClusterRoles()
+
+	// list clusterroles
+	clusterRoleList, err := clusterAdminClusterRoleClient.List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkRoles := sets.String{}
+	for _, role := range clusterRoleList.Items {
+		checkRoles.Insert(role.Name)
+	}
+	// ensure there are at least some of the expected roles in the clusterrole list
+	if !checkRoles.HasAll("admin", "basic-user", "cluster-admin", "edit", "sudoer") {
+		t.Fatalf("clusterrole list does not have the expected roles")
+	}
+
+	// create clusterrole
+	clusterRoleToCreate := &authorizationv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: testRole},
+		Rules: []authorizationv1.PolicyRule{
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+			},
+		},
+	}
+
+	createdClusterRole, err := clusterAdminClusterRoleClient.Create(clusterRoleToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if createdClusterRole.Name != clusterRoleToCreate.Name {
+		t.Fatalf("expected to create %v, got %v", clusterRoleToCreate.Name, createdClusterRole.Name)
+	}
+
+	if !sets.NewString(createdClusterRole.Rules[0].Verbs...).Has("get") {
+		t.Fatalf("expected clusterrole to have a get rule")
+	}
+
+	// update clusterrole
+	clusterRoleUpdate := &authorizationv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: testRole},
+		Rules: []authorizationv1.PolicyRule{
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+			},
+		},
+	}
+
+	clusterRoleUpdateBytes, err := runtime.Encode(authorizationV1Encoder, clusterRoleUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedClusterRole, err := clusterAdminClusterRoleClient.Patch(testRole, types.StrategicMergePatchType, clusterRoleUpdateBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updatedClusterRole.Name != clusterRoleUpdate.Name {
+		t.Fatalf("expected to update %s, got %s", clusterRoleUpdate.Name, updatedClusterRole.Name)
+	}
+
+	if !sets.NewString(updatedClusterRole.Rules[0].Verbs...).HasAll("get", "list") {
+		t.Fatalf("expected clusterrole to have a get and list rule")
+	}
+
+	// get clusterrole
+	getRole, err := clusterAdminClusterRoleClient.Get(testRole, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRole.Name != testRole {
+		t.Fatalf("expected %s role, got %s instead", testRole, getRole.Name)
+	}
+	// get clusterrole via RBAC
+	getRoleRBAC, err := clusterAdminRBACClusterRoleClient.Get(testRole, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRoleRBAC.Name != testRole {
+		t.Fatalf("expected %s role, got %s instead", testRole, getRoleRBAC.Name)
+	}
+
+	// delete clusterrole
+	err = clusterAdminClusterRoleClient.Delete(testRole, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm deletion
+	_, err = clusterAdminClusterRoleClient.Get(testRole, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+	// confirm deletion via RBAC
+	_, err = clusterAdminRBACClusterRoleClient.Get(testRole, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+}
+
+// TestLegacyLocalRoleEndpoint exercises the legacy role endpoint that is proxied to rbac
+func TestLegacyLocalRoleEndpoint(t *testing.T) {
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := "testproject"
+	testRole := "testrole"
+
+	clusterAdminRoleClient := authorizationv1client.NewForConfigOrDie(clusterAdminClientConfig).Roles(namespace)
+	clusterAdminRBACRoleClient := rbacv1client.NewForConfigOrDie(clusterAdminClientConfig).Roles(namespace)
+
+	_, _, err = testserver.CreateNewProject(clusterAdminClientConfig, namespace, "testuser")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create role
+	roleToCreate := &authorizationv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRole,
+			Namespace: namespace,
+		},
+		Rules: []authorizationv1.PolicyRule{
+			{
+				Verbs:     []string{"get"},
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+			},
+		},
+	}
+
+	createdRole, err := clusterAdminRoleClient.Create(roleToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if createdRole.Name != roleToCreate.Name {
+		t.Fatalf("expected to create %v, got %v", roleToCreate.Name, createdRole.Name)
+	}
+
+	if !sets.NewString(createdRole.Rules[0].Verbs...).Has("get") {
+		t.Fatalf("expected clusterRole to have a get rule")
+	}
+
+	// list roles
+	roleList, err := clusterAdminRoleClient.List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkRoles := sets.String{}
+	for _, role := range roleList.Items {
+		checkRoles.Insert(role.Name)
+	}
+	// ensure the role list has the created role
+	if !checkRoles.HasAll(testRole) {
+		t.Fatalf("role list does not have the expected roles")
+	}
+
+	// update role
+	roleUpdate := &authorizationv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testRole,
+			Namespace: namespace,
+		},
+		Rules: []authorizationv1.PolicyRule{
+			{
+				Verbs:     []string{"get", "list"},
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+			},
+		},
+	}
+
+	roleUpdateBytes, err := runtime.Encode(authorizationV1Encoder, roleUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedRole, err := clusterAdminRoleClient.Patch(testRole, types.StrategicMergePatchType, roleUpdateBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updatedRole.Name != roleUpdate.Name {
+		t.Fatalf("expected to update %s, got %s", roleUpdate.Name, updatedRole.Name)
+	}
+
+	if !sets.NewString(updatedRole.Rules[0].Verbs...).HasAll("get", "list") {
+		t.Fatalf("expected role to have a get and list rule")
+	}
+
+	// get role
+	getRole, err := clusterAdminRoleClient.Get(testRole, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRole.Name != testRole {
+		t.Fatalf("expected %s role, got %s instead", testRole, getRole.Name)
+	}
+	// get role via RBAC
+	getRoleRBAC, err := clusterAdminRBACRoleClient.Get(testRole, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getRoleRBAC.Name != testRole {
+		t.Fatalf("expected %s role, got %s instead", testRole, getRoleRBAC.Name)
+	}
+
+	// delete role
+	err = clusterAdminRoleClient.Delete(testRole, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm deletion
+	_, err = clusterAdminRoleClient.Get(testRole, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+	// confirm deletion via RBAC
+	_, err = clusterAdminRBACRoleClient.Get(testRole, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("expected error")
+	} else if !kapierror.IsNotFound(err) {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The conversion code now has extra hops from:

rbac v1 -> rbac internal -> authorization internal
authorization internal -> rbac internal -> rbac v1

The "rbac v1" hops were introduced in this change.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Update impersonating client to use external clients

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

Restore authorization to RBAC proxy test

This test was removed in b93335cf0e36985a864db01e860858bad0645dfa as part of the removal of all oapi related code.  The functionality this test checks is not related to oapi (even though the original version of the test explicitly used the oapi endpoints).  The updated test does not rely on any internal clients.

Signed-off-by: Monis Khan <mkhan@redhat.com>

---

@openshift/sig-auth 
/assign @deads2k 