### PR TITLE
Move the COPY scriptes to below the RUN INSTALL_PKGS for sdn image

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -18,7 +18,6 @@ COPY --from=builder /tmp/build/openshift-sdn /usr/bin/
 COPY --from=builder /tmp/build/sdn-cni-plugin /opt/cni/bin/openshift-sdn
 COPY --from=builder /tmp/build/loopback /opt/cni/bin/
 COPY --from=builder /tmp/build/host-local /opt/cni/bin/
-COPY images/sdn/scripts/* /usr/sbin/
 
 RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \
@@ -29,6 +28,15 @@ RUN INSTALL_PKGS=" \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \
     yum clean all && rm -rf /var/cache/*
+
+COPY ./images/sdn/scripts/iptables /usr/sbin/
+COPY ./images/sdn/scripts/iptables-save /usr/sbin/
+COPY ./images/sdn/scripts/iptables-restore /usr/sbin/
+COPY ./images/sdn/scripts/ip6tables /usr/sbin/
+COPY ./images/sdn/scripts/ip6tables-save /usr/sbin/
+COPY ./images/sdn/scripts/ip6tables-restore /usr/sbin/
+COPY ./images/sdn/scripts/iptables /usr/sbin/
+
 LABEL io.k8s.display-name="OpenShift SDN" \
       io.k8s.description="This is a component of OpenShift and contains the networking tool stack for the default SDN implementation." \
       io.openshift.tags="openshift,sdn"

--- a/images/sdn/scripts/ip6tables
+++ b/images/sdn/scripts/ip6tables
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/ip6tables $@
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/images/sdn/scripts/ip6tables-restore
+++ b/images/sdn/scripts/ip6tables-restore
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/ip6tables-restore $@
+exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/images/sdn/scripts/ip6tables-save
+++ b/images/sdn/scripts/ip6tables-save
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/ip6tables-save $@
+exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/images/sdn/scripts/iptables
+++ b/images/sdn/scripts/iptables
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/iptables $@
+exec chroot /host /usr/sbin/iptables "$@"

--- a/images/sdn/scripts/iptables-restore
+++ b/images/sdn/scripts/iptables-restore
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/iptables-restore $@
+exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/images/sdn/scripts/iptables-save
+++ b/images/sdn/scripts/iptables-save
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec chroot /host /usr/sbin/iptables-save $@
+exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
somewhere in the build path for the sdn image iptables gets installed as a dependancey. If the scripts are copied into the image after we are assured that the iptables wrappers get used.