### PR TITLE
 split scopes into descriptions/validation and action

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -422,7 +422,7 @@
     "allowedImportPackages": [
       "vendor/k8s.io/klog",
       "vendor/github.com/davecgh/go-spew/spew",
-      "github.com/openshift/origin/pkg/authorization/authorizer/scope",
+      "github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary",
       "github.com/openshift/origin/pkg/oauth/apis/oauth/validation",
       "github.com/openshift/origin/pkg/oauth/scope",
       "github.com/openshift/origin/pkg/cmd/server/apis/config",

--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -423,8 +423,6 @@
       "vendor/k8s.io/klog",
       "vendor/github.com/davecgh/go-spew/spew",
       "github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary",
-      "github.com/openshift/origin/pkg/oauth/apis/oauth/validation",
-      "github.com/openshift/origin/pkg/oauth/scope",
       "github.com/openshift/origin/pkg/cmd/server/apis/config",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/install",
       "github.com/openshift/origin/pkg/cmd/server/apis/config/latest",

--- a/pkg/authorization/apis/authorization/types.go
+++ b/pkg/authorization/apis/authorization/types.go
@@ -24,8 +24,7 @@ const (
 	VerbAll        = "*"
 	NonResourceAll = "*"
 
-	ScopesKey           = "scopes.authorization.openshift.io"
-	ScopesAllNamespaces = "*"
+	ScopesKey = "scopes.authorization.openshift.io"
 
 	UserKind           = "User"
 	GroupKind          = "Group"
@@ -33,11 +32,10 @@ const (
 	SystemUserKind     = "SystemUser"
 	SystemGroupKind    = "SystemGroup"
 
-	UserResource           = "users"
-	GroupResource          = "groups"
-	ServiceAccountResource = "serviceaccounts"
-	SystemUserResource     = "systemusers"
-	SystemGroupResource    = "systemgroups"
+	UserResource        = "users"
+	GroupResource       = "groups"
+	SystemUserResource  = "systemusers"
+	SystemGroupResource = "systemgroups"
 )
 
 // DiscoveryRule is a rule that allows a client to discover the API resources available on this server

--- a/pkg/authorization/authorizer/scope/converter_test.go
+++ b/pkg/authorization/authorizer/scope/converter_test.go
@@ -9,8 +9,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 )
 
 func TestUserEvaluator(t *testing.T) {
@@ -222,7 +220,7 @@ func TestEscalationProtection(t *testing.T) {
 					Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods", "secrets"}}},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{""}, Resources: []string{"pods"}}},
+			expectedRules: []rbacv1.PolicyRule{scopeDiscoveryRule, {APIGroups: []string{""}, Resources: []string{"pods"}}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
 		{
@@ -233,7 +231,7 @@ func TestEscalationProtection(t *testing.T) {
 					Rules:      []rbacv1.PolicyRule{{APIGroups: []string{}, Resources: []string{"pods", "secrets"}}},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{}, Resources: []string{"pods", "secrets"}}},
+			expectedRules: []rbacv1.PolicyRule{scopeDiscoveryRule, {APIGroups: []string{}, Resources: []string{"pods", "secrets"}}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
 		{
@@ -244,7 +242,7 @@ func TestEscalationProtection(t *testing.T) {
 					Rules:      []rbacv1.PolicyRule{{APIGroups: []string{"foo"}, Resources: []string{"pods", "secrets"}}},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{"foo"}, Resources: []string{"pods", "secrets"}}},
+			expectedRules: []rbacv1.PolicyRule{scopeDiscoveryRule, {APIGroups: []string{"foo"}, Resources: []string{"pods", "secrets"}}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
 		{
@@ -255,7 +253,7 @@ func TestEscalationProtection(t *testing.T) {
 					Rules:      []rbacv1.PolicyRule{{APIGroups: []string{"", "and-foo"}, Resources: []string{"pods", "oauthaccesstokens"}}},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{"", "and-foo"}, Resources: []string{"pods"}}},
+			expectedRules: []rbacv1.PolicyRule{scopeDiscoveryRule, {APIGroups: []string{"", "and-foo"}, Resources: []string{"pods"}}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*"},
 		},
 		{
@@ -266,7 +264,7 @@ func TestEscalationProtection(t *testing.T) {
 					Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods", "secrets"}}},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{authorizationapi.DiscoveryRule, {APIGroups: []string{""}, Resources: []string{"pods", "secrets"}}},
+			expectedRules: []rbacv1.PolicyRule{scopeDiscoveryRule, {APIGroups: []string{""}, Resources: []string{"pods", "secrets"}}},
 			scopes:        []string{ClusterRoleIndicator + "admin:*:!"},
 		},
 	}

--- a/pkg/authorization/authorizer/scope/validate_test.go
+++ b/pkg/authorization/authorizer/scope/validate_test.go
@@ -4,53 +4,53 @@ import (
 	"strings"
 	"testing"
 
-	oauthapi "github.com/openshift/api/oauth/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 )
 
 func TestValidateScopeRestrictions(t *testing.T) {
 	testCases := []struct {
 		name   string
 		scopes []string
-		client *oauthapi.OAuthClient
+		client *oauthv1.OAuthClient
 
 		expectedErrors []string
 	}{
 		{
 			name:   "unrestricted allows any",
 			scopes: []string{"one"},
-			client: &oauthapi.OAuthClient{},
+			client: &oauthv1.OAuthClient{},
 		},
 		{
 			name:   "unrestricted allows empty",
 			scopes: []string{""},
-			client: &oauthapi.OAuthClient{},
+			client: &oauthv1.OAuthClient{},
 		},
 		{
 			name:           "missing scopes check precedes unrestricted",
 			scopes:         []string{},
-			client:         &oauthapi.OAuthClient{},
+			client:         &oauthv1.OAuthClient{},
 			expectedErrors: []string{"may not request unscoped tokens"},
 		},
 		{
 			name:   "simple literal",
 			scopes: []string{"one"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ExactValues: []string{"two", "one"}}},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ExactValues: []string{"two", "one"}}},
 			},
 		},
 		{
 			name:   "simple must match",
 			scopes: []string{"missing"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ExactValues: []string{"two", "one"}}},
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ExactValues: []string{"two", "one"}}},
 			},
 			expectedErrors: []string{`missing not found in [two one]`},
 		},
 		{
 			name:   "cluster role name must match",
 			scopes: []string{ClusterRoleIndicator + "three:alfa"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
 					Namespaces:      []string{"alfa", "bravo"},
 					AllowEscalation: false,
@@ -61,8 +61,8 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		{
 			name:   "cluster role namespace must match",
 			scopes: []string{ClusterRoleIndicator + "two:charlie"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
 					Namespaces:      []string{"alfa", "bravo"},
 					AllowEscalation: false,
@@ -73,8 +73,8 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		{
 			name:   "cluster role escalation must match",
 			scopes: []string{ClusterRoleIndicator + "two:bravo:!"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
 					Namespaces:      []string{"alfa", "bravo"},
 					AllowEscalation: false,
@@ -85,8 +85,8 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		{
 			name:   "cluster role matches",
 			scopes: []string{ClusterRoleIndicator + "two:bravo:!"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
 					Namespaces:      []string{"alfa", "bravo"},
 					AllowEscalation: true,
@@ -96,8 +96,8 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		{
 			name:   "cluster role matches 2",
 			scopes: []string{ClusterRoleIndicator + "two:bravo"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
 					Namespaces:      []string{"alfa", "bravo"},
 					AllowEscalation: false,
@@ -107,8 +107,8 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		{
 			name:   "cluster role star matches",
 			scopes: []string{ClusterRoleIndicator + "two:bravo"},
-			client: &oauthapi.OAuthClient{
-				ScopeRestrictions: []oauthapi.ScopeRestriction{{ClusterRole: &oauthapi.ClusterRoleScopeRestriction{
+			client: &oauthv1.OAuthClient{
+				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two", "*"},
 					Namespaces:      []string{"alfa", "bravo", "*"},
 					AllowEscalation: true,

--- a/pkg/authorization/authorizer/scopeauthorizer/authorizer.go
+++ b/pkg/authorization/authorizer/scopeauthorizer/authorizer.go
@@ -1,4 +1,4 @@
-package scope
+package scopeauthorizer
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	authorizerrbac "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 )
 
 type scopeAuthorizer struct {
@@ -32,7 +33,7 @@ func (a *scopeAuthorizer) Authorize(attributes authorizer.Attributes) (authorize
 	nonFatalErrors := ""
 
 	// scopeResolutionErrors aren't fatal.  If any of the scopes we find allow this, then the overall scope limits allow it
-	rules, err := ScopesToRules(scopes, attributes.GetNamespace(), a.clusterRoleGetter)
+	rules, err := scope.ScopesToRules(scopes, attributes.GetNamespace(), a.clusterRoleGetter)
 	if err != nil {
 		nonFatalErrors = fmt.Sprintf(", additionally the following non-fatal errors were reported: %v", err)
 	}

--- a/pkg/authorization/authorizer/scopeauthorizer/authorizer_test.go
+++ b/pkg/authorization/authorizer/scopeauthorizer/authorizer_test.go
@@ -1,4 +1,4 @@
-package scope
+package scopeauthorizer
 
 import (
 	"strings"

--- a/pkg/authorization/authorizer/scopelibrary/clusterrole_describers.go
+++ b/pkg/authorization/authorizer/scopelibrary/clusterrole_describers.go
@@ -1,0 +1,86 @@
+package scopelibrary
+
+import (
+	"fmt"
+	"strings"
+)
+
+// role:<clusterrole name>:<namespace to allow the cluster role, * means all>
+type ClusterRoleEvaluator struct{}
+
+var clusterRoleEvaluatorInstance = ClusterRoleEvaluator{}
+
+func (ClusterRoleEvaluator) Handles(scope string) bool {
+	return ClusterRoleEvaluatorHandles(scope)
+}
+
+func (e ClusterRoleEvaluator) Validate(scope string) error {
+	_, _, _, err := ClusterRoleEvaluatorParseScope(scope)
+	return err
+}
+
+func (e ClusterRoleEvaluator) Describe(scope string) (string, string, error) {
+	roleName, scopeNamespace, escalating, err := ClusterRoleEvaluatorParseScope(scope)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Anything you can do [in project "foo" | server-wide] that is also allowed by the "admin" role[, except access escalating resources like secrets]
+
+	scopePhrase := ""
+	if scopeNamespace == scopesAllNamespaces {
+		scopePhrase = "server-wide"
+	} else {
+		scopePhrase = fmt.Sprintf("in project %q", scopeNamespace)
+	}
+
+	warning := ""
+	escalatingPhrase := ""
+	if escalating {
+		warning = fmt.Sprintf("Includes access to escalating resources like secrets")
+	} else {
+		escalatingPhrase = ", except access escalating resources like secrets"
+	}
+
+	description := fmt.Sprintf("Anything you can do %s that is also allowed by the %q role%s", scopePhrase, roleName, escalatingPhrase)
+
+	return description, warning, nil
+}
+
+func ClusterRoleEvaluatorHandles(scope string) bool {
+	return strings.HasPrefix(scope, clusterRoleIndicator)
+}
+
+// ClusterRoleEvaluatorParseScope parses the requested scope, determining the requested role name, namespace, and if
+// access to escalating objects is required.  It will return an error if it doesn't parse cleanly
+func ClusterRoleEvaluatorParseScope(scope string) (string /*role name*/, string /*namespace*/, bool /*escalating*/, error) {
+	if !ClusterRoleEvaluatorHandles(scope) {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+	return parseClusterRoleScope(scope)
+}
+
+func parseClusterRoleScope(scope string) (string /*role name*/, string /*namespace*/, bool /*escalating*/, error) {
+	if !strings.HasPrefix(scope, clusterRoleIndicator) {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+	escalating := false
+	if strings.HasSuffix(scope, ":!") {
+		escalating = true
+		// clip that last segment before parsing the rest
+		scope = scope[:strings.LastIndex(scope, ":")]
+	}
+
+	tokens := strings.SplitN(scope, ":", 2)
+	if len(tokens) != 2 {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+
+	// namespaces can't have colons, but roles can.  pick last.
+	lastColonIndex := strings.LastIndex(tokens[1], ":")
+	if lastColonIndex <= 0 || lastColonIndex == (len(tokens[1])-1) {
+		return "", "", false, fmt.Errorf("bad format for scope %v", scope)
+	}
+
+	return tokens[1][0:lastColonIndex], tokens[1][lastColonIndex+1:], escalating, nil
+}

--- a/pkg/authorization/authorizer/scopelibrary/describers.go
+++ b/pkg/authorization/authorizer/scopelibrary/describers.go
@@ -1,0 +1,17 @@
+package scopelibrary
+
+// ScopeDescriber takes a scope and returns metadata about it
+type ScopeDescriber interface {
+	// Handles returns true if this evaluator can evaluate this scope
+	Handles(scope string) bool
+	// Validate returns an error if the scope is malformed
+	Validate(scope string) error
+	// Describe returns a description, warning (typically used to warn about escalation dangers), or an error if the scope is malformed
+	Describe(scope string) (description string, warning string, err error)
+}
+
+// ScopeDescribers map prefixes to a function that handles that prefix
+var ScopeDescribers = []ScopeDescriber{
+	UserEvaluator{},
+	ClusterRoleEvaluator{},
+}

--- a/pkg/authorization/authorizer/scopelibrary/user_describers.go
+++ b/pkg/authorization/authorizer/scopelibrary/user_describers.go
@@ -1,0 +1,68 @@
+package scopelibrary
+
+import (
+	"fmt"
+)
+
+// these must agree with the scope authorizer, but it's an API we cannot realistically change
+const (
+	scopesAllNamespaces = "*"
+
+	userIndicator        = "user:"
+	clusterRoleIndicator = "role:"
+
+	userInfo        = userIndicator + "info"
+	userAccessCheck = userIndicator + "check-access"
+
+	// UserListScopedProjects gives explicit permission to see the projects that this token can see.
+	userListScopedProjects = userIndicator + "list-scoped-projects"
+
+	// UserListAllProjects gives explicit permission to see the projects a user can see.  This is often used to prime secondary ACL systems
+	// unrelated to openshift and to display projects for selection in a secondary UI.
+	userListAllProjects = userIndicator + "list-projects"
+
+	// UserFull includes all permissions of the user
+	userFull = userIndicator + "full"
+)
+
+// user:<scope name>
+type UserEvaluator struct{}
+
+func (UserEvaluator) Handles(scope string) bool {
+	return UserEvaluatorHandles(scope)
+}
+
+func (e UserEvaluator) Validate(scope string) error {
+	if e.Handles(scope) {
+		return nil
+	}
+
+	return fmt.Errorf("unrecognized scope: %v", scope)
+}
+
+var defaultSupportedScopesMap = map[string]string{
+	userInfo:               "Read-only access to your user information (including username, identities, and group membership)",
+	userAccessCheck:        `Read-only access to view your privileges (for example, "can I create builds?")`,
+	userListScopedProjects: `Read-only access to list your projects viewable with this token and view their metadata (display name, description, etc.)`,
+	userListAllProjects:    `Read-only access to list your projects and view their metadata (display name, description, etc.)`,
+	userFull:               `Full read/write access with all of your permissions`,
+}
+
+func (UserEvaluator) Describe(scope string) (string, string, error) {
+	switch scope {
+	case userInfo, userAccessCheck, userListScopedProjects, userListAllProjects:
+		return defaultSupportedScopesMap[scope], "", nil
+	case userFull:
+		return defaultSupportedScopesMap[scope], `Includes any access you have to escalating resources like secrets`, nil
+	default:
+		return "", "", fmt.Errorf("unrecognized scope: %v", scope)
+	}
+}
+
+func UserEvaluatorHandles(scope string) bool {
+	switch scope {
+	case userFull, userInfo, userAccessCheck, userListScopedProjects, userListAllProjects:
+		return true
+	}
+	return false
+}

--- a/pkg/authorization/authorizer/scopelibrary/validation.go
+++ b/pkg/authorization/authorizer/scopelibrary/validation.go
@@ -1,0 +1,152 @@
+package scopelibrary
+
+import (
+	"fmt"
+
+	kutilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+)
+
+func ValidateScopes(scopes []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(scopes) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "may not be empty"))
+	}
+
+	for i, scope := range scopes {
+		illegalCharacter := false
+		// https://tools.ietf.org/html/rfc6749#section-3.3 (full list of allowed chars is %x21 / %x23-5B / %x5D-7E)
+		// for those without an ascii table, that's `!`, `#-[`, `]-~` inclusive.
+		for _, ch := range scope {
+			switch {
+			case ch == '!':
+			case ch >= '#' && ch <= '[':
+			case ch >= ']' && ch <= '~':
+			default:
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, fmt.Sprintf("%v not allowed", ch)))
+				illegalCharacter = true
+			}
+		}
+		if illegalCharacter {
+			continue
+		}
+
+		found := false
+		for _, evaluator := range ScopeDescribers {
+			if !evaluator.Handles(scope) {
+				continue
+			}
+
+			found = true
+			if err := evaluator.Validate(scope); err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, err.Error()))
+				break
+			}
+		}
+
+		if !found {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, "no scope handler found"))
+		}
+	}
+
+	return allErrs
+}
+
+func ValidateScopeRestrictions(client *oauthv1.OAuthClient, scopes ...string) error {
+	if len(scopes) == 0 {
+		return fmt.Errorf("%s may not request unscoped tokens", client.Name)
+	}
+
+	if len(client.ScopeRestrictions) == 0 {
+		return nil
+	}
+
+	errs := []error{}
+	for _, scope := range scopes {
+		if err := validateScopeRestrictions(client, scope); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return kutilerrors.NewAggregate(errs)
+}
+
+func validateScopeRestrictions(client *oauthv1.OAuthClient, scope string) error {
+	errs := []error{}
+
+	for _, restriction := range client.ScopeRestrictions {
+		if len(restriction.ExactValues) > 0 {
+			if err := validateLiteralScopeRestrictions(scope, restriction.ExactValues); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			return nil
+		}
+
+		if restriction.ClusterRole != nil {
+			if !ClusterRoleEvaluatorHandles(scope) {
+				continue
+			}
+			if err := validateClusterRoleScopeRestrictions(scope, *restriction.ClusterRole); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			return nil
+		}
+	}
+
+	// if we got here, then nothing matched.   If we already have errors, do nothing, otherwise add one to make it report failed.
+	if len(errs) == 0 {
+		errs = append(errs, fmt.Errorf("%v did not match any scope restriction", scope))
+	}
+
+	return kutilerrors.NewAggregate(errs)
+}
+
+func validateLiteralScopeRestrictions(scope string, literals []string) error {
+	for _, literal := range literals {
+		if literal == scope {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%v not found in %v", scope, literals)
+}
+
+func validateClusterRoleScopeRestrictions(scope string, restriction oauthv1.ClusterRoleScopeRestriction) error {
+	role, namespace, escalating, err := ClusterRoleEvaluatorParseScope(scope)
+	if err != nil {
+		return err
+	}
+
+	foundName := false
+	for _, restrictedRoleName := range restriction.RoleNames {
+		if restrictedRoleName == "*" || restrictedRoleName == role {
+			foundName = true
+			break
+		}
+	}
+	if !foundName {
+		return fmt.Errorf("%v does not use an approved name", scope)
+	}
+
+	foundNamespace := false
+	for _, restrictedNamespace := range restriction.Namespaces {
+		if restrictedNamespace == "*" || restrictedNamespace == namespace {
+			foundNamespace = true
+			break
+		}
+	}
+	if !foundNamespace {
+		return fmt.Errorf("%v does not use an approved namespace", scope)
+	}
+
+	if escalating && !restriction.AllowEscalation {
+		return fmt.Errorf("%v is not allowed to escalate", scope)
+	}
+
+	return nil
+}

--- a/pkg/authorization/authorizer/scopelibrary/validation_test.go
+++ b/pkg/authorization/authorizer/scopelibrary/validation_test.go
@@ -1,4 +1,4 @@
-package scope
+package scopelibrary
 
 import (
 	"strings"
@@ -48,7 +48,7 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		},
 		{
 			name:   "cluster role name must match",
-			scopes: []string{ClusterRoleIndicator + "three:alfa"},
+			scopes: []string{clusterRoleIndicator + "three:alfa"},
 			client: &oauthv1.OAuthClient{
 				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
@@ -60,7 +60,7 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		},
 		{
 			name:   "cluster role namespace must match",
-			scopes: []string{ClusterRoleIndicator + "two:charlie"},
+			scopes: []string{clusterRoleIndicator + "two:charlie"},
 			client: &oauthv1.OAuthClient{
 				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
@@ -72,7 +72,7 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		},
 		{
 			name:   "cluster role escalation must match",
-			scopes: []string{ClusterRoleIndicator + "two:bravo:!"},
+			scopes: []string{clusterRoleIndicator + "two:bravo:!"},
 			client: &oauthv1.OAuthClient{
 				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
@@ -84,7 +84,7 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		},
 		{
 			name:   "cluster role matches",
-			scopes: []string{ClusterRoleIndicator + "two:bravo:!"},
+			scopes: []string{clusterRoleIndicator + "two:bravo:!"},
 			client: &oauthv1.OAuthClient{
 				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
@@ -95,7 +95,7 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		},
 		{
 			name:   "cluster role matches 2",
-			scopes: []string{ClusterRoleIndicator + "two:bravo"},
+			scopes: []string{clusterRoleIndicator + "two:bravo"},
 			client: &oauthv1.OAuthClient{
 				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two"},
@@ -106,7 +106,7 @@ func TestValidateScopeRestrictions(t *testing.T) {
 		},
 		{
 			name:   "cluster role star matches",
-			scopes: []string{ClusterRoleIndicator + "two:bravo"},
+			scopes: []string{clusterRoleIndicator + "two:bravo"},
 			client: &oauthv1.OAuthClient{
 				ScopeRestrictions: []oauthv1.ScopeRestriction{{ClusterRole: &oauthv1.ClusterRoleScopeRestriction{
 					RoleNames:       []string{"one", "two", "*"},

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_authorizer.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch_authorizer.go
@@ -1,6 +1,7 @@
 package openshiftkubeapiserver
 
 import (
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopeauthorizer"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
@@ -12,13 +13,12 @@ import (
 	kbootstrappolicy "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 
 	"github.com/openshift/origin/pkg/authorization/authorizer/browsersafe"
-	"github.com/openshift/origin/pkg/authorization/authorizer/scope"
 )
 
 func NewAuthorizer(versionedInformers informers.SharedInformerFactory) authorizer.Authorizer {
 	rbacInformers := versionedInformers.Rbac().V1()
 
-	scopeLimitedAuthorizer := scope.NewAuthorizer(rbacInformers.ClusterRoles().Lister())
+	scopeLimitedAuthorizer := scopeauthorizer.NewAuthorizer(rbacInformers.ClusterRoles().Lister())
 
 	kubeAuthorizer := rbacauthorizer.New(
 		&rbacauthorizer.RoleGetter{Lister: rbacInformers.Roles().Lister()},

--- a/pkg/oauth/apis/oauth/validation/validation.go
+++ b/pkg/oauth/apis/oauth/validation/validation.go
@@ -14,7 +14,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	bootstrap "github.com/openshift/library-go/pkg/authentication/bootstrapauthenticator"
-	authorizerscopes "github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	uservalidation "github.com/openshift/origin/pkg/user/apis/user/validation"
 )
@@ -75,7 +75,7 @@ func ValidateAccessToken(accessToken *oauthapi.OAuthAccessToken) field.ErrorList
 	allErrs := validation.ValidateObjectMeta(&accessToken.ObjectMeta, false, ValidateTokenName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClientNameField(accessToken.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(accessToken.UserName, field.NewPath("userName"))...)
-	allErrs = append(allErrs, ValidateScopes(accessToken.Scopes, field.NewPath("scopes"))...)
+	allErrs = append(allErrs, scopelibrary.ValidateScopes(accessToken.Scopes, field.NewPath("scopes"))...)
 
 	if len(accessToken.UserUID) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("userUID"), ""))
@@ -129,7 +129,7 @@ func ValidateAuthorizeToken(authorizeToken *oauthapi.OAuthAuthorizeToken) field.
 	allErrs := validation.ValidateObjectMeta(&authorizeToken.ObjectMeta, false, ValidateTokenName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateClientNameField(authorizeToken.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(authorizeToken.UserName, field.NewPath("userName"))...)
-	allErrs = append(allErrs, ValidateScopes(authorizeToken.Scopes, field.NewPath("scopes"))...)
+	allErrs = append(allErrs, scopelibrary.ValidateScopes(authorizeToken.Scopes, field.NewPath("scopes"))...)
 
 	if len(authorizeToken.UserUID) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("userUID"), ""))
@@ -293,7 +293,7 @@ func ValidateClientAuthorization(clientAuthorization *oauthapi.OAuthClientAuthor
 
 	allErrs = append(allErrs, ValidateClientNameField(clientAuthorization.ClientName, field.NewPath("clientName"))...)
 	allErrs = append(allErrs, ValidateUserNameField(clientAuthorization.UserName, field.NewPath("userName"))...)
-	allErrs = append(allErrs, ValidateScopes(clientAuthorization.Scopes, field.NewPath("scopes"))...)
+	allErrs = append(allErrs, scopelibrary.ValidateScopes(clientAuthorization.Scopes, field.NewPath("scopes"))...)
 
 	if len(clientAuthorization.UserUID) == 0 {
 		allErrs = append(allErrs, field.Required(field.NewPath("useruid"), ""))
@@ -346,52 +346,6 @@ func ValidateUserNameField(value string, fldPath *field.Path) field.ErrorList {
 		return field.ErrorList{field.Invalid(fldPath, value, strings.Join(reasons, ", "))}
 	}
 	return field.ErrorList{}
-}
-
-func ValidateScopes(scopes []string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if len(scopes) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath, "may not be empty"))
-	}
-
-	for i, scope := range scopes {
-		illegalCharacter := false
-		// https://tools.ietf.org/html/rfc6749#section-3.3 (full list of allowed chars is %x21 / %x23-5B / %x5D-7E)
-		// for those without an ascii table, that's `!`, `#-[`, `]-~` inclusive.
-		for _, ch := range scope {
-			switch {
-			case ch == '!':
-			case ch >= '#' && ch <= '[':
-			case ch >= ']' && ch <= '~':
-			default:
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, fmt.Sprintf("%v not allowed", ch)))
-				illegalCharacter = true
-			}
-		}
-		if illegalCharacter {
-			continue
-		}
-
-		found := false
-		for _, evaluator := range authorizerscopes.ScopeEvaluators {
-			if !evaluator.Handles(scope) {
-				continue
-			}
-
-			found = true
-			if err := evaluator.Validate(scope); err != nil {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, err.Error()))
-				break
-			}
-		}
-
-		if !found {
-			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), scope, "no scope handler found"))
-		}
-	}
-
-	return allErrs
 }
 
 func ValidateOAuthRedirectReference(sref *oauthapi.OAuthRedirectReference) field.ErrorList {

--- a/pkg/oauth/apiserver/registry/oauthaccesstoken/strategy.go
+++ b/pkg/oauth/apiserver/registry/oauthaccesstoken/strategy.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
-	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/apis/oauth/validation"
 	"github.com/openshift/origin/pkg/oauth/apiserver/registry/oauthclient"
@@ -57,7 +57,7 @@ func (s strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorL
 	if err != nil {
 		return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 	}
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, token.Scopes...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, token.Scopes...); err != nil {
 		return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 	}
 

--- a/pkg/oauth/apiserver/registry/oauthauthorizetoken/strategy.go
+++ b/pkg/oauth/apiserver/registry/oauthauthorizetoken/strategy.go
@@ -3,13 +3,14 @@ package oauthauthorizetoken
 import (
 	"context"
 
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
-	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/apis/oauth/validation"
 	"github.com/openshift/origin/pkg/oauth/apiserver/registry/oauthclient"
@@ -61,7 +62,7 @@ func (s strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorL
 	if err != nil {
 		return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 	}
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, token.Scopes...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, token.Scopes...); err != nil {
 		return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 	}
 

--- a/pkg/oauth/apiserver/registry/oauthclientauthorization/strategy.go
+++ b/pkg/oauth/apiserver/registry/oauthclientauthorization/strategy.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
-	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/apis/oauth/validation"
 	"github.com/openshift/origin/pkg/oauth/apiserver/registry/oauthclient"
@@ -68,7 +68,7 @@ func (s strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorL
 	if err != nil {
 		return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 	}
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, auth.Scopes...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, auth.Scopes...); err != nil {
 		return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 	}
 
@@ -87,7 +87,7 @@ func (s strategy) ValidateUpdate(ctx context.Context, obj runtime.Object, old ru
 		if err != nil {
 			return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 		}
-		if err := scopeauthorizer.ValidateScopeRestrictions(client, clientAuth.Scopes...); err != nil {
+		if err := scopelibrary.ValidateScopeRestrictions(client, clientAuth.Scopes...); err != nil {
 			return append(validationErrors, field.InternalError(field.NewPath("clientName"), err))
 		}
 	}

--- a/pkg/oauthserver/oauth/handlers/grant.go
+++ b/pkg/oauthserver/oauth/handlers/grant.go
@@ -16,9 +16,9 @@ import (
 
 	oauthapi "github.com/openshift/api/oauth/v1"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
-	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/osinserver"
+	"github.com/openshift/origin/pkg/oauthserver/scopecovers"
 )
 
 // GrantCheck implements osinserver.AuthorizeHandler to ensure requested scopes have been authorized
@@ -64,11 +64,11 @@ func (h *GrantCheck) HandleAuthorize(ar *osin.AuthorizeRequest, resp *osin.Respo
 	}
 
 	// Normalize the scope request, and ensure all tokens contain a scope
-	scopes := scope.Split(ar.Scope)
+	scopes := scopecovers.Split(ar.Scope)
 	if len(scopes) == 0 {
 		scopes = append(scopes, "user:full")
 	}
-	ar.Scope = scope.Join(scopes)
+	ar.Scope = scopecovers.Join(scopes)
 
 	// Validate the requested scopes
 	if scopeErrors := scopelibrary.ValidateScopes(scopes, nil); len(scopeErrors) > 0 {

--- a/pkg/oauthserver/oauth/registry/grantchecker.go
+++ b/pkg/oauthserver/oauth/registry/grantchecker.go
@@ -10,8 +10,8 @@ import (
 
 	oauth "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
-	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/api"
+	"github.com/openshift/origin/pkg/oauthserver/scopecovers"
 
 	"k8s.io/klog"
 )
@@ -49,7 +49,7 @@ func (c *ClientAuthorizationGrantChecker) HasAuthorizedClient(user kuser.Info, g
 	}
 
 	// TODO: improve this to allow the scope implementation to determine overlap
-	if authorization == nil || !scope.Covers(authorization.Scopes, scope.Split(grant.Scope)) {
+	if authorization == nil || !scopecovers.Covers(authorization.Scopes, scopecovers.Split(grant.Scope)) {
 		return false, nil
 	}
 

--- a/pkg/oauthserver/osinserver/registrystorage/storage.go
+++ b/pkg/oauthserver/osinserver/registrystorage/storage.go
@@ -16,9 +16,9 @@ import (
 
 	oauthapi "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
-	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/oauth/handlers"
+	"github.com/openshift/origin/pkg/oauthserver/scopecovers"
 )
 
 type storage struct {
@@ -196,7 +196,7 @@ func (s *storage) convertToAuthorizeToken(data *osin.AuthorizeData) (*oauthapi.O
 		CodeChallengeMethod: data.CodeChallengeMethod,
 		ClientName:          data.Client.GetId(),
 		ExpiresIn:           int64(data.ExpiresIn),
-		Scopes:              scope.Split(data.Scope),
+		Scopes:              scopecovers.Split(data.Scope),
 		RedirectURI:         data.RedirectUri,
 		State:               data.State,
 	}
@@ -226,7 +226,7 @@ func (s *storage) convertFromAuthorizeToken(authorize *oauthapi.OAuthAuthorizeTo
 		CodeChallengeMethod: authorize.CodeChallengeMethod,
 		Client:              &clientWrapper{authorize.ClientName, client},
 		ExpiresIn:           int32(authorize.ExpiresIn),
-		Scope:               scope.Join(authorize.Scopes),
+		Scope:               scopecovers.Join(authorize.Scopes),
 		RedirectUri:         authorize.RedirectURI,
 		State:               authorize.State,
 		CreatedAt:           authorize.CreationTimestamp.Time,
@@ -244,7 +244,7 @@ func (s *storage) convertToAccessToken(data *osin.AccessData) (*oauthapi.OAuthAc
 		ExpiresIn:    int64(data.ExpiresIn),
 		RefreshToken: data.RefreshToken,
 		ClientName:   data.Client.GetId(),
-		Scopes:       scope.Split(data.Scope),
+		Scopes:       scopecovers.Split(data.Scope),
 		RedirectURI:  data.RedirectUri,
 	}
 	if data.AuthorizeData != nil {
@@ -284,7 +284,7 @@ func (s *storage) convertFromAccessToken(access *oauthapi.OAuthAccessToken) (*os
 		RefreshToken: access.RefreshToken,
 		Client:       &clientWrapper{access.ClientName, client},
 		ExpiresIn:    int32(access.ExpiresIn),
-		Scope:        scope.Join(access.Scopes),
+		Scope:        scopecovers.Join(access.Scopes),
 		RedirectUri:  access.RedirectURI,
 		CreatedAt:    access.CreationTimestamp.Time,
 		UserData:     user,

--- a/pkg/oauthserver/osinserver/registrystorage/storage.go
+++ b/pkg/oauthserver/osinserver/registrystorage/storage.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
+
 	"github.com/RangelReale/osin"
 	"k8s.io/klog"
 
@@ -14,7 +16,6 @@ import (
 
 	oauthapi "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
-	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/api"
 	"github.com/openshift/origin/pkg/oauthserver/oauth/handlers"
@@ -215,7 +216,7 @@ func (s *storage) convertFromAuthorizeToken(authorize *oauthapi.OAuthAuthorizeTo
 	if err != nil {
 		return nil, err
 	}
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, authorize.Scopes...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, authorize.Scopes...); err != nil {
 		return nil, err
 	}
 
@@ -274,7 +275,7 @@ func (s *storage) convertFromAccessToken(access *oauthapi.OAuthAccessToken) (*os
 	if err != nil {
 		return nil, err
 	}
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, access.Scopes...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, access.Scopes...); err != nil {
 		return nil, err
 	}
 

--- a/pkg/oauthserver/scopecovers/scope.go
+++ b/pkg/oauthserver/scopecovers/scope.go
@@ -1,4 +1,4 @@
-package scope
+package scopecovers
 
 import (
 	"sort"

--- a/pkg/oauthserver/scopecovers/scope_test.go
+++ b/pkg/oauthserver/scopecovers/scope_test.go
@@ -1,4 +1,4 @@
-package scope
+package scopecovers
 
 import (
 	"reflect"

--- a/pkg/oauthserver/server/grant/grant.go
+++ b/pkg/oauthserver/server/grant/grant.go
@@ -17,9 +17,9 @@ import (
 	oapi "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
-	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver"
 	"github.com/openshift/origin/pkg/oauthserver/api"
+	"github.com/openshift/origin/pkg/oauthserver/scopecovers"
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
 	"github.com/openshift/origin/pkg/oauthserver/server/redirect"
 )
@@ -121,7 +121,7 @@ func (l *Grant) handleForm(user user.Info, w http.ResponseWriter, req *http.Requ
 	q := req.URL.Query()
 	then := q.Get(thenParam)
 	clientID := q.Get(clientIDParam)
-	scopes := scope.Split(q.Get(scopeParam))
+	scopes := scopecovers.Split(q.Get(scopeParam))
 	redirectURI := q.Get(redirectURIParam)
 
 	client, err := l.clientregistry.Get(clientID, metav1.GetOptions{})
@@ -196,7 +196,7 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 
 	req.ParseForm()
 	then := req.PostFormValue(thenParam)
-	scopes := scope.Join(req.PostForm[scopeParam])
+	scopes := scopecovers.Join(req.PostForm[scopeParam])
 	username := req.PostFormValue(userNameParam)
 
 	if username != user.GetName() {
@@ -226,7 +226,7 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 		l.failed("Could not find client for client_id", w, req)
 		return
 	}
-	if err := scopelibrary.ValidateScopeRestrictions(client, scope.Split(scopes)...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, scopecovers.Split(scopes)...); err != nil {
 		failure := fmt.Sprintf("%v requested illegal scopes (%v): %v", client.Name, scopes, err)
 		l.failed(failure, w, req)
 		return
@@ -237,7 +237,7 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 	clientAuth, err := l.authregistry.Get(clientAuthID, metav1.GetOptions{})
 	if err == nil && clientAuth != nil {
 		// Add new scopes and update
-		clientAuth.Scopes = scope.Add(clientAuth.Scopes, scope.Split(scopes))
+		clientAuth.Scopes = scopecovers.Add(clientAuth.Scopes, scopecovers.Split(scopes))
 		if _, err = l.authregistry.Update(clientAuth); err != nil {
 			klog.Errorf("Unable to update authorization: %v", err)
 			l.failed("Could not update client authorization", w, req)
@@ -249,7 +249,7 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 			UserName:   user.GetName(),
 			UserUID:    user.GetUID(),
 			ClientName: client.Name,
-			Scopes:     scope.Split(scopes),
+			Scopes:     scopecovers.Split(scopes),
 		}
 		clientAuth.Name = clientAuthID
 
@@ -295,7 +295,7 @@ func getScopeData(scopeName string, grantedScopeNames []string) Scope {
 	scopeData := Scope{
 		Name:    scopeName,
 		Error:   fmt.Sprintf("Unknown scope"),
-		Granted: scope.Covers(grantedScopeNames, []string{scopeName}),
+		Granted: scopecovers.Covers(grantedScopeNames, []string{scopeName}),
 	}
 	for _, evaluator := range scopelibrary.ScopeDescribers {
 		if !evaluator.Handles(scopeName) {

--- a/pkg/oauthserver/server/grant/grant.go
+++ b/pkg/oauthserver/server/grant/grant.go
@@ -16,7 +16,7 @@ import (
 
 	oapi "github.com/openshift/api/oauth/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
-	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
+	"github.com/openshift/origin/pkg/authorization/authorizer/scopelibrary"
 	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver"
 	"github.com/openshift/origin/pkg/oauthserver/api"
@@ -130,7 +130,7 @@ func (l *Grant) handleForm(user user.Info, w http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, scopes...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, scopes...); err != nil {
 		failure := fmt.Sprintf("%v requested illegal scopes (%v): %v", client.Name, scopes, err)
 		l.failed(failure, w, req)
 		return
@@ -226,7 +226,7 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 		l.failed("Could not find client for client_id", w, req)
 		return
 	}
-	if err := scopeauthorizer.ValidateScopeRestrictions(client, scope.Split(scopes)...); err != nil {
+	if err := scopelibrary.ValidateScopeRestrictions(client, scope.Split(scopes)...); err != nil {
 		failure := fmt.Sprintf("%v requested illegal scopes (%v): %v", client.Name, scopes, err)
 		l.failed(failure, w, req)
 		return
@@ -297,7 +297,7 @@ func getScopeData(scopeName string, grantedScopeNames []string) Scope {
 		Error:   fmt.Sprintf("Unknown scope"),
 		Granted: scope.Covers(grantedScopeNames, []string{scopeName}),
 	}
-	for _, evaluator := range scopeauthorizer.ScopeEvaluators {
+	for _, evaluator := range scopelibrary.ScopeDescribers {
 		if !evaluator.Handles(scopeName) {
 			continue
 		}

--- a/test/integration/oauth_serviceaccount_client_events_test.go
+++ b/test/integration/oauth_serviceaccount_client_events_test.go
@@ -27,7 +27,7 @@ import (
 	oauthapiv1 "github.com/openshift/api/oauth/v1"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config"
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset"
-	"github.com/openshift/origin/pkg/oauth/scope"
+	"github.com/openshift/origin/pkg/oauthserver/scopecovers"
 	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
 	testutil "github.com/openshift/origin/test/util"
 	htmlutil "github.com/openshift/origin/test/util/html"
@@ -87,7 +87,7 @@ func TestOAuthServiceAccountClientEvent(t *testing.T) {
 			annotationPrefix:    saoauth.OAuthRedirectModelAnnotationReferencePrefix + "1",
 			annotation:          `{"kind":"foo","apiVersion":"oauth.openshift.io/v1","metadata":{"creationTimestamp":null},"reference":{"group":"foo","kind":"Route","name":"route1"}}`,
 			expectedEventReason: "NoSAOAuthRedirectURIs",
-			expectedEventMsg:    `[no kind "foo" is registered for version "oauth.openshift.io/v1" in scheme "github.com/openshift/origin/pkg/serviceaccounts/oauthclient/oauthclientregistry.go:54", system:serviceaccount:` + projectName + ":" + saName + " has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]",
+			expectedEventMsg:    `[no kind "foo" is registered for version "oauth.openshift.io/v1" in scheme "github.com/openshift/origin/pkg/serviceaccounts/oauthclient/oauthclientregistry.go:53", system:serviceaccount:` + projectName + ":" + saName + " has no redirectURIs; set serviceaccounts.openshift.io/oauth-redirecturi.<some-value>=<redirect> or create a dynamic URI using serviceaccounts.openshift.io/oauth-redirectreference.<some-value>=<reference>]",
 			numEvents:           1,
 			expectBadRequest:    true,
 		},
@@ -319,7 +319,7 @@ func runTestOAuthFlow(t *testing.T, ts *testServer, sa *corev1.ServiceAccount, s
 		AuthorizeUrl:             ts.clusterAdminClientConfig.Host + "/oauth/authorize",
 		TokenUrl:                 ts.clusterAdminClientConfig.Host + "/oauth/token",
 		RedirectUrl:              redirectURL,
-		Scope:                    scope.Join([]string{"user:info", "role:edit:" + projectName}),
+		Scope:                    scopecovers.Join([]string{"user:info", "role:edit:" + projectName}),
 		SendClientSecretInParams: true,
 	}
 

--- a/test/integration/oauth_serviceaccount_client_test.go
+++ b/test/integration/oauth_serviceaccount_client_test.go
@@ -28,7 +28,7 @@ import (
 	buildv1client "github.com/openshift/client-go/build/clientset/versioned"
 	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset"
-	"github.com/openshift/origin/pkg/oauth/scope"
+	"github.com/openshift/origin/pkg/oauthserver/scopecovers"
 	saoauth "github.com/openshift/origin/pkg/serviceaccounts/oauthclient"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
 	testutil "github.com/openshift/origin/test/util"
@@ -264,7 +264,7 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			AuthorizeUrl:             clusterAdminClientConfig.Host + "/oauth/authorize",
 			TokenUrl:                 clusterAdminClientConfig.Host + "/oauth/token",
 			RedirectUrl:              redirectURL,
-			Scope:                    scope.Join([]string{"user:info", "role:edit:" + projectName}),
+			Scope:                    scopecovers.Join([]string{"user:info", "role:edit:" + projectName}),
 			SendClientSecretInParams: true,
 		}
 		t.Log("Testing allowed scopes")
@@ -300,7 +300,7 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			AuthorizeUrl:             clusterAdminClientConfig.Host + "/oauth/authorize",
 			TokenUrl:                 clusterAdminClientConfig.Host + "/oauth/token",
 			RedirectUrl:              redirectURL,
-			Scope:                    scope.Join([]string{"user:info", "role:edit:other-ns"}),
+			Scope:                    scopecovers.Join([]string{"user:info", "role:edit:other-ns"}),
 			SendClientSecretInParams: true,
 		}
 		t.Log("Testing disallowed scopes")
@@ -322,7 +322,7 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			AuthorizeUrl:             clusterAdminClientConfig.Host + "/oauth/authorize",
 			TokenUrl:                 clusterAdminClientConfig.Host + "/oauth/token",
 			RedirectUrl:              redirectURL,
-			Scope:                    scope.Join([]string{"unknown-scope"}),
+			Scope:                    scopecovers.Join([]string{"unknown-scope"}),
 			SendClientSecretInParams: true,
 		}
 		runOAuthFlow(t, clusterAdminClientConfig, projectName, oauthClientConfig, nil, authorizationCodes, authorizationErrors, false, false, []string{
@@ -343,7 +343,7 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			AuthorizeUrl:             clusterAdminClientConfig.Host + "/oauth/authorize",
 			TokenUrl:                 clusterAdminClientConfig.Host + "/oauth/token",
 			RedirectUrl:              redirectURL,
-			Scope:                    scope.Join([]string{"user:info"}),
+			Scope:                    scopecovers.Join([]string{"user:info"}),
 			SendClientSecretInParams: true,
 		}
 		// First time, the approval is needed
@@ -378,7 +378,7 @@ func TestOAuthServiceAccountClient(t *testing.T) {
 			AuthorizeUrl:             clusterAdminClientConfig.Host + "/oauth/authorize",
 			TokenUrl:                 clusterAdminClientConfig.Host + "/oauth/token",
 			RedirectUrl:              redirectURL,
-			Scope:                    scope.Join([]string{"user:info", "role:edit:" + projectName}),
+			Scope:                    scopecovers.Join([]string{"user:info", "role:edit:" + projectName}),
 			SendClientSecretInParams: true,
 		}
 		t.Log("Testing grant flow is reentrant")


### PR DESCRIPTION
This is needed to allow the descriptions to go into library-go for re-use between oauth-server, the openshift-apiserver, and kube-apiserver.