### PR TITLE
Revert "Disable resource quota"

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -414,9 +414,6 @@ var (
 			`CSI Volumes CSI attach test using HostPath driver`,
 			`CSI Volumes CSI plugin test using CSI driver: hostPath`,
 			`Volume metrics should create volume metrics in Volume Manager`,
-			// TODO: Enable the following tests once resource quota is enabled in
-			`\[Feature:ScopeSelectors\]`, // @ravig - sig-pod
-			`\[Feature:PodPriority\]`,    // @ravig - sig-pod
 		},
 		// tests too slow to be part of conformance
 		"[Slow]": {


### PR DESCRIPTION
Since we have not disabled resource quota in featuregates, there is no point in not having these tests now.

/cc @sjenning @deads2k 