### PR TITLE
Dont rely on machine labels for listing worker nodes

### DIFF
--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -20,9 +20,8 @@ import (
 )
 
 const (
-	machineLabelSelectorWorker = "machine.openshift.io/cluster-api-machine-role=worker"
-	machineAPINamespace        = "openshift-machine-api"
-	nodeLabelSelectorWorker    = "node-role.kubernetes.io/worker"
+	machineAPINamespace     = "openshift-machine-api"
+	nodeLabelSelectorWorker = "node-role.kubernetes.io/worker"
 
 	// time after purge of machine to wait for replacement and ready node
 	// TODO: tighten this further based on node lifecycle controller [appears to be ~5m30s]
@@ -78,32 +77,18 @@ func machineNames(machines []objx.Map) sets.String {
 	return result
 }
 
-// mapNodeNameToMachineName returns a tuple (map node to machine by name, true if a match is found for every node)
-func mapNodeNameToMachineName(nodes []corev1.Node, machines []objx.Map) (map[string]string, bool) {
-	result := map[string]string{}
+// mapNodeNameToMachine returns a tuple (map node to machine by name, true if a match is found for every node)
+func mapNodeNameToMachine(nodes []corev1.Node, machines []objx.Map) (map[string]objx.Map, bool) {
+	result := map[string]objx.Map{}
 	for i := range nodes {
 		for j := range machines {
 			if nodes[i].Name == nodeNameFromNodeRef(machines[j]) {
-				result[nodes[i].Name] = machineName(machines[j])
+				result[nodes[i].Name] = machines[j]
 				break
 			}
 		}
 	}
 	return result, len(nodes) == len(result)
-}
-
-// mapMachineNameToNodeName returns a tuple (map node to machine by name, true if a match is found for every node)
-func mapMachineNameToNodeName(machines []objx.Map, nodes []corev1.Node) (map[string]string, bool) {
-	result := map[string]string{}
-	for i := range machines {
-		for j := range nodes {
-			if nodes[j].Name == nodeNameFromNodeRef(machines[i]) {
-				result[machineName(machines[i])] = nodes[j].Name
-				break
-			}
-		}
-	}
-	return result, len(machines) == len(result)
 }
 
 func isNodeReady(node corev1.Node) bool {
@@ -131,67 +116,63 @@ var _ = g.Describe("[Feature:Machines][Disruptive] Managed cluster should", func
 		skipUnlessMachineAPIOperator(c.CoreV1().Namespaces())
 
 		g.By("validating node and machine invariants")
-		// fetch machines
-		machines, err := listMachines(dc, machineLabelSelectorWorker)
+		// fetch all machines
+		allMachines, err := listMachines(dc, "")
 		if err != nil {
 			e2e.Failf("unable to fetch worker machines: %v", err)
 		}
-		numMachineWorkers := len(machines)
-		if numMachineWorkers == 0 {
-			e2e.Failf("cluster should have worker machines")
+
+		if len(allMachines) == 0 {
+			e2e.Failf("cluster should have machines")
 		}
 
-		// fetch nodes
-		nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{
+		// fetch worker nodes
+		workerNodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{
 			LabelSelector: nodeLabelSelectorWorker,
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(workerNodes.Items) == 0 {
+			e2e.Failf("cluster should have nodes")
+		}
 		// map node -> machine
-		nodeToMachine, nodeMatch := mapNodeNameToMachineName(nodes.Items, machines)
+		workerNodeToMachine, nodeMatch := mapNodeNameToMachine(workerNodes.Items, allMachines)
 		if !nodeMatch {
-			e2e.Failf("unable to map every node to machine.  nodeToMachine: %v, nodeName: %v", nodeToMachine, nodeNames(nodes.Items))
+			e2e.Failf("unable to map every node to machine.  workerNodeToMachine: %v, nodeName: %v", workerNodeToMachine, nodeNames(workerNodes.Items))
 		}
-		machineToNode, machineMatch := mapMachineNameToNodeName(machines, nodes.Items)
-		if !machineMatch {
-			e2e.Failf("unable to map every machine to node.  machineToNode: %v, machineNames: %v", machineToNode, machineNames(machines))
-		}
+		numMachineWorkers := len(workerNodeToMachine)
 
 		g.By("deleting all worker nodes")
-		for _, machine := range machines {
+		for _, machine := range workerNodeToMachine {
 			machineName := machine.Get("metadata.name").String()
 			if err := deleteMachine(dc, machineName); err != nil {
 				e2e.Failf("Unable to delete machine %s/%s with error: %v", machineAPINamespace, machineName, err)
 			}
 		}
-
 		g.By("waiting for cluster to replace and recover workers")
 		if pollErr := wait.PollImmediate(3*time.Second, machineRepairWait, func() (bool, error) {
-			machines, err = listMachines(dc, machineLabelSelectorWorker)
+			allMachines, err = listMachines(dc, "")
 			if err != nil {
 				return false, nil
 			}
-			if numMachineWorkers != len(machines) {
-				e2e.Logf("Waiting for %v machines, but only found: %v", numMachineWorkers, len(machines))
-				return false, nil
-			}
-			nodes, err = c.CoreV1().Nodes().List(metav1.ListOptions{
+			workerNodes, err = c.CoreV1().Nodes().List(metav1.ListOptions{
 				LabelSelector: nodeLabelSelectorWorker,
 			})
 			if err != nil {
+				e2e.Logf("Waiting for workerNodes to show up, but getting error: %v", err)
 				return false, nil
 			}
 			// map both data sets for easy comparison now
-			nodeToMachine, nodeMatch = mapNodeNameToMachineName(nodes.Items, machines)
-			machineToNode, machineMatch = mapMachineNameToNodeName(machines, nodes.Items)
+			workerNodeToMachine, nodeMatch = mapNodeNameToMachine(workerNodes.Items, allMachines)
+			if numMachineWorkers != len(workerNodeToMachine) {
+				e2e.Logf("Waiting for %v machines, but only found: %v", numMachineWorkers, len(workerNodeToMachine))
+				return false, nil
+			}
+
 			if !nodeMatch {
-				e2e.Logf("unable to map every node to machine.  nodeToMachine: %v\n, \tnodeName: %v", nodeToMachine, nodeNames(nodes.Items))
+				e2e.Logf("unable to map every node to machine.  workerNodeToMachine: %v\n, \tnodeName: %v", workerNodeToMachine, nodeNames(workerNodes.Items))
 				return false, nil
 			}
-			if !machineMatch {
-				e2e.Logf("unable to map every machine to node.  machineToNode: %v\n, \tmachineNames: %v", machineToNode, machineNames(machines))
-				return false, nil
-			}
-			for _, node := range nodes.Items {
+			for _, node := range workerNodes.Items {
 				if !isNodeReady(node) {
 					e2e.Logf("node %q is not ready: %v", node.Name, node.Status)
 					return false, nil
@@ -203,7 +184,7 @@ var _ = g.Describe("[Feature:Machines][Disruptive] Managed cluster should", func
 			buf := &bytes.Buffer{}
 			w := tabwriter.NewWriter(buf, 0, 4, 1, ' ', 0)
 			fmt.Fprintf(w, "NAMESPACE\tNAME\tNODE NAME\n")
-			for _, machine := range machines {
+			for _, machine := range workerNodeToMachine {
 				ns := machine.Get("metadata.namespace").String()
 				name := machine.Get("metadata.name").String()
 				nodeName := nodeNameFromNodeRef(machine)
@@ -214,12 +195,10 @@ var _ = g.Describe("[Feature:Machines][Disruptive] Managed cluster should", func
 				)
 			}
 			w.Flush()
-			e2e.Logf("Machines:\n%s", buf.String())
-			e2e.Logf("Machines to nodes:\n%v", machineToNode)
-			e2e.Logf("Node to machines:\n%v", nodeToMachine)
+			e2e.Logf("Worker Machines:\n%s", buf.String())
+			e2e.Logf("Worker node to machines:\n%v", workerNodeToMachine)
 			e2e.Failf("Worker machines were not replaced as expected: %v", pollErr)
 		}
-
 		// TODO: ensure no pods pending
 	})
 })


### PR DESCRIPTION
This PR removes dependency on openshift specific labels on the machine object for listing worker nodes.

/cc @enxebre @mfojtik 