### PR TITLE
Remove Disruptive tests from serial suite

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -439,7 +439,6 @@ var (
 		},
 		// tests that must be run without competition
 		"[Serial]": {
-			`\[Disruptive\]`,
 			`\[Feature:Performance\]`,            // requires isolation
 			`\[Feature:ManualPerformance\]`,      // requires isolation
 			`\[Feature:HighDensityPerformance\]`, // requires no other namespaces


### PR DESCRIPTION
We don't run them, they're skipped in excludedTests few lines below:

https://github.com/openshift/origin/blob/6d437442529f7e940bd44d9bd43852b7ea6f496e/test/extended/util/test.go#L460-L462