### PR TITLE
oc: make it clear what challenge handlers are enabled

### DIFF
--- a/pkg/oc/lib/tokencmd/basicauth.go
+++ b/pkg/oc/lib/tokencmd/basicauth.go
@@ -14,10 +14,6 @@ import (
 	"github.com/openshift/origin/pkg/cmd/util/term"
 )
 
-func BasicEnabled() bool {
-	return true
-}
-
 type BasicChallengeHandler struct {
 	// Host is the server being authenticated to. Used only for displaying messages when prompting for username/password
 	Host string


### PR DESCRIPTION
We used to be able to tell this information via "oc version"

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth @soltysh 