### PR TITLE
Bug 1704874: Copy Registry CA to Build Pods

### DIFF
--- a/pkg/build/controller/build/build_controller_test.go
+++ b/pkg/build/controller/build/build_controller_test.go
@@ -1809,6 +1809,7 @@ func newFakeBuildController(buildClient buildv1client.Interface, imageClient ima
 		ImageStreamInformer:              imageInformers.Image().V1().ImageStreams(),
 		PodInformer:                      kubeExternalInformers.Core().V1().Pods(),
 		SecretInformer:                   kubeExternalInformers.Core().V1().Secrets(),
+		ServiceAccountInformer:           kubeExternalInformers.Core().V1().ServiceAccounts(),
 		OpenshiftConfigConfigMapInformer: kubeExternalInformers.Core().V1().ConfigMaps(),
 		BuildControllerConfigInformer:    configInformers.Config().V1().Builds(),
 		ImageConfigInformer:              configInformers.Config().V1().Images(),

--- a/pkg/cmd/openshift-controller-manager/controller/build.go
+++ b/pkg/cmd/openshift-controller-manager/controller/build.go
@@ -45,20 +45,22 @@ func RunBuildController(ctx *ControllerContext) (bool, error) {
 	serviceAccountInformer := ctx.KubernetesInformers.Core().V1().ServiceAccounts()
 	controllerConfigInformer := ctx.ConfigInformers.Config().V1().Builds()
 	imageConfigInformer := ctx.ConfigInformers.Config().V1().Images()
-	configMapInformer := ctx.OpenshiftConfigKubernetesInformers.Core().V1().ConfigMaps()
+	openshiftConfigConfigMapInformer := ctx.OpenshiftConfigKubernetesInformers.Core().V1().ConfigMaps()
+	controllerManagerConfigMapInformer := ctx.ControllerManagerKubeInformers.Core().V1().ConfigMaps()
 
 	buildControllerParams := &buildcontroller.BuildControllerParams{
-		BuildInformer:                    buildInformer,
-		BuildConfigInformer:              buildConfigInformer,
-		BuildControllerConfigInformer:    controllerConfigInformer,
-		ImageConfigInformer:              imageConfigInformer,
-		ImageStreamInformer:              imageStreamInformer,
-		PodInformer:                      podInformer,
-		SecretInformer:                   secretInformer,
-		ServiceAccountInformer:           serviceAccountInformer,
-		OpenshiftConfigConfigMapInformer: configMapInformer,
-		KubeClient:                       externalKubeClient,
-		BuildClient:                      buildClient,
+		BuildInformer:                      buildInformer,
+		BuildConfigInformer:                buildConfigInformer,
+		BuildControllerConfigInformer:      controllerConfigInformer,
+		ImageConfigInformer:                imageConfigInformer,
+		ImageStreamInformer:                imageStreamInformer,
+		PodInformer:                        podInformer,
+		SecretInformer:                     secretInformer,
+		ServiceAccountInformer:             serviceAccountInformer,
+		OpenshiftConfigConfigMapInformer:   openshiftConfigConfigMapInformer,
+		ControllerManagerConfigMapInformer: controllerManagerConfigMapInformer,
+		KubeClient:                         externalKubeClient,
+		BuildClient:                        buildClient,
 		DockerBuildStrategy: &buildstrategy.DockerBuildStrategy{
 			Image: imageTemplate.ExpandOrDie("docker-builder"),
 		},

--- a/pkg/cmd/openshift-controller-manager/controller/interfaces.go
+++ b/pkg/cmd/openshift-controller-manager/controller/interfaces.go
@@ -114,6 +114,7 @@ func NewControllerContext(
 		},
 		KubernetesInformers:                informers.NewSharedInformerFactory(kubeClient, defaultInformerResyncPeriod),
 		OpenshiftConfigKubernetesInformers: informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultInformerResyncPeriod, informers.WithNamespace("openshift-config")),
+		ControllerManagerKubeInformers:     informers.NewSharedInformerFactoryWithOptions(kubeClient, defaultInformerResyncPeriod, informers.WithNamespace("openshift-controller-manager")),
 		AppsInformers:                      appsinformer.NewSharedInformerFactory(appsClient, defaultInformerResyncPeriod),
 		BuildInformers:                     buildinformer.NewSharedInformerFactory(buildClient, defaultInformerResyncPeriod),
 		ConfigInformers:                    configinformer.NewSharedInformerFactory(configClient, defaultInformerResyncPeriod),
@@ -170,6 +171,7 @@ type ControllerContext struct {
 
 	KubernetesInformers                informers.SharedInformerFactory
 	OpenshiftConfigKubernetesInformers informers.SharedInformerFactory
+	ControllerManagerKubeInformers     informers.SharedInformerFactory
 
 	TemplateInformers templateinformer.SharedInformerFactory
 	QuotaInformers    quotainformer.SharedInformerFactory
@@ -197,6 +199,7 @@ type ControllerContext struct {
 func (c *ControllerContext) StartInformers(stopCh <-chan struct{}) {
 	c.KubernetesInformers.Start(stopCh)
 	c.OpenshiftConfigKubernetesInformers.Start(stopCh)
+	c.ControllerManagerKubeInformers.Start(stopCh)
 
 	c.AppsInformers.Start(stopCh)
 	c.BuildInformers.Start(stopCh)


### PR DESCRIPTION
With openshift/cluster-openshift-controller-manager-operator#96,
the openshift controller manager will be able to read the internal registry's
certificate authority from a central ConfigMap.
Updating build controller to copy the registry CA into each build's CA ConfigMap.