### PR TITLE
UPSTREAM: <drop>: TestNewManagerImplStartProbeMode is flaky 

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -74,6 +74,7 @@ func TestNewManagerImplStart(t *testing.T) {
 }
 
 func TestNewManagerImplStartProbeMode(t *testing.T) {
+	t.Skipf("flaky, disabled")
 	socketDir, socketName, pluginSocketName, err := tmpSocketDir()
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)


### PR DESCRIPTION
To unblock the queue, disable just this one test. Future releases should
investigate why it is flaking.