### PR TITLE
kube-apiserver: exit with zero code on term signal

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/cmd.go
+++ b/pkg/cmd/openshift-kube-apiserver/cmd.go
@@ -70,6 +70,9 @@ func NewOpenShiftKubeAPIServerServerCommand(name, basename string, out, errout i
 				}
 				klog.Fatal(err)
 			}
+			// When no error is returned, always return with zero exit code.
+			// This is here to make sure the container that run apiserver won't get accidentally restarted
+			// when the pod runs with restart on failure.
 		},
 	}
 

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -1,8 +1,6 @@
 package openshift_kube_apiserver
 
 import (
-	"fmt"
-
 	"k8s.io/klog"
 
 	"k8s.io/apiserver/pkg/admission"
@@ -69,5 +67,5 @@ func RunOpenShiftKubeAPIServerServer(kubeAPIServerConfig *kubecontrolplanev1.Kub
 		return err
 	}
 
-	return fmt.Errorf("`kube-apiserver %v` exited", args)
+	return nil
 }


### PR DESCRIPTION
This fixes the case when kube apiserver is shut down using the TERM signal and should exit with 0 code (after gracefully stopping all connections/etc.). Otherwise if the apiserver run in a static pod with restart on failure, with kubelet managing it, the container will be restarted.

/cc @deads2k
/cc @sttts