### PR TITLE
fix problem running custom must-gather command

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -62,4 +62,23 @@ var _ = g.Describe("[cli] oc adm must-gather", func() {
 		}
 
 	})
+
+	g.It("runs successfully with options", func() {
+		tempDir, err := ioutil.TempDir("", "test.oc-adm-must-gather.")
+		o.Expect(err).ToNot(o.HaveOccurred())
+		defer os.RemoveAll(tempDir)
+		args := []string{
+			"--dest-dir", tempDir,
+			"--source-dir", "/artifacts",
+			"--",
+			"/bin/bash", "-c",
+			"ls -l > /artifacts/ls.log",
+		}
+		o.Expect(oc.Run("adm", "must-gather").Args(args...).Execute()).To(o.Succeed())
+		expectedFilePath := path.Join(tempDir, "ls.log")
+		o.Expect(expectedFilePath).To(o.BeAnExistingFile())
+		stat, err := os.Stat(expectedFilePath)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(stat.Size()).To(o.BeNumerically(">", 0))
+	})
 })


### PR DESCRIPTION
Running a command such as `oc adm must-gather --source-dir /output -- bash -c "ls -l > /output/out.log"` ran into 2 issues: 1) the custom command was not executed properly, and 2) the `--source-dir` option was not properly applied.