### PR TITLE
UPSTREAM: <drop>: Revert: disable CRD validation until openapi fixes land

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
@@ -403,8 +403,8 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
-	DynamicKubeletConfig:                        {Default: true, PreRelease: utilfeature.Beta},
+	AppArmor:             {Default: true, PreRelease: utilfeature.Beta},
+	DynamicKubeletConfig: {Default: true, PreRelease: utilfeature.Beta},
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
 	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
 	DevicePlugins:                               {Default: true, PreRelease: utilfeature.Beta},
@@ -474,8 +474,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	// TODO fix after crash landing rebase
-	apiextensionsfeatures.CustomResourceValidation:        {Default: false, PreRelease: utilfeature.Beta},
+	apiextensionsfeatures.CustomResourceValidation:        {Default: true, PreRelease: utilfeature.Beta},
 	apiextensionsfeatures.CustomResourceSubresources:      {Default: true, PreRelease: utilfeature.Beta},
 	apiextensionsfeatures.CustomResourceWebhookConversion: {Default: false, PreRelease: utilfeature.Alpha},
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
@@ -56,7 +56,7 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	CustomResourceValidation:        {Default: false, PreRelease: utilfeature.Beta},
+	CustomResourceValidation:        {Default: true, PreRelease: utilfeature.Beta},
 	CustomResourceSubresources:      {Default: true, PreRelease: utilfeature.Beta},
 	CustomResourceWebhookConversion: {Default: false, PreRelease: utilfeature.Alpha},
 }


### PR DESCRIPTION
Now that nullable support is in again, we should enable validation ASAP to avoid broken code being merged.

This independent of CRD openapi publishing.

Prereq: https://github.com/openshift/cluster-kube-apiserver-operator/pull/376