### PR TITLE
disable registry v1 client test

### DIFF
--- a/test/integration/dockerregistryclient_test.go
+++ b/test/integration/dockerregistryclient_test.go
@@ -242,7 +242,7 @@ func TestRegistryClientAPIv2ManifestV2Schema1(t *testing.T) {
 	doTestRegistryClientImage(t, dockerHubV2RegistryName, "schema-v1-test-repo", "v2")
 }
 
-func TestRegistryClientAPIv1(t *testing.T) {
+func DISABLEDTestRegistryClientAPIv1(t *testing.T) {
 	t.Log("openshift/schema-v1-test-repo was pushed by Docker 1.8.2")
 	doTestRegistryClientImage(t, dockerHubV1RegistryName, "schema-v1-test-repo", "v1")
 }


### PR DESCRIPTION
```
=== RUN   TestIntegration/TestRegistryClientAPIv1
=== PAUSE TestIntegration/TestRegistryClientAPIv1
=== CONT  TestIntegration/TestRegistryClientAPIv1
    --- FAIL: TestIntegration/TestRegistryClientAPIv1 (1.98s)
        runner_test.go:129: FAILED TestRegistryClientAPIv1, retrying:
            
                dockerregistryclient_test.go:246: openshift/schema-v1-test-repo was pushed by Docker 1.8.2
                dockerregistryclient_test.go:207: error retrieving tag: server returned 503
            
            === OUTPUT
            
            I0515 17:28:23.233141   26920 client.go:493] Getting repository openshift/origin-not-found from https://registry.hub.docker.com
            I0515 17:28:23.440353   26920 client.go:493] Getting repository openshift/schema-v1-test-repo from https://registry.hub.docker.com
        runner_test.go:125: 
                dockerregistryclient_test.go:246: openshift/schema-v1-test-repo was pushed by Docker 1.8.2
                dockerregistryclient_test.go:207: error retrieving tag: server returned 503
            
            === OUTPUT
            
            I0515 17:28:24.110706   27031 client.go:493] Getting repository openshift/origin-not-found from https://registry.hub.docker.com
            I0515 17:28:24.463195   27031 client.go:493] Getting repository openshift/schema-v1-test-repo from https://registry.hub.docker.com
```
