### PR TITLE
Restrict access to EC2 metadata

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -160,6 +160,9 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 		otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:90", clusterCIDR)
 	}
 
+	// Link-local traffic
+	otx.AddFlow("table=30, priority=75, ip, nw_dst=169.254.0.0/16, actions=drop")
+
 	// Multicast coming from the VXLAN
 	otx.AddFlow("table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120")
 	// Multicast coming from local pods


### PR DESCRIPTION
Block access to the EC2 metadata service from (non-hostNetwork) pods.

The EC2 metadata IP is actually in the IPv4 link-local address range, so technically it's incorrect for us to be forwarding packets addressed to that IP range out of the SDN anyway. So in addition to the iptables rules, this also adjusts the OVS flows to drop all packets destined for that range. (The iptables rules are still needed to block output via egress-router and multus interfaces.)

So, there are three parts:
- iptables rules to block access just to 169.254.169.254, for security
- OVS flows to block access to all of 169.254.0.0/16, for correctness
- RestrictedEndpointsAdmission changes to block creating services pointing to all of 169.254.0.0/16, for security and correctness