### PR TITLE
Quay tightened rate limits, causing release creation to fail

### DIFF
--- a/pkg/oc/cli/admin/release/info.go
+++ b/pkg/oc/cli/admin/release/info.go
@@ -540,7 +540,9 @@ func (o *InfoOptions) LoadReleaseInfo(image string, retrieveImages bool) (*Relea
 			SecurityOptions: o.SecurityOptions,
 			ParallelOptions: o.ParallelOptions,
 			ImageMetadataCallback: func(name string, image *imageinfo.Image, err error) error {
-				verifier.Verify(image.Digest, image.ContentDigest)
+				if image != nil {
+					verifier.Verify(image.Digest, image.ContentDigest)
+				}
 				lock.Lock()
 				defer lock.Unlock()
 				if err != nil {
@@ -906,6 +908,7 @@ func describeReleaseInfo(out io.Writer, release *ReleaseInfo, showCommit, pullSp
 				image, ok := release.Images[tag.Name]
 				if !ok {
 					fmt.Fprintf(w, "  %s\t\t\t\t\t\n", tag.Name)
+					continue
 				}
 
 				// create a column for a small number of unique base layers that visually indicates


### PR DESCRIPTION
Introduce a global rate limiter for a given registry client context at 5qps
/ 5 burst, then have the retry repository wrapper enforce limiting. Make
429 from the client trigger a 2s cooldown. In combination this allows us to
avoid the limits. Do not expose rate limit as a tunable for now in CLI, but
future iterations may do so.

This should allow nightly builds to succeed.