### PR TITLE
PSP subject review: do not pass empty user to FindApplicableSCCs

### DIFF
--- a/pkg/security/apis/security/validation/validation.go
+++ b/pkg/security/apis/security/validation/validation.go
@@ -281,9 +281,13 @@ func ValidatePodSecurityPolicySubjectReview(podSecurityPolicySubjectReview *secu
 	return allErrs
 }
 
-func validatePodSecurityPolicySubjectReviewSpec(podSecurityPolicySubjectReviewSpec *securityapi.PodSecurityPolicySubjectReviewSpec, fldPath *field.Path) field.ErrorList {
+func validatePodSecurityPolicySubjectReviewSpec(spec *securityapi.PodSecurityPolicySubjectReviewSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, kapivalidation.ValidatePodSpec(&podSecurityPolicySubjectReviewSpec.Template.Spec, fldPath.Child("template", "spec"))...)
+	allErrs = append(allErrs, kapivalidation.ValidatePodSpec(&spec.Template.Spec, fldPath.Child("template", "spec"))...)
+	// make sure we never pass an empty user list to FindApplicableSCCs as it will consider that as matching all SCCs
+	if len(spec.User) == 0 && len(spec.Groups) == 0 && len(spec.Template.Spec.ServiceAccountName) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("user"), "at least one of user, groups or serviceAccountName must be specified"))
+	}
 	return allErrs
 }
 

--- a/pkg/security/apis/security/validation/validation_test.go
+++ b/pkg/security/apis/security/validation/validation_test.go
@@ -432,7 +432,7 @@ func TestValidatePodSecurityPolicySubjectReview(t *testing.T) {
 	}
 
 	koCases := map[string]securityapi.PodSecurityPolicySubjectReview{
-		"[spec.template.spec.containers[0].name: Required value, spec.template.spec.containers[0].image: Required value, spec.template.spec.containers[0].imagePullPolicy: Required value]": {
+		"[spec.template.spec.containers[0].name: Required value, spec.template.spec.containers[0].image: Required value, spec.template.spec.containers[0].imagePullPolicy: Required value, spec.user: Required value: at least one of user, groups or serviceAccountName must be specified]": {
 			Spec: securityapi.PodSecurityPolicySubjectReviewSpec{
 				Template: kapi.PodTemplateSpec{
 					Spec: invalidPodSpec(),

--- a/pkg/security/apiserver/registry/podsecuritypolicysubjectreview/rest.go
+++ b/pkg/security/apiserver/registry/podsecuritypolicysubjectreview/rest.go
@@ -64,9 +64,13 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, kapierrors.NewInvalid(coreapi.Kind("PodSecurityPolicySubjectReview"), "", errs)
 	}
 
-	userInfo := &user.DefaultInfo{Name: pspsr.Spec.User, Groups: pspsr.Spec.Groups}
+	var users []user.Info
 
-	users := []user.Info{userInfo}
+	specUser := &user.DefaultInfo{Name: pspsr.Spec.User, Groups: pspsr.Spec.Groups}
+	if len(specUser.Name) > 0 || len(specUser.Groups) > 0 {
+		users = append(users, specUser)
+	}
+
 	saName := pspsr.Spec.Template.Spec.ServiceAccountName
 	if len(saName) > 0 {
 		users = append(users, serviceaccount.UserInfo(ns, saName, ""))


### PR DESCRIPTION
The spec.user and spec.groups field of PSP subject review are
optional.  Per the API docs:

    If User and Groups are empty, then the check is performed using
    *only* the ServiceAccountName in the PodTemplateSpec.

Thus we check if either field is specified before attempting to
perform a check via FindApplicableSCCs.

This does not cause any issues as the the error is simply logged and
the SA is consulted as usual.  The error just looks scary.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth @deads2k 