### PR TITLE
Bug 1708280: UPSTREAM: 77681: Fix handling empty result when invoking kubectl get

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/get/get.go
@@ -759,7 +759,8 @@ func (o *GetOptions) printGeneric(r *resource.Result) error {
 		errs = append(errs, err)
 	}
 
-	if len(infos) == 0 && o.IgnoreNotFound {
+	if len(infos) == 0 {
+		fmt.Fprintln(o.ErrOut, "No resources found.")
 		return utilerrors.Reduce(utilerrors.Flatten(utilerrors.NewAggregate(errs)))
 	}
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1708280

/hold 
until we get approval upstream