### PR TITLE
UPSTREAM: <carry>: filter out RBR and SCC paths from OpenAPI

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
@@ -47,7 +47,7 @@ func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) (*hand
 	// apiextensions-apiserver spec during merging.
 	for pth := range spec.Paths.Paths {
 		if strings.HasPrefix(pth, "/apis/quota.openshift.io/v1/clusterresourcequotas") ||
-			strings.HasPrefix(pth, "/apis/authorization.openshift.io/v1/rolebindingrestrictions") ||
+			strings.Contains(pth, "rolebindingrestrictions") ||
 			strings.HasPrefix(pth, "/apis/security.openshift.io/v1/securitycontextconstraints") {
 			delete(spec.Paths.Paths, pth)
 		}


### PR DESCRIPTION
RBR is namespace scoped, so the check cannot be a simple prefix.  Just nuke them all from orbit for now.