### PR TITLE
extract_tools: pass security options

### DIFF
--- a/pkg/oc/cli/admin/release/extract_tools.go
+++ b/pkg/oc/cli/admin/release/extract_tools.go
@@ -180,6 +180,7 @@ func (o *ExtractOptions) extractCommand(command string) error {
 	// load the release image
 	dir := o.Directory
 	infoOptions := NewInfoOptions(o.IOStreams)
+	infoOptions.SecurityOptions = o.SecurityOptions
 	release, err := infoOptions.LoadReleaseInfo(o.From, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
Pass security options so that e.g. adm release extract --tools from an image in a private repository can work.