### PR TITLE
images: use cli:4.2 as a base for all images

### DIFF
--- a/images/cli-artifacts/Dockerfile.rhel
+++ b/images/cli-artifacts/Dockerfile.rhel
@@ -7,6 +7,6 @@ WORKDIR /go/src/github.com/openshift/origin
 COPY . .
 RUN OS_RELEASE_WITHOUT_LINKS=y OS_BUILD_RELEASE_ARCHIVES=n OS_ONLY_BUILD_PLATFORMS="^(darwin|windows)/amd64$" bash -x hack/build-cross.sh
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:cli
+FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/darwin/amd64/oc /usr/share/openshift/mac/oc
 COPY --from=builder /go/src/github.com/openshift/origin/_output/local/bin/windows/amd64/oc.exe /usr/share/openshift/windows/oc.exe

--- a/images/cli/Dockerfile.rhel
+++ b/images/cli/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=cmd/oc; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/oc /tmp/build/oc
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /tmp/build/oc /usr/bin/
 RUN for i in kubectl openshift-deploy openshift-docker-build openshift-sti-build openshift-git-clone openshift-manage-dockerfile openshift-extract-image-content openshift-recycle; do ln -s /usr/bin/oc /usr/bin/$i; done
 LABEL io.k8s.display-name="OpenShift Client" \

--- a/images/deployer/Dockerfile.rhel
+++ b/images/deployer/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/4.0:cli
+FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 
 LABEL io.k8s.display-name="OpenShift Deployer" \
       io.k8s.description="This is a component of OpenShift and executes the user deployment process to roll out new containers. It may be used as a base image for building your own custom deployer image." \

--- a/images/hyperkube/Dockerfile.rhel
+++ b/images/hyperkube/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=vendor/k8s.io/kubernetes/cmd/hyperkube; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/hyperkube /tmp/build/hyperkube
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /tmp/build/hyperkube /usr/bin/
 LABEL io.k8s.display-name="OpenShift Kubernetes Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \

--- a/images/hypershift/Dockerfile.rhel
+++ b/images/hypershift/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=cmd/hypershift; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/hypershift /tmp/build/hypershift
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /tmp/build/hypershift /usr/bin/
 LABEL io.k8s.display-name="OpenShift Server Commands" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \

--- a/images/recycler/Dockerfile.rhel
+++ b/images/recycler/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/4.0:cli
+FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 
 LABEL io.k8s.display-name="OpenShift Volume Recycler" \
       io.k8s.description="This is a component of OpenShift and is used to prepare persistent volumes for reuse after they are deleted." \

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -13,7 +13,7 @@ RUN mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/loopback /tmp/build/loopback; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/host-local /tmp/build/host-local
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /tmp/build/openshift-sdn /usr/bin/
 COPY --from=builder /tmp/build/sdn-cni-plugin /opt/cni/bin/openshift-sdn
 COPY --from=builder /tmp/build/loopback /opt/cni/bin/

--- a/images/template-service-broker/Dockerfile.rhel
+++ b/images/template-service-broker/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=cmd/template-service-broker; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/template-service-broker /tmp/build/template-service-broker
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /tmp/build/template-service-broker /usr/bin/
 LABEL io.k8s.display-name="OpenShift Template Service Broker" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \

--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -5,7 +5,7 @@ RUN make build WHAT=cmd/openshift-tests; \
     mkdir -p /tmp/build; \
     cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/openshift-tests /tmp/build/openshift-tests
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:cli
+FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \


### PR DESCRIPTION
This ensure a newer cli image is used in all images.

Note, that this is in fact ignored on CI and downstream builds (these replace build image during build), but its nice to replace these for consistency. Also it may prevent confusion when doing local builds