### PR TITLE
Enable GlusterFS tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -352,7 +352,6 @@ var (
 			`Cinder`, // requires an OpenStack cluster
 			// See the CanSupport implementation in upstream to determine wether these work.
 			`Ceph RBD`,                              // Works if ceph-common Binary installed (but we can't guarantee this on all clusters).
-			`GlusterFS`,                             // May work if /sbin/mount.glusterfs to be installed for plugin to work (also possibly blocked by serial pulling)
 			`Horizontal pod autoscaling`,            // needs heapster
 			`authentication: OpenLDAP`,              // needs separate setup and bucketing for openldap bootstrapping
 			`NodeProblemDetector`,                   // requires a non-master node to run on


### PR DESCRIPTION
`mount.glusterfs` is present in RHCOS images.

@openshift/sig-storage 