### PR TITLE
test/e2e: scheduling: disable preemption tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -389,6 +389,7 @@ var (
 			`should be rejected when no endpoints exist`,                                 // https://bugzilla.redhat.com/show_bug.cgi?id=1711605
 			`PreemptionExecutionPath runs ReplicaSets to verify preemption running path`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711606
 			`TaintBasedEvictions`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711608
+			`SchedulerPreemption`, // https://bugzilla.redhat.com/show_bug.cgi?id=1717198
 
 			`\[Driver: iscsi\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
 			`\[Driver: ceph\]\[Feature:Volumes\] \[Testpattern: Pre-provisioned PV \(default fs\)\] subPath should verify container cannot write to subpath`,


### PR DESCRIPTION
After Prometheus starting making reasonable memory requests, the assumptions that the `SchedulerPreemption` tests make about the scheduled load on test nodes do not hold (i.e. less than 40% of capacity is scheduled).

Example e2e failure
https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2/598

```
Jun  4 15:35:22.846: INFO: At 2019-06-04 15:35:10 +0000 UTC - event for pod0-sched-preemption-low-priority: {default-scheduler } Scheduled: Successfully assigned sched-preemption-2604/pod0-sched-preemption-low-priority to ip-10-0-138-81.ec2.internal
Jun  4 15:35:22.846: INFO: At 2019-06-04 15:35:10 +0000 UTC - event for pod0-sched-preemption-low-priority: {default-scheduler } Preempted: by sched-preemption-2604/pod1-sched-preemption-medium-priority on node ip-10-0-138-81.ec2.internal
Jun  4 15:35:22.846: INFO: At 2019-06-04 15:35:10 +0000 UTC - event for pod1-sched-preemption-medium-priority: {default-scheduler } FailedScheduling: 0/6 nodes are available: 1 Insufficient memory, 3 Insufficient cpu, 3 node(s) had taints that the pod didn't tolerate.
```

Flaking since https://github.com/openshift/prometheus-operator/pull/30 which allowed the resource requests for the prometheus statefulset to flow through
https://testgrid.k8s.io/redhat-openshift-release-blocking#redhat-release-openshift-origin-installer-e2e-aws-serial-4.2&sort-by-flakiness=

BZ to track reenablement
https://bugzilla.redhat.com/show_bug.cgi?id=1717198

@smarterclayton @wking @ravisantoshgudimetla 