### PR TITLE
Sort the release changelog by newest pull request first

### DIFF
--- a/pkg/oc/cli/admin/release/git.go
+++ b/pkg/oc/cli/admin/release/git.go
@@ -157,7 +157,7 @@ func mergeLogForRepo(g *git, repo string, from, to string) ([]MergeCommit, error
 		return nil, err
 	}
 
-	args := []string{"log", "--merges", "--topo-order", "-z", "--pretty=format:%H %P%x1E%ct%x1E%s%x1E%b", "--reverse", fmt.Sprintf("%s..%s", from, to)}
+	args := []string{"log", "--merges", "--topo-order", "-z", "--pretty=format:%H %P%x1E%ct%x1E%s%x1E%b", fmt.Sprintf("%s..%s", from, to)}
 	out, err := g.exec(args...)
 	if err != nil {
 		// retry once if there's a chance we haven't fetched the latest commits


### PR DESCRIPTION
It's a more natural ordering and is less confusing when comparing
repos.