### PR TITLE
Run e2e tests with "custom" distro

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -78,6 +78,11 @@ func InitTest() {
 	TestContext.KubeConfig = KubeConfigPath()
 	os.Setenv("KUBECONFIG", TestContext.KubeConfig)
 
+	// "debian" is used when not set. At least GlusterFS tests need "custom".
+	// (There is no option for "rhel" or "centos".)
+	TestContext.NodeOSDistro = "custom"
+	TestContext.MasterOSDistro = "custom"
+
 	// load and set the host variable for kubectl
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: TestContext.KubeConfig}, &clientcmd.ConfigOverrides{})
 	cfg, err := clientConfig.ClientConfig()


### PR DESCRIPTION
When undefined, distro is set to "debian" and that disables GlusterFS tests.

@openshift/sig-storage 