### PR TITLE
tests: include several test files necessary for DR scenario tests

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -7,6 +7,7 @@ RUN make build WHAT=cmd/openshift-tests; \
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/origin/test/testdata /usr/local/share/testdata
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \

--- a/test/testdata/disaster-recovery/machineconfig-rollback-a.yaml
+++ b/test/testdata/disaster-recovery/machineconfig-rollback-a.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-rollback-test
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,A
+        filesystem: root
+        mode: 420
+        path: /etc/rollback-test

--- a/test/testdata/disaster-recovery/machineconfig-rollback-b.yaml
+++ b/test/testdata/disaster-recovery/machineconfig-rollback-b.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-rollback-test
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:,B
+        filesystem: root
+        mode: 420
+        path: /etc/rollback-test

--- a/test/testdata/disaster-recovery/update_route_53.py
+++ b/test/testdata/disaster-recovery/update_route_53.py
@@ -1,0 +1,29 @@
+import boto3
+import os
+import sys
+if len(sys.argv) < 3:
+    print("Usage: ./update_route_53.py <RECORD> <IP>")
+    sys.exit(1)
+record = sys.argv[1]
+ip = sys.argv[2]
+print("record: %s" % record)
+print("ip: %s" % ip)
+domain = "%s.%s" % (os.environ["CLUSTER_NAME"], os.environ["BASE_DOMAIN"])
+client = boto3.client('route53')
+r = client.list_hosted_zones_by_name(DNSName=domain, MaxItems="1")
+zone_id = r['HostedZones'][0]['Id'].split('/')[-1]
+response = client.change_resource_record_sets(
+    HostedZoneId=zone_id,
+    ChangeBatch= {
+        'Comment': 'add %s -> %s' % (record, ip),
+        'Changes': [
+        {
+            'Action': 'UPSERT',
+            'ResourceRecordSet': {
+                'Name': record,
+                'Type': 'A',
+                'TTL': 60,
+                'ResourceRecords': [{'Value': ip}]
+            }
+        }]
+})


### PR DESCRIPTION
This PR would include several testdata files in `:tests` image. These files are now being created via `cat` in https://github.com/openshift/release/pull/3572 and https://github.com/openshift/release/pull/3842.