### PR TITLE
text/extended: Check both IP and Hostname on LB

### DIFF
--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -29,9 +29,9 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.BeforeEach(func() {
 		var err error
-		routerIP, err = waitForRouterServiceIP(oc)
+		routerIP, err = exutil.WaitForRouterServiceIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		metricsIP, err = waitForRouterInternalIP(oc)
+		metricsIP, err = exutil.WaitForRouterInternalIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		if routerIP != metricsIP {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -66,10 +66,10 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			}
 		}
 
-		host, err = waitForRouterInternalIP(oc)
+		host, err = exutil.WaitForRouterInternalIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		serviceIP, err = waitForRouterServiceIP(oc)
+		serviceIP, err = exutil.WaitForRouterServiceIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		bearerToken, err = findMetricsBearerToken(oc)

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -39,7 +39,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.BeforeEach(func() {
 		var err error
-		ip, err = waitForRouterServiceIP(oc)
+		ip, err = exutil.WaitForRouterServiceIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -7,8 +7,6 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -51,7 +49,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.BeforeEach(func() {
 		var err error
-		host, err = waitForRouterServiceIP(oc)
+		host, err = exutil.WaitForRouterServiceIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name
@@ -99,72 +97,3 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		})
 	})
 })
-
-func waitForRouterInternalIP(oc *exutil.CLI) (string, error) {
-	return waitForNamedRouterServiceIP(oc, "router-internal-default")
-}
-
-func waitForRouterExternalIP(oc *exutil.CLI) (string, error) {
-	return waitForNamedRouterServiceIP(oc, "router-default")
-}
-
-func routerShouldHaveExternalService(oc *exutil.CLI) (bool, error) {
-	foundLoadBalancerServiceStrategyType := false
-	err := wait.PollImmediate(2*time.Second, 30*time.Second, func() (bool, error) {
-		ic, err := oc.AdminOperatorClient().OperatorV1().IngressControllers("openshift-ingress-operator").Get("default", metav1.GetOptions{})
-		if kapierrs.IsNotFound(err) {
-			return false, nil
-		}
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if ic.Status.EndpointPublishingStrategy == nil {
-			return false, nil
-		}
-		if ic.Status.EndpointPublishingStrategy.Type == "LoadBalancerService" {
-			foundLoadBalancerServiceStrategyType = true
-		}
-		return true, nil
-	})
-	return foundLoadBalancerServiceStrategyType, err
-}
-
-func waitForRouterServiceIP(oc *exutil.CLI) (string, error) {
-	if useExternal, err := routerShouldHaveExternalService(oc); err != nil {
-		return "", err
-	} else if useExternal {
-		return waitForRouterExternalIP(oc)
-	}
-	return waitForRouterInternalIP(oc)
-}
-
-func waitForNamedRouterServiceIP(oc *exutil.CLI, name string) (string, error) {
-	_, ns, err := exutil.GetRouterPodTemplate(oc)
-	if err != nil {
-		return "", err
-	}
-
-	// wait for the service to show up
-	var endpoint string
-	err = wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
-		svc, err := oc.AdminKubeClient().CoreV1().Services(ns).Get(name, metav1.GetOptions{})
-		if kapierrs.IsNotFound(err) {
-			return false, nil
-		}
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
-			if len(svc.Status.LoadBalancer.Ingress) != 0 {
-				if len(svc.Status.LoadBalancer.Ingress[0].IP) != 0 {
-					endpoint = svc.Status.LoadBalancer.Ingress[0].IP
-					return true, nil
-				}
-				if len(svc.Status.LoadBalancer.Ingress[0].Hostname) != 0 {
-					endpoint = svc.Status.LoadBalancer.Ingress[0].Hostname
-					return true, nil
-				}
-			}
-			return false, nil
-		}
-		endpoint = svc.Spec.ClusterIP
-		return true, nil
-	})
-	return endpoint, err
-}

--- a/test/extended/util/router.go
+++ b/test/extended/util/router.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"time"
+
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func WaitForRouterInternalIP(oc *CLI) (string, error) {
+	return waitForNamedRouterServiceIP(oc, "router-internal-default")
+}
+
+func waitForRouterExternalIP(oc *CLI) (string, error) {
+	return waitForNamedRouterServiceIP(oc, "router-default")
+}
+
+func routerShouldHaveExternalService(oc *CLI) (bool, error) {
+	foundLoadBalancerServiceStrategyType := false
+	err := wait.PollImmediate(2*time.Second, 30*time.Second, func() (bool, error) {
+		ic, err := oc.AdminOperatorClient().OperatorV1().IngressControllers("openshift-ingress-operator").Get("default", metav1.GetOptions{})
+		if kapierrs.IsNotFound(err) {
+			return false, nil
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if ic.Status.EndpointPublishingStrategy == nil {
+			return false, nil
+		}
+		if ic.Status.EndpointPublishingStrategy.Type == "LoadBalancerService" {
+			foundLoadBalancerServiceStrategyType = true
+		}
+		return true, nil
+	})
+	return foundLoadBalancerServiceStrategyType, err
+}
+
+func WaitForRouterServiceIP(oc *CLI) (string, error) {
+	if useExternal, err := routerShouldHaveExternalService(oc); err != nil {
+		return "", err
+	} else if useExternal {
+		return waitForRouterExternalIP(oc)
+	}
+	return WaitForRouterInternalIP(oc)
+}
+
+func waitForNamedRouterServiceIP(oc *CLI, name string) (string, error) {
+	_, ns, err := GetRouterPodTemplate(oc)
+	if err != nil {
+		return "", err
+	}
+
+	// wait for the service to show up
+	var endpoint string
+	err = wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+		svc, err := oc.AdminKubeClient().CoreV1().Services(ns).Get(name, metav1.GetOptions{})
+		if kapierrs.IsNotFound(err) {
+			return false, nil
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			if len(svc.Status.LoadBalancer.Ingress) != 0 {
+				if len(svc.Status.LoadBalancer.Ingress[0].IP) != 0 {
+					endpoint = svc.Status.LoadBalancer.Ingress[0].IP
+					return true, nil
+				}
+				if len(svc.Status.LoadBalancer.Ingress[0].Hostname) != 0 {
+					endpoint = svc.Status.LoadBalancer.Ingress[0].Hostname
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+		endpoint = svc.Spec.ClusterIP
+		return true, nil
+	})
+	return endpoint, err
+}


### PR DESCRIPTION
#### `test/extended`: Move some helpers to `util/router.go`

* `test/extended/router/headers.go`:
* `test/extended/router/metrics.go`:
* `test/extended/router/reencrypt.go`: Use `WaitForRouterServiceIP` and `WaitForRouterInternalIP` from the `exutil` package.
* `test/extended/router/router.go`: Move `waitForRouterInternalIP`, `waitForRouterExternalIP`, `routerShouldHaveExternalService`, `waitForRouterServiceIP`, and `waitForNamedRouterServiceIP` from here...
* `test/extended/util/router.go`: ...to here.  Rename `waitForRouterServiceIP` to `WaitForRouterServiceIP` and `waitForRouterInternalIP` to `WaitForRouterInternalIP`.

#### `text/extended`: Check both `IP` and `Hostname` on LB

Some platforms may set an IP address and not set a host name on LoadBalancer services, so check both fields.

* `test/extended/router/router.go` (`waitForNamedRouterServiceIP`): Check both `IP` and `Hostname`.  Delete check for the service name that was used in v3.

