### PR TITLE
log more failures during e2e

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -117,6 +117,7 @@ func newRunCommand() *cobra.Command {
 					return err
 				}
 				e2e.AfterReadingAllFlags(exutil.TestContext)
+				e2e.TestContext.DumpLogsOnFailure = true
 				exutil.TestContext.DumpLogsOnFailure = true
 				return opt.Run(args)
 			})
@@ -179,6 +180,7 @@ func newRunUpgradeCommand() *cobra.Command {
 					return err
 				}
 				e2e.AfterReadingAllFlags(exutil.TestContext)
+				e2e.TestContext.DumpLogsOnFailure = true
 				exutil.TestContext.DumpLogsOnFailure = true
 				return opt.Run(args)
 			})
@@ -215,6 +217,7 @@ func newRunTestCommand() *cobra.Command {
 				return err
 			}
 			e2e.AfterReadingAllFlags(exutil.TestContext)
+			e2e.TestContext.DumpLogsOnFailure = true
 			exutil.TestContext.DumpLogsOnFailure = true
 			return testOpt.Run(args)
 		},

--- a/vendor/k8s.io/kubernetes/test/e2e/upgrades/apps/job.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/upgrades/apps/job.go
@@ -55,6 +55,11 @@ func (t *JobUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgr
 	By("Ensuring active pods == parallelism")
 	running, err := framework.CheckForAllJobPodsRunning(f.ClientSet, t.namespace, t.job.Name, 2)
 	Expect(err).NotTo(HaveOccurred())
+
+	if !running {
+		framework.DumpAllNamespaceInfo(f.ClientSet, t.namespace)
+	}
+
 	Expect(running).To(BeTrue())
 }
 

--- a/vendor/k8s.io/kubernetes/test/e2e/upgrades/apps/replicasets.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/upgrades/apps/replicasets.go
@@ -82,7 +82,13 @@ func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	}
 
 	By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after upgrade", rsName))
-	framework.ExpectNoError(framework.WaitForReadyReplicaSet(c, ns, rsName))
+
+	err = framework.WaitForReadyReplicaSet(c, ns, rsName)
+	if err != nil {
+		framework.DumpAllNamespaceInfo(f.ClientSet, ns)
+	}
+
+	framework.ExpectNoError(err)
 
 	// Verify the upgraded RS is active by scaling up the RS to scaleNum and ensuring all pods are Ready
 	By(fmt.Sprintf("Scaling up replicaset %s to %d", rsName, scaleNum))


### PR DESCRIPTION
Try to gather logs for https://bugzilla.redhat.com/show_bug.cgi?id=1706082 again.

This does two things:
 1. hard code dumping logs where we're failing in upgrades
 2. attempt to set the *other* global test context to dump them