### PR TITLE
Bug 1705627: Add --show-console flag to whoami command

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -15080,6 +15080,8 @@ _oc_whoami()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--show-console")
+    local_nonpersistent_flags+=("--show-console")
     flags+=("--show-context")
     flags+=("-c")
     local_nonpersistent_flags+=("--show-context")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -15222,6 +15222,8 @@ _oc_whoami()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--show-console")
+    local_nonpersistent_flags+=("--show-console")
     flags+=("--show-context")
     flags+=("-c")
     local_nonpersistent_flags+=("--show-context")

--- a/pkg/oc/cli/whoami/whoami.go
+++ b/pkg/oc/cli/whoami/whoami.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd/api"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 
@@ -16,7 +18,11 @@ import (
 	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 )
 
-const WhoAmIRecommendedCommandName = "whoami"
+const (
+	WhoAmIRecommendedCommandName        = "whoami"
+	openShiftConfigManagedNamespaceName = "openshift-config-managed"
+	consolePublicConfigMap              = "console-public"
+)
 
 var whoamiLong = templates.LongDesc(`
 	Show information about the current session
@@ -29,11 +35,13 @@ type WhoAmIOptions struct {
 	UserInterface userv1typedclient.UserV1Interface
 
 	ClientConfig *rest.Config
+	KubeClient   kubernetes.Interface
 	RawConfig    api.Config
 
-	ShowToken   bool
-	ShowContext bool
-	ShowServer  bool
+	ShowToken      bool
+	ShowContext    bool
+	ShowServer     bool
+	ShowConsoleUrl bool
 
 	genericclioptions.IOStreams
 }
@@ -61,6 +69,7 @@ func NewCmdWhoAmI(name, fullName string, f kcmdutil.Factory, streams genericclio
 	cmd.Flags().BoolVarP(&o.ShowToken, "show-token", "t", o.ShowToken, "Print the token the current session is using. This will return an error if you are using a different form of authentication.")
 	cmd.Flags().BoolVarP(&o.ShowContext, "show-context", "c", o.ShowContext, "Print the current user context name")
 	cmd.Flags().BoolVar(&o.ShowServer, "show-server", o.ShowServer, "If true, print the current server's REST API URL")
+	cmd.Flags().BoolVar(&o.ShowConsoleUrl, "show-console", o.ShowConsoleUrl, "If true, print the current server's web console URL")
 
 	return cmd
 }
@@ -76,10 +85,17 @@ func (o WhoAmIOptions) WhoAmI() (*userv1.User, error) {
 
 func (o *WhoAmIOptions) Complete(f kcmdutil.Factory) error {
 	var err error
+
 	o.ClientConfig, err = f.ToRESTConfig()
 	if err != nil {
 		return err
 	}
+
+	kubeClient, err := kubernetes.NewForConfig(o.ClientConfig)
+	if err != nil {
+		return err
+	}
+	o.KubeClient = kubeClient
 
 	o.RawConfig, err = f.ToRawKubeConfigLoader().RawConfig()
 	return err
@@ -96,17 +112,40 @@ func (o *WhoAmIOptions) Validate() error {
 	return nil
 }
 
+func (o *WhoAmIOptions) getWebConsoleUrl() (string, error) {
+	consolePublicConfig, err := o.KubeClient.CoreV1().ConfigMaps(openShiftConfigManagedNamespaceName).Get(consolePublicConfigMap, metav1.GetOptions{})
+	// This means the command was run against 3.x server
+	if errors.IsNotFound(err) {
+		return o.ClientConfig.Host, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to determine console location: %v", err)
+	}
+
+	consoleUrl, exists := consolePublicConfig.Data["consoleURL"]
+	if !exists {
+		return "", fmt.Errorf("unable to determine console location from the cluster")
+	}
+	return consoleUrl, nil
+}
+
 func (o *WhoAmIOptions) Run() error {
-	if o.ShowToken {
+	switch {
+	case o.ShowToken:
 		fmt.Fprintf(o.Out, "%s\n", o.ClientConfig.BearerToken)
 		return nil
-	}
-	if o.ShowContext {
+	case o.ShowContext:
 		fmt.Fprintf(o.Out, "%s\n", o.RawConfig.CurrentContext)
 		return nil
-	}
-	if o.ShowServer {
+	case o.ShowServer:
 		fmt.Fprintf(o.Out, "%s\n", o.ClientConfig.Host)
+		return nil
+	case o.ShowConsoleUrl:
+		consoleUrl, err := o.getWebConsoleUrl()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(o.Out, "%s\n", consoleUrl)
 		return nil
 	}
 

--- a/test/cmd/whoami.sh
+++ b/test/cmd/whoami.sh
@@ -13,6 +13,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/whoami"
 # This test validates the whoami command's --show-server flag
 os::cmd::expect_success_and_text 'oc whoami --show-server' 'http(s)?:\/\/localhost\:[0-9]+'
+os::cmd::expect_success_and_text 'oc whoami --show-console' 'http(s)?:\/\/localhost\:[0-9]+'
 
 echo "whoami: ok"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
This flag will fetch configmap that contain location of web console URL and print it to user.
For 3.x API servers, this will use the API server hostname which should redirect user to console.

Example output:

```
$ oc whoami --show-console
https://api.ci.openshift.org:443
```

xref: https://github.com/openshift/console-operator/pull/218
