### PR TITLE
Bug 1713262: pkg/oc/cli/admin/upgrade: Fix and test sortSemanticVersions

### DIFF
--- a/pkg/oc/cli/admin/upgrade/upgrade.go
+++ b/pkg/oc/cli/admin/upgrade/upgrade.go
@@ -336,26 +336,21 @@ func updateIsEquivalent(a, b configv1.Update) bool {
 	}
 }
 
+// sortSemanticVersions sorts the input slice in increasing order.
 func sortSemanticVersions(versions []configv1.Update) {
 	sort.Slice(versions, func(i, j int) bool {
 		a, errA := semver.Parse(versions[i].Version)
 		b, errB := semver.Parse(versions[j].Version)
 		if errA == nil && errB != nil {
-			return true
-		}
-		if errB == nil && errA == nil {
 			return false
+		}
+		if errB == nil && errA != nil {
+			return true
 		}
 		if errA != nil && errB != nil {
-			if versions[i].Version < versions[j].Version {
-				return true
-			}
-			return false
+			return versions[i].Version < versions[j].Version
 		}
-		if a.Compare(b) < 0 {
-			return true
-		}
-		return false
+		return a.LT(b)
 	})
 }
 

--- a/pkg/oc/cli/admin/upgrade/upgrade_test.go
+++ b/pkg/oc/cli/admin/upgrade/upgrade_test.go
@@ -1,0 +1,29 @@
+package upgrade
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestSortSemanticVersions(t *testing.T) {
+	expected := []configv1.Update{
+		{Version: "not-sem-ver-1"},
+		{Version: "not-sem-ver-2"},
+		{Version: "2.0.0"},
+		{Version: "2.0.1"},
+		{Version: "10.0.0"},
+	}
+
+	actual := make([]configv1.Update, len(expected))
+	for i, j := range rand.Perm(len(expected)) {
+		actual[i] = expected[j]
+	}
+
+	sortSemanticVersions(actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("%v != %v", actual, expected)
+	}
+}


### PR DESCRIPTION
The previous implementation would always return false if both `errA` and `errB` were nil, without actually comparing the valid-SemVer versions [rhbz#1713262][1].

/cherrypick release-4.1

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1713262