### PR TITLE
Re-fix pod reattachment on SDN restart

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -385,7 +385,7 @@ func (node *OsdnNode) reattachPods(existingPods map[string]podNetworkInfo) error
 			klog.Warningf("Could not find sandbox for existing pod with IP %s; it may be in an inconsistent state", podInfo.ip)
 			continue
 		}
-		if _, err := node.oc.ovs.GetOFPort(podInfo.vethName); err != nil {
+		if _, err := netlink.LinkByName(podInfo.vethName); err != nil {
 			klog.Infof("Interface %s for pod '%s/%s' no longer exists", podInfo.vethName, sandbox.Metadata.Namespace, sandbox.Metadata.Name)
 			failed = append(failed, sandbox)
 			continue


### PR DESCRIPTION
In trying to improve the logging on SDN restart in #22471 I accidentally broke the pod-reattachment code. I had assumed that the PR wouldn't merge if e2e-aws-upgrade had failed, but it looks like the bot didn't even wait for it to finish. :-/

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1702194