### PR TITLE
move RoleBindingRestriction to CRD Part 1

### DIFF
--- a/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
@@ -68,11 +68,18 @@ func (q *restrictUsersAdmission) SetExternalKubeClientSet(c kubernetes.Interface
 
 func (q *restrictUsersAdmission) SetRESTClientConfig(restClientConfig rest.Config) {
 	var err error
-	q.roleBindingRestrictionsGetter, err = authorizationtypedclient.NewForConfig(&restClientConfig)
+
+	// RoleBindingRestriction is served using CRD resource any status update must use JSON
+	jsonClientConfig := rest.CopyConfig(&restClientConfig)
+	jsonClientConfig.ContentConfig.AcceptContentTypes = "application/json"
+	jsonClientConfig.ContentConfig.ContentType = "application/json"
+
+	q.roleBindingRestrictionsGetter, err = authorizationtypedclient.NewForConfig(jsonClientConfig)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return
 	}
+
 	q.userClient, err = userclient.NewForConfig(&restClientConfig)
 	if err != nil {
 		utilruntime.HandleError(err)

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
@@ -39,7 +39,7 @@ type InformerHolder struct {
 
 // NewInformers is only exposed for the build's integration testing until it can be fixed more appropriately.
 func NewInformers(kubeInformers kexternalinformers.SharedInformerFactory, kubeClientConfig *rest.Config, loopbackClientConfig *rest.Config) (*InformerHolder, error) {
-	authorizationClient, err := authorizationv1client.NewForConfig(loopbackClientConfig)
+	authorizationClient, err := authorizationv1client.NewForConfig(nonProtobufConfig(kubeClientConfig))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Goal of this change plus [this](https://github.com/openshift/origin/pull/22699) is to move RoleBindingRestrictions from OpenShift API server to CRD so the admission plugins that run in kubernetes apiserver do not have dependency on OpenShift API resource. 

This PR moves to external client,types for RBRs
openshift/cluster-config-operator#32 adds the CRD