### PR TITLE
Azure disk attacher cherry-pick 

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/azure_dd/attacher.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/azure_dd/attacher.go
@@ -149,8 +149,6 @@ func (a *azureDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName ty
 }
 
 func (a *azureDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, _ *v1.Pod, timeout time.Duration) (string, error) {
-	var err error
-
 	volumeSource, _, err := getVolumeSource(spec)
 	if err != nil {
 		return "", err
@@ -164,13 +162,22 @@ func (a *azureDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, 
 	nodeName := types.NodeName(a.plugin.host.GetHostName())
 	diskName := volumeSource.DiskName
 
-	glog.V(5).Infof("azureDisk - WaitForAttach: begin to GetDiskLun by diskName(%s), DataDiskURI(%s), nodeName(%s), devicePath(%s)",
-		diskName, volumeSource.DataDiskURI, nodeName, devicePath)
-	lun, err := diskController.GetDiskLun(diskName, volumeSource.DataDiskURI, nodeName)
-	if err != nil {
-		return "", err
+	var lun int32
+	if runtime.GOOS == "windows" {
+		glog.V(2).Infof("azureDisk - WaitForAttach: begin to GetDiskLun by diskName(%s), DataDiskURI(%s), nodeName(%s), devicePath(%s)",
+			diskName, volumeSource.DataDiskURI, nodeName, devicePath)
+		lun, err = diskController.GetDiskLun(diskName, volumeSource.DataDiskURI, nodeName)
+		if err != nil {
+			return "", err
+		}
+		glog.V(2).Infof("azureDisk - WaitForAttach: GetDiskLun succeeded, got lun(%v)", lun)
+	} else {
+		lun, err = getDiskLUN(devicePath)
+		if err != nil {
+			return "", err
+		}
 	}
-	glog.V(5).Infof("azureDisk - WaitForAttach: GetDiskLun succeeded, got lun(%v)", lun)
+
 	exec := a.plugin.host.GetExec(a.plugin.GetPluginName())
 
 	io := &osIOHandler{}

--- a/vendor/k8s.io/kubernetes/pkg/volume/azure_dd/azure_common_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/azure_dd/azure_common_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -132,5 +133,60 @@ func TestIoHandler(t *testing.T) {
 		if disk != "/dev/"+devName || err != nil {
 			t.Errorf("no data disk found: disk %v err %v", disk, err)
 		}
+	}
+}
+
+func TestGetDiskLUN(t *testing.T) {
+	tests := []struct {
+		deviceInfo  string
+		expectedLUN int32
+		expectError bool
+	}{
+		{
+			deviceInfo:  "0",
+			expectedLUN: 0,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "10",
+			expectedLUN: 10,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "11d",
+			expectedLUN: -1,
+			expectError: true,
+		},
+		{
+			deviceInfo:  "999",
+			expectedLUN: -1,
+			expectError: true,
+		},
+		{
+			deviceInfo:  "",
+			expectedLUN: -1,
+			expectError: true,
+		},
+		{
+			deviceInfo:  "/dev/disk/azure/scsi1/lun2",
+			expectedLUN: 2,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "/dev/disk/azure/scsi0/lun12",
+			expectedLUN: 12,
+			expectError: false,
+		},
+		{
+			deviceInfo:  "/dev/disk/by-id/scsi1/lun2",
+			expectedLUN: -1,
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		result, err := getDiskLUN(test.deviceInfo)
+		assert.Equal(t, result, test.expectedLUN)
+		assert.Equal(t, err != nil, test.expectError, fmt.Sprintf("error msg: %v", err))
 	}
 }


### PR DESCRIPTION
UPSTREAM: 70002: Cherry-picked

Cherry-pick azure disk attacher fix from https://github.com/kubernetes/kubernetes/pull/70002 
Issue: https://github.com/openshift/openshift-azure/issues/1362

cc: @jim-minter @mfojtik 