### PR TITLE
Bug 1703506: Move OAuth server to standard handler chain

### DIFF
--- a/pkg/cmd/openshift-integrated-oauth-server/server.go
+++ b/pkg/cmd/openshift-integrated-oauth-server/server.go
@@ -3,7 +3,9 @@ package openshift_integrated_oauth_server
 import (
 	"errors"
 
+	"k8s.io/apiserver/pkg/authentication/user"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -48,20 +50,41 @@ func newOAuthServerConfig(osinConfig *osinv1.OsinServerConfig) (*oauthserver.OAu
 	// the oauth-server must only run in http1 to avoid http2 connection re-use problems when improperly re-using a wildcard certificate
 	genericConfig.Config.SecureServing.HTTP1Only = true
 
+	authenticationOptions := genericapiserveroptions.NewDelegatingAuthenticationOptions()
+	authenticationOptions.ClientCert.ClientCA = osinConfig.ServingInfo.ClientCA
+	authenticationOptions.RemoteKubeConfigFile = osinConfig.KubeClientConfig.KubeConfig
+	if err := authenticationOptions.ApplyTo(&genericConfig.Authentication, genericConfig.SecureServing, genericConfig.OpenAPIConfig); err != nil {
+		return nil, err
+	}
+
+	authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions().
+		// TODO better formalize / generate this list as trailing * matters
+		WithAlwaysAllowPaths( // The five sections are:
+			"/healthz", "/healthz/", // 1. Health checks (root, no wildcard)
+			"/oauth/*",           // 2. OAuth (wildcard)
+			"/login", "/login/*", // 3. Login (both root and wildcard)
+			"/logout", "/logout/", // 4. Logout (root, no wildcard)
+			"/oauth2callback/*", // 5. OAuth callbacks (wildcard)
+		).
+		WithAlwaysAllowGroups(user.SystemPrivilegedGroup)
+	authorizationOptions.RemoteKubeConfigFile = osinConfig.KubeClientConfig.KubeConfig
+	if err := authorizationOptions.ApplyTo(&genericConfig.Authorization); err != nil {
+		return nil, err
+	}
+
 	// TODO You need real overrides for rate limiting
 	kubeClientConfig, err := helpers.GetKubeConfigOrInClusterConfig(osinConfig.KubeClientConfig.KubeConfig, osinConfig.KubeClientConfig.ConnectionOverrides)
 	if err != nil {
 		return nil, err
 	}
 
-	oauthServerConfig, err := oauthserver.NewOAuthServerConfig(osinConfig.OAuthConfig, kubeClientConfig)
+	oauthServerConfig, err := oauthserver.NewOAuthServerConfig(osinConfig.OAuthConfig, kubeClientConfig, genericConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO you probably want to set this
 	oauthServerConfig.GenericConfig.CorsAllowedOriginList = osinConfig.CORSAllowedOrigins
-	oauthServerConfig.GenericConfig.SecureServing = genericConfig.SecureServing
 	//oauthServerConfig.GenericConfig.AuditBackend = genericConfig.AuditBackend
 	//oauthServerConfig.GenericConfig.AuditPolicyChecker = genericConfig.AuditPolicyChecker
 

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_oauthserver.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_oauthserver.go
@@ -11,7 +11,7 @@ import (
 // TODO this is taking a very large config for a small piece of it.  The information must be broken up at some point so that
 // we can run this in a pod.  This is an indication of leaky abstraction because it spent too much time in openshift start
 func NewOAuthServerConfigFromMasterConfig(genericConfig *genericapiserver.Config, oauthConfig *osinv1.OAuthConfig) (*oauthserver.OAuthServerConfig, error) {
-	oauthServerConfig, err := oauthserver.NewOAuthServerConfig(*oauthConfig, genericConfig.LoopbackClientConfig)
+	oauthServerConfig, err := oauthserver.NewOAuthServerConfig(*oauthConfig, genericConfig.LoopbackClientConfig, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauthserver/server/headers/oauthbasic.go
+++ b/pkg/oauthserver/server/headers/oauthbasic.go
@@ -1,0 +1,29 @@
+package headers
+
+import "net/http"
+
+const (
+	authzHeader     = "Authorization"
+	copyAuthzHeader = "oauth.openshift.io:" + authzHeader // will never conflict because : is not a valid header key
+)
+
+func WithPreserveAuthorizationHeader(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if vv, ok := r.Header[authzHeader]; ok {
+			r.Header[copyAuthzHeader] = vv // capture the values before they are deleted
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func WithRestoreAuthorizationHeader(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if vv, ok := r.Header[copyAuthzHeader]; ok {
+			r.Header[authzHeader] = vv // add them back afterwards for use in OAuth flows
+			delete(r.Header, copyAuthzHeader)
+		}
+
+		handler.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
This change allows us to have delegated authentication and
authorization back to the kube API server for all non-OAuth
endpoints.  For example, this will make our metrics endpoint
protected with auth.

Bug 1703506
Bug 1704822

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth 
/assign @stlaz 