### PR TITLE
Remove /healthz/* from bootstrap RBAC

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -436,7 +436,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 			},
 			Rules: []rbacv1.PolicyRule{
 				// Health
-				rbacv1helpers.NewRule("get").URLs("/healthz", "/healthz/*").RuleOrDie(),
+				rbacv1helpers.NewRule("get").URLs("/healthz", "/healthz/").RuleOrDie(),
 				authorizationapi.DiscoveryRule,
 			},
 		},

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1313,7 +1313,7 @@ items:
   rules:
   - nonResourceURLs:
     - /healthz
-    - /healthz/*
+    - /healthz/
     verbs:
     - get
   - nonResourceURLs:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -1313,7 +1313,7 @@ items:
   rules:
   - nonResourceURLs:
     - /healthz
-    - /healthz/*
+    - /healthz/
     verbs:
     - get
   - nonResourceURLs:


### PR DESCRIPTION
The contents of detailed healthz are considered sensitive.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth @openshift/sig-master 
/assign @deads2k 