### PR TITLE
If only one test is being run in a suite, always include success output

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -159,7 +159,12 @@ func (opt *Options) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	status := newTestStatus(opt.Out, opt.IncludeSuccessOutput, len(tests), timeout, m)
+	// if we run a single test, always include success output
+	includeSuccess := opt.IncludeSuccessOutput
+	if len(tests) == 1 {
+		includeSuccess = true
+	}
+	status := newTestStatus(opt.Out, includeSuccess, len(tests), timeout, m)
 
 	smoke, normal := splitTests(tests, func(t *testCase) bool {
 		return strings.Contains(t.name, "[Smoke]")


### PR DESCRIPTION
In the future, we might want to allow users to definitively turn this
off.