### PR TITLE
add timeout decorator for admission and limit to 13 seconds

### DIFF
--- a/pkg/admission/admissiontimeout/decorator.go
+++ b/pkg/admission/admissiontimeout/decorator.go
@@ -1,0 +1,20 @@
+package admissiontimeout
+
+import (
+	"time"
+
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// AdmissionTimeout provides a decorator that will fail an admission plugin after a certain amount of time
+type AdmissionTimeout struct {
+	Timeout time.Duration
+}
+
+func (d AdmissionTimeout) WithTimeout(admissionPlugin admission.Interface, name string) admission.Interface {
+	return pluginHandlerWithTimeout{
+		name:            name,
+		admissionPlugin: admissionPlugin,
+		timeout:         d.Timeout,
+	}
+}

--- a/pkg/admission/admissiontimeout/timeoutadmission.go
+++ b/pkg/admission/admissiontimeout/timeoutadmission.go
@@ -1,0 +1,67 @@
+package admissiontimeout
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+type pluginHandlerWithTimeout struct {
+	name            string
+	admissionPlugin admission.Interface
+	timeout         time.Duration
+}
+
+var _ admission.ValidationInterface = &pluginHandlerWithTimeout{}
+var _ admission.MutationInterface = &pluginHandlerWithTimeout{}
+
+func (p pluginHandlerWithTimeout) Handles(operation admission.Operation) bool {
+	return p.admissionPlugin.Handles(operation)
+}
+
+func (p pluginHandlerWithTimeout) Admit(a admission.Attributes, o admission.ObjectInterfaces) error {
+	mutatingHandler, ok := p.admissionPlugin.(admission.MutationInterface)
+	if !ok {
+		return nil
+	}
+
+	admissionDone := make(chan struct{})
+	admissionErr := fmt.Errorf("default to mutation error")
+	go func() {
+		defer utilruntime.HandleCrash()
+		defer close(admissionDone)
+		admissionErr = mutatingHandler.Admit(a, o)
+	}()
+
+	select {
+	case <-admissionDone:
+		return admissionErr
+	case <-time.After(p.timeout):
+		return errors.NewInternalError(fmt.Errorf("admission plugin %q failed to complete mutation in %v", p.name, p.timeout))
+	}
+}
+
+func (p pluginHandlerWithTimeout) Validate(a admission.Attributes, o admission.ObjectInterfaces) error {
+	validatingHandler, ok := p.admissionPlugin.(admission.ValidationInterface)
+	if !ok {
+		return nil
+	}
+
+	admissionDone := make(chan struct{})
+	admissionErr := fmt.Errorf("default to validation error")
+	go func() {
+		defer utilruntime.HandleCrash()
+		defer close(admissionDone)
+		admissionErr = validatingHandler.Validate(a, o)
+	}()
+
+	select {
+	case <-admissionDone:
+		return admissionErr
+	case <-time.After(p.timeout):
+		return errors.NewInternalError(fmt.Errorf("admission plugin %q failed to complete validation in %v", p.name, p.timeout))
+	}
+}

--- a/pkg/admission/admissiontimeout/timeoutadmission_test.go
+++ b/pkg/admission/admissiontimeout/timeoutadmission_test.go
@@ -1,0 +1,106 @@
+package admissiontimeout
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+type admitFunc func(a admission.Attributes, o admission.ObjectInterfaces) error
+
+type dummyAdmit struct {
+	admitFn admitFunc
+}
+
+func (p dummyAdmit) Handles(operation admission.Operation) bool {
+	return true
+}
+
+func (p dummyAdmit) Admit(a admission.Attributes, o admission.ObjectInterfaces) error {
+	return p.admitFn(a, o)
+}
+
+func (p dummyAdmit) Validate(a admission.Attributes, o admission.ObjectInterfaces) error {
+	return p.admitFn(a, o)
+}
+
+func TestTimeoutAdmission(t *testing.T) {
+	utilruntime.ReallyCrash = false
+
+	tests := []struct {
+		name string
+
+		timeout         time.Duration
+		admissionPlugin func() (admit admitFunc, stopCh chan struct{})
+		expectedError   string
+	}{
+		{
+			name:    "stops on time",
+			timeout: 50 * time.Millisecond,
+			admissionPlugin: func() (admitFunc, chan struct{}) {
+				stopCh := make(chan struct{})
+				return func(a admission.Attributes, o admission.ObjectInterfaces) error {
+					<-stopCh
+					return nil
+				}, stopCh
+			},
+			expectedError: `fake-name" failed to complete`,
+		},
+		{
+			name:    "stops on success",
+			timeout: 500 * time.Millisecond,
+			admissionPlugin: func() (admitFunc, chan struct{}) {
+				stopCh := make(chan struct{})
+				return func(a admission.Attributes, o admission.ObjectInterfaces) error {
+					return fmt.Errorf("fake failure to finish")
+				}, stopCh
+			},
+			expectedError: "fake failure to finish",
+		},
+		{
+			name:    "no crash on panic",
+			timeout: 500 * time.Millisecond,
+			admissionPlugin: func() (admitFunc, chan struct{}) {
+				stopCh := make(chan struct{})
+				return func(a admission.Attributes, o admission.ObjectInterfaces) error {
+					panic("fail!")
+				}, stopCh
+			},
+			expectedError: "default to ",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			admitFn, stopCh := test.admissionPlugin()
+			defer close(stopCh)
+
+			fakePlugin := dummyAdmit{admitFn: admitFn}
+			decorator := AdmissionTimeout{Timeout: test.timeout}
+			decoratedPlugin := decorator.WithTimeout(fakePlugin, "fake-name")
+
+			actualErr := decoratedPlugin.(admission.MutationInterface).Admit(nil, nil)
+			validateErr(t, actualErr, test.expectedError)
+
+			actualErr = decoratedPlugin.(admission.ValidationInterface).Validate(nil, nil)
+			validateErr(t, actualErr, test.expectedError)
+		})
+	}
+}
+
+func validateErr(t *testing.T, actualErr error, expectedError string) {
+	t.Helper()
+	switch {
+	case actualErr == nil && len(expectedError) != 0:
+		t.Fatal(expectedError)
+	case actualErr == nil && len(expectedError) == 0:
+	case actualErr != nil && len(expectedError) == 0:
+		t.Fatal(actualErr)
+	case actualErr != nil && !strings.Contains(actualErr.Error(), expectedError):
+		t.Fatal(actualErr)
+	}
+}

--- a/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/origin/pkg/admission/admissiontimeout"
+
 	"k8s.io/apiserver/pkg/admission"
 	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -127,6 +129,7 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 		options.Decorators = admission.Decorators{
 			admission.DecoratorFunc(namespaceLabelDecorator.WithNamespaceLabelConditions),
 			admission.DecoratorFunc(admissionmetrics.WithControllerMetrics),
+			admission.DecoratorFunc(admissiontimeout.AdmissionTimeout{Timeout: 13 * time.Second}.WithTimeout),
 		}
 		// END ADMISSION
 


### PR DESCRIPTION
Adding a limit for individual admission plugins of 13 seconds so we don't wait forever and to see if I can catch https://bugzilla.redhat.com/show_bug.cgi?id=1714699

/hold

holding until I actually try it

/assign @sttts @p0lyn0mial 