### PR TITLE
SCC in all namespaces

### DIFF
--- a/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
+++ b/pkg/cmd/openshift-kube-apiserver/kubeadmission/register.go
@@ -45,8 +45,6 @@ var (
 		"authorization.openshift.io/RestrictSubjectBindings",
 		imagepolicyapiv1.PluginName, // "image.openshift.io/ImagePolicy"
 		"quota.openshift.io/ClusterResourceQuota",
-		"security.openshift.io/SecurityContextConstraint",
-		"security.openshift.io/SCCExecRestrictions",
 	)
 
 	// AfterKubeAdmissionPlugins are the admission plugins to add after kube admission, before mutating webhooks


### PR DESCRIPTION
Now that it is crd based, the only reason to restrict it is if we can't sort permissions in time (or mcs labels). Let's see what fails