### PR TITLE
Bug 1702743: Wait for internal registry hostname to be published before running e2e test (2)

### DIFF
--- a/test/extended/imageapis/limitrange_admission.go
+++ b/test/extended/imageapis/limitrange_admission.go
@@ -28,6 +28,11 @@ var _ = g.Describe("[Feature:ImageQuota][registry][Serial][Suite:openshift/regis
 
 	var oc = exutil.NewCLI("limitrange-admission", exutil.KubeConfigPath())
 
+	g.BeforeEach(func() {
+		_, err := exutil.WaitForInternalRegistryHostname(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
 	g.It(fmt.Sprintf("should deny a push of built image exceeding %s limit", imageapi.LimitTypeImage), func() {
 		_, err := createLimitRangeOfType(oc, imageapi.LimitTypeImage, kapi.ResourceList{
 			kapi.ResourceStorage: resource.MustParse("10Ki"),


### PR DESCRIPTION
Identical to #22705, but adds a wait to the templateinstance readiness test.