### PR TITLE
UPSTREAM: <carry>: squash to dynamic certs, don't load zero length certs

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/certs/clientca.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/certs/clientca.go
@@ -74,7 +74,7 @@ func (c *DynamicCA) CheckCerts() error {
 		return err
 	}
 	if len(certBytes) == 0 {
-		return fmt.Errorf("not updating to an empty ca bundle from %q", c.caFile.Cert)
+		return fmt.Errorf("ca-bundle %q must not be empty", c.caFile.Cert)
 	}
 	newContent := caFileContent{Cert: certBytes}
 

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/certs/single_certkey_pair.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/certs/single_certkey_pair.go
@@ -1,6 +1,7 @@
 package certs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"sync/atomic"
 	"time"
@@ -80,9 +81,15 @@ func (c *DynamicCertKeyPairLoader) CheckCerts() error {
 	if err != nil {
 		return err
 	}
+	if len(servingCertBytes) == 0 {
+		return fmt.Errorf("cert %q must not be empty", c.fileReference.Cert)
+	}
 	servingKeyBytes, err := ioutil.ReadFile(c.fileReference.Key)
 	if err != nil {
 		return err
+	}
+	if len(servingKeyBytes) == 0 {
+		return fmt.Errorf("key %q must not be empty", c.fileReference.Key)
 	}
 	newContent := certKeyFileContent{Cert: servingCertBytes, Key: servingKeyBytes}
 


### PR DESCRIPTION
One possibility for unauthorized is that we haven't read the client cert.  I haven't seen any evidence of this (every log I've seen looks good), but this makes it an error.