### PR TITLE
Bug 1697206: Return a status error on GET user with invalid name

### DIFF
--- a/pkg/user/apiserver/registry/user/etcd/etcd.go
+++ b/pkg/user/apiserver/registry/user/etcd/etcd.go
@@ -100,8 +100,10 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 	}
 
 	// do not bother looking up users that cannot be persisted
+	// make sure we return a status error otherwise the API server will complain
 	if reasons := validation.ValidateUserName(name, false); len(reasons) != 0 {
-		return nil, field.Invalid(field.NewPath("metadata", "name"), name, strings.Join(reasons, ", "))
+		err := field.Invalid(field.NewPath("metadata", "name"), name, strings.Join(reasons, ", "))
+		return nil, kerrs.NewInvalid(usergroup.Kind("User"), name, field.ErrorList{err})
 	}
 
 	return r.Store.Get(ctx, name, options)


### PR DESCRIPTION
The use of the kube:admin user against the API causes lookups against the API that will result in "validation" errors:

    apiserver received an error that is not an metav1.Status:
    &field.Error{Type:"FieldValueInvalid", Field:"metadata.name",
    BadValue:"kube:admin", Detail:"may not contain \":\""}

By returning a proper status error, we make sure that the API server does not attempt to log these expected "failures."

Bug 1697206

Fixes #21632

Signed-off-by: Monis Khan <mkhan@redhat.com>