### PR TITLE
Use openshift controller image from dockerhub in integration

### DIFF
--- a/test/integration/dockerregistryclient_test.go
+++ b/test/integration/dockerregistryclient_test.go
@@ -142,7 +142,7 @@ func TestRegistryClientDockerHubV2(t *testing.T) {
 
 	var image *dockerregistry.Image
 	err = retryWhenUnreachable(t, func() error {
-		image, err = conn.ImageByTag("kubernetes", "guestbook", "latest")
+		image, err = conn.ImageByTag("openshift", "hello-openshift", "latest")
 		return err
 	})
 	if err != nil {
@@ -163,7 +163,7 @@ func TestRegistryClientDockerHubV1(t *testing.T) {
 
 	var image *dockerregistry.Image
 	err = retryWhenUnreachable(t, func() error {
-		image, err = conn.ImageByTag("kubernetes", "guestbook", "latest")
+		image, err = conn.ImageByTag("openshift", "hello-openshift", "latest")
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Something happened over night (~4am CET) and `kubernetes/guestbook` is not available anymore. I'm switching to using our `openshift/hello-openshift` image from dockerhub. 

/assign @mfojtik @dmage 