### PR TITLE
build controller should ignore builds that are being deleted

### DIFF
--- a/pkg/build/controller/build/build_controller.go
+++ b/pkg/build/controller/build/build_controller.go
@@ -476,6 +476,12 @@ func shouldIgnore(build *buildv1.Build) bool {
 		return true
 	}
 
+	// builds that are in the process of being deleted should be ignored, otherwise
+	// they might attempt to recreate a pod that was just GCed as part of the build
+	// deletion propagation.
+	if build.DeletionTimestamp != nil {
+		return true
+	}
 	// If a build is in a terminal state, ignore it; unless it is in a succeeded or failed
 	// state and its completion time or logsnippet is not set, then we should at least attempt to set its
 	// completion time and logsnippet if possible because the build pod may have put the build in


### PR DESCRIPTION
this came up during a CI infra investigation...  the ci operator would attempt to delete a build, the foreground propagation policy would delete the pod first (due to GC ownership relationship), then the build controller would see the build get updated and create a new build pod for the build, before the deletion propagation finished deleting the build object.

At least that was what we speculated.  Regardless this seems like an appropriate check to have.
