### PR TITLE
Move ClusterResourceQuota to CRD

### DIFF
--- a/hack/local-up-master/kube-apiserver-manifests/01_cluster_resource_quota_crd.yaml
+++ b/hack/local-up-master/kube-apiserver-manifests/01_cluster_resource_quota_crd.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterresourcequotas.quota.openshift.io
+spec:
+  group: quota.openshift.io
+  names:
+    kind: ClusterResourceQuota
+    listKind: ClusterResourceQuotaList
+    plural: clusterresourcequotas
+    singular: clusterresourcequota
+  scope: Cluster
+  subresources:
+    status: {}
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: Spec defines the desired quota
+          properties:
+            quota:
+              description: Quota defines the desired quota
+              type: object
+            selector:
+              description: Selector is the selector used to match projects. It should
+                only select active projects on the scale of dozens (though it can
+                select many more less active projects).  These projects will contend
+                on object creation through this resource.
+              properties:
+                annotations:
+                  description: AnnotationSelector is used to select projects by annotation.
+                  type: object
+                labels:
+                  description: LabelSelector is used to select projects by label.
+                  type: object
+              type: object
+          type: object
+        status:
+          description: Status defines the actual enforced quota and its current usage
+          properties:
+            namespaces:
+              description: Namespaces slices the usage by project.  This division
+                allows for quick resolution of deletion reconciliation inside of a
+                single project without requiring a recalculation across all projects.  This
+                can be used to pull the deltas for a given project.
+              items:
+                properties:
+                  namespace:
+                    description: Namespace the project this status applies to
+                    type: string
+                  status:
+                    description: Status indicates how many resources have been consumed
+                      by this project
+                    type: object
+                type: object
+              type: array
+            total:
+              description: Total defines the actual enforced quota and its current
+                usage across all projects
+              type: object
+          type: object

--- a/hack/local-up-master/lib.sh
+++ b/hack/local-up-master/lib.sh
@@ -216,6 +216,10 @@ function localup::start_kubeapiserver() {
     # Create kubeconfigs for all components, using client certs
     kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" admin
     chown "${USER:-$(id -u)}" "${CERT_DIR}/client-admin.key" # make readable for kubectl
+
+    for filename in ${OS_ROOT}/hack/local-up-master/kube-apiserver-manifests/*.yaml; do
+       oc --config=${LOCALUP_CONFIG}/kube-apiserver/admin.kubeconfig apply -f ${filename}
+    done
 }
 
 function localup::start_kubecontrollermanager() {

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -97,6 +97,8 @@ os::test::junit::declare_suite_start "setup/localup"
 os::cmd::try_until_text "oc get --raw /healthz --as system:unauthenticated --config='${ADMIN_KUBECONFIG}'" 'ok' $(( 160 * second )) 0.25
 os::cmd::try_until_success "oc get service kubernetes --namespace default --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
 os::cmd::try_until_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority ${MASTER_CONFIG_DIR}/server-ca.crt -u test-user -p anything" $(( 160 * second )) 0.25
+# wait for the CRD to be available
+os::cmd::try_until_success "oc get clusterresourcequotas --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
 os::test::junit::declare_suite_end
 os::log::debug "localup server health checks done at: $( date )"
 

--- a/pkg/admission/customresourcevalidation/clusterresourcequota/validate_crq.go
+++ b/pkg/admission/customresourcevalidation/clusterresourcequota/validate_crq.go
@@ -1,0 +1,83 @@
+package clusterresourcequota
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation"
+	quotavalidation "github.com/openshift/origin/pkg/admission/customresourcevalidation/clusterresourcequota/validation"
+)
+
+const PluginName = "quota.openshift.io/ValidateClusterResourceQuota"
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return customresourcevalidation.NewValidator(
+			map[schema.GroupResource]bool{
+				{Group: quotav1.GroupName, Resource: "clusterresourcequotas"}: true,
+			},
+			map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+				quotav1.GroupVersion.WithKind("ClusterResourceQuota"): clusterResourceQuotaV1{},
+			})
+	})
+}
+
+func toClusterResourceQuota(uncastObj runtime.Object) (*quotav1.ClusterResourceQuota, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	allErrs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*quotav1.ClusterResourceQuota)
+	if !ok {
+		return nil, append(allErrs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"ClusterResourceQuota"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{quotav1.GroupVersion.String()}))
+	}
+
+	return obj, nil
+}
+
+type clusterResourceQuotaV1 struct {
+}
+
+func (clusterResourceQuotaV1) ValidateCreate(obj runtime.Object) field.ErrorList {
+	clusterResourceQuotaObj, errs := toClusterResourceQuota(obj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&clusterResourceQuotaObj.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
+	errs = append(errs, quotavalidation.ValidateClusterResourceQuota(clusterResourceQuotaObj)...)
+
+	return errs
+}
+
+func (clusterResourceQuotaV1) ValidateUpdate(obj runtime.Object, oldObj runtime.Object) field.ErrorList {
+	clusterResourceQuotaObj, errs := toClusterResourceQuota(obj)
+	if len(errs) > 0 {
+		return errs
+	}
+	clusterResourceQuotaOldObj, errs := toClusterResourceQuota(oldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&clusterResourceQuotaObj.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
+	errs = append(errs, quotavalidation.ValidateClusterResourceQuotaUpdate(clusterResourceQuotaObj, clusterResourceQuotaOldObj)...)
+
+	return errs
+}
+
+func (c clusterResourceQuotaV1) ValidateStatusUpdate(obj runtime.Object, oldObj runtime.Object) field.ErrorList {
+	return c.ValidateUpdate(obj, oldObj)
+}

--- a/pkg/admission/customresourcevalidation/clusterresourcequota/validation/validation.go
+++ b/pkg/admission/customresourcevalidation/clusterresourcequota/validation/validation.go
@@ -1,0 +1,77 @@
+package validation
+
+import (
+	"sort"
+
+	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/v1"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+)
+
+// convertClusterResourceQuotaToAppliedClusterQuota returns back a converted AppliedClusterResourceQuota which is NOT a deep copy.
+func convertAppliedClusterResourceQuotaToClusterResourceQuota(in *quotav1.AppliedClusterResourceQuota) *quotav1.ClusterResourceQuota {
+	return &quotav1.ClusterResourceQuota{
+		ObjectMeta: in.ObjectMeta,
+		Spec:       in.Spec,
+		Status:     in.Status,
+	}
+}
+
+func ValidateClusterResourceQuota(clusterquota *quotav1.ClusterResourceQuota) field.ErrorList {
+	allErrs := validation.ValidateObjectMeta(&clusterquota.ObjectMeta, false, validation.ValidateResourceQuotaName, field.NewPath("metadata"))
+
+	hasSelectionCriteria := (clusterquota.Spec.Selector.LabelSelector != nil && len(clusterquota.Spec.Selector.LabelSelector.MatchLabels)+len(clusterquota.Spec.Selector.LabelSelector.MatchExpressions) > 0) ||
+		(len(clusterquota.Spec.Selector.AnnotationSelector) > 0)
+
+	if !hasSelectionCriteria {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "selector"), "must restrict the selected projects"))
+	}
+	if clusterquota.Spec.Selector.LabelSelector != nil {
+		allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(clusterquota.Spec.Selector.LabelSelector, field.NewPath("spec", "selector", "labels"))...)
+		if len(clusterquota.Spec.Selector.LabelSelector.MatchLabels)+len(clusterquota.Spec.Selector.LabelSelector.MatchExpressions) == 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "selector", "labels"), clusterquota.Spec.Selector.LabelSelector, "must restrict the selected projects"))
+		}
+	}
+	if clusterquota.Spec.Selector.AnnotationSelector != nil {
+		allErrs = append(allErrs, validation.ValidateAnnotations(clusterquota.Spec.Selector.AnnotationSelector, field.NewPath("spec", "selector", "annotations"))...)
+	}
+
+	internalQuota := &core.ResourceQuotaSpec{}
+	if err := v1.Convert_v1_ResourceQuotaSpec_To_core_ResourceQuotaSpec(&clusterquota.Spec.Quota, internalQuota, nil); err != nil {
+		panic(err)
+	}
+	internalStatus := &core.ResourceQuotaStatus{}
+	if err := v1.Convert_v1_ResourceQuotaStatus_To_core_ResourceQuotaStatus(&clusterquota.Status.Total, internalStatus, nil); err != nil {
+		panic(err)
+	}
+
+	allErrs = append(allErrs, validation.ValidateResourceQuotaSpec(internalQuota, field.NewPath("spec", "quota"))...)
+	allErrs = append(allErrs, validation.ValidateResourceQuotaStatus(internalStatus, field.NewPath("status", "overall"))...)
+
+	orderedNamespaces := clusterquota.Status.Namespaces.DeepCopy()
+	sort.Slice(orderedNamespaces, func(i, j int) bool {
+		return orderedNamespaces[i].Namespace < orderedNamespaces[j].Namespace
+	})
+
+	for _, namespace := range orderedNamespaces {
+		fldPath := field.NewPath("status", "namespaces").Key(namespace.Namespace)
+		for k, v := range namespace.Status.Used {
+			resPath := fldPath.Key(string(k))
+			allErrs = append(allErrs, validation.ValidateResourceQuotaResourceName(string(k), resPath)...)
+			allErrs = append(allErrs, validation.ValidateResourceQuantityValue(string(k), v, resPath)...)
+		}
+	}
+
+	return allErrs
+}
+
+func ValidateClusterResourceQuotaUpdate(clusterquota, oldClusterResourceQuota *quotav1.ClusterResourceQuota) field.ErrorList {
+	allErrs := validation.ValidateObjectMetaUpdate(&clusterquota.ObjectMeta, &oldClusterResourceQuota.ObjectMeta, field.NewPath("metadata"))
+	allErrs = append(allErrs, ValidateClusterResourceQuota(clusterquota)...)
+
+	return allErrs
+}

--- a/pkg/admission/customresourcevalidation/clusterresourcequota/validation/validation_test.go
+++ b/pkg/admission/customresourcevalidation/clusterresourcequota/validation/validation_test.go
@@ -1,0 +1,173 @@
+package validation
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/pkg/apis/core"
+	corekubev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+)
+
+func spec(scopes ...corev1.ResourceQuotaScope) corev1.ResourceQuotaSpec {
+	return corev1.ResourceQuotaSpec{
+		Hard: corev1.ResourceList{
+			corev1.ResourceCPU:                    resource.MustParse("100"),
+			corev1.ResourceMemory:                 resource.MustParse("10000"),
+			corev1.ResourceRequestsCPU:            resource.MustParse("100"),
+			corev1.ResourceRequestsMemory:         resource.MustParse("10000"),
+			corev1.ResourceLimitsCPU:              resource.MustParse("100"),
+			corev1.ResourceLimitsMemory:           resource.MustParse("10000"),
+			corev1.ResourcePods:                   resource.MustParse("10"),
+			corev1.ResourceServices:               resource.MustParse("0"),
+			corev1.ResourceReplicationControllers: resource.MustParse("10"),
+			corev1.ResourceQuotas:                 resource.MustParse("10"),
+			corev1.ResourceConfigMaps:             resource.MustParse("10"),
+			corev1.ResourceSecrets:                resource.MustParse("10"),
+		},
+		Scopes: scopes,
+	}
+}
+
+func scopeableSpec(scopes ...corev1.ResourceQuotaScope) corev1.ResourceQuotaSpec {
+	return corev1.ResourceQuotaSpec{
+		Hard: corev1.ResourceList{
+			corev1.ResourceCPU:            resource.MustParse("100"),
+			corev1.ResourceMemory:         resource.MustParse("10000"),
+			corev1.ResourceRequestsCPU:    resource.MustParse("100"),
+			corev1.ResourceRequestsMemory: resource.MustParse("10000"),
+			corev1.ResourceLimitsCPU:      resource.MustParse("100"),
+			corev1.ResourceLimitsMemory:   resource.MustParse("10000"),
+		},
+		Scopes: scopes,
+	}
+}
+
+func TestValidationClusterQuota(t *testing.T) {
+	// storage is not yet supported as a quota tracked resource
+	invalidQuotaResourceSpec := corev1.ResourceQuotaSpec{
+		Hard: corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse("10"),
+		},
+	}
+	validLabels := map[string]string{"a": "b"}
+
+	errs := ValidateClusterResourceQuota(
+		&quotav1.ClusterResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{Name: "good"},
+			Spec: quotav1.ClusterResourceQuotaSpec{
+				Selector: quotav1.ClusterResourceQuotaSelector{LabelSelector: &metav1.LabelSelector{MatchLabels: validLabels}},
+				Quota:    spec(),
+			},
+		},
+	)
+	if len(errs) != 0 {
+		t.Errorf("expected success: %v", errs)
+	}
+
+	errorCases := map[string]struct {
+		A quotav1.ClusterResourceQuota
+		T field.ErrorType
+		F string
+	}{
+		"non-zero-length namespace": {
+			A: quotav1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "bad", Name: "good"},
+				Spec: quotav1.ClusterResourceQuotaSpec{
+					Selector: quotav1.ClusterResourceQuotaSelector{LabelSelector: &metav1.LabelSelector{MatchLabels: validLabels}},
+					Quota:    spec(),
+				},
+			},
+			T: field.ErrorTypeForbidden,
+			F: "metadata.namespace",
+		},
+		"missing label selector": {
+			A: quotav1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "good"},
+				Spec: quotav1.ClusterResourceQuotaSpec{
+					Quota: spec(),
+				},
+			},
+			T: field.ErrorTypeRequired,
+			F: "spec.selector",
+		},
+		"ok scope": {
+			A: quotav1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "good"},
+				Spec: quotav1.ClusterResourceQuotaSpec{
+					Quota: scopeableSpec(corev1.ResourceQuotaScopeNotTerminating),
+				},
+			},
+			T: field.ErrorTypeRequired,
+			F: "spec.selector",
+		},
+		"bad scope": {
+			A: quotav1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "good"},
+				Spec: quotav1.ClusterResourceQuotaSpec{
+					Selector: quotav1.ClusterResourceQuotaSelector{LabelSelector: &metav1.LabelSelector{MatchLabels: validLabels}},
+					Quota:    spec(corev1.ResourceQuotaScopeNotTerminating),
+				},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "spec.quota.scopes",
+		},
+		"bad quota spec": {
+			A: quotav1.ClusterResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Name: "good"},
+				Spec: quotav1.ClusterResourceQuotaSpec{
+					Selector: quotav1.ClusterResourceQuotaSelector{LabelSelector: &metav1.LabelSelector{MatchLabels: validLabels}},
+					Quota:    invalidQuotaResourceSpec,
+				},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "spec.quota.hard[storage]",
+		},
+	}
+	for k, v := range errorCases {
+		errs := ValidateClusterResourceQuota(&v.A)
+		if len(errs) == 0 {
+			t.Errorf("expected failure %s for %v", k, v.A)
+			continue
+		}
+		for i := range errs {
+			if errs[i].Type != v.T {
+				t.Errorf("%s: expected errors to have type %s: %v", k, v.T, errs[i])
+			}
+			if errs[i].Field != v.F {
+				t.Errorf("%s: expected errors to have field %s: %v", k, v.F, errs[i])
+			}
+		}
+	}
+}
+
+func TestValidationQuota(t *testing.T) {
+	tests := map[string]struct {
+		A corev1.ResourceQuota
+		T field.ErrorType
+		F string
+	}{
+		"scope": {
+			A: corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "good"},
+				Spec:       scopeableSpec(corev1.ResourceQuotaScopeNotTerminating),
+			},
+		},
+	}
+	for k, v := range tests {
+		internal := core.ResourceQuota{}
+		if err := corekubev1.Convert_v1_ResourceQuota_To_core_ResourceQuota(&v.A, &internal, nil); err != nil {
+			panic(err)
+		}
+		errs := validation.ValidateResourceQuota(&internal)
+		if len(errs) != 0 {
+			t.Errorf("%s: %v", k, errs)
+			continue
+		}
+	}
+}

--- a/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/authentication"
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation/clusterresourcequota"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/config"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/console"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/features"
@@ -23,6 +24,7 @@ var AllCustomResourceValidators = []string{
 	project.PluginName,
 	config.PluginName,
 	scheduler.PluginName,
+	clusterresourcequota.PluginName,
 }
 
 func RegisterCustomResourceValidation(plugins *admission.Plugins) {
@@ -34,4 +36,8 @@ func RegisterCustomResourceValidation(plugins *admission.Plugins) {
 	project.Register(plugins)
 	config.Register(plugins)
 	scheduler.Register(plugins)
+
+	// This plugin validates the quota.openshift.io/v1 ClusterResourceQuota resources.
+	// NOTE: This is only allowed because it is required to get a running control plane operator.
+	clusterresourcequota.Register(plugins)
 }

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
@@ -51,7 +51,7 @@ func NewInformers(kubeInformers kexternalinformers.SharedInformerFactory, kubeCl
 	if err != nil {
 		return nil, err
 	}
-	quotaClient, err := quotaclient.NewForConfig(loopbackClientConfig)
+	quotaClient, err := quotaclient.NewForConfig(kubeClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
@@ -51,7 +51,7 @@ func NewInformers(kubeInformers kexternalinformers.SharedInformerFactory, kubeCl
 	if err != nil {
 		return nil, err
 	}
-	quotaClient, err := quotaclient.NewForConfig(kubeClientConfig)
+	quotaClient, err := quotaclient.NewForConfig(nonProtobufConfig(kubeClientConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +82,15 @@ func NewInformers(kubeInformers kexternalinformers.SharedInformerFactory, kubeCl
 		securityInformers:      securityv1informer.NewSharedInformerFactory(securityClient, defaultInformerResyncPeriod),
 		userInformers:          userv1informer.NewSharedInformerFactory(userClient, defaultInformerResyncPeriod),
 	}, nil
+}
+
+// nonProtobufConfig returns a copy of inConfig that doesn't force the use of protobufs,
+// for working with CRD-based APIs.
+func nonProtobufConfig(inConfig *rest.Config) *rest.Config {
+	npConfig := rest.CopyConfig(inConfig)
+	npConfig.ContentConfig.AcceptContentTypes = "application/json"
+	npConfig.ContentConfig.ContentType = "application/json"
+	return npConfig
 }
 
 func (i *InformerHolder) GetKubernetesInformers() kexternalinformers.SharedInformerFactory {

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -100,10 +100,10 @@ func (c *OpenshiftAPIExtraConfig) Validate() error {
 		ret = append(ret, fmt.Errorf("KubeInformers is required"))
 	}
 	if c.QuotaInformers == nil {
-		ret = append(ret, fmt.Errorf("InternalQuotaInformers is required"))
+		ret = append(ret, fmt.Errorf("QuotaInformers is required"))
 	}
 	if c.SecurityInformers == nil {
-		ret = append(ret, fmt.Errorf("InternalSecurityInformers is required"))
+		ret = append(ret, fmt.Errorf("SecurityInformers is required"))
 	}
 	if c.RuleResolver == nil {
 		ret = append(ret, fmt.Errorf("RuleResolver is required"))

--- a/pkg/cmd/openshift-controller-manager/controller/interfaces.go
+++ b/pkg/cmd/openshift-controller-manager/controller/interfaces.go
@@ -88,7 +88,7 @@ func NewControllerContext(
 	if err != nil {
 		return nil, err
 	}
-	quotaClient, err := quotaclient.NewForConfig(clientConfig)
+	quotaClient, err := quotaclient.NewForConfig(nonProtobufConfig(clientConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (b OpenshiftControllerClientBuilder) OpenshiftQuotaClient(name string) (quo
 	if err != nil {
 		return nil, err
 	}
-	return quotaclient.NewForConfig(clientConfig)
+	return quotaclient.NewForConfig(nonProtobufConfig(clientConfig))
 }
 
 // OpenshiftInternalBuildClientOrDie provides a REST client for the build API.

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -174,11 +174,16 @@ func (c *KubeAPIServerServerPatchContext) PatchServer(server *master.Master) err
 
 // NewInformers is only exposed for the build's integration testing until it can be fixed more appropriately.
 func NewInformers(versionedInformers clientgoinformers.SharedInformerFactory, loopbackClientConfig *rest.Config) (*KubeAPIServerInformers, error) {
+	// ClusterResourceQuota is served using CRD resource any status update must use JSON
+	jsonLoopbackClientConfig := rest.CopyConfig(loopbackClientConfig)
+	jsonLoopbackClientConfig.ContentConfig.AcceptContentTypes = "application/json"
+	jsonLoopbackClientConfig.ContentConfig.ContentType = "application/json"
+
 	oauthClient, err := oauthclient.NewForConfig(loopbackClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	quotaClient, err := quotaclient.NewForConfig(loopbackClientConfig)
+	quotaClient, err := quotaclient.NewForConfig(jsonLoopbackClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -7,15 +7,18 @@ import (
 
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/kube-aggregator/pkg/apiserver"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/pkg/capabilities"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 
 	kubecontrolplanev1 "github.com/openshift/api/kubecontrolplane/v1"
+
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/customresourcevalidationregistration"
 	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/kubeadmission"
 	"github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver"
+
 	"k8s.io/kubernetes/pkg/kubeapiserver/options"
 
 	// for metrics
@@ -23,6 +26,9 @@ import (
 )
 
 func RunOpenShiftKubeAPIServerServer(kubeAPIServerConfig *kubecontrolplanev1.KubeAPIServerConfig, stopCh <-chan struct{}) error {
+	// This allows to move cluster resource quota to CRD
+	apiserver.AddAlwaysLocalDelegateForPrefix("/apis/quota.openshift.io/v1/clusterresourcequotas")
+
 	// Allow privileged containers
 	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: true,

--- a/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/apiserver/admission/clusterresourcequota/admission.go
@@ -141,7 +141,13 @@ func (q *clusterQuotaAdmission) SetExternalKubeInformerFactory(informers informe
 
 func (q *clusterQuotaAdmission) SetRESTClientConfig(restClientConfig rest.Config) {
 	var err error
-	q.clusterQuotaClient, err = quotatypedclient.NewForConfig(&restClientConfig)
+
+	// ClusterResourceQuota is served using CRD resource any status update must use JSON
+	jsonClientConfig := rest.CopyConfig(&restClientConfig)
+	jsonClientConfig.ContentConfig.AcceptContentTypes = "application/json"
+	jsonClientConfig.ContentConfig.ContentType = "application/json"
+
+	q.clusterQuotaClient, err = quotatypedclient.NewForConfig(jsonClientConfig)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/quota/apiserver/apiserver.go
+++ b/pkg/quota/apiserver/apiserver.go
@@ -93,7 +93,7 @@ func (c *completedConfig) V1RESTStorage() (map[string]rest.Storage, error) {
 }
 
 func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
-	clusterResourceQuotaStorage, clusterResourceQuotaStatusStorage, err := clusterresourcequotaetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	clusterResourceQuotaStorage, clusterResourceQuotaStatusStorage, err := clusterresourcequotaetcd.NewREST()
 	if err != nil {
 		return nil, fmt.Errorf("error building REST storage: %v", err)
 	}

--- a/pkg/quota/apiserver/registry/clusterresourcequota/etcd/etcd.go
+++ b/pkg/quota/apiserver/registry/clusterresourcequota/etcd/etcd.go
@@ -2,27 +2,26 @@ package etcd
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/watch"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/registry/generic"
-	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/kubernetes/pkg/printers"
-	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
-	"github.com/openshift/api/quota"
-	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 	quotaapi "github.com/openshift/origin/pkg/quota/apis/quota"
-	"github.com/openshift/origin/pkg/quota/apiserver/registry/clusterresourcequota"
 )
 
 type REST struct {
-	*registry.Store
 }
 
 var _ rest.StandardStorage = &REST{}
 var _ rest.ShortNamesProvider = &REST{}
+var _ rest.Scoper = &REST{}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {
@@ -30,35 +29,52 @@ func (r *REST) ShortNames() []string {
 }
 
 // NewREST returns a RESTStorage object that will work against ClusterResourceQuota objects.
-func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, error) {
-	store := &registry.Store{
-		NewFunc:                  func() runtime.Object { return &quotaapi.ClusterResourceQuota{} },
-		NewListFunc:              func() runtime.Object { return &quotaapi.ClusterResourceQuotaList{} },
-		DefaultQualifiedResource: quota.Resource("clusterresourcequotas"),
+func NewREST() (*REST, *StatusREST, error) {
+	return &REST{}, &StatusREST{}, nil
+}
 
-		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+func (r *REST) NamespaceScoped() bool {
+	return false
+}
 
-		CreateStrategy: clusterresourcequota.Strategy,
-		UpdateStrategy: clusterresourcequota.Strategy,
-		DeleteStrategy: clusterresourcequota.Strategy,
-	}
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter}
-	if err := store.CompleteWithOptions(options); err != nil {
-		return nil, nil, err
-	}
+func (r *REST) NewList() runtime.Object {
+	return &quotaapi.ClusterResourceQuotaList{}
+}
 
-	statusStore := *store
-	statusStore.CreateStrategy = nil
-	statusStore.DeleteStrategy = nil
-	statusStore.UpdateStrategy = clusterresourcequota.StatusStrategy
+func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
 
-	return &REST{store}, &StatusREST{store: &statusStore}, nil
+func (r *REST) New() runtime.Object {
+	return &quotaapi.ClusterResourceQuota{}
+}
+
+func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) Delete(ctx context.Context, name string, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	return nil, false, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) DeleteCollection(ctx context.Context, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
 }
 
 // StatusREST implements the REST endpoint for changing the status of a resourcequota.
 type StatusREST struct {
-	store *registry.Store
 }
 
 // StatusREST implements Patcher
@@ -70,10 +86,10 @@ func (r *StatusREST) New() runtime.Object {
 
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	return r.store.Get(ctx, name, options)
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
 }
 
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+	return nil, false, errors.NewInternalError(fmt.Errorf("unsupported"))
 }

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -14,6 +14,7 @@ import (
 
 	quotav1 "github.com/openshift/api/quota/v1"
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned"
+
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset"
 	testutil "github.com/openshift/origin/test/util"
@@ -37,6 +38,10 @@ func TestClusterQuota(t *testing.T) {
 	}
 	clusterAdminQuotaClient := quotaclient.NewForConfigOrDie(clusterAdminClientConfig)
 	clusterAdminImageClient := imageclient.NewForConfigOrDie(clusterAdminClientConfig).Image()
+
+	if err := testutil.WaitForClusterResourceQuotaCRDAvailable(clusterAdminClientConfig); err != nil {
+		t.Fatal(err)
+	}
 
 	cq := &quotav1.ClusterResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: "overall"},

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -80,8 +81,11 @@ func TestClusterQuota(t *testing.T) {
 	if err := waitForQuotaLabeling(clusterAdminQuotaClient, "second"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) bool {
-		return equality.Semantic.DeepEqual(quota.Spec.Quota.Hard, quota.Status.Total.Hard)
+	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) error {
+		if !equality.Semantic.DeepEqual(quota.Spec.Quota.Hard, quota.Status.Total.Hard) {
+			return fmt.Errorf("%#v != %#v", quota.Spec.Quota.Hard, quota.Status.Total.Hard)
+		}
+		return nil
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -91,24 +95,30 @@ func TestClusterQuota(t *testing.T) {
 	if _, err := clusterAdminKubeClient.CoreV1().ConfigMaps("first").Create(configmap); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) bool {
+	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) error {
 		q := quota.Status.Total.Used[corev1.ResourceConfigMaps]
 		if i, ok := q.AsInt64(); ok {
-			return i == 1
+			if i == 1 {
+				return nil
+			}
+			return fmt.Errorf("%d != 1", i)
 		}
-		return false
+		return fmt.Errorf("quota=%+v AsInt64() failed", q)
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err := clusterAdminKubeClient.CoreV1().ConfigMaps("second").Create(configmap); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) bool {
+	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) error {
 		q := quota.Status.Total.Used[corev1.ResourceConfigMaps]
 		if i, ok := q.AsInt64(); ok {
-			return i == 2
+			if i == 2 {
+				return nil
+			}
+			return fmt.Errorf("%d != 1", i)
 		}
-		return false
+		return fmt.Errorf("quota=%+v AsInt64() failed", q)
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -131,12 +141,15 @@ func TestClusterQuota(t *testing.T) {
 	if _, err := clusterAdminImageClient.ImageStreams("first").Create(imagestream); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) bool {
+	if err := waitForQuotaStatus(clusterAdminQuotaClient, cq.Name, func(quota *quotav1.ClusterResourceQuota) error {
 		q := quota.Status.Total.Used["openshift.io/imagestreams"]
 		if i, ok := q.AsInt64(); ok {
-			return i == 1
+			if i == 1 {
+				return nil
+			}
+			return fmt.Errorf("%d != 1", i)
 		}
-		return false
+		return fmt.Errorf("quota=%+v AsInt64() failed", q)
 	}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,21 +197,28 @@ func labelNamespace(clusterAdminKubeClient corev1client.NamespacesGetter, namesp
 	return nil
 }
 
-func waitForQuotaStatus(clusterAdminClient quotaclient.Interface, name string, conditionFn func(*quotav1.ClusterResourceQuota) bool) error {
+func waitForQuotaStatus(clusterAdminClient quotaclient.Interface, name string, conditionFn func(*quotav1.ClusterResourceQuota) error) error {
+	var pollErr error
 	err := utilwait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (done bool, err error) {
 		quota, err := clusterAdminClient.QuotaV1().ClusterResourceQuotas().Get(name, metav1.GetOptions{})
 		if err != nil {
+			pollErr = err
 			return false, nil
 		}
-		if conditionFn(quota) {
+		err = conditionFn(quota)
+		if err == nil {
 			return true, nil
 		}
+		pollErr = err
 		return false, nil
 	})
 	if err == nil {
 		// since now we run each process separately we need to wait for the informers
 		// to catch up on the update and only then continue
 		time.Sleep(3 * time.Second)
+	}
+	if err != nil {
+		err = fmt.Errorf("%s: %s", err, pollErr)
 	}
 	return err
 }

--- a/test/integration/clusterquota_test.go
+++ b/test/integration/clusterquota_test.go
@@ -36,7 +36,7 @@ func TestClusterQuota(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	clusterAdminQuotaClient := quotaclient.NewForConfigOrDie(clusterAdminClientConfig)
+	clusterAdminQuotaClient := quotaclient.NewForConfigOrDie(testutil.NonProtobufConfig(clusterAdminClientConfig))
 	clusterAdminImageClient := imageclient.NewForConfigOrDie(clusterAdminClientConfig).Image()
 
 	if err := testutil.WaitForClusterResourceQuotaCRDAvailable(clusterAdminClientConfig); err != nil {

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -150,6 +150,9 @@ func setupClusterResourceOverrideTest(t *testing.T, pluginConfig *overrideapi.Cl
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := testutil.WaitForClusterResourceQuotaCRDAvailable(clusterAdminClientConfig); err != nil {
+		t.Fatal(err)
+	}
 	_, _, err = testserver.CreateNewProject(clusterAdminClientConfig, testutil.Namespace(), "peon")
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -145,13 +145,6 @@ var openshiftEtcdStorageData = map[schema.GroupVersionResource]etcddata.StorageD
 	},
 	// --
 
-	// github.com/openshift/origin/pkg/quota/apis/quota/v1
-	gvr("quota.openshift.io", "v1", "clusterresourcequotas"): {
-		Stub:             `{"metadata": {"name": "quota1g"}, "spec": {"selector": {"labels": {"matchLabels": {"a": "b"}}}}}`,
-		ExpectedEtcdPath: "openshift.io/clusterresourcequotas/quota1g",
-	},
-	// --
-
 	// github.com/openshift/origin/pkg/route/apis/route/v1
 	gvr("route.openshift.io", "v1", "routes"): {
 		Stub:             `{"metadata": {"name": "route1g"}, "spec": {"host": "hostname1", "to": {"name": "service1"}}}`,
@@ -207,6 +200,7 @@ var openshiftEtcdStorageData = map[schema.GroupVersionResource]etcddata.StorageD
 var kindWhiteList = sets.NewString(
 	"ImageStreamTag",
 	"UserIdentityMapping",
+	"ClusterResourceQuota",
 )
 
 // namespace used for all tests, do not change this
@@ -325,6 +319,7 @@ func TestEtcd3StoragePath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	resourcesToPersist := append(
 		etcddata.GetResources(t, serverResources),
 	)

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -263,6 +263,11 @@ func TestEtcd3StoragePath(t *testing.T) {
 	// create CRDs so we can make sure that custom resources do not get lost
 	etcddata.CreateTestCRDs(t, apiextensionsclientset.NewForConfigOrDie(kubeConfig), false, etcddata.GetCustomResourceDefinitionData()...)
 
+	// wait for cluster resource quota CRD to be available
+	if err := testutil.WaitForClusterResourceQuotaCRDAvailable(kubeConfig); err != nil {
+		t.Fatal(err)
+	}
+
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discocache.NewMemCacheClient(kubeClient.Discovery()))
 	mapper.Reset()
 

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -291,6 +291,13 @@ func isLimitSynced(received, expected corev1.ResourceList) bool {
 	return true
 }
 
+func NonProtobufConfig(inConfig *rest.Config) *rest.Config {
+	npConfig := rest.CopyConfig(inConfig)
+	npConfig.ContentConfig.AcceptContentTypes = "application/json"
+	npConfig.ContentConfig.ContentType = "application/json"
+	return npConfig
+}
+
 // turnOffRateLimiting reduces the chance that a flaky test can be written while using this package
 func turnOffRateLimiting(config *restclient.Config) *restclient.Config {
 	configCopy := *config

--- a/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	"k8s.io/kube-aggregator/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/controller"
 )
 
@@ -193,6 +194,10 @@ func (c *crdRegistrationController) enqueueCRD(crd *apiextensions.CustomResource
 
 func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.GroupVersion) error {
 	apiServiceName := groupVersion.Version + "." + groupVersion.Group
+	
+	if apiserver.APIServiceAlreadyExists(groupVersion) {
+		return nil
+	}
 
 	// check all CRDs.  There shouldn't that many, but if we have problems later we can index them
 	crds, err := c.crdLister.List(labels.Everything())

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -110,6 +110,9 @@ type APIAggregator struct {
 	// handledGroups are the groups that already have routes
 	handledGroups sets.String
 
+	// handledAlwaysLocalDelegatePaths are the URL paths that already have routes registered
+	handledAlwaysLocalDelegatePaths sets.String
+
 	// lister is used to add group handling for /apis/<group> aggregator lookups based on
 	// controller state
 	lister listers.APIServiceLister
@@ -161,14 +164,15 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 	)
 
 	s := &APIAggregator{
-		GenericAPIServer:         genericServer,
-		delegateHandler:          delegationTarget.UnprotectedHandler(),
-		proxyTransport:           c.ExtraConfig.ProxyTransport,
-		proxyHandlers:            map[string]*proxyHandler{},
-		handledGroups:            sets.String{},
-		lister:                   informerFactory.Apiregistration().InternalVersion().APIServices().Lister(),
-		APIRegistrationInformers: informerFactory,
-		serviceResolver:          c.ExtraConfig.ServiceResolver,
+		GenericAPIServer:                genericServer,
+		delegateHandler:                 delegationTarget.UnprotectedHandler(),
+		proxyTransport:                  c.ExtraConfig.ProxyTransport,
+		proxyHandlers:                   map[string]*proxyHandler{},
+		handledGroups:                   sets.String{},
+		handledAlwaysLocalDelegatePaths: sets.String{},
+		lister:                          informerFactory.Apiregistration().InternalVersion().APIServices().Lister(),
+		APIRegistrationInformers:        informerFactory,
+		serviceResolver:                 c.ExtraConfig.ServiceResolver,
 	}
 
 	apiGroupInfo := apiservicerest.NewRESTStorage(c.GenericConfig.MergedResourceConfig, c.GenericConfig.RESTOptionsGetter)
@@ -323,6 +327,18 @@ func (s *APIAggregator) AddAPIService(apiService *apiregistration.APIService) er
 	// if we've already registered the path with the handler, we don't want to do it again.
 	if s.handledGroups.Has(apiService.Spec.Group) {
 		return nil
+	}
+
+	// For some resources we always want to delegate to local API server.
+	// These resources have to exists as CRD to be served locally.
+	for _, alwaysLocalDelegatePath := range alwaysLocalDelegatePathPrefixes.List() {
+		if s.handledAlwaysLocalDelegatePaths.Has(alwaysLocalDelegatePath) {
+			continue
+		}
+		s.GenericAPIServer.Handler.NonGoRestfulMux.Handle(alwaysLocalDelegatePath, proxyHandler.localDelegate)
+		// Always use local delegate for this prefix
+		s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandlePrefix(alwaysLocalDelegatePath+"/", proxyHandler.localDelegate)
+		s.handledAlwaysLocalDelegatePaths.Insert(alwaysLocalDelegatePath)
 	}
 
 	// it's time to register the group aggregation endpoint

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_always_local_delegate.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_always_local_delegate.go
@@ -1,6 +1,10 @@
 package apiserver
 
 import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -15,4 +19,14 @@ func AddAlwaysLocalDelegateForPrefix(prefix string) {
 		return
 	}
 	alwaysLocalDelegatePathPrefixes.Insert(prefix)
+}
+
+func APIServiceAlreadyExists(groupVersion schema.GroupVersion) bool {
+	testPrefix := fmt.Sprintf("/apis/%s/%s/", groupVersion.Group, groupVersion.Version)
+	for _, prefix := range alwaysLocalDelegatePathPrefixes.List() {
+		if strings.HasPrefix(prefix, testPrefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_always_local_delegate.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kube-aggregator/pkg/apiserver/patch_always_local_delegate.go
@@ -1,0 +1,18 @@
+package apiserver
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// alwaysLocalDelegatePrefixes specify a list of API paths that we want to delegate to Kubernetes API server
+// instead of handling with OpenShift API server.
+var alwaysLocalDelegatePathPrefixes = sets.NewString()
+
+// AddAlwaysLocalDelegateForPrefix will cause the given URL prefix always be served by local API server (kube apiserver).
+// This allows to move some resources from aggregated API server into CRD.
+func AddAlwaysLocalDelegateForPrefix(prefix string) {
+	if alwaysLocalDelegatePathPrefixes.Has(prefix) {
+		return
+	}
+	alwaysLocalDelegatePathPrefixes.Insert(prefix)
+}


### PR DESCRIPTION
Goal of this change is to move ClusterResourceQuota from OpenShift API server to CRD so the admission plugins that run in kubernetes apiserver do not have dependency on OpenShift API resource. In case the OpenShift API server have downtime that means every request to Kubernetes API server is delayed.

This PR require https://github.com/openshift/cluster-config-operator/pull/25 to land first, otherwise CRQ is broken.
This will also disable etcd storage for openshift clusterresourcequota so we don't accidentally write to a wrong bucket (and we can actually prove this works).

TODO:

- [x] Fix `TestIntegration/TestClusterQuota`
- [x] Fix `TestIntegration/TestEtcd3StoragePath`
- [x] Fix test-cmd (need to create CRD)
- [x] Fix appliedresourcequota

/cc @sttts 
/cc @deads2k 
/cc @enj 
/cc @derekwaynecarr 