### PR TITLE
tools: verify the commit author

### DIFF
--- a/tools/rebasehelpers/commitchecker/validate.go
+++ b/tools/rebasehelpers/commitchecker/validate.go
@@ -42,6 +42,22 @@ var AllValidators = []func([]util.Commit) error{
 	ValidateUpstreamCommitsWithoutGodepsChanges,
 	ValidateUpstreamCommitModifiesOnlyGodeps,
 	ValidateUpstreamCommitModifiesOnlyKubernetes,
+	ValidateCommitAuthorEmail,
+}
+
+func ValidateCommitAuthorEmail(commits []util.Commit) error {
+	problemCommits := []util.Commit{}
+	for _, commit := range commits {
+		if strings.HasPrefix(commit.Email, "root@") {
+			fmt.Printf("Invalid email in commit %s: %q\n", commit.Sha, commit.Email)
+			problemCommits = append(problemCommits, commit)
+		}
+	}
+	if len(problemCommits) > 0 {
+		label := "Found commits with invalid commit author"
+		return fmt.Errorf(label)
+	}
+	return nil
 }
 
 // ValidateUpstreamCommitsWithoutGodepsChanges returns an error if any

--- a/tools/rebasehelpers/util/git.go
+++ b/tools/rebasehelpers/util/git.go
@@ -35,6 +35,7 @@ type Commit struct {
 	Summary     string
 	Description []string
 	Files       []File
+	Email       string
 }
 
 func (c Commit) DeclaresUpstreamChange() bool {
@@ -231,6 +232,10 @@ func NewCommitFromOnelineLog(log string) (Commit, error) {
 		return commit, err
 	}
 	commit.Files = files
+	commit.Email, err = emailInCommit(commit.Sha)
+	if err != nil {
+		return commit, err
+	}
 	return commit, nil
 }
 
@@ -324,6 +329,14 @@ func CurrentRev(repoDir string) (string, error) {
 	} else {
 		return strings.TrimSpace(stdout), nil
 	}
+}
+
+func emailInCommit(sha string) (string, error) {
+	stdout, stderr, err := run("git", "show", `--format=%ae`, "-s", sha)
+	if err != nil {
+		return "", fmt.Errorf("%s: %s", stderr, err)
+	}
+	return strings.TrimSpace(stdout), nil
 }
 
 func filesInCommit(sha string) ([]File, error) {


### PR DESCRIPTION
Prevents commits like https://github.com/openshift/origin/pull/22572/commits/ce473d8e13f02834177da0f6cb9a42fd6b234cb2 from landing and force committers to configure `git` properly.

Sample output:

```
FAILURE after 0.000s: hack/verify-upstream-commits.sh:19: executing 'commitchecker' expecting success: the command returned the wrong error code
Standard output from the command:
Invalid email in commit 6f0e6c3b10: "root@dhcp-140-138.nay.redhat.com"

Standard error from the command:
Found commits with invalid commit author
[ERROR] hack/lib/cmd.sh:10: `return "${return_code}"` exited with status 1.
[ERROR] hack/verify-upstream-commits.sh exited with code 1 after 00h 00m 04s
```