### PR TITLE
Add a disruptive suite to openshift-tests

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -44,6 +44,15 @@ var staticSuites = []*ginkgo.TestSuite{
 		},
 	},
 	{
+		Name: "openshift/disruptive",
+		Description: templates.LongDesc(`
+		The disruptive test suite.
+		`),
+		Matches: func(name string) bool {
+			return !strings.Contains(name, "[Disabled") && strings.Contains(name, "[Disruptive]")
+		},
+	},
+	{
 		Name: "kubernetes/conformance",
 		Description: templates.LongDesc(`
 		The default Kubernetes conformance suite.

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -283,6 +283,9 @@ func decodeProviderTo(provider string, testContext *e2e.TestContextType) error {
 			return fmt.Errorf("provider must decode into the cloud config object: %v", err)
 		}
 	}
+	if len(testContext.Provider) == 0 {
+		testContext.Provider = "skeleton"
+	}
 	klog.V(2).Infof("Provider %s: %#v", testContext.Provider, testContext.CloudConfig)
 	return nil
 }

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -253,6 +253,10 @@ func initProvider(provider string) error {
 	exutil.TestContext.MaxNodesToGather = 0
 	exutil.TestContext.Viper = os.Getenv("VIPERCONFIG")
 
+	// set defaults so these tests don't log
+	exutil.TestContext.LoggingSoak.Scale = 1
+	exutil.TestContext.LoggingSoak.MilliSecondsBetweenWaves = 5000
+
 	exutil.AnnotateTestSuite()
 	exutil.InitTest()
 	gomega.RegisterFailHandler(ginkgo.Fail)

--- a/vendor/k8s.io/kubernetes/test/e2e/instrumentation/logging/generic_soak.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/instrumentation/logging/generic_soak.go
@@ -23,13 +23,18 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	instrumentation "k8s.io/kubernetes/test/e2e/instrumentation/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
+
+var loggingSoak struct {
+	Scale            int           `default:"1" usage:"number of waves of pods"`
+	TimeBetweenWaves time.Duration `default:"5000ms" usage:"time to wait before dumping the next wave of pods"`
+}
 
 var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disruptive]", func() {
 
@@ -44,43 +49,24 @@ var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disrupti
 	// This can expose problems in your docker configuration (logging), log searching infrastructure, to tune deployments to match high load
 	// scenarios.  TODO jayunit100 add this to the kube CI in a follow on infra patch.
 
-	// Returns scale (how many waves of pods).
-	// Returns wave interval (how many seconds to wait before dumping the next wave of pods).
-	readConfig := func() (int, time.Duration) {
-		// Read in configuration settings, reasonable defaults.
-		scale := framework.TestContext.LoggingSoak.Scale
-		if framework.TestContext.LoggingSoak.Scale == 0 {
-			scale = 1
-			framework.Logf("Overriding default scale value of zero to %d", scale)
-		}
-
-		milliSecondsBetweenWaves := framework.TestContext.LoggingSoak.MilliSecondsBetweenWaves
-		if milliSecondsBetweenWaves == 0 {
-			milliSecondsBetweenWaves = 5000
-			framework.Logf("Overriding default milliseconds value of zero to %d", milliSecondsBetweenWaves)
-		}
-
-		return scale, time.Duration(milliSecondsBetweenWaves) * time.Millisecond
-	}
-
-	scale, millisecondsBetweenWaves := readConfig()
-	It(fmt.Sprintf("should survive logging 1KB every %v seconds, for a duration of %v, scaling up to %v pods per node", kbRateInSeconds, totalLogTime, scale), func() {
-		defer GinkgoRecover()
+	ginkgo.It(fmt.Sprintf("should survive logging 1KB every %v seconds, for a duration of %v", kbRateInSeconds, totalLogTime), func() {
+		ginkgo.By(fmt.Sprintf("scaling up to %v pods per node", loggingSoak.Scale))
+		defer ginkgo.GinkgoRecover()
 		var wg sync.WaitGroup
-		wg.Add(scale)
-		for i := 0; i < scale; i++ {
+		wg.Add(loggingSoak.Scale)
+		for i := 0; i < loggingSoak.Scale; i++ {
 			go func() {
 				defer wg.Done()
-				defer GinkgoRecover()
+				defer ginkgo.GinkgoRecover()
 				wave := fmt.Sprintf("wave%v", strconv.Itoa(i))
 				framework.Logf("Starting logging soak, wave = %v", wave)
 				RunLogPodsWithSleepOf(f, kbRateInSeconds, wave, totalLogTime)
 				framework.Logf("Completed logging soak, wave %v", i)
 			}()
 			// Niceness.
-			time.Sleep(millisecondsBetweenWaves)
+			time.Sleep(loggingSoak.TimeBetweenWaves)
 		}
-		framework.Logf("Waiting on all %v logging soak waves to complete", scale)
+		framework.Logf("Waiting on all %v logging soak waves to complete", loggingSoak.Scale)
 		wg.Wait()
 	})
 })
@@ -91,7 +77,7 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 
 	nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 	totalPods := len(nodes.Items)
-	Expect(totalPods).NotTo(Equal(0))
+	gomega.Expect(totalPods).NotTo(gomega.Equal(0))
 
 	kilobyte := strings.Repeat("logs-123", 128) // 8*128=1024 = 1KB of text.
 


### PR DESCRIPTION
This is just a placeholder to allow us to prep the jobs. It will be
clarified later.

Also cleans up output logging that doesn't add anything.