### PR TITLE
tests follow-up to tightening authn APIs validation

### DIFF
--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -68,6 +68,16 @@ func TestBasicUserBasedGroupManipulation(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	// make sure that user/~ returns system groups for backed users when it merges
+	expectedValerieGroups := []string{"system:authenticated", "system:authenticated:oauth"}
+	secondValerie, err := userclient.NewForConfigOrDie(valerieConfig).Users().Get("~", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(secondValerie.Groups, expectedValerieGroups) {
+		t.Errorf("expected %v, got %v", expectedValerieGroups, secondValerie.Groups)
+	}
+
 	_, err = valerieProjectClient.Projects().Get("empty", metav1.GetOptions{})
 	if err == nil {
 		t.Fatalf("expected error")

--- a/test/integration/oauth_serviceaccount_client_test.go
+++ b/test/integration/oauth_serviceaccount_client_test.go
@@ -160,7 +160,26 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		} else if !reflect.DeepEqual(clientAuth.Scopes, []string{"user:full"}) {
 			t.Fatalf("Unexpected scopes: %v", clientAuth.Scopes)
+		} else {
+			// update the authorization to contain only read scopes
+			clientAuth.Scopes = []string{"user:info"}
+			if _, err := clusterAdminOAuthClient.OAuthClientAuthorizations().Update(clientAuth); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
 		}
+		// approval steps are needed again for unscoped access
+		runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, nil, authorizationCodes, authorizationErrors, true, true, []string{
+			"GET /oauth/authorize",
+			"received challenge",
+			"GET /oauth/authorize",
+			"redirect to /oauth/authorize/approve",
+			"form",
+			"POST /oauth/authorize/approve",
+			"redirect to /oauth/authorize",
+			"redirect to /oauthcallback",
+			"code",
+			"scope:user:full",
+		})
 
 		// with the authorization stored, approval steps are skipped
 		runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, nil, authorizationCodes, authorizationErrors, true, true, []string{


### PR DESCRIPTION
Readd tests that check the "~" user endpoint and that check that approval for full-scopes is once again needed when scope of the original oauthclientauthorization gets restricted

cc @enj @openshift/sig-auth 