### PR TITLE
Router pod throws fatal errors when configuring ROUTER_SYSLOG_ADDRESS

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -180,6 +180,9 @@ frontend public
 # determined by the next backend in the chain which may be an app backend (passthrough termination) or a backend
 # that terminates encryption in this router (edge)
 frontend public_ssl
+    {{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
+  option tcplog
+    {{- end }}
     {{ if eq "v4v6" $router_ip_v4_v6_mode }}
   bind :::{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v4v6
     {{- else if eq "v6" $router_ip_v4_v6_mode }}


### PR DESCRIPTION
Router pod throws fatal errors when configuring ROUTER_SYSLOG_ADDRESS


[root@master ~]# oc set env dc/router ROUTER_SYSLOG_FORMAT='"%s|%ci - - [%t] \"%r\" %ST %B"'
[root@master ~]# oc set env dc/router ROUTER_SYSLOG_ADDRESS=127.0.0.1 ROUTER_LOG_LEVEL=debug


Check router pod logs.


[root@master-0 ~]# oc logs router-4-tsjlw
I0227 02:29:36.313658       1 template.go:260] Starting template router (v3.9.68)
I0227 02:29:36.325557       1 metrics.go:157] Router health and metrics port listening at 0.0.0.0:1936
I0227 02:29:38.011135       1 router.go:228] Router is including routes in all namespaces
E0227 02:29:38.320584       1 limiter.go:137] error reloading router: exit status 1
[WARNING] 057/022938 (154) : parsing [/var/lib/haproxy/conf/haproxy.config:203] : backend 'be_tcp:default:docker-registry' : 'option tcplog' directive is ignored in backends.
[WARNING] 057/022938 (154) : parsing [/var/lib/haproxy/conf/haproxy.config:212] : backend 'be_tcp:default:registry-console' : 'option tcplog' directive is ignored in backends.
[WARNING] 057/022938 (154) : parsing [/var/lib/haproxy/conf/haproxy.config:221] : backend 'be_tcp:emirates:secure-sso' : 'option tcplog' directive is ignored in backends.
[WARNING] 057/022938 (154) : parsing [/var/lib/haproxy/conf/haproxy.config:244] : backend 'be_tcp:kube-service-catalog:apiserver' : 'option tcplog' directive is ignored in backends.
[ALERT] 057/022938 (154) : Parsing [/var/lib/haproxy/conf/haproxy.config:31]: failed to parse log-format : format variable 'r' is reserved for HTTP mode.


This fixes [BZ 1683501](https://bugzilla.redhat.com/show_bug.cgi?id=1683501)