### PR TITLE
Fix invocation of log function on local-up

### DIFF
--- a/hack/local-up-master/lib.sh
+++ b/hack/local-up-master/lib.sh
@@ -95,7 +95,7 @@ function localup::healthcheck() {
 }
 
 function localup::warning_log() {
-  os::log::info/warning/error/fatal "$1" "W$(date "+%m%d %H:%M:%S")]" 1
+  os::log::warning "$1" "W$(date "+%m%d %H:%M:%S")]" 1
 }
 
 


### PR DESCRIPTION
Running master.sh script dies as soon as something needs to be logged,
since the name of the function doesn't exist.
The warning function should be called instead.