### PR TITLE
add e2e-oauth-server and idp/htpasswd to e2e

### DIFF
--- a/test/extended/oauth/e2e-oauth-server/README.md
+++ b/test/extended/oauth/e2e-oauth-server/README.md
@@ -1,0 +1,43 @@
+## OpenShift extended test oauth server
+
+This is what I have so far.
+
+Prerequisites
+-------------
+
+* Have the environment variable `KUBECONFIG` set pointing to your cluster.
+
+
+## Run the following from this directory
+
+First, you'll need to edit the cliconfig-noidp.yaml with values from your cluster.
+
+```console
+$ oc create -f ns-svc-svcaccct.yaml
+$ oc create -f cliconfig-noidp.yaml or cliconfig-htpasswd.yaml
+$ oc create -f route.yaml
+$ oc create -f serviceca-configmap.yaml
+$ oc create -f session-secret.yaml
+$ oc create -f htpasswd-secret.yaml
+$ oc create -f pod.yaml or pod-htpasswd.yaml  (need a deployment)
+```
+
+
+What's created
+------------------------
+
+* service - e2e-oauth - with annotation for service-ca-op to create serving-certs secret
+* configmap - e2e-oauth-cliconfig - holds oauth config, will edit/replace data w/ updated IDP configs eventually
+* configmap - service-ca - service-ca-operator-managed service-ca.crt injected
+* secret - serving-cert - service-ca-operator-managed serving-certs
+* secret - session
+* secret - v4-0-config-user-idp-0-file-data - required for htpasswd configuration (not sure this exact name is necessary)
+* route - e2e-oauth
+* pod - e2e-oauth 
+
+Need to transform the above in a test/extended/oauth/something.go file
+(also, whatever yaml we end up requiring will go in test/extended/testdata)
+
+
+NOTE: oauthclients get created, need to be cleaned up, so if you have a test-oauth-server running,
+      you'll need to `oc delete oauthclient openshift-browser-client` b4 re-creating a new one.  

--- a/test/extended/oauth/e2e-oauth-server/cliconfig-htpasswd.yaml
+++ b/test/extended/oauth/e2e-oauth-server/cliconfig-htpasswd.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  e2e-cliconfig: |
+      {"admission": null,"apiVersion": "osin.config.openshift.io/v1","kind": "OsinServerConfig","oauthConfig": {"alwaysShowProviderSelection": false,"assetPublicURL": "https://console-openshift-console.apps.somalley6101.devcluster.openshift.com","grantConfig":{"method":"deny","serviceAccountMethod":"prompt"},"identityProviders": [{"challenge":true,"login":true,"mappingMethod":"claim","name":"htpasswd","provider":{"apiVersion":"osin.config.openshift.io/v1","file":"/var/config/user/idp/0/secret/v4-0-config-user-idp-0-file-data/htpasswd","kind":"HTPasswdPasswordIdentityProvider"}}],"loginURL": "https://api.somalley6101.devcluster.openshift.com:6443","masterCA": "/var/config/system/configmaps/service-ca/service-ca.crt","masterPublicURL": "https://e2e-oauth-e2e-oauth.apps.somalley6101.devcluster.openshift.com","masterURL": "https://e2e-oauth.e2e-oauth.svc","sessionConfig":{"sessionMaxAgeSeconds":300,"sessionName":"ssn","sessionSecretsFile":"/var/config/system/secrets/session/session"},"tokenConfig": {"accessTokenMaxAgeSeconds": 86400,"authorizeTokenMaxAgeSeconds": 300}},"servingInfo": {"bindAddress": "0.0.0.0:6443","bindNetwork": "tcp4","certFile": "/var/config/system/secrets/serving-cert/tls.crt","keyFile": "/var/config/system/secrets/serving-cert/tls.key"}}
+kind: ConfigMap
+metadata:
+  labels:
+    app: e2e-oauth
+  name: e2e-oauth-cliconfig
+  namespace: e2e-oauth

--- a/test/extended/oauth/e2e-oauth-server/cliconfig-noidp.yaml
+++ b/test/extended/oauth/e2e-oauth-server/cliconfig-noidp.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  e2e-cliconfig: |
+      {"admission": null,"apiVersion": "osin.config.openshift.io/v1","kind": "OsinServerConfig","oauthConfig": {"alwaysShowProviderSelection": false,"assetPublicURL": "https://console-openshift-console.apps.somalley6101.devcluster.openshift.com","grantConfig":{"method":"deny","serviceAccountMethod":"prompt"},"identityProviders": null,"loginURL": "https://api.somalley6101.devcluster.openshift.com:6443","masterCA": "/var/config/system/configmaps/service-ca/service-ca.crt","masterPublicURL": "https://e2e-oauth-e2e-oauth.apps.somalley6101.devcluster.openshift.com","masterURL": "https://e2e-oauth.e2e-oauth.svc","sessionConfig":{"sessionMaxAgeSeconds":300,"sessionName":"ssn","sessionSecretsFile":"/var/config/system/secrets/session/session"},"tokenConfig": {"accessTokenMaxAgeSeconds": 86400,"authorizeTokenMaxAgeSeconds": 300}},"servingInfo": {"bindAddress": "0.0.0.0:6443","bindNetwork": "tcp4","certFile": "/var/config/system/secrets/serving-cert/tls.crt","keyFile": "/var/config/system/secrets/serving-cert/tls.key"}}
+kind: ConfigMap
+metadata:
+  labels:
+    app: e2e-oauth
+  name: e2e-oauth-cliconfig
+  namespace: e2e-oauth

--- a/test/extended/oauth/e2e-oauth-server/htpasswd-secret.yaml
+++ b/test/extended/oauth/e2e-oauth-server/htpasswd-secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: v4-0-config-user-idp-0-file-data
+  namespace: e2e-oauth
+data:
+    htpasswd: dGVzdHVzZXI6JGFwcjEkU3dyUFQ4TnIkbjJKYmtqMUV2a0tYU21haVZXOVdxMQo= #userinfo testuser:password

--- a/test/extended/oauth/e2e-oauth-server/ns-svc-svcaccct.yaml
+++ b/test/extended/oauth/e2e-oauth-server/ns-svc-svcaccct.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e-oauth
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+  labels:
+    app: e2e-oauth
+  name: e2e-oauth
+  namespace: e2e-oauth
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: e2e-oauth
+  sessionAffinity: None
+  type: ClusterIP
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: e2e-oauth
+  name: e2e-oauth
+  labels:
+    app: e2e-oauth
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:e2e:authentication
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin  # TODO fix, this is madness
+subjects:
+- kind: ServiceAccount
+  namespace: e2e-oauth
+  name: e2e-oauth
+

--- a/test/extended/oauth/e2e-oauth-server/pod-htpasswd.yaml
+++ b/test/extended/oauth/e2e-oauth-server/pod-htpasswd.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: e2e-oauth
+  annotations:
+    openshift.io/scc: anyuid
+  name: e2e-oauth
+  namespace: e2e-oauth
+spec:
+  containers:
+  - command:
+    - hypershift
+    - openshift-osinserver
+    - --config=/var/config/system/configmaps/e2e-oauth-cliconfig/e2e-cliconfig
+    - --v=100
+    image: registry.svc.ci.openshift.org/ocp/4.2-2019-06-10-121736@sha256:38e800312afa329a9c794b32133dead59ecf15e298c926f4dea19a1db3d18fb3
+    imagePullPolicy: IfNotPresent
+    name: e2e-oauth-1
+    ports:
+    - containerPort: 6443
+      name: https
+      protocol: TCP
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext:
+      capabilities:
+        drop:
+        - MKNOD
+      procMount: Default
+    volumeMounts:
+    - mountPath: /var/config/user/idp/0/secret/v4-0-config-user-idp-0-file-data
+      name: v4-0-config-user-idp-0-file-data
+      readOnly: true
+    - mountPath: /var/config/system/secrets/session
+      name: session
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/e2e-oauth-cliconfig
+      name: e2e-oauth-cliconfig
+      readOnly: true
+    - mountPath: /var/config/system/secrets/serving-cert
+      name: serving-cert
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/service-ca
+      name: service-ca
+      readOnly: true
+  serviceAccount: e2e-oauth
+  serviceAccountName: e2e-oauth
+  volumes:
+  - name: v4-0-config-user-idp-0-file-data
+    secret:
+      defaultMode: 420
+      items:
+      - key: htpasswd
+        path: htpasswd
+      secretName: v4-0-config-user-idp-0-file-data
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: e2e-cliconfig
+        path: e2e-cliconfig
+      name: e2e-oauth-cliconfig
+    name: e2e-oauth-cliconfig
+  - name: session
+    secret:
+      defaultMode: 420
+      items:
+      - key: session
+        path: session
+      secretName: session
+  - name: serving-cert
+    secret:
+      defaultMode: 420
+      items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+      secretName: serving-cert
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: service-ca.crt
+      name: service-ca
+    name: service-ca

--- a/test/extended/oauth/e2e-oauth-server/pod.yaml
+++ b/test/extended/oauth/e2e-oauth-server/pod.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: e2e-oauth
+  annotations:
+    openshift.io/scc: anyuid
+  name: e2e-oauth
+  namespace: e2e-oauth
+spec:
+  containers:
+  - command:
+    - hypershift
+    - openshift-osinserver
+    - --config=/var/config/system/configmaps/e2e-oauth-cliconfig/e2e-cliconfig
+    - --v=100
+    image: registry.svc.ci.openshift.org/ocp/4.2-2019-06-10-121736@sha256:38e800312afa329a9c794b32133dead59ecf15e298c926f4dea19a1db3d18fb3
+    imagePullPolicy: IfNotPresent
+    name: e2e-oauth-1
+    ports:
+    - containerPort: 6443
+      name: https
+      protocol: TCP
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext:
+      capabilities:
+        drop:
+        - MKNOD
+      procMount: Default
+    volumeMounts:
+    - mountPath: /var/config/system/secrets/session
+      name: session
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/e2e-oauth-cliconfig
+      name: e2e-oauth-cliconfig
+      readOnly: true
+    - mountPath: /var/config/system/secrets/serving-cert
+      name: serving-cert
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/service-ca
+      name: service-ca
+      readOnly: true
+  serviceAccount: e2e-oauth
+  serviceAccountName: e2e-oauth
+  volumes:
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: e2e-cliconfig
+        path: e2e-cliconfig
+      name: e2e-oauth-cliconfig
+    name: e2e-oauth-cliconfig
+  - name: session
+    secret:
+      defaultMode: 420
+      items:
+      - key: session
+        path: session
+      secretName: session
+  - name: serving-cert
+    secret:
+      defaultMode: 420
+      items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+      secretName: serving-cert
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: service-ca.crt
+      name: service-ca
+    name: service-ca

--- a/test/extended/oauth/e2e-oauth-server/route.yaml
+++ b/test/extended/oauth/e2e-oauth-server/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: e2e-oauth
+  name: e2e-oauth
+  namespace: e2e-oauth
+spec:
+  port:
+    targetPort: 6443
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: passthrough
+  to:
+    kind: Service
+    name: e2e-oauth
+    weight: 100
+  wildcardPolicy: None

--- a/test/extended/oauth/e2e-oauth-server/serviceca-configmap.yaml
+++ b/test/extended/oauth/e2e-oauth-server/serviceca-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app: e2e-oauth
+  name: service-ca
+  namespace: e2e-oauth

--- a/test/extended/oauth/e2e-oauth-server/session-secret.yaml
+++ b/test/extended/oauth/e2e-oauth-server/session-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  session: eyJraW5kIjoiU2Vzc2lvblNlY3JldHMiLCJhcGlWZXJzaW9uIjoidjEiLCJzZWNyZXRzIjpbeyJhdXRoZW50aWNhdGlvbiI6IkdqNDk3TjlwWDIySkRKSUsxWTlWc3F4WmpHa25FS24tVWtuVFpNcUJSR2NUeFM2WnYwcUFqenVpc09oLXBiVkkiLCJlbmNyeXB0aW9uIjoicHF0RnZ5ek5SSmt5YncySmtLT0J0eFZ0MWVBSm4zb2QifV19
+kind: Secret
+metadata:
+  labels:
+    app: e2e-oauth
+  name: session
+  namespace: e2e-oauth

--- a/test/extended/oauth/helpers.go
+++ b/test/extended/oauth/helpers.go
@@ -1,0 +1,36 @@
+package oauth
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+func waitForAuthOperatorAvailable(oc *exutil.CLI) error {
+	err := wait.Poll(1*time.Second, 5*time.Minute, func() (done bool, err error) {
+		authOp, err := oc.AdminOperatorClient().OperatorV1().Authentications().Get("cluster", metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		conditions := authOp.Status.Conditions
+		if v1helpers.IsOperatorConditionFalse(conditions, "Available") {
+			e2e.Logf("authentication operator is not yet available")
+			return false, nil
+		}
+		if v1helpers.IsOperatorConditionTrue(conditions, "Progressing") {
+			e2e.Logf("authentication operator is progressing")
+			return false, nil
+		}
+		if v1helpers.IsOperatorConditionTrue(conditions, "Degraded") {
+			e2e.Logf("authentication operator is degraded")
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -1,0 +1,69 @@
+package oauth
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Serial][Suite:openshift/oauth/serial] Htpasswd identity provider", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc                    = exutil.NewCLI("htpasswd-configure", exutil.KubeConfigPath())
+		testDataBaseDir       = exutil.FixturePath("testdata", "oauth_idp")
+		oauthHtpasswdFixture  = filepath.Join(testDataBaseDir, "oauth-htpasswd.yaml")
+		htpasswdSecretFixture = filepath.Join(testDataBaseDir, "htpasswd-secret.yaml")
+		htpasswdSecretName    = "htpasswd"
+		oauthNoIdpFixture     = filepath.Join(testDataBaseDir, "oauth-noidp.yaml")
+	)
+	g.AfterEach(func() {
+		err := oc.AsAdmin().KubeClient().CoreV1().Secrets("openshift-config").Delete(htpasswdSecretName, &metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("removing htpasswd idp from oauth")
+		err = oc.AsAdmin().Run("replace").Args("-f", oauthNoIdpFixture).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForAuthOperatorAvailable(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// cleanup created user/identity
+		err = oc.AsAdmin().Run("delete").Args("identities", "htpasswd:testuser").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().Run("delete").Args("user", "testuser").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("should successfully be configured", func() {
+		e2e.Logf("configuring htpasswd")
+		oc.SetNamespace("openshift-config")
+		err := oc.AsAdmin().Run("apply").Args("-f", htpasswdSecretFixture).Execute()
+		err = oc.AsAdmin().Run("replace").Args("-f", oauthHtpasswdFixture).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForAuthOperatorAvailable(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("logging in as htpasswd user testuser")
+		err = wait.Poll(2*time.Second, 30*time.Second, func() (done bool, err error) {
+			out, err := oc.Run("login").Args("-u", "testuser").InputString("password" + "\n").Output()
+			if err != nil {
+				e2e.Logf("waiting for oc login as htpasswd configured user to succeed")
+				return false, nil
+			}
+			if !strings.Contains(out, "Login successful") {
+				e2e.Logf("oc login output did not contain success message:\n%s", strings.Replace(out, "password", "<redacted>", -1))
+				return false, nil
+			}
+			e2e.Logf("oc login -u testuser succeeded")
+			return true, nil
+		})
+		user, err := oc.Run("whoami").Args().Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(user).To(o.ContainSubstring("testuser"))
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -181,6 +181,9 @@
 // test/extended/testdata/long_names/fixture.json
 // test/extended/testdata/multi-namespace-pipeline.yaml
 // test/extended/testdata/multi-namespace-template.yaml
+// test/extended/testdata/oauth_idp/htpasswd-secret.yaml
+// test/extended/testdata/oauth_idp/oauth-htpasswd.yaml
+// test/extended/testdata/oauth_idp/oauth-noidp.yaml
 // test/extended/testdata/openshift-secret-to-jenkins-credential.yaml
 // test/extended/testdata/reencrypt-serving-cert.yaml
 // test/extended/testdata/releases/payload-1/etcd-operator/image-references
@@ -10437,6 +10440,80 @@ func testExtendedTestdataMultiNamespaceTemplateYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/multi-namespace-template.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauth_idpHtpasswdSecretYaml = []byte(`kind: Secret
+apiVersion: v1
+metadata:
+  name: htpasswd
+  namespace: openshift-config
+data:
+    htpasswd: dGVzdHVzZXI6JGFwcjEkU3dyUFQ4TnIkbjJKYmtqMUV2a0tYU21haVZXOVdxMQo= #userinfo testuser:password
+`)
+
+func testExtendedTestdataOauth_idpHtpasswdSecretYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauth_idpHtpasswdSecretYaml, nil
+}
+
+func testExtendedTestdataOauth_idpHtpasswdSecretYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauth_idpHtpasswdSecretYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauth_idp/htpasswd-secret.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauth_idpOauthHtpasswdYaml = []byte(`apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - htpasswd:
+        fileData:
+          name: htpasswd
+      name: htpasswd
+      type: HTPasswd
+`)
+
+func testExtendedTestdataOauth_idpOauthHtpasswdYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauth_idpOauthHtpasswdYaml, nil
+}
+
+func testExtendedTestdataOauth_idpOauthHtpasswdYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauth_idpOauthHtpasswdYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauth_idp/oauth-htpasswd.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauth_idpOauthNoidpYaml = []byte(`apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec: {}
+`)
+
+func testExtendedTestdataOauth_idpOauthNoidpYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauth_idpOauthNoidpYaml, nil
+}
+
+func testExtendedTestdataOauth_idpOauthNoidpYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauth_idpOauthNoidpYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauth_idp/oauth-noidp.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -32730,6 +32807,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/long_names/fixture.json": testExtendedTestdataLong_namesFixtureJson,
 	"test/extended/testdata/multi-namespace-pipeline.yaml": testExtendedTestdataMultiNamespacePipelineYaml,
 	"test/extended/testdata/multi-namespace-template.yaml": testExtendedTestdataMultiNamespaceTemplateYaml,
+	"test/extended/testdata/oauth_idp/htpasswd-secret.yaml": testExtendedTestdataOauth_idpHtpasswdSecretYaml,
+	"test/extended/testdata/oauth_idp/oauth-htpasswd.yaml": testExtendedTestdataOauth_idpOauthHtpasswdYaml,
+	"test/extended/testdata/oauth_idp/oauth-noidp.yaml": testExtendedTestdataOauth_idpOauthNoidpYaml,
 	"test/extended/testdata/openshift-secret-to-jenkins-credential.yaml": testExtendedTestdataOpenshiftSecretToJenkinsCredentialYaml,
 	"test/extended/testdata/reencrypt-serving-cert.yaml": testExtendedTestdataReencryptServingCertYaml,
 	"test/extended/testdata/releases/payload-1/etcd-operator/image-references": testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences,
@@ -33221,6 +33301,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 				"multi-namespace-pipeline.yaml": &bintree{testExtendedTestdataMultiNamespacePipelineYaml, map[string]*bintree{}},
 				"multi-namespace-template.yaml": &bintree{testExtendedTestdataMultiNamespaceTemplateYaml, map[string]*bintree{}},
+				"oauth_idp": &bintree{nil, map[string]*bintree{
+					"htpasswd-secret.yaml": &bintree{testExtendedTestdataOauth_idpHtpasswdSecretYaml, map[string]*bintree{}},
+					"oauth-htpasswd.yaml": &bintree{testExtendedTestdataOauth_idpOauthHtpasswdYaml, map[string]*bintree{}},
+					"oauth-noidp.yaml": &bintree{testExtendedTestdataOauth_idpOauthNoidpYaml, map[string]*bintree{}},
+				}},
 				"openshift-secret-to-jenkins-credential.yaml": &bintree{testExtendedTestdataOpenshiftSecretToJenkinsCredentialYaml, map[string]*bintree{}},
 				"reencrypt-serving-cert.yaml": &bintree{testExtendedTestdataReencryptServingCertYaml, map[string]*bintree{}},
 				"releases": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/oauth_idp/htpasswd-secret.yaml
+++ b/test/extended/testdata/oauth_idp/htpasswd-secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: htpasswd
+  namespace: openshift-config
+data:
+    htpasswd: dGVzdHVzZXI6JGFwcjEkU3dyUFQ4TnIkbjJKYmtqMUV2a0tYU21haVZXOVdxMQo= #userinfo testuser:password

--- a/test/extended/testdata/oauth_idp/oauth-htpasswd.yaml
+++ b/test/extended/testdata/oauth_idp/oauth-htpasswd.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - htpasswd:
+        fileData:
+          name: htpasswd
+      name: htpasswd
+      type: HTPasswd

--- a/test/extended/testdata/oauth_idp/oauth-noidp.yaml
+++ b/test/extended/testdata/oauth_idp/oauth-noidp.yaml
@@ -1,0 +1,5 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec: {}


### PR DESCRIPTION
@stlaz  This PR will provide a standalone test oauth server to be used for idp-configuration e2es, look at the `standalone oauth server for e2e` commit, and follow the [README](https://github.com/openshift/origin/blob/07a12d44567f6c7036b71c274d8e406340f318e2/test/extended/oauth/e2e-oauth-server/README.md) to see where I'm at :) .  Didn't get to writing the Go for it yet. Also, have to edit the cliconfig-*.yaml files to match your cluster, and figure out best way to automate all of it.  We should have this mostly done by tomorrow : ) I always say that though.. 

*outdated atm*
@enj @stlaz please review, provides e2e test for htpasswd idp.  The idp test is serial.  

Note: for other idp e2es, to remove the idp from oauth/cluster, use `oc replace -f oauth-noidp.yaml`.  This works, while `oc apply` and `oc patch --type=merge` do not.  


/hold