### PR TITLE
WIP: Audit the contents of a remote repo against release integrity

### DIFF
--- a/pkg/oc/cli/admin/release/audit.go
+++ b/pkg/oc/cli/admin/release/audit.go
@@ -1,0 +1,279 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/openshift/origin/pkg/oc/cli/image/workqueue"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/util/templates"
+
+	imagereference "github.com/openshift/origin/pkg/image/apis/image/reference"
+	"github.com/openshift/origin/pkg/oc/cli/image/info"
+	imagemanifest "github.com/openshift/origin/pkg/oc/cli/image/manifest"
+)
+
+func NewAuditOptions(streams genericclioptions.IOStreams) *AuditOptions {
+	return &AuditOptions{
+		IOStreams: streams,
+		ParallelOptions: imagemanifest.ParallelOptions{
+			MaxPerRegistry: 4,
+		},
+	}
+}
+
+func NewAudit(f kcmdutil.Factory, parentName string, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewAuditOptions(streams)
+	cmd := &cobra.Command{
+		Use:   "audit REPOSITORY",
+		Short: "Perform consistency checks against a release repository",
+		Long: templates.LongDesc(`
+			Perform consistency checks against a release repository
+
+			Experimental: This command is under active development and may change without notice.
+		`),
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete(f, cmd, args))
+			kcmdutil.CheckErr(o.Validate())
+			kcmdutil.CheckErr(o.Run())
+		},
+	}
+	flags := cmd.Flags()
+	o.SecurityOptions.Bind(flags)
+	o.ParallelOptions.Bind(flags)
+
+	return cmd
+}
+
+type AuditOptions struct {
+	genericclioptions.IOStreams
+
+	SecurityOptions imagemanifest.SecurityOptions
+	ParallelOptions imagemanifest.ParallelOptions
+
+	Images []string
+	From   string
+}
+
+func (o *AuditOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args []string) error {
+	switch len(args) {
+	case 1:
+		o.From = args[0]
+	default:
+		return fmt.Errorf("a single image repository argument must be provided to audit")
+	}
+	return nil
+}
+
+func (o *AuditOptions) Validate() error {
+	return nil
+}
+
+func (o *AuditOptions) Run() error {
+	from, err := imagereference.Parse(o.From)
+	if err != nil {
+		return fmt.Errorf("--from must point to a repository: %v", err)
+	}
+	if len(from.ID) > 0 || len(from.Tag) > 0 {
+		return fmt.Errorf("--from must point to a repository, not a tag or digest")
+	}
+
+	ctx := context.Background()
+	context, err := o.SecurityOptions.Context()
+	if err != nil {
+		return err
+	}
+
+	repo, err := context.Repository(ctx, from.DockerClientDefaults().RegistryURL(), from.RepositoryName(), o.SecurityOptions.Insecure)
+	if err != nil {
+		return fmt.Errorf("unable to connect to image repository %s: %v", from.Exact(), err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	tags := newTagStore()
+	images := newImageStore()
+
+	fmt.Fprintf(o.ErrOut, "Retrieving tags ... ")
+	tagSvc := repo.Tags(ctx)
+	tagNames, err := tagSvc.All(ctx)
+	if err != nil {
+		fmt.Fprintf(o.ErrOut, "failed\n")
+		return fmt.Errorf("unable to retrieve tags: %v", err)
+	}
+	fmt.Fprintf(o.ErrOut, "%d found\n", len(tagNames))
+
+	work := workqueue.New(o.ParallelOptions.MaxPerRegistry, stopCh)
+
+	retriever := &info.ImageRetriever{
+		SecurityOptions: o.SecurityOptions,
+		ParallelOptions: o.ParallelOptions,
+
+		Image: make(map[string]imagereference.DockerImageReference),
+	}
+	for _, name := range tagNames {
+		copy := from
+		copy.Tag = name
+		retriever.Image[name] = copy
+	}
+	infoOptions := NewInfoOptions(o.IOStreams)
+	infoOptions.SecurityOptions = o.SecurityOptions
+	infoOptions.ParallelOptions = o.ParallelOptions
+
+	retriever.ImageMetadataCallback = func(name string, image *info.Image, err error) error {
+		if err != nil {
+			tags.AddError(fmt.Errorf("unable to retrieve tag %s: %v", name, err))
+			return nil
+		}
+		tags.Add(name, image.Digest)
+		images.Add(image)
+		if !isReleaseCandidate(image) {
+			fmt.Fprintf(o.Out, "%s %s image %s\n", image.Digest, image.Config.Created.UTC().Format(time.RFC3339), name)
+			return nil
+		}
+
+		work.Queue(func(_ workqueue.Work) {
+			release, err := infoOptions.LoadReleaseInfo(image.Name, true)
+			if err != nil {
+				tags.AddError(fmt.Errorf("the tag %s could not be loaded as a release: %v", name, err))
+				return
+			}
+			preferredName := release.PreferredName()
+			if preferredName != name {
+				tags.AddError(fmt.Errorf("the release at tag %s should be tagged %s", name, preferredName))
+				return
+			}
+			if len(release.Warnings) > 0 {
+				for _, warning := range release.Warnings {
+					tags.AddError(fmt.Errorf("the release at tag %s is not valid: %s", name, warning))
+				}
+				return
+			}
+			fmt.Fprintf(o.Out, "%s %s release %s\n", image.Digest, image.Config.Created.UTC().Format(time.RFC3339), release.PreferredName())
+		})
+		return nil
+	}
+	if err := retriever.Run(); err != nil {
+		return err
+	}
+
+	work.Done()
+
+	tagErrs, imageErrs := tags.Errors(), images.Errors()
+	errs := make([]string, 0, len(tagErrs)+len(imageErrs))
+	for _, err := range tagErrs {
+		errs = append(errs, err.Error())
+	}
+	for _, err := range imageErrs {
+		errs = append(errs, err.Error())
+	}
+	sort.Strings(errs)
+	uniqueStrings(errs)
+	for _, err := range errs {
+		fmt.Fprintf(o.ErrOut, "error: %v\n", err)
+	}
+
+	return nil
+}
+
+func isReleaseCandidate(image *info.Image) bool {
+	if image.Config != nil && image.Config.Config != nil {
+		return len(image.Config.Config.Labels["io.openshift.release"]) > 0
+	}
+	return false
+}
+
+type tagStore struct {
+	lock sync.Mutex
+	tags map[string]digest.Digest
+	errs []error
+}
+
+func newTagStore() *tagStore {
+	return &tagStore{
+		tags: make(map[string]digest.Digest),
+	}
+}
+
+func (s *tagStore) Add(name string, dgst digest.Digest) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	existing, ok := s.tags[name]
+	if ok {
+		if existing != dgst {
+			s.errs = append(s.errs, fmt.Errorf("tag %s changed from digest %s to %s at %s", name, existing, dgst, time.Now().UTC().Format(time.RFC3339)))
+		}
+		return
+	}
+	s.tags[name] = dgst
+}
+
+func (s *tagStore) AddError(err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.errs = append(s.errs, err)
+}
+
+func (s *tagStore) Errors() []error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.errs
+}
+
+type imageStore struct {
+	lock   sync.Mutex
+	images map[digest.Digest]*info.Image
+	errs   []error
+}
+
+func newImageStore() *imageStore {
+	return &imageStore{
+		images: make(map[digest.Digest]*info.Image),
+	}
+}
+
+func (s *imageStore) Add(image *info.Image) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	existing, ok := s.images[image.Digest]
+	if ok {
+		if !reflect.DeepEqual(existing.Config, image.Config) {
+			s.errs = append(s.errs, fmt.Errorf("image %s has inconsistent internal contents", image.Digest))
+		}
+		return
+	}
+	s.images[image.Digest] = image
+}
+
+func (s *imageStore) Errors() []error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.errs
+}
+
+func uniqueStrings(arr []string) []string {
+	var last int
+	for i := 1; i < len(arr); i++ {
+		if arr[i] == arr[last] {
+			continue
+		}
+		last++
+		if last != i {
+			arr[last] = arr[i]
+		}
+	}
+	if last < len(arr) {
+		last++
+	}
+	return arr[:last]
+}

--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -540,7 +540,9 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 			SecurityOptions: o.SecurityOptions,
 			ParallelOptions: o.ParallelOptions,
 			ImageMetadataCallback: func(name string, image *imageinfo.Image, err error) error {
-				verifier.Verify(image.Digest, image.ContentDigest)
+				if image != nil {
+					verifier.Verify(image.Digest, image.ContentDigest)
+				}
 				lock.Lock()
 				defer lock.Unlock()
 				if err != nil {
@@ -906,6 +908,7 @@ func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, pullSp
 				image, ok := release.Images[tag.Name]
 				if !ok {
 					fmt.Fprintf(w, "  %s\t\t\t\t\t\n", tag.Name)
+					continue
 				}
 
 				// create a column for a small number of unique base layers that visually indicates

--- a/pkg/oc/cli/admin/release/release.go
+++ b/pkg/oc/cli/admin/release/release.go
@@ -27,5 +27,6 @@ func NewCmd(f kcmdutil.Factory, parentName string, streams genericclioptions.IOS
 	cmd.AddCommand(NewRelease(f, parentName+" release", streams))
 	cmd.AddCommand(NewExtract(f, parentName+" release", streams))
 	cmd.AddCommand(NewMirror(f, parentName+" release", streams))
+	cmd.AddCommand(NewAudit(f, parentName+" release", streams))
 	return cmd
 }

--- a/pkg/oc/cli/image/info/info.go
+++ b/pkg/oc/cli/image/info/info.go
@@ -88,6 +88,12 @@ func (o *InfoOptions) Run() error {
 		return fmt.Errorf("must specify one or more images as arguments")
 	}
 
+	// cache the context
+	_, err := o.SecurityOptions.Context()
+	if err != nil {
+		return err
+	}
+
 	hadError := false
 	for _, location := range o.Images {
 		src, err := imagereference.Parse(location)
@@ -98,55 +104,31 @@ func (o *InfoOptions) Run() error {
 			return fmt.Errorf("--from must point to an image ID or image tag")
 		}
 
-		ctx := context.Background()
-		context, err := o.SecurityOptions.Context()
-		if err != nil {
+		var image *Image
+		retriever := &ImageRetriever{
+			Image:           map[string]imagereference.DockerImageReference{},
+			SecurityOptions: o.SecurityOptions,
+			ManifestListCallback: func(from string, list *manifestlist.DeserializedManifestList) (map[digest.Digest]distribution.Manifest, error) {
+				buf := &bytes.Buffer{}
+				w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+				fmt.Fprintf(w, "  OS\tDIGEST\n")
+				for _, manifest := range list.Manifests {
+					fmt.Fprintf(w, "  %s\t%s\n", imagemanifest.PlatformSpecString(manifest.Platform), manifest.Digest)
+				}
+				w.Flush()
+				return nil, fmt.Errorf("the image is a manifest list and contains multiple images - use --filter-by-os to select from:\n\n%s\n", buf.String())
+			},
+
+			ImageMetadataCallback: func(from string, i *Image, err error) error {
+				if err != nil {
+					return err
+				}
+				image = i
+				return nil
+			},
+		}
+		if err := retriever.Run(); err != nil {
 			return err
-		}
-
-		repo, err := context.Repository(ctx, src.DockerClientDefaults().RegistryURL(), src.RepositoryName(), o.SecurityOptions.Insecure)
-		if err != nil {
-			return err
-		}
-
-		srcManifest, manifestLocation, err := imagemanifest.FirstManifest(ctx, src, repo, o.FilterOptions.IncludeAll)
-		if err != nil {
-			return fmt.Errorf("unable to read image %s: %v", location, err)
-		}
-
-		switch t := srcManifest.(type) {
-		case *manifestlist.DeserializedManifestList:
-			buf := &bytes.Buffer{}
-			w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
-			fmt.Fprintf(w, "  OS\tDIGEST\n")
-			for _, manifest := range t.Manifests {
-				fmt.Fprintf(w, "  %s\t%s\n", imagemanifest.PlatformSpecString(manifest.Platform), manifest.Digest)
-			}
-			w.Flush()
-			return fmt.Errorf("the image is a manifest list and contains multiple images - use --filter-by-os to select from:\n\n%s\n", buf.String())
-		}
-
-		imageConfig, layers, err := imagemanifest.ManifestToImageConfig(ctx, srcManifest, repo.Blobs(ctx), manifestLocation)
-		if err != nil {
-			return fmt.Errorf("unable to parse image %s: %v", location, err)
-		}
-
-		mediaType, _, _ := srcManifest.Payload()
-		contentDigest, err := registryclient.ContentDigestForManifest(srcManifest, manifestLocation.Manifest.Algorithm())
-		if err != nil {
-			return err
-		}
-
-		image := &Image{
-			Name:          location,
-			Ref:           src,
-			Config:        imageConfig,
-			Digest:        manifestLocation.Manifest,
-			ContentDigest: contentDigest,
-			ListDigest:    manifestLocation.ManifestList,
-			MediaType:     mediaType,
-			Layers:        layers,
-			Manifest:      srcManifest,
 		}
 
 		switch o.Output {
@@ -168,6 +150,7 @@ func (o *InfoOptions) Run() error {
 				fmt.Fprintf(o.ErrOut, "error: %v", err)
 			}
 		}
+
 	}
 	if hadError {
 		return kcmdutil.ErrExit
@@ -330,6 +313,11 @@ type ImageRetriever struct {
 	// MaxPerRegistry is set higher than 1. If err is passed image is nil. If an error is returned
 	// execution will stop.
 	ImageMetadataCallback func(from string, image *Image, err error) error
+	// ManifestListCallback, if specified, is invoked if the root image is a manifest list. If an
+	// error returned processing stops. If zero manifests are returned the next item is rendered
+	// and no ImageMetadataCallback calls occur. If more than one manifest is returned
+	// ImageMetadataCallback will be invoked once for each item.
+	ManifestListCallback func(from string, list *manifestlist.DeserializedManifestList) (map[digest.Digest]distribution.Manifest, error)
 }
 
 func (o *ImageRetriever) Run() error {
@@ -339,6 +327,12 @@ func (o *ImageRetriever) Run() error {
 		return err
 	}
 
+	callbackFn := o.ImageMetadataCallback
+	if callbackFn == nil {
+		callbackFn = func(_ string, _ *Image, err error) error {
+			return err
+		}
+	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	q := workqueue.New(o.ParallelOptions.MaxPerRegistry, stopCh)
@@ -349,10 +343,10 @@ func (o *ImageRetriever) Run() error {
 			q.Try(func() error {
 				repo, err := fromContext.Repository(ctx, from.DockerClientDefaults().RegistryURL(), from.RepositoryName(), o.SecurityOptions.Insecure)
 				if err != nil {
-					return fmt.Errorf("unable to connect to image repository %s: %v", from.Exact(), err)
+					return callbackFn(name, nil, fmt.Errorf("unable to connect to image repository %s: %v", from.Exact(), err))
 				}
 
-				allManifests, _, listDigest, err := imagemanifest.AllManifests(ctx, from, repo)
+				allManifests, manifestList, listDigest, err := imagemanifest.AllManifests(ctx, from, repo)
 				if err != nil {
 					if imagemanifest.IsImageForbidden(err) {
 						var msg string
@@ -361,7 +355,7 @@ func (o *ImageRetriever) Run() error {
 						} else {
 							msg = fmt.Sprintf("image %q does not exist or you don't have permission to access the repository", from)
 						}
-						return imagemanifest.NewImageForbidden(msg, err)
+						return callbackFn(name, nil, imagemanifest.NewImageForbidden(msg, err))
 					}
 					if imagemanifest.IsImageNotFound(err) {
 						var msg string
@@ -370,35 +364,37 @@ func (o *ImageRetriever) Run() error {
 						} else {
 							msg = fmt.Sprintf("image %q does not exist", from)
 						}
-						return imagemanifest.NewImageNotFound(msg, err)
+						return callbackFn(name, nil, imagemanifest.NewImageNotFound(msg, err))
 					}
-					return fmt.Errorf("unable to read image %s: %v", from, err)
+					return callbackFn(name, nil, fmt.Errorf("unable to read image %s: %v", from, err))
 				}
 
-				if o.ImageMetadataCallback != nil {
-					for srcDigest, srcManifest := range allManifests {
-						imageConfig, layers, err := imagemanifest.ManifestToImageConfig(ctx, srcManifest, repo.Blobs(ctx), imagemanifest.ManifestLocation{ManifestList: listDigest, Manifest: srcDigest})
-						mediaType, _, _ := srcManifest.Payload()
-						contentDigest, err := registryclient.ContentDigestForManifest(srcManifest, srcDigest.Algorithm())
-						if err != nil {
-							return err
-						}
-
-						if err := o.ImageMetadataCallback(name, &Image{
-							Name:          from.Exact(),
-							MediaType:     mediaType,
-							Digest:        srcDigest,
-							ContentDigest: contentDigest,
-							ListDigest:    listDigest,
-							Config:        imageConfig,
-							Layers:        layers,
-							Manifest:      srcManifest,
-						}, err); err != nil {
-							return err
-						}
-					}
-				} else {
+				if o.ManifestListCallback != nil {
+					allManifests, err = o.ManifestListCallback(name, manifestList)
 					if err != nil {
+						return err
+					}
+				}
+
+				for srcDigest, srcManifest := range allManifests {
+					contentDigest, contentErr := registryclient.ContentDigestForManifest(srcManifest, srcDigest.Algorithm())
+					if contentErr != nil {
+						return callbackFn(name, nil, contentErr)
+					}
+
+					imageConfig, layers, manifestErr := imagemanifest.ManifestToImageConfig(ctx, srcManifest, repo.Blobs(ctx), imagemanifest.ManifestLocation{ManifestList: listDigest, Manifest: srcDigest})
+					mediaType, _, _ := srcManifest.Payload()
+					if err := callbackFn(name, &Image{
+						Name:          from.Exact(),
+						Ref:           from,
+						MediaType:     mediaType,
+						Digest:        srcDigest,
+						ContentDigest: contentDigest,
+						ListDigest:    listDigest,
+						Config:        imageConfig,
+						Layers:        layers,
+						Manifest:      srcManifest,
+					}, manifestErr); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
Add a new `oc adm release audit` command that audits a repository
for integrity. Right now it checks tags that look like releases and
verifies all tagged manifest integrity. We also need to look for
releases that aren't images.