### PR TITLE
Bug 1705686: Work around a kernel bug in the assign-macvlan code

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -193,7 +193,13 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 			// add a route to that via the SDN
 			var addrs []netlink.Addr
 			err = hostNS.Do(func(ns.NetNS) error {
-				parent, err := netlink.LinkByIndex(link.Attrs().ParentIndex)
+				// workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1705686
+				parentIndex := link.Attrs().ParentIndex
+				if parentIndex == 0 {
+					parentIndex = link.Attrs().Index
+				}
+
+				parent, err := netlink.LinkByIndex(parentIndex)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
As seen in https://bugzilla.redhat.com/show_bug.cgi?id=1705686, there's a bug in the kernel where if you create a macvlan directly into a different namespace from its parent, and it ends up getting the same ifindex in that namespace as its parent has in its namespace, then if you ask about the macvlan's attributes via netlink later, the kernel won't report the parent link ifindex, so our golang netlink code leaves the field 0-initialized, and since we don't actually check that the field got set (because it's a macvlan, it *has to* have a parent) we end up using the "0" later and asking for information about a non-existent interface and getting back `EINVAL`.

There should eventually be a kernel fix, but this works around the problem on our side by assuming that if netlink reports that the macvlan has a `ParentIndex` of `0`, then that means we hit this bug and so the `ParentIndex` is actually the same as the `Index`. I'm pretty sure there shouldn't be any other case where `ParentIndex` was 0, and even if there was, the effect of this patch would be either (a) `Index` is not a valid ifindex in the root netnamespace, so we still get an error (maybe `ENOENT` instead of `EINVAL`), or (b) `Index` is valid in the root netnamespace, but it's the wrong interface, in which case we'd end up adding a route to the wrong IP address (and not adding a route to the parent interface IP address), which is not great, but is at least better than failing the pod creation entirely.

(Does not need to make it into 4.1.0 but we do want to get it merged and tested soonish so we can backport it to 3.11.)