### PR TITLE
openshift-sdn: exit with 0 when gracefully shut down

### DIFF
--- a/pkg/cmd/openshift-sdn/cmd.go
+++ b/pkg/cmd/openshift-sdn/cmd.go
@@ -116,7 +116,6 @@ func (sdn *OpenShiftSDN) Run(c *cobra.Command, errout io.Writer, stopCh chan str
 
 	<-stopCh
 	time.Sleep(500 * time.Millisecond) // gracefully shut down
-	os.Exit(1)
 }
 
 // ValidateAndParse validates the command line options, parses the node


### PR DESCRIPTION
There's no need for this to return an error, and it annoys the upgrade tests.