### PR TITLE
Install Ceph tools for Ceph RBD dynamic provisioning

### DIFF
--- a/images/hyperkube/Dockerfile.rhel
+++ b/images/hyperkube/Dockerfile.rhel
@@ -5,6 +5,12 @@ RUN make build WHAT=vendor/k8s.io/kubernetes/cmd/hyperkube
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/hyperkube /usr/bin/
+
+RUN INSTALL_PKGS="ceph-common" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    mkdir -p /etc/sysconfig/cni/net.d && \
+    yum clean all && rm -rf /var/cache/*
+
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,hyperkube" \


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1665912

`/bin/rbd` must be available in kube-controller-manager for Ceph RBD dynamic provisioning to work.

/assign @smarterclayton  @sdodson 
Please review carefully, not tested! The image will grow by few dozens of megabytes (how do I build such image on my machine to check its size)?. Talk to product management if this is undesirable - we can either have in-tree Ceph dynamic provisioning or small images, not both.

Note that this PR is not needed when Ceph is deployed as CSI driver. We could in theory deprecate the in-tree one in favor of CSI. Again, talk to product management. We (aos-storage) don't ship any drivers and CSI is still tech preview in 4.1. 

