### PR TITLE
[release-3.10] Clear conntrack entries for externalIPs 

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -648,6 +648,9 @@ func (proxier *Proxier) syncProxyRules() {
 		if svcInfo, ok := proxier.serviceMap[svcPortName]; ok && svcInfo != nil && svcInfo.GetProtocol() == api.ProtocolUDP {
 			glog.V(2).Infof("Stale udp service %v -> %s", svcPortName, svcInfo.ClusterIPString())
 			staleServices.Insert(svcInfo.ClusterIPString())
+			for _, extIP := range svcInfo.ExternalIPStrings() {
+				staleServices.Insert(extIP)
+			}
 		}
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -608,6 +608,12 @@ func (proxier *Proxier) deleteEndpointConnections(connectionMap []proxy.ServiceE
 			if err != nil {
 				glog.Errorf("Failed to delete %s endpoint connections, error: %v", epSvcPair.ServicePortName.String(), err)
 			}
+			for _, extIP := range svcInfo.ExternalIPStrings() {
+				err := conntrack.ClearEntriesForNAT(proxier.exec, extIP, endpointIP, v1.ProtocolUDP)
+				if err != nil {
+					glog.Errorf("Failed to delete %s endpoint connections for externalIP %s, error: %v", epSvcPair.ServicePortName.String(), extIP, err)
+				}
+			}
 		}
 	}
 }

--- a/vendor/k8s.io/kubernetes/pkg/proxy/ipvs/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/ipvs/proxier.go
@@ -1265,6 +1265,12 @@ func (proxier *Proxier) deleteEndpointConnections(connectionMap []proxy.ServiceE
 			if err != nil {
 				glog.Errorf("Failed to delete %s endpoint connections, error: %v", epSvcPair.ServicePortName.String(), err)
 			}
+			for _, extIP := range svcInfo.ExternalIPStrings() {
+				err := conntrack.ClearEntriesForNAT(proxier.exec, extIP, endpointIP, clientv1.ProtocolUDP)
+				if err != nil {
+					glog.Errorf("Failed to delete %s endpoint connections for externalIP %s, error: %v", epSvcPair.ServicePortName.String(), extIP, err)
+				}
+			}
 		}
 	}
 }

--- a/vendor/k8s.io/kubernetes/pkg/proxy/ipvs/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/ipvs/proxier.go
@@ -636,6 +636,9 @@ func (proxier *Proxier) syncProxyRules() {
 		if svcInfo, ok := proxier.serviceMap[svcPortName]; ok && svcInfo != nil && svcInfo.GetProtocol() == api.ProtocolUDP {
 			glog.V(2).Infof("Stale udp service %v -> %s", svcPortName, svcInfo.ClusterIPString())
 			staleServices.Insert(svcInfo.ClusterIPString())
+			for _, extIP := range svcInfo.ExternalIPStrings() {
+				staleServices.Insert(extIP)
+			}
 		}
 	}
 

--- a/vendor/k8s.io/kubernetes/pkg/proxy/service.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/service.go
@@ -80,6 +80,11 @@ func (info *BaseServiceInfo) GetNodePort() int {
 }
 
 
+// ExternalIPStrings is part ofServicePort interface
+func (info *BaseServiceInfo) ExternalIPStrings() []string {
+	return info.ExternalIPs
+}
+
 func (sct *ServiceChangeTracker) newBaseServiceInfo(port *api.ServicePort, service *api.Service) *BaseServiceInfo {
 	onlyNodeLocalEndpoints := false
 	if apiservice.RequestsOnlyLocalTraffic(service) {

--- a/vendor/k8s.io/kubernetes/pkg/proxy/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/types.go
@@ -50,6 +50,8 @@ type ServicePort interface {
 	String() string
 	// ClusterIPString returns service cluster IP in string format.
 	ClusterIPString() string
+	// ExternalIPStrings returns service ExternalIPs as a string array.
+	ExternalIPStrings() []string
 	// GetProtocol returns service protocol.
 	GetProtocol() api.Protocol
 	// GetHealthCheckNodePort returns service health check node port if present.  If return 0, it means not present.


### PR DESCRIPTION
This brings in two Upstream commits to clear conntrack entries for externalIP addresses

fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1632192
https://bugzilla.redhat.com/show_bug.cgi?id=1679260