### PR TITLE
UPSTREAM: <carry>: Disable excessive success logging in HTTP checking

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/networking_utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/networking_utils.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -824,7 +824,8 @@ func PokeHTTP(host string, port int, path string, params *HTTPPokeParams) HTTPPo
 	}
 
 	ret.Status = HTTPSuccess
-	Logf("Poke(%q): success", url)
+	// causes excessive logging that provides no value
+	// Logf("Poke(%q): success", url)
 	return ret
 }
 


### PR DESCRIPTION
The e2e tests that use this method don't need to report success, only failure.
This removes thousands of pointless lines of output from specific e2e tests that
use this framework.

This carry was lost during rebase to 1.14 because the method was refactored.

Example from upgrade tests:

```
May 19 18:13:23.055: INFO: cluster upgrade is failing: Cluster operator network is still updating
May 19 18:13:24.427: INFO: Poke("http://a1c8cff807a5811e99543121d93a203b-926229886.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
May 19 18:13:26.460: INFO: Poke("http://a1c8cff807a5811e99543121d93a203b-926229886.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
May 19 18:13:28.498: INFO: Poke("http://a1c8cff807a5811e99543121d93a203b-926229886.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
May 19 18:13:30.532: INFO: Poke("http://a1c8cff807a5811e99543121d93a203b-926229886.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
May 19 18:13:32.567: INFO: Poke("http://a1c8cff807a5811e99543121d93a203b-926229886.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
```