### PR TITLE
test/extended/operators/cluster: Don't error on SIGTERMed containers

### DIFF
--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"syscall"
 	"time"
 
 	g "github.com/onsi/ginkgo"
@@ -151,7 +152,7 @@ func hasImagePullError(pod *corev1.Pod) bool {
 
 func hasFailingContainer(pod *corev1.Pod) bool {
 	for _, status := range append(append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...), pod.Status.ContainerStatuses...) {
-		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 && syscall.Signal(status.State.Terminated.Signal) != syscall.SIGTERM {
 			pod.Status.Message = status.State.Terminated.Message
 			if len(pod.Status.Message) == 0 {
 				pod.Status.Message = fmt.Sprintf("container %s exited with non-zero exit code", status.Name)


### PR DESCRIPTION
This is currently creating distracting noise:

```console
$ curl -s https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/22731/pull-ci-openshift-origin-master-e2e-aws-upgrade/414 | grep 'container exited with code 143' | head -n3
May 02 02:45:30.680 E ns/openshift-cluster-node-tuning-operator pod/tuned-rj9vq node/ip-10-0-129-149.ec2.internal container=tuned container exited with code 143 (Error):
May 02 02:45:33.578 E ns/openshift-monitoring pod/node-exporter-wb2xg node/ip-10-0-165-247.ec2.internal container=node-exporter container exited with code 143 (Error):
May 02 02:46:15.166 E ns/openshift-cluster-node-tuning-operator pod/tuned-5vsbx node/ip-10-0-149-250.ec2.internal container=tuned container exited with code 143 (Error):
```

Containers that don't need graceful shutdown logic should be allowed to let `TERM` kill them, and with this commit we'll no longer complain about that.

Using `syscall.SIGTERM` is a bit dicey, because in general signal numbers are not cross-platform.  For example, see the table in [`signal(7)`][1], which includes:

```
   Signal        x86/ARM     Alpha/   MIPS   PARISC   Notes
               most others   SPARC
   ─────────────────────────────────────────────────────────────────
   ...
   SIGUSR1         10          30      16      16
   ...
   SIGTERM         15          15      15      15
   ...
```

But luckily for us, `TERM` is portable cross-arch.  And Go commits to that:

```console
$ curl -s https://raw.githubusercontent.com/golang/go/0a338f75d4c64ba72cf586a28ec1a674c8b4bb77/api/go1.1.txt | grep SIGTERM
pkg syscall, const SIGTERM = 15
```

I dunno how this will work on other OSes (e.g. if we start running kubelets on Windows), but we'll cross that bridge when we come to it.

[1]:http://man7.org/linux/man-pages/man7/signal.7.html