### PR TITLE
pkg/oc/cli/admin/release: "--to" -> "release target" in MirrorOptions.Run

### DIFF
--- a/pkg/oc/cli/admin/release/mirror.go
+++ b/pkg/oc/cli/admin/release/mirror.go
@@ -117,7 +117,7 @@ func (o *MirrorOptions) Run() error {
 		format := strings.Replace(dst, "${component}", replaceComponentMarker, -1)
 		dstRef, err := imagereference.Parse(format)
 		if err != nil {
-			return fmt.Errorf("--to must be a valid image reference: %v", err)
+			return fmt.Errorf("release target must be a valid image reference: %v", err)
 		}
 		targetFn = func(name string) imagereference.DockerImageReference {
 			value := strings.Replace(dst, "${component}", name, -1)
@@ -133,10 +133,10 @@ func (o *MirrorOptions) Run() error {
 	} else {
 		ref, err := imagereference.Parse(dst)
 		if err != nil {
-			return fmt.Errorf("--to must be a valid image repository: %v", err)
+			return fmt.Errorf("release target must be a valid image repository: %v", err)
 		}
 		if len(ref.ID) > 0 || len(ref.Tag) > 0 {
-			return fmt.Errorf("--to must be to an image repository and may not contain a tag or digest")
+			return fmt.Errorf("release target must be to an image repository and may not contain a tag or digest")
 		}
 		targetFn = func(name string) imagereference.DockerImageReference {
 			copied := ref


### PR DESCRIPTION
To avoid confusing folks who get into this function via:

```console
$ oc adm release new --mirror ...
```

because `NewOptions.mirrorImages` has:

```go
opts.To = o.Mirror
```

fed by `--mirror`.