### PR TITLE
Bug 1708648: pkg/oc/cli/admin/release/new: Guard against inconsistent sources

### DIFF
--- a/contrib/completions/bash/oc
+++ b/contrib/completions/bash/oc
@@ -4401,6 +4401,8 @@ _oc_adm_release_new()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--allow-inconsistent-sources")
+    local_nonpersistent_flags+=("--allow-inconsistent-sources")
     flags+=("--allow-missing-images")
     local_nonpersistent_flags+=("--allow-missing-images")
     flags+=("--component-versions=")

--- a/contrib/completions/zsh/oc
+++ b/contrib/completions/zsh/oc
@@ -4543,6 +4543,8 @@ _oc_adm_release_new()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--allow-inconsistent-sources")
+    local_nonpersistent_flags+=("--allow-inconsistent-sources")
     flags+=("--allow-missing-images")
     local_nonpersistent_flags+=("--allow-missing-images")
     flags+=("--component-versions=")


### PR DESCRIPTION
Sometimes folks attempt to build release images with images built from different commits from the same Git repository.  This can [sometimes break the release][1] and is almost always a bad idea.  This commit fails fast in this situation, because it's harder to root-cause this if we fail later on.  I'd be ok with a flag to allow divergence for callers who feel like they know what they're doing, ~but have not added it in this commit~ [edit: [now I have][2]].  And of course, the real fix is to not do this ;), although I don't think that means this oc code shouldn't guard against it.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1708648
[2]: https://github.com/openshift/origin/pull/22816#issuecomment-491416044