### PR TITLE
Disable kcm metrics endpoint temporarily

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -130,7 +130,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 					// TODO: this should be https
 					targets.Expect(labels{"job": "scheduler"}, "up", "^http://.*/metrics$"),
 					// TODO: this should be https
-					targets.Expect(labels{"job": "kube-controller-manager"}, "up", "^http://.*/metrics$"),
+					// targets.Expect(labels{"job": "kube-controller-manager"}, "up", "^http://.*/metrics$"),
 					targets.Expect(labels{"job": "kube-state-metrics"}, "up", "^https://.*/metrics$"),
 					// TODO: should probably be https
 					targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^http://.*/metrics$"),


### PR DESCRIPTION
To be able to land https://github.com/openshift/cluster-kube-controller-manager-operator/pull/207 we need to disable temporarily kcm verification. After the aforementioned PR lands we need to switch to `https`. 

/assign @sttts 