### PR TITLE
staging: update publishing rules for oauth-server and controller manager

### DIFF
--- a/publishing-staging-rules.yaml
+++ b/publishing-staging-rules.yaml
@@ -20,3 +20,15 @@ rules:
       source:
         branch: master
         dir: staging/src/github.com/openshift/template-service-broker
+- destination: openshift-controller-manager
+  branches:
+    - name: release-4.2
+      source:
+        branch: master
+        dir: staging/src/github.com/openshift/openshift-controller-manager
+- destination: oauth-server
+  branches:
+    - name: release-4.2
+      source:
+        branch: master
+        dir: staging/src/github.com/openshift/oauth-server


### PR DESCRIPTION
This updates the publishing bot rules for origins staging by adding openshift-controller-manager and oauth-server.

- [x] pre-require: https://github.com/openshift/origin/pull/22963
- [x] pre-require: setup initial commits in external repos 

/hold