### PR TITLE
quota: move cluster resource quota helpers closer to usage

### DIFF
--- a/pkg/quota/apis/quota/v1/helpers.go
+++ b/pkg/quota/apis/quota/v1/helpers.go
@@ -2,10 +2,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	quotav1 "github.com/openshift/api/quota/v1"
 )
@@ -49,91 +45,4 @@ func InsertResourceQuotasStatus(namespaceStatuses *quotav1.ResourceQuotasStatusB
 		newNamespaceStatuses = append(newNamespaceStatuses, newStatus)
 	}
 	*namespaceStatuses = newNamespaceStatuses
-}
-
-var accessor = meta.NewAccessor()
-
-func GetMatcher(selector quotav1.ClusterResourceQuotaSelector) (func(obj runtime.Object) (bool, error), error) {
-	var labelSelector labels.Selector
-	if selector.LabelSelector != nil {
-		var err error
-		labelSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var annotationSelector map[string]string
-	if len(selector.AnnotationSelector) > 0 {
-		// ensure our matcher has a stable copy of the map
-		annotationSelector = make(map[string]string, len(selector.AnnotationSelector))
-		for k, v := range selector.AnnotationSelector {
-			annotationSelector[k] = v
-		}
-	}
-
-	return func(obj runtime.Object) (bool, error) {
-		if labelSelector != nil {
-			objLabels, err := accessor.Labels(obj)
-			if err != nil {
-				return false, err
-			}
-			if !labelSelector.Matches(labels.Set(objLabels)) {
-				return false, nil
-			}
-		}
-
-		if annotationSelector != nil {
-			objAnnotations, err := accessor.Annotations(obj)
-			if err != nil {
-				return false, err
-			}
-			for k, v := range annotationSelector {
-				if objValue, exists := objAnnotations[k]; !exists || objValue != v {
-					return false, nil
-				}
-			}
-		}
-
-		return true, nil
-	}, nil
-}
-
-func GetObjectMatcher(selector quotav1.ClusterResourceQuotaSelector) (func(obj metav1.Object) (bool, error), error) {
-	var labelSelector labels.Selector
-	if selector.LabelSelector != nil {
-		var err error
-		labelSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var annotationSelector map[string]string
-	if len(selector.AnnotationSelector) > 0 {
-		// ensure our matcher has a stable copy of the map
-		annotationSelector = make(map[string]string, len(selector.AnnotationSelector))
-		for k, v := range selector.AnnotationSelector {
-			annotationSelector[k] = v
-		}
-	}
-
-	return func(obj metav1.Object) (bool, error) {
-		if labelSelector != nil {
-			if !labelSelector.Matches(labels.Set(obj.GetLabels())) {
-				return false, nil
-			}
-		}
-
-		if annotationSelector != nil {
-			objAnnotations := obj.GetAnnotations()
-			for k, v := range annotationSelector {
-				if objValue, exists := objAnnotations[k]; !exists || objValue != v {
-					return false, nil
-				}
-			}
-		}
-
-		return true, nil
-	}, nil
 }

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping.go
@@ -22,7 +22,6 @@ import (
 	quotav1 "github.com/openshift/api/quota/v1"
 	quotainformer "github.com/openshift/client-go/quota/informers/externalversions/quota/v1"
 	quotalister "github.com/openshift/client-go/quota/listers/quota/v1"
-	quotav1conversions "github.com/openshift/origin/pkg/quota/apis/quota/v1"
 )
 
 // Look out, here there be dragons!
@@ -145,7 +144,7 @@ func (c *ClusterQuotaMappingController) Run(workers int, stopCh <-chan struct{})
 }
 
 func (c *ClusterQuotaMappingController) syncQuota(quota *quotav1.ClusterResourceQuota) error {
-	matcherFunc, err := quotav1conversions.GetObjectMatcher(quota.Spec.Selector)
+	matcherFunc, err := getObjectMatcher(quota.Spec.Selector)
 	if err != nil {
 		return err
 	}
@@ -199,7 +198,7 @@ func (c *ClusterQuotaMappingController) syncNamespace(namespace metav1.Object) e
 		quota := allQuotas[i]
 
 		for {
-			matcherFunc, err := quotav1conversions.GetObjectMatcher(quota.Spec.Selector)
+			matcherFunc, err := getObjectMatcher(quota.Spec.Selector)
 			if err != nil {
 				utilruntime.HandleError(err)
 				break

--- a/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
+++ b/pkg/quota/controller/clusterquotamapping/clusterquotamapping_test.go
@@ -20,7 +20,6 @@ import (
 	quotav1 "github.com/openshift/api/quota/v1"
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned/fake"
 	quotainformer "github.com/openshift/client-go/quota/informers/externalversions"
-	quotav1conversions "github.com/openshift/origin/pkg/quota/apis/quota/v1"
 )
 
 var (
@@ -192,7 +191,7 @@ func checkState(controller *ClusterQuotaMappingController, finalNamespaces map[s
 		namespacesToQuota[namespaceName] = sets.String{}
 	}
 	for _, quota := range finalQuotas {
-		matcherFunc, err := quotav1conversions.GetMatcher(quota.Spec.Selector)
+		matcherFunc, err := getMatcher(quota.Spec.Selector)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/quota/controller/clusterquotamapping/helper.go
+++ b/pkg/quota/controller/clusterquotamapping/helper.go
@@ -1,0 +1,97 @@
+package clusterquotamapping
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+)
+
+var accessor = meta.NewAccessor()
+
+func getObjectMatcher(selector quotav1.ClusterResourceQuotaSelector) (func(obj metav1.Object) (bool, error), error) {
+	var labelSelector labels.Selector
+	if selector.LabelSelector != nil {
+		var err error
+		labelSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var annotationSelector map[string]string
+	if len(selector.AnnotationSelector) > 0 {
+		// ensure our matcher has a stable copy of the map
+		annotationSelector = make(map[string]string, len(selector.AnnotationSelector))
+		for k, v := range selector.AnnotationSelector {
+			annotationSelector[k] = v
+		}
+	}
+
+	return func(obj metav1.Object) (bool, error) {
+		if labelSelector != nil {
+			if !labelSelector.Matches(labels.Set(obj.GetLabels())) {
+				return false, nil
+			}
+		}
+
+		if annotationSelector != nil {
+			objAnnotations := obj.GetAnnotations()
+			for k, v := range annotationSelector {
+				if objValue, exists := objAnnotations[k]; !exists || objValue != v {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	}, nil
+}
+
+func getMatcher(selector quotav1.ClusterResourceQuotaSelector) (func(obj runtime.Object) (bool, error), error) {
+	var labelSelector labels.Selector
+	if selector.LabelSelector != nil {
+		var err error
+		labelSelector, err = metav1.LabelSelectorAsSelector(selector.LabelSelector)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var annotationSelector map[string]string
+	if len(selector.AnnotationSelector) > 0 {
+		// ensure our matcher has a stable copy of the map
+		annotationSelector = make(map[string]string, len(selector.AnnotationSelector))
+		for k, v := range selector.AnnotationSelector {
+			annotationSelector[k] = v
+		}
+	}
+
+	return func(obj runtime.Object) (bool, error) {
+		if labelSelector != nil {
+			objLabels, err := accessor.Labels(obj)
+			if err != nil {
+				return false, err
+			}
+			if !labelSelector.Matches(labels.Set(objLabels)) {
+				return false, nil
+			}
+		}
+
+		if annotationSelector != nil {
+			objAnnotations, err := accessor.Annotations(obj)
+			if err != nil {
+				return false, err
+			}
+			for k, v := range annotationSelector {
+				if objValue, exists := objAnnotations[k]; !exists || objValue != v {
+					return false, nil
+				}
+			}
+		}
+
+		return true, nil
+	}, nil
+}


### PR DESCRIPTION
This moves helpers from internal api closer to controller. The controller now has no dependencies to internal api or origin.

@deads2k admission need this controller as well as controller manager I think. In this state it  can be moved to library-go if we want.

/cc @soltysh 