### PR TITLE
OAS: allow /healthz/* without delegated auth

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -126,7 +126,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	if err := authenticationOptions.ApplyTo(&genericConfig.Authentication, genericConfig.SecureServing, genericConfig.OpenAPIConfig); err != nil {
 		return nil, err
 	}
-	authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/healthz/").WithAlwaysAllowGroups("system:masters")
+	authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/healthz/*").WithAlwaysAllowGroups("system:masters")
 	authorizationOptions.RemoteKubeConfigFile = config.KubeClientConfig.KubeConfig
 	if err := authorizationOptions.ApplyTo(&genericConfig.Authorization); err != nil {
 		return nil, err


### PR DESCRIPTION
Star must be specified for prefix matching via WithAlwaysAllowPaths.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-master 