### PR TITLE
sdn: install nftables in SDN image

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -23,7 +23,7 @@ RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute bridge-utils procps-ng openssl \
-      binutils xz sysvinit-tools dbus \
+      binutils xz sysvinit-tools dbus nftables \
       " && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \


### PR DESCRIPTION
Makes it easier to debug any issues that iptables/iptables-nft might
have. Yes we can run iptables-save but we can get the raw info by
rsh-ing into the SDN pod and running nftables too.

@squeed @danwinship @JacobTanenbaum @knobunc @pecameron @rcarrillocruz 