### PR TITLE
Bug 1703595: oauth/user/authz: tighten API validation checks

### DIFF
--- a/pkg/apiserver/authentication/oauth/tokenauthenticator.go
+++ b/pkg/apiserver/authentication/oauth/tokenauthenticator.go
@@ -50,11 +50,10 @@ func (a *tokenAuthenticator) AuthenticateToken(ctx context.Context, name string)
 	if err != nil {
 		return nil, false, err
 	}
-	groupNames := make([]string, 0, len(groups)+len(user.Groups))
+	groupNames := make([]string, 0, len(groups))
 	for _, group := range groups {
 		groupNames = append(groupNames, group.Name)
 	}
-	groupNames = append(groupNames, user.Groups...)
 
 	return &kauthenticator.Response{
 		User: &kuser.DefaultInfo{

--- a/pkg/authorization/authorizer/scope/converter.go
+++ b/pkg/authorization/authorizer/scope/converter.go
@@ -483,11 +483,12 @@ func removeEscalatingResources(in rbacv1.PolicyRule) rbacv1.PolicyRule {
 }
 
 func ValidateScopeRestrictions(client *oauthapi.OAuthClient, scopes ...string) error {
+	if len(scopes) == 0 {
+		return fmt.Errorf("%s may not request unscoped tokens", client.Name)
+	}
+
 	if len(client.ScopeRestrictions) == 0 {
 		return nil
-	}
-	if len(scopes) == 0 {
-		return fmt.Errorf("%v may not request unscoped tokens", client.Name)
 	}
 
 	errs := []error{}
@@ -502,10 +503,6 @@ func ValidateScopeRestrictions(client *oauthapi.OAuthClient, scopes ...string) e
 
 func validateScopeRestrictions(client *oauthapi.OAuthClient, scope string) error {
 	errs := []error{}
-
-	if len(client.ScopeRestrictions) == 0 {
-		return nil
-	}
 
 	for _, restriction := range client.ScopeRestrictions {
 		if len(restriction.ExactValues) > 0 {

--- a/pkg/authorization/authorizer/scope/validate_test.go
+++ b/pkg/authorization/authorizer/scope/validate_test.go
@@ -26,9 +26,10 @@ func TestValidateScopeRestrictions(t *testing.T) {
 			client: &oauthapi.OAuthClient{},
 		},
 		{
-			name:   "unrestricted allows none",
-			scopes: []string{},
-			client: &oauthapi.OAuthClient{},
+			name:           "missing scopes check precedes unrestricted",
+			scopes:         []string{},
+			client:         &oauthapi.OAuthClient{},
+			expectedErrors: []string{"may not request unscoped tokens"},
 		},
 		{
 			name:   "simple literal",

--- a/pkg/oauth/apis/oauth/validation/validation.go
+++ b/pkg/oauth/apis/oauth/validation/validation.go
@@ -329,6 +329,10 @@ func ValidateUserNameField(value string, fldPath *field.Path) field.ErrorList {
 func ValidateScopes(scopes []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if len(scopes) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "may not be empty"))
+	}
+
 	for i, scope := range scopes {
 		illegalCharacter := false
 		// https://tools.ietf.org/html/rfc6749#section-3.3 (full list of allowed chars is %x21 / %x23-5B / %x5D-7E)

--- a/pkg/oauth/apiserver/registry/oauthclientauthorization/strategy_test.go
+++ b/pkg/oauth/apiserver/registry/oauthclientauthorization/strategy_test.go
@@ -3,11 +3,10 @@ package oauthclientauthorization
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	oauth "github.com/openshift/api/oauth/v1"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestValidateScopeUpdate asserts that a live client lookup only occurs when new scopes are added during an update
@@ -18,12 +17,6 @@ func TestValidateScopeUpdate(t *testing.T) {
 		obj            []string
 		old            []string
 	}{
-		{
-			name:           "both empty",
-			expectedCalled: false,
-			obj:            []string{},
-			old:            []string{},
-		},
 		{
 			name:           "both equal",
 			expectedCalled: false,
@@ -54,12 +47,6 @@ func TestValidateScopeUpdate(t *testing.T) {
 			obj:            []string{scope.UserFull, scope.UserAccessCheck},
 			old:            []string{scope.UserFull, scope.UserInfo},
 		},
-		{
-			name:           "deleted scopes to empty",
-			expectedCalled: true,
-			obj:            []string{},
-			old:            []string{scope.UserFull},
-		},
 	} {
 		clientGetter := &wasCalledClientGetter{}
 		s := strategy{clientGetter: clientGetter}
@@ -73,18 +60,50 @@ func TestValidateScopeUpdate(t *testing.T) {
 	}
 }
 
+func TestValidateScopeUpdateFailures(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		expectedCalled bool
+		obj            []string
+		old            []string
+	}{
+		{
+			name:           "both empty",
+			expectedCalled: false,
+			obj:            []string{},
+			old:            []string{},
+		},
+		{
+			name:           "deleted scopes to empty",
+			expectedCalled: true,
+			obj:            []string{},
+			old:            []string{scope.UserFull},
+		},
+	} {
+		clientGetter := &wasCalledClientGetter{}
+		s := strategy{clientGetter: clientGetter}
+		if errs := s.ValidateUpdate(nil, validClientWithScopes(test.obj), validClientWithScopes(test.old)); len(errs) == 0 {
+			t.Errorf("%s: expected error: %s", test.name, errs)
+			continue
+		}
+		if test.expectedCalled != clientGetter.called {
+			t.Errorf("%s: expected call behavior %v does not match %v", test.name, test.expectedCalled, clientGetter.called)
+		}
+	}
+}
+
 type wasCalledClientGetter struct {
 	called bool
 }
 
-func (g *wasCalledClientGetter) Get(_ string, _ v1.GetOptions) (*oauth.OAuthClient, error) {
+func (g *wasCalledClientGetter) Get(_ string, _ metav1.GetOptions) (*oauth.OAuthClient, error) {
 	g.called = true
 	return &oauth.OAuthClient{}, nil
 }
 
 func validClientWithScopes(scopes []string) *oauthapi.OAuthClientAuthorization {
 	return &oauthapi.OAuthClientAuthorization{
-		ObjectMeta: v1.ObjectMeta{Name: "un:cn", ResourceVersion: "0"},
+		ObjectMeta: metav1.ObjectMeta{Name: "un:cn", ResourceVersion: "0"},
 		ClientName: "cn",
 		UserName:   "un",
 		UserUID:    "uid",

--- a/pkg/user/apis/user/validation/validation.go
+++ b/pkg/user/apis/user/validation/validation.go
@@ -107,16 +107,9 @@ func ValidateUser(user *userapi.User) field.ErrorList {
 		}
 	}
 
-	groupsPath := field.NewPath("groups")
-	for index, group := range user.Groups {
-		idxPath := groupsPath.Index(index)
-		if len(group) == 0 {
-			allErrs = append(allErrs, field.Invalid(idxPath, group, "may not be empty"))
-			continue
-		}
-		if reasons := ValidateGroupName(group, false); len(reasons) != 0 {
-			allErrs = append(allErrs, field.Invalid(idxPath, group, strings.Join(reasons, ", ")))
-		}
+	// our strategy should prevent us from ever hitting this case
+	if len(user.Groups) != 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("groups"), user.Groups, "is deprecated and cannot be set"))
 	}
 
 	return allErrs

--- a/pkg/user/apis/user/validation/validation_test.go
+++ b/pkg/user/apis/user/validation/validation_test.go
@@ -84,7 +84,6 @@ func TestValidateUser(t *testing.T) {
 				Name: "myname",
 			},
 			Identities: []string{"myprovider:mylogin"},
-			Groups:     []string{"mygroup"},
 		}
 	}
 
@@ -104,15 +103,15 @@ func TestValidateUser(t *testing.T) {
 		t.Errorf("Expected error, got none")
 	}
 
-	emptyGroup := validObj()
-	emptyGroup.Groups = []string{""}
-	if errs := ValidateUser(emptyGroup); len(errs) == 0 {
+	emptyGroupIsSet := validObj()
+	emptyGroupIsSet.Groups = []string{""}
+	if errs := ValidateUser(emptyGroupIsSet); len(errs) == 0 {
 		t.Errorf("Expected error, got none")
 	}
 
-	invalidGroup := validObj()
-	invalidGroup.Groups = []string{"bad:group:name"}
-	if errs := ValidateUser(invalidGroup); len(errs) == 0 {
+	groupIsSet := validObj()
+	groupIsSet.Groups = []string{"suchGroup"}
+	if errs := ValidateUser(groupIsSet); len(errs) == 0 {
 		t.Errorf("Expected error, got none")
 	}
 }
@@ -126,7 +125,6 @@ func TestValidateUserUpdate(t *testing.T) {
 				ResourceVersion: "1",
 			},
 			Identities: []string{"myprovider:mylogin"},
-			Groups:     []string{"mygroup"},
 		}
 	}
 
@@ -148,15 +146,15 @@ func TestValidateUserUpdate(t *testing.T) {
 		t.Errorf("Expected error, got none")
 	}
 
-	emptyGroup := validObj()
-	emptyGroup.Groups = []string{""}
-	if errs := ValidateUserUpdate(emptyGroup, oldObj); len(errs) == 0 {
+	emptyGroupIsSet := validObj()
+	emptyGroupIsSet.Groups = []string{""}
+	if errs := ValidateUserUpdate(emptyGroupIsSet, oldObj); len(errs) == 0 {
 		t.Errorf("Expected error, got none")
 	}
 
-	invalidGroup := validObj()
-	invalidGroup.Groups = []string{"bad:group:name"}
-	if errs := ValidateUserUpdate(invalidGroup, oldObj); len(errs) == 0 {
+	groupIsSet := validObj()
+	groupIsSet.Groups = []string{"suchGroup"}
+	if errs := ValidateUserUpdate(groupIsSet, oldObj); len(errs) == 0 {
 		t.Errorf("Expected error, got none")
 	}
 

--- a/pkg/user/apiserver/registry/user/strategy.go
+++ b/pkg/user/apiserver/registry/user/strategy.go
@@ -27,7 +27,11 @@ func (userStrategy) DefaultGarbageCollectionPolicy(ctx context.Context) rest.Gar
 	return rest.Unsupported
 }
 
-func (userStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {}
+func (userStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	// persisting this field is no longer allowed
+	// it solely exists to echo back the user's current groups via the ~ virtual user
+	obj.(*userapi.User).Groups = nil
+}
 
 // NamespaceScoped is false for users
 func (userStrategy) NamespaceScoped() bool {
@@ -39,6 +43,9 @@ func (userStrategy) GenerateName(base string) string {
 }
 
 func (userStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	// persisting this field is no longer allowed
+	// it solely exists to echo back the user's current groups via the ~ virtual user
+	obj.(*userapi.User).Groups = nil
 }
 
 // Validate validates a new user

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -112,27 +112,27 @@ var openshiftEtcdStorageData = map[schema.GroupVersionResource]etcddata.StorageD
 		},
 	},
 	gvr("oauth.openshift.io", "v1", "oauthaccesstokens"): {
-		Stub:             `{"clientName": "client1g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "userUID": "cannot be empty"}`,
+		Stub:             `{"clientName": "client1g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "scopes": ["user:info"], "redirectURI": "https://something.com/", "userUID": "cannot be empty"}`,
 		ExpectedEtcdPath: "openshift.io/oauth/accesstokens/tokenneedstobelongenoughelseitwontworkg",
 		Prerequisites: []etcddata.Prerequisite{
 			{
 				GvrData: gvr("oauth.openshift.io", "v1", "oauthclients"),
-				Stub:    `{"metadata": {"name": "client1g"}}`,
+				Stub:    `{"metadata": {"name": "client1g"}, "grantMethod": "prompt"}`,
 			},
 		},
 	},
 	gvr("oauth.openshift.io", "v1", "oauthauthorizetokens"): {
-		Stub:             `{"clientName": "client0g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "userUID": "cannot be empty", "expiresIn": 86400}`,
+		Stub:             `{"clientName": "client0g", "metadata": {"name": "tokenneedstobelongenoughelseitwontworkg"}, "userName": "user", "scopes": ["user:info"], "redirectURI": "https://something.com/", "userUID": "cannot be empty", "expiresIn": 86400}`,
 		ExpectedEtcdPath: "openshift.io/oauth/authorizetokens/tokenneedstobelongenoughelseitwontworkg",
 		Prerequisites: []etcddata.Prerequisite{
 			{
 				GvrData: gvr("oauth.openshift.io", "v1", "oauthclients"),
-				Stub:    `{"metadata": {"name": "client0g"}}`,
+				Stub:    `{"metadata": {"name": "client0g"}, "grantMethod": "auto"}`,
 			},
 		},
 	},
 	gvr("oauth.openshift.io", "v1", "oauthclients"): {
-		Stub:             `{"metadata": {"name": "clientg"}}`,
+		Stub:             `{"metadata": {"name": "clientg"}, "grantMethod": "prompt"}`,
 		ExpectedEtcdPath: "openshift.io/oauth/clients/clientg",
 	},
 	// --

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -52,6 +53,7 @@ func TestOAuthLDAP(t *testing.T) {
 		myUserName     = "My User, Jr."
 		myUserEmail    = "myuser@example.com"
 		myUserDN       = searchAttr + "=" + myUserUID + "," + searchDN
+		myUserDNBase64 = base64.RawURLEncoding.EncodeToString([]byte(myUserDN))
 		myUserPassword = "myuser-password-" + randomSuffix
 	)
 
@@ -246,11 +248,11 @@ func TestOAuthLDAP(t *testing.T) {
 	}
 
 	// Make sure the identity got created and contained the mapped attributes
-	identity, err := userclient.NewForConfigOrDie(clusterAdminClientConfig).Identities().Get(fmt.Sprintf("%s:%s", providerName, myUserDN), metav1.GetOptions{})
+	identity, err := userclient.NewForConfigOrDie(clusterAdminClientConfig).Identities().Get(fmt.Sprintf("%s:%s", providerName, myUserDNBase64), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if identity.ProviderUserName != myUserDN {
+	if identity.ProviderUserName != myUserDNBase64 {
 		t.Errorf("Expected %q, got %q", myUserDN, identity.ProviderUserName)
 	}
 	if v := identity.Extra[authapi.IdentityDisplayNameKey]; v != myUserName {

--- a/test/integration/oauth_serviceaccount_client_test.go
+++ b/test/integration/oauth_serviceaccount_client_test.go
@@ -160,26 +160,8 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		} else if !reflect.DeepEqual(clientAuth.Scopes, []string{"user:full"}) {
 			t.Fatalf("Unexpected scopes: %v", clientAuth.Scopes)
-		} else {
-			// update the authorization to not contain any approved scopes
-			clientAuth.Scopes = nil
-			if _, err := clusterAdminOAuthClient.OAuthClientAuthorizations().Update(clientAuth); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
 		}
-		// approval steps are needed again for unscoped access
-		runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, nil, authorizationCodes, authorizationErrors, true, true, []string{
-			"GET /oauth/authorize",
-			"received challenge",
-			"GET /oauth/authorize",
-			"redirect to /oauth/authorize/approve",
-			"form",
-			"POST /oauth/authorize/approve",
-			"redirect to /oauth/authorize",
-			"redirect to /oauthcallback",
-			"code",
-			"scope:user:full",
-		})
+
 		// with the authorization stored, approval steps are skipped
 		runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, nil, authorizationCodes, authorizationErrors, true, true, []string{
 			"GET /oauth/authorize",

--- a/test/integration/oauthstorage_test.go
+++ b/test/integration/oauthstorage_test.go
@@ -94,6 +94,7 @@ func TestOAuthStorage(t *testing.T) {
 	oaclientConfig := &osincli.ClientConfig{
 		ClientId:     testClient,
 		ClientSecret: testClientSecret0,
+		Scope:        "user:full",
 		RedirectUrl:  assertServer.URL + testClientRedirect,
 		AuthorizeUrl: server.URL + authorizePath,
 		TokenUrl:     server.URL + tokenPath,
@@ -112,6 +113,7 @@ func TestOAuthStorage(t *testing.T) {
 			ObjectMeta:        metav1.ObjectMeta{Name: testClient},
 			Secret:            testClientSecret0,
 			AdditionalSecrets: []string{testClientSecret1},
+			GrantMethod:       oauthapi.GrantHandlerAuto,
 			RedirectURIs:      []string{assertServer.URL + testClientRedirect},
 		}); err != nil {
 			t.Fatal(err)

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -66,12 +66,13 @@ func TestScopedTokens(t *testing.T) {
 	}
 
 	whoamiOnlyToken := &oauthapi.OAuthAccessToken{
-		ObjectMeta: metav1.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
-		ClientName: "openshift-challenging-client",
-		ExpiresIn:  200,
-		Scopes:     []string{scope.UserInfo},
-		UserName:   userName,
-		UserUID:    string(haroldUser.UID),
+		ObjectMeta:  metav1.ObjectMeta{Name: "whoami-token-plus-some-padding-here-to-make-the-limit"},
+		ClientName:  "openshift-challenging-client",
+		ExpiresIn:   200,
+		Scopes:      []string{scope.UserInfo},
+		UserName:    userName,
+		UserUID:     string(haroldUser.UID),
+		RedirectURI: "https://localhost:8443/oauth/token/implicit",
 	}
 	if _, err := oauthclient.NewForConfigOrDie(clusterAdminClientConfig).OAuthAccessTokens().Create(whoamiOnlyToken); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -170,12 +171,13 @@ func TestScopeEscalations(t *testing.T) {
 	}
 
 	nonEscalatingEditToken := &oauthapi.OAuthAccessToken{
-		ObjectMeta: metav1.ObjectMeta{Name: "non-escalating-edit-plus-some-padding-here-to-make-the-limit"},
-		ClientName: "openshift-challenging-client",
-		ExpiresIn:  200,
-		Scopes:     []string{scope.ClusterRoleIndicator + "edit:*"},
-		UserName:   userName,
-		UserUID:    string(haroldUser.UID),
+		ObjectMeta:  metav1.ObjectMeta{Name: "non-escalating-edit-plus-some-padding-here-to-make-the-limit"},
+		ClientName:  "openshift-challenging-client",
+		ExpiresIn:   200,
+		Scopes:      []string{scope.ClusterRoleIndicator + "edit:*"},
+		UserName:    userName,
+		UserUID:     string(haroldUser.UID),
+		RedirectURI: "https://localhost:8443/oauth/token/implicit",
 	}
 	if _, err := clusterAdminOAuthClient.OAuthAccessTokens().Create(nonEscalatingEditToken); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -193,12 +195,13 @@ func TestScopeEscalations(t *testing.T) {
 	}
 
 	escalatingEditToken := &oauthapi.OAuthAccessToken{
-		ObjectMeta: metav1.ObjectMeta{Name: "escalating-edit-plus-some-padding-here-to-make-the-limit"},
-		ClientName: "openshift-challenging-client",
-		ExpiresIn:  200,
-		Scopes:     []string{scope.ClusterRoleIndicator + "edit:*:!"},
-		UserName:   userName,
-		UserUID:    string(haroldUser.UID),
+		ObjectMeta:  metav1.ObjectMeta{Name: "escalating-edit-plus-some-padding-here-to-make-the-limit"},
+		ClientName:  "openshift-challenging-client",
+		ExpiresIn:   200,
+		Scopes:      []string{scope.ClusterRoleIndicator + "edit:*:!"},
+		UserName:    userName,
+		UserUID:     string(haroldUser.UID),
+		RedirectURI: "https://localhost:8443/oauth/token/implicit",
 	}
 	if _, err := clusterAdminOAuthClient.OAuthAccessTokens().Create(escalatingEditToken); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -241,6 +244,7 @@ func TestTokensWithIllegalScopes(t *testing.T) {
 				},
 			},
 		},
+		GrantMethod: oauthapi.GrantHandlerAuto,
 	}
 	if _, err := clusterAdminOAuthClient.OAuthClients().Create(client); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -314,42 +318,46 @@ func TestTokensWithIllegalScopes(t *testing.T) {
 			name: "no scopes",
 			fail: true,
 			obj: &oauthapi.OAuthAccessToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				UserName:   "name",
-				UserUID:    "uid",
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				UserName:    "name",
+				UserUID:     "uid",
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 		{
 			name: "denied literal",
 			fail: true,
 			obj: &oauthapi.OAuthAccessToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				UserName:   "name",
-				UserUID:    "uid",
-				Scopes:     []string{"user:info", "user:check-access"},
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				UserName:    "name",
+				UserUID:     "uid",
+				Scopes:      []string{"user:info", "user:check-access"},
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 		{
 			name: "denied role",
 			fail: true,
 			obj: &oauthapi.OAuthAccessToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				UserName:   "name",
-				UserUID:    "uid",
-				Scopes:     []string{"role:one:*"},
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				UserName:    "name",
+				UserUID:     "uid",
+				Scopes:      []string{"role:one:*"},
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 		{
 			name: "ok role",
 			obj: &oauthapi.OAuthAccessToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				UserName:   "name",
-				UserUID:    "uid",
-				Scopes:     []string{"role:one:bravo"},
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				UserName:    "name",
+				UserUID:     "uid",
+				Scopes:      []string{"role:one:bravo"},
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 	}
@@ -373,46 +381,50 @@ func TestTokensWithIllegalScopes(t *testing.T) {
 			name: "no scopes",
 			fail: true,
 			obj: &oauthapi.OAuthAuthorizeToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				ExpiresIn:  86400,
-				UserName:   "name",
-				UserUID:    "uid",
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				ExpiresIn:   86400,
+				UserName:    "name",
+				UserUID:     "uid",
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 		{
 			name: "denied literal",
 			fail: true,
 			obj: &oauthapi.OAuthAuthorizeToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				ExpiresIn:  86400,
-				UserName:   "name",
-				UserUID:    "uid",
-				Scopes:     []string{"user:info", "user:check-access"},
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				ExpiresIn:   86400,
+				UserName:    "name",
+				UserUID:     "uid",
+				Scopes:      []string{"user:info", "user:check-access"},
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 		{
 			name: "denied role",
 			fail: true,
 			obj: &oauthapi.OAuthAuthorizeToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				ExpiresIn:  86400,
-				UserName:   "name",
-				UserUID:    "uid",
-				Scopes:     []string{"role:one:*"},
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				ExpiresIn:   86400,
+				UserName:    "name",
+				UserUID:     "uid",
+				Scopes:      []string{"role:one:*"},
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 		{
 			name: "ok role",
 			obj: &oauthapi.OAuthAuthorizeToken{
-				ObjectMeta: metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
-				ClientName: client.Name,
-				ExpiresIn:  86400,
-				UserName:   "name",
-				UserUID:    "uid",
-				Scopes:     []string{"role:one:bravo"},
+				ObjectMeta:  metav1.ObjectMeta{Name: "tokenlongenoughtobecreatedwithoutfailing"},
+				ClientName:  client.Name,
+				ExpiresIn:   86400,
+				UserName:    "name",
+				UserUID:     "uid",
+				Scopes:      []string{"role:one:bravo"},
+				RedirectURI: "https://localhost:8443/oauth/token/implicit",
 			},
 		},
 	}

--- a/test/testdata/oauthaccesstoken.yaml
+++ b/test/testdata/oauthaccesstoken.yaml
@@ -7,3 +7,5 @@ metadata:
 redirectURI: https://localhost:8443/oauth/token/implicit
 userName: test
 userUID: 322b236b-22b9-11e6-b307-080027242396
+scopes:
+  - user:info

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -97,7 +97,8 @@ func GetClientForUser(clusterAdminConfig *restclient.Config, username string) (k
 	}
 
 	oauthClientObj := &oauthapi.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-integration-client"},
+		ObjectMeta:  metav1.ObjectMeta{Name: "test-integration-client"},
+		GrantMethod: oauthapi.GrantHandlerAuto,
 	}
 	if _, err := oauthClient.Oauth().OAuthClients().Create(oauthClientObj); err != nil && !kerrs.IsAlreadyExists(err) {
 		return nil, nil, err
@@ -110,10 +111,12 @@ func GetClientForUser(clusterAdminConfig *restclient.Config, username string) (k
 		accesstoken += "A"
 	}
 	token := &oauthapi.OAuthAccessToken{
-		ObjectMeta: metav1.ObjectMeta{Name: accesstoken},
-		ClientName: oauthClientObj.Name,
-		UserName:   username,
-		UserUID:    string(user.UID),
+		ObjectMeta:  metav1.ObjectMeta{Name: accesstoken},
+		ClientName:  oauthClientObj.Name,
+		UserName:    username,
+		UserUID:     string(user.UID),
+		Scopes:      []string{"user:full"},
+		RedirectURI: "https://localhost:8443/oauth/token/implicit",
 	}
 	if _, err := oauthClient.Oauth().OAuthAccessTokens().Create(token); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This PR makes changes to the validation of the authn-owned objects and tightens the edges around them.

cc @openshift/sig-auth @enj 