### PR TITLE
change the sdn pod to run the iptables command on the host

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -27,4 +27,4 @@ RUN INSTALL_PKGS=" \
 LABEL io.k8s.display-name="OpenShift SDN" \
       io.k8s.description="This is a component of OpenShift and contains the networking tool stack for the default SDN implementation." \
       io.openshift.tags="openshift,sdn"
-ENTRYPOINT [ "/usr/local/bin/openshift-sdn" ]
+ENTRYPOINT [ "/usr/bin/openshift-sdn" ]

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -13,8 +13,10 @@ COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/sdn-cni-plugin /opt/cni/bin/openshift-sdn
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/loopback /opt/cni/bin/
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/host-local /opt/cni/bin/
+COPY images/sdn/scripts/* /usr/sbin/
+
 RUN INSTALL_PKGS=" \
-      openvswitch2.11 container-selinux socat ethtool iptables nmap-ncat \
+      openvswitch2.11 container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute bridge-utils procps-ng openssl \
       binutils xz sysvinit-tools dbus \

--- a/images/sdn/scripts/ip6tables
+++ b/images/sdn/scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables $@

--- a/images/sdn/scripts/ip6tables-restore
+++ b/images/sdn/scripts/ip6tables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-restore $@

--- a/images/sdn/scripts/ip6tables-save
+++ b/images/sdn/scripts/ip6tables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-save $@

--- a/images/sdn/scripts/iptables
+++ b/images/sdn/scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables $@

--- a/images/sdn/scripts/iptables-restore
+++ b/images/sdn/scripts/iptables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-restore $@

--- a/images/sdn/scripts/iptables-save
+++ b/images/sdn/scripts/iptables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-save $@


### PR DESCRIPTION
In order to use the hosts versions of the iptables command scripts are added to replace the containerized versions to point to the versions in the host.

https://github.com/openshift/cluster-network-operator/pull/127 needs to merge first so the hosts iptables will be mounted in 