### PR TITLE
test/extenden/prometheus: add monitoring team as owners

### DIFF
--- a/test/extended/prometheus/OWNERS
+++ b/test/extended/prometheus/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+- brancz
+- mxinden
+- squat
+- s-urbaniak
+- paulfantom
+- metalmatze
+
+approvers:
+- brancz
+- mxinden
+- squat
+- s-urbaniak
+- paulfantom
+- metalmatze


### PR DESCRIPTION
This unblocks the monitoring team from adding new tests into origin.

/cc @smarterclayton