### PR TITLE
Enable local storage e2e

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -334,7 +334,6 @@ var (
 			`kube-ui`,                         // Not installed by default
 			`Kubernetes Dashboard`,            // Not installed by default (also probably slow image pull)
 			`\[Feature:ServiceLoadBalancer\]`, // Not enabled yet
-			`PersistentVolumes-local`,         // Disable local storage in 4.0 for now (sig-storage/hekumar@redhat.com)
 			`\[Feature:RuntimeClass\]`,        // disable runtimeclass tests in 4.1 (sig-pod/sjenning@redhat.com)
 			`\[Feature:CustomResourceWebhookConversion\]`, // webhook conversion is off by default.  sig-master/@sttts
 


### PR DESCRIPTION
This depends on https://github.com/openshift/cluster-kube-apiserver-operator/pull/344 and https://github.com/openshift/cluster-kube-controller-manager-operator/pull/195

We are going to re-enable local storage in preparation for 4.1

