### PR TITLE
Collapse version changes in monitor output

### DIFF
--- a/pkg/monitor/operator.go
+++ b/pkg/monitor/operator.go
@@ -62,13 +62,13 @@ func startClusterOperatorMonitoring(ctx context.Context, m Recorder, client conf
 						Message: msg,
 					})
 				}
-				if changes := findOperatorVersionChange(oldCO.Status.Versions, co.Status.Versions); len(changes) > 0 {
-					conditions = append(conditions, Condition{
-						Level:   Info,
-						Locator: locateClusterOperator(co),
-						Message: fmt.Sprintf("versions: %v", strings.Join(changes, ", ")),
-					})
-				}
+			}
+			if changes := findOperatorVersionChange(oldCO.Status.Versions, co.Status.Versions); len(changes) > 0 {
+				conditions = append(conditions, Condition{
+					Level:   Info,
+					Locator: locateClusterOperator(co),
+					Message: fmt.Sprintf("versions: %v", strings.Join(changes, ", ")),
+				})
 			}
 			return conditions
 		},
@@ -296,7 +296,7 @@ func findOperatorVersionChange(old, new []configv1.OperandVersion) []string {
 				continue
 			}
 			if old[p].Version == new[i].Version {
-				continue
+				break
 			}
 			changed = append(changed, fmt.Sprintf("%s %s -> %s", new[i].Name, old[p].Version, new[i].Version))
 			break

--- a/pkg/monitor/operator_test.go
+++ b/pkg/monitor/operator_test.go
@@ -1,0 +1,62 @@
+package monitor
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func Test_findOperatorVersionChange(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name string
+		old  []configv1.OperandVersion
+		new  []configv1.OperandVersion
+		want []string
+	}{
+		{
+			old: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}, {Name: "b", Version: "1.0.1"}},
+			new: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}, {Name: "b", Version: "1.0.1"}},
+		},
+		{
+			old:  []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}, {Name: "b", Version: "1.0.1"}},
+			new:  []configv1.OperandVersion{{Name: "a", Version: "1.0.1"}, {Name: "b", Version: "1.0.1"}},
+			want: []string{"a 1.0.0 -> 1.0.1"},
+		},
+		{
+			old: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}, {Name: "b", Version: "1.0.1"}},
+			new: []configv1.OperandVersion{{Name: "b", Version: "1.0.1"}, {Name: "a", Version: "1.0.0"}},
+		},
+		{
+			old:  []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}, {Name: "b", Version: "1.0.1"}},
+			new:  []configv1.OperandVersion{{Name: "b", Version: "1.0.1"}, {Name: "a", Version: "1.0.1"}},
+			want: []string{"a 1.0.0 -> 1.0.1"},
+		},
+		{
+			old:  []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}},
+			new:  []configv1.OperandVersion{{Name: "a", Version: "1.0.1"}},
+			want: []string{"a 1.0.0 -> 1.0.1"},
+		},
+		{
+			old: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}},
+			new: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}},
+		},
+		{
+			old: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}},
+			new: []configv1.OperandVersion{},
+		},
+		{
+			old: []configv1.OperandVersion{},
+			new: []configv1.OperandVersion{{Name: "a", Version: "1.0.0"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findOperatorVersionChange(tt.old, tt.new); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findOperatorVersionChange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Versions are showing up multiple times.

```
Apr 27 04:19:51.684 I clusteroperator/monitoring versions: operator 0.0.1-2019-04-27-030828 -> 0.0.1-2019-04-27-030928
Apr 27 04:19:51.684 I clusteroperator/monitoring versions: operator 0.0.1-2019-04-27-030828 -> 0.0.1-2019-04-27-030928
Apr 27 04:19:51.684 I clusteroperator/monitoring versions: operator 0.0.1-2019-04-27-030828 -> 0.0.1-2019-04-27-030928
```

should be one line