### PR TITLE
Bug 171309: backport prometheus client_go race fix to 4.1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1132,7 +1132,8 @@ imports:
   - fflib/v1
   - fflib/v1/internal
 - name: github.com/prometheus/client_golang
-  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
+  version: origin-4.1-e7e903064f5e9eb5da98208bae10b475d4db0f8c
+  repo: https://github.com/openshift/prometheus-client_golang
   subpackages:
   - prometheus
   - prometheus/promhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -97,6 +97,9 @@ import:
 - package: github.com/containers/image
   repo:    https://github.com/openshift/containers-image.git
   version: openshift-3.8
+- package: github.com/prometheus/client_golang
+  repo:    https://github.com/openshift/prometheus-client_golang
+  version: origin-4.1-e7e903064f5e9eb5da98208bae10b475d4db0f8c
 # pod - sjenning
 # origin-3.11-runc-871ba2e
 - package: github.com/opencontainers/runc

--- a/vendor/github.com/prometheus/client_golang/OWNERS
+++ b/vendor/github.com/prometheus/client_golang/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - rphillips
+  - sjenning
+approvers:
+  - rphillips
+  - sjenning


### PR DESCRIPTION
> checkMetricConsistency relies on labels being sorted. If they are not, it is sorting them, which is modifying a slice that is assumed to be immutable elsewhere. Even if they are sorted, sort.Sort might temporarily change order (even if no equal elements are in the slice) if there are more than 12 labels (where the implementation switches from ShellSort to HeapSort or QuickSort).
> Just using sort.Stable is not a solution as the immutable slice will still be mutated if it is not sorted (which can only happen with home-grown metric families, but it can still happen).

This is fixed in 4.2.

ref: https://github.com/prometheus/client_golang/pull/513
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1713098