### PR TITLE
publishing: remove legacy rules

### DIFF
--- a/publishing-kube-rules.yaml
+++ b/publishing-kube-rules.yaml
@@ -140,6 +140,7 @@ rules:
       source:
         branch: origin-4.2-kubernetes-1.14.0
         dir: staging/src/k8s.io/sample-controller
+
 # origin-4.1-kubernetes-1.13.4
 - destination: kubernetes-api
   branches:
@@ -255,73 +256,7 @@ rules:
       source:
         branch: origin-4.1-kubernetes-1.13.4
         dir: staging/src/k8s.io/sample-controller
-# origin-4.0-kubernetes-1.12.4
-- destination: kubernetes-code-generator
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/code-generator
-- destination: kubernetes-apimachinery
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/apimachinery
-- destination: kubernetes-api
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/api
-- destination: kubernetes-client-go
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/client-go
-- destination: kubernetes-cli-runtime
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/cli-runtime
-- destination: kubernetes-metrics
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/metrics
-- destination: kubernetes-apiserver
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/apiserver
-- destination: kubernetes-kube-aggregator
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/kube-aggregator
-- destination: kubernetes-apiextensions-apiserver
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/apiextensions-apiserver
-- destination: kubernetes-sample-apiserver
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/sample-apiserver
-- destination: kubernetes-sample-controller
-  branches:
-  - name: origin-4.0-kubernetes-1.12.4
-    source:
-      branch: origin-4.0-kubernetes-1.12.4
-      dir: staging/src/k8s.io/sample-controller
+
 # origin-3.11-kubernetes-1.11.1
 - destination: kubernetes-code-generator
   branches:
@@ -432,54 +367,4 @@ rules:
   - name: origin-3.10-kubernetes-1.10.2
     source:
       branch: origin-3.10-kubernetes-1.10.2
-      dir: staging/src/k8s.io/apiextensions-apiserver
-
-# release-1.9.1
-- destination: kubernetes-code-generator
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/code-generator
-- destination: kubernetes-apimachinery
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/apimachinery
-- destination: kubernetes-api
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/api
-- destination: kubernetes-client-go
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/client-go
-- destination: kubernetes-metrics
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/metrics
-- destination: kubernetes-apiserver
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/apiserver
-- destination: kubernetes-kube-aggregator
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
-      dir: staging/src/k8s.io/kube-aggregator
-- destination: kubernetes-apiextensions-apiserver
-  branches:
-  - name: release-1.9.1
-    source:
-      branch: release-1.9.1
       dir: staging/src/k8s.io/apiextensions-apiserver

--- a/publishing-rules.yaml
+++ b/publishing-rules.yaml
@@ -15,7 +15,3 @@ rules:
     source:
       branch: release-3.10
       dir: vendor/k8s.io/kubernetes
-  - name: release-1.9.1
-    source:
-      branch: release-3.9
-      dir: vendor/k8s.io/kubernetes


### PR DESCRIPTION
We don't backport stuff to 3.9 here that would be worth publishing and 4.0 was never published.

/cc @deads2k 