### PR TITLE
UPSTREAM: 75943: Fix AWS driver to provision specified fsType

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/awsebs/aws_util.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/awsebs/aws_util.go
@@ -120,8 +120,10 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner, node *
 	}
 
 	fstype := ""
-	if v, ok := c.options.Parameters[volume.VolumeParameterFSType]; ok {
-		fstype = v
+	for k, v := range c.options.Parameters {
+		if strings.ToLower(k) == volume.VolumeParameterFSType {
+			fstype = v
+		}
 	}
 
 	return name, volumeOptions.CapacityGB, labels, fstype, nil


### PR DESCRIPTION
In Kubernetes 1.13, `fstype` was parsed as case-sensitive. We need to fix it to case-insensitive, so `fsType` works.

https://bugzilla.redhat.com/show_bug.cgi?id=1694656
https://github.com/kubernetes/kubernetes/pull/75943


@openshift/sig-storage 