### PR TITLE
Check for secure endpoints for scheduler and kcm in prometheus

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -127,10 +127,9 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				lastErrs = all(
 					targets.Expect(labels{"job": "apiserver"}, "up", "^https://.*/metrics$"),
 					// TODO: add openshift api
-					// TODO: this should be https
-					// targets.Expect(labels{"job": "kube-controller-manager"}, "up", "^http://.*/metrics$"),
 					// TODO: check only for https after merging https://github.com/openshift/cluster-monitoring-operator/pull/308
 					targets.Expect(labels{"job": "scheduler"}, "up", "^(http|https)://.*/metrics$"),
+					targets.Expect(labels{"job": "kube-controller-manager"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "kube-state-metrics"}, "up", "^https://.*/metrics$"),
 					// TODO: should probably be https
 					targets.Expect(labels{"job": "cluster-version-operator"}, "up", "^http://.*/metrics$"),


### PR DESCRIPTION
This reverts changes from https://github.com/openshift/origin/pull/22476 and is currently blocked by https://github.com/openshift/cluster-kube-controller-manager-operator/pull/207. 

/assign @mfojtik @sttts 
