### PR TITLE
Rbr to CRD part 2

### DIFF
--- a/hack/local-up-master/kube-apiserver-manifests/01_role_binding_restriction_crd.yaml
+++ b/hack/local-up-master/kube-apiserver-manifests/01_role_binding_restriction_crd.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: rolebindingrestrictions.authorization.openshift.io
+spec:
+  group: authorization.openshift.io
+  names:
+    kind: RoleBindingRestriction
+    listKind: RoleBindingRestrictionList
+    plural: rolebindingrestrictions
+    singular: rolebindingrestriction
+  subresources:
+    status: {}
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: Spec defines the matcher.
+          properties:
+            grouprestriction:
+              description: GroupRestriction matches against group subjects.
+              nullable: true
+              properties:
+                groups:
+                  description: Groups is a list of groups used to match against an
+                    individual user's groups. If the user is a member of one of the
+                    whitelisted groups, the user is allowed to be bound to a role.
+                  items:
+                    type: string
+                  type: array
+                labels:
+                  description: Selectors specifies a list of label selectors over
+                    group labels.
+                  items:
+                    type: object
+                  type: array
+              type: object
+            serviceaccountrestriction:
+              description: ServiceAccountRestriction matches against service-account
+                subjects.
+              nullable: true
+              properties:
+                namespaces:
+                  description: Namespaces specifies a list of literal namespace names.
+                  items:
+                    type: string
+                  type: array
+                serviceaccounts:
+                  description: ServiceAccounts specifies a list of literal service-account
+                    names.
+                  items:
+                    properties:
+                      name:
+                        description: Name is the name of the service account.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the service account.  Service
+                          accounts from inside the whitelisted namespaces are allowed
+                          to be bound to roles.  If Namespace is empty, then the namespace
+                          of the RoleBindingRestriction in which the ServiceAccountReference
+                          is embedded is used.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            userrestriction:
+              description: UserRestriction matches against user subjects.
+              nullable: true
+              properties:
+                groups:
+                  description: Groups specifies a list of literal group names.
+                  items:
+                    type: string
+                  type: array
+                labels:
+                  description: Selectors specifies a list of label selectors over
+                    user labels.
+                  items:
+                    type: object
+                  type: array
+                users:
+                  description: Users specifies a list of literal user names.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object

--- a/hack/local-up-master/kube-apiserver-manifests/01_role_binding_restriction_crd.yaml
+++ b/hack/local-up-master/kube-apiserver-manifests/01_role_binding_restriction_crd.yaml
@@ -11,7 +11,7 @@ spec:
     singular: rolebindingrestriction
   subresources:
     status: {}
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     served: true

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -99,6 +99,7 @@ os::cmd::try_until_success "oc get service kubernetes --namespace default --conf
 os::cmd::try_until_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority ${MASTER_CONFIG_DIR}/server-ca.crt -u test-user -p anything" $(( 160 * second )) 0.25
 # wait for the CRD to be available
 os::cmd::try_until_success "oc get clusterresourcequotas --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
+os::cmd::try_until_success "oc get rolebindingrestrictions --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
 os::test::junit::declare_suite_end
 os::log::debug "localup server health checks done at: $( date )"
 

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -99,7 +99,7 @@ os::cmd::try_until_success "oc get service kubernetes --namespace default --conf
 os::cmd::try_until_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority ${MASTER_CONFIG_DIR}/server-ca.crt -u test-user -p anything" $(( 160 * second )) 0.25
 # wait for the CRD to be available
 os::cmd::try_until_success "oc get clusterresourcequotas --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
-os::cmd::try_until_success "oc get rolebindingrestrictions --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
+os::cmd::try_until_success "oc get rolebindingrestrictions --all-namespaces --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
 os::test::junit::declare_suite_end
 os::log::debug "localup server health checks done at: $( date )"
 

--- a/pkg/admission/customresourcevalidation/attributes.go
+++ b/pkg/admission/customresourcevalidation/attributes.go
@@ -5,6 +5,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission"
 
+	authorizationv1 "github.com/openshift/api/authorization/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -48,4 +49,5 @@ func init() {
 	utilruntime.Must(configv1.Install(supportedObjectsScheme))
 	utilruntime.Must(quotav1.Install(supportedObjectsScheme))
 	utilruntime.Must(securityv1.Install(supportedObjectsScheme))
+	utilruntime.Must(authorizationv1.Install(supportedObjectsScheme))
 }

--- a/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/pkg/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/image"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/oauth"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/project"
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation/rolebindingrestriction"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/scheduler"
 	"github.com/openshift/origin/pkg/admission/customresourcevalidation/securitycontextconstraints"
 )
@@ -27,6 +28,7 @@ var AllCustomResourceValidators = []string{
 	scheduler.PluginName,
 	clusterresourcequota.PluginName,
 	securitycontextconstraints.PluginName,
+	rolebindingrestriction.PluginName,
 
 	// this one is special because we don't work without it.
 	securitycontextconstraints.DefaultingPluginName,
@@ -47,6 +49,8 @@ func RegisterCustomResourceValidation(plugins *admission.Plugins) {
 	clusterresourcequota.Register(plugins)
 	// This plugin validates the security.openshift.io/v1 SecurityContextConstraints resources.
 	securitycontextconstraints.Register(plugins)
+	// This plugin validates the authorization.openshift.io/v1 RoleBindingRestriction resources.
+	rolebindingrestriction.Register(plugins)
 
 	// this one is special because we don't work without it.
 	securitycontextconstraints.RegisterDefaulting(plugins)

--- a/pkg/admission/customresourcevalidation/rolebindingrestriction/validate_rbr.go
+++ b/pkg/admission/customresourcevalidation/rolebindingrestriction/validate_rbr.go
@@ -1,0 +1,83 @@
+package rolebindingrestriction
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	authorizationv1 "github.com/openshift/api/authorization/v1"
+
+	"github.com/openshift/origin/pkg/admission/customresourcevalidation"
+	rbrvalidation "github.com/openshift/origin/pkg/admission/customresourcevalidation/rolebindingrestriction/validation"
+)
+
+const PluginName = "authorization.openshift.io/ValidateRoleBindingRestriction"
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return customresourcevalidation.NewValidator(
+			map[schema.GroupResource]bool{
+				{Group: authorizationv1.GroupName, Resource: "rolebindingrestrictions"}: true,
+			},
+			map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+				authorizationv1.GroupVersion.WithKind("RoleBindingRestriction"): roleBindingRestrictionV1{},
+			})
+	})
+}
+
+func toRoleBindingRestriction(uncastObj runtime.Object) (*authorizationv1.RoleBindingRestriction, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	allErrs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*authorizationv1.RoleBindingRestriction)
+	if !ok {
+		return nil, append(allErrs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"RoleBindingRestriction"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{authorizationv1.GroupVersion.String()}))
+	}
+
+	return obj, nil
+}
+
+type roleBindingRestrictionV1 struct {
+}
+
+func (roleBindingRestrictionV1) ValidateCreate(obj runtime.Object) field.ErrorList {
+	roleBindingRestrictionObj, errs := toRoleBindingRestriction(obj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&roleBindingRestrictionObj.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
+	errs = append(errs, rbrvalidation.ValidateRoleBindingRestriction(roleBindingRestrictionObj)...)
+
+	return errs
+}
+
+func (roleBindingRestrictionV1) ValidateUpdate(obj runtime.Object, oldObj runtime.Object) field.ErrorList {
+	roleBindingRestrictionObj, errs := toRoleBindingRestriction(obj)
+	if len(errs) > 0 {
+		return errs
+	}
+	roleBindingRestrictionOldObj, errs := toRoleBindingRestriction(oldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&roleBindingRestrictionObj.ObjectMeta, false, validation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
+	errs = append(errs, rbrvalidation.ValidateRoleBindingRestrictionUpdate(roleBindingRestrictionObj, roleBindingRestrictionOldObj)...)
+
+	return errs
+}
+
+func (r roleBindingRestrictionV1) ValidateStatusUpdate(obj runtime.Object, oldObj runtime.Object) field.ErrorList {
+	return r.ValidateUpdate(obj, oldObj)
+}

--- a/pkg/admission/customresourcevalidation/rolebindingrestriction/validation/validation.go
+++ b/pkg/admission/customresourcevalidation/rolebindingrestriction/validation/validation.go
@@ -1,0 +1,113 @@
+package validation
+
+import (
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
+
+	authorizationv1 "github.com/openshift/api/authorization/v1"
+)
+
+func ValidateRoleBindingRestriction(rbr *authorizationv1.RoleBindingRestriction) field.ErrorList {
+	allErrs := validation.ValidateObjectMeta(&rbr.ObjectMeta, true,
+		apimachineryvalidation.NameIsDNSSubdomain, field.NewPath("metadata"))
+
+	allErrs = append(allErrs,
+		ValidateRoleBindingRestrictionSpec(&rbr.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+func ValidateRoleBindingRestrictionUpdate(rbr, old *authorizationv1.RoleBindingRestriction) field.ErrorList {
+	allErrs := ValidateRoleBindingRestriction(rbr)
+
+	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&rbr.ObjectMeta,
+		&old.ObjectMeta, field.NewPath("metadata"))...)
+
+	return allErrs
+}
+
+func ValidateRoleBindingRestrictionSpec(spec *authorizationv1.RoleBindingRestrictionSpec, fld *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	const invalidMsg = `must specify exactly one of userrestriction, grouprestriction, or serviceaccountrestriction`
+
+	if spec.UserRestriction != nil {
+		if spec.GroupRestriction != nil {
+			allErrs = append(allErrs, field.Invalid(fld.Child("grouprestriction"),
+				"both userrestriction and grouprestriction specified", invalidMsg))
+		}
+		if spec.ServiceAccountRestriction != nil {
+			allErrs = append(allErrs,
+				field.Invalid(fld.Child("serviceaccountrestriction"),
+					"both userrestriction and serviceaccountrestriction specified", invalidMsg))
+		}
+	} else if spec.GroupRestriction != nil {
+		if spec.ServiceAccountRestriction != nil {
+			allErrs = append(allErrs,
+				field.Invalid(fld.Child("serviceaccountrestriction"),
+					"both grouprestriction and serviceaccountrestriction specified", invalidMsg))
+		}
+	} else if spec.ServiceAccountRestriction == nil {
+		allErrs = append(allErrs, field.Required(fld.Child("userrestriction"),
+			invalidMsg))
+	}
+
+	if spec.UserRestriction != nil {
+		allErrs = append(allErrs, ValidateRoleBindingRestrictionUser(spec.UserRestriction, fld.Child("userrestriction"))...)
+	}
+	if spec.GroupRestriction != nil {
+		allErrs = append(allErrs, ValidateRoleBindingRestrictionGroup(spec.GroupRestriction, fld.Child("grouprestriction"))...)
+	}
+	if spec.ServiceAccountRestriction != nil {
+		allErrs = append(allErrs, ValidateRoleBindingRestrictionServiceAccount(spec.ServiceAccountRestriction, fld.Child("serviceaccountrestriction"))...)
+	}
+
+	return allErrs
+}
+
+func ValidateRoleBindingRestrictionUser(user *authorizationv1.UserRestriction, fld *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	const invalidMsg = `must specify at least one user, group, or label selector`
+
+	if !(len(user.Users) > 0 || len(user.Groups) > 0 || len(user.Selectors) > 0) {
+		allErrs = append(allErrs, field.Required(fld.Child("users"), invalidMsg))
+	}
+
+	for i, selector := range user.Selectors {
+		allErrs = append(allErrs,
+			unversionedvalidation.ValidateLabelSelector(&selector,
+				fld.Child("selector").Index(i))...)
+	}
+
+	return allErrs
+}
+
+func ValidateRoleBindingRestrictionGroup(group *authorizationv1.GroupRestriction, fld *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	const invalidMsg = `must specify at least one group or label selector`
+
+	if !(len(group.Groups) > 0 || len(group.Selectors) > 0) {
+		allErrs = append(allErrs, field.Required(fld.Child("groups"), invalidMsg))
+	}
+
+	for i, selector := range group.Selectors {
+		allErrs = append(allErrs,
+			unversionedvalidation.ValidateLabelSelector(&selector,
+				fld.Child("selector").Index(i))...)
+	}
+
+	return allErrs
+}
+
+func ValidateRoleBindingRestrictionServiceAccount(sa *authorizationv1.ServiceAccountRestriction, fld *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	const invalidMsg = `must specify at least one service account or namespace`
+
+	if !(len(sa.ServiceAccounts) > 0 || len(sa.Namespaces) > 0) {
+		allErrs = append(allErrs,
+			field.Required(fld.Child("serviceaccounts"), invalidMsg))
+	}
+
+	return allErrs
+}

--- a/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
+++ b/pkg/authorization/apiserver/admission/restrictusers/restrictusers.go
@@ -171,7 +171,7 @@ func (q *restrictUsersAdmission) Validate(a admission.Attributes) (err error) {
 	roleBindingRestrictionList, err := q.roleBindingRestrictionsGetter.RoleBindingRestrictions(ns).
 		List(metav1.ListOptions{})
 	if err != nil {
-		return admission.NewForbidden(a, err)
+		return admission.NewForbidden(a, fmt.Errorf("failed getting rolebinding restrictions: %v", err))
 	}
 	if len(roleBindingRestrictionList.Items) == 0 {
 		klog.V(4).Infof("No rolebinding restrictions specified; admitting")

--- a/pkg/authorization/apiserver/apiserver.go
+++ b/pkg/authorization/apiserver/apiserver.go
@@ -120,7 +120,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	resourceAccessReviewStorage := resourceaccessreview.NewREST(c.GenericConfig.Authorization.Authorizer, c.ExtraConfig.SubjectLocator)
 	resourceAccessReviewRegistry := resourceaccessreview.NewRegistry(resourceAccessReviewStorage)
 	localResourceAccessReviewStorage := localresourceaccessreview.NewREST(resourceAccessReviewRegistry)
-	roleBindingRestrictionStorage, err := rolebindingrestrictionetcd.NewREST(c.GenericConfig.RESTOptionsGetter)
+	roleBindingRestrictionStorage, err := rolebindingrestrictionetcd.NewREST()
 	if err != nil {
 		return nil, fmt.Errorf("error building REST storage: %v", err)
 	}

--- a/pkg/authorization/apiserver/apiserver.go
+++ b/pkg/authorization/apiserver/apiserver.go
@@ -1,7 +1,6 @@
 package apiserver
 
 import (
-	"fmt"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,10 +119,7 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 	resourceAccessReviewStorage := resourceaccessreview.NewREST(c.GenericConfig.Authorization.Authorizer, c.ExtraConfig.SubjectLocator)
 	resourceAccessReviewRegistry := resourceaccessreview.NewRegistry(resourceAccessReviewStorage)
 	localResourceAccessReviewStorage := localresourceaccessreview.NewREST(resourceAccessReviewRegistry)
-	roleBindingRestrictionStorage, err := rolebindingrestrictionetcd.NewREST()
-	if err != nil {
-		return nil, fmt.Errorf("error building REST storage: %v", err)
-	}
+	roleBindingRestrictionStorage := rolebindingrestrictionetcd.NewREST()
 
 	v1Storage := map[string]rest.Storage{}
 	v1Storage["resourceAccessReviews"] = resourceAccessReviewStorage

--- a/pkg/authorization/apiserver/registry/rolebindingrestriction/etcd/etcd.go
+++ b/pkg/authorization/apiserver/registry/rolebindingrestriction/etcd/etcd.go
@@ -23,8 +23,8 @@ var _ rest.StandardStorage = &REST{}
 var _ rest.Scoper = &REST{}
 
 // NewREST returns a RESTStorage object that will work against nodes.
-func NewREST() (*REST, error) {
-	return &REST{}, nil
+func NewREST() (*REST) {
+	return &REST{}
 }
 
 func (r *REST) NamespaceScoped() bool {

--- a/pkg/authorization/apiserver/registry/rolebindingrestriction/etcd/etcd.go
+++ b/pkg/authorization/apiserver/registry/rolebindingrestriction/etcd/etcd.go
@@ -1,43 +1,68 @@
 package etcd
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/registry/generic"
-	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/kubernetes/pkg/printers"
-	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
+	"context"
+	"fmt"
 
-	authorization "github.com/openshift/api/authorization"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	"github.com/openshift/origin/pkg/authorization/apiserver/registry/rolebindingrestriction"
-	printersinternal "github.com/openshift/origin/pkg/printers/internalversion"
 )
 
 type REST struct {
-	*registry.Store
 }
 
 var _ rest.StandardStorage = &REST{}
+var _ rest.Scoper = &REST{}
 
 // NewREST returns a RESTStorage object that will work against nodes.
-func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
-	store := &registry.Store{
-		NewFunc:                  func() runtime.Object { return &authorizationapi.RoleBindingRestriction{} },
-		NewListFunc:              func() runtime.Object { return &authorizationapi.RoleBindingRestrictionList{} },
-		DefaultQualifiedResource: authorization.Resource("rolebindingrestrictions"),
+func NewREST() (*REST, error) {
+	return &REST{}, nil
+}
 
-		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+func (r *REST) NamespaceScoped() bool {
+	return false
+}
 
-		CreateStrategy: rolebindingrestriction.Strategy,
-		UpdateStrategy: rolebindingrestriction.Strategy,
-		DeleteStrategy: rolebindingrestriction.Strategy,
-	}
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
 
-	options := &generic.StoreOptions{RESTOptions: optsGetter}
-	if err := store.CompleteWithOptions(options); err != nil {
-		return nil, err
-	}
+func (r *REST) NewList() runtime.Object {
+	return &authorizationapi.RoleBindingRestrictionList{}
+}
 
-	return &REST{Store: store}, nil
+func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) New() runtime.Object {
+	return &authorizationapi.RoleBindingRestriction{}
+}
+
+func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return nil, false, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) Delete(ctx context.Context, name string, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	return nil, false, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) DeleteCollection(ctx context.Context, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
+}
+
+func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	return nil, errors.NewInternalError(fmt.Errorf("unsupported"))
 }

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -96,6 +96,8 @@ func NewDefaultOffPluginsFunc(kubeDefaultOffAdmission sets.String) func() sets.S
 		kubeOff.Delete(additionalDefaultOnPlugins.List()...)
 		kubeOff.Delete(openshiftAdmissionPluginsForKube...)
 		kubeOff.Delete(customresourcevalidationregistration.AllCustomResourceValidators...)
+		// temporarily disable RBR until we move it to a CRD (it is causing install timeout failures)
+		kubeOff.Insert("authorization.openshift.io/RestrictSubjectBindings")
 		return kubeOff
 	}
 }

--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -96,8 +96,6 @@ func NewDefaultOffPluginsFunc(kubeDefaultOffAdmission sets.String) func() sets.S
 		kubeOff.Delete(additionalDefaultOnPlugins.List()...)
 		kubeOff.Delete(openshiftAdmissionPluginsForKube...)
 		kubeOff.Delete(customresourcevalidationregistration.AllCustomResourceValidators...)
-		// temporarily disable RBR until we move it to a CRD (it is causing install timeout failures)
-		kubeOff.Insert("authorization.openshift.io/RestrictSubjectBindings")
 		return kubeOff
 	}
 }

--- a/pkg/cmd/openshift-kube-apiserver/server.go
+++ b/pkg/cmd/openshift-kube-apiserver/server.go
@@ -22,10 +22,10 @@ import (
 )
 
 func RunOpenShiftKubeAPIServerServer(kubeAPIServerConfig *kubecontrolplanev1.KubeAPIServerConfig, stopCh <-chan struct{}) error {
-	// This allows to move cluster resource quota to CRD
+	// This allows to move crqs, sccs, and rbrs to CRD
 	apiserver.AddAlwaysLocalDelegateForPrefix("/apis/quota.openshift.io/v1/clusterresourcequotas")
-	// This allows to move SCC to CRD
 	apiserver.AddAlwaysLocalDelegateForPrefix("/apis/security.openshift.io/v1/securitycontextconstraints")
+	apiserver.AddAlwaysLocalDelegateForPrefix("/apis/authorization.openshift.io/v1/rolebindingrestrictions")
 
 	// This allows the CRD registration to avoid fighting with the APIService from the operator
 	apiserver.AddOverlappingGroupVersion(schema.GroupVersion{Group: "authorization.openshift.io", Version: "v1"})

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -61,10 +61,6 @@ var openshiftEtcdStorageData = map[schema.GroupVersionResource]etcddata.StorageD
 		ExpectedEtcdPath: "kubernetes.io/clusterrolebindings/crb1a1o2",
 		ExpectedGVK:      gvkP("rbac.authorization.k8s.io", "v1", "ClusterRoleBinding"), // proxy to RBAC
 	},
-	gvr("authorization.openshift.io", "v1", "rolebindingrestrictions"): {
-		Stub:             `{"metadata": {"name": "rbrg"}, "spec": {"serviceaccountrestriction": {"serviceaccounts": [{"name": "sa"}]}}}`,
-		ExpectedEtcdPath: "openshift.io/rolebindingrestrictions/etcdstoragepathtestnamespace/rbrg",
-	},
 	// --
 
 	// github.com/openshift/origin/pkg/build/apis/build/v1
@@ -199,6 +195,7 @@ var kindWhiteList = sets.NewString(
 	// these are now served using CRDs
 	"ClusterResourceQuota",
 	"SecurityContextConstraints",
+	"RoleBindingRestriction",
 )
 
 // namespace used for all tests, do not change this

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -260,6 +260,11 @@ func TestEtcd3StoragePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// wait for RoleBindingRestriction CRD to be available
+	if err := testutil.WaitForRoleBindingRestrictionCRDAvailable(kubeConfig); err != nil {
+		t.Fatal(err)
+	}
+
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discocache.NewMemCacheClient(kubeClient.Discovery()))
 	mapper.Reset()
 

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -41,6 +41,10 @@ func TestRestrictUsers(t *testing.T) {
 	}
 	clusterAdminAuthorizationClient := authorizationclient.NewForConfigOrDie(testutil.NonProtobufConfig(clusterAdminClientConfig))
 
+	if err := testutil.WaitForRoleBindingRestrictionCRDAvailable(clusterAdminClientConfig); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, _, err := testserver.CreateNewProject(clusterAdminClientConfig, "namespace", "carol"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/test/util/client.go
+++ b/test/util/client.go
@@ -225,6 +225,14 @@ func WaitForSecurityContextConstraintsCRDAvailable(clusterAdminClientConfig *res
 	})
 }
 
+func WaitForRoleBindingRestrictionCRDAvailable(clusterAdminClientConfig *rest.Config) error {
+	return WaitForCRDAvailable(clusterAdminClientConfig, schema.GroupVersionResource{
+		Version:  "v1",
+		Group:    "authorization.openshift.io",
+		Resource: "rolebindingrestrictions",
+	})
+}
+
 func WaitForCRDAvailable(clusterAdminClientConfig *rest.Config, gvr schema.GroupVersionResource) error {
 	dynamicClient := dynamic.NewForConfigOrDie(clusterAdminClientConfig)
 	stopCh := make(chan struct{})


### PR DESCRIPTION
Goal of this change plus [this](https://github.com/openshift/origin/pull/22534) is to move RoleBindingRestrictions from OpenShift API server to CRD so the admission plugins that run in kubernetes apiserver do not have dependency on OpenShift API resource. 

This also disables etcd storage for openshift rolebindingrestriction
This PR follows [@mfojtik 's PR](https://github.com/openshift/origin/pull/22425) that moved ClusterResourceQuotas to CRD

https://github.com/openshift/cluster-config-operator/pull/32 adds the CRD

@stlaz @mfojtik 