### PR TITLE
Defer bootstrapping SCC to KAS-O via CVO

### DIFF
--- a/hack/local-up-master/bootstrap-manifests/scc/anyuid.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/anyuid.yaml
@@ -1,0 +1,39 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+  - system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: anyuid provides all features of the restricted SCC
+      but allows users to run with any UID and any GID.
+  creationTimestamp: null
+  name: anyuid
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/hack/local-up-master/bootstrap-manifests/scc/hostaccess.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/hostaccess.yaml
@@ -1,0 +1,45 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'hostaccess allows access to all host namespaces
+      but still requires pods to be run with a UID and SELinux context that are
+      allocated to the namespace. WARNING: this SCC allows host access to namespaces,
+      file systems, and PIDS.  It should only be used by trusted pods.  Grant with
+      caution.'
+  creationTimestamp: null
+  name: hostaccess
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/hack/local-up-master/bootstrap-manifests/scc/hostmount-anyuid.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/hostmount-anyuid.yaml
@@ -1,0 +1,43 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'hostmount-anyuid provides all the features of the
+      restricted SCC but allows host mounts and any UID by a pod.  This is primarily
+      used by the persistent volume recycler. WARNING: this SCC allows host file
+      system access as any UID, including UID 0.  Grant with caution.'
+  creationTimestamp: null
+  name: hostmount-anyuid
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:openshift-infra:pv-recycler-controller
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - nfs
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/hack/local-up-master/bootstrap-manifests/scc/hostnetwork.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/hostnetwork.yaml
@@ -1,0 +1,42 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: hostnetwork allows using host networking and host
+      ports but still requires pods to be run with a UID and SELinux context that
+      are allocated to the namespace.
+  creationTimestamp: null
+  name: hostnetwork
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: MustRunAs
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/hack/local-up-master/bootstrap-manifests/scc/nonroot.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/nonroot.yaml
@@ -1,0 +1,42 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: nonroot provides all features of the restricted SCC
+      but allows users to run with any non-root UID.  The user must specify the
+      UID or it must be specified on the by the manifest of the container runtime.
+  creationTimestamp: null
+  name: nonroot
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/hack/local-up-master/bootstrap-manifests/scc/privileged.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/privileged.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+allowedUnsafeSysctls:
+  - '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+  - system:cluster-admins
+  - system:nodes
+  - system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be
+      used only for cluster administration. Grant with caution.'
+  creationTimestamp: null
+  name: privileged
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:admin
+  - system:serviceaccount:openshift-infra:build-controller
+volumes:
+  - '*'

--- a/hack/local-up-master/bootstrap-manifests/scc/restricted.yaml
+++ b/hack/local-up-master/bootstrap-manifests/scc/restricted.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+  - system:authenticated
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: restricted denies access to all host features and
+      requires pods to be run with a UID, and SELinux context that are allocated
+      to the namespace.  This is the most restrictive SCC and it is used by default
+      for authenticated users.
+  creationTimestamp: null
+  name: restricted
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -99,6 +99,8 @@ os::cmd::try_until_success "oc get service kubernetes --namespace default --conf
 os::cmd::try_until_success "oc login --server=${KUBERNETES_MASTER} --certificate-authority ${MASTER_CONFIG_DIR}/server-ca.crt -u test-user -p anything" $(( 160 * second )) 0.25
 # wait for the CRD to be available
 os::cmd::try_until_success "oc get clusterresourcequotas --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
+os::cmd::try_until_success "oc get scc --config='${ADMIN_KUBECONFIG}'" $(( 160 * second )) 0.25
+os::cmd::expect_success "oc apply -R -f ${OS_ROOT}/hack/local-up-master/bootstrap-manifests/ --config='${ADMIN_KUBECONFIG}'"
 os::test::junit::declare_suite_end
 os::log::debug "localup server health checks done at: $( date )"
 

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -498,7 +498,6 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget,
 	s.GenericAPIServer.AddPostStartHookOrDie("authorization.openshift.io-ensureopenshift-infra", c.EnsureOpenShiftInfraNamespace)
 	s.GenericAPIServer.AddPostStartHookOrDie("project.openshift.io-projectcache", c.startProjectCache)
 	s.GenericAPIServer.AddPostStartHookOrDie("project.openshift.io-projectauthorizationcache", c.startProjectAuthorizationCache)
-	s.GenericAPIServer.AddPostStartHookOrDie("security.openshift.io-bootstrapscc", c.bootstrapSCC)
 	s.GenericAPIServer.AddPostStartHookOrDie("openshift.io-startinformers", func(context genericapiserver.PostStartHookContext) error {
 		c.ExtraConfig.InformerStart(context.StopCh)
 		return nil


### PR DESCRIPTION
This change removes the call to the bootstrap SCC post start hook as
that work is now handled by the KAS-O.  For test-cmd and
test-integration, we now have a copy of the SCC manifests.  All of
the bootstrap SCC data and reconciliation logic can be removed now.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: https://github.com/openshift/cluster-kube-apiserver-operator/pull/453

@openshift/sig-auth @openshift/sig-master 