### PR TITLE
[3.11] Fix up VNID tracking on restart / delete unused NetworkPolicy flows

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,14 +121,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
-	if err != nil {
-		return err
-	}
-	inUseNamespaces := sets.NewString()
-	for _, pod := range pods {
-		inUseNamespaces.Insert(pod.Namespace)
-	}
+	inUseVNIDs := np.node.oc.FindPolicyVNIDs()
 
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
@@ -141,7 +134,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    inUseNamespaces.Has(ns.Name),
+				inUse:    inUseVNIDs.Has(int(vnid)),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -186,7 +186,15 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkapi.NetNamespace
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	delete(np.namespaces, netns.NetID)
+	if npns, exists := np.namespaces[netns.NetID]; exists {
+		if npns.inUse {
+			npns.inUse = false
+			// We call syncNamespaceFlows() not syncNamespace() because it
+			// needs to happen before we forget about the namespace.
+			np.syncNamespaceFlows(npns)
+		}
+		delete(np.namespaces, netns.NetID)
+	}
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,6 +121,15 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
+	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
+	if err != nil {
+		return err
+	}
+	inUseNamespaces := sets.NewString()
+	for _, pod := range pods {
+		inUseNamespaces.Insert(pod.Namespace)
+	}
+
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -132,7 +141,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    false,
+				inUse:    inUseNamespaces.Has(ns.Name),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}


### PR DESCRIPTION
Second attempt at a backport of #22158, now including #22302 as well to hopefully fix up the problems from the last backport attempt (#22251)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686025 ("Network Policy Plugin does not clean up flows from deleted namespaces") AND https://bugzilla.redhat.com/show_bug.cgi?id=1694704 ("NetworkPolicy rules don't update reliably after a service restart")