### PR TITLE
When no argument passed to oc adm release new, dry run the output

### DIFF
--- a/pkg/oc/cli/admin/release/image_mapper.go
+++ b/pkg/oc/cli/admin/release/image_mapper.go
@@ -131,7 +131,7 @@ func NewTransformFromImageStreamFile(path string, input *imageapi.ImageStream, a
 			continue
 		}
 		if len(tag.From.Name) == 0 {
-			return nil, fmt.Errorf("Image file %q did not specify a valid target location for tag %q - no from.name for the tag", path, tag.Name)
+			return nil, fmt.Errorf("no from.name for the tag %s", tag.Name)
 		}
 		ref := ImageReference{SourceRepository: tag.From.Name}
 		for _, inputTag := range input.Spec.Tags {
@@ -145,7 +145,7 @@ func NewTransformFromImageStreamFile(path string, input *imageapi.ImageStream, a
 				klog.V(2).Infof("Image file %q referenced an image %q that is not part of the input images, skipping", path, tag.From.Name)
 				continue
 			}
-			return nil, fmt.Errorf("image file %q referenced image %q that is not part of the input images", path, tag.Name)
+			return nil, fmt.Errorf("no input image tag named %q", tag.Name)
 		}
 		references[tag.Name] = ref
 	}

--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -724,7 +724,7 @@ func (o *NewOptions) Run() error {
 	case len(operators) == 0:
 		fmt.Fprintf(o.ErrOut, "warning: No operator metadata was found, no operators will be part of the release.\n")
 	default:
-		fmt.Fprintf(o.Out, "Built release image from %d operators\n", len(operators))
+		fmt.Fprintf(o.ErrOut, "info: Built release image from %d operators\n", len(operators))
 	}
 
 	return nil
@@ -871,7 +871,7 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 			return err
 		}
 		o.cleanupFns = append(o.cleanupFns, func() { os.RemoveAll(dir) })
-		fmt.Fprintf(o.ErrOut, "info: Manifests will be extracted to %s\n", dir)
+		klog.V(2).Infof("Manifests will be extracted to %s\n", dir)
 	}
 
 	verifier := imagemanifest.NewVerifier()
@@ -959,9 +959,9 @@ func (o *NewOptions) extractManifests(is *imageapi.ImageStream, name string, met
 					return false, err
 				}
 				if custom {
-					fmt.Fprintf(o.Out, "Loading override manifests from %s: %s ...\n", tag.Name, m.ImageRef.Exact())
+					fmt.Fprintf(o.ErrOut, "info: Loading override %s %s\n", m.ImageRef.Exact(), tag.Name)
 				} else {
-					fmt.Fprintf(o.Out, "Loading manifests from %s: %s ...\n", tag.Name, m.ImageRef.ID)
+					fmt.Fprintf(o.ErrOut, "info: Loading %s %s\n", m.ImageRef.ID, tag.Name)
 				}
 				return true, nil
 			},
@@ -1291,7 +1291,7 @@ func writePayload(w io.Writer, is *imageapi.ImageStream, cm *CincinnatiMetadata,
 			klog.V(2).Infof("Perform image replacement based on inclusion of %s", path)
 			transform, err = NewTransformFromImageStreamFile(path, is, allowMissingImages)
 			if err != nil {
-				return fmt.Errorf("operator %q failed to map images: %s", name, err)
+				return fmt.Errorf("operator %q contained an invalid image-references file: %s", name, err)
 			}
 		}
 
@@ -1511,7 +1511,7 @@ func pruneUnreferencedImageStreams(out io.Writer, is *imageapi.ImageStream, meta
 		updated = append(updated, tag)
 	}
 	if len(updated) != len(is.Spec.Tags) {
-		fmt.Fprintf(out, "info: Included %d referenced images into the payload\n", len(updated))
+		fmt.Fprintf(out, "info: Included %d images in the release\n", len(updated))
 		is.Spec.Tags = updated
 	}
 	return nil

--- a/pkg/oc/cli/image/append/append.go
+++ b/pkg/oc/cli/image/append/append.go
@@ -332,9 +332,8 @@ func (o *AppendImageOptions) Run() error {
 	}
 
 	if o.DryRun {
-		configJSON, _ := json.MarshalIndent(base, "", "  ")
-		fmt.Fprintf(o.Out, "%s", configJSON)
-		return nil
+		toManifests = &dryRunManifestService{}
+		toBlobs = &dryRunBlobStore{layers: layers}
 	}
 
 	// upload base layers in parallel
@@ -413,12 +412,15 @@ func (o *AppendImageOptions) Run() error {
 	if err != nil {
 		return fmt.Errorf("unable to upload the new image manifest: %v", err)
 	}
+	klog.V(4).Infof("Created config JSON:\n%s", configJSON)
 	toDigest, err := imagemanifest.PutManifestInCompatibleSchema(ctx, manifest, to.Tag, toManifests, toRepo.Named(), fromRepo.Blobs(ctx), configJSON)
 	if err != nil {
 		return fmt.Errorf("unable to convert the image to a compatible schema version: %v", err)
 	}
 	o.ToDigest = toDigest
-	fmt.Fprintf(o.Out, "Pushed image %s to %s\n", toDigest, to)
+	if !o.DryRun {
+		fmt.Fprintf(o.Out, "Pushed %s to %s\n", toDigest, to)
+	}
 	return nil
 }
 
@@ -636,5 +638,71 @@ func (_ scratchRepo) ServeBlob(ctx context.Context, w http.ResponseWriter, r *ht
 }
 
 func (_ scratchRepo) Delete(ctx context.Context, dgst digest.Digest) error {
+	panic("not implemented")
+}
+
+// dryRunManifestService emulates a remote registry for dry run behavior
+type dryRunManifestService struct{}
+
+func (s *dryRunManifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	panic("not implemented")
+}
+
+func (s *dryRunManifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	panic("not implemented")
+}
+
+func (s *dryRunManifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	klog.V(4).Infof("Manifest: %#v", manifest.References())
+	return registryclient.ContentDigestForManifest(manifest, digest.SHA256)
+}
+
+func (s *dryRunManifestService) Delete(ctx context.Context, dgst digest.Digest) error {
+	panic("not implemented")
+}
+
+// dryRunBlobStore emulates a remote registry for dry run behavior
+type dryRunBlobStore struct {
+	layers []distribution.Descriptor
+}
+
+func (s *dryRunBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	for _, layer := range s.layers {
+		if layer.Digest == dgst {
+			return layer, nil
+		}
+	}
+	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+}
+
+func (s *dryRunBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	panic("not implemented")
+}
+
+func (s *dryRunBlobStore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	panic("not implemented")
+}
+
+func (s *dryRunBlobStore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	return distribution.Descriptor{
+		MediaType: mediaType,
+		Size:      int64(len(p)),
+		Digest:    digest.SHA256.FromBytes(p),
+	}, nil
+}
+
+func (s *dryRunBlobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	panic("not implemented")
+}
+
+func (s *dryRunBlobStore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	panic("not implemented")
+}
+
+func (s *dryRunBlobStore) ServeBlob(ctx context.Context, w http.ResponseWriter, r *http.Request, dgst digest.Digest) error {
+	panic("not implemented")
+}
+
+func (s *dryRunBlobStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
Print an output consistent with oc adm release info --verify if no
arguments are specified or if an image is pushed. Other modes bypass the
image creation and so do not have this output.

Make --dry-run on oc image append calculate the SHA instead of just doing
nothing.

Clean up some incremental output from append and in general make the entire
experience more pleasant.

Finally, perform a final step verification that a no-argument recreation
of the payload works correctly.