### PR TITLE
minor fix in "oc get --help" text re. "list of common resources"

### DIFF
--- a/pkg/oc/cli/kubectlwrappers/wrappers.go
+++ b/pkg/oc/cli/kubectlwrappers/wrappers.go
@@ -46,7 +46,7 @@ var (
 		Display one or many resources
 
 		Possible resources include builds, buildConfigs, services, pods, etc. To see
-		a list of common resources, use '%[1]s get'. Some resources may omit advanced
+		a complete list of resources, use '%[1]s api-resources'. Some resources may omit advanced
 		details that you can see with '-o wide'.  If you want an even more detailed
 		view, use '%[1]s describe'.`)
 


### PR DESCRIPTION
because:

    $ oc get --help
    Display one or many resources 

    Possible resources include builds, buildConfigs, services, pods, etc. To see a list of common resources, use 'oc get'.

but:

    $ oc get
    You must specify the type of resource to get. Use "oc api-resources" for a complete list of supported resources.

    error: Required resource not specified.
    Use "oc explain <resource>" for a detailed description of that resource (e.g. oc explain pods).
    See 'oc get -h' for help and examples.

This brings it in line with `kubectl`:

    $ kubectl get --help
    Display one or many resources 
    (...)
    Use "kubectl api-resources" for a complete list of supported resources.