### PR TITLE
pkg/oc/cli/admin/release/extract_tools: Fix false "did not contain" when not hashing

### DIFF
--- a/pkg/oc/cli/admin/release/extract_tools.go
+++ b/pkg/oc/cli/admin/release/extract_tools.go
@@ -311,15 +311,14 @@ func (o *ExtractOptions) extractCommand(command string) error {
 			klog.V(2).Infof("Unable to set extracted file modification time: %v", err)
 		}
 
-		// calculate hashes
-		if hash != nil {
-			func() {
-				extractLock.Lock()
-				defer extractLock.Unlock()
+		func() {
+			extractLock.Lock()
+			defer extractLock.Unlock()
+			delete(targetsByName, layer.Mapping.Name)
+			if hash != nil {
 				hashByTargetName[layer.Mapping.To] = hex.EncodeToString(hash.Sum(nil))
-				delete(targetsByName, layer.Mapping.Name)
-			}()
-		}
+			}
+		}()
 
 		return false, nil
 	}


### PR DESCRIPTION
The installer `Dockerfile` has put the binary in `/bin` since openshift/install@29e4d10eb7 (openshift/installer#343).  Fixes:

```console
$ oc adm release extract --command=openshift-install registry.svc.ci.openshift.org/openshift/origin-release:v4.0
error: image did not contain usr/bin/openshift-install
```

CC @smarterclayton