### PR TITLE
Fix symlink arrays for Bash 3

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -403,17 +403,23 @@ readonly -f os::build::release_sha
 function os::build::make_openshift_binary_symlinks() {
   platform=$(os::build::host_platform)
   if [[ -f "${OS_OUTPUT_BINPATH}/${platform}/openshift" ]]; then
-    for linkname in "${OPENSHIFT_BINARY_SYMLINKS[@]##*/}"; do
-      ln -sf openshift "${OS_OUTPUT_BINPATH}/${platform}/${linkname}"
-    done
+    if (( ${#OPENSHIFT_BINARY_SYMLINKS[@]} )); then
+      for linkname in "${OPENSHIFT_BINARY_SYMLINKS[@]##*/}"; do
+        ln -sf openshift "${OS_OUTPUT_BINPATH}/${platform}/${linkname}"
+      done
+    fi
   fi
   if [[ -f "${OS_OUTPUT_BINPATH}/${platform}/oc" ]]; then
-    for linkname in "${OC_BINARY_SYMLINKS[@]##*/}"; do
-      ln -sf oc "${OS_OUTPUT_BINPATH}/${platform}/${linkname}"
-    done
-    for linkname in "${OC_BINARY_COPY[@]##*/}"; do
-      ln -sf oc "${OS_OUTPUT_BINPATH}/${platform}/${linkname}"
-    done
+    if (( ${#OC_BINARY_SYMLINKS[@]} )); then
+      for linkname in "${OC_BINARY_SYMLINKS[@]##*/}"; do
+        ln -sf oc "${OS_OUTPUT_BINPATH}/${platform}/${linkname}"
+      done
+    fi
+    if (( ${#OC_BINARY_COPY[@]} )); then
+      for linkname in "${OC_BINARY_COPY[@]##*/}"; do
+        ln -sf oc "${OS_OUTPUT_BINPATH}/${platform}/${linkname}"
+      done
+    fi
   fi
 }
 readonly -f os::build::make_openshift_binary_symlinks

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -45,10 +45,8 @@ readonly OS_GOVET_BLACKLIST=(
 
 #If you update this list, be sure to get the images/origin/Dockerfile
 readonly OPENSHIFT_BINARY_SYMLINKS=(
-  ""
 )
 readonly OC_BINARY_SYMLINKS=(
-  ""
 )
 readonly OC_BINARY_COPY=(
   kubectl


### PR DESCRIPTION
Yes, you read right, Bash 3. Unfortunately, there is a difference between how Bash 3 and more recent versions handle looping via arrays.

When https://github.com/openshift/origin/pull/22218 was put in, these arrays were changed to a single entry with an empty string, as opposed to an empty array.

When https://github.com/openshift/origin/blob/71af8a34fc829e902a957da00abb263d33b0df9e/hack/lib/build/binaries.sh#L411-L413 ends up running in Bash 5, it doesn't run the loop because it sees a single empty entry. When it runs on Bash 3 however, it runs a single time, with `${linkname}` being empty. This results in a symlink of `oc -> oc`, overwriting the binary that was just generated.

The one place where this matters is on Darwin, as it still ships with Bash 3 out of the box, and oc is the one binary you may actually need to build on Darwin.

What happens on Bash 5:
```
+ os::build::make_openshift_binary_symlinks
++ os::build::host_platform
+++ go env GOHOSTOS
+++ go env GOHOSTARCH
++ echo darwin/amd64
+ platform=darwin/amd64
+ [[ -f /opt/gopath/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/openshift ]]
+ [[ -f /opt/gopath/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/oc ]]
+ for linkname in "${OC_BINARY_COPY[@]##*/}"
+ ln -sf oc /opt/gopath/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/kubectl
+ cleanup
+ return_code=0
```

What happens on Bash 3, prior to this PR:
```
+ os::build::make_openshift_binary_symlinks
++ os::build::host_platform
+++ go env GOHOSTOS
+++ go env GOHOSTARCH
++ echo darwin/amd64
+ platform=darwin/amd64
+ [[ -f /private/tmp/openshift-cli-20190411-16204-14onmse/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/openshift ]]
+ [[ -f /private/tmp/openshift-cli-20190411-16204-14onmse/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/oc ]]
+ for linkname in '"${OC_BINARY_SYMLINKS[@]##*/}"'
+ ln -sf oc /private/tmp/openshift-cli-20190411-16204-14onmse/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/
+ for linkname in '"${OC_BINARY_COPY[@]##*/}"'
+ ln -sf oc /private/tmp/openshift-cli-20190411-16204-14onmse/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/kubectl
+ cleanup
+ return_code=0
```

What happens on Bash 3, after this PR:
```
+ os::build::make_openshift_binary_symlinks
++ os::build::host_platform
+++ go env GOHOSTOS
+++ go env GOHOSTARCH
++ echo darwin/amd64
+ platform=darwin/amd64
+ [[ -f /private/tmp/openshift-cli-20190411-34396-1mczt4j/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/openshift ]]
+ [[ -f /private/tmp/openshift-cli-20190411-34396-1mczt4j/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/oc ]]
+ ((  0  ))
+ ((  1  ))
+ for linkname in '"${OC_BINARY_COPY[@]##*/}"'
+ ln -sf oc /private/tmp/openshift-cli-20190411-34396-1mczt4j/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/kubectl
+ cleanup
+ return_code=0
```


/assign @smarterclayton @deads2k 

