### PR TITLE
UPSTREAM: <drop>: enable secure serving for scheduler

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/options/options.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/options/options.go
@@ -85,7 +85,7 @@ func NewOptions() (*Options, error) {
 
 	o := &Options{
 		ComponentConfig: *cfg,
-		SecureServing:   nil, // TODO: enable with apiserveroptions.NewSecureServingOptions()
+		SecureServing:   apiserveroptions.NewSecureServingOptions(), // TODO: enable with apiserveroptions.NewSecureServingOptions()
 		CombinedInsecureServing: &CombinedInsecureServingOptions{
 			Healthz: &apiserveroptions.DeprecatedInsecureServingOptions{
 				BindNetwork: "tcp",
@@ -103,6 +103,7 @@ func NewOptions() (*Options, error) {
 			PolicyConfigMapNamespace: metav1.NamespaceSystem,
 		},
 	}
+	o.SecureServing.BindPort = 0
 
 	return o, nil
 }


### PR DESCRIPTION
allow serving the scheduler securely so we can force it insecure, so we can land the rebase.