### PR TITLE
remove oc dependency on origin/pkg/quota/apis/quota

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -498,7 +498,6 @@
       "github.com/openshift/origin/pkg/printers/internalversion",
       "github.com/openshift/origin/pkg/project/apis/project",
       "github.com/openshift/origin/pkg/project/apiserver/registry/projectrequest/delegated",
-      "github.com/openshift/origin/pkg/quota/apis/quota",
       "github.com/openshift/origin/pkg/route/apis/route",
       "github.com/openshift/origin/pkg/route/generator",
       "github.com/openshift/origin/pkg/security/apis/security",

--- a/pkg/oc/lib/describe/describer.go
+++ b/pkg/oc/lib/describe/describer.go
@@ -48,6 +48,7 @@ import (
 	quotaclient "github.com/openshift/client-go/quota/clientset/versioned/typed/quota/v1"
 	buildapihelpers "github.com/openshift/oc/pkg/helpers/build"
 	ocbuildapihelpers "github.com/openshift/oc/pkg/helpers/build"
+	quotahelpers "github.com/openshift/oc/pkg/helpers/quota"
 	routedisplayhelpers "github.com/openshift/oc/pkg/helpers/route"
 
 	oapi "github.com/openshift/origin/pkg/api"
@@ -62,7 +63,6 @@ import (
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
 	projectapi "github.com/openshift/origin/pkg/project/apis/project"
 	projectclient "github.com/openshift/origin/pkg/project/generated/internalclientset/typed/project/internalversion"
-	quotaconvert "github.com/openshift/origin/pkg/quota/apis/quota"
 	routeapi "github.com/openshift/origin/pkg/route/apis/route"
 	routev1conversions "github.com/openshift/origin/pkg/route/apis/route/v1"
 	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset/typed/route/internalversion"
@@ -1730,7 +1730,7 @@ func (d *AppliedClusterQuotaDescriber) Describe(namespace, name string, settings
 	if err != nil {
 		return "", err
 	}
-	return DescribeClusterQuota(quotaconvert.ConvertV1AppliedClusterResourceQuotaToV1ClusterResourceQuota(quota))
+	return DescribeClusterQuota(quotahelpers.ConvertV1AppliedClusterResourceQuotaToV1ClusterResourceQuota(quota))
 }
 
 type ClusterNetworkDescriber struct {

--- a/pkg/quota/apis/quota/convert.go
+++ b/pkg/quota/apis/quota/convert.go
@@ -19,12 +19,3 @@ func ConvertV1ClusterResourceQuotaToV1AppliedClusterResourceQuota(in *quotav1.Cl
 		Status:     in.Status,
 	}
 }
-
-// ConvertV1AppliedClusterResourceQuotaToV1ClusterResourceQuota returns back a converted AppliedClusterResourceQuota which is NOT a deep copy.
-func ConvertV1AppliedClusterResourceQuotaToV1ClusterResourceQuota(in *quotav1.AppliedClusterResourceQuota) *quotav1.ClusterResourceQuota {
-	return &quotav1.ClusterResourceQuota{
-		ObjectMeta: in.ObjectMeta,
-		Spec:       in.Spec,
-		Status:     in.Status,
-	}
-}


### PR DESCRIPTION
Replaced dependency on `github.com/openshift/origin/pkg/quota/apis/quota` with `github.com/openshift/oc/pkg/helpers/quota`.