### PR TITLE
publishing: skip gomod

### DIFF
--- a/publishing-kube-rules.yaml
+++ b/publishing-kube-rules.yaml
@@ -1,4 +1,5 @@
 skip-godeps: true
+skip-gomod: true
 skip-tags: true
 recursive-delete-patterns:
 - BUILD

--- a/publishing-rules.yaml
+++ b/publishing-rules.yaml
@@ -1,4 +1,5 @@
 skip-godeps: true
+skip-gomod: true
 rules:
 - destination: kubernetes
   branches:


### PR DESCRIPTION
The upstream bot master branch switched to go.mod.