### PR TITLE
Move default components to an appropriate upgrade order (generic)

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -1305,7 +1305,7 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 			// get put in a scoped bucket at the end. Only a few components should need to
 			// be in the global order.
 			if !strings.HasPrefix(filename, "0000_") {
-				filename = fmt.Sprintf("0000_70_%s_%s", name, filename)
+				filename = fmt.Sprintf("0000_50_%s_%s", name, filename)
 			}
 			if count, ok := files[filename]; ok {
 				ext := path.Ext(path.Base(filename))


### PR DESCRIPTION
Now that CVO only applies ordering on update, we are reorganizing
the order components are applied to better align with correct
upgrades. The order is:

0000_10_*: config-operator
0000_20_*: kube-apiserver
0000_25_*: kube scheduler and controller manager
0000_30_*: other apiservers: openshift and machine
0000_40_*: reserved
0000_50_*: all non-order specific components
0000_60_*: reserved
0000_70_*: disruptive node-level components: dns, sdn, multus
0000_80_*: machine operators
0000_90_*: reserved for any post-machine updates

Operators in 0000_50_* should have no prefix (like 0000_70_
before). No other rules of ordering have changed.