### PR TITLE
Drop CRI/CNI configurability from openshift-sdn

### DIFF
--- a/pkg/cmd/openshift-sdn/cmd.go
+++ b/pkg/cmd/openshift-sdn/cmd.go
@@ -29,15 +29,12 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
-const openshiftCNIFile string = "80-openshift-network.conf"
-
 // OpenShiftSDN stores the variables needed to initialize the real networking
 // processess from the command line.
 type OpenShiftSDN struct {
 	ConfigFilePath            string
 	KubeConfigFilePath        string
 	URLOnlyKubeConfigFilePath string
-	cniConfFile               string
 
 	NodeConfig  *legacyconfigv1.NodeConfig
 	ProxyConfig *kubeproxyconfig.KubeProxyConfiguration
@@ -99,11 +96,6 @@ func (sdn *OpenShiftSDN) Run(c *cobra.Command, errout io.Writer, stopCh chan str
 				os.Exit(255)
 			}
 		}
-		klog.Fatal(err)
-	}
-
-	// Exit early if we can't create the CNI config file directory
-	if err := os.MkdirAll(filepath.Base(sdn.cniConfFile), 0755); err != nil {
 		klog.Fatal(err)
 	}
 
@@ -173,12 +165,6 @@ func (sdn *OpenShiftSDN) ValidateAndParse() error {
 		klog.V(4).Infof("Unable to build proxy config: %v", err)
 		return err
 	}
-
-	cniConfDir := "/etc/cni/net.d"
-	if val, ok := sdn.NodeConfig.KubeletArguments["cni-conf-dir"]; ok && len(val) == 1 {
-		cniConfDir = val[0]
-	}
-	sdn.cniConfFile = filepath.Join(cniConfDir, openshiftCNIFile)
 
 	return nil
 }

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -43,6 +43,7 @@ import (
 )
 
 const hostLocalDataDir = "/var/lib/cni/networks"
+const cniBinDir = "/opt/cni/bin"
 
 type osdnPolicy interface {
 	Name() string
@@ -66,7 +67,6 @@ type OsdnNodeConfig struct {
 	Hostname   string
 	SelfIP     string
 	MTU        uint32
-	CNIBinDir  string
 
 	NetworkClient networkclient.Interface
 	KClient       kubernetes.Interface
@@ -153,7 +153,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		networkClient:      c.NetworkClient,
 		recorder:           c.Recorder,
 		oc:                 oc,
-		podManager:         newPodManager(c.KClient, policy, c.MTU, c.CNIBinDir, oc),
+		podManager:         newPodManager(c.KClient, policy, c.MTU, oc),
 		localIP:            c.SelfIP,
 		hostName:           c.Hostname,
 		useConnTrack:       useConnTrack,

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -62,13 +62,11 @@ type osdnPolicy interface {
 }
 
 type OsdnNodeConfig struct {
-	PluginName      string
-	Hostname        string
-	SelfIP          string
-	RuntimeEndpoint string
-	MTU             uint32
-	EnableHostports bool
-	CNIBinDir       string
+	PluginName string
+	Hostname   string
+	SelfIP     string
+	MTU        uint32
+	CNIBinDir  string
 
 	NetworkClient networkclient.Interface
 	KClient       kubernetes.Interface
@@ -106,9 +104,7 @@ type OsdnNode struct {
 	networkInformers networkinformers.SharedInformerFactory
 
 	// Holds runtime endpoint shim to make SDN <-> runtime communication
-	runtimeEndpoint       string
-	runtimeRequestTimeout time.Duration
-	runtimeService        kubeletapi.RuntimeService
+	runtimeService kubeletapi.RuntimeService
 
 	egressIP *egressIPWatcher
 }
@@ -157,7 +153,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		networkClient:      c.NetworkClient,
 		recorder:           c.Recorder,
 		oc:                 oc,
-		podManager:         newPodManager(c.KClient, policy, c.MTU, c.CNIBinDir, oc, c.EnableHostports),
+		podManager:         newPodManager(c.KClient, policy, c.MTU, c.CNIBinDir, oc),
 		localIP:            c.SelfIP,
 		hostName:           c.Hostname,
 		useConnTrack:       useConnTrack,
@@ -168,12 +164,6 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		kubeInformers:      c.KubeInformers,
 		networkInformers:   c.NetworkInformers,
 		egressIP:           newEgressIPWatcher(oc, c.SelfIP, c.MasqueradeBit),
-
-		runtimeEndpoint: c.RuntimeEndpoint,
-		// 2 minutes is the current default value used in kubelet
-		runtimeRequestTimeout: 2 * time.Minute,
-		// populated on demand
-		runtimeService: nil,
 	}
 
 	RegisterMetrics()
@@ -337,8 +327,7 @@ func (node *OsdnNode) Start() error {
 
 	klog.V(2).Infof("Starting openshift-sdn pod manager")
 	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR,
-		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String(),
-		networkChanged); err != nil {
+		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String()); err != nil {
 		return err
 	}
 

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -23,11 +23,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	kcontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	kubehostport "k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
 	kbandwidth "k8s.io/kubernetes/pkg/util/bandwidth"
-	utildbus "k8s.io/kubernetes/pkg/util/dbus"
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	utilexec "k8s.io/utils/exec"
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -47,9 +43,8 @@ type podHandler interface {
 }
 
 type runningPod struct {
-	podPortMapping *kubehostport.PodPortMapping
-	vnid           uint32
-	ofport         int
+	vnid   uint32
+	ofport int
 }
 
 type podManager struct {
@@ -58,7 +53,7 @@ type podManager struct {
 	cniServer  *cniserver.CNIServer
 	// Request queue for pod operations incoming from the CNIServer
 	requests chan (*cniserver.PodRequest)
-	// Tracks pod :: IP address for hostport and multicast handling
+	// Tracks pod info for updates
 	runningPods     map[string]*runningPod
 	runningPodsLock sync.Mutex
 
@@ -69,20 +64,13 @@ type podManager struct {
 	cniBinPath string
 	ovs        *ovsController
 
-	enableHostports bool
-	// true if hostports have been synced at least once
-	hostportsSynced bool
-	// true if at least one running pod has a hostport mapping
-	activeHostports bool
-
 	// Things only accessed through the processCNIRequests() goroutine
 	// and thus can be set from Start()
-	ipamConfig     []byte
-	hostportSyncer kubehostport.HostportSyncer
+	ipamConfig []byte
 }
 
 // Creates a new live podManager; used by node code0
-func newPodManager(kClient kubernetes.Interface, policy osdnPolicy, mtu uint32, cniBinPath string, ovs *ovsController, enableHostports bool) *podManager {
+func newPodManager(kClient kubernetes.Interface, policy osdnPolicy, mtu uint32, cniBinPath string, ovs *ovsController) *podManager {
 	pm := newDefaultPodManager()
 	pm.kClient = kClient
 	pm.policy = policy
@@ -90,7 +78,6 @@ func newPodManager(kClient kubernetes.Interface, policy osdnPolicy, mtu uint32, 
 	pm.cniBinPath = cniBinPath
 	pm.podHandler = pm
 	pm.ovs = ovs
-	pm.enableHostports = enableHostports
 	return pm
 }
 
@@ -163,15 +150,7 @@ func getIPAMConfig(clusterNetworks []common.ClusterNetwork, localSubnet string) 
 }
 
 // Start the CNI server and start processing requests from it
-func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string, clearHostPorts bool) error {
-	if m.enableHostports {
-		iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
-		m.hostportSyncer = kubehostport.NewHostportSyncer(iptInterface)
-		if clearHostPorts {
-			_ = m.hostportSyncer.SyncHostports(Tun0, nil)
-		}
-	}
-
+func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string) error {
 	var err error
 	if m.ipamConfig, err = getIPAMConfig(clusterNetworks, localSubnetCIDR); err != nil {
 		return err
@@ -188,50 +167,8 @@ func getPodKey(request *cniserver.PodRequest) string {
 	return fmt.Sprintf("%s/%s", request.PodNamespace, request.PodName)
 }
 
-func (m *podManager) getPod(request *cniserver.PodRequest) *kubehostport.PodPortMapping {
-	if pod := m.runningPods[getPodKey(request)]; pod != nil {
-		return pod.podPortMapping
-	}
-	return nil
-}
-
-func hasHostPorts(pod *kubehostport.PodPortMapping) bool {
-	for _, mapping := range pod.PortMappings {
-		if mapping.HostPort != 0 {
-			return true
-		}
-	}
-	return false
-}
-
-// Return a list of Kubernetes RunningPod objects for hostport operations
-func (m *podManager) shouldSyncHostports(newPod *kubehostport.PodPortMapping) []*kubehostport.PodPortMapping {
-	if m.hostportSyncer == nil {
-		return nil
-	}
-
-	newActiveHostports := false
-	mappings := make([]*kubehostport.PodPortMapping, 0)
-	for _, runningPod := range m.runningPods {
-		mappings = append(mappings, runningPod.podPortMapping)
-		if !newActiveHostports && hasHostPorts(runningPod.podPortMapping) {
-			newActiveHostports = true
-		}
-	}
-	if newPod != nil && hasHostPorts(newPod) {
-		newActiveHostports = true
-	}
-
-	// Sync the first time a pod is started (to clear out stale mappings
-	// if kubelet crashed), or when there are any/will be active hostports.
-	// Otherwise don't bother.
-	if !m.hostportsSynced || m.activeHostports || newActiveHostports {
-		m.hostportsSynced = true
-		m.activeHostports = newActiveHostports
-		return mappings
-	}
-
-	return nil
+func (m *podManager) getPod(request *cniserver.PodRequest) *runningPod {
+	return m.runningPods[getPodKey(request)]
 }
 
 // Add a request to the podManager CNI request queue
@@ -495,16 +432,11 @@ func podIsExited(p *kcontainer.Pod) bool {
 func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *runningPod, error) {
 	defer PodOperationsLatency.WithLabelValues(PodOperationSetup).Observe(sinceInMicroseconds(time.Now()))
 
-	// Release any IPAM allocations and hostports if the setup failed
+	// Release any IPAM allocations if the setup failed
 	var success bool
 	defer func() {
 		if !success {
 			m.ipamDel(req.SandboxID)
-			if mappings := m.shouldSyncHostports(nil); mappings != nil {
-				if err := m.hostportSyncer.SyncHostports(Tun0, mappings); err != nil {
-					klog.Warningf("failed syncing hostports: %v", err)
-				}
-			}
 		}
 	}()
 
@@ -525,14 +457,6 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 		}
 	}
 
-	// Open any hostports the pod wants
-	podPortMapping := constructPodPortMapping(v1Pod, podIP)
-	if mappings := m.shouldSyncHostports(podPortMapping); mappings != nil {
-		if err := m.hostportSyncer.OpenPodHostportsAndSync(podPortMapping, Tun0, mappings); err != nil {
-			return nil, nil, err
-		}
-	}
-
 	vnid, err := m.policy.GetVNID(req.PodNamespace)
 	if err != nil {
 		return nil, nil, err
@@ -548,7 +472,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 
 	m.policy.EnsureVNIDRules(vnid)
 	success = true
-	return ipamResult, &runningPod{podPortMapping: podPortMapping, vnid: vnid, ofport: ofport}, nil
+	return ipamResult, &runningPod{vnid: vnid, ofport: ofport}, nil
 }
 
 // Update OVS flows when something (like the pod's namespace VNID) changes
@@ -578,36 +502,5 @@ func (m *podManager) teardown(req *cniserver.PodRequest) error {
 		errList = append(errList, err)
 	}
 
-	if mappings := m.shouldSyncHostports(nil); mappings != nil {
-		if err := m.hostportSyncer.SyncHostports(Tun0, mappings); err != nil {
-			errList = append(errList, err)
-		}
-	}
-
 	return kerrors.NewAggregate(errList)
-}
-
-// constructPodPortMapping creates a PodPortMapping from the ports specified in the pod's
-// containers.
-func constructPodPortMapping(pod *corev1.Pod, podIP net.IP) *kubehostport.PodPortMapping {
-	portMappings := make([]*kubehostport.PortMapping, 0)
-	for _, c := range pod.Spec.Containers {
-		for _, port := range c.Ports {
-			portMappings = append(portMappings, &kubehostport.PortMapping{
-				Name:          port.Name,
-				HostPort:      port.HostPort,
-				ContainerPort: port.ContainerPort,
-				Protocol:      port.Protocol,
-				HostIP:        port.HostIP,
-			})
-		}
-	}
-
-	return &kubehostport.PodPortMapping{
-		Namespace:    pod.Namespace,
-		Name:         pod.Name,
-		PortMappings: portMappings,
-		HostNetwork:  pod.Spec.HostNetwork,
-		IP:           podIP,
-	}
 }

--- a/pkg/network/node/pod_test.go
+++ b/pkg/network/node/pod_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/origin/pkg/network/node/cniserver"
 
 	utiltesting "k8s.io/client-go/util/testing"
-	khostport "k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	cni020 "github.com/containernetworking/cni/pkg/types/020"
@@ -95,16 +94,6 @@ func (pt *podTester) addExpectedPod(t *testing.T, op *operation) {
 	}
 }
 
-func fakeRunningPod(namespace, name string, ip net.IP) *runningPod {
-	podPortMapping := &khostport.PodPortMapping{
-		Namespace: namespace,
-		Name:      name,
-		IP:        ip,
-	}
-
-	return &runningPod{podPortMapping: podPortMapping, vnid: 0}
-}
-
 func (pt *podTester) setup(req *cniserver.PodRequest) (cnitypes.Result, *runningPod, error) {
 	pod, err := pt.getExpectedPod(req.PodNamespace, req.PodName, req.Command)
 	if err != nil {
@@ -124,7 +113,7 @@ func (pt *podTester) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 		},
 	}
 
-	return result, fakeRunningPod(req.PodNamespace, req.PodName, ip), nil
+	return result, &runningPod{}, nil
 }
 
 func (pt *podTester) update(req *cniserver.PodRequest) (uint32, error) {
@@ -318,7 +307,7 @@ func TestPodManager(t *testing.T) {
 		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
 		_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
+		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
 		if err != nil {
 			t.Fatalf("could not start PodManager: %v", err)
 		}
@@ -417,7 +406,7 @@ func TestDirectPodUpdate(t *testing.T) {
 	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
 	_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
+	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
 	if err != nil {
 		t.Fatalf("could not start PodManager: %v", err)
 	}

--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -12,6 +12,12 @@ import (
 	kubeletremote "k8s.io/kubernetes/pkg/kubelet/remote"
 )
 
+const (
+	runtimeEndpoint = "unix:///var/run/crio/crio.sock"
+	// 2 minutes is the current default value used in kubelet
+	runtimeRequestTimeout = 2 * time.Minute
+)
+
 func (node *OsdnNode) getRuntimeService() (kubeletapi.RuntimeService, error) {
 	if node.runtimeService != nil {
 		return node.runtimeService, nil
@@ -26,7 +32,7 @@ func (node *OsdnNode) getRuntimeService() (kubeletapi.RuntimeService, error) {
 			Steps:    24,
 		},
 		func() (bool, error) {
-			runtimeService, err := kubeletremote.NewRemoteRuntimeService(node.runtimeEndpoint, node.runtimeRequestTimeout)
+			runtimeService, err := kubeletremote.NewRemoteRuntimeService(runtimeEndpoint, runtimeRequestTimeout)
 			if err != nil {
 				// Wait longer
 				return false, nil


### PR DESCRIPTION
We only support CRI-O now, so drop the HostPort stuff that was needed with dockershim