### PR TITLE
use custom scheme for consuming admission configuration

### DIFF
--- a/pkg/autoscaling/admission/clusterresourceoverride/admission.go
+++ b/pkg/autoscaling/admission/clusterresourceoverride/admission.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"strings"
 
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/autoscaling/admission/apis/clusterresourceoverride/v1"
+
 	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +23,6 @@ import (
 
 	api "github.com/openshift/origin/pkg/autoscaling/admission/apis/clusterresourceoverride"
 	"github.com/openshift/origin/pkg/autoscaling/admission/apis/clusterresourceoverride/validation"
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/project/apiserver/registry/projectrequest/delegated"
 )
 
@@ -103,7 +105,7 @@ func (d *clusterResourceOverridePlugin) SetExternalKubeInformerFactory(kubeInfor
 }
 
 func ReadConfig(configFile io.Reader) (*api.ClusterResourceOverrideConfig, error) {
-	obj, err := configlatest.ReadYAML(configFile)
+	obj, err := helpers.ReadYAMLToInternal(configFile, api.Install, v1.Install)
 	if err != nil {
 		klog.V(5).Infof("%s error reading config: %v", api.PluginName, err)
 		return nil, err

--- a/pkg/autoscaling/admission/runonceduration/admission.go
+++ b/pkg/autoscaling/admission/runonceduration/admission.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/autoscaling/admission/apis/runonceduration/v1"
+
 	"k8s.io/klog"
 
 	"k8s.io/apiserver/pkg/admission"
@@ -16,7 +19,6 @@ import (
 
 	"github.com/openshift/origin/pkg/autoscaling/admission/apis/runonceduration"
 	"github.com/openshift/origin/pkg/autoscaling/admission/apis/runonceduration/validation"
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
@@ -36,7 +38,7 @@ func Register(plugins *admission.Plugins) {
 }
 
 func readConfig(reader io.Reader) (*runonceduration.RunOnceDurationConfig, error) {
-	obj, err := configlatest.ReadYAML(reader)
+	obj, err := helpers.ReadYAMLToInternal(reader, runonceduration.Install, v1.Install)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/apiserver/admission/imagepolicy/imagepolicy_test.go
+++ b/pkg/image/apiserver/admission/imagepolicy/imagepolicy_test.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/openshift/api/image"
 	buildapi "github.com/openshift/origin/pkg/build/apis/build"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	configinstall "github.com/openshift/origin/pkg/cmd/server/apis/config/install"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imagepolicy "github.com/openshift/origin/pkg/image/apiserver/admission/apis/imagepolicy/v1"
 	"github.com/openshift/origin/pkg/image/apiserver/admission/apis/imagepolicy/validation"
@@ -47,10 +45,6 @@ var (
 	buildConfigGroupVersionResource = schema.GroupVersionResource{Group: "build.openshift.io", Version: "v1", Resource: "buildconfigs"}
 	buildConfigGroupVersionKind     = schema.GroupVersionKind{Group: "build.openshift.io", Version: "v1", Kind: "BuildConfig"}
 )
-
-func init() {
-	configinstall.InstallLegacyInternal(configapi.Scheme)
-}
 
 type resolveFunc func(ref *kapi.ObjectReference, defaultNamespace string, forceLocalResolve bool) (*rules.ImagePolicyAttributes, error)
 

--- a/pkg/network/admission/externalipranger/externalip_admission.go
+++ b/pkg/network/admission/externalipranger/externalip_admission.go
@@ -4,17 +4,18 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"reflect"
 	"strings"
+
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/network/admission/apis/externalipranger/v1"
 
 	"k8s.io/klog"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	admission "k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/network/admission/apis/externalipranger"
 )
 
@@ -44,10 +45,7 @@ func RegisterExternalIP(plugins *admission.Plugins) {
 }
 
 func readConfig(reader io.Reader) (*externalipranger.ExternalIPRangerAdmissionConfig, error) {
-	if reader == nil || reflect.ValueOf(reader).IsNil() {
-		return nil, nil
-	}
-	obj, err := configlatest.ReadYAML(reader)
+	obj, err := helpers.ReadYAMLToInternal(reader, externalipranger.Install, v1.Install)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/admission/restrictedendpoints/endpoint_admission.go
+++ b/pkg/network/admission/restrictedendpoints/endpoint_admission.go
@@ -6,6 +6,10 @@ import (
 	"net"
 	"reflect"
 
+	v1 "github.com/openshift/origin/pkg/network/admission/apis/restrictedendpoints/v1"
+
+	"github.com/openshift/library-go/pkg/config/helpers"
+
 	"k8s.io/klog"
 
 	"k8s.io/apiserver/pkg/admission"
@@ -13,7 +17,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/network/admission/apis/restrictedendpoints"
 )
 
@@ -41,10 +44,7 @@ func RegisterRestrictedEndpoints(plugins *admission.Plugins) {
 }
 
 func readConfig(reader io.Reader) (*restrictedendpoints.RestrictedEndpointsAdmissionConfig, error) {
-	if reader == nil || reflect.ValueOf(reader).IsNil() {
-		return nil, nil
-	}
-	obj, err := configlatest.ReadYAML(reader)
+	obj, err := helpers.ReadYAMLToInternal(reader, restrictedendpoints.Install, v1.Install)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/apiserver/admission/requestlimit/admission.go
+++ b/pkg/project/apiserver/admission/requestlimit/admission.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"time"
 
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/project/apiserver/admission/apis/requestlimit/v1"
+
 	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,7 +26,6 @@ import (
 	usertypedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 	"github.com/openshift/origin/pkg/api/legacy"
 	oadmission "github.com/openshift/origin/pkg/cmd/server/admission"
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	requestlimitapi "github.com/openshift/origin/pkg/project/apiserver/admission/apis/requestlimit"
 	requestlimitapivalidation "github.com/openshift/origin/pkg/project/apiserver/admission/apis/requestlimit/validation"
@@ -52,7 +54,7 @@ func Register(plugins *admission.Plugins) {
 }
 
 func readConfig(reader io.Reader) (*requestlimitapi.ProjectRequestLimitConfig, error) {
-	obj, err := configlatest.ReadYAML(reader)
+	obj, err := helpers.ReadYAMLToInternal(reader, requestlimitapi.Install, v1.Install)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/route/apiserver/admission/ingress_admission.go
+++ b/pkg/route/apiserver/admission/ingress_admission.go
@@ -5,8 +5,9 @@ package admission
 import (
 	"fmt"
 	"io"
-	"reflect"
 
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/route/apiserver/admission/apis/ingressadmission/v1"
 	"k8s.io/kubernetes/pkg/apis/networking"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -18,7 +19,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kextensions "k8s.io/kubernetes/pkg/apis/extensions"
 
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/route/apiserver/admission/apis/ingressadmission"
 )
 
@@ -54,10 +54,7 @@ func NewIngressAdmission(config *ingressadmission.IngressAdmissionConfig) *ingre
 }
 
 func readConfig(reader io.Reader) (*ingressadmission.IngressAdmissionConfig, error) {
-	if reader == nil || reflect.ValueOf(reader).IsNil() {
-		return nil, nil
-	}
-	obj, err := configlatest.ReadYAML(reader)
+	obj, err := helpers.ReadYAMLToInternal(reader, ingressadmission.Install, v1.Install)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/admission/podnodeconstraints/admission.go
+++ b/pkg/scheduler/admission/podnodeconstraints/admission.go
@@ -3,8 +3,9 @@ package podnodeconstraints
 import (
 	"fmt"
 	"io"
-	"reflect"
 
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints/v1"
 	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,7 +16,6 @@ import (
 	coreapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 
-	configlatest "github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	"github.com/openshift/origin/pkg/scheduler/admission/apis/podnodeconstraints"
 )
 
@@ -79,10 +79,7 @@ var resourcesToCheck = map[schema.GroupResource]schema.GroupKind{
 }
 
 func readConfig(reader io.Reader) (*podnodeconstraints.PodNodeConstraintsConfig, error) {
-	if reader == nil || reflect.ValueOf(reader).IsNil() {
-		return nil, nil
-	}
-	obj, err := configlatest.ReadYAML(reader)
+	obj, err := helpers.ReadYAMLToInternal(reader, podnodeconstraints.Install, v1.Install)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/clusterresourceoverride_admission_test.go
+++ b/test/integration/clusterresourceoverride_admission_test.go
@@ -10,16 +10,10 @@ import (
 
 	overrideapi "github.com/openshift/origin/pkg/autoscaling/admission/apis/clusterresourceoverride"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	configinstall "github.com/openshift/origin/pkg/cmd/server/apis/config/install"
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
-
-func init() {
-	configinstall.InstallLegacyInternal(configapi.Scheme)
-}
 
 func TestClusterResourceOverridePluginWithNoLimits(t *testing.T) {
 	config := &overrideapi.ClusterResourceOverrideConfig{

--- a/test/integration/oauth_ldap_test.go
+++ b/test/integration/oauth_ldap_test.go
@@ -9,6 +9,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openshift/library-go/pkg/config/helpers"
+	v1 "github.com/openshift/origin/pkg/cmd/server/apis/config/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -139,7 +142,7 @@ func TestOAuthLDAP(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// read back in
-	deserializedObject, err := configapilatest.ReadYAML(bytes.NewBuffer(serializedOptions))
+	deserializedObject, err := helpers.ReadYAMLToInternal(bytes.NewBuffer(serializedOptions), configapi.InstallLegacy, v1.InstallLegacy)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
This is needed to unwind bad/legacy/unintended deps on the legacy configuration types.

/assign @soltysh 