### PR TITLE
images/tests/Dockerfile.rhel: Install jq

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=cmd/openshift-tests
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:cli
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/openshift-tests /usr/bin/
-RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
+RUN yum install --setopt=tsflags=nodocs -y git gzip jq util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \


### PR DESCRIPTION
~~`awscli` will allow us to add CI for user-provided infrastructure, as documented by openshift/installer@39a926a918 (openshift/installer#1408).~~

`jq` will allow us to simplify the templating which landed in openshift/release@7e56379d0b (openshift/release#2633).