### PR TITLE
pkg/oc/cli/admin/release/git: Case-insensitive bug regexp allowing prefixes

### DIFF
--- a/pkg/oc/cli/admin/release/git.go
+++ b/pkg/oc/cli/admin/release/git.go
@@ -152,7 +152,7 @@ func mergeLogForRepo(g *git, repo string, from, to string) ([]MergeCommit, error
 	if err != nil {
 		return nil, err
 	}
-	reBug, err := regexp.Compile(`^Bug (\d+)\s*(-|:)\s*`)
+	reBug, err := regexp.Compile(`^(?i)^.*?Bug (\d+)\s*(-|:)\s*`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This gets us closer to [the new Prow plugin's][1]:

```
(?i)^.*Bug ([0-9]+):
```

adding case-insensitive matching with the [`(?i)`][2] and allowing prefixes with the [`.*?`][2] (non-greedy version in flight upstream, kubernetes/test-infra#12910).  Prefixes are useful because the cherry-pick bot generates pull-request subjects [like][4]:

```
[release-4.1] Bug 1715020: oauth validation: ...
```

and we want to allow that without requiring folks to manually adjust their pull-request subjects after using the cherry-pick bot.

Prefixes and case-insensitive matching make it slightly more likely that we get false-positives.  For example:

```console
$ git log --format=%s | grep -i 'bug [0-9][0-9]* *[:-]' | grep -iv '^bug '
Fix bug 1649227: 404 url
We should not be able to create a route when the host is not specified and wildcardpolicy is enabled. Fixes bug 1392862 - https://bugzilla.redhat.com/show_bug.cgi?id=1392862 Rework as per @liggitt review comments. Fix govet issue.
Fixes bug 1380462 - https://bugzilla.redhat.com/show_bug.cgi?id=1380462
Fixes bug 1345773 - https://bugzilla.redhat.com/show_bug.cgi?id=1345773
Revert "Bug 1281735 - remove the internal docker registry information from imagestream"
Changes to markup and the logo so that it isn't clipped at certain dimensions - Fixes bug 1328016 - CSS changes to enable logos of varing dimensions within the following sizes - Logo max width 230px / height 36px
 Bug 1275537 - Fixed the way image import controller informs about errors from imports.
Revert "Bug 1247680 - must not truncate svc names in the cli, rely on API validation"
```

The two reverts are probably fixing a different issue than the commit they're reverting.  But in that case the original issue is probably closed, so the Prow plugin will complain, and folks can adjust the new pull-request's subject to be:

```
Bug 456: Revert "Bug 123: ..."
```

to say "I'm fixing bug 456, which was reporting issues with the earlier broken attempt to fix bug 123".

CC @smarterclayton, @stevekuznetsov

[1]: https://github.com/kubernetes/test-infra/pull/12771/commits/dde8dcd68c3335eda32ac0fb1db5c5c2308cda9c#diff-e0117b7021a6479c5ab4ba9adbd04a81R38
[2]: https://github.com/google/re2/wiki/Syntax
[4]: https://github.com/openshift/origin/pull/22959