### PR TITLE
Confirm escalation is not possible via authorization to RBAC proxy

### DIFF
--- a/test/integration/authorization_rbac_proxy_test.go
+++ b/test/integration/authorization_rbac_proxy_test.go
@@ -1,13 +1,17 @@
 package integration
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	kauthorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -16,6 +20,7 @@ import (
 
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 	authorizationv1client "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
+	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -609,5 +614,267 @@ func TestLegacyLocalRoleEndpoint(t *testing.T) {
 		t.Fatalf("expected error")
 	} else if !kapierror.IsNotFound(err) {
 		t.Fatal(err)
+	}
+}
+
+// TestLegacyEndpointConfirmNoEscalation tests that the authorization proxy endpoints cannot be used to bypass
+// the RBAC escalation checks.  It also makes sure that the GR in the returned error matches authorization v1.
+func TestLegacyEndpointConfirmNoEscalation(t *testing.T) {
+	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testserver.CleanupMasterEtcd(t, masterConfig)
+
+	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := "test-project-no-escalation"
+	resourceName := "test-resource-no-escalation"
+	userName := "test-user"
+	userSubjects := []corev1.ObjectReference{
+		{
+			Kind: rbacv1.UserKind,
+			Name: userName,
+		},
+	}
+	escalationFormat := `%s %q is forbidden: user %q (groups=["system:authenticated:oauth" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:`
+	escalatingRules := []authorizationv1.PolicyRule{
+		{
+			Verbs:     []string{"hug"},
+			APIGroups: []string{"bear"},
+			Resources: []string{"pandas"},
+		},
+	}
+	nonEscalatingRules := []authorizationv1.PolicyRule{
+		{
+			Verbs:     []string{"create"},
+			APIGroups: []string{kauthorizationv1.GroupName},
+			Resources: []string{"selfsubjectaccessreviews"},
+		},
+	}
+
+	userInternalClient, userConfig, err := testserver.CreateNewProject(clusterAdminClientConfig, namespace, userName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userAuthorizationClient := authorizationv1client.NewForConfigOrDie(userConfig)
+	clusterAdminAuthorizationClient := authorizationv1client.NewForConfigOrDie(clusterAdminClientConfig)
+
+	clusterRoleName := "test-cluster-role"
+	clusterRoleObj, err := clusterAdminAuthorizationClient.ClusterRoles().Create(&authorizationv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+		Rules: []authorizationv1.PolicyRule{
+			{
+				Verbs:     []string{"get", "create", "update"},
+				APIGroups: []string{authorizationv1.GroupName, rbacv1.GroupName},
+				Resources: []string{"clusterroles", "clusterrolebindings"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := clusterAdminAuthorizationClient.ClusterRoleBindings().Create(&authorizationv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+		Subjects:   userSubjects,
+		RoleRef: corev1.ObjectReference{
+			Name: clusterRoleName,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rule := range clusterRoleObj.Rules {
+		for _, verb := range rule.Verbs {
+			for _, group := range rule.APIGroups {
+				for _, resource := range rule.Resources {
+					if err := testutil.WaitForClusterPolicyUpdate(
+						userInternalClient.Authorization(),
+						verb,
+						schema.GroupResource{Group: group, Resource: resource},
+						true,
+					); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+		}
+	}
+
+	tests := []struct {
+		name     string
+		resource string
+		run      func() error
+	}{
+		{
+			name:     "role create",
+			resource: "roles",
+			run: func() error {
+				_, err := userAuthorizationClient.Roles(namespace).Create(&authorizationv1.Role{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Rules:      escalatingRules,
+				})
+				return err
+			},
+		},
+		{
+			name:     "role update",
+			resource: "roles",
+			run: func() error {
+				role, err := userAuthorizationClient.Roles(namespace).Create(&authorizationv1.Role{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Rules:      nonEscalatingRules,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to create role: %v", err)
+				}
+
+				role.Rules = escalatingRules
+				_, err = userAuthorizationClient.Roles(namespace).Update(role)
+				return err
+			},
+		},
+		{
+			name:     "role binding create",
+			resource: "rolebindings",
+			run: func() error {
+				_, err := userAuthorizationClient.RoleBindings(namespace).Create(&authorizationv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Subjects:   userSubjects,
+					RoleRef: corev1.ObjectReference{
+						Name: bootstrappolicy.ClusterAdminRoleName,
+					},
+				})
+				return err
+			},
+		},
+		{
+			name:     "role binding update",
+			resource: "rolebindings",
+			run: func() error {
+				roleBinding, err := clusterAdminAuthorizationClient.RoleBindings(namespace).Create(&authorizationv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Subjects: []corev1.ObjectReference{
+						{
+							Kind: rbacv1.UserKind,
+							Name: "some-other-user",
+						},
+					},
+					RoleRef: corev1.ObjectReference{
+						Name: bootstrappolicy.ClusterAdminRoleName,
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to create role binding: %v", err)
+				}
+
+				roleBinding.Subjects = userSubjects
+				roleBinding.UserNames = nil // if set, this field will overwrite subjects
+				_, err = userAuthorizationClient.RoleBindings(namespace).Update(roleBinding)
+				return err
+			},
+		},
+		{
+			name:     "cluster role create",
+			resource: "clusterroles",
+			run: func() error {
+				_, err := userAuthorizationClient.ClusterRoles().Create(&authorizationv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Rules:      escalatingRules,
+				})
+				return err
+			},
+		},
+		{
+			name:     "cluster role update",
+			resource: "clusterroles",
+			run: func() error {
+				clusterRole, err := userAuthorizationClient.ClusterRoles().Create(&authorizationv1.ClusterRole{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Rules:      nonEscalatingRules,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to create cluster role: %v", err)
+				}
+
+				clusterRole.Rules = escalatingRules
+				_, err = userAuthorizationClient.ClusterRoles().Update(clusterRole)
+				return err
+			},
+		},
+		{
+			name:     "cluster role binding create",
+			resource: "clusterrolebindings",
+			run: func() error {
+				_, err := userAuthorizationClient.ClusterRoleBindings().Create(&authorizationv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Subjects:   userSubjects,
+					RoleRef: corev1.ObjectReference{
+						Name: bootstrappolicy.ClusterAdminRoleName,
+					},
+				})
+				return err
+			},
+		},
+		{
+			name:     "cluster role binding update",
+			resource: "clusterrolebindings",
+			run: func() error {
+				clusterRoleBinding, err := clusterAdminAuthorizationClient.ClusterRoleBindings().Create(&authorizationv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+					Subjects: []corev1.ObjectReference{
+						{
+							Kind: rbacv1.UserKind,
+							Name: "some-other-user",
+						},
+					},
+					RoleRef: corev1.ObjectReference{
+						Name: bootstrappolicy.ClusterAdminRoleName,
+					},
+				})
+				if err != nil {
+					return fmt.Errorf("failed to create cluster role binding: %v", err)
+				}
+
+				clusterRoleBinding.Subjects = userSubjects
+				clusterRoleBinding.UserNames = nil // if set, this field will overwrite subjects
+				_, err = userAuthorizationClient.ClusterRoleBindings().Update(clusterRoleBinding)
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+
+			if err == nil {
+				t.Fatal("got nil instead of escalation error")
+			}
+
+			if !kapierror.IsForbidden(err) {
+				t.Fatalf("expected forbidden error, got: %v", err)
+			}
+
+			details := *err.(kapierror.APIStatus).Status().Details
+
+			if resourceName != details.Name {
+				t.Errorf("expected resource name %q got %q", resourceName, details.Name)
+			}
+
+			wantGR := authorizationv1.GroupVersion.WithResource(tt.resource).GroupResource()
+			gotGR := schema.GroupResource{Group: details.Group, Resource: details.Kind}
+			if wantGR != gotGR {
+				t.Errorf("expected group resource %s got %s", wantGR, gotGR)
+			}
+
+			wantErr := fmt.Sprintf(escalationFormat, wantGR.String(), resourceName, userName)
+			gotErr := err.Error()
+			if !strings.HasPrefix(gotErr, wantErr) {
+				t.Errorf("expected escalation message prefix %q got %q", wantErr, gotErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This change adds a test that exercises the authorization to RBAC proxy to make sure that escalation is not possible.  This confirms that the internal impersonation code is working.  It also checks to make sure that the group resource returned matches the authorization resource (and not the proxied RBAC resource).

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 