### PR TITLE
oc explain test update RBR to CRD

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -111,6 +111,7 @@ var (
 		{Group: "operator.openshift.io", Version: "v1", Resource: "servicecatalogcontrollermanagers"},
 
 		{Group: "quota.openshift.io", Version: "v1", Resource: "clusterresourcequotas"},
+		{Group: "authorization.openshift.io", Version: "v1", Resource: "rolebindingrestrictions"},
 
 		// FIXME
 		// schema.GroupVersionResource{Group: "samples.operator.openshift.io", Version: "v1", Resource: "configs"},


### PR DESCRIPTION
oc explain tests are failing in [PR to add RBR CRD](https://github.com/openshift/cluster-config-operator/pull/61)

In cluster w/ payload from that PR and this fix, 
```cli
$ _output/local/bin/linux/amd64/openshift-tests run all --dry-run | grep -E "oc explain" | _output/local/bin/linux/amd64/openshift-tests run -f -
started: (0/1/3) "[cli] oc explain should contain proper spec+status for CRDs [Suite:openshift/conformance/parallel]"

started: (0/2/3) "[cli] oc explain should contain spec+status for builtinTypes [Suite:openshift/conformance/parallel]"

started: (0/3/3) "[cli] oc explain should contain proper fields description for special types [Suite:openshift/conformance/parallel]"

passed: (27.6s) 2019-05-03T17:26:39 "[cli] oc explain should contain spec+status for builtinTypes [Suite:openshift/conformance/parallel]"

passed: (42.6s) 2019-05-03T17:26:54 "[cli] oc explain should contain proper fields description for special types [Suite:openshift/conformance/parallel]"

passed: (59.7s) 2019-05-03T17:27:11 "[cli] oc explain should contain proper spec+status for CRDs [Suite:openshift/conformance/parallel]"

```