### PR TITLE
[release-3.11] Don't send identical SAR checks on ImageStream creation

### DIFF
--- a/pkg/image/apiserver/registry/imagestream/strategy_test.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy_test.go
@@ -62,11 +62,38 @@ func (f *fakeDefaultRegistry) DefaultRegistry() (string, bool) {
 	return f.registry, len(f.registry) > 0
 }
 
-type fakeSubjectAccessReviewRegistry struct {
+type subjectAccessReviewRecord struct {
 	err              error
 	allow            bool
 	request          *authorizationapi.SubjectAccessReview
 	requestNamespace string
+}
+
+type fakeMultiSubjectAccessReviewRegistry struct {
+	records map[identifier]subjectAccessReviewRecord
+}
+
+func (f *fakeMultiSubjectAccessReviewRegistry) Create(subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReview, error) {
+	id := identifier{name: subjectAccessReview.Spec.ResourceAttributes.Name, namespace: subjectAccessReview.Spec.ResourceAttributes.Namespace}
+	if record, exists := f.records[id]; exists {
+		if record.request != nil {
+			return nil, fmt.Errorf("SAR created more than once for %s/%s", id.namespace, id.name)
+		}
+		record.request = subjectAccessReview
+		record.requestNamespace = subjectAccessReview.Spec.ResourceAttributes.Namespace
+		f.records[id] = record
+		return &authorizationapi.SubjectAccessReview{
+			Status: authorizationapi.SubjectAccessReviewStatus{
+				Allowed: record.allow,
+			},
+		}, record.err
+	} else {
+		return nil, fmt.Errorf("no such SAR recorded for %s/%s", id.namespace, id.name)
+	}
+}
+
+type fakeSubjectAccessReviewRegistry struct {
+	subjectAccessReviewRecord
 }
 
 func (f *fakeSubjectAccessReviewRegistry) Create(subjectAccessReview *authorizationapi.SubjectAccessReview) (*authorizationapi.SubjectAccessReview, error) {
@@ -191,14 +218,16 @@ func TestDockerImageRepository(t *testing.T) {
 	}
 }
 
+type identifier struct {
+	name, namespace string
+}
+
 func TestTagVerifier(t *testing.T) {
 	tests := map[string]struct {
-		oldTags    map[string]imageapi.TagReference
-		newTags    map[string]imageapi.TagReference
-		sarError   error
-		sarAllowed bool
-		expectSar  bool
-		expected   field.ErrorList
+		oldTags  map[string]imageapi.TagReference
+		newTags  map[string]imageapi.TagReference
+		sars     map[identifier]subjectAccessReviewRecord
+		expected field.ErrorList
 	}{
 		"old nil, no tags": {},
 		"old nil, all tags are new": {
@@ -211,8 +240,7 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectSar:  true,
-			sarAllowed: true,
+			sars: map[identifier]subjectAccessReviewRecord{{name: "otherstream", namespace: "otherns"}: {allow: true}},
 		},
 		"nil from": {
 			newTags: map[string]imageapi.TagReference{
@@ -223,7 +251,7 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectSar: false,
+			sars: map[identifier]subjectAccessReviewRecord{},
 		},
 		"same namespace": {
 			newTags: map[string]imageapi.TagReference{
@@ -255,7 +283,7 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectSar: false,
+			sars: map[identifier]subjectAccessReviewRecord{},
 		},
 		"invalid from name": {
 			newTags: map[string]imageapi.TagReference{
@@ -281,8 +309,74 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectSar: true,
-			sarError:  errors.New("foo"),
+			sars: map[identifier]subjectAccessReviewRecord{{name: "otherstream", namespace: "otherns"}: {err: errors.New("foo")}},
+			expected: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "tags").Key("latest").Child("from"), `otherns/otherstream: "" ""- foo`),
+			},
+		},
+		"sar error propagates to all tags sharing a SAR": {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "otherns",
+						Name:      "otherstream:latest",
+					},
+				},
+				"other": {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "otherns",
+						Name:      "otherstream:latest",
+					},
+				},
+				"third": {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "secondns",
+						Name:      "something:latest",
+					},
+				},
+				"fourth": {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "secondns",
+						Name:      "something:latest",
+					},
+				},
+			},
+			sars: map[identifier]subjectAccessReviewRecord{
+				{name: "otherstream", namespace: "otherns"}: {err: errors.New("foo")},
+				{name: "something", namespace: "secondns"}:  {err: errors.New("bar")},
+			},
+			expected: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "tags").Key("latest").Child("from"), `otherns/otherstream: "" ""- foo`),
+				field.Forbidden(field.NewPath("spec", "tags").Key("other").Child("from"), `otherns/otherstream: "" ""- foo`),
+				field.Forbidden(field.NewPath("spec", "tags").Key("third").Child("from"), `secondns/something: "" ""- bar`),
+				field.Forbidden(field.NewPath("spec", "tags").Key("fourth").Child("from"), `secondns/something: "" ""- bar`),
+			},
+		},
+		"sar error propagates only to tags sharing a SAR": {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "otherns",
+						Name:      "otherstream:latest",
+					},
+				},
+				"other": {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "thirdns",
+						Name:      "something:latest",
+					},
+				},
+			},
+			sars: map[identifier]subjectAccessReviewRecord{
+				{name: "otherstream", namespace: "otherns"}: {err: errors.New("foo")},
+				{name: "something", namespace: "thirdns"}:   {allow: true},
+			},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "tags").Key("latest").Child("from"), `otherns/otherstream: "" ""- foo`),
 			},
@@ -297,8 +391,7 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectSar:  true,
-			sarAllowed: false,
+			sars: map[identifier]subjectAccessReviewRecord{{name: "otherstream", namespace: "otherns"}: {allow: false}},
 			expected: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "tags").Key("latest").Child("from"), `otherns/otherstream: "" ""`),
 			},
@@ -322,15 +415,35 @@ func TestTagVerifier(t *testing.T) {
 					},
 				},
 			},
-			expectSar:  true,
-			sarAllowed: true,
+			sars: map[identifier]subjectAccessReviewRecord{{name: "otherstream", namespace: "otherns"}: {allow: true}},
+		},
+		"multiple sars to multiple namespaces": {
+			newTags: map[string]imageapi.TagReference{
+				imageapi.DefaultImageTag: {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "otherns",
+						Name:      "otherstream:latest",
+					},
+				},
+				"second": {
+					From: &kapi.ObjectReference{
+						Kind:      "ImageStreamTag",
+						Namespace: "secondns",
+						Name:      "otherstream:latest",
+					},
+				},
+			},
+			sars: map[identifier]subjectAccessReviewRecord{
+				{name: "otherstream", namespace: "otherns"}:  {allow: true},
+				{name: "otherstream", namespace: "secondns"}: {allow: true},
+			},
 		},
 	}
 
 	for name, test := range tests {
-		sar := &fakeSubjectAccessReviewRegistry{
-			err:   test.sarError,
-			allow: test.sarAllowed,
+		sar := &fakeMultiSubjectAccessReviewRegistry{
+			records: test.sars,
 		}
 
 		old := &imageapi.ImageStream{
@@ -352,34 +465,36 @@ func TestTagVerifier(t *testing.T) {
 		tagVerifier := &TagVerifier{sar}
 		errs := tagVerifier.Verify(old, stream, &fakeUser{})
 
-		sarCalled := sar.request != nil
-		if e, a := test.expectSar, sarCalled; e != a {
-			t.Errorf("%s: expected SAR request=%t, got %t", name, e, a)
-		}
-		if test.expectSar {
-			if e, a := "otherns", sar.requestNamespace; e != a {
+		for id, record := range test.sars {
+			if e, a := id.namespace, record.requestNamespace; e != a {
 				t.Errorf("%s: sar namespace: expected %v, got %v", name, e, a)
 			}
 			expectedSar := &authorizationapi.SubjectAccessReview{
 				Spec: authorizationapi.SubjectAccessReviewSpec{
 					ResourceAttributes: &authorizationapi.ResourceAttributes{
-						Namespace:   "otherns",
+						Namespace:   id.namespace,
 						Verb:        "get",
 						Group:       "image.openshift.io",
 						Resource:    "imagestreams",
 						Subresource: "layers",
-						Name:        "otherstream",
+						Name:        id.name,
 					},
 					User:   "user",
 					Groups: []string{"group1"},
 					Extra:  map[string]authorizationapi.ExtraValue{oauthorizationapi.ScopesKey: {"a", "b"}},
 				},
 			}
-			if e, a := expectedSar, sar.request; !reflect.DeepEqual(e, a) {
+			if e, a := expectedSar, record.request; !reflect.DeepEqual(e, a) {
 				t.Errorf("%s: unexpected SAR request: %s", name, diff.ObjectDiff(e, a))
 			}
 		}
 
+		sort.Slice(test.expected, func(i, j int) bool {
+			return test.expected[i].Field < test.expected[j].Field
+		})
+		sort.Slice(errs, func(i, j int) bool {
+			return errs[i].Field < errs[j].Field
+		})
 		if e, a := test.expected, errs; !reflect.DeepEqual(e, a) {
 			t.Errorf("%s: unexpected validation errors: %s", name, diff.ObjectDiff(e, a))
 		}
@@ -566,9 +681,8 @@ func TestLimitVerifier(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		sar := &fakeSubjectAccessReviewRegistry{
-			allow: true,
-		}
+		sar := &fakeSubjectAccessReviewRegistry{}
+		sar.allow = true
 		tagVerifier := &TagVerifier{sar}
 		fakeRegistry := &fakeDefaultRegistry{}
 		s := &Strategy{


### PR DESCRIPTION
When an ImageStream is created with a large number of tags that
reference other ImageStreamTags in the same namespace, it is wasteful to
check for permissions to acces every single one, serially.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 