### PR TITLE
test that must-gather generated audit logs

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -47,6 +47,10 @@ var _ = g.Describe("[cli] oc adm must-gather", func() {
 			{tempDir, "cluster-scoped-resources", "config.openshift.io", "schedulers.yaml"},
 			{tempDir, "namespaces", "openshift-kube-apiserver", "core", "configmaps.yaml"},
 			{tempDir, "namespaces", "openshift-kube-apiserver", "core", "secrets.yaml"},
+			{tempDir, "audit_logs", "kube-apiserver.audit_logs_listing"},
+			{tempDir, "audit_logs", "openshift-apiserver.audit_logs_listing"},
+			{tempDir, "host_service_logs", "masters", "crio_service.log"},
+			{tempDir, "host_service_logs", "masters", "kubelet_service.log"},
 		}
 
 		for _, expectedDirectory := range expectedDirectories {


### PR DESCRIPTION
Checks the following files are created and are > 100 bytes in size:
```
audit_logs/openshift-apiserver_audit.log
audit_logs/kube-apiserver_audit.log
host_service_logs/masters/kubelet_service.log
host_service_logs/masters/crio_service.log
```