### PR TITLE
Improve Cluster Loader VIPERCONFIG handling and template file locating

### DIFF
--- a/test/extended/cluster/context.go
+++ b/test/extended/cluster/context.go
@@ -99,13 +99,13 @@ type ServiceInfo struct {
 // ParseConfig will complete flag parsing as well as viper tasks
 func ParseConfig(config string, isFixture bool) error {
 	// This must be done after common flags are registered, since Viper is a flag option.
-	if isFixture {
+	if filepath.IsAbs(config) || isFixture {
 		dir, file := filepath.Split(config)
 		s := strings.Split(file, ".")
 		viper.SetConfigName(s[0])
 		viper.AddConfigPath(dir)
 	} else {
-		viper.SetConfigName(config)
+		viper.SetConfigName(cleanConfigName(config))
 		viper.AddConfigPath(".")
 	}
 	err := viper.ReadInConfig()
@@ -114,4 +114,13 @@ func ParseConfig(config string, isFixture bool) error {
 	}
 	viper.Unmarshal(&ConfigContext)
 	return nil
+}
+
+func cleanConfigName(filename string) string {
+	extension := filepath.Ext(filename)
+	if extension != "" {
+		return strings.TrimSuffix(filename, extension)
+	}
+
+	return filename
 }

--- a/test/extended/cluster/utils.go
+++ b/test/extended/cluster/utils.go
@@ -438,9 +438,12 @@ func newConfigMap(ns string, name string, vars map[string]string) *kapiv1.Config
 }
 
 // CreateTemplates creates templates in user defined namespaces with user configurable tuning sets.
-func CreateTemplates(oc *exutil.CLI, c kclientset.Interface, nsName string, template ClusterLoaderObjectType, tuning *TuningSetType) error {
+func CreateTemplates(oc *exutil.CLI, c kclientset.Interface, nsName, config string, template ClusterLoaderObjectType, tuning *TuningSetType) error {
 	var allArgs []string
-	templateFile := mkPath(template.File)
+	templateFile, err := mkPath(template.File, config)
+	if err != nil {
+		return err
+	}
 	e2e.Logf("We're loading file %v: ", templateFile)
 	allArgs = append(allArgs, "-f")
 	allArgs = append(allArgs, templateFile)


### PR DESCRIPTION
The specific goals of this PR include:
- Enable user to specify `VIPERCONFIG` that is an absolute path
- Enable user to specify `VIPERCONFIG` file extension
- Improve robustness of the pod/template file location specified in the config