### PR TITLE
UPSTREAM: <carry>: allow running bare kube-controller-manager

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
@@ -3,47 +3,69 @@ package app
 import (
 	"path"
 
+	"github.com/golang/glog"
+
 	"k8s.io/client-go/informers"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
+	utilflag "k8s.io/kubernetes/pkg/util/flag"
 )
 
 var InformerFactoryOverride informers.SharedInformerFactory
 
-func ShimForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions, controllerManager *config.Config) (func(), error) {
+func ShimForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions, controllerManager *config.Config) error {
 	if len(controllerManager.OpenShiftContext.OpenShiftConfig) == 0 {
-		return func() {}, nil
+		return nil
 	}
 
 	// TODO this gets removed when no longer take flags and no longer build a recycler template
 	openshiftConfig, err := getOpenShiftConfig(controllerManager.OpenShiftContext.OpenShiftConfig)
 	if err != nil {
-		return func() {}, err
-	}
-	// apply the config based controller manager flags.  They will override.
-	// TODO this should be replaced by the installer setting up the flags for us
-	if err := applyOpenShiftConfigFlags(controllerManagerOptions, controllerManager, openshiftConfig); err != nil {
-		return func() {}, err
+		return err
 	}
 
 	// TODO this should be replaced by using a flex volume to inject service serving cert CAs into pods instead of adding it to the sa token
 	if err := applyOpenShiftServiceServingCertCAFunc(path.Dir(controllerManager.OpenShiftContext.OpenShiftConfig), openshiftConfig); err != nil {
-		return func() {}, err
+		return err
 	}
 
 	// skip GC on some openshift resources
 	// TODO this should be replaced by discovery information in some way
 	if err := applyOpenShiftGCConfig(controllerManager); err != nil {
-		return func() {}, err
+		return err
 	}
 
 	// Overwrite the informers, because we have our custom generic informers for quota.
 	// TODO update quota to create its own informer like garbage collection
 	if informers, err := newInformerFactory(controllerManager.Kubeconfig); err != nil {
-		return func() {}, err
+		return err
 	} else {
 		InformerFactoryOverride = informers
 	}
 
-	return func() {}, nil
+	return nil
+}
+
+func ShimFlagsForOpenShift(controllerManagerOptions *options.KubeControllerManagerOptions) error {
+	if len(controllerManagerOptions.OpenShiftContext.OpenShiftConfig) == 0 {
+		return nil
+	}
+
+	// TODO this gets removed when no longer take flags and no longer build a recycler template
+	openshiftConfig, err := getOpenShiftConfig(controllerManagerOptions.OpenShiftContext.OpenShiftConfig)
+	if err != nil {
+		return err
+	}
+	// apply the config based controller manager flags.  They will override.
+	// TODO this should be replaced by the installer setting up the flags for us
+	if err := applyOpenShiftConfigFlags(controllerManagerOptions, openshiftConfig); err != nil {
+		return err
+	}
+
+	for name, fs := range controllerManagerOptions.Flags(KnownControllers(), ControllersDisabledByDefault.List()).FlagSets {
+		glog.V(1).Infof("FLAGSET: %s", name)
+		utilflag.PrintFlags(fs)
+	}
+
+	return nil
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_flags.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_flags.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	apiserverflag "k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 )
 
@@ -30,7 +29,7 @@ func getOpenShiftConfig(configFile string) (map[string]interface{}, error) {
 	return config, nil
 }
 
-func applyOpenShiftConfigFlags(controllerManagerOptions *options.KubeControllerManagerOptions, controllerManager *config.Config, openshiftConfig map[string]interface{}) error {
+func applyOpenShiftConfigFlags(controllerManagerOptions *options.KubeControllerManagerOptions, openshiftConfig map[string]interface{}) error {
 	if err := applyOpenShiftConfigControllerArgs(controllerManagerOptions, openshiftConfig); err != nil {
 		return err
 	}
@@ -40,7 +39,7 @@ func applyOpenShiftConfigFlags(controllerManagerOptions *options.KubeControllerM
 	if err := applyOpenShiftConfigKubeDefaultProjectSelector(controllerManagerOptions, openshiftConfig); err != nil {
 		return err
 	}
-	return controllerManagerOptions.ApplyTo(controllerManager)
+	return nil
 }
 
 func applyOpenShiftConfigDefaultProjectSelector(controllerManagerOptions *options.KubeControllerManagerOptions, openshiftConfig map[string]interface{}) error {


### PR DESCRIPTION
I've named the commit to be able to squash it with other during next rebase. 
This is changing how we shim flags when invoking kube-controller-manager.

/assign @deads2k @sttts 