### PR TITLE
test/extended/util/url: Truncate test output files

### DIFF
--- a/test/extended/util/url/url.go
+++ b/test/extended/util/url/url.go
@@ -365,6 +365,7 @@ func (ut *Test) ToShell(i int) string {
 		cmd += ` -k`
 	}
 	cmd += " 2>/tmp/error 1>/tmp/output || rc=$?"
+	lines = append(lines, `: > /tmp/body /tmp/headers`)
 	lines = append(lines, cmd)
 	lines = append(lines, fmt.Sprintf(`echo "{\"test\":%d,\"rc\":$(echo $rc),\"curl\":$(cat /tmp/output),\"error\":$(cat /tmp/error | json_escape),\"body\":\"$(cat /tmp/body | base64 -w 0 -)\",\"headers\":$(cat /tmp/headers | json_escape)}"`, i))
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
Truncate the `/tmp/body` and `/tmp/headers` files in the shell script for each `url.Expect` clause to prevent a failing test from printing "No such file or directory" errors or stale output from a previous test.

* `test/extended/util/url/url.go` (`ToShell`): Add a command to truncate `/tmp/body` and `/tmp/headers` before running `curl` in the generated script.