### PR TITLE
images/tests: Globally-writeable /etc/passwd

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -9,7 +9,8 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
-    git config --system user.email test@test.com
+    git config --system user.email test@test.com && \
+    chmod g+w /etc/passwd
 LABEL io.k8s.display-name="OpenShift End-to-End Tests" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,tests,e2e"


### PR DESCRIPTION
This lets us SSH from the teardown container into the cluster without hitting:

```console
$ ssh -A core@$bootstrap_ip
No user exists for uid 1051910000
```

OpenSSH has [a very early `getpwuid` call][1] with no provision for bypassing via `HOME` or `USER` environment variables [like we did for Bazel][2].  OpenShift runs with the random UIDs by [default][3]:

> By default, all containers that we try and launch within OpenShift, are set blocked from “RunAsAny” which basically means that they are not allowed to use a root user within the container.  This prevents root actions such as chown or chmod from being run and is a sensible security precaution as, should a user be able to perform a local exploit to break out of the container, then they would not be running as root on the underlying container host.  NB what about user-namespaces some of you are no doubt asking, these are definitely coming but the testing/hardening process is taking a while and whilst companies such as Red Hat are working hard in this space, there is still a way to go until they are ready for the mainstream.

while Kubernetes [sorts out user namespacing][4].  Despite the high UIDs, all users on the cluster are GID 0, so the `g+w` is sufficient (vs. `a+w`), and maybe this mitigates concerns about increased writability for such an important file.  The main mitigation is that these are throw-away CI containers, and not long-running production containers where we are concerned about malicious entry.

A more polished fix has [landed in CRI-O][5], but the CI cluster is stuck on OpenShift 3.11 and Docker at the moment.

Our SSH usecase is for [gathering logs in the teardown container][6], but we've been using the tests image for both tests and teardown since b16dcfc7ce (#22094).

[1]: https://github.com/openssh/openssh-portable/blob/V_7_4_P1/ssh.c#L577
[2]: https://github.com/openshift/release/pull/1185
[3]: https://blog.openshift.com/getting-any-docker-image-running-in-your-own-openshift-cluster/
[4]: https://github.com/kubernetes/enhancements/issues/127
[5]: https://github.com/cri-o/cri-o/pull/2022
[6]: https://github.com/openshift/release/pull/3475