### PR TITLE
Bug 1700068: test/extended: Use internal service if no router LB

### DIFF
--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -10,7 +10,6 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -31,16 +30,8 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		var err error
 		routerIP, err = waitForRouterServiceIP(oc)
-		if kapierrs.IsNotFound(err) {
-			g.Skip("no router installed on the cluster")
-			return
-		}
 		o.Expect(err).NotTo(o.HaveOccurred())
-		metricsIP, err = waitForRouterMetricsIP(oc)
-		if kapierrs.IsNotFound(err) {
-			g.Skip("no router installed on the cluster")
-			return
-		}
+		metricsIP, err = waitForRouterInternalIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		if routerIP != metricsIP {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -66,7 +66,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			}
 		}
 
-		host, err = waitForRouterMetricsIP(oc)
+		host, err = waitForRouterInternalIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		serviceIP, err = waitForRouterServiceIP(oc)

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -7,7 +7,6 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -41,10 +40,6 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		var err error
 		ip, err = waitForRouterServiceIP(oc)
-		if kapierrs.IsNotFound(err) {
-			g.Skip("no router installed on the cluster")
-			return
-		}
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name

--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -39,6 +39,7 @@ import (
 	buildv1client "github.com/openshift/client-go/build/clientset/versioned"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned"
+	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
 	templateclient "github.com/openshift/client-go/template/clientset/versioned"
 	_ "github.com/openshift/origin/pkg/api/install"
 	authorizationclientset "github.com/openshift/origin/pkg/authorization/generated/internalclientset"
@@ -431,6 +432,14 @@ func (c *CLI) AdminConfigClient() configv1client.Interface {
 
 func (c *CLI) AdminImageClient() imagev1client.Interface {
 	client, err := imagev1client.NewForConfig(c.AdminConfig())
+	if err != nil {
+		FatalErr(err)
+	}
+	return client
+}
+
+func (c *CLI) AdminOperatorClient() operatorv1client.Interface {
+	client, err := operatorv1client.NewForConfig(c.AdminConfig())
 	if err != nil {
 		FatalErr(err)
 	}


### PR DESCRIPTION
If the ingress controller/router does not have a LoadBalancer service, use the internal service for tests.

Delete broken skip logic.  The logic in question was checking an error value from `wait.PollImmediate` using the `IsNotFound` function from the Kubernetes API machinery.  In the polling in question, if a resource is not found, the polling eventually times out, and `wait.PollImmediate` returns `wait.ErrWaitTimeout`, which is not an `APIStatus` type, which means that `IsNotFound` would never return true for it.

* `test/extended/router/router.go` (`waitForRouterMetricsIP`): Rename from this...
(`waitForRouterInternalIP`): ...to this.
(`waitForRouterServiceIP`): Rename from this...
(`waitForRouterExternalIP`): to this.
(`routerShouldHaveExternalService`): New function that checks the default ingresscontroller's status to determine whether it is supposed to be exposed by an LB service.
(`waitForRouterServiceIP`): New function that uses `routerShouldHaveExternalService` and returns the result of either `waitForRouterInternalIP` or `waitForRouterExternalIP` accordingly.

* `test/extended/util/cli.go` (`AdminOperatorClient`): New method (used by `routerShouldHaveExternalService`).

* `test/extended/router/router.go`:
* `test/extended/router/headers.go`:
* `test/extended/router/metrics.go`:
* `test/extended/router/reencrypt.go`: Delete broken skip logic.  Use `waitForRouterServiceIP` when some address is needed.  Use `waitForRouterInternalIP` when an internal address is needed.