### PR TITLE
Clean up disabled tests #2

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -364,8 +364,6 @@ var (
 			`should check if Kubernetes master services is included in cluster-info`, // Don't run kube-dns
 			`DNS configMap`, // this tests dns federation configuration via configmap, which we don't support yet
 
-			// See the CanSupport implementation in upstream to determine wether these work.
-			`GlusterFS`,                             // May work if /sbin/mount.glusterfs to be installed for plugin to work (also possibly blocked by serial pulling)
 			`authentication: OpenLDAP`,              // needs separate setup and bucketing for openldap bootstrapping
 			`NodeProblemDetector`,                   // requires a non-master node to run on
 			`Advanced Audit should audit API calls`, // expects to be able to call /logs

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -376,7 +376,6 @@ var (
 			`mount an API token into pods`,                                               // We add 6 secrets, not 1
 			`ServiceAccounts should ensure a single API token exists`,                    // We create lots of secrets
 			`unchanging, static URL paths for kubernetes api services`,                   // the test needs to exclude URLs that are not part of conformance (/logs)
-			"PersistentVolumes NFS when invoking the Recycle reclaim policy",             // failing for some reason
 			`Simple pod should handle in-cluster config`,                                 // kubectl cp is not preserving executable bit
 			`Services should be able to up and down services`,                            // we don't have wget installed on nodes
 			`Network should set TCP CLOSE_WAIT timeout`,                                  // possibly some difference between ubuntu and fedora

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -364,9 +364,6 @@ var (
 			`should check if Kubernetes master services is included in cluster-info`, // Don't run kube-dns
 			`DNS configMap`, // this tests dns federation configuration via configmap, which we don't support yet
 
-			// vSphere tests can be skipped generally
-			`vsphere`,
-			`Cinder`, // requires an OpenStack cluster
 			// See the CanSupport implementation in upstream to determine wether these work.
 			`Ceph RBD`,                              // Works if ceph-common Binary installed (but we can't guarantee this on all clusters).
 			`GlusterFS`,                             // May work if /sbin/mount.glusterfs to be installed for plugin to work (also possibly blocked by serial pulling)

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -365,7 +365,6 @@ var (
 			`DNS configMap`, // this tests dns federation configuration via configmap, which we don't support yet
 
 			// See the CanSupport implementation in upstream to determine wether these work.
-			`Ceph RBD`,                              // Works if ceph-common Binary installed (but we can't guarantee this on all clusters).
 			`GlusterFS`,                             // May work if /sbin/mount.glusterfs to be installed for plugin to work (also possibly blocked by serial pulling)
 			`authentication: OpenLDAP`,              // needs separate setup and bucketing for openldap bootstrapping
 			`NodeProblemDetector`,                   // requires a non-master node to run on


### PR DESCRIPTION
* All tests that need specific cloud have proper Skip()
* Remove rules that don't match anything
* Enable tests that depend on 1.13 kubelet

This is continuation of https://github.com/openshift/origin/pull/22460

> @smarterclayton: This looks like it substantially increased test runtime.

I don't see any increase (`openshift/conformance/parallel` was actually slower before the PR than it is now, I blame low nr. of samples).

There are two new real tests:

```
"[sig-storage] GCP Volumes GlusterFS should be mountable [Suite:openshift/conformance/parallel] [Suite:k8s]"
"[sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted. 
[Suite:openshift/conformance/parallel] [Suite:k8s]"
```

Additional 37 tests are skipped (missing `vsphere` / `openstack`), each `Skip()` takes 2-3 seconds for `BeforeEach` + `AfterEach` (divide by nr. of parallel tests).


cc @openshift/storage 