### PR TITLE
Continue improving SDN startup logging

### DIFF
--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -70,7 +70,9 @@ func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, err
 		return nil, err
 	}
 
-	podSandboxList, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{})
+	podSandboxList, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{
+		State: &kruntimeapi.PodSandboxStateValue{State: kruntimeapi.PodSandboxState_SANDBOX_READY},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pod sandboxes: %v", err)
 	}


### PR DESCRIPTION
While we improved SDN's own logging about handling pods after a reboot, we were still logging Events about being forced to kill pods, which then led some people to suspect an upgrade problem was network-related.

This fixes us to recognize and ignore already-dead pods.