### PR TITLE
Remove unused code in prune deployments

### DIFF
--- a/pkg/oc/cli/admin/prune/deployments/deployments.go
+++ b/pkg/oc/cli/admin/prune/deployments/deployments.go
@@ -168,7 +168,7 @@ func (o PruneDeploymentsOptions) Run() error {
 	deploymentDeleter := &describingDeploymentDeleter{w: w}
 
 	if o.Confirm {
-		deploymentDeleter.delegate = NewDeploymentDeleter(o.KubeClient, o.KubeClient)
+		deploymentDeleter.delegate = NewDeploymentDeleter(o.KubeClient)
 	} else {
 		fmt.Fprintln(os.Stderr, "Dry run enabled - no modifications will be made. Add --confirm to remove deployments")
 	}

--- a/pkg/oc/cli/admin/prune/deployments/prune.go
+++ b/pkg/oc/cli/admin/prune/deployments/prune.go
@@ -95,16 +95,14 @@ func (p *pruner) Prune(deleter DeploymentDeleter) error {
 // deploymentDeleter removes a deployment from OpenShift.
 type deploymentDeleter struct {
 	deployments corev1client.ReplicationControllersGetter
-	pods        corev1client.PodsGetter
 }
 
 var _ DeploymentDeleter = &deploymentDeleter{}
 
 // NewDeploymentDeleter creates a new deploymentDeleter.
-func NewDeploymentDeleter(deployments corev1client.ReplicationControllersGetter, pods corev1client.PodsGetter) DeploymentDeleter {
+func NewDeploymentDeleter(deployments corev1client.ReplicationControllersGetter) DeploymentDeleter {
 	return &deploymentDeleter{
 		deployments: deployments,
-		pods:        pods,
 	}
 }
 


### PR DESCRIPTION
This is a followup to https://github.com/openshift/origin/pull/22211 removing dead code from deployments pruning.

/assign @tnozicka 