### PR TITLE
SCC bootstrapping must not return until it has created all defaults

### DIFF
--- a/test/util/server/server.go
+++ b/test/util/server/server.go
@@ -515,11 +515,8 @@ func startOpenShiftAPIServer(masterConfig *configapi.MasterConfig, clientConfig 
 	if err != nil {
 		return err
 	}
-	if err := waitForServerHealthy(openshiftAddr); err != nil {
-		return fmt.Errorf("Waiting for OpenShift API /healthz failed with: %v", err)
-	}
-
 	targetPort := intstr.Parse(openshiftAddr.Port())
+
 	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return err
@@ -596,6 +593,10 @@ func startOpenShiftAPIServer(masterConfig *configapi.MasterConfig, clientConfig 
 		if _, err := apiregistrationclient.APIServices().Create(obj); err != nil {
 			return err
 		}
+	}
+
+	if err := waitForServerHealthy(openshiftAddr); err != nil {
+		return fmt.Errorf("Waiting for OpenShift API /healthz failed with: %v", err)
 	}
 
 	err = wait.Poll(time.Second, 3*time.Minute, func() (bool, error) {


### PR DESCRIPTION
Without this, we end up having inconsistent bootstrapping behavior.  By doing it in a loop, the healthz reports what we expect and we have a clear signal of failure before getting inconsistent results about which SCC have and have not been created.