### PR TITLE
Only accept buildah 1.7.3+ unused build arg error

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -350,7 +350,7 @@ var _ = g.Describe("[Feature:Builds][Slow] starting a build using CLI", func() {
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By("verifying the build completed with a warning.")
-					o.Expect(buildLog).To(o.Or(o.ContainSubstring("One or more build-args [bar] were not consumed"), o.ContainSubstring("one or more build args were not consumed: [bar]")))
+					o.Expect(buildLog).To(o.ContainSubstring("one or more build args were not consumed: [bar]"))
 				})
 			})
 


### PR DESCRIPTION
Buildah 1.7.3 changed how it warns about unused build args, changing a "[Warning] One or more build-args %v were not consumed\n" format string into "[Warning] one or more build args were not consumed: %v\n".  Accept only the new version of the message.

This is a follow-up to https://github.com/openshift/origin/pull/22641#issuecomment-485941286.