### PR TITLE
Don't use the %s formatting directive for ldap.Entry type

### DIFF
--- a/pkg/oc/lib/groupsync/rfc2307/ldapinterface.go
+++ b/pkg/oc/lib/groupsync/rfc2307/ldapinterface.go
@@ -142,7 +142,7 @@ func (e *LDAPInterface) ListGroups() ([]string, error) {
 	for _, group := range groups {
 		ldapGroupUID := ldaputil.GetAttributeValue(group, []string{e.groupQuery.QueryAttribute})
 		if len(ldapGroupUID) == 0 {
-			return nil, fmt.Errorf("unable to find LDAP group UID for %s", group)
+			return nil, fmt.Errorf("unable to find LDAP group UID for %s", group.DN)
 		}
 		e.cachedGroups[ldapGroupUID] = group
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)

--- a/pkg/oc/lib/groupsync/rfc2307/ldapinterface_test.go
+++ b/pkg/oc/lib/groupsync/rfc2307/ldapinterface_test.go
@@ -263,7 +263,7 @@ func TestListGroups(t *testing.T) {
 				},
 			),
 			groupUIDAttribute: "cn",
-			expectedError:     fmt.Errorf("unable to find LDAP group UID for %s", newTestGroup("", "cn=testUser,ou=users,dc=example,dc=com")),
+			expectedError:     fmt.Errorf("unable to find LDAP group UID for %s", newTestGroup("", "cn=testUser,ou=users,dc=example,dc=com").DN),
 			expectedGroups:    nil,
 		},
 		{


### PR DESCRIPTION
Go 1.12's govet throws an error for the %s formatting directive used in these two places to format the ldap.Entry structure, this fixes it by instead using the distinguished name property of the group rather than the group struct itself.

Output of govet step of `make check` on go 1.12.1:


```
# github.com/openshift/origin/pkg/oc/lib/groupsync/rfc2307
pkg/oc/lib/groupsync/rfc2307/ldapinterface.go:145:16: Errorf format %s has arg group of wrong type *github.com/openshift/origin/vendor/gopkg.in/ldap.v2.Entry
pkg/oc/lib/groupsync/rfc2307/ldapinterface_test.go:266:23: Errorf format %s has arg newTestGroup("", "cn=testUser,ou=users,dc=example,dc=com") of wrong type *github.com/openshift/origin/vendor/gopkg.in/ldap.v2.Entry
# github.com/openshift/origin/test/extended/cluster/metrics
test/extended/cluster/metrics/metrics.go:41:3: struct field TestDuration repeats json tag "testDuration" also at metrics.go:28
[FATAL] FAILURE: go vet failed!
[ERROR] hack/verify-govet.sh exited with code 1 after 00h 16m 17s

```