### PR TITLE
UPSTREAM: <carry>: test/e2e: increase timeout for pod readiness test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/pods.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/pods.go
@@ -50,7 +50,7 @@ var (
 	// maxReadyStatusUpdateTolerance specifies the latency that allows kubelet to update pod status.
 	// When kubelet is under heavy load (tests may be parallelized), the delay may be longer, hence
 	// causing tests to be flaky.
-	maxReadyStatusUpdateTolerance = 10 * time.Second
+	maxReadyStatusUpdateTolerance = time.Minute
 )
 
 // testHostIP tests that a pod gets a host IP


### PR DESCRIPTION
Upstream code comment admits the test can become flaky with heavily loaded kubelets (i.e. high test parallelization)
https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/test/e2e/common/pods.go#L50-L52

Increasing from 10s to 1m.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1703881

/assign @smarterclayton 