### PR TITLE
Bug 1707162: Block access to MCS

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -219,6 +219,29 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 			},
 		)
 	}
+
+	// HACK: block access to MCS until we can secure it properly. Note that we share
+	// the same chain between OUTPUT and FORWARD.
+	chainArray = append(chainArray,
+		Chain{
+			table:    "filter",
+			name:     "OPENSHIFT-BLOCK-OUTPUT",
+			srcChain: "OUTPUT",
+			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
+			rules: [][]string{
+				{"-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
+				{"-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+			},
+		},
+		Chain{
+			table:    "filter",
+			name:     "OPENSHIFT-BLOCK-OUTPUT",
+			srcChain: "FORWARD",
+			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
+			rules:    nil,
+		},
+	)
+
 	return chainArray
 }
 


### PR DESCRIPTION
In conjunction with the MCS/approver changes happening elsewhere, this attempts to block all (non-privileged / non-`CAP_NET_ADMIN`) pods from being able to reach the MCS.

There are two commits, and both are hacks which are assumed to be temporary; if we want to keep something like this, we can reimplement the functionality more cleanly later.

The `OUTPUT` rule in the pod netns blocks direct connections from a pod to the MCS (including via egress IP, or via multus-created interfaces). The `FORWARD` rule in the pod netns blocks connections from a pod to the MCS via an egress-router. The `OUTPUT` rule in the root netns blocks direct connections from hostNetwork pods to the MCS. (I'm not sure that the `FORWARD` rule in the root netns actually does anything at this point... but it's not hurting.)

The `RestrictedEndpointsAdmission` part blocks attempts to create Services pointing to the MCS. (The `EndpointController` bypasses the `RestrictedEndpointsAdmission` controller, but it should not be possible for anyone who isn't already a cluster admin to create a hostNetwork pod on a master, or create a Service in a Namespace that already has a hostNetwork pod on a master, so they should not be able to create a Service pointing to the MCS without explicitly setting the Endpoints.) Without this part, someone could create a Service of type `LoadBalancer` pointing to the MCS, and that would bypass all of the iptables rules.

I originally started trying to make the restricted pods in `RestrictedEndpointsAdmission` be configurable, but it was a lot of work for something that's really just an ugly hack anyway. (And if it was going to be an exposed feature, we'd want it to work differently)