### PR TITLE
Use the image retriever and reuse cached command contexts

### DIFF
--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -540,7 +540,9 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 			SecurityOptions: o.SecurityOptions,
 			ParallelOptions: o.ParallelOptions,
 			ImageMetadataCallback: func(name string, image *imageinfo.Image, err error) error {
-				verifier.Verify(image.Digest, image.ContentDigest)
+				if image != nil {
+					verifier.Verify(image.Digest, image.ContentDigest)
+				}
 				lock.Lock()
 				defer lock.Unlock()
 				if err != nil {
@@ -906,6 +908,7 @@ func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, pullSp
 				image, ok := release.Images[tag.Name]
 				if !ok {
 					fmt.Fprintf(w, "  %s\t\t\t\t\t\n", tag.Name)
+					continue
 				}
 
 				// create a column for a small number of unique base layers that visually indicates


### PR DESCRIPTION
The info command had duplicate code, causing it to fail to properly
log errors. Unify the code paths.

Correct two failing edge cases in the release info printers related
to images that don't exist. This panicked:

    oc adm release info quay.io/openshift-release-dev/ocp-release:4.0.0-2

since the images have been deleted out of it now.