### PR TITLE
Pave way for SCC move to CRD

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -524,7 +524,6 @@
       "github.com/openshift/origin/pkg/project/generated",
       "github.com/openshift/origin/pkg/route/apis/route/v1",
       "github.com/openshift/origin/pkg/route/generated",
-      "github.com/openshift/origin/pkg/security/apis/security/v1",
       "github.com/openshift/origin/pkg/template/apis/template/v1",
       "github.com/openshift/origin/pkg/template/client/v1",
       "github.com/openshift/origin/pkg/user/generated",

--- a/pkg/cmd/openshift-apiserver/openshiftadmission/plugin_initializer.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/plugin_initializer.go
@@ -128,7 +128,7 @@ func NewPluginInitializer(
 		ClusterResourceQuotaInformer: informers.GetOpenshiftQuotaInformers().Quota().V1().ClusterResourceQuotas(),
 		ClusterQuotaMapper:           clusterQuotaMappingController.GetClusterQuotaMapper(),
 		RegistryHostnameRetriever:    registryHostnameRetriever,
-		SecurityInformers:            informers.GetOpenshiftSecurityInformers(),
+		SecurityInformers:            informers.GetOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints(),
 		UserInformers:                informers.GetOpenshiftUserInformers(),
 	}
 

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/informers.go
@@ -59,7 +59,7 @@ func NewInformers(kubeInformers kexternalinformers.SharedInformerFactory, kubeCl
 	if err != nil {
 		return nil, err
 	}
-	securityClient, err := securityv1client.NewForConfig(loopbackClientConfig)
+	securityClient, err := securityv1client.NewForConfig(nonProtobufConfig(kubeClientConfig))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/openshift-controller-manager/controller/interfaces.go
+++ b/pkg/cmd/openshift-controller-manager/controller/interfaces.go
@@ -414,7 +414,7 @@ func (b OpenshiftControllerClientBuilder) OpenshiftSecurityClient(name string) (
 	if err != nil {
 		return nil, err
 	}
-	return securityclient.NewForConfig(clientConfig)
+	return securityclient.NewForConfig(nonProtobufConfig(clientConfig))
 }
 
 func (b OpenshiftControllerClientBuilder) OpenshiftSecurityClientOrDie(name string) securityclient.Interface {

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -190,7 +190,7 @@ func NewInformers(versionedInformers clientgoinformers.SharedInformerFactory, lo
 	if err != nil {
 		return nil, err
 	}
-	securityClient, err := securityv1client.NewForConfig(loopbackClientConfig)
+	securityClient, err := securityv1client.NewForConfig(jsonLoopbackClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -110,7 +110,7 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 			ClusterResourceQuotaInformer: kubeAPIServerInformers.GetOpenshiftQuotaInformers().Quota().V1().ClusterResourceQuotas(),
 			ClusterQuotaMapper:           clusterQuotaMappingController.GetClusterQuotaMapper(),
 			RegistryHostnameRetriever:    registryHostnameRetriever,
-			SecurityInformers:            kubeAPIServerInformers.GetOpenshiftSecurityInformers(),
+			SecurityInformers:            kubeAPIServerInformers.GetOpenshiftSecurityInformers().Security().V1().SecurityContextConstraints(),
 			UserInformers:                kubeAPIServerInformers.GetOpenshiftUserInformers(),
 		}
 		*pluginInitializers = append(*pluginInitializers, openshiftPluginInitializer)

--- a/pkg/cmd/server/admission/init.go
+++ b/pkg/cmd/server/admission/init.go
@@ -6,7 +6,7 @@ import (
 	quota "k8s.io/kubernetes/pkg/quota/v1"
 
 	quotainformer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
-	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+	securityv1informer "github.com/openshift/client-go/security/informers/externalversions/security/v1"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	"github.com/openshift/origin/pkg/image/apiserver/registryhostname"
 	"github.com/openshift/origin/pkg/project/cache"
@@ -21,7 +21,7 @@ type PluginInitializer struct {
 	ClusterResourceQuotaInformer quotainformer.ClusterResourceQuotaInformer
 	ClusterQuotaMapper           clusterquotamapping.ClusterQuotaMapper
 	RegistryHostnameRetriever    registryhostname.RegistryHostnameRetriever
-	SecurityInformers            securityv1informer.SharedInformerFactory
+	SecurityInformers            securityv1informer.SecurityContextConstraintsInformer
 	UserInformers                userinformer.SharedInformerFactory
 }
 

--- a/pkg/cmd/server/admission/types.go
+++ b/pkg/cmd/server/admission/types.go
@@ -6,7 +6,7 @@ import (
 	quota "k8s.io/kubernetes/pkg/quota/v1"
 
 	quotainformer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
-	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+	securityv1informer "github.com/openshift/client-go/security/informers/externalversions/security/v1"
 	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	"github.com/openshift/origin/pkg/project/cache"
 	"github.com/openshift/origin/pkg/quota/controller/clusterquotamapping"
@@ -44,7 +44,7 @@ type WantsClusterQuota interface {
 }
 
 type WantsSecurityInformer interface {
-	SetSecurityInformers(securityv1informer.SharedInformerFactory)
+	SetSecurityInformers(securityv1informer.SecurityContextConstraintsInformer)
 	admission.InitializationValidator
 }
 

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints.go
@@ -1,13 +1,12 @@
 package bootstrappolicy
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	securityapiv1 "github.com/openshift/api/security/v1"
-	securityapi "github.com/openshift/origin/pkg/security/apis/security"
 	securityapiinstall "github.com/openshift/origin/pkg/security/apis/security/install"
 )
 
@@ -57,7 +56,7 @@ func init() {
 // GetBootstrapSecurityContextConstraints returns the slice of default SecurityContextConstraints
 // for system bootstrapping.  This method takes additional users and groups that should be added
 // to the strategies.  Use GetBoostrapSCCAccess to produce the default set of mappings.
-func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string][]string, sccNameToAdditionalUsers map[string][]string) []*securityapi.SecurityContextConstraints {
+func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string][]string, sccNameToAdditionalUsers map[string][]string) []*securityapiv1.SecurityContextConstraints {
 	// define priorities here and reference them below so it is easy to see, at a glance
 	// what we're setting
 	var (
@@ -66,7 +65,7 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 		securityContextConstraintsAnyUIDPriority = int32(10)
 	)
 
-	constraints := []*securityapi.SecurityContextConstraints{
+	constraints := []*securityapiv1.SecurityContextConstraints{
 		// SecurityContextConstraintPrivileged allows all access for every field
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -76,23 +75,23 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 				},
 			},
 			AllowPrivilegedContainer: true,
-			AllowedCapabilities:      []kapi.Capability{securityapi.AllowAllCapabilities},
-			Volumes:                  []securityapi.FSType{securityapi.FSTypeAll},
+			AllowedCapabilities:      []corev1.Capability{securityapiv1.AllowAllCapabilities},
+			Volumes:                  []securityapiv1.FSType{securityapiv1.FSTypeAll},
 			AllowHostNetwork:         true,
 			AllowHostPorts:           true,
 			AllowHostPID:             true,
 			AllowHostIPC:             true,
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
-				Type: securityapi.SELinuxStrategyRunAsAny,
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
+				Type: securityapiv1.SELinuxStrategyRunAsAny,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
-				Type: securityapi.RunAsUserStrategyRunAsAny,
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
+				Type: securityapiv1.RunAsUserStrategyRunAsAny,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyRunAsAny,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyRunAsAny,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyRunAsAny,
 			},
 			SeccompProfiles:      []string{"*"},
 			AllowedUnsafeSysctls: []string{"*"},
@@ -106,25 +105,25 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintNonRootDesc,
 				},
 			},
-			Volumes: []securityapi.FSType{securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim, securityapi.FSProjected},
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Volumes: []securityapiv1.FSType{securityapiv1.FSTypeEmptyDir, securityapiv1.FSTypeSecret, securityapiv1.FSTypeDownwardAPI, securityapiv1.FSTypeConfigMap, securityapiv1.FSTypePersistentVolumeClaim, securityapiv1.FSProjected},
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.SELinuxStrategyMustRunAs,
+				Type: securityapiv1.SELinuxStrategyMustRunAs,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
 				// This strategy requires that the user request to run as a specific UID or that
 				// the docker file contain a USER directive.
-				Type: securityapi.RunAsUserStrategyMustRunAsNonRoot,
+				Type: securityapiv1.RunAsUserStrategyMustRunAsNonRoot,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyRunAsAny,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyRunAsAny,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyRunAsAny,
 			},
-			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
+			RequiredDropCapabilities: []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
 		},
 		// SecurityContextConstraintHostMountAndAnyUID is the same as the restricted scc but allows the use of the hostPath and NFS plugins, and running as any UID.
 		// Used by the PV recycler.
@@ -135,26 +134,26 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintHostMountAndAnyUIDDesc,
 				},
 			},
-			Volumes: []securityapi.FSType{securityapi.FSTypeHostPath, securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim, securityapi.FSTypeNFS, securityapi.FSProjected},
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Volumes: []securityapiv1.FSType{securityapiv1.FSTypeHostPath, securityapiv1.FSTypeEmptyDir, securityapiv1.FSTypeSecret, securityapiv1.FSTypeDownwardAPI, securityapiv1.FSTypeConfigMap, securityapiv1.FSTypePersistentVolumeClaim, securityapiv1.FSTypeNFS, securityapiv1.FSProjected},
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.SELinuxStrategyMustRunAs,
+				Type: securityapiv1.SELinuxStrategyMustRunAs,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.RunAsUserStrategyRunAsAny,
+				Type: securityapiv1.RunAsUserStrategyRunAsAny,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyRunAsAny,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyRunAsAny,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyRunAsAny,
 			},
-			RequiredDropCapabilities: []kapi.Capability{"MKNOD"},
+			RequiredDropCapabilities: []corev1.Capability{"MKNOD"},
 		},
 		// SecurityContextConstraintHostNS allows access to everything except privileged on the host
 		// but still allocates UIDs and SELinux.
@@ -165,30 +164,30 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintHostNSDesc,
 				},
 			},
-			Volumes:          []securityapi.FSType{securityapi.FSTypeHostPath, securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim, securityapi.FSProjected},
+			Volumes:          []securityapiv1.FSType{securityapiv1.FSTypeHostPath, securityapiv1.FSTypeEmptyDir, securityapiv1.FSTypeSecret, securityapiv1.FSTypeDownwardAPI, securityapiv1.FSTypeConfigMap, securityapiv1.FSTypePersistentVolumeClaim, securityapiv1.FSProjected},
 			AllowHostNetwork: true,
 			AllowHostPorts:   true,
 			AllowHostPID:     true,
 			AllowHostIPC:     true,
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.SELinuxStrategyMustRunAs,
+				Type: securityapiv1.SELinuxStrategyMustRunAs,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.RunAsUserStrategyMustRunAsRange,
+				Type: securityapiv1.RunAsUserStrategyMustRunAsRange,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyMustRunAs,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyMustRunAs,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyRunAsAny,
 			},
-			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
+			RequiredDropCapabilities: []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
 		},
 		// SecurityContextConstraintRestricted allows no host access and allocates UIDs and SELinux.
 		{
@@ -198,27 +197,27 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintRestrictedDesc,
 				},
 			},
-			Volumes: []securityapi.FSType{securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim, securityapi.FSProjected},
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Volumes: []securityapiv1.FSType{securityapiv1.FSTypeEmptyDir, securityapiv1.FSTypeSecret, securityapiv1.FSTypeDownwardAPI, securityapiv1.FSTypeConfigMap, securityapiv1.FSTypePersistentVolumeClaim, securityapiv1.FSProjected},
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.SELinuxStrategyMustRunAs,
+				Type: securityapiv1.SELinuxStrategyMustRunAs,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.RunAsUserStrategyMustRunAsRange,
+				Type: securityapiv1.RunAsUserStrategyMustRunAsRange,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyMustRunAs,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyMustRunAs,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyRunAsAny,
 			},
 			// drops unsafe caps
-			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
+			RequiredDropCapabilities: []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
 		},
 		// SecurityContextConstraintsAnyUID allows no host access and allocates SELinux.
 		{
@@ -228,26 +227,26 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 					DescriptionAnnotation: SecurityContextConstraintsAnyUIDDesc,
 				},
 			},
-			Volumes: []securityapi.FSType{securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim, securityapi.FSProjected},
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Volumes: []securityapiv1.FSType{securityapiv1.FSTypeEmptyDir, securityapiv1.FSTypeSecret, securityapiv1.FSTypeDownwardAPI, securityapiv1.FSTypeConfigMap, securityapiv1.FSTypePersistentVolumeClaim, securityapiv1.FSProjected},
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.SELinuxStrategyMustRunAs,
+				Type: securityapiv1.SELinuxStrategyMustRunAs,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
-				Type: securityapi.RunAsUserStrategyRunAsAny,
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
+				Type: securityapiv1.RunAsUserStrategyRunAsAny,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyRunAsAny,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyRunAsAny,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyRunAsAny,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyRunAsAny,
 			},
 			// prefer the anyuid SCC over ones that force a uid
 			Priority: &securityContextConstraintsAnyUIDPriority,
 			// drops unsafe caps
-			RequiredDropCapabilities: []kapi.Capability{"MKNOD"},
+			RequiredDropCapabilities: []corev1.Capability{"MKNOD"},
 		},
 		// SecurityContextConstraintsHostNetwork allows host network and host ports
 		{
@@ -259,42 +258,35 @@ func GetBootstrapSecurityContextConstraints(sccNameToAdditionalGroups map[string
 			},
 			AllowHostNetwork: true,
 			AllowHostPorts:   true,
-			Volumes:          []securityapi.FSType{securityapi.FSTypeEmptyDir, securityapi.FSTypeSecret, securityapi.FSTypeDownwardAPI, securityapi.FSTypeConfigMap, securityapi.FSTypePersistentVolumeClaim, securityapi.FSProjected},
-			SELinuxContext: securityapi.SELinuxContextStrategyOptions{
+			Volumes:          []securityapiv1.FSType{securityapiv1.FSTypeEmptyDir, securityapiv1.FSTypeSecret, securityapiv1.FSTypeDownwardAPI, securityapiv1.FSTypeConfigMap, securityapiv1.FSTypePersistentVolumeClaim, securityapiv1.FSProjected},
+			SELinuxContext: securityapiv1.SELinuxContextStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.SELinuxStrategyMustRunAs,
+				Type: securityapiv1.SELinuxStrategyMustRunAs,
 			},
-			RunAsUser: securityapi.RunAsUserStrategyOptions{
+			RunAsUser: securityapiv1.RunAsUserStrategyOptions{
 				// This strategy requires that annotations on the namespace which will be populated
 				// by the admission controller.  If namespaces are not annotated creating the strategy
 				// will fail.
-				Type: securityapi.RunAsUserStrategyMustRunAsRange,
+				Type: securityapiv1.RunAsUserStrategyMustRunAsRange,
 			},
-			FSGroup: securityapi.FSGroupStrategyOptions{
-				Type: securityapi.FSGroupStrategyMustRunAs,
+			FSGroup: securityapiv1.FSGroupStrategyOptions{
+				Type: securityapiv1.FSGroupStrategyMustRunAs,
 			},
-			SupplementalGroups: securityapi.SupplementalGroupsStrategyOptions{
-				Type: securityapi.SupplementalGroupsStrategyMustRunAs,
+			SupplementalGroups: securityapiv1.SupplementalGroupsStrategyOptions{
+				Type: securityapiv1.SupplementalGroupsStrategyMustRunAs,
 			},
 			// drops unsafe caps
-			RequiredDropCapabilities: []kapi.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
+			RequiredDropCapabilities: []corev1.Capability{"KILL", "MKNOD", "SETUID", "SETGID"},
 		},
 	}
 
 	// add default access
-	for i := range constraints {
-		// round trip to external, apply defaults, to ensure we match what we compare against the server
-		v1constraint := &securityapiv1.SecurityContextConstraints{}
-		constraint := &securityapi.SecurityContextConstraints{}
-		if err := bootstrapSCCScheme.Convert(constraints[i], v1constraint, nil); err != nil {
-			panic(err)
-		}
-		bootstrapSCCScheme.Default(v1constraint)
-		if err := bootstrapSCCScheme.Convert(v1constraint, constraint, nil); err != nil {
-			panic(err)
-		}
+	for i, constraint := range constraints {
+		// apply defaults, to ensure we match what we compare against the server
+		bootstrapSCCScheme.Default(constraint)
+
 		constraints[i] = constraint
 
 		if usersToAdd, ok := sccNameToAdditionalUsers[constraint.Name]; ok {

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -14,13 +14,14 @@ import (
 
 func TestBootstrappedConstraints(t *testing.T) {
 	// ordering of expectedConstraintNames is important, we check it against scc.ByPriority
+	// TODO: Fix/Check order, changed HostNS,HostNetwork
 	expectedConstraintNames := []string{
 		SecurityContextConstraintsAnyUID,
 		SecurityContextConstraintRestricted,
 		SecurityContextConstraintNonRoot,
 		SecurityContextConstraintHostMountAndAnyUID,
-		SecurityContextConstraintsHostNetwork,
 		SecurityContextConstraintHostNS,
+		SecurityContextConstraintsHostNetwork,
 		SecurityContextConstraintPrivileged,
 	}
 	expectedGroups, expectedUsers := getExpectedAccess()
@@ -33,14 +34,9 @@ func TestBootstrappedConstraints(t *testing.T) {
 		t.Errorf("unexpected number of constraints: found %d, wanted %d", len(bootstrappedConstraints), len(expectedConstraintNames))
 	}
 
-	bootstrappedConstraintsExternal, err := sccsort.ByPriorityConvert(bootstrappedConstraints)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	sort.Sort(sccsort.ByPriority(bootstrappedConstraints))
 
-	sort.Sort(bootstrappedConstraintsExternal)
-
-	for i, constraint := range bootstrappedConstraintsExternal {
+	for i, constraint := range bootstrappedConstraints {
 		if constraint.Name != expectedConstraintNames[i] {
 			t.Errorf("unexpected contraint no. %d (by priority).  Found %v, wanted %v", i, constraint.Name, expectedConstraintNames[i])
 		}

--- a/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
+++ b/pkg/cmd/server/bootstrappolicy/securitycontextconstraints_test.go
@@ -14,14 +14,13 @@ import (
 
 func TestBootstrappedConstraints(t *testing.T) {
 	// ordering of expectedConstraintNames is important, we check it against scc.ByPriority
-	// TODO: Fix/Check order, changed HostNS,HostNetwork
 	expectedConstraintNames := []string{
 		SecurityContextConstraintsAnyUID,
 		SecurityContextConstraintRestricted,
 		SecurityContextConstraintNonRoot,
 		SecurityContextConstraintHostMountAndAnyUID,
-		SecurityContextConstraintHostNS,
 		SecurityContextConstraintsHostNetwork,
+		SecurityContextConstraintHostNS,
 		SecurityContextConstraintPrivileged,
 	}
 	expectedGroups, expectedUsers := getExpectedAccess()

--- a/pkg/security/apiserver/admission/sccadmission/admission.go
+++ b/pkg/security/apiserver/admission/sccadmission/admission.go
@@ -20,7 +20,7 @@ import (
 	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 
-	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
+	securityv1informer "github.com/openshift/client-go/security/informers/externalversions/security/v1"
 	securityv1listers "github.com/openshift/client-go/security/listers/security/v1"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	allocator "github.com/openshift/origin/pkg/security"
@@ -241,8 +241,8 @@ func shouldIgnore(a admission.Attributes) (bool, error) {
 }
 
 // SetSecurityInformers implements WantsSecurityInformer interface for constraint.
-func (c *constraint) SetSecurityInformers(informers securityv1informer.SharedInformerFactory) {
-	c.sccLister = informers.Security().V1().SecurityContextConstraints().Lister()
+func (c *constraint) SetSecurityInformers(informers securityv1informer.SecurityContextConstraintsInformer) {
+	c.sccLister = informers.Lister()
 }
 
 func (c *constraint) SetExternalKubeClientSet(client kubernetes.Interface) {

--- a/pkg/security/apiserver/admission/sccadmission/scc_exec.go
+++ b/pkg/security/apiserver/admission/sccadmission/scc_exec.go
@@ -12,7 +12,7 @@ import (
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
 	coreapiv1conversions "k8s.io/kubernetes/pkg/apis/core/v1"
 
-	securityv1informers "github.com/openshift/client-go/security/informers/externalversions"
+	securityv1informers "github.com/openshift/client-go/security/informers/externalversions/security/v1"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 )
 
@@ -85,7 +85,7 @@ func (d *sccExecRestrictions) SetExternalKubeClientSet(c kubernetes.Interface) {
 	d.constraintAdmission.SetExternalKubeClientSet(c)
 }
 
-func (d *sccExecRestrictions) SetSecurityInformers(informers securityv1informers.SharedInformerFactory) {
+func (d *sccExecRestrictions) SetSecurityInformers(informers securityv1informers.SecurityContextConstraintsInformer) {
 	d.constraintAdmission.SetSecurityInformers(informers)
 }
 

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -206,8 +206,7 @@ os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/tes
 # In the past system:admin only had access to a few SCCs, so the following command resulted in the privileged SCC being used
 # Since SCCs are now authorized via RBAC, and system:admin can perform all RBAC actions == system:admin can access all SCCs now
 # Thus the following command now results in the use of the hostnetwork SCC which is the most restrictive SCC that still allows the pod to run
-# TODO: SWITCHED hostnetwork to hostaccess??? OK???
-os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml -o=jsonpath={.status.allowedBy.name}' 'hostaccess'
+os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml -o=jsonpath={.status.allowedBy.name}' 'hostnetwork'
 # Make sure that the legacy ungroupified objects continue to work by directly doing a create
 os::cmd::expect_success_and_text 'oc create -f ${OS_ROOT}/test/testdata/legacy_ungroupified_psp_review.yaml -o=jsonpath={.status.allowedBy.name}' 'restricted'
 os::cmd::expect_success "oc login -u bob -p bobpassword"

--- a/test/cmd/policy.sh
+++ b/test/cmd/policy.sh
@@ -206,7 +206,8 @@ os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/tes
 # In the past system:admin only had access to a few SCCs, so the following command resulted in the privileged SCC being used
 # Since SCCs are now authorized via RBAC, and system:admin can perform all RBAC actions == system:admin can access all SCCs now
 # Thus the following command now results in the use of the hostnetwork SCC which is the most restrictive SCC that still allows the pod to run
-os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml -o=jsonpath={.status.allowedBy.name}' 'hostnetwork'
+# TODO: SWITCHED hostnetwork to hostaccess??? OK???
+os::cmd::expect_success_and_text 'oc policy scc-subject-review -f ${OS_ROOT}/test/testdata/nginx_pod.yaml -o=jsonpath={.status.allowedBy.name}' 'hostaccess'
 # Make sure that the legacy ungroupified objects continue to work by directly doing a create
 os::cmd::expect_success_and_text 'oc create -f ${OS_ROOT}/test/testdata/legacy_ungroupified_psp_review.yaml -o=jsonpath={.status.allowedBy.name}' 'restricted'
 os::cmd::expect_success "oc login -u bob -p bobpassword"


### PR DESCRIPTION
Pave way for SCCs move to CRD
Goal of this change plus [this](https://github.com/openshift/origin/pull/22658) is to move SecurityContextConstraints from OpenShift API server to CRD so the admission plugins that run in kubernetes apiserver do not have dependency on OpenShift API resource. 

also see [this](https://github.com/openshift/cluster-config-operator/pull/41)


Bug 1698625