### PR TITLE
update publishing rules for kube 1.13.4 and kube 1.14.0

### DIFF
--- a/publishing-rules.yaml
+++ b/publishing-rules.yaml
@@ -3,9 +3,13 @@ skip-gomod: true
 rules:
 - destination: kubernetes
   branches:
-  - name: origin-4.1-kubernetes-1.13.4
+  - name: origin-4.2-kubernetes-1.14.0
     source:
       branch: master
+      dir: vendor/k8s.io/kubernetes
+  - name: origin-4.1-kubernetes-1.13.4
+    source:
+      branch: release-4.1
       dir: vendor/k8s.io/kubernetes
   - name: origin-3.11-kubernetes-1.11.1
     source:


### PR DESCRIPTION
Without this fix, the publishing bot is publishing `master branch from openshift/origin repository to 1.13.4 branch in kube fork. That broke the publishing. This PR is:

1) Adding rule to publish "master" branch to kube fork "1.14.0"
2) Adding rule to publish "release-4.1" branch to kube fork "1.13.4"

