### PR TITLE
switch oauth server to http1

### DIFF
--- a/pkg/cmd/openshift-integrated-oauth-server/server.go
+++ b/pkg/cmd/openshift-integrated-oauth-server/server.go
@@ -45,6 +45,8 @@ func newOAuthServerConfig(osinConfig *osinv1.OsinServerConfig) (*oauthserver.OAu
 	if err := servingOptions.ApplyTo(&genericConfig.Config.SecureServing, &genericConfig.Config.LoopbackClientConfig); err != nil {
 		return nil, err
 	}
+	// the oauth-server must only run in http1 to avoid http2 connection re-use problems when improperly re-using a wildcard certificate
+	genericConfig.Config.SecureServing.HTTP1Only = true
 
 	// TODO You need real overrides for rate limiting
 	kubeClientConfig, err := helpers.GetKubeConfigOrInClusterConfig(osinConfig.KubeClientConfig.KubeConfig, osinConfig.KubeClientConfig.ConnectionOverrides)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -234,6 +234,9 @@ type SecureServingInfo struct {
 	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
 	// A value of zero means to use the default provided by golang's HTTP/2 support.
 	HTTP2MaxStreamsPerConnection int
+
+	// HTTP1Only indicates that http2 should not be enabled.
+	HTTP1Only bool
 }
 
 type AuthenticationInfo struct {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -117,9 +117,11 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 	// increase the connection buffer size from the 1MB default to handle the specified number of concurrent streams
 	http2Options.MaxUploadBufferPerConnection = http2Options.MaxUploadBufferPerStream * int32(http2Options.MaxConcurrentStreams)
 
-	// apply settings to the server
-	if err := http2.ConfigureServer(secureServer, http2Options); err != nil {
-		return fmt.Errorf("error configuring http2: %v", err)
+	if !s.HTTP1Only {
+		// apply settings to the server
+		if err := http2.ConfigureServer(secureServer, http2Options); err != nil {
+			return fmt.Errorf("error configuring http2: %v", err)
+		}
 	}
 
 	klog.Infof("Serving securely on %s", secureServer.Addr)


### PR DESCRIPTION
This updates the oauthserver to only use http1 when run as a separate unit.  This avoid a problem that happens with http2 connection caching when improperly reusing a wildcard certificate.