### PR TITLE
UPSTREAM: <carry>: patch aggregator to allow delegating resources

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -312,7 +312,13 @@ func (s *APIAggregator) AddAPIService(apiService *apiregistration.APIService) er
 	}()
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle(proxyPath, proxyHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandlePrefix(proxyPath+"/", proxyHandler)
-
+	
+	// register prefixes we always want to delegate
+	for _, alwaysDelegatePath := range alwaysDelegatePathPrefixes.List() {
+		s.GenericAPIServer.Handler.NonGoRestfulMux.Handle(alwaysDelegatePath, proxyHandler.localDelegate)
+		s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandlePrefix(alwaysDelegatePath+"/", proxyHandler.localDelegate)
+	}
+	
 	// if we're dealing with the legacy group, we're done here
 	if apiService.Name == legacyAPIServiceName {
 		return nil

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/openshift_always_delegate_patch.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/openshift_always_delegate_patch.go
@@ -1,0 +1,12 @@
+package apiserver
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// alwaysDelegatePrefixes specify a list of API paths that we want to delegate to Kubernetes API server
+// instead of handling with OpenShift API server.
+// Usually this means that these resources were moved from OpenShift API into CRD.
+var alwaysDelegatePathPrefixes = sets.NewString(
+	"/apis/quota.openshift.io/v1/clusterresourcequotas",
+	)


### PR DESCRIPTION
Add always delegate path knob that allows to specify list of URL prefixes that will be always served by the kube apiserver instead of aggregated API server (openshift api server in this case).

This allows to migrate some resources from openshift apiserver to CRD.

Lets start with this here, this will likely break any cluster resource quota tests without CRD installed.

/cc @sttts 
/cc @deads2k 
/cc @derekwaynecarr 