### PR TITLE
DO NOT MERGE: Set the hyperkube component version to include a commit qualifier

### DIFF
--- a/hack/update-generated-versions.sh
+++ b/hack/update-generated-versions.sh
@@ -7,7 +7,7 @@ verify="${VERIFY:-}"
 
 os::build::version::kubernetes_vars
 if [[ "${KUBE_GIT_VERSION}" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-	version_kubernetes=${BASH_REMATCH[1]}
+	version_kubernetes="${BASH_REMATCH[1]}+$(git rev-parse --short HEAD)"
 else
   os::log::fatal "Unable to find kubernetes version from ${KUBE_GIT_VERSION}"
 fi

--- a/images/hyperkube/Dockerfile.rhel
+++ b/images/hyperkube/Dockerfile.rhel
@@ -10,4 +10,4 @@ COPY --from=builder /tmp/build/hyperkube /usr/bin/
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
       io.openshift.tags="openshift,hyperkube" \
-      io.openshift.build.versions="kubernetes=1.13.4"
+      io.openshift.build.versions="kubernetes=1.13.4+2315db4450"


### PR DESCRIPTION
The qualifier is the commit of this repo (since we carry patches) and
consistent with the CLI command. This prevents hyperkube component
version from being used in names for API objects and other fields that
cannot show the + character.

/hold

testing