### PR TITLE
Bug 1671528: clearly state new-app's non-support for CRDs, offer oc p…

### DIFF
--- a/pkg/oc/cli/newapp/newapp.go
+++ b/pkg/oc/cli/newapp/newapp.go
@@ -1019,7 +1019,15 @@ func TransformRunError(err error, baseName, commandName, commandPath string, gro
 		// TODO: suggest things to the user
 		groups.Add("", "", "", UsageError(commandPath, newAppNoInput, baseName, commandName))
 	default:
-		groups.Add("", "", "", err)
+		if runtime.IsNotRegisteredError(err) {
+			useProcessMsg := fmt.Sprintf("The template contained an object type unknown to `oc new-app`.  Use `oc process | oc create` instead.  Error details: %v", err)
+			if len(config.ComponentInputs.TemplateFiles) > 0 {
+				useProcessMsg = fmt.Sprintf("The template contained an object type unknown to `oc new-app`.  Use `oc process -f %s | oc create -f -` instead.  Error details: %v", config.ComponentInputs.TemplateFiles[0], err)
+			}
+			groups.Add("", "", "", fmt.Errorf(useProcessMsg))
+		} else {
+			groups.Add("", "", "", err)
+		}
 	}
 	return
 }

--- a/test/cmd/newapp.sh
+++ b/test/cmd/newapp.sh
@@ -107,6 +107,9 @@ os::cmd::try_until_success 'oc get imagestreamtags myruby:latest'
 os::cmd::expect_success 'oc new-app myruby~https://github.com/openshift/ruby-hello-world.git --dry-run'
 os::cmd::expect_success 'oc delete is myruby'
 
+# Ensure clear error message wrt templates container CRDs and new-app appears
+os::cmd::expect_failure_and_text 'oc new-app -f test/testdata/newapp/template-with-crd.yaml' 'error: The template contained an object type unknown to '
+
 # docker strategy with repo that has no dockerfile
 os::cmd::expect_failure_and_text 'oc new-app https://github.com/sclorg/nodejs-ex --strategy=docker' 'No Dockerfile was found'
 

--- a/test/testdata/newapp/template-with-crd.yaml
+++ b/test/testdata/newapp/template-with-crd.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: template-with-crd
+objects:
+- kind: CustomResourceDefinition
+  apiVersion: apiextensions.k8s.io/v1beta1
+  metadata:
+    name: template-with-crd


### PR DESCRIPTION
…rocess as alternative

Sample output:
```
$ oc new-app https://raw.githubusercontent.com/Maistra/openshift-ansible/maistra-0.7/istio/istio_community_operator_template.yaml
error: The template contained an object type not registered with the runtime decoder used by `oc new-app`.  Use `oc process | oc create` instead.  The decoder returned: no kind "CustomResourceDefinition" is registered for version "apiextensions.k8s.io/v1beta1" in scheme "k8s.io/kubernetes/pkg/kubectl/scheme/scheme.go:28"
$
```

Note, there are some restrictions with the k8s libs used with cmd error reporting coupled with when the problem occurs.

In particular, there is no way to avoid the error string starting with `error:`

@openshift/sig-developer-experience fyi / ptal

/assign @adambkaplan 