### PR TITLE
Revert "e2e must-gather disable check for file sizes"

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -70,7 +70,7 @@ var _ = g.Describe("[cli] oc adm must-gather", func() {
 			}
 		}
 		if len(emptyFiles) > 0 {
-			fmt.Printf("expected files should not be empty: \n%s", strings.Join(emptyFiles, "\n"))
+			o.Expect(fmt.Errorf("expected files should not be empty: %s", strings.Join(emptyFiles, ","))).NotTo(o.HaveOccurred())
 		}
 
 	})


### PR DESCRIPTION
This reverts commit 6abc26cf63bab324a9719e4cca0637563d9b1138.