### PR TITLE
move ldap to point of use

### DIFF
--- a/pkg/oauthserver/authenticator/password/ldappassword/identityfactory.go
+++ b/pkg/oauthserver/authenticator/password/ldappassword/identityfactory.go
@@ -1,0 +1,92 @@
+package ldappassword
+
+import (
+	"fmt"
+
+	"gopkg.in/ldap.v2"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	osinv1 "github.com/openshift/api/osin/v1"
+	authapi "github.com/openshift/origin/pkg/oauthserver/api"
+	"github.com/openshift/origin/pkg/oauthserver/ldaputil"
+)
+
+// LDAPUserIdentityFactory creates Identites for LDAP user entries.
+type LDAPUserIdentityFactory interface {
+	IdentityFor(user *ldap.Entry) (identity authapi.UserIdentityInfo, err error)
+}
+
+// DefaultLDAPUserIdentityFactory creates Identities for LDAP user entries using an LDAPUserAttributeDefiner
+type DefaultLDAPUserIdentityFactory struct {
+	ProviderName string
+	Definer      LDAPUserAttributeDefiner
+}
+
+func (f *DefaultLDAPUserIdentityFactory) IdentityFor(user *ldap.Entry) (identity authapi.UserIdentityInfo, err error) {
+	uid := f.Definer.ID(user)
+	if uid == "" {
+		err = fmt.Errorf("Could not retrieve a non-empty value for ID attributes for dn=%q", user.DN)
+		return
+	}
+	id := authapi.NewDefaultUserIdentityInfo(f.ProviderName, uid)
+
+	// Add optional extra attributes if present
+	if name := f.Definer.Name(user); len(name) != 0 {
+		id.Extra[authapi.IdentityDisplayNameKey] = name
+	}
+
+	if email := f.Definer.Email(user); len(email) != 0 {
+		id.Extra[authapi.IdentityEmailKey] = email
+	}
+
+	if prefUser := f.Definer.PreferredUsername(user); len(prefUser) != 0 {
+		id.Extra[authapi.IdentityPreferredUsernameKey] = prefUser
+	}
+
+	identity = id
+	return
+}
+
+func NewLDAPUserAttributeDefiner(attributeMapping osinv1.LDAPAttributeMapping) LDAPUserAttributeDefiner {
+	return LDAPUserAttributeDefiner{
+		attributeMapping: attributeMapping,
+	}
+}
+
+// LDAPUserAttributeDefiner defines the values corresponding to OpenShift Identities in LDAP entries
+// by using a deterministic mapping of LDAP entry attributes to OpenShift Identity fields
+type LDAPUserAttributeDefiner struct {
+	// attributeMapping holds the attributes mapped to email, name, preferred username and ID
+	attributeMapping osinv1.LDAPAttributeMapping
+}
+
+// AllAttributes gets all attributes listed in the LDAPUserAttributeDefiner
+func (d *LDAPUserAttributeDefiner) AllAttributes() sets.String {
+	attrs := sets.NewString(d.attributeMapping.Email...)
+	attrs.Insert(d.attributeMapping.Name...)
+	attrs.Insert(d.attributeMapping.PreferredUsername...)
+	attrs.Insert(d.attributeMapping.ID...)
+	return attrs
+}
+
+// Email extracts the email value from an LDAP user entry
+func (d *LDAPUserAttributeDefiner) Email(user *ldap.Entry) string {
+	return ldaputil.GetAttributeValue(user, d.attributeMapping.Email)
+}
+
+// Name extracts the name value from an LDAP user entry
+func (d *LDAPUserAttributeDefiner) Name(user *ldap.Entry) string {
+	return ldaputil.GetAttributeValue(user, d.attributeMapping.Name)
+}
+
+// PreferredUsername extracts the preferred username value from an LDAP user entry
+func (d *LDAPUserAttributeDefiner) PreferredUsername(user *ldap.Entry) string {
+	return ldaputil.GetAttributeValue(user, d.attributeMapping.PreferredUsername)
+}
+
+// ID extracts the ID value from an LDAP user entry
+func (d *LDAPUserAttributeDefiner) ID(user *ldap.Entry) string {
+	// support binary ID fields as those the only stable identifiers in some environments
+	return ldaputil.GetRawAttributeValue(user, d.attributeMapping.ID)
+}

--- a/pkg/oauthserver/authenticator/password/ldappassword/ldap.go
+++ b/pkg/oauthserver/authenticator/password/ldappassword/ldap.go
@@ -29,7 +29,7 @@ type Options struct {
 	// by using a deterministic mapping of LDAP entry attributes to OpenShift Identity fields. The first
 	// attribute with a non-empty value is used for all but the latter identity field. If no LDAP attributes
 	// are given for the ID address, login fails.
-	UserAttributeDefiner ldaputil.LDAPUserAttributeDefiner
+	UserAttributeDefiner LDAPUserAttributeDefiner
 }
 
 // Authenticator validates username/passwords against an LDAP v3 server
@@ -37,7 +37,7 @@ type Authenticator struct {
 	providerName    string
 	options         Options
 	mapper          authapi.UserIdentityMapper
-	identityFactory ldaputil.LDAPUserIdentityFactory
+	identityFactory LDAPUserIdentityFactory
 }
 
 // New returns an authenticator which will validate usernames/passwords using LDAP.
@@ -46,7 +46,7 @@ func New(providerName string, options Options, mapper authapi.UserIdentityMapper
 		providerName: providerName,
 		options:      options,
 		mapper:       mapper,
-		identityFactory: &ldaputil.DefaultLDAPUserIdentityFactory{
+		identityFactory: &DefaultLDAPUserIdentityFactory{
 			ProviderName: providerName,
 			Definer:      options.UserAttributeDefiner,
 		},

--- a/pkg/oauthserver/ldaputil/identityfactory.go
+++ b/pkg/oauthserver/ldaputil/identityfactory.go
@@ -2,95 +2,10 @@ package ldaputil
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strings"
 
 	"gopkg.in/ldap.v2"
-
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	osinv1 "github.com/openshift/api/osin/v1"
-	authapi "github.com/openshift/origin/pkg/oauthserver/api"
 )
-
-// LDAPUserIdentityFactory creates Identites for LDAP user entries.
-type LDAPUserIdentityFactory interface {
-	IdentityFor(user *ldap.Entry) (identity authapi.UserIdentityInfo, err error)
-}
-
-// DefaultLDAPUserIdentityFactory creates Identities for LDAP user entries using an LDAPUserAttributeDefiner
-type DefaultLDAPUserIdentityFactory struct {
-	ProviderName string
-	Definer      LDAPUserAttributeDefiner
-}
-
-func (f *DefaultLDAPUserIdentityFactory) IdentityFor(user *ldap.Entry) (identity authapi.UserIdentityInfo, err error) {
-	uid := f.Definer.ID(user)
-	if uid == "" {
-		err = fmt.Errorf("Could not retrieve a non-empty value for ID attributes for dn=%q", user.DN)
-		return
-	}
-	id := authapi.NewDefaultUserIdentityInfo(f.ProviderName, uid)
-
-	// Add optional extra attributes if present
-	if name := f.Definer.Name(user); len(name) != 0 {
-		id.Extra[authapi.IdentityDisplayNameKey] = name
-	}
-
-	if email := f.Definer.Email(user); len(email) != 0 {
-		id.Extra[authapi.IdentityEmailKey] = email
-	}
-
-	if prefUser := f.Definer.PreferredUsername(user); len(prefUser) != 0 {
-		id.Extra[authapi.IdentityPreferredUsernameKey] = prefUser
-	}
-
-	identity = id
-	return
-}
-
-func NewLDAPUserAttributeDefiner(attributeMapping osinv1.LDAPAttributeMapping) LDAPUserAttributeDefiner {
-	return LDAPUserAttributeDefiner{
-		attributeMapping: attributeMapping,
-	}
-}
-
-// LDAPUserAttributeDefiner defines the values corresponding to OpenShift Identities in LDAP entries
-// by using a deterministic mapping of LDAP entry attributes to OpenShift Identity fields
-type LDAPUserAttributeDefiner struct {
-	// attributeMapping holds the attributes mapped to email, name, preferred username and ID
-	attributeMapping osinv1.LDAPAttributeMapping
-}
-
-// AllAttributes gets all attributes listed in the LDAPUserAttributeDefiner
-func (d *LDAPUserAttributeDefiner) AllAttributes() sets.String {
-	attrs := sets.NewString(d.attributeMapping.Email...)
-	attrs.Insert(d.attributeMapping.Name...)
-	attrs.Insert(d.attributeMapping.PreferredUsername...)
-	attrs.Insert(d.attributeMapping.ID...)
-	return attrs
-}
-
-// Email extracts the email value from an LDAP user entry
-func (d *LDAPUserAttributeDefiner) Email(user *ldap.Entry) string {
-	return GetAttributeValue(user, d.attributeMapping.Email)
-}
-
-// Name extracts the name value from an LDAP user entry
-func (d *LDAPUserAttributeDefiner) Name(user *ldap.Entry) string {
-	return GetAttributeValue(user, d.attributeMapping.Name)
-}
-
-// PreferredUsername extracts the preferred username value from an LDAP user entry
-func (d *LDAPUserAttributeDefiner) PreferredUsername(user *ldap.Entry) string {
-	return GetAttributeValue(user, d.attributeMapping.PreferredUsername)
-}
-
-// ID extracts the ID value from an LDAP user entry
-func (d *LDAPUserAttributeDefiner) ID(user *ldap.Entry) string {
-	// support binary ID fields as those the only stable identifiers in some environments
-	return GetRawAttributeValue(user, d.attributeMapping.ID)
-}
 
 // GetAttributeValue finds the first attribute of those given that the LDAP entry has, and
 // returns it. GetAttributeValue is able to query the DN as well as Attributes of the LDAP entry.

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -586,7 +586,7 @@ func (c *OAuthServerConfig) getPasswordAuthenticator(identityProvider osinv1.Ide
 		opts := ldappassword.Options{
 			URL:                  url,
 			ClientConfig:         clientConfig,
-			UserAttributeDefiner: ldaputil.NewLDAPUserAttributeDefiner(provider.Attributes),
+			UserAttributeDefiner: ldappassword.NewLDAPUserAttributeDefiner(provider.Attributes),
 		}
 		return ldappassword.New(identityProvider.Name, opts, identityMapper)
 

--- a/pkg/oc/lib/groupsync/consts.go
+++ b/pkg/oc/lib/groupsync/consts.go
@@ -1,4 +1,4 @@
-package ldaputil
+package syncgroups
 
 // These constants contain values for annotations and labels affixed to Groups by the LDAP sync job
 const (

--- a/pkg/oc/lib/groupsync/grouplister.go
+++ b/pkg/oc/lib/groupsync/grouplister.go
@@ -10,7 +10,6 @@ import (
 
 	userv1 "github.com/openshift/api/user/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
-	"github.com/openshift/origin/pkg/oauthserver/ldaputil"
 	"github.com/openshift/origin/pkg/oc/lib/groupsync/interfaces"
 )
 
@@ -40,7 +39,7 @@ func (l *allOpenShiftGroupLister) ListGroups() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	hostSelector := labels.Set(map[string]string{ldaputil.LDAPHostLabel: host}).AsSelector()
+	hostSelector := labels.Set(map[string]string{LDAPHostLabel: host}).AsSelector()
 	allGroups, err := l.client.List(metav1.ListOptions{LabelSelector: hostSelector.String()})
 	if err != nil {
 		return nil, err
@@ -60,7 +59,7 @@ func (l *allOpenShiftGroupLister) ListGroups() ([]string, error) {
 			continue
 		}
 
-		ldapGroupUID := group.Annotations[ldaputil.LDAPUIDAnnotation]
+		ldapGroupUID := group.Annotations[LDAPUIDAnnotation]
 		l.ldapGroupUIDToOpenShiftGroupName[ldapGroupUID] = group.Name
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)
 	}
@@ -86,15 +85,15 @@ func (l *allOpenShiftGroupLister) GroupNameFor(ldapGroupUID string) (string, err
 
 // validateGroupAnnotations determines if the group matches and errors if the annotations are missing
 func validateGroupAnnotations(ldapURL string, group userv1.Group) (bool, error) {
-	if actualURL, exists := group.Annotations[ldaputil.LDAPURLAnnotation]; !exists {
-		return false, fmt.Errorf("group %q marked as having been synced did not have an %s annotation", group.Name, ldaputil.LDAPURLAnnotation)
+	if actualURL, exists := group.Annotations[LDAPURLAnnotation]; !exists {
+		return false, fmt.Errorf("group %q marked as having been synced did not have an %s annotation", group.Name, LDAPURLAnnotation)
 
 	} else if actualURL != ldapURL {
 		return false, nil
 	}
 
-	if _, exists := group.Annotations[ldaputil.LDAPUIDAnnotation]; !exists {
-		return false, fmt.Errorf("group %q marked as having been synced did not have an %s annotation", group.Name, ldaputil.LDAPUIDAnnotation)
+	if _, exists := group.Annotations[LDAPUIDAnnotation]; !exists {
+		return false, fmt.Errorf("group %q marked as having been synced did not have an %s annotation", group.Name, LDAPUIDAnnotation)
 	}
 
 	return true, nil
@@ -148,7 +147,7 @@ func (l *openshiftGroupLister) ListGroups() ([]string, error) {
 			return nil, fmt.Errorf("group %q was not synchronized from: %s", group.Name, l.ldapURL)
 		}
 
-		ldapGroupUID := group.Annotations[ldaputil.LDAPUIDAnnotation]
+		ldapGroupUID := group.Annotations[LDAPUIDAnnotation]
 		l.ldapGroupUIDToOpenShiftGroupName[ldapGroupUID] = group.Name
 		ldapGroupUIDs = append(ldapGroupUIDs, ldapGroupUID)
 	}

--- a/pkg/oc/lib/groupsync/grouplister_test.go
+++ b/pkg/oc/lib/groupsync/grouplister_test.go
@@ -12,7 +12,6 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	fakeuserclient "github.com/openshift/client-go/user/clientset/versioned/fake"
 	fakeuserv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1/fake"
-	"github.com/openshift/origin/pkg/oauthserver/ldaputil"
 	_ "github.com/openshift/origin/pkg/user/apis/user/install"
 )
 
@@ -27,26 +26,26 @@ func TestListAllOpenShiftGroups(t *testing.T) {
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "alpha-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			expectedName: "alpha-uid",
 		},
 		"no url annotation": {
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
-					Annotations: map[string]string{ldaputil.LDAPUIDAnnotation: "alpha-uid"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Annotations: map[string]string{LDAPUIDAnnotation: "alpha-uid"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.url annotation`,
 		},
 		"no uid annotation": {
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
-					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.uid annotation`,
 		},
@@ -54,16 +53,16 @@ func TestListAllOpenShiftGroups(t *testing.T) {
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port2",
-						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+						LDAPURLAnnotation: "test-host:port2",
+						LDAPUIDAnnotation: "alpha-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "beta",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "beta-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "beta-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			expectedName: "beta-uid",
 		},
@@ -71,16 +70,16 @@ func TestListAllOpenShiftGroups(t *testing.T) {
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "alpha-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "beta",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "beta-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "beta-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			blacklist:    []string{"alpha"},
 			expectedName: "beta-uid",
@@ -142,10 +141,10 @@ func TestListWhitelistOpenShiftGroups(t *testing.T) {
 			startingGroups: []*userv1.Group{
 				{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "alpha-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			whitelist:    []string{"alpha"},
 			expectedName: "alpha-uid",
@@ -153,8 +152,8 @@ func TestListWhitelistOpenShiftGroups(t *testing.T) {
 		"no url annotation": {
 			startingGroups: []*userv1.Group{
 				{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
-					Annotations: map[string]string{ldaputil.LDAPUIDAnnotation: "alpha-uid"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Annotations: map[string]string{LDAPUIDAnnotation: "alpha-uid"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			whitelist:   []string{"alpha"},
 			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.url annotation`,
@@ -162,8 +161,8 @@ func TestListWhitelistOpenShiftGroups(t *testing.T) {
 		"no uid annotation": {
 			startingGroups: []*userv1.Group{
 				{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
-					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			whitelist:   []string{"alpha"},
 			expectedErr: `group "alpha" marked as having been synced did not have an openshift.io/ldap.uid annotation`,
@@ -172,10 +171,10 @@ func TestListWhitelistOpenShiftGroups(t *testing.T) {
 			startingGroups: []*userv1.Group{
 				{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port2",
-						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+						LDAPURLAnnotation: "test-host:port2",
+						LDAPUIDAnnotation: "alpha-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			whitelist:   []string{"alpha"},
 			expectedErr: `group "alpha" was not synchronized from: test-host:port`,
@@ -184,16 +183,16 @@ func TestListWhitelistOpenShiftGroups(t *testing.T) {
 			startingGroups: []*userv1.Group{
 				{ObjectMeta: metav1.ObjectMeta{Name: "alpha",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "alpha-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "alpha-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "beta",
 					Annotations: map[string]string{
-						ldaputil.LDAPURLAnnotation: "test-host:port",
-						ldaputil.LDAPUIDAnnotation: "beta-uid",
+						LDAPURLAnnotation: "test-host:port",
+						LDAPUIDAnnotation: "beta-uid",
 					},
-					Labels: map[string]string{ldaputil.LDAPHostLabel: "test-host"}}},
+					Labels: map[string]string{LDAPHostLabel: "test-host"}}},
 			},
 			whitelist:    []string{"alpha", "beta"},
 			blacklist:    []string{"alpha"},

--- a/pkg/oc/lib/groupsync/groupsyncer.go
+++ b/pkg/oc/lib/groupsync/groupsyncer.go
@@ -14,7 +14,6 @@ import (
 
 	userv1 "github.com/openshift/api/user/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
-	"github.com/openshift/origin/pkg/oauthserver/ldaputil"
 	"github.com/openshift/origin/pkg/oc/lib/groupsync/interfaces"
 )
 
@@ -146,11 +145,11 @@ func (s *LDAPGroupSyncer) makeOpenShiftGroup(ldapGroupUID string, usernames []st
 		group = &userv1.Group{}
 		group.Name = groupName
 		group.Annotations = map[string]string{
-			ldaputil.LDAPURLAnnotation: s.Host,
-			ldaputil.LDAPUIDAnnotation: ldapGroupUID,
+			LDAPURLAnnotation: s.Host,
+			LDAPUIDAnnotation: ldapGroupUID,
 		}
 		group.Labels = map[string]string{
-			ldaputil.LDAPHostLabel: hostIP,
+			LDAPHostLabel: hostIP,
 		}
 
 	} else if err != nil {
@@ -158,22 +157,22 @@ func (s *LDAPGroupSyncer) makeOpenShiftGroup(ldapGroupUID string, usernames []st
 	}
 
 	// make sure we aren't taking over an OpenShift group that is already related to a different LDAP group
-	if host, exists := group.Labels[ldaputil.LDAPHostLabel]; !exists || (host != hostIP) {
+	if host, exists := group.Labels[LDAPHostLabel]; !exists || (host != hostIP) {
 		return nil, fmt.Errorf("group %q: %s label did not match sync host: wanted %s, got %s",
-			group.Name, ldaputil.LDAPHostLabel, hostIP, host)
+			group.Name, LDAPHostLabel, hostIP, host)
 	}
-	if url, exists := group.Annotations[ldaputil.LDAPURLAnnotation]; !exists || (url != s.Host) {
+	if url, exists := group.Annotations[LDAPURLAnnotation]; !exists || (url != s.Host) {
 		return nil, fmt.Errorf("group %q: %s annotation did not match sync host: wanted %s, got %s",
-			group.Name, ldaputil.LDAPURLAnnotation, s.Host, url)
+			group.Name, LDAPURLAnnotation, s.Host, url)
 	}
-	if uid, exists := group.Annotations[ldaputil.LDAPUIDAnnotation]; !exists || (uid != ldapGroupUID) {
+	if uid, exists := group.Annotations[LDAPUIDAnnotation]; !exists || (uid != ldapGroupUID) {
 		return nil, fmt.Errorf("group %q: %s annotation did not match LDAP UID: wanted %s, got %s",
-			group.Name, ldaputil.LDAPUIDAnnotation, ldapGroupUID, uid)
+			group.Name, LDAPUIDAnnotation, ldapGroupUID, uid)
 	}
 
 	// overwrite Group Users data
 	group.Users = usernames
-	group.Annotations[ldaputil.LDAPSyncTimeAnnotation] = ISO8601(time.Now())
+	group.Annotations[LDAPSyncTimeAnnotation] = ISO8601(time.Now())
 
 	return group, nil
 }

--- a/pkg/oc/lib/groupsync/groupsyncer_test.go
+++ b/pkg/oc/lib/groupsync/groupsyncer_test.go
@@ -47,21 +47,21 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 			ldapGroupUID: "alfa",
 			usernames:    []string{"valerie"},
 			expectedGroup: &userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-				Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port", ldaputil.LDAPUIDAnnotation: "alfa"},
-				Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}},
+				Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
+				Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 				Users: []string{"valerie"}},
 		},
 		"replaced good": {
 			ldapGroupUID: "alfa",
 			usernames:    []string{"valerie"},
 			expectedGroup: &userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-				Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port", ldaputil.LDAPUIDAnnotation: "alfa"},
-				Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}},
+				Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
+				Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 				Users: []string{"valerie"}},
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port", ldaputil.LDAPUIDAnnotation: "alfa"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "alfa"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 					Users: []string{"other-user"}},
 			},
 		},
@@ -70,8 +70,8 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 			usernames:    []string{"valerie"},
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port", ldaputil.LDAPUIDAnnotation: "bravo"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port", LDAPUIDAnnotation: "bravo"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 					Users: []string{"other-user"}},
 			},
 			expectedErr: `group "zulu": openshift.io/ldap.uid annotation did not match LDAP UID: wanted alfa, got bravo`,
@@ -81,8 +81,8 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 			usernames:    []string{"valerie"},
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "bad-host:port", ldaputil.LDAPUIDAnnotation: "alfa"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "bad-host"}},
+					Annotations: map[string]string{LDAPURLAnnotation: "bad-host:port", LDAPUIDAnnotation: "alfa"},
+					Labels:      map[string]string{LDAPHostLabel: "bad-host"}},
 					Users: []string{"other-user"}},
 			},
 			expectedErr: `group "zulu": openshift.io/ldap.host label did not match sync host: wanted test-host, got bad-host`,
@@ -92,8 +92,8 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 			usernames:    []string{"valerie"},
 			startingGroups: []runtime.Object{
 				&userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: "zulu",
-					Annotations: map[string]string{ldaputil.LDAPURLAnnotation: "test-host:port2", ldaputil.LDAPUIDAnnotation: "alfa"},
-					Labels:      map[string]string{ldaputil.LDAPHostLabel: "test-host"}},
+					Annotations: map[string]string{LDAPURLAnnotation: "test-host:port2", LDAPUIDAnnotation: "alfa"},
+					Labels:      map[string]string{LDAPHostLabel: "test-host"}},
 					Users: []string{"other-user"}},
 			},
 			expectedErr: `group "zulu": openshift.io/ldap.url annotation did not match sync host: wanted test-host:port, got test-host:port2`,
@@ -118,7 +118,7 @@ func TestMakeOpenShiftGroup(t *testing.T) {
 		}
 
 		if actualGroup != nil {
-			delete(actualGroup.Annotations, ldaputil.LDAPSyncTimeAnnotation)
+			delete(actualGroup.Annotations, LDAPSyncTimeAnnotation)
 		}
 
 		if !reflect.DeepEqual(tc.expectedGroup, actualGroup) {
@@ -244,7 +244,7 @@ func checkClientForGroups(tc *fakeuserv1client.FakeUserV1, expectedGroups []*use
 func groupExists(haystack []*userv1.Group, needle *userv1.Group) bool {
 	for _, actual := range haystack {
 		actualGroup := actual.DeepCopy()
-		delete(actualGroup.Annotations, ldaputil.LDAPSyncTimeAnnotation)
+		delete(actualGroup.Annotations, LDAPSyncTimeAnnotation)
 
 		if reflect.DeepEqual(needle, actualGroup) {
 			return true
@@ -274,11 +274,11 @@ func newDefaultOpenShiftGroups(host string) []*userv1.Group {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os" + Group1UID,
 				Annotations: map[string]string{
-					ldaputil.LDAPURLAnnotation: host,
-					ldaputil.LDAPUIDAnnotation: Group1UID,
+					LDAPURLAnnotation: host,
+					LDAPUIDAnnotation: Group1UID,
 				},
 				Labels: map[string]string{
-					ldaputil.LDAPHostLabel: strings.Split(host, ":")[0],
+					LDAPHostLabel: strings.Split(host, ":")[0],
 				},
 			},
 			Users: []string{Member1UID, Member2UID},
@@ -287,11 +287,11 @@ func newDefaultOpenShiftGroups(host string) []*userv1.Group {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os" + Group2UID,
 				Annotations: map[string]string{
-					ldaputil.LDAPURLAnnotation: host,
-					ldaputil.LDAPUIDAnnotation: Group2UID,
+					LDAPURLAnnotation: host,
+					LDAPUIDAnnotation: Group2UID,
 				},
 				Labels: map[string]string{
-					ldaputil.LDAPHostLabel: strings.Split(host, ":")[0],
+					LDAPHostLabel: strings.Split(host, ":")[0],
 				},
 			},
 			Users: []string{Member2UID, Member3UID},
@@ -300,11 +300,11 @@ func newDefaultOpenShiftGroups(host string) []*userv1.Group {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "os" + Group3UID,
 				Annotations: map[string]string{
-					ldaputil.LDAPURLAnnotation: host,
-					ldaputil.LDAPUIDAnnotation: Group3UID,
+					LDAPURLAnnotation: host,
+					LDAPUIDAnnotation: Group3UID,
 				},
 				Labels: map[string]string{
-					ldaputil.LDAPHostLabel: strings.Split(host, ":")[0],
+					LDAPHostLabel: strings.Split(host, ":")[0],
 				},
 			},
 			Users: []string{Member3UID, Member4UID},


### PR DESCRIPTION
Moves single-use parts of ldaputil to their points of use in preparation for getting the rest from library-go.

/assign @enj 