### PR TITLE
 UPSTREAM: <carry>: filter out RBR and SCC paths from OpenAPI

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
@@ -41,11 +41,14 @@ func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) (*hand
 		klog.Fatalf("Failed to register open api spec for root: %v", err)
 	}
 
-	// we shadow ClustResourceQuotas with a CRD. This loop removes all CRQ paths
+	// we shadow ClustResourceQuotas, RoleBindingRestrictions, and SecurityContextContstraints
+	// with a CRD. This loop removes all CRQ,RBR, SCC paths
 	// from the OpenAPI spec such that they don't conflict with the CRD
 	// apiextensions-apiserver spec during merging.
 	for pth := range spec.Paths.Paths {
-		if strings.HasPrefix(pth, "/apis/quota.openshift.io/v1/clusterresourcequotas") {
+		if strings.HasPrefix(pth, "/apis/quota.openshift.io/v1/clusterresourcequotas") ||
+			strings.HasPrefix(pth, "/apis/authorization.openshift.io/v1/rolebindingrestrictions") ||
+			strings.HasPrefix(pth, "/apis/security.openshift.io/v1/securitycontextconstraints") {
 			delete(spec.Paths.Paths, pth)
 		}
 	}


### PR DESCRIPTION
We'll need this patch for:
Bug 1698625
Bug 1684344
(and PRs associated w/ those)

/cc @deads2k 
/cc @mfojtik 