### PR TITLE
test/extented/prometheus: Relax alert firing smoke test

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -207,7 +207,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			tests := map[string][]metricTest{
 				// should be checking there is no more than 1 alerts firing.
 				// Checking for specific alert is done in "should have a Watchdog alert in firing state".
-				`sum(ALERTS{alertstate=~"firing|pending"})`: {metricTest{greaterThanEqual: false, value: 2}},
+				`sum(ALERTS{alertstate="firing"})`: {metricTest{greaterThanEqual: false, value: 2}},
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})


### PR DESCRIPTION
Pending alerts are not necessarily worth a test failure, firing alerts definitely are, but pending alerts can happen due to various reasons and are too flaky to fail on, in some cases it's even expected to see pending alerts from time to time. The fact that they may not be firing would validate that the `for` value has been chosen appropriately.

@mxinden @paulfantom @squat @s-urbaniak @metalmatze