### PR TITLE
Bug 1715055: Work around a kernel bug in the assign-macvlan code [4.1]

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -206,7 +206,13 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 			// add a route to that via the SDN
 			var addrs []netlink.Addr
 			err = hostNS.Do(func(ns.NetNS) error {
-				parent, err := netlink.LinkByIndex(link.Attrs().ParentIndex)
+				// workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1705686
+				parentIndex := link.Attrs().ParentIndex
+				if parentIndex == 0 {
+					parentIndex = link.Attrs().Index
+				}
+
+				parent, err := netlink.LinkByIndex(parentIndex)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Backport of #22784 to 4.1. While the bug is also being fixed in the RHEL kernel, this ensures that the feature works before that is release, and for people on older RHEL 7 releases.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1715055