### PR TITLE
Bug 1699285: Add warning when unrecognized resource is found

### DIFF
--- a/pkg/oc/cli/policy/cani/cani.go
+++ b/pkg/oc/cli/policy/cani/cani.go
@@ -116,7 +116,7 @@ func (o *CanIOptions) Complete(cmd *cobra.Command, f kcmdutil.Factory, args []st
 			return err
 		}
 		o.Verb = args[0]
-		o.Resource = policy.ResourceFor(restMapper, args[1])
+		o.Resource = policy.ResourceFor(restMapper, args[1], o.ErrOut)
 	default:
 		if !o.ListAll {
 			return errors.New("you must specify two or three arguments: verb, resource, and optional resourceName")


### PR DESCRIPTION
I took the same approach as upstream here: https://github.com/kubernetes/kubernetes/blob/bf79c7c7eedf2e79a721259cf0cbf519cdea623c/pkg/kubectl/cmd/auth/cani.go#L294-L301
although I wonder if we shouldn't either error out.
/assign @enj @sallyom 