### PR TITLE
Bug 1694878: Do not cache token authentication errors

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_authenticator.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_authenticator.go
@@ -175,7 +175,7 @@ func newAuthenticator(
 		// wrap with short cache on success.
 		// this means a revoked service account token or access token will be valid for up to 10 seconds.
 		// it also means group membership changes on users may take up to 10 seconds to become effective.
-		tokenAuth = tokencache.New(tokenAuth, true, 10*time.Second, 0)
+		tokenAuth = tokencache.New(tokenAuth, false, 10*time.Second, 0)
 
 		authenticators = append(authenticators,
 			bearertoken.New(tokenAuth),


### PR DESCRIPTION
For authentication, the returned ok and error are supposed to be
distinct in the sense that the former refers to "unauthenticated" vs
"something is broken."  In practice though we return errors in cases
that are really just "unauthenticated" (i.e. some lookup failed
because the object has been deleted).

xref:

https://github.com/openshift/origin/pull/22387#discussion_r268764805

Bug 1694878

Signed-off-by: Monis Khan <mkhan@redhat.com>