### PR TITLE
Allow oc adm upgrade with --force even if versions match

### DIFF
--- a/pkg/oc/cli/admin/upgrade/upgrade.go
+++ b/pkg/oc/cli/admin/upgrade/upgrade.go
@@ -206,7 +206,7 @@ func (o *Options) Run() error {
 			}
 		}
 		if len(o.ToImage) > 0 {
-			if o.ToImage == cv.Status.Desired.Image {
+			if o.ToImage == cv.Status.Desired.Image && !o.Force {
 				fmt.Fprintf(o.Out, "info: Cluster is already using release image %s\n", o.ToImage)
 				return nil
 			}


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1706245

If you try to upgrade to an image which fails (ex: `the image may not be safe to use`), and re-attempt with `--force` it should allow you to proceed. Other workarounds include cancelling the first attempt with `oc adm upgrade --clear` and trying again with `--force`