### PR TITLE
Bug 1695554 - SDN may be very slow to start up after a reboot

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -385,6 +385,11 @@ func (node *OsdnNode) reattachPods(existingPods map[string]podNetworkInfo) error
 			glog.Warningf("Could not find sandbox for existing pod with IP %s; it may be in an inconsistent state", podInfo.ip)
 			continue
 		}
+		if _, err := node.oc.ovs.GetOFPort(podInfo.vethName); err != nil {
+			glog.Infof("Interface %s for pod '%s/%s' no longer exists", podInfo.vethName, sandbox.Metadata.Namespace, sandbox.Metadata.Name)
+			failed = append(failed, sandbox)
+			continue
+		}
 
 		req := &cniserver.PodRequest{
 			Command:      cniserver.CNI_ADD,


### PR DESCRIPTION
Cleaning up pods on startup may involve doing CNI DELETEs. When Multus is in use, this will require making apiserver calls, and it will try to use the kubernetes service IP, which openshift-sdn may not have set
up yet, resulting in network errors and timeouts. Fix this by doing the deletes in a goroutine, so SDN can continue initializing and set up the proxy.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1695554