### PR TITLE
[3.10] Fix up VNID tracking on restart / delete unused NetworkPolicy flows

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,14 +121,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
-	if err != nil {
-		return err
-	}
-	inUseNamespaces := sets.NewString()
-	for _, pod := range pods {
-		inUseNamespaces.Insert(pod.Namespace)
-	}
+	inUseVNIDs := np.node.oc.FindPolicyVNIDs()
 
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
@@ -141,7 +134,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    inUseNamespaces.Has(ns.Name),
+				inUse:    inUseVNIDs.Has(int(vnid)),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -186,7 +186,15 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkapi.NetNamespace
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	delete(np.namespaces, netns.NetID)
+	if npns, exists := np.namespaces[netns.NetID]; exists {
+		if npns.inUse {
+			npns.inUse = false
+			// We call syncNamespaceFlows() not syncNamespace() because it
+			// needs to happen before we forget about the namespace.
+			np.syncNamespaceFlows(npns)
+		}
+		delete(np.namespaces, netns.NetID)
+	}
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -121,6 +121,15 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
+	pods, err := np.node.GetLocalPods(metav1.NamespaceAll)
+	if err != nil {
+		return err
+	}
+	inUseNamespaces := sets.NewString()
+	for _, pod := range pods {
+		inUseNamespaces.Insert(pod.Namespace)
+	}
+
 	namespaces, err := np.node.kClient.Core().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -132,7 +141,7 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 			np.namespaces[vnid] = &npNamespace{
 				name:     ns.Name,
 				vnid:     vnid,
-				inUse:    false,
+				inUse:    inUseNamespaces.Has(ns.Name),
 				policies: make(map[ktypes.UID]*npPolicy),
 			}
 		}

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -600,28 +600,39 @@ func (oc *ovsController) UpdateVXLANMulticastFlows(remoteIPs []string) error {
 	return otx.Commit()
 }
 
-// FindUnusedVNIDs returns a list of VNIDs for which there are table 80 "check" rules,
+// FindPolicyVNIDs returns the set of VNIDs for which there are currently "policy" rules
+// in OVS. (This is used to reinitialize the osdnPolicy after a restart.)
+func (oc *ovsController) FindPolicyVNIDs() sets.Int {
+	_, policyVNIDs := oc.findInUseAndPolicyVNIDs()
+	return policyVNIDs
+}
+
+// FindUnusedVNIDs returns a list of VNIDs for which there are table 80 "policy" rules,
 // but no table 60/70 "load" rules (meaning that there are no longer any pods or services
 // on this node with that VNID). There is no locking with respect to other ovsController
 // actions, but as long the "add a pod" and "add a service" codepaths add the
 // pod/service-specific rules before they call policy.EnsureVNIDRules(), then there is no
 // race condition.
 func (oc *ovsController) FindUnusedVNIDs() []int {
+	inUseVNIDs, policyVNIDs := oc.findInUseAndPolicyVNIDs()
+	return policyVNIDs.Difference(inUseVNIDs).UnsortedList()
+}
+
+func (oc *ovsController) findInUseAndPolicyVNIDs() (sets.Int, sets.Int) {
+	// VNID 0 is always in use, even if there aren't any explicit flows for it
+	inUseVNIDs := sets.NewInt(0)
+	policyVNIDs := sets.NewInt()
+
 	flows, err := oc.ovs.DumpFlows("")
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("FindUnusedVNIDs: could not DumpFlows: %v", err))
-		return nil
+		utilruntime.HandleError(fmt.Errorf("findInUseAndPolicyVNIDs: could not DumpFlows: %v", err))
+		return inUseVNIDs, policyVNIDs
 	}
 
-	// inUseVNIDs is the set of VNIDs in use by pods or services on this node.
-	// policyVNIDs is the set of VNIDs that we have rules for delivering to.
-	// VNID 0 is always assumed to be in both sets.
-	inUseVNIDs := sets.NewInt(0)
-	policyVNIDs := sets.NewInt(0)
 	for _, flow := range flows {
 		parsed, err := ovs.ParseFlow(ovs.ParseForDump, flow)
 		if err != nil {
-			glog.Warningf("FindUnusedVNIDs: could not parse flow %q: %v", flow, err)
+			glog.Warningf("findInUseAndPolicyVNIDs: could not parse flow %q: %v", flow, err)
 			continue
 		}
 
@@ -639,7 +650,7 @@ func (oc *ovsController) FindUnusedVNIDs() []int {
 				}
 				vnid, err := strconv.ParseInt(action.Value[:vnidEnd], 0, 32)
 				if err != nil {
-					glog.Warningf("FindUnusedVNIDs: could not parse VNID in 'load:%s': %v", action.Value, err)
+					glog.Warningf("findInUseAndPolicyVNIDs: could not parse VNID in 'load:%s': %v", action.Value, err)
 					continue
 				}
 				inUseVNIDs.Insert(int(vnid))
@@ -652,7 +663,7 @@ func (oc *ovsController) FindUnusedVNIDs() []int {
 			if field, exists := parsed.FindField("reg1"); exists {
 				vnid, err := strconv.ParseInt(field.Value, 0, 32)
 				if err != nil {
-					glog.Warningf("FindUnusedVNIDs: could not parse VNID in 'reg1=%s': %v", field.Value, err)
+					glog.Warningf("findInUseAndPolicyVNIDs: could not parse VNID in 'reg1=%s': %v", field.Value, err)
 					continue
 				}
 				policyVNIDs.Insert(int(vnid))
@@ -660,7 +671,7 @@ func (oc *ovsController) FindUnusedVNIDs() []int {
 		}
 	}
 
-	return policyVNIDs.Difference(inUseVNIDs).UnsortedList()
+	return inUseVNIDs, policyVNIDs
 }
 
 func (oc *ovsController) ensureTunMAC() error {

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -814,9 +814,10 @@ func TestAlreadySetUp(t *testing.T) {
 	}
 }
 
-func TestSyncVNIDRules(t *testing.T) {
+func TestFindUnusedVNIDs(t *testing.T) {
 	testcases := []struct {
 		flows  []string
+		policy []int
 		unused []int
 	}{
 		{
@@ -843,6 +844,7 @@ func TestSyncVNIDRules(t *testing.T) {
 				"table=80,priority=100,reg0=0xcb81e9,reg1=0xcb81e9 actions=output:NXM_NX_REG2[]",
 				"table=80,priority=0 actions=drop",
 			},
+			policy: []int{0x0, 0x55fac, 0xcb81e9},
 			unused: []int{},
 		},
 		{
@@ -866,6 +868,7 @@ func TestSyncVNIDRules(t *testing.T) {
 				"table=80,priority=100,reg0=0xcb81e9,reg1=0xcb81e9 actions=output:NXM_NX_REG2[]",
 				"table=80,priority=0 actions=drop",
 			},
+			policy: []int{0x0, 0x55fac, 0xcb81e9},
 			unused: []int{},
 		},
 		{
@@ -889,6 +892,7 @@ func TestSyncVNIDRules(t *testing.T) {
 				"table=80,priority=100,reg0=0xcb81e9,reg1=0xcb81e9 actions=output:NXM_NX_REG2[]",
 				"table=80,priority=0 actions=drop",
 			},
+			policy: []int{0x0, 0x55fac, 0xcb81e9},
 			unused: []int{0xcb81e9},
 		},
 		{
@@ -908,7 +912,31 @@ func TestSyncVNIDRules(t *testing.T) {
 				"table=80,priority=100,reg0=0xcb81e9,reg1=0xcb81e9 actions=output:NXM_NX_REG2[]",
 				"table=80,priority=0 actions=drop",
 			},
+			policy: []int{0x0, 0x55fac, 0xcb81e9},
 			unused: []int{0x55fac, 0xcb81e9},
+		},
+		{
+			/* Invalid state; we lost the 0x55fac policy rules somehow. But we should still notice that 0xcb81e9 is unused. */
+			flows: []string{
+				"table=60,priority=200,reg0=0 actions=output:2",
+				"table=60,priority=100,ip,nw_dst=172.30.0.1,nw_frag=later actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=100,ip,nw_dst=172.30.76.192,nw_frag=later actions=load:0x55fac->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=100,tcp,nw_dst=172.30.0.1,tp_dst=443 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=100,udp,nw_dst=172.30.0.1,tp_dst=53 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=100,tcp,nw_dst=172.30.0.1,tp_dst=53 actions=load:0->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=100,tcp,nw_dst=172.30.76.192,tp_dst=5454 actions=load:0x55fac->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=100,tcp,nw_dst=172.30.76.192,tp_dst=5455 actions=load:0x55fac->NXM_NX_REG1[],load:0x2->NXM_NX_REG2[],goto_table:80",
+				"table=60,priority=0 actions=drop",
+				"table=70,priority=100,ip,nw_dst=10.129.0.2 actions=load:0x55fac->NXM_NX_REG1[],load:0x3->NXM_NX_REG2[],goto_table:80",
+				"table=70,priority=0 actions=drop",
+				"table=80,priority=300,ip,nw_src=10.129.0.1 actions=output:NXM_NX_REG2[]",
+				"table=80,priority=200,reg0=0 actions=output:NXM_NX_REG2[]",
+				"table=80,priority=200,reg1=0 actions=output:NXM_NX_REG2[]",
+				"table=80,priority=100,reg0=0xcb81e9,reg1=0xcb81e9 actions=output:NXM_NX_REG2[]",
+				"table=80,priority=0 actions=drop",
+			},
+			policy: []int{0x0, 0xcb81e9},
+			unused: []int{0xcb81e9},
 		},
 	}
 
@@ -923,10 +951,14 @@ func TestSyncVNIDRules(t *testing.T) {
 			t.Fatalf("(%d) unexpected error from AddFlow: %v", i, err)
 		}
 
+		policy := oc.FindPolicyVNIDs()
+		if !reflect.DeepEqual(policy.List(), tc.policy) {
+			t.Fatalf("(%d) wrong result for policy, expected %v, got %v", i, tc.policy, policy.List())
+		}
 		unused := oc.FindUnusedVNIDs()
 		sort.Ints(unused)
 		if !reflect.DeepEqual(unused, tc.unused) {
-			t.Fatalf("(%d) wrong result, expected %v, got %v", i, tc.unused, unused)
+			t.Fatalf("(%d) wrong result for unused, expected %v, got %v", i, tc.unused, unused)
 		}
 	}
 }


### PR DESCRIPTION
For testing purposes for #22443; the last attempt to backport this fix passed 3.11 CI but reliably failed 3.10 CI. We may not be actually backporting the fix to 3.10 but I want to test it there anyway...