### PR TITLE
Fix case when operator fight with CRD registration on quota.openshift.io

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -196,6 +196,10 @@ func (c *crdRegistrationController) handleVersionUpdate(groupVersion schema.Grou
 	apiServiceName := groupVersion.Version + "." + groupVersion.Group
 	
 	if apiserver.APIServiceAlreadyExists(groupVersion) {
+		// Removing APIService from sync means the CRD registration controller won't sync this APIService
+		// anymore. If the APIService is managed externally, this will mean the external component can
+		// update this APIService without CRD controller stomping the changes on it.
+		c.apiServiceRegistration.RemoveAPIServiceToSync(apiServiceName)
 		return nil
 	}
 


### PR DESCRIPTION
This should mitigate the issue when the CRD registration controller was stomping the `quota.openshift.io/v1` APIService and fighting with OpenShift API server operator.

The change will remove the APIService from the sync and it won't be reconciled. The APIService will still be created (we want this when the cluster is installed), but consequent updated from OpenShift API server operator won't be overridden.