### PR TITLE
Don't send identical SAR checks on ImageStream creation

### DIFF
--- a/pkg/image/apiserver/registry/imagestream/strategy.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy.go
@@ -463,6 +463,8 @@ func (v *TagVerifier) Verify(old, stream *imageapi.ImageStream, user user.Info) 
 	if old != nil && old.Spec.Tags != nil {
 		oldTags = old.Spec.Tags
 	}
+	// Store tags by the ImageStreamTags they reference on creation to minimize the number of SAR checks to make
+	tagsByNamespacedStream := make(map[string]map[string][]string)
 	for tag, tagRef := range stream.Spec.Tags {
 		if tagRef.From == nil {
 			continue
@@ -484,31 +486,44 @@ func (v *TagVerifier) Verify(old, stream *imageapi.ImageStream, user user.Info) 
 			continue
 		}
 
-		// Make sure this user can pull the specified image before allowing them to tag it into another imagestream
-		subjectAccessReview := authorizationutil.AddUserToSAR(user, &authorizationapi.SubjectAccessReview{
-			Spec: authorizationapi.SubjectAccessReviewSpec{
-				ResourceAttributes: &authorizationapi.ResourceAttributes{
-					Namespace:   tagRef.From.Namespace,
-					Verb:        "get",
-					Group:       imageapi.GroupName,
-					Resource:    "imagestreams",
-					Subresource: "layers",
-					Name:        streamName,
+		mapping, ok := tagsByNamespacedStream[tagRef.From.Namespace]
+		if !ok {
+			mapping = make(map[string][]string)
+		}
+		mapping[streamName] = append(mapping[streamName], tag)
+		tagsByNamespacedStream[tagRef.From.Namespace] = mapping
+	}
+	for namespace, mapping := range tagsByNamespacedStream {
+		for streamName, tags := range mapping {
+			// Make sure this user can pull the specified image before allowing them to tag it into another imagestream
+			subjectAccessReview := authorizationutil.AddUserToSAR(user, &authorizationapi.SubjectAccessReview{
+				Spec: authorizationapi.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationapi.ResourceAttributes{
+						Namespace:   namespace,
+						Verb:        "get",
+						Group:       imageapi.GroupName,
+						Resource:    "imagestreams",
+						Subresource: "layers",
+						Name:        streamName,
+					},
 				},
-			},
-		})
-		klog.V(4).Infof("Performing SubjectAccessReview for user=%s, groups=%v to %s/%s", user.GetName(), user.GetGroups(), tagRef.From.Namespace, streamName)
-		resp, err := v.subjectAccessReviewClient.Create(subjectAccessReview)
-		if err != nil || resp == nil || (resp != nil && !resp.Status.Allowed) {
-			message := fmt.Sprintf("%s/%s", tagRef.From.Namespace, streamName)
-			if resp != nil {
-				message = message + fmt.Sprintf(": %q %q", resp.Status.Reason, resp.Status.EvaluationError)
+			})
+			klog.V(4).Infof("Performing SubjectAccessReview for user=%s, groups=%v to %s/%s", user.GetName(), user.GetGroups(), namespace, streamName)
+			resp, err := v.subjectAccessReviewClient.Create(subjectAccessReview)
+			if err != nil || resp == nil || (resp != nil && !resp.Status.Allowed) {
+				message := fmt.Sprintf("%s/%s", namespace, streamName)
+				if resp != nil {
+					message = message + fmt.Sprintf(": %q %q", resp.Status.Reason, resp.Status.EvaluationError)
+				}
+				if err != nil {
+					message = message + fmt.Sprintf("- %v", err)
+				}
+				for _, tag := range tags {
+					fromPath := field.NewPath("spec", "tags").Key(tag).Child("from")
+					errors = append(errors, field.Forbidden(fromPath, message))
+				}
+				continue
 			}
-			if err != nil {
-				message = message + fmt.Sprintf("- %v", err)
-			}
-			errors = append(errors, field.Forbidden(fromPath, message))
-			continue
 		}
 	}
 	return errors


### PR DESCRIPTION
When an ImageStream is created with a large number of tags that
reference other ImageStreamTags in the same namespace, it is wasteful to
check for permissions to acces every single one, serially.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton @adambkaplan 