### PR TITLE
The new release command incorrectly detected user metadata

### DIFF
--- a/pkg/oc/cli/admin/release/new.go
+++ b/pkg/oc/cli/admin/release/new.go
@@ -351,10 +351,10 @@ func (o *NewOptions) Run() error {
 		}
 	}
 
-	hasMetadataOverrides := len(o.Name) > 0 &&
-		len(o.ReleaseMetadata) > 0 &&
-		len(o.PreviousVersions) > 0 &&
-		len(o.ToImageBase) > 0 &&
+	hasMetadataOverrides := len(o.Name) > 0 ||
+		len(o.ReleaseMetadata) > 0 ||
+		len(o.PreviousVersions) > 0 ||
+		len(o.ToImageBase) > 0 ||
 		len(o.ExtraComponentVersions) > 0
 
 	exclude := sets.NewString()


### PR DESCRIPTION
We have overrides if any field is set, not all fields are set.

Prevents building a release from an existing nightly correctly.