### PR TITLE
template: move processor client to oc

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -446,7 +446,6 @@
       "github.com/openshift/origin/pkg/route/apis/route/v1",
       "github.com/openshift/origin/pkg/route/generated",
       "github.com/openshift/origin/pkg/template/apis/template/v1",
-      "github.com/openshift/origin/pkg/template/client/v1",
       "github.com/openshift/origin/pkg/user/generated",
       "github.com/openshift/origin/pkg/security/generated",
       "github.com/openshift/origin/pkg/template/generated",

--- a/pkg/oc/cli/importer/appjson/appjson.go
+++ b/pkg/oc/cli/importer/appjson/appjson.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/templates"
 
+	"github.com/openshift/oc/pkg/helpers/template/templateprocessorclient"
 	"github.com/openshift/origin/pkg/oc/lib/newapp/appjson"
 	appcmd "github.com/openshift/origin/pkg/oc/lib/newapp/cmd"
-	templatev1client "github.com/openshift/origin/pkg/template/client/v1"
 )
 
 const AppJSONV1GeneratorName = "app-json/v1"
@@ -245,7 +245,7 @@ func (o *AppJSONOptions) Run() error {
 		return o.Printer.PrintObj(obj, o.Out)
 	}
 
-	templateProcessor := templatev1client.NewTemplateProcessorClient(o.Client, o.Namespace)
+	templateProcessor := templateprocessorclient.NewTemplateProcessorClient(o.Client, o.Namespace)
 	result, err := appcmd.TransformTemplate(template, templateProcessor, o.Namespace, nil, false)
 	if err != nil {
 		return err

--- a/pkg/oc/cli/process/process.go
+++ b/pkg/oc/cli/process/process.go
@@ -33,11 +33,11 @@ import (
 	"github.com/openshift/library-go/pkg/template/generator"
 	"github.com/openshift/library-go/pkg/template/templateprocessing"
 	cmdutil "github.com/openshift/oc/pkg/helpers/cmd"
+	"github.com/openshift/oc/pkg/helpers/template/templateprocessorclient"
 	"github.com/openshift/origin/pkg/oc/lib/describe"
 	"github.com/openshift/origin/pkg/oc/lib/newapp/app"
 	templateapi "github.com/openshift/origin/pkg/template/apis/template"
 	templateapiv1 "github.com/openshift/origin/pkg/template/apis/template/v1"
-	templateclientv1 "github.com/openshift/origin/pkg/template/client/v1"
 )
 
 var (
@@ -262,7 +262,7 @@ func (o *ProcessOptions) Complete(f kcmdutil.Factory, cmd *cobra.Command, args [
 			return err
 		}
 
-		templateProcessorClient := templateclientv1.NewTemplateProcessorClient(o.templateClient.RESTClient(), o.namespace)
+		templateProcessorClient := templateprocessorclient.NewTemplateProcessorClient(o.templateClient.RESTClient(), o.namespace)
 
 		o.templateProcessor = func(template *templatev1.Template) (*templatev1.Template, error) {
 			t, err := templateProcessorClient.Process(template)

--- a/pkg/oc/lib/newapp/cmd/newapp.go
+++ b/pkg/oc/lib/newapp/cmd/newapp.go
@@ -37,6 +37,7 @@ import (
 	ometa "github.com/openshift/library-go/pkg/image/referencemutator"
 	"github.com/openshift/oc/pkg/helpers/env"
 	utilenv "github.com/openshift/oc/pkg/helpers/env"
+	"github.com/openshift/oc/pkg/helpers/template/templateprocessorclient"
 	"github.com/openshift/origin/pkg/build/buildapihelpers"
 	imageapi "github.com/openshift/origin/pkg/image/apis/image"
 	dockerregistry "github.com/openshift/origin/pkg/image/importer/dockerv1client"
@@ -46,7 +47,6 @@ import (
 	"github.com/openshift/origin/pkg/oc/lib/newapp/dockerfile"
 	"github.com/openshift/origin/pkg/oc/lib/newapp/jenkinsfile"
 	"github.com/openshift/origin/pkg/oc/lib/newapp/source"
-	templateclientv1 "github.com/openshift/origin/pkg/template/client/v1"
 )
 
 const (
@@ -525,7 +525,7 @@ func (c *AppConfig) buildPipelines(components app.ComponentReferences, environme
 }
 
 // buildTemplates converts a set of resolved, valid references into references to template objects.
-func (c *AppConfig) buildTemplates(components app.ComponentReferences, parameters app.Environment, environment app.Environment, buildEnvironment app.Environment, templateProcessor templateclientv1.TemplateProcessorInterface) (string, []runtime.Object, error) {
+func (c *AppConfig) buildTemplates(components app.ComponentReferences, parameters app.Environment, environment app.Environment, buildEnvironment app.Environment, templateProcessor templateprocessorclient.TemplateProcessorInterface) (string, []runtime.Object, error) {
 	objects := []runtime.Object{}
 	name := ""
 	for _, ref := range components {
@@ -901,7 +901,7 @@ func (c *AppConfig) Run() (*AppResult, error) {
 
 	objects = app.AddServices(objects, false)
 
-	templateProcessor := templateclientv1.NewTemplateProcessorClient(c.TemplateClient.RESTClient(), c.OriginNamespace)
+	templateProcessor := templateprocessorclient.NewTemplateProcessorClient(c.TemplateClient.RESTClient(), c.OriginNamespace)
 	templateName, templateObjects, err := c.buildTemplates(components.TemplateComponentRefs(), parameters, env, buildenv, templateProcessor)
 	if err != nil {
 		return nil, err

--- a/pkg/oc/lib/newapp/cmd/template.go
+++ b/pkg/oc/lib/newapp/cmd/template.go
@@ -7,12 +7,12 @@ import (
 
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/openshift/library-go/pkg/template/templateprocessing"
+	"github.com/openshift/oc/pkg/helpers/template/templateprocessorclient"
 	"github.com/openshift/origin/pkg/oc/lib/newapp/app"
-	templateclientv1 "github.com/openshift/origin/pkg/template/client/v1"
 )
 
 // TransformTemplateV1 processes a template with the provided parameters, returning an error if transformation fails.
-func TransformTemplate(tpl *templatev1.Template, templateProcessor templateclientv1.TemplateProcessorInterface, namespace string, parameters map[string]string, ignoreUnknownParameters bool) (*templatev1.Template, error) {
+func TransformTemplate(tpl *templatev1.Template, templateProcessor templateprocessorclient.TemplateProcessorInterface, namespace string, parameters map[string]string, ignoreUnknownParameters bool) (*templatev1.Template, error) {
 	// only set values that match what's expected by the template.
 	for k, value := range parameters {
 		v := templateprocessing.GetParameterByName(tpl, k)

--- a/staging/src/github.com/openshift/oc/pkg/helpers/template/templateprocessorclient/templateconfig.go
+++ b/staging/src/github.com/openshift/oc/pkg/helpers/template/templateprocessorclient/templateconfig.go
@@ -1,4 +1,4 @@
-package v1
+package templateprocessorclient
 
 import (
 	"k8s.io/client-go/rest"


### PR DESCRIPTION
Only used by `oc`, straight move to staging.

/cc @soltysh 