### PR TITLE
UPSTREAM: 71804: Add e2e tests for stale mounts

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/subpath.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/testsuites/subpath.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -384,6 +384,31 @@ func testSubPath(input *subPathTestInput) {
 		input.pod.Spec.Volumes[0].VolumeSource = *input.roVol
 		// Pod should fail
 		testPodFailSubpathError(input.f, input.pod, "")
+	})
+
+	It("should be able to unmount after the subpath directory is deleted", func() {
+		// Change volume container to busybox so we can exec later
+		input.pod.Spec.Containers[1].Image = imageutils.GetE2EImage(imageutils.BusyBox)
+		input.pod.Spec.Containers[1].Command = []string{"/bin/sh", "-ec", "sleep 100000"}
+
+		By(fmt.Sprintf("Creating pod %s", input.pod.Name))
+		pod, err := input.f.ClientSet.CoreV1().Pods(input.f.Namespace.Name).Create(input.pod)
+		Expect(err).ToNot(HaveOccurred(), "while creating pod")
+		defer func() {
+			By(fmt.Sprintf("Deleting pod %s", pod.Name))
+			framework.DeletePodWithWait(input.f, input.f.ClientSet, pod)
+		}()
+
+		// Wait for pod to be running
+		err = framework.WaitForPodRunningInNamespace(input.f.ClientSet, pod)
+		Expect(err).ToNot(HaveOccurred(), "while waiting for pod to be running")
+
+		// Exec into container that mounted the volume, delete subpath directory
+		rmCmd := fmt.Sprintf("rm -rf %s", input.subPathDir)
+		_, err = podContainerExec(pod, 1, rmCmd)
+		Expect(err).ToNot(HaveOccurred(), "while removing subpath directory")
+
+		// Delete pod (from defer) and wait for it to be successfully deleted
 	})
 
 	// TODO: add a test case for the same disk with two partitions


### PR DESCRIPTION
This is originally part of 71804 upstream, split into two PRs in Origin to work aroung old kubelet in RHCOS during CI tests. We need to merge e2e test only when RHCOS is regenerated.

@openshift/sig-storage 