### PR TITLE
Bug 1710973: reduce minimum size of expected files in must-gather tests

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -65,7 +65,7 @@ var _ = g.Describe("[cli] oc adm must-gather", func() {
 			o.Expect(expectedFilePath).To(o.BeAnExistingFile())
 			stat, err := os.Stat(expectedFilePath)
 			o.Expect(err).ToNot(o.HaveOccurred())
-			if size := stat.Size(); size < 100 {
+			if size := stat.Size(); size < 50 {
 				emptyFiles = append(emptyFiles, expectedFilePath)
 			}
 		}


### PR DESCRIPTION
The "oc adm must-gather" test in the e2e-vsphere suite is failing because the `audit_logs/openshift-apiserver.audit_logs_listing` file is only 78 bytes while the test is expecting the size to be at least 100 bytes. This commit changes the minimum required size to 50 bytes.

https://bugzilla.redhat.com/show_bug.cgi?id=1710973

/cc @sanchezl 