### PR TITLE
test/extended/prometheus: Add etcd target check

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -130,6 +130,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 					targets.Expect(labels{"job": "controller-manager"}, "up", "^https://.*/metrics$"),
 
 					// The kube control plane
+					targets.Expect(labels{"job": "etcd"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "apiserver"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "kube-controller-manager"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "scheduler"}, "up", "^https://.*/metrics$"),


### PR DESCRIPTION
This will fail currently until 

* https://github.com/openshift/installer/pull/1666
* https://github.com/openshift/cluster-monitoring-operator/pull/336

are merged. Putting this in place to prevent breaking this in the future or at least explicitly track it.

@s-urbaniak @squat @metalmatze @mxinden @paulfantom @deads2k @hexfusion 