### PR TITLE
Refactor UserFor helper to ResponseFor

### DIFF
--- a/pkg/oauthserver/authenticator/identitymapper/identitymapper.go
+++ b/pkg/oauthserver/authenticator/identitymapper/identitymapper.go
@@ -3,15 +3,15 @@ package identitymapper
 import (
 	"fmt"
 
-	"k8s.io/apiserver/pkg/authentication/user"
-
 	"github.com/golang/glog"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 
 	"github.com/openshift/origin/pkg/oauthserver/api"
 )
 
-// UserFor bridges the UserIdentityMapper interface with the authenticator.{Password|Request} interfaces
-func UserFor(mapper api.UserIdentityMapper, identity api.UserIdentityInfo) (user.Info, bool, error) {
+// ResponseFor bridges the UserIdentityMapper interface with the authenticator.{Password|Request} interfaces
+func ResponseFor(mapper api.UserIdentityMapper, identity api.UserIdentityInfo) (*authenticator.Response, bool, error) {
 	user, err := mapper.UserFor(identity)
 	if err != nil {
 		logf("error creating or updating mapping for: %#v due to %v", identity, err)
@@ -19,7 +19,8 @@ func UserFor(mapper api.UserIdentityMapper, identity api.UserIdentityInfo) (user
 	}
 	logf("got userIdentityMapping: %#v", user)
 
-	return user, true, nil
+	// only set User field as IDPs have no concept of Audiences
+	return &authenticator.Response{User: user}, true, nil
 }
 
 // logf(...) is the same as glog.V(4).Infof(...) except it reports the caller as the line number

--- a/pkg/oauthserver/authenticator/password/allowanypassword/anyauthpassword.go
+++ b/pkg/oauthserver/authenticator/password/allowanypassword/anyauthpassword.go
@@ -33,6 +33,5 @@ func (a alwaysAcceptPasswordAuthenticator) AuthenticatePassword(ctx context.Cont
 
 	identity := authapi.NewDefaultUserIdentityInfo(a.providerName, username)
 
-	user, ok, err := identitymapper.UserFor(a.identityMapper, identity)
-	return &authenticator.Response{User: user}, ok, err
+	return identitymapper.ResponseFor(a.identityMapper, identity)
 }

--- a/pkg/oauthserver/authenticator/password/basicauthpassword/basicauthpassword.go
+++ b/pkg/oauthserver/authenticator/password/basicauthpassword/basicauthpassword.go
@@ -133,7 +133,5 @@ func (a *Authenticator) AuthenticatePassword(ctx context.Context, username, pass
 		identity.Extra[authapi.IdentityEmailKey] = remoteUserData.Email
 	}
 
-	user, ok, err := identitymapper.UserFor(a.mapper, identity)
-	return &authenticator.Response{User: user}, ok, err
-
+	return identitymapper.ResponseFor(a.mapper, identity)
 }

--- a/pkg/oauthserver/authenticator/password/htpasswd/htpasswd.go
+++ b/pkg/oauthserver/authenticator/password/htpasswd/htpasswd.go
@@ -61,8 +61,7 @@ func (a *Authenticator) AuthenticatePassword(ctx context.Context, username, pass
 
 	identity := authapi.NewDefaultUserIdentityInfo(a.providerName, username)
 
-	user, ok, err := identitymapper.UserFor(a.mapper, identity)
-	return &authenticator.Response{User: user}, ok, err
+	return identitymapper.ResponseFor(a.mapper, identity)
 }
 
 func (a *Authenticator) load() error {

--- a/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword.go
+++ b/pkg/oauthserver/authenticator/password/keystonepassword/keystonepassword.go
@@ -108,6 +108,5 @@ func (a keystonePasswordAuthenticator) AuthenticatePassword(ctx context.Context,
 	identity := authapi.NewDefaultUserIdentityInfo(a.providerName, providerUserID)
 	identity.Extra[authapi.IdentityPreferredUsernameKey] = username
 
-	user, ok, err := identitymapper.UserFor(a.identityMapper, identity)
-	return &authenticator.Response{User: user}, ok, err
+	return identitymapper.ResponseFor(a.identityMapper, identity)
 }

--- a/pkg/oauthserver/authenticator/password/ldappassword/ldap.go
+++ b/pkg/oauthserver/authenticator/password/ldappassword/ldap.go
@@ -64,8 +64,7 @@ func (a *Authenticator) AuthenticatePassword(ctx context.Context, username, pass
 		return nil, false, nil
 	}
 
-	user, ok, err := identitymapper.UserFor(a.mapper, identity)
-	return &authenticator.Response{User: user}, ok, err
+	return identitymapper.ResponseFor(a.mapper, identity)
 }
 
 // getIdentity looks up a username in an LDAP server, and attempts to bind to the user's DN using the provided password

--- a/pkg/oauthserver/authenticator/request/headerrequest/requestheader.go
+++ b/pkg/oauthserver/authenticator/request/headerrequest/requestheader.go
@@ -49,8 +49,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 		identity.Extra[authapi.IdentityPreferredUsernameKey] = preferredUsername
 	}
 
-	user, ok, err := identitymapper.UserFor(a.mapper, identity)
-	return &authenticator.Response{User: user}, ok, err
+	return identitymapper.ResponseFor(a.mapper, identity)
 }
 
 func headerValue(h http.Header, headerNames []string) string {

--- a/pkg/oauthserver/oauth/external/handler.go
+++ b/pkg/oauthserver/oauth/external/handler.go
@@ -138,8 +138,7 @@ func (h *Handler) AuthenticatePassword(ctx context.Context, username, password s
 		return nil, false, err
 	}
 
-	user, ok, err := identitymapper.UserFor(h.mapper, identity)
-	return &authenticator.Response{User: user}, ok, err
+	return identitymapper.ResponseFor(h.mapper, identity)
 }
 
 // ServeHTTP handles the callback request in response to an external oauth flow


### PR DESCRIPTION
This change reduces some code duplication related to the bridge code between the UserIdentityMapper and kube authenticator interfaces.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: https://github.com/openshift/origin/pull/22363#discussion_r267016511

/assign @stlaz 