### PR TITLE
hack: Handle multiple entries in OS_EXTRA_GOPATH for brew builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,9 @@
 #   clean: Clean up.
 
 OUT_DIR = _output
-OS_OUTPUT_GOPATH ?= 1
 
 export GOFLAGS
 export TESTFLAGS
-# If set to 1, create an isolated GOPATH inside _output using symlinks to avoid
-# other packages being accidentally included. Defaults to on.
-export OS_OUTPUT_GOPATH
 # May be used to set additional arguments passed to the image build commands for
 # mounting secrets specific to a build environment.
 export OS_BUILD_IMAGE_ARGS

--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -91,20 +91,9 @@ function os::build::setup_env() {
 
   unset GOBIN
 
-  # default to OS_OUTPUT_GOPATH if no GOPATH set
-  if [[ -z "${GOPATH:-}" ]]; then
-    export OS_OUTPUT_GOPATH=1
-  fi
-
-  # use the regular gopath for building
-  if [[ -z "${OS_OUTPUT_GOPATH:-}" ]]; then
-    export OS_TARGET_BIN=${GOPATH}/bin
-    return
-  fi
-
   # create a local GOPATH in _output
   GOPATH="${OS_OUTPUT}/go"
-  OS_TARGET_BIN=${GOPATH}/bin
+  OS_TARGET_BIN="${OS_OUTPUT}/go/bin"
   local go_pkg_dir="${GOPATH}/src/${OS_GO_PACKAGE}"
   local go_pkg_basedir=$(dirname "${go_pkg_dir}")
 
@@ -120,9 +109,8 @@ function os::build::setup_env() {
   # Append OS_EXTRA_GOPATH to the GOPATH if it is defined.
   if [[ -n ${OS_EXTRA_GOPATH:-} ]]; then
     GOPATH="${GOPATH}:${OS_EXTRA_GOPATH}"
-    # TODO: needs to handle multiple directories
-    OS_TARGET_BIN=${OS_EXTRA_GOPATH}/bin
   fi
+
   export GOPATH
   export OS_TARGET_BIN
 }
@@ -234,7 +222,6 @@ os::build::internal::build_binaries() {
 
       if [[ ${#nonstatics[@]} -gt 0 ]]; then
         GOOS=${platform%/*} GOARCH=${platform##*/} go install \
-          -pkgdir "${pkgdir}/${platform}" \
           -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_envvar:-}" \
           -ldflags="${local_ldflags}" \
           "${goflags[@]:+${goflags[@]}}" \
@@ -256,7 +243,6 @@ os::build::internal::build_binaries() {
         local outfile="${OS_OUTPUT_BINPATH}/${platform}/$(basename ${test})"
         # disabling cgo allows use of delve
         CGO_ENABLED="${OS_TEST_CGO_ENABLED:-}" GOOS=${platform%/*} GOARCH=${platform##*/} go test \
-          -pkgdir "${pkgdir}/${platform}" \
           -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_test_envvar:-}" \
           -ldflags "${local_ldflags}" \
           -i -c -o "${outfile}" \


### PR DESCRIPTION
The cross-platform builds are failing because brew uses /go:/opt/rhtoolset/...
and the release copy step fails to find the generated binary because
`/go:/opt/rhtoolset/...` is not a valid path. We must set OS_TARGET_BIN
to the internal GOPATH.  We will remove support for external GOPATH in preparation for Go 1.12.

Failed with:

```
2019-04-05 17:00:42,409 - atomic_reactor.plugins.imagebuilder - INFO - + go install -pkgdir /go/src/github.com/openshift/origin/_output/local/pkgdir/darwin/amd64 -tags 'include_gcs include_oss containers_image_openpgp ' '-ldflags=-s -w -X github.com/openshift/origin/pkg/oc/clusterup.defaultImageStreams=centos7 -X github.com/openshift/origin/pkg/cmd/util/variable.DefaultImagePrefix=openshift/origin -X github.com/openshift/origin/pkg/version.majorFromGit=4 -X github.com/openshift/origin/pkg/version.minorFromGit=0+ -X github.com/openshift/origin/pkg/version.versionFromGit=v4.0.22-201904032147+8d39259-dirty -X github.com/openshift/origin/pkg/version.commitFromGit=8d39259 -X github.com/openshift/origin/pkg/version.buildDate=2019-04-05T17:00:42Z -X github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/version.gitMajor=1 -X github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/version.gitMinor=13+ -X github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/version.gitCommit=8d39259 -X github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/version.gitVersion=v1.13.4+8d39259 -X github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/version.buildDate=2019-04-05T17:00:42Z -X github.com/openshift/origin/vendor/k8s.io/kubernetes/pkg/version.gitTreeState=clean -X github.com/openshift/origin/vendor/k8s.io/client-go/pkg/version.gitMajor=1 -X github.com/openshift/origin/vendor/k8s.io/client-go/pkg/version.gitMinor=13+ -X github.com/openshift/origin/vendor/k8s.io/client-go/pkg/version.gitCommit=8d39259 -X github.com/openshift/origin/vendor/k8s.io/client-go/pkg/version.gitVersion=v1.13.4+8d39259 -X github.com/openshift/origin/vendor/k8s.io/client-go/pkg/version.buildDate=2019-04-05T17:00:42Z -X github.com/openshift/origin/vendor/k8s.io/client-go/pkg/version.gitTreeState=clean -s' -gcflags '' github.com/openshift/origin/cmd/oc
2019-04-05 17:01:21,602 - atomic_reactor.plugins.imagebuilder - INFO - + [[ darwin/amd64 != linux/amd64 ]]
2019-04-05 17:01:21,603 - atomic_reactor.plugins.imagebuilder - INFO - + local platform_src=/darwin_amd64
2019-04-05 17:01:21,604 - atomic_reactor.plugins.imagebuilder - INFO - + mv '/go:/opt/rh/go-toolset-1.10/root/usr/share/gocode/bin//darwin_amd64/*' /go/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/
```