### PR TITLE
add find leaves script

### DIFF
--- a/hack/find-leaves.sh
+++ b/hack/find-leaves.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# this is all the dependencies we have
+#go list -f '{{.Deps}}'  github.com/openshift/origin/pkg/cmd/openshift-apiserver | xargs -n 1 echo | grep 'github.com/openshift/origin' | grep -v 'github.com/openshift/origin/vendor' | sort
+all_packages=$(go list -f '{{.Deps}}' $1 | xargs -n 1 echo | grep 'github.com/openshift/origin' | grep -v 'github.com/openshift/origin/vendor' | sort)
+
+for package in ${all_packages}
+do
+    curr_packages=$(go list -f '{{.Deps}}'  ${package} | xargs -n 1 echo | grep 'github.com/openshift/origin' | grep -v 'github.com/openshift/origin/vendor' | sort)
+    if [ -z "${curr_packages}" ]
+    then
+        echo "${package} should move"
+    else
+        echo "${package} has deps"
+    fi
+done


### PR DESCRIPTION
```
[deads@deads-02 origin]$ hack/find-leaves.sh  github.com/openshift/origin/pkg/cmd/openshift-apiserver | grep "should move"
github.com/openshift/origin/pkg/admission/customresourcevalidation should move
github.com/openshift/origin/pkg/admission/customresourcevalidation/clusterresourcequota/validation should move
github.com/openshift/origin/pkg/admission/customresourcevalidation/config should move
github.com/openshift/origin/pkg/admission/customresourcevalidation/rolebindingrestriction/validation should move
github.com/openshift/origin/pkg/admission/customresourcevalidation/securitycontextconstraints/validation should move
github.com/openshift/origin/pkg/api should move
github.com/openshift/origin/pkg/api/apihelpers should move
github.com/openshift/origin/pkg/apiserver/rest should move
github.com/openshift/origin/pkg/apps/apis/apps should move
github.com/openshift/origin/pkg/authorization/apis/authorization/internal/serviceaccount should move
github.com/openshift/origin/pkg/authorization/util should move
github.com/openshift/origin/pkg/autoscaling/admission/apis/clusterresourceoverride should move
github.com/openshift/origin/pkg/autoscaling/admission/apis/runonceduration should move
github.com/openshift/origin/pkg/build/apiserver/registry/wait should move
github.com/openshift/origin/pkg/build/client should move
github.com/openshift/origin/pkg/client/impersonatingclient should move
github.com/openshift/origin/pkg/client/templateprocessing should move
github.com/openshift/origin/pkg/cmd/configflags should move
github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/configdefault should move
github.com/openshift/origin/pkg/cmd/server/cm should move
github.com/openshift/origin/pkg/cmd/util should move
github.com/openshift/origin/pkg/cmd/util/flags should move
github.com/openshift/origin/pkg/cmd/util/pem should move
github.com/openshift/origin/pkg/image/apiserver/admission/apis/imagepolicy/v1 should move
github.com/openshift/origin/pkg/image/apiserver/registryhostname should move
github.com/openshift/origin/pkg/image/apis/image/docker10 should move
github.com/openshift/origin/pkg/image/internal/digest should move
github.com/openshift/origin/pkg/image/registryclient should move
github.com/openshift/origin/pkg/network/admission/apis/externalipranger should move
github.com/openshift/origin/pkg/network/admission/apis/restrictedendpoints should move
github.com/openshift/origin/pkg/network/apis/network should move
github.com/openshift/origin/pkg/oauth/apis/oauth should move
github.com/openshift/origin/pkg/oauth/scope should move
github.com/openshift/origin/pkg/oauthserver should move
github.com/openshift/origin/pkg/oauthserver/api should move
github.com/openshift/origin/pkg/oauthserver/authenticator/password/bootstrap should move
github.com/openshift/origin/pkg/oauthserver/authenticator/tokens should move
github.com/openshift/origin/pkg/oauthserver/ldaputil/ldapclient should move
github.com/openshift/origin/pkg/oauthserver/prometheus should move
github.com/openshift/origin/pkg/oauthserver/server/crypto should move
github.com/openshift/origin/pkg/oauthserver/server/redirect should move
github.com/openshift/origin/pkg/oauth/urls should move
github.com/openshift/origin/pkg/openapi should move
github.com/openshift/origin/pkg/project/apiserver/admission/apis/requestlimit should move
github.com/openshift/origin/pkg/project/apis/project should move
github.com/openshift/origin/pkg/quota/apis/quota should move
github.com/openshift/origin/pkg/quota/util should move
github.com/openshift/origin/pkg/route/apiserver/admission/apis/ingressadmission should move
github.com/openshift/origin/pkg/route/apis/route should move
github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints should move
github.com/openshift/origin/pkg/security should move
github.com/openshift/origin/pkg/security/apis/security should move
github.com/openshift/origin/pkg/security/mcs should move
github.com/openshift/origin/pkg/security/securitycontextconstraints/seccomp should move
github.com/openshift/origin/pkg/security/uid should move
github.com/openshift/origin/pkg/template/apis/template should move
github.com/openshift/origin/pkg/template/generator should move
github.com/openshift/origin/pkg/user/apis/user should move
github.com/openshift/origin/pkg/user/cache should move
github.com/openshift/origin/pkg/util should move
github.com/openshift/origin/pkg/util/errors should move
github.com/openshift/origin/pkg/util/httprequest should move
github.com/openshift/origin/pkg/util/labelselector should move
github.com/openshift/origin/pkg/util/netutils should move
github.com/openshift/origin/pkg/util/stringreplace should move
github.com/openshift/origin/pkg/util/strings should move
github.com/openshift/origin/pkg/util/urlpattern should move
github.com/openshift/origin/pkg/version should move
```

Packages with dependers are copied or are moved to library-go.  then iterate