### PR TITLE
Remove extraneous package from sdn image dockerfile

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -19,7 +19,7 @@ RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute bridge-utils procps-ng openssl \
-      binutils xz sysvinit-tools dbus \
+      binutils xz dbus \
       " && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \


### PR DESCRIPTION
it appears that sysvinit does not have any purpose in the sdn image and is no longer present in RHEL8 or Fedora29