### PR TITLE
test/extended/util/test: Restore "Pod should prefer to scheduled..."

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -383,8 +383,6 @@ var (
 
 			`validates that there is no conflict between pods with same hostPort but different hostIP and protocol`, // https://github.com/kubernetes/kubernetes/issues/61018
 
-			`Pod should perfer to scheduled to nodes pod can tolerate`, // broken due to multi-zone cluster in 1.11, enable in 1.12
-
 			`Services should be able to create a functioning NodePort service`, // https://github.com/openshift/origin/issues/21708
 
 			`SSH`,                // TRIAGE


### PR DESCRIPTION
We're now well past the 1.11 -> 1.12 rebase and have just passed the 1.12 -> 1.13 pivot.  Drop some of the exclusions that claimed to need 1.12 kubelets.  The lines I'm dropping were added in d6951f9e7a (#21730) and c27ddecb0f (#21776).  CC @smarterclayton and @soltysh, since those were your commits.