### PR TITLE
Add test/extended to cover  bz1694871

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -132,6 +132,9 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					g.By(fmt.Sprintf("verifying the build output is verbose"))
 					o.Expect(buildLog).To(o.ContainSubstring("Creating a new S2I builder"))
 					o.Expect(buildLog).To(o.ContainSubstring("openshift-builder v"))
+					// Bug 1694871: logging before flag.Parse error
+					g.By(fmt.Sprintf("verifying the build output has no error about flag.Parse"))
+					o.Expect(buildLog).NotTo(o.ContainSubstring("ERROR: logging before flag.Parse"))
 				})
 
 				g.It("BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel", func() {


### PR DESCRIPTION
Now there's a case [OCP-23057](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-23057) about  [bz1694871](https://bugzilla.redhat.com/show_bug.cgi?id=1694871), so add extended test, here is a pass log[1] [2]for my local host. 
@wzheng1 @xiuwang Could you help to review it,  and @adambkaplan ,  hope devels can review it and give advice too, thanks. 
[1]http://pastebin.test.redhat.com/754739
[2]http://pastebin.test.redhat.com/754740


