### PR TITLE
move the SDN config to external types

### DIFF
--- a/pkg/cmd/openshift-sdn/config.go
+++ b/pkg/cmd/openshift-sdn/config.go
@@ -8,24 +8,27 @@ import (
 
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	configv1 "github.com/openshift/origin/pkg/cmd/server/apis/config/v1"
 )
 
-func readNodeConfig(filename string) (*configapi.NodeConfig, error) {
+func readNodeConfig(filename string) (*legacyconfigv1.NodeConfig, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	uncast, err := helpers.ReadYAMLToInternal(bytes.NewBuffer(data), configapi.InstallLegacy, legacyconfigv1.InstallLegacy, configv1.InstallLegacy, configv1.InstallLegacyExternal)
+	uncast, err := helpers.ReadYAML(bytes.NewBuffer(data), legacyconfigv1.InstallLegacy)
 	if err != nil {
 		return nil, err
 	}
-	return uncast.(*configapi.NodeConfig), nil
+
+	ret := uncast.(*legacyconfigv1.NodeConfig)
+	// at this point defaults need to be set
+	setDefaults_NodeConfig(ret)
+
+	return ret, nil
 }
 
-func readAndResolveNodeConfig(filename string) (*configapi.NodeConfig, error) {
+func readAndResolveNodeConfig(filename string) (*legacyconfigv1.NodeConfig, error) {
 	nodeConfig, err := readNodeConfig(filename)
 	if err != nil {
 		return nil, err
@@ -38,15 +41,15 @@ func readAndResolveNodeConfig(filename string) (*configapi.NodeConfig, error) {
 	return nodeConfig, nil
 }
 
-func resolveNodeConfigPaths(config *configapi.NodeConfig, base string) error {
+func resolveNodeConfigPaths(config *legacyconfigv1.NodeConfig, base string) error {
 	return helpers.ResolvePaths(getNodeFileReferences(config), base)
 }
 
-func getNodeFileReferences(config *configapi.NodeConfig) []*string {
+func getNodeFileReferences(config *legacyconfigv1.NodeConfig) []*string {
 	refs := []*string{}
 
-	refs = append(refs, &config.ServingInfo.ServerCert.CertFile)
-	refs = append(refs, &config.ServingInfo.ServerCert.KeyFile)
+	refs = append(refs, &config.ServingInfo.CertInfo.CertFile)
+	refs = append(refs, &config.ServingInfo.CertInfo.KeyFile)
 	refs = append(refs, &config.ServingInfo.ClientCA)
 	for i := range config.ServingInfo.NamedCertificates {
 		refs = append(refs, &config.ServingInfo.NamedCertificates[i].CertFile)
@@ -68,7 +71,7 @@ func getNodeFileReferences(config *configapi.NodeConfig) []*string {
 	return refs
 }
 
-func appendFlagsWithFileExtensions(refs []*string, args configapi.ExtendedArguments) []*string {
+func appendFlagsWithFileExtensions(refs []*string, args legacyconfigv1.ExtendedArguments) []*string {
 	for key, s := range args {
 		if len(s) == 0 {
 			continue
@@ -81,4 +84,57 @@ func appendFlagsWithFileExtensions(refs []*string, args configapi.ExtendedArgume
 		}
 	}
 	return refs
+}
+
+func setDefaults_NodeConfig(obj *legacyconfigv1.NodeConfig) {
+	if obj.MasterClientConnectionOverrides == nil {
+		obj.MasterClientConnectionOverrides = &legacyconfigv1.ClientConnectionOverrides{
+			// historical values
+			QPS:   10.0,
+			Burst: 20,
+		}
+	}
+	setDefaults_ClientConnectionOverrides(obj.MasterClientConnectionOverrides)
+
+	// Defaults/migrations for NetworkConfig
+	if len(obj.NetworkConfig.NetworkPluginName) == 0 {
+		obj.NetworkConfig.NetworkPluginName = obj.DeprecatedNetworkPluginName
+	}
+	if obj.NetworkConfig.MTU == 0 {
+		obj.NetworkConfig.MTU = 1450
+	}
+	if len(obj.IPTablesSyncPeriod) == 0 {
+		obj.IPTablesSyncPeriod = "30s"
+	}
+
+	// Auth cache defaults
+	if len(obj.AuthConfig.AuthenticationCacheTTL) == 0 {
+		obj.AuthConfig.AuthenticationCacheTTL = "5m"
+	}
+	if obj.AuthConfig.AuthenticationCacheSize == 0 {
+		obj.AuthConfig.AuthenticationCacheSize = 1000
+	}
+	if len(obj.AuthConfig.AuthorizationCacheTTL) == 0 {
+		obj.AuthConfig.AuthorizationCacheTTL = "5m"
+	}
+	if obj.AuthConfig.AuthorizationCacheSize == 0 {
+		obj.AuthConfig.AuthorizationCacheSize = 1000
+	}
+
+	// EnableUnidling by default
+	if obj.EnableUnidling == nil {
+		v := true
+		obj.EnableUnidling = &v
+	}
+}
+
+// SetDefaults_ClientConnectionOverrides defaults a client connection to the pre-1.3 settings of
+// being JSON only. Callers must explicitly opt-in to Protobuf support in 1.3+.
+func setDefaults_ClientConnectionOverrides(overrides *legacyconfigv1.ClientConnectionOverrides) {
+	if len(overrides.AcceptContentTypes) == 0 {
+		overrides.AcceptContentTypes = "application/json"
+	}
+	if len(overrides.ContentType) == 0 {
+		overrides.ContentType = "application/json"
+	}
 }

--- a/pkg/cmd/openshift-sdn/informers.go
+++ b/pkg/cmd/openshift-sdn/informers.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	networkclient "github.com/openshift/client-go/network/clientset/versioned"
 	networkinformers "github.com/openshift/client-go/network/informers/externalversions"
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 )
 
 var defaultInformerResyncPeriod = 30 * time.Minute
@@ -65,7 +65,7 @@ func (i *informers) start(stopCh <-chan struct{}) {
 
 // getKubeConfigOrInClusterConfig loads in-cluster config if kubeConfigFile is empty or the file if not,
 // then applies overrides.
-func getKubeConfigOrInClusterConfig(kubeConfigFile string, overrides *configapi.ClientConnectionOverrides) (*rest.Config, error) {
+func getKubeConfigOrInClusterConfig(kubeConfigFile string, overrides *legacyconfigv1.ClientConnectionOverrides) (*rest.Config, error) {
 	if len(kubeConfigFile) > 0 {
 		return getClientConfig(kubeConfigFile, overrides)
 	}
@@ -80,7 +80,7 @@ func getKubeConfigOrInClusterConfig(kubeConfigFile string, overrides *configapi.
 	return clientConfig, nil
 }
 
-func getClientConfig(kubeConfigFile string, overrides *configapi.ClientConnectionOverrides) (*rest.Config, error) {
+func getClientConfig(kubeConfigFile string, overrides *legacyconfigv1.ClientConnectionOverrides) (*rest.Config, error) {
 	kubeConfigBytes, err := ioutil.ReadFile(kubeConfigFile)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func defaultClientTransport(rt http.RoundTripper) http.RoundTripper {
 }
 
 // applyClientConnectionOverrides updates a kubeConfig with the overrides from the config.
-func applyClientConnectionOverrides(overrides *configapi.ClientConnectionOverrides, kubeConfig *rest.Config) {
+func applyClientConnectionOverrides(overrides *legacyconfigv1.ClientConnectionOverrides, kubeConfig *rest.Config) {
 	if overrides == nil {
 		return
 	}

--- a/pkg/cmd/openshift-sdn/proxy.go
+++ b/pkg/cmd/openshift-sdn/proxy.go
@@ -33,7 +33,7 @@ import (
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilexec "k8s.io/utils/exec"
 
-	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	cmdflags "github.com/openshift/origin/pkg/cmd/util/flags"
 	sdnproxy "github.com/openshift/origin/pkg/network/proxy"
 	"github.com/openshift/origin/pkg/proxy/hybrid"
@@ -43,7 +43,7 @@ import (
 )
 
 // ProxyConfigFromNodeConfig builds the kube-proxy configuration from the already-parsed nodeconfig.
-func ProxyConfigFromNodeConfig(options configapi.NodeConfig) (*kubeproxyconfig.KubeProxyConfiguration, error) {
+func ProxyConfigFromNodeConfig(options legacyconfigv1.NodeConfig) (*kubeproxyconfig.KubeProxyConfiguration, error) {
 	proxyOptions := kubeproxyoptions.NewOptions()
 	// get default config
 	proxyconfig := proxyOptions.GetConfig()
@@ -247,7 +247,8 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		sdn.ProxyConfig.ConfigSyncPeriod.Duration,
 	)
 
-	if sdn.NodeConfig.EnableUnidling {
+	// nil means true today
+	if sdn.NodeConfig.EnableUnidling == nil || *sdn.NodeConfig.EnableUnidling {
 		unidlingLoadBalancer := userspace.NewLoadBalancerRR()
 		signaler := unidler.NewEventSignaler(recorder)
 		unidlingUserspaceProxy, err := unidler.NewUnidlerProxier(unidlingLoadBalancer, bindAddr, iptInterface, execer, *portRange, sdn.ProxyConfig.IPTables.SyncPeriod.Duration, sdn.ProxyConfig.IPTables.MinSyncPeriod.Duration, sdn.ProxyConfig.UDPIdleTimeout.Duration, sdn.ProxyConfig.NodePortAddresses, signaler)


### PR DESCRIPTION
This frees up the old internal config types to be used only for integration tests, which will be removed and allows us to fix our scheme to not include these.

