### PR TITLE
Upgrading with --force should set the force boolean

### DIFF
--- a/pkg/oc/cli/admin/upgrade/upgrade.go
+++ b/pkg/oc/cli/admin/upgrade/upgrade.go
@@ -58,8 +58,6 @@ func New(f kcmdutil.Factory, parentName string, streams genericclioptions.IOStre
 			rolling back to a previous micro version (4.0.2 -> 4.0.1) may be safe, upgrading more
 			than one minor version ahead (4.0 -> 4.2) or downgrading one minor version (4.1 -> 4.0)
 			is likely to cause data corruption or to completely break a cluster.
-
-			Experimental: This command is under active development and may change without notice.
 		`),
 		Run: func(cmd *cobra.Command, args []string) {
 			kcmdutil.CheckErr(o.Complete(f, cmd, args))
@@ -218,7 +216,9 @@ func (o *Options) Run() error {
 			}
 		}
 
-		if !o.Force {
+		if o.Force {
+			update.Force = true
+		} else {
 			if err := checkForUpgrade(cv); err != nil {
 				return err
 			}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -317,6 +317,7 @@ func clusterUpgrade(c configv1client.Interface, version upgrades.VersionContext)
 	desired := configv1.Update{
 		Version: version.Version.String(),
 		Image:   version.NodeImage,
+		Force:   true,
 	}
 	cv.Spec.DesiredUpdate = &desired
 	updated, err := c.ConfigV1().ClusterVersions().Update(cv)
@@ -347,7 +348,7 @@ func clusterUpgrade(c configv1client.Interface, version upgrades.VersionContext)
 
 	framework.Logf("Cluster version operator acknowledged upgrade request")
 
-	if err := wait.PollImmediate(5*time.Second, 45*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(5*time.Second, 75*time.Minute, func() (bool, error) {
 		cv, err := c.ConfigV1().ClusterVersions().Get("version", metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("unable to retrieve cluster version during upgrade: %v", err)


### PR DESCRIPTION
As part of adding certificate verification to the payload we must now
tell the CVO to bypass certain failing conditions. Wire --force to
force and mark that upgrade is not experimental for 4.1.

First two commits from #22644 