### PR TITLE
protect kube control plane operator instances

### DIFF
--- a/pkg/admission/customresourcevalidation/config/deny_delete_cluster_config_resource.go
+++ b/pkg/admission/customresourcevalidation/config/deny_delete_cluster_config_resource.go
@@ -31,23 +31,39 @@ func (p *admissionPlugin) Validate(attributes admission.Attributes) error {
 	if len(attributes.GetSubresource()) > 0 {
 		return nil
 	}
-	if attributes.GetResource().Group != "config.openshift.io" {
-		return nil
-	}
-	// clusteroperators can be deleted so that we can force status refreshes and change over time.
-	// clusterversions not named `version` can be deleted (none are expected to exist).
-	// other config.openshift.io resources not named `cluster` can be deleted (none are expected to exist).
-	switch attributes.GetResource().Resource {
-	case "clusteroperators":
-		return nil
-	case "clusterversions":
-		if attributes.GetName() != "version" {
+	switch attributes.GetResource().Group {
+	case "config.openshift.io":
+		// clusteroperators can be deleted so that we can force status refreshes and change over time.
+		// clusterversions not named `version` can be deleted (none are expected to exist).
+		// other config.openshift.io resources not named `cluster` can be deleted (none are expected to exist).
+		switch attributes.GetResource().Resource {
+		case "clusteroperators":
+			return nil
+		case "clusterversions":
+			if attributes.GetName() != "version" {
+				return nil
+			}
+		default:
+			if attributes.GetName() != "cluster" {
+				return nil
+			}
+		}
+
+	case "operator.openshift.io":
+		switch attributes.GetResource().Resource {
+		// for these specific groups, fallthrough to returning an error.
+		// these are special because they are strictly required for keeping a running control plane.  Without them,
+		// you cannot repair other errors.
+		case "kubeapiservers", "kubecontrollermanagers", "kubeschedulers":
+			if attributes.GetName() != "cluster" { // you can delete them if they do not use the canonical name
+				return nil
+			}
+
+		default: // all other resources in operator.openshift.io can be deleted.
 			return nil
 		}
-	default:
-		if attributes.GetName() != "cluster" {
-			return nil
-		}
+	default: // for all other groups, do nothing
+		return nil
 	}
 	return admission.NewForbidden(attributes, fmt.Errorf("deleting required %s.%s resource, named %s, is not allowed", attributes.GetResource().Resource, attributes.GetResource().Group, attributes.GetName()))
 }

--- a/pkg/admission/customresourcevalidation/config/deny_delete_cluster_config_resource_test.go
+++ b/pkg/admission/customresourcevalidation/config/deny_delete_cluster_config_resource_test.go
@@ -57,6 +57,27 @@ func TestAdmissionPlugin_Validate(t *testing.T) {
 			name:       "cluster",
 			denyDelete: false,
 		},
+		{
+			tcName:     "operator-banned-excluded-name",
+			group:      "operator.openshift.io",
+			resource:   "kubeapiservers",
+			name:       "not-cluster",
+			denyDelete: false,
+		},
+		{
+			tcName:     "operator-banned",
+			group:      "operator.openshift.io",
+			resource:   "kubeapiservers",
+			name:       "cluster",
+			denyDelete: true,
+		},
+		{
+			tcName:     "operator-different-resource",
+			group:      "operator.openshift.io",
+			resource:   "dns",
+			name:       "cluster",
+			denyDelete: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.tcName, func(t *testing.T) {


### PR DESCRIPTION
These resources are special because if there isn't an active operator managing them, the configuration can rot (certs for instance) and your cluster can die beyond a point where it is easy to recover.

/assign @sanchezl 