### PR TITLE
add/remove scc commands: internally wire to RBAC

### DIFF
--- a/pkg/oc/cli/admin/policy/authz_helpers.go
+++ b/pkg/oc/cli/admin/policy/authz_helpers.go
@@ -2,24 +2,25 @@ package policy
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 )
 
-func buildSubjects(users, groups []string) []corev1.ObjectReference {
-	subjects := []corev1.ObjectReference{}
+func buildSubjects(users, groups []string) []rbacv1.Subject {
+	subjects := []rbacv1.Subject{}
 
 	for _, user := range users {
 		saNamespace, saName, err := serviceaccount.SplitUsername(user)
 		if err == nil {
-			subjects = append(subjects, corev1.ObjectReference{Kind: "ServiceAccount", Namespace: saNamespace, Name: saName})
+			subjects = append(subjects, rbacv1.Subject{Kind: "ServiceAccount", Namespace: saNamespace, Name: saName})
 			continue
 		}
 
-		subjects = append(subjects, corev1.ObjectReference{Kind: "User", Name: user})
+		subjects = append(subjects, rbacv1.Subject{Kind: "User", Name: user})
 	}
 
 	for _, group := range groups {
-		subjects = append(subjects, corev1.ObjectReference{Kind: "Group", Name: group})
+		subjects = append(subjects, rbacv1.Subject{Kind: "Group", Name: group})
 	}
 
 	return subjects

--- a/pkg/oc/cli/admin/policy/modify_roles.go
+++ b/pkg/oc/cli/admin/policy/modify_roles.go
@@ -385,7 +385,7 @@ func (o *RoleModificationOptions) CompleteUserWithSA(f kcmdutil.Factory, cmd *co
 	}
 
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
-		o.PrintFlags.NamePrintFlags.Operation = getSuccessMessage(o.DryRun, operation, o.Targets)
+		o.PrintFlags.NamePrintFlags.Operation = getRolesSuccessMessage(o.DryRun, operation, o.Targets)
 		return o.PrintFlags.ToPrinter()
 	}
 
@@ -407,7 +407,7 @@ func (o *RoleModificationOptions) Complete(f kcmdutil.Factory, cmd *cobra.Comman
 	}
 
 	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
-		o.PrintFlags.NamePrintFlags.Operation = getSuccessMessage(o.DryRun, operation, o.Targets)
+		o.PrintFlags.NamePrintFlags.Operation = getRolesSuccessMessage(o.DryRun, operation, o.Targets)
 		return o.PrintFlags.ToPrinter()
 	}
 
@@ -754,7 +754,7 @@ existingLoop:
 	return newSubjects, found
 }
 
-func getSuccessMessage(dryRun bool, operation string, targets []string) string {
+func getRolesSuccessMessage(dryRun bool, operation string, targets []string) string {
 	allTargets := fmt.Sprintf("%q", targets)
 	if len(targets) == 1 {
 		allTargets = fmt.Sprintf("%q", targets[0])

--- a/pkg/oc/cli/admin/policy/modify_roles.go
+++ b/pkg/oc/cli/admin/policy/modify_roles.go
@@ -671,42 +671,22 @@ func (o *RoleModificationOptions) RemoveRole() error {
 			return fmt.Errorf("unable to find target %v", o.Targets)
 		}
 
-		var updated *unstructured.UnstructuredList
-		if len(o.RoleBindingNamespace) > 0 {
-			updatedBindings := &unstructured.UnstructuredList{
-				Object: map[string]interface{}{
-					"kind":       "List",
-					"apiVersion": "v1",
-					"metadata":   map[string]interface{}{},
-				},
+		updatedBindings := &unstructured.UnstructuredList{
+			Object: map[string]interface{}{
+				"kind":       "List",
+				"apiVersion": "v1",
+				"metadata":   map[string]interface{}{},
+			},
+		}
+		for _, binding := range roleBindings {
+			obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(binding.Object())
+			if err != nil {
+				return err
 			}
-			for _, binding := range roleBindings {
-				obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(binding.Object())
-				if err != nil {
-					return err
-				}
-				updatedBindings.Items = append(updatedBindings.Items, unstructured.Unstructured{Object: obj})
-			}
-			updated = updatedBindings
-		} else {
-			updatedBindings := &unstructured.UnstructuredList{
-				Object: map[string]interface{}{
-					"kind":       "List",
-					"apiVersion": "v1",
-					"metadata":   map[string]interface{}{},
-				},
-			}
-			for _, binding := range roleBindings {
-				obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(binding.Object())
-				if err != nil {
-					return err
-				}
-				updatedBindings.Items = append(updatedBindings.Items, unstructured.Unstructured{Object: obj})
-			}
-			updated = updatedBindings
+			updatedBindings.Items = append(updatedBindings.Items, unstructured.Unstructured{Object: obj})
 		}
 
-		return p.PrintObj(updated, o.Out)
+		return p.PrintObj(updatedBindings, o.Out)
 	}
 
 	roleToPrint := o.roleObjectToPrint()

--- a/pkg/oc/cli/admin/policy/modify_scc_test.go
+++ b/pkg/oc/cli/admin/policy/modify_scc_test.go
@@ -1,141 +1,168 @@
 package policy
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
 	clientgotesting "k8s.io/client-go/testing"
 
-	securityv1 "github.com/openshift/api/security/v1"
-	fakesecurityclient "github.com/openshift/client-go/security/clientset/versioned/fake"
-	fakesecurityv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1/fake"
+	fakekubeclient "k8s.io/client-go/kubernetes/fake"
+	fakerbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1/fake"
+	fakerbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1/fake"
 )
 
 func TestModifySCC(t *testing.T) {
 	tests := map[string]struct {
-		startingSCC *securityv1.SecurityContextConstraints
-		subjects    []corev1.ObjectReference
-		expectedSCC *securityv1.SecurityContextConstraints
+		startingCRB *rbacv1.ClusterRoleBinding
+		subjects    []rbacv1.Subject
+		expectedCRB *rbacv1.ClusterRoleBinding
 		remove      bool
 	}{
 		"add-user-to-empty": {
-			startingSCC: &securityv1.SecurityContextConstraints{},
-			subjects:    []corev1.ObjectReference{{Name: "one", Kind: "User"}, {Name: "two", Kind: "User"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"one", "two"}},
-			remove:      false,
+			startingCRB: &rbacv1.ClusterRoleBinding{},
+			subjects:    []rbacv1.Subject{{Name: "one", Kind: "User"}, {Name: "two", Kind: "User"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}, {Kind: "User", Name: "two"}},
+			},
+			remove: false,
 		},
 		"add-user-to-existing": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"one"}},
-			subjects:    []corev1.ObjectReference{{Name: "two", Kind: "User"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"one", "two"}},
-			remove:      false,
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}}},
+			subjects:    []rbacv1.Subject{{Name: "two", Kind: "User"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}, {Kind: "User", Name: "two"}},
+			},
+			remove: false,
 		},
 		"add-user-to-existing-with-overlap": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"one"}},
-			subjects:    []corev1.ObjectReference{{Name: "one", Kind: "User"}, {Name: "two", Kind: "User"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"one", "two"}},
-			remove:      false,
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}}},
+			subjects:    []rbacv1.Subject{{Name: "one", Kind: "User"}, {Name: "two", Kind: "User"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}, {Kind: "User", Name: "two"}},
+			},
+			remove: false,
 		},
-
 		"add-sa-to-empty": {
-			startingSCC: &securityv1.SecurityContextConstraints{},
-			subjects:    []corev1.ObjectReference{{Namespace: "a", Name: "one", Kind: "ServiceAccount"}, {Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
-			remove:      false,
+			startingCRB: &rbacv1.ClusterRoleBinding{},
+			subjects:    []rbacv1.Subject{{Namespace: "a", Name: "one", Kind: "ServiceAccount"}, {Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "a", Name: "one"}, {Kind: "ServiceAccount", Namespace: "b", Name: "two"}},
+			},
+			remove: false,
 		},
 		"add-sa-to-existing": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"one"}},
-			subjects:    []corev1.ObjectReference{{Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"one", "system:serviceaccount:b:two"}},
-			remove:      false,
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}}},
+			subjects:    []rbacv1.Subject{{Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}, {Kind: "ServiceAccount", Namespace: "b", Name: "two"}},
+			},
+			remove: false,
 		},
 		"add-sa-to-existing-with-overlap": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one"}},
-			subjects:    []corev1.ObjectReference{{Namespace: "a", Name: "one", Kind: "ServiceAccount"}, {Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
-			remove:      false,
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "a", Name: "one"}}},
+			subjects:    []rbacv1.Subject{{Namespace: "a", Name: "one", Kind: "ServiceAccount"}, {Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "a", Name: "one"}, {Kind: "ServiceAccount", Namespace: "b", Name: "two"}},
+			},
+			remove: false,
 		},
 
 		"add-group-to-empty": {
-			startingSCC: &securityv1.SecurityContextConstraints{},
-			subjects:    []corev1.ObjectReference{{Name: "one", Kind: "Group"}, {Name: "two", Kind: "Group"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			startingCRB: &rbacv1.ClusterRoleBinding{},
+			subjects:    []rbacv1.Subject{{Name: "one", Kind: "Group"}, {Name: "two", Kind: "Group"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}, {Kind: "Group", Name: "two"}}},
 			remove:      false,
 		},
 		"add-group-to-existing": {
-			startingSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one"}},
-			subjects:    []corev1.ObjectReference{{Name: "two", Kind: "Group"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}}},
+			subjects:    []rbacv1.Subject{{Name: "two", Kind: "Group"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}, {Kind: "Group", Name: "two"}}},
 			remove:      false,
 		},
 		"add-group-to-existing-with-overlap": {
-			startingSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one"}},
-			subjects:    []corev1.ObjectReference{{Name: "one", Kind: "Group"}, {Name: "two", Kind: "Group"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one", "two"}},
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}}},
+			subjects:    []rbacv1.Subject{{Name: "one", Kind: "Group"}, {Name: "two", Kind: "Group"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}, {Kind: "Group", Name: "two"}}},
 			remove:      false,
 		},
 
 		"remove-user": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"one", "two"}},
-			subjects:    []corev1.ObjectReference{{Name: "one", Kind: "User"}, {Name: "two", Kind: "User"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{},
+			startingCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}, {Kind: "User", Name: "two"}},
+			},
+			subjects:    []rbacv1.Subject{{Name: "one", Kind: "User"}, {Name: "two", Kind: "User"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{},
 			remove:      true,
 		},
 		"remove-user-from-existing-with-overlap": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"one", "two"}},
-			subjects:    []corev1.ObjectReference{{Name: "two", Kind: "User"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"one"}},
+			startingCRB: &rbacv1.ClusterRoleBinding{
+				Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}, {Kind: "User", Name: "two"}},
+			},
+			subjects:    []rbacv1.Subject{{Name: "two", Kind: "User"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "User", Name: "one"}}},
 			remove:      true,
 		},
 
 		"remove-sa": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
-			subjects:    []corev1.ObjectReference{{Namespace: "a", Name: "one", Kind: "ServiceAccount"}, {Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{},
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "a", Name: "one"}, {Kind: "ServiceAccount", Namespace: "b", Name: "two"}}},
+			subjects:    []rbacv1.Subject{{Namespace: "a", Name: "one", Kind: "ServiceAccount"}, {Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{},
 			remove:      true,
 		},
 		"remove-sa-from-existing-with-overlap": {
-			startingSCC: &securityv1.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one", "system:serviceaccount:b:two"}},
-			subjects:    []corev1.ObjectReference{{Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Users: []string{"system:serviceaccount:a:one"}},
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "a", Name: "one"}, {Kind: "ServiceAccount", Namespace: "b", Name: "two"}}},
+			subjects:    []rbacv1.Subject{{Namespace: "b", Name: "two", Kind: "ServiceAccount"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Namespace: "a", Name: "one"}}},
 			remove:      true,
 		},
 
 		"remove-group": {
-			startingSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one", "two"}},
-			subjects:    []corev1.ObjectReference{{Name: "one", Kind: "Group"}, {Name: "two", Kind: "Group"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{},
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}, {Kind: "Group", Name: "two"}}},
+			subjects:    []rbacv1.Subject{{Name: "one", Kind: "Group"}, {Name: "two", Kind: "Group"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{},
 			remove:      true,
 		},
 		"remove-group-from-existing-with-overlap": {
-			startingSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one", "two"}},
-			subjects:    []corev1.ObjectReference{{Name: "two", Kind: "Group"}},
-			expectedSCC: &securityv1.SecurityContextConstraints{Groups: []string{"one"}},
+			startingCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}, {Kind: "Group", Name: "two"}}},
+			subjects:    []rbacv1.Subject{{Name: "two", Kind: "Group"}},
+			expectedCRB: &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{{Kind: "Group", Name: "one"}}},
 			remove:      true,
 		},
 	}
 
 	for tcName, tc := range tests {
-		fakeClient := fakesecurityv1client.FakeSecurityV1{Fake: &(fakesecurityclient.NewSimpleClientset().Fake)}
-		fakeClient.Fake.PrependReactor("get", "securitycontextconstraints", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-			return true, tc.startingSCC, nil
+		fakeRbacClient := fakerbacv1.FakeRbacV1{Fake: &(fakekubeclient.NewSimpleClientset().Fake)}
+		fakeClient := fakerbacv1client.FakeClusterRoleBindings{Fake: &fakeRbacClient}
+
+		sccName := "foo"
+		roleRef := rbacv1.RoleRef{Kind: "ClusterRole", Name: fmt.Sprintf(RBACNamesFmt, sccName)}
+		tc.expectedCRB.RoleRef = roleRef
+		tc.startingCRB.RoleRef = roleRef
+
+		fakeClient.Fake.PrependReactor("get", "clusterrolebindings", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, tc.startingCRB, nil
 		})
-		var actualSCC *securityv1.SecurityContextConstraints
-		fakeClient.Fake.PrependReactor("update", "securitycontextconstraints", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-			actualSCC = action.(clientgotesting.UpdateAction).GetObject().(*securityv1.SecurityContextConstraints)
-			return true, actualSCC, nil
+		var actualCRB *rbacv1.ClusterRoleBinding
+		fakeClient.Fake.PrependReactor("update", "clusterrolebindings", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+			actualCRB = action.(clientgotesting.UpdateAction).GetObject().(*rbacv1.ClusterRoleBinding)
+			return true, actualCRB, nil
+		})
+		fakeClient.Fake.PrependReactor("delete", "clusterrolebindings", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+			actualCRB = &rbacv1.ClusterRoleBinding{Subjects: []rbacv1.Subject{}}
+			return true, actualCRB, nil
 		})
 
 		o := &SCCModificationOptions{
 			PrintFlags: genericclioptions.NewPrintFlags(""),
 			ToPrinter:  func(string) (printers.ResourcePrinter, error) { return printers.NewDiscardingPrinter(), nil },
 
-			SCCName:                 "foo",
-			SCCInterface:            fakeClient.SecurityContextConstraints(),
+			SCCName:                 sccName,
+			RbacClient:              &fakeRbacClient,
 			DefaultSubjectNamespace: "",
 			Subjects:                tc.subjects,
 
@@ -151,10 +178,16 @@ func TestModifySCC(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: unexpected err %v", tcName, err)
 		}
-		if e, a := tc.expectedSCC.Users, actualSCC.Users; !reflect.DeepEqual(e, a) {
-			t.Errorf("%s: expected %v, actual %v", tcName, e, a)
+
+		shouldUpdate := !reflect.DeepEqual(tc.expectedCRB.Subjects, tc.startingCRB.Subjects)
+		if shouldUpdate && actualCRB == nil {
+			t.Errorf("'%s': clusterrolebinding should have been updated", tcName)
+			continue
 		}
-		if e, a := tc.expectedSCC.Groups, actualSCC.Groups; !reflect.DeepEqual(e, a) {
+		if e, a := tc.expectedCRB.Subjects, actualCRB.Subjects; !reflect.DeepEqual(e, a) {
+			if len(e) == 0 && len(a) == 0 {
+				continue
+			}
 			t.Errorf("%s: expected %v, actual %v", tcName, e, a)
 		}
 	}

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2195,6 +2195,118 @@ items:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
+    name: system:openshift:scc:anyuid
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - anyuid
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:hostaccess
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - hostaccess
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:hostmount
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - hostmount
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:hostnetwork
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - hostnetwork
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:nonroot
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - nonroot
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:privileged
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - privileged
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:restricted
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - restricted
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
     name: system:openshift:controller:build-controller
   rules:
   - apiGroups:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -2195,6 +2195,118 @@ items:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
+    name: system:openshift:scc:anyuid
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - anyuid
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:hostaccess
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - hostaccess
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:hostmount
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - hostmount
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:hostnetwork
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - hostnetwork
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:nonroot
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - nonroot
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:privileged
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - privileged
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    name: system:openshift:scc:restricted
+  rules:
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - restricted
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
     name: system:openshift:controller:build-controller
   rules:
   - apiGroups:


### PR DESCRIPTION
Hotwires the insides of the add/remove admin commands to
use RBAC instead of the fields in SCC policies. This is
done by adding a set of new RBAC clusterroles and respective
bindings.

The change needs to be done as SCCs are now part of the KAS-o
manifests so any change to them would be stomped on.

cc @openshift/sig-auth