### PR TITLE
BZ 1592217 Correct error message when joining two projects

### DIFF
--- a/pkg/oc/cli/admin/network/join_projects.go
+++ b/pkg/oc/cli/admin/network/join_projects.go
@@ -32,14 +32,16 @@ var (
 )
 
 type JoinOptions struct {
-	Options *ProjectOptions
+	Options     *ProjectOptions
+	JoinProject *ProjectOptions
 
 	joinProjectName string
 }
 
 func NewJoinOptions(streams genericclioptions.IOStreams) *JoinOptions {
 	return &JoinOptions{
-		Options: NewProjectOptions(streams),
+		Options:     NewProjectOptions(streams),
+		JoinProject: NewProjectOptions(streams),
 	}
 }
 
@@ -69,6 +71,9 @@ func (o *JoinOptions) Complete(f kcmdutil.Factory, c *cobra.Command, args []stri
 	if err := o.Options.Complete(f, c, args); err != nil {
 		return err
 	}
+	if err := o.JoinProject.Complete(f, c, []string{o.joinProjectName}); err != nil {
+		return err
+	}
 	o.Options.CheckSelector = c.Flag("selector").Changed
 	return nil
 }
@@ -86,6 +91,10 @@ func (o *JoinOptions) Validate() error {
 
 func (o *JoinOptions) Run() error {
 	projects, err := o.Options.GetProjects()
+	if err != nil {
+		return err
+	}
+	_, err = o.JoinProject.GetProjects()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When joing two projects if the first one specified does not exist
instead of issueing the error "no projects found" the command fails
with a timeout.

Correct this so that regardless of which project does not exist the
correct error is thrown

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1592217