### PR TITLE
Fix a mistake in the label selector example of oc observe

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/observe/observe.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/observe/observe.go
@@ -162,7 +162,7 @@ var (
 	  %[1]s observe services -a '{ .spec.clusterIP }' -- register_dns.sh
 
 	  # Observe changes to services filtered by a label selector
-	  %[1]s observe namespaces -l regist-dns=true -a '{ .spec.clusterIP }' -- register_dns.sh`)
+	  %[1]s observe services -l regist-dns=true -a '{ .spec.clusterIP }' -- register_dns.sh`)
 )
 
 type ObserveOptions struct {


### PR DESCRIPTION
It should be `services`, but actually I used `namespaces` by a mistake. :bow:

/ref #22310 