### PR TITLE
UPSTREAM: <carry>: Return journal logs from previous boot if possible

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_server_journal_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_server_journal_test.go
@@ -15,7 +15,7 @@ func Test_journalArgs_Args(t *testing.T) {
 		args journalArgs
 		want []string
 	}{
-		{args: journalArgs{}, want: []string{"--utc", "--no-pager", "--boot"}},
+		{args: journalArgs{}, want: []string{"--utc", "--no-pager"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
During upgrades or other significant disruptive events, being able
to look at node logs from the previous boot may be very very important.
Have the journal log endpoint check whether there are multiple boot
entries present, and if so, use `-1` to denote the current and previous.