### PR TITLE
UPSTREAM: <carry>: Always test PDB's during service upgrade test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/upgrades/services.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/upgrades/services.go
@@ -36,7 +36,7 @@ type ServiceUpgradeTest struct {
 
 func (ServiceUpgradeTest) Name() string { return "service-upgrade" }
 
-func shouldTestPDBs() bool { return framework.ProviderIs("gce", "gke") }
+func shouldTestPDBs() bool { return true }
 
 // Setup creates a service with a load balancer and makes sure it's reachable.
 func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {


### PR DESCRIPTION
The upstream can't enable this, but we need to do so in order to
properly validate that cluster upgrades retain availability.