### PR TITLE
Simplify pod node constraints

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
@@ -55,7 +55,6 @@ var (
 		"build.openshift.io/BuildByStrategy",
 		"image.openshift.io/ImageLimitRange",
 		"image.openshift.io/ImagePolicy",
-		"scheduling.openshift.io/PodNodeConstraints",
 		"quota.openshift.io/ClusterResourceQuota",
 
 		// the rest of the kube chain goes here

--- a/pkg/image/apiserver/admission/imagepolicy/accept.go
+++ b/pkg/image/apiserver/admission/imagepolicy/accept.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
-	imagereferencemutators "github.com/openshift/origin/pkg/api/imagereferencemutators/internalversion"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagepolicy "github.com/openshift/origin/pkg/image/apiserver/admission/apis/imagepolicy/v1"
+	"github.com/openshift/origin/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators"
 	"github.com/openshift/origin/pkg/image/apiserver/admission/imagepolicy/rules"
 )
 
@@ -28,7 +28,7 @@ type policyDecision struct {
 	resolutionErr error
 }
 
-func accept(accepter rules.Accepter, policy imageResolutionPolicy, resolver imageResolver, m imagereferencemutators.ImageReferenceMutator, annotations imagereferencemutators.AnnotationAccessor, attr admission.Attributes, excludedRules sets.String) error {
+func accept(accepter rules.Accepter, policy imageResolutionPolicy, resolver imageResolver, m internalimagereferencemutators.ImageReferenceMutator, annotations internalimagereferencemutators.AnnotationAccessor, attr admission.Attributes, excludedRules sets.String) error {
 	decisions := policyDecisions{}
 
 	t := attr.GetResource().GroupResource()

--- a/pkg/image/apiserver/admission/imagepolicy/imagepolicy.go
+++ b/pkg/image/apiserver/admission/imagepolicy/imagepolicy.go
@@ -27,11 +27,11 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
-	internalimagereferencemutators "github.com/openshift/origin/pkg/api/imagereferencemutators/internalversion"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagepolicy "github.com/openshift/origin/pkg/image/apiserver/admission/apis/imagepolicy/v1"
 	"github.com/openshift/origin/pkg/image/apiserver/admission/apis/imagepolicy/validation"
+	"github.com/openshift/origin/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators"
 	"github.com/openshift/origin/pkg/image/apiserver/admission/imagepolicy/rules"
 	imageinternalclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	"k8s.io/client-go/rest"

--- a/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/builds.go
+++ b/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/builds.go
@@ -1,4 +1,4 @@
-package internalversion
+package internalimagereferencemutators
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/builds_test.go
+++ b/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/builds_test.go
@@ -1,4 +1,4 @@
-package internalversion
+package internalimagereferencemutators
 
 import (
 	"reflect"

--- a/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/meta.go
+++ b/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/meta.go
@@ -1,4 +1,4 @@
-package internalversion
+package internalimagereferencemutators
 
 import (
 	"fmt"

--- a/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/pods.go
+++ b/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/pods.go
@@ -1,4 +1,4 @@
-package internalversion
+package internalimagereferencemutators
 
 import (
 	"fmt"

--- a/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/pods_test.go
+++ b/pkg/image/apiserver/admission/imagepolicy/internalimagereferencemutators/pods_test.go
@@ -1,4 +1,4 @@
-package internalversion
+package internalimagereferencemutators
 
 import (
 	"reflect"


### PR DESCRIPTION
This updates PodNodeConstraints to only run against pods as we discussed a while back and then cleans up the related cruft.

/assign @ravisantoshgudimetla 