### PR TITLE
test/e2e: re-enable kubelet hostAliases test

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -411,8 +411,6 @@ var (
 			`CSI Volumes CSI attach test using HostPath driver`,
 			`CSI Volumes CSI plugin test using CSI driver: hostPath`,
 			`Volume metrics should create volume metrics in Volume Manager`,
-
-			`Kubelet when scheduling a busybox Pod with hostAliases should write entries to /etc/hosts`, // https://bugzilla.redhat.com/show_bug.cgi?id=1695278
 		},
 		// tests too slow to be part of conformance
 		"[Slow]": {


### PR DESCRIPTION
@smarterclayton @deads2k 
xref https://bugzilla.redhat.com/show_bug.cgi?id=1694182
/hold
until os-container is verified to be at 1.13