### PR TITLE
Always set standard security headers for OAuth server

### DIFF
--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/origin/pkg/oauthserver/authenticator/password/bootstrap"
 	"github.com/openshift/origin/pkg/oauthserver/config"
 	"github.com/openshift/origin/pkg/oauthserver/server/crypto"
+	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 	"github.com/openshift/origin/pkg/oauthserver/server/session"
 	"github.com/openshift/origin/pkg/oauthserver/userregistry/identitymapper"
 )
@@ -289,6 +290,7 @@ func (c *OAuthServerConfig) buildHandlerChainForOAuth(startingHandler http.Handl
 	handler = genericfilters.WithCORS(handler, genericConfig.CorsAllowedOriginList, nil, nil, nil, "true")
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, genericConfig.LongRunningFunc, genericConfig.RequestTimeout)
 	handler = genericapifilters.WithRequestInfo(handler, genericapiserver.NewRequestInfoResolver(genericConfig))
+	handler = headers.WithStandardHeaders(handler)
 	handler = genericfilters.WithPanicRecovery(handler)
 	return handler
 }

--- a/pkg/oauthserver/server/grant/grant.go
+++ b/pkg/oauthserver/server/grant/grant.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/origin/pkg/oauthserver"
 	"github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
-	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 	"github.com/openshift/origin/pkg/oauthserver/server/redirect"
 )
 
@@ -109,8 +108,6 @@ func (l *Grant) Install(mux oauthserver.Mux, paths ...string) {
 }
 
 func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
-
 	authResponse, ok, err := l.auth.AuthenticateRequest(req)
 	if err != nil || !ok {
 		l.redirect("You must reauthenticate before continuing", w, req)

--- a/pkg/oauthserver/server/headers/headers.go
+++ b/pkg/oauthserver/server/headers/headers.go
@@ -1,28 +1,32 @@
 package headers
 
-import (
-	"net/http"
-)
+import "net/http"
 
-func SetStandardHeaders(w http.ResponseWriter) {
-	// We cannot set HSTS by default, it has too many drawbacks in environments
-	// that use self-signed certs
-	standardHeaders := map[string]string{
-		// Turn off caching, it never makes sense for authorization pages
-		"Cache-Control": "no-cache, no-store",
-		"Pragma":        "no-cache",
-		"Expires":       "0",
-		// Use a reasonably strict Referer policy by default
-		"Referrer-Policy": "strict-origin-when-cross-origin",
-		// Do not allow embedding as that can lead to clickjacking attacks
-		"X-Frame-Options": "DENY",
-		// Add other basic security hygiene headers
-		"X-Content-Type-Options": "nosniff",
-		"X-DNS-Prefetch-Control": "off",
-		"X-XSS-Protection":       "1; mode=block",
-	}
+// We cannot set HSTS by default, it has too many drawbacks in environments
+// that use self-signed certs
+var standardHeaders = map[string]string{
+	// Turn off caching, it never makes sense for authorization pages
+	"Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+	"Pragma":        "no-cache",
+	"Expires":       "0",
+	// Use a reasonably strict Referer policy by default
+	"Referrer-Policy": "strict-origin-when-cross-origin",
+	// Do not allow embedding as that can lead to clickjacking attacks
+	"X-Frame-Options": "DENY",
+	// Add other basic security hygiene headers
+	"X-Content-Type-Options": "nosniff",
+	"X-DNS-Prefetch-Control": "off",
+	"X-XSS-Protection":       "1; mode=block",
+}
 
-	for key, val := range standardHeaders {
-		w.Header().Set(key, val)
-	}
+func WithStandardHeaders(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// force every request into the OAuth server to have our standard headers
+		h := w.Header()
+		for k, v := range standardHeaders {
+			h.Set(k, v)
+		}
+
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/pkg/oauthserver/server/login/login.go
+++ b/pkg/oauthserver/server/login/login.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/origin/pkg/oauthserver/prometheus"
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
 	"github.com/openshift/origin/pkg/oauthserver/server/errorpage"
-	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 	"github.com/openshift/origin/pkg/oauthserver/server/redirect"
 )
 
@@ -100,7 +99,6 @@ func (l *Login) Install(mux oauthserver.Mux, paths ...string) {
 }
 
 func (l *Login) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
 	switch req.Method {
 	case http.MethodGet:
 		l.handleLoginForm(w, req)

--- a/pkg/oauthserver/server/logout/logout.go
+++ b/pkg/oauthserver/server/logout/logout.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"github.com/openshift/origin/pkg/oauthserver"
-	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 	"github.com/openshift/origin/pkg/oauthserver/server/redirect"
 	"github.com/openshift/origin/pkg/oauthserver/server/session"
 	"github.com/openshift/origin/pkg/oauthserver/server/tokenrequest"
@@ -36,10 +35,6 @@ func (l *logout) Install(mux oauthserver.Mux, paths ...string) {
 }
 
 func (l *logout) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// TODO this seems like something that should happen automatically at a higher level
-	// we also do not set these headers on the OAuth endpoints or the token request endpoint...
-	headers.SetStandardHeaders(w)
-
 	// TODO while having a POST provides some protection, this endpoint is invokable via JS.
 	// we could easily add CSRF protection, but then it would make it really hard for the console
 	// to actually use this endpoint.  we could have some alternative logout path that validates


### PR DESCRIPTION
We should always set these headers on all pages of the OAuth server.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 