### PR TITLE
test/extended/util: DumpPodLogs: Always specify ns

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -258,7 +258,7 @@ func DumpPodLogsStartingWithInNamespace(prefix, namespace string, oc *CLI) {
 
 func DumpPodLogs(pods []kapiv1.Pod, oc *CLI) {
 	for _, pod := range pods {
-		descOutput, err := oc.AsAdmin().Run("describe").Args("pod/" + pod.Name).Output()
+		descOutput, err := oc.AsAdmin().Run("describe").WithoutNamespace().Args("pod/"+pod.Name, "-n", pod.Namespace).Output()
 		if err == nil {
 			e2e.Logf("Describing pod %q\n%s\n\n", pod.Name, descOutput)
 		} else {


### PR DESCRIPTION
Specify the namespace in the `oc describe` command in `DumpPodLogs`.

Before this commit, `DumpPodLogs` used the current namespace in the `oc describe` command.  As a result, if the pod was in a different namespace, the `oc describe` command could fail:

    INFO: Running 'oc describe --config=[...] --namespace=e2e-test-router-stress-47g75 pod/router-default-bf57996-scvhc'
    INFO: Error running &{/home/mmasters/bin/oc [oc describe --config=[...] --namespace=e2e-test-router-stress-47g75 pod/router-default-bf57996-scvhc] []   Error from server (NotFound): pods "router-default-bf57996-scvhc" not found
     Error from server (NotFound): pods "router-default-bf57996-scvhc" not found
     [] <nil> 0xc42310d200 exit status 1 <nil> <nil> true [0xc4223f06a0 0xc4223f06c8 0xc4223f06c8] [0xc4223f06a0 0xc4223f06c8] [0xc4223f06a8 0xc4223f06c0] [0x8b85c0 0x8b86c0] 0xc422af2ba0 <nil>}:
    Error from server (NotFound): pods "router-default-bf57996-scvhc" not found
    INFO: Error retrieving description for pod "router-default-bf57996-scvhc": exit status 1

After this commit, `DumpPodLogs` uses the pod's namespace, so the `oc describe` command prints the correct output.

(`DumpPodLogs` already specifies the pod namespace in the `oc logs` command.)

* `test/extended/util/framework.go` (`DumpPodLogs`): Specify the pod namespace in the `oc describe` command.