### PR TITLE
UPSTREAM: 75368: handle apiserver is shutting down errors

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
@@ -43,7 +43,9 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters",
     importpath = "k8s.io/apiserver/pkg/server/filters",
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
@@ -53,6 +55,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/httplog:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/waitgroup.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/filters/waitgroup.go
@@ -38,6 +38,7 @@ func WithWaitGroup(handler http.Handler, longRunning apirequest.LongRunningReque
 
 		if !longRunning(req, requestInfo) {
 			if err := wg.Add(1); err != nil {
+				w.Header().Add("Retry-After", "1")
 				http.Error(w, "apiserver is shutting down.", http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
First commit will cause the client-go to retry after it get "apiserver is shutting down error".
Second commit will make the error structured (metav1.Status) and it change the error code from 500 to 503.

NOTE: This is not fixing the reason why we see that much apiserver shutting down errors. These errors should be rare and there is probably bug in shutdown order that is causing them.

picks: https://github.com/kubernetes/kubernetes/pull/75368

/cc @deads2k 
/cc @smarterclayton 
/cc @sttts 