### PR TITLE
Make sure SIGTERM shutdown the controller manager and scheduler API server

### DIFF
--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -41,6 +41,7 @@ import (
 	authorizationv1typedclient "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
 	projectv1typedclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/library-go/pkg/crypto"
+
 	"github.com/openshift/origin/pkg/api/legacy"
 	"github.com/openshift/origin/pkg/cmd/openshift-apiserver"
 	"github.com/openshift/origin/pkg/cmd/openshift-controller-manager"
@@ -56,10 +57,11 @@ import (
 	newproject "github.com/openshift/origin/pkg/oc/cli/admin/project"
 	"github.com/openshift/origin/test/util"
 
-	// install all APIs
-	_ "github.com/openshift/origin/pkg/api/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
+
+	// install all APIs
+	_ "github.com/openshift/origin/pkg/api/install"
 )
 
 var (
@@ -667,7 +669,7 @@ func startKubernetesControllers(masterConfig *configapi.MasterConfig, adminKubeC
 	}
 
 	go func() {
-		cmd := kube_controller_manager.NewControllerManagerCommand()
+		cmd := kube_controller_manager.NewControllerManagerCommand(wait.NeverStop)
 		if err := cmd.ParseFlags(args); err != nil {
 			klog.Errorf("kube-controller-manager failed to parse flags: %v", err)
 			return

--- a/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/cloud-controller-manager/app/controllermanager.go
@@ -149,7 +149,8 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan struct{}) error
 	if c.SecureServing != nil {
 		unsecuredMux := genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)
-		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		// TODO: handle stoppedCh returned by c.SecureServing.Serve
+		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			return err
 		}
 	}

--- a/vendor/k8s.io/kubernetes/cmd/hyperkube/main.go
+++ b/vendor/k8s.io/kubernetes/cmd/hyperkube/main.go
@@ -94,7 +94,7 @@ func NewHyperKubeCommand(stopCh <-chan struct{}) (*cobra.Command, []func() *cobr
 		return ret
 	}
 	controller := func() *cobra.Command {
-		ret := kubecontrollermanager.NewControllerManagerCommand()
+		ret := kubecontrollermanager.NewControllerManagerCommand(stopCh)
 		// add back some unfortunate aliases that should be removed
 		ret.Aliases = []string{"controller-manager"}
 		return ret
@@ -106,7 +106,7 @@ func NewHyperKubeCommand(stopCh <-chan struct{}) (*cobra.Command, []func() *cobr
 		return ret
 	}
 	scheduler := func() *cobra.Command {
-		ret := kubescheduler.NewSchedulerCommand()
+		ret := kubescheduler.NewSchedulerCommand(stopCh)
 		// add back some unfortunate aliases that should be removed
 		ret.Aliases = []string{"scheduler"}
 		return ret

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -178,7 +178,8 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	if c.SecureServing != nil {
 		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)
-		if err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		// TODO: handle stoppedCh returned by c.SecureServing.Serve
+		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			return err
 		}
 	}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -78,7 +78,7 @@ const (
 )
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
-func NewControllerManagerCommand() *cobra.Command {
+func NewControllerManagerCommand(stopCh <-chan struct{}) *cobra.Command {
 	s, err := options.NewKubeControllerManagerOptions()
 	if err != nil {
 		klog.Fatalf("unable to initialize command options: %v", err)
@@ -113,7 +113,7 @@ controller, and serviceaccounts controller.`,
 				os.Exit(1)
 			}
 
-			if err := Run(c.Complete(), wait.NeverStop); err != nil {
+			if err := Run(c.Complete(), stopCh); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -155,6 +155,16 @@ func ResyncPeriod(c *config.CompletedConfig) func() time.Duration {
 
 // Run runs the KubeControllerManagerOptions.  This should never exit.
 func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	go func() {
+		select {
+		case <-stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
@@ -178,16 +188,20 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	if c.SecureServing != nil {
 		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, &c.Authorization, &c.Authentication)
-		// TODO: handle stoppedCh returned by c.SecureServing.Serve
-		if _, err := c.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		if serverStoppedCh, err := c.SecureServing.Serve(handler, 0, ctx.Done()); err != nil {
 			return err
+		} else {
+			defer func() {
+				cancel()
+				<-serverStoppedCh
+			}()
 		}
 	}
 	if c.InsecureServing != nil {
 		unsecuredMux = genericcontrollermanager.NewBaseHandler(&c.ComponentConfig.Generic.Debugging, checks...)
 		insecureSuperuserAuthn := server.AuthenticationInfo{Authenticator: &server.InsecureSuperuser{}}
 		handler := genericcontrollermanager.BuildHandlerChain(unsecuredMux, nil, &insecureSuperuserAuthn)
-		if err := c.InsecureServing.Serve(handler, 0, stopCh); err != nil {
+		if err := c.InsecureServing.Serve(handler, 0, ctx.Done()); err != nil {
 			return err
 		}
 	}
@@ -256,7 +270,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 		klog.Fatalf("error creating lock: %v", err)
 	}
 
-	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:          rl,
 		LeaseDuration: c.ComponentConfig.Generic.LeaderElection.LeaseDuration.Duration,
 		RenewDeadline: c.ComponentConfig.Generic.LeaderElection.RenewDeadline.Duration,
@@ -264,13 +278,15 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: run,
 			OnStoppedLeading: func() {
-				klog.Fatalf("leaderelection lost")
+				cancel()
+				utilruntime.HandleError(fmt.Errorf("leaderelection lost"))
 			},
 		},
 		WatchDog: electionChecker,
 		Name:     "kube-controller-manager",
 	})
-	panic("unreachable")
+
+	return nil
 }
 
 type ControllerContext struct {

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
@@ -67,7 +67,7 @@ import (
 )
 
 // NewSchedulerCommand creates a *cobra.Command object with default parameters
-func NewSchedulerCommand() *cobra.Command {
+func NewSchedulerCommand(stopCh <-chan struct{}) *cobra.Command {
 	opts, err := options.NewOptions()
 	if err != nil {
 		klog.Fatalf("unable to initialize command options: %v", err)
@@ -83,7 +83,7 @@ constraints, affinity and anti-affinity specifications, data locality, inter-wor
 interference, deadlines, and so on. Workload-specific requirements will be exposed
 through the API as necessary.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := runCommand(cmd, args, opts); err != nil {
+			if err := runCommand(cmd, args, opts, stopCh); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}
@@ -114,7 +114,7 @@ through the API as necessary.`,
 }
 
 // runCommand runs the scheduler.
-func runCommand(cmd *cobra.Command, args []string, opts *options.Options) error {
+func runCommand(cmd *cobra.Command, args []string, opts *options.Options, stopCh <-chan struct{}) error {
 	verflag.PrintAndExitIfRequested()
 	utilflag.PrintFlags(cmd.Flags())
 
@@ -140,8 +140,6 @@ func runCommand(cmd *cobra.Command, args []string, opts *options.Options) error 
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-
-	stopCh := make(chan struct{})
 
 	// Get the completed config
 	cc := c.Complete()

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
@@ -220,7 +220,8 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 	}
 	if cc.SecureServing != nil {
 		handler := buildHandlerChain(newHealthzHandler(&cc.ComponentConfig, false, checks...), cc.Authentication.Authenticator, cc.Authorization.Authorizer)
-		if err := cc.SecureServing.Serve(handler, 0, stopCh); err != nil {
+		// TODO: handle stoppedCh returned by c.SecureServing.Serve
+		if _, err := cc.SecureServing.Serve(handler, 0, stopCh); err != nil {
 			// fail early for secure handlers, removing the old error loop from above
 			return fmt.Errorf("failed to start healthz server: %v", err)
 		}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
@@ -50,7 +50,9 @@ func (s *DeprecatedInsecureServingInfo) Serve(handler http.Handler, shutdownTime
 	} else {
 		klog.Infof("Serving insecurely on %s", s.Listener.Addr())
 	}
-	return RunServer(insecureServer, s.Listener, shutdownTimeout, stopCh)
+	_, err := RunServer(insecureServer, s.Listener, shutdownTimeout, stopCh)
+	// NOTE: we do not handle stoppedCh returned by RunServer for graceful termination here
+	return err
 }
 
 func (s *DeprecatedInsecureServingInfo) NewLoopbackClientConfig() (*rest.Config, error) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -280,7 +280,7 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 	s.installReadyz(stopCh)
 
 	// close socket after delayed stopCh
-	err := s.NonBlockingRun(delayedStopCh)
+	serverDoneCh, err := s.NonBlockingRun(delayedStopCh)
 	if err != nil {
 		return err
 	}
@@ -299,12 +299,15 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 	// Wait for all requests to finish, which are bounded by the RequestTimeout variable.
 	s.HandlerChainWaitGroup.Wait()
 
+	// wait for server listener to be closed
+	<-serverDoneCh
+
 	return nil
 }
 
 // NonBlockingRun spawns the secure http server. An error is
 // returned if the secure port cannot be listened on.
-func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
+func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) (<-chan struct{}, error) {
 	// Use an stop channel to allow graceful shutdown without dropping audit events
 	// after http server shutdown.
 	auditStopCh := make(chan struct{})
@@ -313,7 +316,7 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 	// before http server start serving. Otherwise the Backend.ProcessEvents call might block.
 	if s.AuditBackend != nil {
 		if err := s.AuditBackend.Run(auditStopCh); err != nil {
-			return fmt.Errorf("failed to run the audit backend: %v", err)
+			return nil, fmt.Errorf("failed to run the audit backend: %v", err)
 		}
 	}
 
@@ -325,8 +328,12 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 		stoppedCh, err = s.SecureServingInfo.Serve(s.Handler, s.ShutdownTimeout, internalStopCh)
 		if err != nil {
 			close(internalStopCh)
-			return err
+			return nil, err
 		}
+	} else {
+		ch := make(chan struct{})
+		close(ch)
+		stoppedCh = ch
 	}
 
 	// Now that listener have bound successfully, it is the
@@ -349,7 +356,7 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 		klog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)
 	}
 
-	return nil
+	return stoppedCh, nil
 }
 
 // installAPIResources is a private method for installing the REST storage backing each api groupversionresource

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -544,9 +544,9 @@ func TestGracefulShutdown(t *testing.T) {
 
 	// get port
 	serverPort := ln.Addr().(*net.TCPAddr).Port
-	err = RunServer(insecureServer, ln, 10*time.Second, stopCh)
+	stoppedCh, err := RunServer(insecureServer, ln, 10*time.Second, stopCh)
 	if err != nil {
-		t.Errorf("RunServer err: %v", err)
+		t.Fatalf("RunServer err: %v", err)
 	}
 
 	graceCh := make(chan struct{})
@@ -567,6 +567,7 @@ func TestGracefulShutdown(t *testing.T) {
 	close(stopCh)
 	// wait for wait group handler finish
 	s.HandlerChainWaitGroup.Wait()
+	<-stoppedCh
 
 	// check server all handlers finished.
 	if !graceShutdown {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -86,7 +86,7 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 
 		// need to load the certs at least once
 		if err := loader.CheckCerts(); err != nil {
-			return err
+			return nil, err
 		}
 		go loader.Run(stopCh)
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -38,12 +38,12 @@ const (
 	defaultKeepAlivePeriod = 3 * time.Minute
 )
 
-// serveSecurely runs the secure http server. It fails only if certificates cannot
-// be loaded or the initial listen call fails. The actual server loop (stoppable by closing
-// stopCh) runs in a go routine, i.e. serveSecurely does not block.
-func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Duration, stopCh <-chan struct{}) error {
+// Serve runs the secure http server. It fails only if certificates cannot be loaded or the initial listen call fails.
+// The actual server loop (stoppable by closing stopCh) runs in a go routine, i.e. Serve does not block.
+// It returns a stoppedCh that is closed when all non-hijacked active requests have been processed.
+func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Duration, stopCh <-chan struct{}) (<-chan struct{}, error) {
 	if s.Listener == nil {
-		return fmt.Errorf("listener must not be nil")
+		return nil, fmt.Errorf("listener must not be nil")
 	}
 
 	secureServer := &http.Server{
@@ -119,7 +119,7 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 
 	// apply settings to the server
 	if err := http2.ConfigureServer(secureServer, http2Options); err != nil {
-		return fmt.Errorf("error configuring http2: %v", err)
+		return nil, fmt.Errorf("error configuring http2: %v", err)
 	}
 
 	klog.Infof("Serving securely on %s", secureServer.Addr)
@@ -127,21 +127,25 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 }
 
 // RunServer listens on the given port if listener is not given,
-// then spawns a go-routine continuously serving
-// until the stopCh is closed. This function does not block.
+// then spawns a go-routine continuously serving until the stopCh is closed.
+// It returns a stoppedCh that is closed when all non-hijacked active requests
+// have been processed.
+// This function does not block
 // TODO: make private when insecure serving is gone from the kube-apiserver
 func RunServer(
 	server *http.Server,
 	ln net.Listener,
 	shutDownTimeout time.Duration,
 	stopCh <-chan struct{},
-) error {
+) (<-chan struct{}, error) {
 	if ln == nil {
-		return fmt.Errorf("listener must not be nil")
+		return nil, fmt.Errorf("listener must not be nil")
 	}
 
 	// Shutdown server gracefully.
+	stoppedCh := make(chan struct{})
 	go func() {
+		defer close(stoppedCh)
 		<-stopCh
 		ctx, cancel := context.WithTimeout(context.Background(), shutDownTimeout)
 		server.Shutdown(ctx)
@@ -168,7 +172,7 @@ func RunServer(
 		}
 	}()
 
-	return nil
+	return stoppedCh, nil
 }
 
 type NamedTLSCert struct {


### PR DESCRIPTION
Right know the upstream does not call the `server.Shutdown()` when the controller manager receives SIGTERM. The SIGTERM `stopCh` is not even wired into controller manager and scheduler.

In that case, when the controller manager or scheduler are terminated, their ports will keep open until kernel timeout is hit (~60s++) and the port is freed. Since for these two components we use host network, this is causing the operator observing container restart in pod and ultimately setting failure condition to true.
