### PR TITLE
Add test/extended/networking/OWNERS, clean up others

### DIFF
--- a/test/cmd/OWNERS
+++ b/test/cmd/OWNERS
@@ -1,15 +1,8 @@
 reviewers:
-  - pecameron
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship
   - soltysh
 approvers:
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship
   - soltysh

--- a/test/end-to-end/OWNERS
+++ b/test/end-to-end/OWNERS
@@ -8,18 +8,12 @@ reviewers:
   - bparees
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship
   - dmage
 approvers:
   - smarterclayton
   - soltysh
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship
   - legionus
   - miminar
   - dmage

--- a/test/extended/networking/OWNERS
+++ b/test/extended/networking/OWNERS
@@ -1,16 +1,15 @@
 reviewers:
-  - smarterclayton
-  - bparees
-  - mfojtik
-  - gabemontero
-  - deads2k
   - knobunc
-  - ironcladlou
-  - adambkaplan
+  - squeed
+  - dcbw
+  - danwinship
 approvers:
   - smarterclayton
   - bparees
   - mfojtik
   - knobunc
   - ironcladlou
+  - squeed
+  - dcbw
+  - danwinship
   - adambkaplan

--- a/test/integration/OWNERS
+++ b/test/integration/OWNERS
@@ -7,9 +7,6 @@ reviewers:
   - bparees
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship
 approvers:
   - deads2k
   - smarterclayton
@@ -17,6 +14,3 @@ approvers:
   - csrwng
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship

--- a/test/testdata/OWNERS
+++ b/test/testdata/OWNERS
@@ -6,9 +6,6 @@ reviewers:
   - soltysh
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship
   - ericavonb
   - mrogers950
 approvers:
@@ -18,6 +15,3 @@ approvers:
   - enj
   - knobunc
   - ironcladlou
-  - squeed
-  - dcbw
-  - danwinship


### PR DESCRIPTION
A long time ago we added some sig-network people to test-related OWNERS files so we could update the network-related tests easily, but these days, this mostly just results in us being asked to review test changes that we don't know anything about. And the networking tests were split out into their own subdirectory and there aren't any networking cmd or integration tests any more.

(`approvers` in the new networking/OWNERS file is just copied from the parent directory's `approvers`)