### PR TITLE
[wip] Remove internal clients/apis from describer pkg

### DIFF
--- a/pkg/oc/cli/process/process.go
+++ b/pkg/oc/cli/process/process.go
@@ -34,8 +34,6 @@ import (
 	cmdutil "github.com/openshift/oc/pkg/helpers/cmd"
 	"github.com/openshift/origin/pkg/oc/lib/describe"
 	"github.com/openshift/origin/pkg/oc/lib/newapp/app"
-	templateapi "github.com/openshift/origin/pkg/template/apis/template"
-	templateapiv1 "github.com/openshift/origin/pkg/template/apis/template/v1"
 	templateclientv1 "github.com/openshift/origin/pkg/template/client/v1"
 	"github.com/openshift/origin/pkg/template/templateprocessing"
 )
@@ -179,17 +177,11 @@ func (p *processPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 			return fmt.Errorf("attempt to describe a non-template object of type %T", obj)
 		}
 
-		// TODO(juanvallejo): remove once we have external describers
-		internalTemplate := &templateapi.Template{}
-		if err := templateapiv1.Convert_v1_Template_To_template_Template(templateObj, internalTemplate, nil); err != nil {
-			return err
-		}
-
 		s, err := (&describe.TemplateDescriber{
 			MetadataAccessor: meta.NewAccessor(),
 			ObjectTyper:      legacyscheme.Scheme,
 			ObjectDescriber:  nil,
-		}).DescribeTemplate(internalTemplate)
+		}).DescribeTemplate(templateObj)
 
 		if err != nil {
 			return fmt.Errorf("error describing %q: %v\n", templateObj.Name, err)
@@ -395,12 +387,7 @@ func (o *ProcessOptions) RunProcess() error {
 	// If 'parameters' flag is set it does not do processing but only print
 	// the template parameters to console for inspection.
 	if o.parameters {
-		// TODO(juanvallejo): remove once we have external describers
-		internalTemplate := &templateapi.Template{}
-		if err := templateapiv1.Convert_v1_Template_To_template_Template(obj, internalTemplate, nil); err != nil {
-			return err
-		}
-		return describe.PrintTemplateParameters(internalTemplate.Parameters, o.Out)
+		return describe.PrintTemplateParameters(obj.Parameters, o.Out)
 	}
 
 	if label := o.labels; len(label) > 0 {

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -57,7 +57,7 @@ import (
 	ocbuildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	routedisplayhelpers "github.com/openshift/oc/pkg/helpers/route"
 
-	oapi "github.com/openshift/origin/pkg/api"
+	oapi "github.com/openshift/api/annotations"
 	"github.com/openshift/origin/pkg/api/legacy"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	oauthorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -46,6 +46,7 @@ import (
 	buildv1clienttyped "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	onetworktypedclient "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	projectclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned/typed/quota/v1"
 	buildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	ocbuildapihelpers "github.com/openshift/oc/pkg/helpers/build"
@@ -59,7 +60,6 @@ import (
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
-	projectclient "github.com/openshift/origin/pkg/project/generated/internalclientset/typed/project/internalversion"
 	quotaconvert "github.com/openshift/origin/pkg/quota/apis/quota"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	routev1conversions "github.com/openshift/origin/pkg/route/apis/route/v1"
@@ -976,7 +976,7 @@ func (d *RouteDescriber) Describe(namespace, name string, settings describe.Desc
 
 // ProjectDescriber generates information about a Project
 type ProjectDescriber struct {
-	projectClient projectclient.ProjectInterface
+	projectClient projectclient.ProjectV1Interface
 	kubeClient    kubernetes.Interface
 }
 

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/kubectl/describe"
 	"k8s.io/kubernetes/pkg/kubectl/describe/versioned"
 
@@ -40,6 +39,7 @@ import (
 	"github.com/openshift/api/route"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/api/security"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/api/template"
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/openshift/api/user"
@@ -50,6 +50,7 @@ import (
 	projectclient "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned/typed/quota/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	templateclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 	buildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	ocbuildapihelpers "github.com/openshift/oc/pkg/helpers/build"
@@ -64,8 +65,6 @@ import (
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	quotaconvert "github.com/openshift/origin/pkg/quota/apis/quota"
-	securityapi "github.com/openshift/origin/pkg/security/apis/security"
-	securityclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
 	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
 )
 
@@ -1880,7 +1879,7 @@ func (d *SecurityContextConstraintsDescriber) Describe(namespace, name string, s
 	return describeSecurityContextConstraints(scc)
 }
 
-func describeSecurityContextConstraints(scc *securityapi.SecurityContextConstraints) (string, error) {
+func describeSecurityContextConstraints(scc *securityv1.SecurityContextConstraints) (string, error) {
 	return tabbedString(func(out *tabwriter.Writer) error {
 		fmt.Fprintf(out, "Name:\t%s\n", scc.Name)
 
@@ -1970,7 +1969,7 @@ func stringOrDefaultValue(s, defaultValue string) string {
 	return defaultValue
 }
 
-func fsTypeToString(volumes []securityapi.FSType) string {
+func fsTypeToString(volumes []securityv1.FSType) string {
 	strVolumes := []string{}
 	for _, v := range volumes {
 		strVolumes = append(strVolumes, string(v))
@@ -1978,7 +1977,7 @@ func fsTypeToString(volumes []securityapi.FSType) string {
 	return stringOrNone(strings.Join(strVolumes, ","))
 }
 
-func flexVolumesToString(flexVolumes []securityapi.AllowedFlexVolume) string {
+func flexVolumesToString(flexVolumes []securityv1.AllowedFlexVolume) string {
 	volumes := []string{}
 	for _, flexVolume := range flexVolumes {
 		volumes = append(volumes, "driver="+flexVolume.Driver)
@@ -1990,7 +1989,7 @@ func sysctlsToString(sysctls []string) string {
 	return stringOrNone(strings.Join(sysctls, ","))
 }
 
-func idRangeToString(ranges []securityapi.IDRange) string {
+func idRangeToString(ranges []securityv1.IDRange) string {
 	formattedString := ""
 	if ranges != nil {
 		strRanges := []string{}
@@ -2002,7 +2001,7 @@ func idRangeToString(ranges []securityapi.IDRange) string {
 	return stringOrNone(formattedString)
 }
 
-func capsToString(caps []kapi.Capability) string {
+func capsToString(caps []corev1.Capability) string {
 	formattedString := ""
 	if caps != nil {
 		strCaps := []string{}

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -54,7 +54,6 @@ import (
 	"github.com/openshift/origin/pkg/api/legacy"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	oauthorizationclient "github.com/openshift/origin/pkg/authorization/generated/internalclientset/typed/authorization/internalversion"
-	buildapi "github.com/openshift/origin/pkg/build/apis/build"
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
@@ -526,12 +525,12 @@ func describeBuildTriggers(triggers []buildv1.BuildTriggerPolicy, name, namespac
 		fmt.Fprintf(w, "Webhook %s:\n", strings.Title(webHookType))
 		for _, trigger := range webHookDesc {
 			_, seen := seenHookTypes[webHookType]
-			if webHookType != string(buildapi.GenericWebHookBuildTriggerType) && seen {
+			if webHookType != string(buildv1.GenericWebHookBuildTriggerType) && seen {
 				continue
 			}
 			seenHookTypes[webHookType] = true
 			fmt.Fprintf(w, "\tURL:\t%s\n", trigger.URL)
-			if webHookType == string(buildapi.GenericWebHookBuildTriggerType) && trigger.AllowEnv != nil {
+			if webHookType == string(buildv1.GenericWebHookBuildTriggerType) && trigger.AllowEnv != nil {
 				fmt.Fprintf(w, fmt.Sprintf("\t%s:\t%v\n", "AllowEnv", *trigger.AllowEnv))
 			}
 		}

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -52,6 +52,7 @@ import (
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	templateclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
+	userclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 	buildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	ocbuildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	routedisplayhelpers "github.com/openshift/oc/pkg/helpers/route"
@@ -65,7 +66,6 @@ import (
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	quotaconvert "github.com/openshift/origin/pkg/quota/apis/quota"
-	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
 )
 
 func describerMap(clientConfig *rest.Config, kclient kubernetes.Interface, host string) map[schema.GroupKind]describe.Describer {
@@ -1307,7 +1307,7 @@ func (d *TemplateInstanceDescriber) DescribeParameters(template templatev1.Templ
 
 // IdentityDescriber generates information about a user
 type IdentityDescriber struct {
-	c userclient.UserInterface
+	c userclient.UserV1Interface
 }
 
 // Describe returns the description of an identity
@@ -1355,7 +1355,7 @@ func (d *IdentityDescriber) Describe(namespace, name string, settings describe.D
 
 // UserIdentityMappingDescriber generates information about a user
 type UserIdentityMappingDescriber struct {
-	c userclient.UserInterface
+	c userclient.UserV1Interface
 }
 
 // Describe returns the description of a userIdentity
@@ -1378,7 +1378,7 @@ func (d *UserIdentityMappingDescriber) Describe(namespace, name string, settings
 
 // UserDescriber generates information about a user
 type UserDescriber struct {
-	c userclient.UserInterface
+	c userclient.UserV1Interface
 }
 
 // Describe returns the description of a user
@@ -1427,7 +1427,7 @@ func (d *UserDescriber) Describe(namespace, name string, settings describe.Descr
 
 // GroupDescriber generates information about a group
 type GroupDescriber struct {
-	c userclient.UserInterface
+	c userclient.UserV1Interface
 }
 
 // Describe returns the description of a group

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -45,6 +45,7 @@ import (
 	appstypedclient "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	buildv1clienttyped "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 	onetworktypedclient "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
+	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned/typed/quota/v1"
 	buildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	ocbuildapihelpers "github.com/openshift/oc/pkg/helpers/build"
@@ -57,7 +58,6 @@ import (
 	buildutil "github.com/openshift/origin/pkg/build/util"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	imageclient "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
-	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectclient "github.com/openshift/origin/pkg/project/generated/internalclientset/typed/project/internalversion"
 	quotaconvert "github.com/openshift/origin/pkg/quota/apis/quota"
@@ -603,7 +603,7 @@ func (d *BuildConfigDescriber) Describe(namespace, name string, settings describ
 
 // OAuthAccessTokenDescriber generates information about an OAuth Acess Token (OAuth)
 type OAuthAccessTokenDescriber struct {
-	client oauthclient.OauthInterface
+	client oauthclient.OauthV1Interface
 }
 
 func (d *OAuthAccessTokenDescriber) Describe(namespace, name string, settings describe.DescriberSettings) (string, error) {

--- a/pkg/oc/lib/describe/helpers.go
+++ b/pkg/oc/lib/describe/helpers.go
@@ -19,11 +19,11 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 
 	buildv1 "github.com/openshift/api/build/v1"
+	templateapi "github.com/openshift/api/template/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
 	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
 	buildmanualclient "github.com/openshift/origin/pkg/build/client/v1"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
-	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 )
 
 const emptyString = "<none>"


### PR DESCRIPTION
Broken up into different commits, not sure if that's easier or harder but would obviously want to squash before merging

Only ones I'm stuck on are `authorization` and `image` clients/apis, because each of those seem to have a bunch of custom casts and helpers that aren't in openshift/api. So I'm not sure what exactly to do with them
