### PR TITLE
 update for new authentication APIs

### DIFF
--- a/pkg/apiserver/authentication/oauth/bootstrapauthenticator.go
+++ b/pkg/apiserver/authentication/oauth/bootstrapauthenticator.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kauthenticator "k8s.io/apiserver/pkg/authentication/authenticator"
@@ -27,7 +29,7 @@ func NewBootstrapAuthenticator(tokens oauthclient.OAuthAccessTokenInterface, get
 	}
 }
 
-func (a *bootstrapAuthenticator) AuthenticateToken(name string) (kuser.Info, bool, error) {
+func (a *bootstrapAuthenticator) AuthenticateToken(ctx context.Context, name string) (*kauthenticator.Response, bool, error) {
 	token, err := a.tokens.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, errLookup // mask the error so we do not leak token data in logs
@@ -56,26 +58,28 @@ func (a *bootstrapAuthenticator) AuthenticateToken(name string) (kuser.Info, boo
 	}
 
 	// we explicitly do not set UID as we do not want to leak any derivative of the password
-	return &kuser.DefaultInfo{
-		Name: bootstrap.BootstrapUser,
-		// we cannot use SystemPrivilegedGroup because it cannot be properly scoped.
-		// see openshift/origin#18922 and how loopback connections are handled upstream via AuthorizeClientBearerToken.
-		// api aggregation with delegated authorization makes this impossible to control, see WithAlwaysAllowGroups.
-		// an openshift specific cluster role binding binds ClusterAdminGroup to the cluster role cluster-admin.
-		// thus this group is authorized to do everything via RBAC.
-		// this does make the bootstrap user susceptible to anything that causes the RBAC authorizer to fail.
-		// this is a safe trade-off because scopes must always be evaluated before RBAC for them to work at all.
-		// a failure in that logic means scopes are broken instead of a specific failure related to the bootstrap user.
-		// if this becomes a problem in the future, we could generate a custom extra value based on the secret content
-		// and store it in BootstrapUserData, similar to how UID is calculated.  this extra value would then be wired
-		// to a custom authorizer that allows all actions.  the problem with such an approach is that since we do not
-		// allow remote authorizers in OpenShift, the BootstrapUserDataGetter logic would have to be shared between the
-		// the kube api server and osin instead of being an implementation detail hidden inside of osin.  currently the
-		// only shared code is the value of the BootstrapUser constant (since it is special cased in validation).
-		Groups: []string{bootstrappolicy.ClusterAdminGroup},
-		Extra: map[string][]string{
-			// this user still needs scopes because it can be used in OAuth flows (unlike cert based users)
-			authorizationapi.ScopesKey: token.Scopes,
+	return &kauthenticator.Response{
+		User: &kuser.DefaultInfo{
+			Name: bootstrap.BootstrapUser,
+			// we cannot use SystemPrivilegedGroup because it cannot be properly scoped.
+			// see openshift/origin#18922 and how loopback connections are handled upstream via AuthorizeClientBearerToken.
+			// api aggregation with delegated authorization makes this impossible to control, see WithAlwaysAllowGroups.
+			// an openshift specific cluster role binding binds ClusterAdminGroup to the cluster role cluster-admin.
+			// thus this group is authorized to do everything via RBAC.
+			// this does make the bootstrap user susceptible to anything that causes the RBAC authorizer to fail.
+			// this is a safe trade-off because scopes must always be evaluated before RBAC for them to work at all.
+			// a failure in that logic means scopes are broken instead of a specific failure related to the bootstrap user.
+			// if this becomes a problem in the future, we could generate a custom extra value based on the secret content
+			// and store it in BootstrapUserData, similar to how UID is calculated.  this extra value would then be wired
+			// to a custom authorizer that allows all actions.  the problem with such an approach is that since we do not
+			// allow remote authorizers in OpenShift, the BootstrapUserDataGetter logic would have to be shared between the
+			// the kube api server and osin instead of being an implementation detail hidden inside of osin.  currently the
+			// only shared code is the value of the BootstrapUser constant (since it is special cased in validation).
+			Groups: []string{bootstrappolicy.ClusterAdminGroup},
+			Extra: map[string][]string{
+				// this user still needs scopes because it can be used in OAuth flows (unlike cert based users)
+				authorizationapi.ScopesKey: token.Scopes,
+			},
 		},
 	}, true, nil
 }

--- a/pkg/apiserver/authentication/oauth/expirationvalidator_test.go
+++ b/pkg/apiserver/authentication/oauth/expirationvalidator_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func TestAuthenticateTokenExpired(t *testing.T) {
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.Oauth().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, NewExpirationValidator())
 
 	for _, tokenName := range []string{"token1", "token2"} {
-		userInfo, found, err := tokenAuthenticator.AuthenticateToken(tokenName)
+		userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), tokenName)
 		if found {
 			t.Error("Found token, but it should be missing!")
 		}
@@ -58,7 +59,7 @@ func TestAuthenticateTokenValidated(t *testing.T) {
 
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.Oauth().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, NewExpirationValidator(), NewUIDValidator())
 
-	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
+	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if !found {
 		t.Error("Did not find a token!")
 	}

--- a/pkg/apiserver/authentication/oauth/tokenauthenticator_test.go
+++ b/pkg/apiserver/authentication/oauth/tokenauthenticator_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ func TestAuthenticateTokenInvalidUID(t *testing.T) {
 
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.Oauth().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{}, NewUIDValidator())
 
-	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
+	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if found {
 		t.Error("Found token, but it should be missing!")
 	}
@@ -49,7 +50,7 @@ func TestAuthenticateTokenNotFoundSuppressed(t *testing.T) {
 	fakeUserClient := userfake.NewSimpleClientset()
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.Oauth().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{})
 
-	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
+	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if found {
 		t.Error("Found token, but it should be missing!")
 	}
@@ -69,7 +70,7 @@ func TestAuthenticateTokenOtherGetErrorSuppressed(t *testing.T) {
 	fakeUserClient := userfake.NewSimpleClientset()
 	tokenAuthenticator := NewTokenAuthenticator(fakeOAuthClient.Oauth().OAuthAccessTokens(), fakeUserClient.UserV1().Users(), NoopGroupMapper{})
 
-	userInfo, found, err := tokenAuthenticator.AuthenticateToken("token")
+	userInfo, found, err := tokenAuthenticator.AuthenticateToken(context.TODO(), "token")
 	if found {
 		t.Error("Found token, but it should be missing!")
 	}
@@ -314,7 +315,7 @@ func (f fakeOAuthClientLister) List(selector labels.Selector) ([]*oauthv1.OAuthC
 
 func checkToken(t *testing.T, name string, authf authenticator.Token, tokens oauthclient.OAuthAccessTokenInterface, current clock.Clock, present bool) {
 	t.Helper()
-	userInfo, found, err := authf.AuthenticateToken(name)
+	userInfo, found, err := authf.AuthenticateToken(context.TODO(), name)
 	if present {
 		if !found {
 			t.Errorf("Did not find token %s!", name)

--- a/pkg/client/config/smart_merge.go
+++ b/pkg/client/config/smart_merge.go
@@ -26,12 +26,12 @@ func GetClusterNicknameFromURL(apiServerLocation string) (string, error) {
 }
 
 func GetUserNicknameFromCert(clusterNick string, chain ...*x509.Certificate) (string, error) {
-	userInfo, _, err := x509request.CommonNameUserConversion(chain)
+	authResponse, _, err := x509request.CommonNameUserConversion(chain)
 	if err != nil {
 		return "", err
 	}
 
-	return userInfo.GetName() + "/" + clusterNick, nil
+	return authResponse.User.GetName() + "/" + clusterNick, nil
 }
 
 func GetContextNickname(namespace, clusterNick, userNick string) string {

--- a/pkg/cmd/openshift-controller-manager/controller/standalone_apiserver.go
+++ b/pkg/cmd/openshift-controller-manager/controller/standalone_apiserver.go
@@ -56,7 +56,8 @@ func RunControllerServer(servingInfo configv1.HTTPServingInfo, kubeExternal clie
 	// we use direct bypass to allow readiness and health to work regardless of the master health
 	authz := newBypassAuthorizer(remoteAuthz, "/healthz", "/healthz/ready")
 	handler := apifilters.WithAuthorization(mux, authz, legacyscheme.Codecs)
-	handler = apifilters.WithAuthentication(handler, authn, apifilters.Unauthorized(legacyscheme.Codecs, false))
+	// TODO need audiences
+	handler = apifilters.WithAuthentication(handler, authn, apifilters.Unauthorized(legacyscheme.Codecs, false), nil)
 	handler = apiserverfilters.WithPanicRecovery(handler)
 	handler = apifilters.WithRequestInfo(handler, requestInfoResolver)
 

--- a/pkg/oauthserver/authenticator/interfaces.go
+++ b/pkg/oauthserver/authenticator/interfaces.go
@@ -1,15 +1,15 @@
 package authenticator
 
 import (
-	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 
 	"github.com/openshift/origin/pkg/oauthserver/api"
 )
 
 type Assertion interface {
-	AuthenticateAssertion(assertionType, data string) (user.Info, bool, error)
+	AuthenticateAssertion(assertionType, data string) (*authenticator.Response, bool, error)
 }
 
 type Client interface {
-	AuthenticateClient(client api.Client) (user.Info, bool, error)
+	AuthenticateClient(client api.Client) (*authenticator.Response, bool, error)
 }

--- a/pkg/oauthserver/authenticator/password/allowanypassword/anyauthpassword.go
+++ b/pkg/oauthserver/authenticator/password/allowanypassword/anyauthpassword.go
@@ -1,10 +1,10 @@
 package allowanypassword
 
 import (
+	"context"
 	"strings"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 
 	authapi "github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/authenticator/identitymapper"
@@ -22,7 +22,7 @@ func New(providerName string, identityMapper authapi.UserIdentityMapper) authent
 }
 
 // AuthenticatePassword approves any login attempt with non-blank username and password
-func (a alwaysAcceptPasswordAuthenticator) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+func (a alwaysAcceptPasswordAuthenticator) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
 	// Since this IDP doesn't validate usernames or passwords, disallow usernames consisting entirely of spaces
 	// Normalize usernames by removing leading/trailing spaces
 	username = strings.TrimSpace(username)
@@ -33,5 +33,6 @@ func (a alwaysAcceptPasswordAuthenticator) AuthenticatePassword(username, passwo
 
 	identity := authapi.NewDefaultUserIdentityInfo(a.providerName, username)
 
-	return identitymapper.UserFor(a.identityMapper, identity)
+	user, ok, err := identitymapper.UserFor(a.identityMapper, identity)
+	return &authenticator.Response{User: user}, ok, err
 }

--- a/pkg/oauthserver/authenticator/password/allowanypassword/anyauthpassword_test.go
+++ b/pkg/oauthserver/authenticator/password/allowanypassword/anyauthpassword_test.go
@@ -1,6 +1,7 @@
 package allowanypassword
 
 import (
+	"context"
 	"testing"
 
 	"github.com/openshift/origin/pkg/oauthserver/api"
@@ -59,7 +60,7 @@ func TestAnyAuthPassword(t *testing.T) {
 	}
 
 	for k, tc := range testcases {
-		user, ok, err := a.AuthenticatePassword(tc.Username, tc.Password)
+		response, ok, err := a.AuthenticatePassword(context.TODO(), tc.Username, tc.Password)
 		if tc.ExpectedErr != (err != nil) {
 			t.Errorf("%s: expected error=%v, got %v", k, tc.ExpectedErr, err)
 			continue
@@ -70,7 +71,7 @@ func TestAnyAuthPassword(t *testing.T) {
 		}
 		username := ""
 		if ok {
-			username = user.GetName()
+			username = response.User.GetName()
 		}
 		if tc.ExpectedUsername != username {
 			t.Errorf("%s: expected username=%v, got %v", k, tc.ExpectedUsername, username)

--- a/pkg/oauthserver/authenticator/password/bootstrap/bootstrap.go
+++ b/pkg/oauthserver/authenticator/password/bootstrap/bootstrap.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
@@ -50,7 +51,7 @@ type bootstrapPassword struct {
 	names  sets.String
 }
 
-func (b *bootstrapPassword) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+func (b *bootstrapPassword) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
 	if !b.names.Has(username) {
 		return nil, false, nil
 	}
@@ -75,9 +76,11 @@ func (b *bootstrapPassword) AuthenticatePassword(username, password string) (use
 	}
 
 	// do not set other fields, see identitymapper.userToInfo func
-	return &user.DefaultInfo{
-		Name: BootstrapUser,
-		UID:  data.UID, // uid ties this authentication to the current state of the secret
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name: BootstrapUser,
+			UID:  data.UID, // uid ties this authentication to the current state of the secret
+		},
 	}, true, nil
 }
 

--- a/pkg/oauthserver/authenticator/password/denypassword/denypassword.go
+++ b/pkg/oauthserver/authenticator/password/denypassword/denypassword.go
@@ -1,8 +1,9 @@
 package denypassword
 
 import (
+	"context"
+
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // denyPasswordAuthenticator denies all password requests
@@ -15,6 +16,6 @@ func New() authenticator.Password {
 }
 
 // AuthenticatePassword denies any login attempt
-func (a denyPasswordAuthenticator) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+func (a denyPasswordAuthenticator) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
 	return nil, false, nil
 }

--- a/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword_test.go
+++ b/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword_test.go
@@ -1,6 +1,7 @@
 package keystonepassword
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -96,22 +97,22 @@ func TestKeystoneLogin(t *testing.T) {
 	keystoneAuth := New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &mapperClaim, true)
 
 	// 1. User authenticates for the first time, new identity is created
-	_, ok, err := keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	_, ok, err := keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "testpw")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, true, ok)
 	th.CheckEquals(t, "keystone_auth:initial_keystone_id", mapperClaim.idnts["testuser"])
 
 	// 2. Authentication with wrong or empty password fails
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "badpw")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "badpw")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, false, ok)
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, false, ok)
 
 	// 3. Id of "testuser" has changed, authentication will fail
 	keystoneID = "new_keystone_id"
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "testpw")
 	th.CheckEquals(t, false, ok)
 	th.CheckEquals(t, "Ooops", err.Error())
 
@@ -121,22 +122,22 @@ func TestKeystoneLogin(t *testing.T) {
 	keystoneAuth = New("keystone_auth", th.Endpoint(), http.DefaultTransport, "default", &mapperClaim, false)
 
 	// 1. User authenticates for the first time, new identity is created
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "testpw")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, true, ok)
 	th.CheckEquals(t, "keystone_auth:testuser", mapperClaim.idnts["testuser"])
 
 	// 2. Authentication with wrong or empty password fails
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "badpw")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "badpw")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, false, ok)
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "")
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, false, ok)
 
 	// 3. Id of "testuser" has changed, authentication will work as before
 	keystoneID = "new_keystone_id"
-	_, ok, err = keystoneAuth.AuthenticatePassword("testuser", "testpw")
+	_, ok, err = keystoneAuth.AuthenticatePassword(context.TODO(), "testuser", "testpw")
 	th.CheckEquals(t, true, ok)
 	th.AssertNoErr(t, err)
 }

--- a/pkg/oauthserver/authenticator/request/basicauthrequest/basicauth_test.go
+++ b/pkg/oauthserver/authenticator/request/basicauthrequest/basicauth_test.go
@@ -1,9 +1,11 @@
 package basicauthrequest
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -21,11 +23,11 @@ type mockPasswordAuthenticator struct {
 	passedPassword  string
 }
 
-func (mock *mockPasswordAuthenticator) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+func (mock *mockPasswordAuthenticator) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
 	mock.passedUser = username
 	mock.passedPassword = password
 
-	return mock.returnUser, mock.isAuthenticated, mock.err
+	return &authenticator.Response{User: mock.returnUser}, mock.isAuthenticated, mock.err
 }
 
 func TestAuthenticateRequestValid(t *testing.T) {

--- a/pkg/oauthserver/authenticator/request/headerrequest/requestheader.go
+++ b/pkg/oauthserver/authenticator/request/headerrequest/requestheader.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 
 	authapi "github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/authenticator/identitymapper"
@@ -31,7 +31,7 @@ func NewAuthenticator(providerName string, config *Config, mapper authapi.UserId
 	return &Authenticator{providerName, config, mapper}
 }
 
-func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	id := headerValue(req.Header, a.config.IDHeaders)
 	if len(id) == 0 {
 		return nil, false, nil
@@ -49,7 +49,8 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 		identity.Extra[authapi.IdentityPreferredUsernameKey] = preferredUsername
 	}
 
-	return identitymapper.UserFor(a.mapper, identity)
+	user, ok, err := identitymapper.UserFor(a.mapper, identity)
+	return &authenticator.Response{User: user}, ok, err
 }
 
 func headerValue(h http.Header, headerNames []string) string {

--- a/pkg/oauthserver/authenticator/request/headerrequest/requestheader_test.go
+++ b/pkg/oauthserver/authenticator/request/headerrequest/requestheader_test.go
@@ -97,7 +97,7 @@ func TestRequestHeader(t *testing.T) {
 		auth := NewAuthenticator("testprovider", &testcase.Config, mapper)
 		req := &http.Request{Header: testcase.RequestHeaders}
 
-		user, ok, err := auth.AuthenticateRequest(req)
+		authResponse, ok, err := auth.AuthenticateRequest(req)
 		if testcase.ExpectedUsername == "" {
 			if ok {
 				t.Errorf("%s: Didn't expect user, authentication succeeded", k)
@@ -113,8 +113,8 @@ func TestRequestHeader(t *testing.T) {
 				t.Errorf("%s: Expected user, auth failed", k)
 				continue
 			}
-			if testcase.ExpectedUsername != user.GetName() {
-				t.Errorf("%s: Expected username %s, got %s", k, testcase.ExpectedUsername, user.GetName())
+			if testcase.ExpectedUsername != authResponse.User.GetName() {
+				t.Errorf("%s: Expected username %s, got %s", k, testcase.ExpectedUsername, authResponse.User.GetName())
 				continue
 			}
 		}

--- a/pkg/oauthserver/oauth/external/handler.go
+++ b/pkg/oauthserver/oauth/external/handler.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -111,7 +112,7 @@ func NewOAuthPasswordAuthenticator(provider Provider, mapper authapi.UserIdentit
 	}, nil
 }
 
-func (h *Handler) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+func (h *Handler) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
 	// Exchange password for a token
 	accessReq := h.client.NewAccessRequest(osincli.PASSWORD, &osincli.AuthorizeData{Username: username, Password: password})
 	accessData, err := accessReq.GetToken()
@@ -137,7 +138,8 @@ func (h *Handler) AuthenticatePassword(username, password string) (user.Info, bo
 		return nil, false, err
 	}
 
-	return identitymapper.UserFor(h.mapper, identity)
+	user, ok, err := identitymapper.UserFor(h.mapper, identity)
+	return &authenticator.Response{User: user}, ok, err
 }
 
 // ServeHTTP handles the callback request in response to an external oauth flow

--- a/pkg/oauthserver/oauth/handlers/authenticator_test.go
+++ b/pkg/oauthserver/oauth/handlers/authenticator_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestAuthenticator(t *testing.T) {
 }
 
 func TestDenyPassword(t *testing.T) {
-	user, ok, err := deny.AuthenticatePassword("", "")
+	user, ok, err := deny.AuthenticatePassword(context.TODO(), "", "")
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/pkg/oauthserver/oauth/registry/registry_test.go
+++ b/pkg/oauthserver/oauth/registry/registry_test.go
@@ -10,6 +10,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -63,8 +64,8 @@ func (h *testHandlers) AuthenticationError(err error, w http.ResponseWriter, req
 	return true, nil
 }
 
-func (h *testHandlers) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	return h.User, h.Authenticate, h.Err
+func (h *testHandlers) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return &authenticator.Response{User: h.User}, h.Authenticate, h.Err
 }
 
 func (h *testHandlers) GrantNeeded(user user.Info, grant *api.Grant, w http.ResponseWriter, req *http.Request) (bool, bool, error) {

--- a/pkg/oauthserver/server/grant/grant.go
+++ b/pkg/oauthserver/server/grant/grant.go
@@ -111,16 +111,16 @@ func (l *Grant) Install(mux oauthserver.Mux, paths ...string) {
 func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	headers.SetStandardHeaders(w)
 
-	user, ok, err := l.auth.AuthenticateRequest(req)
+	authResponse, ok, err := l.auth.AuthenticateRequest(req)
 	if err != nil || !ok {
 		l.redirect("You must reauthenticate before continuing", w, req)
 		return
 	}
 	switch req.Method {
 	case "GET":
-		l.handleForm(user, w, req)
+		l.handleForm(authResponse.User, w, req)
 	case "POST":
-		l.handleGrant(user, w, req)
+		l.handleGrant(authResponse.User, w, req)
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}

--- a/pkg/oauthserver/server/grant/grant_test.go
+++ b/pkg/oauthserver/server/grant/grant_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	knet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	clienttesting "k8s.io/client-go/testing"
 
@@ -28,8 +29,8 @@ type testAuth struct {
 	Err     error
 }
 
-func (t *testAuth) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	return t.User, t.Success, t.Err
+func (t *testAuth) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return &authenticator.Response{User: t.User}, t.Success, t.Err
 }
 
 func goodAuth(username string) *testAuth {

--- a/pkg/oauthserver/server/login/login.go
+++ b/pkg/oauthserver/server/login/login.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -173,7 +174,7 @@ func (l *Login) handleLogin(w http.ResponseWriter, req *http.Request) {
 	defer func() {
 		metrics.RecordFormPasswordAuth(result)
 	}()
-	user, ok, err := l.auth.AuthenticatePassword(username, password)
+	authResponse, ok, err := l.auth.AuthenticatePassword(context.TODO(), username, password)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf(`Error authenticating %q with provider %q: %v`, username, l.provider, err))
 		failed(errorpage.AuthenticationErrorCode(err), w, req)
@@ -186,8 +187,8 @@ func (l *Login) handleLogin(w http.ResponseWriter, req *http.Request) {
 		result = metrics.FailResult
 		return
 	}
-	glog.V(4).Infof(`Login with provider %q succeeded for %q: %#v`, l.provider, username, user)
-	l.auth.AuthenticationSucceeded(user, then, w, req)
+	glog.V(4).Infof(`Login with provider %q succeeded for %q: %#v`, l.provider, username, authResponse.User)
+	l.auth.AuthenticationSucceeded(authResponse.User, then, w, req)
 }
 
 // NewLoginFormRenderer creates a login form renderer that takes in an optional custom template to

--- a/pkg/oauthserver/server/login/login_test.go
+++ b/pkg/oauthserver/server/login/login_test.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
@@ -25,10 +27,10 @@ type testAuth struct {
 	Called   bool
 }
 
-func (t *testAuth) AuthenticatePassword(user, password string) (user.Info, bool, error) {
+func (t *testAuth) AuthenticatePassword(ctx context.Context, user, password string) (*authenticator.Response, bool, error) {
 	t.Username = user
 	t.Password = password
-	return t.User, t.Success, t.Err
+	return &authenticator.Response{User: t.User}, t.Success, t.Err
 }
 
 func (t *testAuth) AuthenticationSucceeded(user user.Info, then string, w http.ResponseWriter, req *http.Request) (bool, error) {

--- a/pkg/oauthserver/server/session/authenticator.go
+++ b/pkg/oauthserver/server/session/authenticator.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -27,7 +28,7 @@ func NewAuthenticator(store Store, maxAge time.Duration) SessionAuthenticator {
 	}
 }
 
-func (a *sessionAuthenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *sessionAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	values := a.store.Get(req)
 
 	expires, ok := values.GetInt64(expKey)
@@ -49,9 +50,11 @@ func (a *sessionAuthenticator) AuthenticateRequest(req *http.Request) (user.Info
 		return nil, false, nil
 	}
 
-	return &user.DefaultInfo{
-		Name: name,
-		UID:  uid,
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name: name,
+			UID:  uid,
+		},
 	}, true, nil
 }
 

--- a/vendor/k8s.io/kubernetes/cmd/controller-manager/app/serve.go
+++ b/vendor/k8s.io/kubernetes/cmd/controller-manager/app/serve.go
@@ -43,7 +43,7 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 		handler = genericapifilters.WithAuthorization(apiHandler, authorizationInfo.Authorizer, legacyscheme.Codecs)
 	}
 	if authenticationInfo != nil {
-		handler = genericapifilters.WithAuthentication(handler, authenticationInfo.Authenticator, failedHandler)
+		handler = genericapifilters.WithAuthentication(handler, authenticationInfo.Authenticator, failedHandler, nil)
 	}
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericfilters.WithPanicRecovery(handler)

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
@@ -229,7 +229,7 @@ func buildHandlerChain(handler http.Handler, authn authenticator.Request, authz 
 
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericapifilters.WithAuthorization(handler, authz, legacyscheme.Codecs)
-	handler = genericapifilters.WithAuthentication(handler, authn, failedHandler)
+	handler = genericapifilters.WithAuthentication(handler, authn, failedHandler, nil)
 	handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 	handler = genericfilters.WithPanicRecovery(handler)
 

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/authentication.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/options/authentication.go
@@ -29,7 +29,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
+	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
 
@@ -283,8 +283,8 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 }
 
-func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() authenticator.AuthenticatorConfig {
-	ret := authenticator.AuthenticatorConfig{
+func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() kubeauthenticator.AuthenticatorConfig {
+	ret := kubeauthenticator.AuthenticatorConfig{
 		TokenSuccessCacheTTL: s.TokenSuccessCacheTTL,
 		TokenFailureCacheTTL: s.TokenFailureCacheTTL,
 	}
@@ -367,6 +367,7 @@ func (o *BuiltInAuthenticationOptions) ApplyTo(c *genericapiserver.Config) error
 	}
 
 	c.Authentication.SupportsBasicAuth = o.PasswordFile != nil && len(o.PasswordFile.BasicAuthFile) > 0
+	c.Authentication.APIAudiences = o.ServiceAccounts.APIAudiences
 
 	return nil
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubeapiserver/server/insecure_handler.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubeapiserver/server/insecure_handler.go
@@ -31,7 +31,7 @@ import (
 func BuildInsecureHandlerChain(apiHandler http.Handler, c *server.Config) http.Handler {
 	handler := apiHandler
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyChecker, c.LongRunningFunc)
-	handler = genericapifilters.WithAuthentication(handler, server.InsecureSuperuser{}, nil)
+	handler = genericapifilters.WithAuthentication(handler, server.InsecureSuperuser{}, nil, nil)
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.LongRunningFunc, c.RequestTimeout)
 	handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.LongRunningFunc)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/server/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/server/BUILD
@@ -77,6 +77,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//staging/src/k8s.io/client-go/tools/remotecommand:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/server/server.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/server/server.go
@@ -225,7 +225,7 @@ func NewServer(
 func (s *Server) InstallAuthFilter() {
 	s.restfulCont.Filter(func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		// Authenticate
-		u, ok, err := s.auth.AuthenticateRequest(req.Request)
+		info, ok, err := s.auth.AuthenticateRequest(req.Request)
 		if err != nil {
 			glog.Errorf("Unable to authenticate the request due to an error: %v", err)
 			resp.WriteErrorString(http.StatusUnauthorized, "Unauthorized")
@@ -237,18 +237,18 @@ func (s *Server) InstallAuthFilter() {
 		}
 
 		// Get authorization attributes
-		attrs := s.auth.GetRequestAttributes(u, req.Request)
+		attrs := s.auth.GetRequestAttributes(info.User, req.Request)
 
 		// Authorize
 		decision, _, err := s.auth.Authorize(attrs)
 		if err != nil {
-			msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
+			msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", attrs.GetUser().GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
 			glog.Errorf(msg, err)
 			resp.WriteErrorString(http.StatusInternalServerError, msg)
 			return
 		}
 		if decision != authorizer.DecisionAllow {
-			msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", u.GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
+			msg := fmt.Sprintf("Forbidden (user=%s, verb=%s, resource=%s, subresource=%s)", attrs.GetUser().GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
 			glog.V(2).Info(msg)
 			resp.WriteErrorString(http.StatusForbidden, msg)
 			return

--- a/vendor/k8s.io/kubernetes/pkg/registry/authentication/tokenreview/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/authentication/tokenreview/storage.go
@@ -68,19 +68,23 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	fakeReq := &http.Request{Header: http.Header{}}
 	fakeReq.Header.Add("Authorization", "Bearer "+tokenReview.Spec.Token)
 
-	tokenUser, ok, err := r.tokenAuthenticator.AuthenticateRequest(fakeReq)
+	resp, ok, err := r.tokenAuthenticator.AuthenticateRequest(fakeReq)
 	tokenReview.Status.Authenticated = ok
 	if err != nil {
 		tokenReview.Status.Error = err.Error()
 	}
-	if tokenUser != nil {
+
+	// TODO(mikedanese): verify the response audience matches one of apiAuds if
+	// non-empty
+
+	if resp != nil && resp.User != nil {
 		tokenReview.Status.User = authentication.UserInfo{
-			Username: tokenUser.GetName(),
-			UID:      tokenUser.GetUID(),
-			Groups:   tokenUser.GetGroups(),
+			Username: resp.User.GetName(),
+			UID:      resp.User.GetUID(),
+			Groups:   resp.User.GetGroups(),
 			Extra:    map[string]authentication.ExtraValue{},
 		}
-		for k, v := range tokenUser.GetExtra() {
+		for k, v := range resp.User.GetExtra() {
 			tokenReview.Status.User.Extra[k] = authentication.ExtraValue(v)
 		}
 	}

--- a/vendor/k8s.io/kubernetes/pkg/serviceaccount/claims.go
+++ b/vendor/k8s.io/kubernetes/pkg/serviceaccount/claims.go
@@ -22,10 +22,10 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"gopkg.in/square/go-jose.v2/jwt"
+
 	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/kubernetes/pkg/apis/core"
-
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // time.Now stubbed out to allow testing

--- a/vendor/k8s.io/kubernetes/pkg/serviceaccount/claims_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/serviceaccount/claims_test.go
@@ -22,10 +22,10 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/square/go-jose.v2/jwt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
-
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func init() {

--- a/vendor/k8s.io/kubernetes/pkg/serviceaccount/jwt.go
+++ b/vendor/k8s.io/kubernetes/pkg/serviceaccount/jwt.go
@@ -17,6 +17,7 @@ limitations under the License.
 package serviceaccount
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
@@ -25,13 +26,12 @@ import (
 	"fmt"
 	"strings"
 
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+
 	"k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
-
-	jose "gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // ServiceAccountTokenGetter defines functions to retrieve a named service account and secret
@@ -140,7 +140,7 @@ type Validator interface {
 	NewPrivateClaims() interface{}
 }
 
-func (j *jwtTokenAuthenticator) AuthenticateToken(tokenData string) (user.Info, bool, error) {
+func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData string) (*authenticator.Response, bool, error) {
 	if !j.hasCorrectIssuer(tokenData) {
 		return nil, false, nil
 	}
@@ -177,7 +177,7 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(tokenData string) (user.Info, 
 		return nil, false, err
 	}
 
-	return sa.UserInfo(), true, nil
+	return &authenticator.Response{User: sa.UserInfo()}, true, nil
 }
 
 // hasCorrectIssuer returns true if tokenData is a valid JWT in compact

--- a/vendor/k8s.io/kubernetes/pkg/serviceaccount/jwt_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/serviceaccount/jwt_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package serviceaccount_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -278,12 +279,12 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 		authenticator := serviceaccount.JWTTokenAuthenticator(serviceaccount.LegacyIssuer, tc.Keys, serviceaccount.NewLegacyValidator(tc.Client != nil, getter))
 
 		// An invalid, non-JWT token should always fail
-		if _, ok, err := authenticator.AuthenticateToken("invalid token"); err != nil || ok {
+		if _, ok, err := authenticator.AuthenticateToken(context.Background(), "invalid token"); err != nil || ok {
 			t.Errorf("%s: Expected err=nil, ok=false for non-JWT token", k)
 			continue
 		}
 
-		user, ok, err := authenticator.AuthenticateToken(tc.Token)
+		resp, ok, err := authenticator.AuthenticateToken(context.Background(), tc.Token)
 		if (err != nil) != tc.ExpectedErr {
 			t.Errorf("%s: Expected error=%v, got %v", k, tc.ExpectedErr, err)
 			continue
@@ -298,16 +299,16 @@ func TestTokenGenerateAndValidate(t *testing.T) {
 			continue
 		}
 
-		if user.GetName() != tc.ExpectedUserName {
-			t.Errorf("%s: Expected username=%v, got %v", k, tc.ExpectedUserName, user.GetName())
+		if resp.User.GetName() != tc.ExpectedUserName {
+			t.Errorf("%s: Expected username=%v, got %v", k, tc.ExpectedUserName, resp.User.GetName())
 			continue
 		}
-		if user.GetUID() != tc.ExpectedUserUID {
-			t.Errorf("%s: Expected userUID=%v, got %v", k, tc.ExpectedUserUID, user.GetUID())
+		if resp.User.GetUID() != tc.ExpectedUserUID {
+			t.Errorf("%s: Expected userUID=%v, got %v", k, tc.ExpectedUserUID, resp.User.GetUID())
 			continue
 		}
-		if !reflect.DeepEqual(user.GetGroups(), tc.ExpectedGroups) {
-			t.Errorf("%s: Expected groups=%v, got %v", k, tc.ExpectedGroups, user.GetGroups())
+		if !reflect.DeepEqual(resp.User.GetGroups(), tc.ExpectedGroups) {
+			t.Errorf("%s: Expected groups=%v, got %v", k, tc.ExpectedGroups, resp.User.GetGroups())
 			continue
 		}
 	}

--- a/vendor/k8s.io/kubernetes/pkg/serviceaccount/legacy.go
+++ b/vendor/k8s.io/kubernetes/pkg/serviceaccount/legacy.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/api/core/v1"
-	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
-
 	"github.com/golang/glog"
 	"gopkg.in/square/go-jose.v2/jwt"
+
+	"k8s.io/api/core/v1"
+	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 )
 
 func LegacyClaims(serviceAccount v1.ServiceAccount, secret v1.Secret) (*jwt.Claims, interface{}) {

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap/BUILD
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//pkg/client/listers/core/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/client-go/tools/bootstrap/token/api:go_default_library",
         "//staging/src/k8s.io/client-go/tools/bootstrap/token/util:go_default_library",

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ Package bootstrap provides a token authenticator for TLS bootstrap secrets.
 package bootstrap
 
 import (
+	"context"
 	"crypto/subtle"
 	"fmt"
 	"regexp"
@@ -30,6 +31,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	bootstrapapi "k8s.io/client-go/tools/bootstrap/token/api"
 	bootstraputil "k8s.io/client-go/tools/bootstrap/token/util"
@@ -89,7 +91,7 @@ func tokenErrorf(s *api.Secret, format string, i ...interface{}) {
 //
 //     ( token-id ).( token-secret )
 //
-func (t *TokenAuthenticator) AuthenticateToken(token string) (user.Info, bool, error) {
+func (t *TokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 	tokenID, tokenSecret, err := parseToken(token)
 	if err != nil {
 		// Token isn't of the correct form, ignore it.
@@ -144,9 +146,11 @@ func (t *TokenAuthenticator) AuthenticateToken(token string) (user.Info, bool, e
 		return nil, false, nil
 	}
 
-	return &user.DefaultInfo{
-		Name:   bootstrapapi.BootstrapUserPrefix + string(id),
-		Groups: groups,
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   bootstrapapi.BootstrapUserPrefix + string(id),
+			Groups: groups,
+		},
 	}, true, nil
 }
 

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package bootstrap
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -262,7 +263,7 @@ func TestTokenAuthenticator(t *testing.T) {
 	for _, test := range tests {
 		func() {
 			a := NewTokenAuthenticator(&lister{test.secrets})
-			u, found, err := a.AuthenticateToken(test.token)
+			resp, found, err := a.AuthenticateToken(context.Background(), test.token)
 			if err != nil {
 				t.Errorf("test %q returned an error: %v", test.name, err)
 				return
@@ -280,8 +281,7 @@ func TestTokenAuthenticator(t *testing.T) {
 				return
 			}
 
-			gotUser := u.(*user.DefaultInfo)
-
+			gotUser := resp.User.(*user.DefaultInfo)
 			if !reflect.DeepEqual(gotUser, test.wantUser) {
 				t.Errorf("test %q want user=%#v, got=%#v", test.name, test.wantUser, gotUser)
 			}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/BUILD
@@ -7,7 +7,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["interfaces.go"],
+    srcs = [
+        "helpers.go",
+        "interfaces.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/authenticator",
     importpath = "k8s.io/apiserver/pkg/authentication/authenticator",
     deps = ["//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library"],

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/helpers.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/helpers.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authenticator
+
+// Audiences is a container for the Audiences of a token.
+type Audiences []string

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
@@ -17,52 +17,64 @@ limitations under the License.
 package authenticator
 
 import (
+	"context"
 	"net/http"
 
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-// Token checks a string value against a backing authentication store and returns
-// information about the current user and true if successful, false if not successful,
-// or an error if the token could not be checked.
+// Token checks a string value against a backing authentication store and
+// returns a Response or an error if the token could not be checked.
 type Token interface {
-	AuthenticateToken(token string) (user.Info, bool, error)
+	AuthenticateToken(ctx context.Context, token string) (*Response, bool, error)
 }
 
-// Request attempts to extract authentication information from a request and returns
-// information about the current user and true if successful, false if not successful,
-// or an error if the request could not be checked.
+// Request attempts to extract authentication information from a request and
+// returns a Response or an error if the request could not be checked.
 type Request interface {
-	AuthenticateRequest(req *http.Request) (user.Info, bool, error)
+	AuthenticateRequest(req *http.Request) (*Response, bool, error)
 }
 
-// Password checks a username and password against a backing authentication store and
-// returns information about the user and true if successful, false if not successful,
-// or an error if the username and password could not be checked
+// Password checks a username and password against a backing authentication
+// store and returns a Response or an error if the password could not be
+// checked.
 type Password interface {
-	AuthenticatePassword(user, password string) (user.Info, bool, error)
+	AuthenticatePassword(ctx context.Context, user, password string) (*Response, bool, error)
 }
 
 // TokenFunc is a function that implements the Token interface.
-type TokenFunc func(token string) (user.Info, bool, error)
+type TokenFunc func(ctx context.Context, token string) (*Response, bool, error)
 
 // AuthenticateToken implements authenticator.Token.
-func (f TokenFunc) AuthenticateToken(token string) (user.Info, bool, error) {
-	return f(token)
+func (f TokenFunc) AuthenticateToken(ctx context.Context, token string) (*Response, bool, error) {
+	return f(ctx, token)
 }
 
 // RequestFunc is a function that implements the Request interface.
-type RequestFunc func(req *http.Request) (user.Info, bool, error)
+type RequestFunc func(req *http.Request) (*Response, bool, error)
 
 // AuthenticateRequest implements authenticator.Request.
-func (f RequestFunc) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (f RequestFunc) AuthenticateRequest(req *http.Request) (*Response, bool, error) {
 	return f(req)
 }
 
 // PasswordFunc is a function that implements the Password interface.
-type PasswordFunc func(user, password string) (user.Info, bool, error)
+type PasswordFunc func(ctx context.Context, user, password string) (*Response, bool, error)
 
 // AuthenticatePassword implements authenticator.Password.
-func (f PasswordFunc) AuthenticatePassword(user, password string) (user.Info, bool, error) {
-	return f(user, password)
+func (f PasswordFunc) AuthenticatePassword(ctx context.Context, user, password string) (*Response, bool, error) {
+	return f(ctx, user, password)
+}
+
+// Response is the struct returned by authenticator interfaces upon successful
+// authentication. It contains information about whether the authenticator
+// authenticated the request, information about the context of the
+// authentication, and information about the authenticated user.
+type Response struct {
+	// Audiences is the set of audiences the authenticator was able to validate
+	// the token against. If the authenticator is not audience aware, this field
+	// will be empty.
+	Audiences Audiences
+	// User is the UserInfo associated with the authentication context.
+	User user.Info
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
@@ -36,25 +36,26 @@ func NewAuthenticatedGroupAdder(auth authenticator.Request) authenticator.Reques
 	return &AuthenticatedGroupAdder{auth}
 }
 
-func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	u, ok, err := g.Authenticator.AuthenticateRequest(req)
+func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	r, ok, err := g.Authenticator.AuthenticateRequest(req)
 	if err != nil || !ok {
 		return nil, ok, err
 	}
 
-	if u.GetName() == user.Anonymous {
-		return u, true, nil
+	if r.User.GetName() == user.Anonymous {
+		return r, true, nil
 	}
-	for _, group := range u.GetGroups() {
+	for _, group := range r.User.GetGroups() {
 		if group == user.AllAuthenticated || group == user.AllUnauthenticated {
-			return u, true, nil
+			return r, true, nil
 		}
 	}
 
-	return &user.DefaultInfo{
-		Name:   u.GetName(),
-		UID:    u.GetUID(),
-		Groups: append(u.GetGroups(), user.AllAuthenticated),
-		Extra:  u.GetExtra(),
-	}, true, nil
+	r.User = &user.DefaultInfo{
+		Name:   r.User.GetName(),
+		UID:    r.User.GetUID(),
+		Groups: append(r.User.GetGroups(), user.AllAuthenticated),
+		Extra:  r.User.GetExtra(),
+	}
+	return r, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
@@ -36,15 +36,16 @@ func NewGroupAdder(auth authenticator.Request, groups []string) authenticator.Re
 	return &GroupAdder{auth, groups}
 }
 
-func (g *GroupAdder) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	u, ok, err := g.Authenticator.AuthenticateRequest(req)
+func (g *GroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	r, ok, err := g.Authenticator.AuthenticateRequest(req)
 	if err != nil || !ok {
 		return nil, ok, err
 	}
-	return &user.DefaultInfo{
-		Name:   u.GetName(),
-		UID:    u.GetUID(),
-		Groups: append(u.GetGroups(), g.Groups...),
-		Extra:  u.GetExtra(),
-	}, true, nil
+	r.User = &user.DefaultInfo{
+		Name:   r.User.GetName(),
+		UID:    r.User.GetUID(),
+		Groups: append(r.User.GetGroups(), g.Groups...),
+		Extra:  r.User.GetExtra(),
+	}
+	return r, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
@@ -28,16 +28,16 @@ import (
 func TestGroupAdder(t *testing.T) {
 	adder := authenticator.Request(
 		NewGroupAdder(
-			authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
-				return &user.DefaultInfo{Name: "user", Groups: []string{"original"}}, true, nil
+			authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				return &authenticator.Response{User: &user.DefaultInfo{Name: "user", Groups: []string{"original"}}}, true, nil
 			}),
 			[]string{"added"},
 		),
 	)
 
-	user, _, _ := adder.AuthenticateRequest(nil)
-	if !reflect.DeepEqual(user.GetGroups(), []string{"original", "added"}) {
-		t.Errorf("Expected original,added groups, got %#v", user.GetGroups())
+	r, _, _ := adder.AuthenticateRequest(nil)
+	if want := []string{"original", "added"}; !reflect.DeepEqual(r.User.GetGroups(), want) {
+		t.Errorf("Unexpected groups\ngot:\t%#v\nwant:\t%#v", r.User.GetGroups(), want)
 	}
 }
 
@@ -96,15 +96,15 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 	for _, test := range tests {
 		adder := authenticator.Request(
 			NewAuthenticatedGroupAdder(
-				authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
-					return test.inputUser, true, nil
+				authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+					return &authenticator.Response{User: test.inputUser}, true, nil
 				}),
 			),
 		)
 
-		user, _, _ := adder.AuthenticateRequest(nil)
-		if !reflect.DeepEqual(user, test.expectedUser) {
-			t.Errorf("got %#v", user)
+		r, _, _ := adder.AuthenticateRequest(nil)
+		if !reflect.DeepEqual(r.User, test.expectedUser) {
+			t.Errorf("Unexpected user\ngot:\t%#v\nwant:\t%#v", r.User, test.expectedUser)
 		}
 	}
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder.go
@@ -17,6 +17,8 @@ limitations under the License.
 package group
 
 import (
+	"context"
+
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -34,15 +36,16 @@ func NewTokenGroupAdder(auth authenticator.Token, groups []string) authenticator
 	return &TokenGroupAdder{auth, groups}
 }
 
-func (g *TokenGroupAdder) AuthenticateToken(token string) (user.Info, bool, error) {
-	u, ok, err := g.Authenticator.AuthenticateToken(token)
+func (g *TokenGroupAdder) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+	r, ok, err := g.Authenticator.AuthenticateToken(ctx, token)
 	if err != nil || !ok {
 		return nil, ok, err
 	}
-	return &user.DefaultInfo{
-		Name:   u.GetName(),
-		UID:    u.GetUID(),
-		Groups: append(u.GetGroups(), g.Groups...),
-		Extra:  u.GetExtra(),
-	}, true, nil
+	r.User = &user.DefaultInfo{
+		Name:   r.User.GetName(),
+		UID:    r.User.GetUID(),
+		Groups: append(r.User.GetGroups(), g.Groups...),
+		Extra:  r.User.GetExtra(),
+	}
+	return r, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package group
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -27,15 +28,15 @@ import (
 func TestTokenGroupAdder(t *testing.T) {
 	adder := authenticator.Token(
 		NewTokenGroupAdder(
-			authenticator.TokenFunc(func(token string) (user.Info, bool, error) {
-				return &user.DefaultInfo{Name: "user", Groups: []string{"original"}}, true, nil
+			authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+				return &authenticator.Response{User: &user.DefaultInfo{Name: "user", Groups: []string{"original"}}}, true, nil
 			}),
 			[]string{"added"},
 		),
 	)
 
-	user, _, _ := adder.AuthenticateToken("")
-	if !reflect.DeepEqual(user.GetGroups(), []string{"original", "added"}) {
-		t.Errorf("Expected original,added groups, got %#v", user.GetGroups())
+	r, _, _ := adder.AuthenticateToken(context.Background(), "")
+	if !reflect.DeepEqual(r.User.GetGroups(), []string{"original", "added"}) {
+		t.Errorf("Expected original,added groups, got %#v", r.User.GetGroups())
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
@@ -30,7 +30,12 @@ const (
 )
 
 func NewAuthenticator() authenticator.Request {
-	return authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
-		return &user.DefaultInfo{Name: anonymousUser, Groups: []string{unauthenticatedGroup}}, true, nil
+	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{
+			User: &user.DefaultInfo{
+				Name:   anonymousUser,
+				Groups: []string{unauthenticatedGroup},
+			},
+		}, true, nil
 	})
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous_test.go
@@ -26,17 +26,17 @@ import (
 
 func TestAnonymous(t *testing.T) {
 	var a authenticator.Request = NewAuthenticator()
-	u, ok, err := a.AuthenticateRequest(nil)
+	r, ok, err := a.AuthenticateRequest(nil)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
 	if !ok {
 		t.Fatalf("Unexpectedly unauthenticated")
 	}
-	if u.GetName() != user.Anonymous {
-		t.Fatalf("Expected username %s, got %s", user.Anonymous, u.GetName())
+	if r.User.GetName() != user.Anonymous {
+		t.Fatalf("Expected username %s, got %s", user.Anonymous, r.User.GetName())
 	}
-	if !sets.NewString(u.GetGroups()...).Equal(sets.NewString(user.AllUnauthenticated)) {
-		t.Fatalf("Expected group %s, got %v", user.AllUnauthenticated, u.GetGroups())
+	if !sets.NewString(r.User.GetGroups()...).Equal(sets.NewString(user.AllUnauthenticated)) {
+		t.Fatalf("Expected group %s, got %v", user.AllUnauthenticated, r.User.GetGroups())
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/BUILD
@@ -21,10 +21,7 @@ go_library(
     srcs = ["bearertoken.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/bearertoken",
     importpath = "k8s.io/apiserver/pkg/authentication/request/bearertoken",
-    deps = [
-        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
-    ],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library"],
 )
 
 filegroup(

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 type Authenticator struct {
@@ -35,7 +34,7 @@ func New(auth authenticator.Token) *Authenticator {
 
 var invalidToken = errors.New("invalid bearer token")
 
-func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	auth := strings.TrimSpace(req.Header.Get("Authorization"))
 	if auth == "" {
 		return nil, false, nil
@@ -52,7 +51,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 		return nil, false, nil
 	}
 
-	user, ok, err := a.auth.AuthenticateToken(token)
+	resp, ok, err := a.auth.AuthenticateToken(req.Context(), token)
 	// if we authenticated successfully, go ahead and remove the bearer token so that no one
 	// is ever tempted to use it inside of the API server
 	if ok {
@@ -64,5 +63,5 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 		err = invalidToken
 	}
 
-	return user, ok, err
+	return resp, ok, err
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -96,7 +96,7 @@ func NewSecure(clientCA string, proxyClientNames []string, nameHeaders []string,
 	return x509request.NewDynamicVerifier(dynamicVerifier.GetVerifier, headerAuthenticator, sets.NewString(proxyClientNames...)), dynamicVerifier.Run, nil
 }
 
-func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	name := headerValue(req.Header, a.nameHeaders)
 	if len(name) == 0 {
 		return nil, false, nil
@@ -117,10 +117,12 @@ func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request)
 		}
 	}
 
-	return &user.DefaultInfo{
-		Name:   name,
-		Groups: groups,
-		Extra:  extra,
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   name,
+			Groups: groups,
+			Extra:  extra,
+		},
 	}, true, nil
 }
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
@@ -186,19 +186,23 @@ func TestRequestHeader(t *testing.T) {
 	}
 
 	for k, testcase := range testcases {
-		auth, err := New(testcase.nameHeaders, testcase.groupHeaders, testcase.extraPrefixHeaders)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req := &http.Request{Header: testcase.requestHeaders}
+		t.Run(k, func(t *testing.T) {
+			auth, err := New(testcase.nameHeaders, testcase.groupHeaders, testcase.extraPrefixHeaders)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req := &http.Request{Header: testcase.requestHeaders}
 
-		user, ok, _ := auth.AuthenticateRequest(req)
-		if testcase.expectedOk != ok {
-			t.Errorf("%v: expected %v, got %v", k, testcase.expectedOk, ok)
-		}
-		if e, a := testcase.expectedUser, user; !reflect.DeepEqual(e, a) {
-			t.Errorf("%v: expected %#v, got %#v", k, e, a)
-
-		}
+			resp, ok, _ := auth.AuthenticateRequest(req)
+			if testcase.expectedOk != ok {
+				t.Errorf("%v: expected %v, got %v", k, testcase.expectedOk, ok)
+			}
+			if !ok {
+				return
+			}
+			if e, a := testcase.expectedUser, resp.User; !reflect.DeepEqual(e, a) {
+				t.Errorf("%v: expected %#v, got %#v", k, e, a)
+			}
+		})
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/union/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/union/BUILD
@@ -10,7 +10,10 @@ go_test(
     name = "go_default_test",
     srcs = ["unionauth_test.go"],
     embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+    ],
 )
 
 go_library(
@@ -21,7 +24,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/union/union.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/union/union.go
@@ -21,7 +21,6 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // unionAuthRequestHandler authenticates requests using a chain of authenticator.Requests
@@ -51,20 +50,20 @@ func NewFailOnError(authRequestHandlers ...authenticator.Request) authenticator.
 }
 
 // AuthenticateRequest authenticates the request using a chain of authenticator.Request objects.
-func (authHandler *unionAuthRequestHandler) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (authHandler *unionAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	var errlist []error
 	for _, currAuthRequestHandler := range authHandler.Handlers {
-		info, ok, err := currAuthRequestHandler.AuthenticateRequest(req)
+		resp, ok, err := currAuthRequestHandler.AuthenticateRequest(req)
 		if err != nil {
 			if authHandler.FailOnError {
-				return info, ok, err
+				return resp, ok, err
 			}
 			errlist = append(errlist, err)
 			continue
 		}
 
 		if ok {
-			return info, ok, err
+			return resp, ok, err
 		}
 	}
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/BUILD
@@ -13,7 +13,6 @@ go_library(
     importpath = "k8s.io/apiserver/pkg/authentication/request/websocket",
     deps = [
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
     ],
 )

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/protocol.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/request/websocket/protocol.go
@@ -25,7 +25,6 @@ import (
 	"unicode/utf8"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/util/wsstream"
 )
 
@@ -46,7 +45,7 @@ func NewProtocolAuthenticator(auth authenticator.Token) *ProtocolAuthenticator {
 	return &ProtocolAuthenticator{auth}
 }
 
-func (a *ProtocolAuthenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *ProtocolAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	// Only accept websocket connections
 	if !wsstream.IsWebSocketRequest(req) {
 		return nil, false, nil
@@ -91,7 +90,7 @@ func (a *ProtocolAuthenticator) AuthenticateRequest(req *http.Request) (user.Inf
 		return nil, false, nil
 	}
 
-	user, ok, err := a.auth.AuthenticateToken(token)
+	resp, ok, err := a.auth.AuthenticateToken(req.Context(), token)
 
 	// on success, remove the protocol with the token
 	if ok {
@@ -105,5 +104,5 @@ func (a *ProtocolAuthenticator) AuthenticateRequest(req *http.Request) (user.Inf
 		err = errInvalidToken
 	}
 
-	return user, ok, err
+	return resp, ok, err
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/BUILD
@@ -17,6 +17,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
     ],
 )
@@ -34,7 +35,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/cache:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_striped.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_striped.go
@@ -24,36 +24,36 @@ import (
 // split cache lookups across N striped caches
 type stripedCache struct {
 	stripeCount uint32
-	keyFunc     func(string) uint32
+	hashFunc    func(string) uint32
 	caches      []cache
 }
 
-type keyFunc func(string) uint32
+type hashFunc func(string) uint32
 type newCacheFunc func() cache
 
-func newStripedCache(stripeCount int, keyFunc keyFunc, newCacheFunc newCacheFunc) cache {
+func newStripedCache(stripeCount int, hash hashFunc, newCacheFunc newCacheFunc) cache {
 	caches := []cache{}
 	for i := 0; i < stripeCount; i++ {
 		caches = append(caches, newCacheFunc())
 	}
 	return &stripedCache{
 		stripeCount: uint32(stripeCount),
-		keyFunc:     keyFunc,
+		hashFunc:    hash,
 		caches:      caches,
 	}
 }
 
 func (c *stripedCache) get(key string) (*cacheRecord, bool) {
-	return c.caches[c.keyFunc(key)%c.stripeCount].get(key)
+	return c.caches[c.hashFunc(key)%c.stripeCount].get(key)
 }
 func (c *stripedCache) set(key string, value *cacheRecord, ttl time.Duration) {
-	c.caches[c.keyFunc(key)%c.stripeCount].set(key, value, ttl)
+	c.caches[c.hashFunc(key)%c.stripeCount].set(key, value, ttl)
 }
 func (c *stripedCache) remove(key string) {
-	c.caches[c.keyFunc(key)%c.stripeCount].remove(key)
+	c.caches[c.hashFunc(key)%c.stripeCount].remove(key)
 }
 
-func fnvKeyFunc(key string) uint32 {
+func fnvHashFunc(key string) uint32 {
 	f := fnv.New32()
 	f.Write([]byte(key))
 	return f.Sum32()

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
@@ -21,10 +21,11 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/clock"
-	"k8s.io/apiserver/pkg/authentication/user"
-
 	"github.com/pborman/uuid"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 func TestSimpleCache(t *testing.T) {
@@ -36,11 +37,11 @@ func BenchmarkSimpleCache(b *testing.B) {
 }
 
 func TestStripedCache(t *testing.T) {
-	testCache(newStripedCache(32, fnvKeyFunc, func() cache { return newSimpleCache(128, clock.RealClock{}) }), t)
+	testCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(128, clock.RealClock{}) }), t)
 }
 
 func BenchmarkStripedCache(b *testing.B) {
-	benchmarkCache(newStripedCache(32, fnvKeyFunc, func() cache { return newSimpleCache(128, clock.RealClock{}) }), b)
+	benchmarkCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(128, clock.RealClock{}) }), b)
 }
 
 func benchmarkCache(cache cache, b *testing.B) {
@@ -71,8 +72,8 @@ func testCache(cache cache, t *testing.T) {
 		t.Errorf("Expected null, false, got %#v, %v", result, ok)
 	}
 
-	record1 := &cacheRecord{user: &user.DefaultInfo{Name: "bob"}}
-	record2 := &cacheRecord{user: &user.DefaultInfo{Name: "alice"}}
+	record1 := &cacheRecord{resp: &authenticator.Response{User: &user.DefaultInfo{Name: "bob"}}}
+	record2 := &cacheRecord{resp: &authenticator.Response{User: &user.DefaultInfo{Name: "alice"}}}
 
 	// when empty, record is stored
 	cache.set("foo", record1, time.Hour)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 func TestCachedTokenAuthenticator(t *testing.T) {
@@ -34,21 +36,21 @@ func TestCachedTokenAuthenticator(t *testing.T) {
 		resultOk    bool
 		resultErr   error
 	)
-	fakeAuth := authenticator.TokenFunc(func(token string) (user.Info, bool, error) {
+	fakeAuth := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 		calledWithToken = append(calledWithToken, token)
-		return resultUsers[token], resultOk, resultErr
+		return &authenticator.Response{User: resultUsers[token]}, resultOk, resultErr
 	})
 	fakeClock := utilclock.NewFakeClock(time.Now())
 
 	a := newWithClock(fakeAuth, time.Minute, 0, fakeClock)
 
 	calledWithToken, resultUsers, resultOk, resultErr = []string{}, nil, false, nil
-	a.AuthenticateToken("bad1")
-	a.AuthenticateToken("bad2")
-	a.AuthenticateToken("bad3")
-	a.AuthenticateToken("bad1")
-	a.AuthenticateToken("bad2")
-	a.AuthenticateToken("bad3")
+	a.AuthenticateToken(context.Background(), "bad1")
+	a.AuthenticateToken(context.Background(), "bad2")
+	a.AuthenticateToken(context.Background(), "bad3")
+	a.AuthenticateToken(context.Background(), "bad1")
+	a.AuthenticateToken(context.Background(), "bad2")
+	a.AuthenticateToken(context.Background(), "bad3")
 	if !reflect.DeepEqual(calledWithToken, []string{"bad1", "bad2", "bad3", "bad1", "bad2", "bad3"}) {
 		t.Errorf("Expected failing calls to bypass cache, got %v", calledWithToken)
 	}
@@ -61,13 +63,13 @@ func TestCachedTokenAuthenticator(t *testing.T) {
 	resultUsers["usertoken3"] = &user.DefaultInfo{Name: "user3"}
 
 	// populate cache
-	if user, ok, err := a.AuthenticateToken("usertoken1"); err != nil || !ok || user.GetName() != "user1" {
+	if resp, ok, err := a.AuthenticateToken(context.Background(), "usertoken1"); err != nil || !ok || resp.User.GetName() != "user1" {
 		t.Errorf("Expected user1")
 	}
-	if user, ok, err := a.AuthenticateToken("usertoken2"); err != nil || !ok || user.GetName() != "user2" {
+	if resp, ok, err := a.AuthenticateToken(context.Background(), "usertoken2"); err != nil || !ok || resp.User.GetName() != "user2" {
 		t.Errorf("Expected user2")
 	}
-	if user, ok, err := a.AuthenticateToken("usertoken3"); err != nil || !ok || user.GetName() != "user3" {
+	if resp, ok, err := a.AuthenticateToken(context.Background(), "usertoken3"); err != nil || !ok || resp.User.GetName() != "user3" {
 		t.Errorf("Expected user3")
 	}
 	if !reflect.DeepEqual(calledWithToken, []string{"usertoken1", "usertoken2", "usertoken3"}) {
@@ -79,13 +81,13 @@ func TestCachedTokenAuthenticator(t *testing.T) {
 	resultUsers, resultOk, resultErr = nil, false, nil
 
 	// authenticate calls still succeed and backend is not hit
-	if user, ok, err := a.AuthenticateToken("usertoken1"); err != nil || !ok || user.GetName() != "user1" {
+	if resp, ok, err := a.AuthenticateToken(context.Background(), "usertoken1"); err != nil || !ok || resp.User.GetName() != "user1" {
 		t.Errorf("Expected user1")
 	}
-	if user, ok, err := a.AuthenticateToken("usertoken2"); err != nil || !ok || user.GetName() != "user2" {
+	if resp, ok, err := a.AuthenticateToken(context.Background(), "usertoken2"); err != nil || !ok || resp.User.GetName() != "user2" {
 		t.Errorf("Expected user2")
 	}
-	if user, ok, err := a.AuthenticateToken("usertoken3"); err != nil || !ok || user.GetName() != "user3" {
+	if resp, ok, err := a.AuthenticateToken(context.Background(), "usertoken3"); err != nil || !ok || resp.User.GetName() != "user3" {
 		t.Errorf("Expected user3")
 	}
 	if !reflect.DeepEqual(calledWithToken, []string{}) {
@@ -96,10 +98,31 @@ func TestCachedTokenAuthenticator(t *testing.T) {
 	fakeClock.Step(2 * time.Minute)
 
 	// backend is consulted again and fails
-	a.AuthenticateToken("usertoken1")
-	a.AuthenticateToken("usertoken2")
-	a.AuthenticateToken("usertoken3")
+	a.AuthenticateToken(context.Background(), "usertoken1")
+	a.AuthenticateToken(context.Background(), "usertoken2")
+	a.AuthenticateToken(context.Background(), "usertoken3")
 	if !reflect.DeepEqual(calledWithToken, []string{"usertoken1", "usertoken2", "usertoken3"}) {
 		t.Errorf("Expected token calls, got %v", calledWithToken)
+	}
+}
+
+func TestCachedTokenAuthenticatorWithAudiences(t *testing.T) {
+	resultUsers := make(map[string]user.Info)
+	fakeAuth := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+		auds, _ := request.AudiencesFrom(ctx)
+		return &authenticator.Response{User: resultUsers[auds[0]+token]}, true, nil
+	})
+	fakeClock := utilclock.NewFakeClock(time.Now())
+
+	a := newWithClock(fakeAuth, time.Minute, 0, fakeClock)
+
+	resultUsers["audAusertoken1"] = &user.DefaultInfo{Name: "user1"}
+	resultUsers["audBusertoken1"] = &user.DefaultInfo{Name: "user1-different"}
+
+	if u, ok, _ := a.AuthenticateToken(request.WithAudiences(context.Background(), []string{"audA"}), "usertoken1"); !ok || u.User.GetName() != "user1" {
+		t.Errorf("Expected user1")
+	}
+	if u, ok, _ := a.AuthenticateToken(request.WithAudiences(context.Background(), []string{"audB"}), "usertoken1"); !ok || u.User.GetName() != "user1-different" {
+		t.Errorf("Expected user1-different")
 	}
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/BUILD
@@ -19,6 +19,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/token/tokenfile",
     importpath = "k8s.io/apiserver/pkg/authentication/token/tokenfile",
     deps = [
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tokenfile
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -88,10 +90,10 @@ func NewCSV(path string) (*TokenAuthenticator, error) {
 	}, nil
 }
 
-func (a *TokenAuthenticator) AuthenticateToken(value string) (user.Info, bool, error) {
+func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, error) {
 	user, ok := a.tokens[value]
 	if !ok {
 		return nil, false, nil
 	}
-	return user, true, nil
+	return &authenticator.Response{User: user}, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tokenfile
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -85,13 +86,13 @@ token7,user7,uid7,"group1,group2",otherdata
 		},
 	}
 	for i, testCase := range testCases {
-		user, ok, err := auth.AuthenticateToken(testCase.Token)
+		resp, ok, err := auth.AuthenticateToken(context.Background(), testCase.Token)
 		if testCase.User == nil {
-			if user != nil {
-				t.Errorf("%d: unexpected non-nil user %#v", i, user)
+			if resp != nil {
+				t.Errorf("%d: unexpected non-nil user %#v", i, resp.User)
 			}
-		} else if !reflect.DeepEqual(testCase.User, user) {
-			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, user)
+		} else if !reflect.DeepEqual(testCase.User, resp.User) {
+			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, resp.User)
 		}
 
 		if testCase.Ok != ok {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/union/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/union/BUILD
@@ -10,7 +10,10 @@ go_test(
     name = "go_default_test",
     srcs = ["unionauth_test.go"],
     embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+    ],
 )
 
 go_library(
@@ -21,7 +24,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
     ],
 )
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/union/union.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/authentication/token/union/union.go
@@ -17,9 +17,10 @@ limitations under the License.
 package union
 
 import (
+	"context"
+
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // unionAuthTokenHandler authenticates tokens using a chain of authenticator.Token objects
@@ -49,10 +50,10 @@ func NewFailOnError(authTokenHandlers ...authenticator.Token) authenticator.Toke
 }
 
 // AuthenticateToken authenticates the token using a chain of authenticator.Token objects.
-func (authHandler *unionAuthTokenHandler) AuthenticateToken(token string) (user.Info, bool, error) {
+func (authHandler *unionAuthTokenHandler) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 	var errlist []error
 	for _, currAuthRequestHandler := range authHandler.Handlers {
-		info, ok, err := currAuthRequestHandler.AuthenticateToken(token)
+		info, ok, err := currAuthRequestHandler.AuthenticateToken(ctx, token)
 		if err != nil {
 			if authHandler.FailOnError {
 				return info, ok, err

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -56,7 +56,10 @@ func WithAuthentication(handler http.Handler, auth authenticator.Request, failed
 		return handler
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		user, ok, err := auth.AuthenticateRequest(req)
+		if len(apiAuds) > 0 {
+			req = req.WithContext(genericapirequest.WithAudiences(req.Context(), apiAuds))
+		}
+		resp, ok, err := auth.AuthenticateRequest(req)
 		if err != nil || !ok {
 			if err != nil {
 				glog.Errorf("Unable to authenticate the request due to an error: %v", err)
@@ -65,12 +68,15 @@ func WithAuthentication(handler http.Handler, auth authenticator.Request, failed
 			return
 		}
 
+		// TODO(mikedanese): verify the response audience matches one of apiAuds if
+		// non-empty
+
 		// authorization header is not required anymore in case of a successful authentication.
 		req.Header.Del("Authorization")
 
-		req = req.WithContext(genericapirequest.WithUser(req.Context(), user))
+		req = req.WithContext(genericapirequest.WithUser(req.Context(), resp.User))
 
-		authenticatedUserCounter.WithLabelValues(compressUsername(user.GetName())).Inc()
+		authenticatedUserCounter.WithLabelValues(compressUsername(resp.User.GetName())).Inc()
 
 		handler.ServeHTTP(w, req)
 	})

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -50,7 +50,7 @@ func init() {
 // stores any such user found onto the provided context for the request. If authentication fails or returns an error
 // the failed handler is used. On success, "Authorization" header is removed from the request and handler
 // is invoked to serve the request.
-func WithAuthentication(handler http.Handler, auth authenticator.Request, failed http.Handler) http.Handler {
+func WithAuthentication(handler http.Handler, auth authenticator.Request, failed http.Handler, apiAuds authenticator.Audiences) http.Handler {
 	if auth == nil {
 		glog.Warningf("Authentication is disabled")
 		return handler

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -50,6 +50,7 @@ func TestAuthenticateRequest(t *testing.T) {
 		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			t.Errorf("unexpected call to failed")
 		}),
+		nil,
 	)
 
 	auth.ServeHTTP(httptest.NewRecorder(), &http.Request{Header: map[string][]string{"Authorization": {"Something"}}})
@@ -69,6 +70,7 @@ func TestAuthenticateRequestFailed(t *testing.T) {
 		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			close(failed)
 		}),
+		nil,
 	)
 
 	auth.ServeHTTP(httptest.NewRecorder(), &http.Request{})
@@ -88,6 +90,7 @@ func TestAuthenticateRequestError(t *testing.T) {
 		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 			close(failed)
 		}),
+		nil,
 	)
 
 	auth.ServeHTTP(httptest.NewRecorder(), &http.Request{})

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -41,9 +41,9 @@ func TestAuthenticateRequest(t *testing.T) {
 			}
 			close(success)
 		}),
-		authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
+		authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 			if req.Header.Get("Authorization") == "Something" {
-				return &user.DefaultInfo{Name: "user"}, true, nil
+				return &authenticator.Response{User: &user.DefaultInfo{Name: "user"}}, true, nil
 			}
 			return nil, false, errors.New("Authorization header is missing.")
 		}),
@@ -63,7 +63,7 @@ func TestAuthenticateRequestFailed(t *testing.T) {
 		http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 			t.Errorf("unexpected call to handler")
 		}),
-		authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
+		authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 			return nil, false, nil
 		}),
 		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -82,7 +82,7 @@ func TestAuthenticateRequestError(t *testing.T) {
 		http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 			t.Errorf("unexpected call to handler")
 		}),
-		authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
+		authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 			return nil, false, errors.New("failure")
 		}),
 		http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/request/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/request/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -36,6 +37,9 @@ const (
 
 	// auditKey is the context key for the audit event.
 	auditKey
+
+	// audiencesKey is the context key for request audiences.
+	audiencesKey
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -90,4 +94,15 @@ func WithAuditEvent(parent context.Context, ev *audit.Event) context.Context {
 func AuditEventFrom(ctx context.Context) *audit.Event {
 	ev, _ := ctx.Value(auditKey).(*audit.Event)
 	return ev
+}
+
+// WithAudiences returns a context that stores a request's expected audiences.
+func WithAudiences(ctx context.Context, auds authenticator.Audiences) context.Context {
+	return context.WithValue(ctx, audiencesKey, auds)
+}
+
+// AudiencesFrom returns a request's expected audiences stored in the request context.
+func AudiencesFrom(ctx context.Context) (authenticator.Audiences, bool) {
+	auds, ok := ctx.Value(audiencesKey).(authenticator.Audiences)
+	return auds, ok
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -237,6 +237,9 @@ type SecureServingInfo struct {
 }
 
 type AuthenticationInfo struct {
+	// APIAudiences is a list of identifier that the API identifies as. This is
+	// used by some authenticators to validate audience bound credentials.
+	APIAudiences authenticator.Audiences
 	// Authenticator determines which subject is making the request
 	Authenticator authenticator.Request
 	// SupportsBasicAuth indicates that's at least one Authenticator supports basic auth
@@ -582,7 +585,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyChecker, c.LongRunningFunc)
 	failedHandler := genericapifilters.Unauthorized(c.Serializer, c.Authentication.SupportsBasicAuth)
 	failedHandler = genericapifilters.WithFailedAuthenticationAudit(failedHandler, c.AuditBackend, c.AuditPolicyChecker)
-	handler = genericapifilters.WithAuthentication(handler, c.Authentication.Authenticator, failedHandler)
+	handler = genericapifilters.WithAuthentication(handler, c.Authentication.Authenticator, failedHandler, c.Authentication.APIAudiences)
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.LongRunningFunc, c.RequestTimeout)
 	handler = genericfilters.WithWaitGroup(handler, c.LongRunningFunc, c.HandlerChainWaitGroup)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/rest"
 )
@@ -77,9 +78,11 @@ func (s *DeprecatedInsecureServingInfo) NewLoopbackClientConfig() (*rest.Config,
 // but allows apiserver code to stop special-casing a nil user to skip authorization checks.
 type InsecureSuperuser struct{}
 
-func (InsecureSuperuser) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
-	return &user.DefaultInfo{
-		Name:   "system:unsecured",
-		Groups: []string{user.SystemPrivilegedGroup, user.AllAuthenticated},
+func (InsecureSuperuser) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   "system:unsecured",
+			Groups: []string{user.SystemPrivilegedGroup, user.AllAuthenticated},
+		},
 	}, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/BUILD
@@ -19,6 +19,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile",
     importpath = "k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile",
     deps = [
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
     ],

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go
@@ -17,6 +17,7 @@ limitations under the License.
 package passwordfile
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -78,7 +80,7 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 	return &PasswordAuthenticator{users}, nil
 }
 
-func (a *PasswordAuthenticator) AuthenticatePassword(username, password string) (user.Info, bool, error) {
+func (a *PasswordAuthenticator) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
 	user, ok := a.users[username]
 	if !ok {
 		return nil, false, nil
@@ -86,5 +88,5 @@ func (a *PasswordAuthenticator) AuthenticatePassword(username, password string) 
 	if user.password != password {
 		return nil, false, nil
 	}
-	return user.info, true, nil
+	return &authenticator.Response{User: user.info}, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package passwordfile
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -110,16 +111,16 @@ password7,user7,uid7,"group1,group2",otherdata
 		},
 	}
 	for i, testCase := range testCases {
-		user, ok, err := auth.AuthenticatePassword(testCase.Username, testCase.Password)
+		resp, ok, err := auth.AuthenticatePassword(context.Background(), testCase.Username, testCase.Password)
 		if err != nil {
 			t.Errorf("%d: unexpected error: %v", i, err)
 		}
 		if testCase.User == nil {
-			if user != nil {
-				t.Errorf("%d: unexpected non-nil user %#v", i, user)
+			if resp != nil {
+				t.Errorf("%d: unexpected non-nil user %#v", i, resp.User)
 			}
-		} else if !reflect.DeepEqual(testCase.User, user) {
-			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, user)
+		} else if !reflect.DeepEqual(testCase.User, resp.User) {
+			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, resp.User)
 		}
 		if testCase.Ok != ok {
 			t.Errorf("%d: expected auth %v, got %v", i, testCase.Ok, ok)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/BUILD
@@ -21,10 +21,7 @@ go_library(
     srcs = ["basicauth.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth",
     importpath = "k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth",
-    deps = [
-        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
-    ],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library"],
 )
 
 filegroup(

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // Authenticator authenticates requests using basic auth
@@ -37,18 +36,18 @@ func New(auth authenticator.Password) *Authenticator {
 var errInvalidAuth = errors.New("invalid username/password combination")
 
 // AuthenticateRequest authenticates the request using the "Authorization: Basic" header in the request
-func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	username, password, found := req.BasicAuth()
 	if !found {
 		return nil, false, nil
 	}
 
-	user, ok, err := a.auth.AuthenticatePassword(username, password)
+	resp, ok, err := a.auth.AuthenticatePassword(req.Context(), username, password)
 
 	// If the password authenticator didn't error, provide a default error
 	if !ok && err == nil {
 		err = errInvalidAuth
 	}
 
-	return user, ok, err
+	return resp, ok, err
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package basicauth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -35,11 +36,11 @@ type testPassword struct {
 	Err  error
 }
 
-func (t *testPassword) AuthenticatePassword(user, password string) (user.Info, bool, error) {
+func (t *testPassword) AuthenticatePassword(ctx context.Context, user, password string) (*authenticator.Response, bool, error) {
 	t.Called = true
 	t.Username = user
 	t.Password = password
-	return t.User, t.OK, t.Err
+	return &authenticator.Response{User: t.User}, t.OK, t.Err
 }
 
 func TestBasicAuth(t *testing.T) {
@@ -94,7 +95,7 @@ func TestBasicAuth(t *testing.T) {
 			req.SetBasicAuth(testCase.ExpectedUsername, testCase.ExpectedPassword)
 		}
 
-		user, ok, err := auth.AuthenticateRequest(req)
+		resp, ok, err := auth.AuthenticateRequest(req)
 
 		if testCase.ExpectedCalled != password.Called {
 			t.Errorf("%s: Expected called=%v, got %v", k, testCase.ExpectedCalled, password.Called)
@@ -117,8 +118,8 @@ func TestBasicAuth(t *testing.T) {
 			t.Errorf("%s: Expected ok=%v, got ok=%v", k, testCase.ExpectedOK, ok)
 			continue
 		}
-		if testCase.ExpectedUser != "" && testCase.ExpectedUser != user.GetName() {
-			t.Errorf("%s: Expected user.GetName()=%v, got %v", k, testCase.ExpectedUser, user.GetName())
+		if testCase.ExpectedUser != "" && testCase.ExpectedUser != resp.User.GetName() {
+			t.Errorf("%s: Expected user.GetName()=%v, got %v", k, testCase.ExpectedUser, resp.User.GetName())
 			continue
 		}
 	}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/BUILD
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/github.com/coreos/go-oidc:go_default_library",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -44,8 +44,10 @@ import (
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	certutil "k8s.io/client-go/util/cert"
 )
@@ -523,7 +525,7 @@ func (r *claimResolver) resolve(endpoint endpoint, allClaims claims) error {
 	return nil
 }
 
-func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error) {
+func (a *Authenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 	if !hasCorrectIssuer(a.issuerURL, token) {
 		return nil, false, nil
 	}
@@ -533,7 +535,6 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 		return nil, false, fmt.Errorf("oidc: authenticator not initialized")
 	}
 
-	ctx := context.Background()
 	idToken, err := verifier.Verify(ctx, token)
 	if err != nil {
 		return nil, false, fmt.Errorf("oidc: verify token: %v", err)
@@ -611,7 +612,7 @@ func (a *Authenticator) AuthenticateToken(token string) (user.Info, bool, error)
 		}
 	}
 
-	return info, true, nil
+	return &authenticator.Response{User: info}, true, nil
 }
 
 // getClaimJWT gets a distributed claim JWT from url, using the supplied access

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -296,7 +296,8 @@ func (c *claimsTest) run(t *testing.T) {
 		t.Fatalf("serialize token: %v", err)
 	}
 
-	got, ok, err := a.AuthenticateToken(token)
+	got, ok, err := a.AuthenticateToken(context.Background(), token)
+
 	if err != nil {
 		if !c.wantErr {
 			t.Fatalf("authenticate token: %v", err)
@@ -318,7 +319,7 @@ func (c *claimsTest) run(t *testing.T) {
 		t.Fatalf("expected authenticator to skip token")
 	}
 
-	gotUser := got.(*user.DefaultInfo)
+	gotUser := got.User.(*user.DefaultInfo)
 	if !reflect.DeepEqual(gotUser, c.want) {
 		t.Fatalf("wanted user=%#v, got=%#v", c.want, gotUser)
 	}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/BUILD
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/BUILD
@@ -10,7 +10,10 @@ go_library(
     srcs = ["tokentest.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest",
     importpath = "k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest",
-    deps = ["//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+    ],
 )
 
 filegroup(

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/tokentest.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/tokentest.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package tokentest
 
-import "k8s.io/apiserver/pkg/authentication/user"
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
 
 type TokenAuthenticator struct {
 	Tokens map[string]*user.DefaultInfo
@@ -27,10 +32,11 @@ func New() *TokenAuthenticator {
 		Tokens: make(map[string]*user.DefaultInfo),
 	}
 }
-func (a *TokenAuthenticator) AuthenticateToken(value string) (user.Info, bool, error) {
+
+func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, error) {
 	user, ok := a.Tokens[value]
 	if !ok {
 		return nil, false, nil
 	}
-	return user, true, nil
+	return &authenticator.Response{User: user}, true, nil
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -18,6 +18,7 @@ limitations under the License.
 package webhook
 
 import (
+	"context"
 	"time"
 
 	"github.com/golang/glog"
@@ -69,7 +70,7 @@ func newWithBackoff(tokenReview authenticationclient.TokenReviewInterface, ttl, 
 }
 
 // AuthenticateToken implements the authenticator.Token interface.
-func (w *WebhookTokenAuthenticator) AuthenticateToken(token string) (user.Info, bool, error) {
+func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 	r := &authentication.TokenReview{
 		Spec: authentication.TokenReviewSpec{Token: token},
 	}
@@ -104,11 +105,13 @@ func (w *WebhookTokenAuthenticator) AuthenticateToken(token string) (user.Info, 
 		}
 	}
 
-	return &user.DefaultInfo{
-		Name:   r.Status.User.Username,
-		UID:    r.Status.User.UID,
-		Groups: r.Status.User.Groups,
-		Extra:  extra,
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   r.Status.User.Username,
+			UID:    r.Status.User.UID,
+			Groups: r.Status.User.Groups,
+			Extra:  extra,
+		},
 	}, true, nil
 }
 

--- a/vendor/k8s.io/kubernetes/test/integration/auth/accessreview_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/auth/accessreview_test.go
@@ -46,9 +46,11 @@ func (sarAuthorizer) Authorize(a authorizer.Attributes) (authorizer.Decision, st
 	return authorizer.DecisionAllow, "you're not dave", nil
 }
 
-func alwaysAlice(req *http.Request) (user.Info, bool, error) {
-	return &user.DefaultInfo{
-		Name: "alice",
+func alwaysAlice(req *http.Request) (*authenticator.Response, bool, error) {
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name: "alice",
+		},
 	}, true, nil
 }
 
@@ -145,8 +147,10 @@ func TestSubjectAccessReview(t *testing.T) {
 func TestSelfSubjectAccessReview(t *testing.T) {
 	username := "alice"
 	masterConfig := framework.NewIntegrationTestMasterConfig()
-	masterConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (user.Info, bool, error) {
-		return &user.DefaultInfo{Name: username}, true, nil
+	masterConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		return &authenticator.Response{
+			User: &user.DefaultInfo{Name: username},
+		}, true, nil
 	})
 	masterConfig.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
 	_, s, closeFn := framework.RunAMaster(masterConfig)

--- a/vendor/k8s.io/kubernetes/test/integration/framework/master_utils.go
+++ b/vendor/k8s.io/kubernetes/test/integration/framework/master_utils.go
@@ -82,9 +82,11 @@ func (alwaysAllow) Authorize(requestAttributes authorizer.Attributes) (authorize
 }
 
 // alwaysEmpty simulates "no authentication" for old tests
-func alwaysEmpty(req *http.Request) (user.Info, bool, error) {
-	return &user.DefaultInfo{
-		Name: "",
+func alwaysEmpty(req *http.Request) (*authauthenticator.Response, bool, error) {
+	return &authauthenticator.Response{
+		User: &user.DefaultInfo{
+			Name: "",
+		},
 	}, true, nil
 }
 

--- a/vendor/k8s.io/kubernetes/test/integration/serviceaccount/service_account_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/serviceaccount/service_account_test.go
@@ -21,6 +21,7 @@ package serviceaccount
 // to work for any client of the HTTP interface.
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -365,9 +366,9 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	// Set up two authenticators:
 	// 1. A token authenticator that maps the rootToken to the "root" user
 	// 2. A ServiceAccountToken authenticator that validates ServiceAccount tokens
-	rootTokenAuth := authenticator.TokenFunc(func(token string) (user.Info, bool, error) {
+	rootTokenAuth := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 		if token == rootToken {
-			return &user.DefaultInfo{Name: rootUserName}, true, nil
+			return &authenticator.Response{User: &user.DefaultInfo{Name: rootUserName}}, true, nil
 		}
 		return nil, false, nil
 	})


### PR DESCRIPTION
In 1.13, the authenticator APIs changed.  This picks that change back so that we can have a small pull updating them.

/assign @enj 
@openshift/sig-auth 