### PR TITLE
tests: sweep extended tests for referenced to origin

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -30,7 +30,7 @@ import (
 	"github.com/openshift/api/project"
 	"github.com/openshift/api/template"
 	"github.com/openshift/api/user"
-	"github.com/openshift/origin/pkg/cmd/openshift-apiserver/openshiftapiserver"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -138,7 +138,7 @@ var _ = g.Describe("The default cluster RBAC policy", func() {
 	oc := exutil.NewCLI("default-rbac-policy", exutil.KubeConfigPath())
 
 	kubeInformers := informers.NewSharedInformerFactory(oc.AdminKubeClient(), 20*time.Minute)
-	ruleResolver := openshiftapiserver.NewRuleResolver(kubeInformers.Rbac().V1()) // signal what informers we want to use early
+	ruleResolver := exutil.NewRuleResolver(kubeInformers.Rbac().V1()) // signal what informers we want to use early
 
 	stopCh := make(chan struct{})
 	defer func() { close(stopCh) }()

--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -74,7 +74,7 @@ func testBuildDigest(oc *exutil.CLI, buildFixture string, buildLogLevel uint) {
 		g.By("checking that the image digest has been saved to the build status")
 		o.Expect(br.Build.Status.Output.To).NotTo(o.BeNil())
 
-		ist, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("test:latest", v1.GetOptions{})
+		ist, err := oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get("test:latest", v1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(br.Build.Status.Output.To.ImageDigest).To(o.Equal(ist.Image.Name))
 	})

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -8,6 +8,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/api/image/docker10"
+	"github.com/openshift/library-go/pkg/image/imageutil"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -66,9 +68,10 @@ USER 1001
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("getting the build Docker image reference from ImageStream")
-				image, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("busybox:custom", metav1.GetOptions{})
+				image, err := oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get("busybox:custom", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
+				imageutil.ImageWithMetadataOrDie(&image.Image)
+				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 			})
 
 			g.It("should create a image via new-build and infer the origin tag", func() {
@@ -94,12 +97,13 @@ USER 1001
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("getting the built Docker image reference from ImageStream")
-				image, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("centos:latest", metav1.GetOptions{})
+				image, err := oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get("centos:latest", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(image.Image.DockerImageMetadata.Config.User).To(o.Equal("1001"))
+				imageutil.ImageWithMetadataOrDie(&image.Image)
+				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 
 				g.By("checking for the imported tag")
-				_, err = oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("centos:7", metav1.GetOptions{})
+				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get("centos:7", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -62,7 +62,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use private repositories as build
 
 			sourceSecretName := secretFunc()
 
-			route, err := oc.AdminRouteClient().Route().Routes(oc.Namespace()).Get(routeName, metav1.GetOptions{})
+			route, err := oc.AdminRouteClient().RouteV1().Routes(oc.Namespace()).Get(routeName, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			sourceURL := fmt.Sprintf(urlTemplate, route.Spec.Host)

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[Feature:Builds][Slow] build can have Docker image source", 
 
 		g.JustBeforeEach(func() {
 			g.By("waiting for imagestreams to be imported")
-			err := exutil.WaitForAnImageStream(oc.AdminInternalImageClient().Image().ImageStreams("openshift"), "ruby", exutil.CheckImageStreamLatestTagPopulated, exutil.CheckImageStreamTagNotFound)
+			err := exutil.WaitForAnImageStream(oc.AdminImageClient().ImageV1().ImageStreams("openshift"), "ruby", exutil.CheckImageStreamLatestTagPopulated, exutil.CheckImageStreamTagNotFound)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -50,10 +50,10 @@ var _ = g.Describe("[Feature:Builds] result image should have proper labels set"
 				br.AssertSuccess()
 
 				g.By("getting the Docker image reference from ImageStream")
-				imageRef, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
+				imageRef, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()), "test", "latest")
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				imageLabels, err := eximages.GetImageLabels(oc.ImageClient().Image().ImageStreamImages(oc.Namespace()), "test", imageRef)
+				imageLabels, err := eximages.GetImageLabels(oc.ImageClient().ImageV1().ImageStreamImages(oc.Namespace()), "test", imageRef)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("inspecting the new image for proper Docker labels")
@@ -78,10 +78,10 @@ var _ = g.Describe("[Feature:Builds] result image should have proper labels set"
 				br.AssertSuccess()
 
 				g.By("getting the Docker image reference from ImageStream")
-				imageRef, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
+				imageRef, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()), "test", "latest")
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				imageLabels, err := eximages.GetImageLabels(oc.ImageClient().Image().ImageStreamImages(oc.Namespace()), "test", imageRef)
+				imageLabels, err := eximages.GetImageLabels(oc.ImageClient().ImageV1().ImageStreamImages(oc.Namespace()), "test", imageRef)
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("inspecting the new image for proper Docker labels")

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[Feature:Builds][Slow] s2i build with environment file in so
 				br.AssertSuccess()
 
 				g.By("getting the Docker image reference from ImageStream")
-				imageName, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
+				imageName, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()), "test", "latest")
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("instantiating a pod and service with the new image")

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[Feature:Builds][Slow] incremental s2i build", func() {
 				br2.AssertSuccess()
 
 				g.By("getting the Docker image reference from ImageStream")
-				imageName, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "incremental-image", "latest")
+				imageName, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()), "incremental-image", "latest")
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("instantiating a pod and service with the new image")

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -5,9 +5,11 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	buildutil "github.com/openshift/openshift-controller-manager/pkg/build/buildutil"
+	buildv1 "github.com/openshift/api/build/v1"
+	"github.com/openshift/openshift-controller-manager/pkg/build/buildutil"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -58,7 +60,10 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func(
 				// TODO: re-enable this check when https://github.com/containers/buildah/issues/1213 is resolved.
 				//o.Expect(buildLog).To(o.ContainSubstring("MEMORYSWAP=209715200"))
 
-				events, err := oc.KubeClient().CoreV1().Events(oc.Namespace()).Search(legacyscheme.Scheme, br.Build)
+				testScheme := runtime.NewScheme()
+				utilruntime.Must(buildv1.Install(testScheme))
+
+				events, err := oc.KubeClient().CoreV1().Events(oc.Namespace()).Search(testScheme, br.Build)
 				o.Expect(err).NotTo(o.HaveOccurred(), "Should be able to get events from the build")
 				o.Expect(events).NotTo(o.BeNil(), "Build event list should not be nil")
 

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -69,11 +69,11 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a root user ima
 		defer After(oc)
 		g.By("adding builder account to privileged SCC")
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			scc, err := oc.AdminSecurityClient().Security().SecurityContextConstraints().Get("privileged", metav1.GetOptions{})
+			scc, err := oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Get("privileged", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			scc.Users = append(scc.Users, "system:serviceaccount:"+oc.Namespace()+":builder")
-			_, err = oc.AdminSecurityClient().Security().SecurityContextConstraints().Update(scc)
+			_, err = oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Update(scc)
 			return err
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 				br.AssertSuccess()
 
 				g.By("getting the image name")
-				image, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
+				image, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()), "test", "latest")
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("verifying the build sources were available during build and secrets were not present in the output image")
@@ -99,7 +99,7 @@ var _ = g.Describe("[Feature:Builds][Slow] can use build secrets", func() {
 				br.AssertSuccess()
 
 				g.By("getting the image name")
-				image, err := exutil.GetDockerImageReference(oc.ImageClient().Image().ImageStreams(oc.Namespace()), "test", "latest")
+				image, err := exutil.GetDockerImageReference(oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()), "test", "latest")
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				g.By("verifying the build sources are present in container output")

--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -15,9 +15,9 @@ import (
 	kclientset "k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
-	oapi "github.com/openshift/origin/pkg/api"
-	projectapi "github.com/openshift/origin/pkg/project/apis/project"
-	metrics "github.com/openshift/origin/test/extended/cluster/metrics"
+	"github.com/openshift/api/annotations"
+	projectapi "github.com/openshift/api/project/v1"
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -252,7 +252,7 @@ func newProject(nsName string) *projectapi.Project {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
 			Annotations: map[string]string{
-				oapi.OpenShiftDisplayName: nsName,
+				annotations.OpenShiftDisplayName: nsName,
 				//"openshift.io/node-selector": "purpose=test",
 			},
 		},

--- a/test/extended/cluster/utils.go
+++ b/test/extended/cluster/utils.go
@@ -567,7 +567,7 @@ func SetNamespaceLabels(c kclientset.Interface, name string, labels map[string]s
 }
 
 func ProjectExists(oc *exutil.CLI, name string) (bool, error) {
-	p, err := oc.AdminProjectClient().Project().Projects().Get(name, metav1.GetOptions{})
+	p, err := oc.AdminProjectClient().ProjectV1().Projects().Get(name, metav1.GetOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return false, nil
@@ -582,7 +582,7 @@ func ProjectExists(oc *exutil.CLI, name string) (bool, error) {
 
 func DeleteProject(oc *exutil.CLI, name string, interval, timeout time.Duration) error {
 	e2e.Logf("Deleting project %v ...", name)
-	err := oc.AdminProjectClient().Project().Projects().Delete(name, &metav1.DeleteOptions{})
+	err := oc.AdminProjectClient().ProjectV1().Projects().Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/extended/deployments/util.go
+++ b/test/extended/deployments/util.go
@@ -30,6 +30,7 @@ import (
 	appsv1 "github.com/openshift/api/apps/v1"
 	appstypedclient "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	"github.com/openshift/library-go/pkg/apps/appsutil"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
-	unidlingproxy "github.com/openshift/origin/pkg/proxy/unidler"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -364,14 +364,14 @@ var _ = g.Describe("idling and unidling", func() {
 
 			connWG.Wait()
 
-			g.By(fmt.Sprintf("Expecting all but %v of those connections to fail", unidlingproxy.MaxHeldConnections))
+			g.By(fmt.Sprintf("Expecting all but %v of those connections to fail", 16))
 			errCount := 0
 			for _, err := range errors {
 				if err != nil {
 					errCount++
 				}
 			}
-			o.Expect(errCount).To(o.Equal(connectionsToStart - unidlingproxy.MaxHeldConnections))
+			o.Expect(errCount).To(o.Equal(connectionsToStart - 16))
 
 			g.By("Waiting until we have endpoints")
 			err = exutil.WaitForEndpointsAvailable(oc, serviceName)

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -78,7 +78,7 @@ var _ = g.Describe("[Feature:ImageQuota][registry] Image resource quota", func()
 		assertQuotaExceeded(err)
 
 		g.By("deleting first image stream")
-		err = oc.ImageClient().Image().ImageStreams(oc.Namespace()).Delete("first", nil)
+		err = oc.ImageClient().ImageV1().ImageStreams(oc.Namespace()).Delete("first", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		used, err = exutil.WaitForResourceQuotaSync(
 			oc.KubeClient().CoreV1().ResourceQuotas(oc.Namespace()),

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -10,6 +10,8 @@ import (
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/api/image/docker10"
+	"github.com/openshift/library-go/pkg/image/imageutil"
 	"github.com/openshift/oc/pkg/helpers/image/dockerlayer"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -79,7 +81,7 @@ var _ = g.Describe("[Feature:ImageAppend] Image append", func() {
 	oc = exutil.NewCLI("image-append", exutil.KubeConfigPath())
 
 	g.It("should create images by appending them", func() {
-		is, err := oc.ImageClient().Image().ImageStreams("openshift").Get("php", metav1.GetOptions{})
+		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get("php", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
 		registry := strings.Split(is.Status.DockerImageRepository, "/")[0]
@@ -111,32 +113,37 @@ var _ = g.Describe("[Feature:ImageAppend] Image append", func() {
 		`, ns, registry)))
 		cli.WaitForSuccess(pod.Name, podStartupTimeout)
 
-		istag, err := oc.ImageClient().Image().ImageStreamTags(ns).Get("test:scratch1", metav1.GetOptions{})
+		istag, err := oc.ImageClient().ImageV1().ImageStreamTags(ns).Get("test:scratch1", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(istag.Image).NotTo(o.BeNil())
+
+		imageutil.ImageWithMetadataOrDie(&istag.Image)
+
 		o.Expect(istag.Image.DockerImageLayers).To(o.HaveLen(1))
 		o.Expect(istag.Image.DockerImageLayers[0].Name).To(o.Equal(dockerlayer.GzippedEmptyLayerDigest))
-		o.Expect(istag.Image.DockerImageMetadata.Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
+		o.Expect(istag.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
 
-		istag2, err := oc.ImageClient().Image().ImageStreamTags(ns).Get("test:scratch2", metav1.GetOptions{})
+		istag2, err := oc.ImageClient().ImageV1().ImageStreamTags(ns).Get("test:scratch2", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(istag2.Image).NotTo(o.BeNil())
 		o.Expect(istag2.Image.Name).To(o.Equal(istag.Image.Name))
 
-		istag, err = oc.ImageClient().Image().ImageStreamTags(ns).Get("test:busybox1", metav1.GetOptions{})
+		istag, err = oc.ImageClient().ImageV1().ImageStreamTags(ns).Get("test:busybox1", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(istag.Image).NotTo(o.BeNil())
+		imageutil.ImageWithMetadataOrDie(&istag.Image)
 		o.Expect(istag.Image.DockerImageLayers).To(o.HaveLen(1))
 		o.Expect(istag.Image.DockerImageLayers[0].Name).NotTo(o.Equal(dockerlayer.GzippedEmptyLayerDigest))
-		o.Expect(istag.Image.DockerImageMetadata.Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
+		o.Expect(istag.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
 		busyboxLayer := istag.Image.DockerImageLayers[0].Name
 
-		istag, err = oc.ImageClient().Image().ImageStreamTags(ns).Get("test:busybox2", metav1.GetOptions{})
+		istag, err = oc.ImageClient().ImageV1().ImageStreamTags(ns).Get("test:busybox2", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(istag.Image).NotTo(o.BeNil())
+		imageutil.ImageWithMetadataOrDie(&istag.Image)
 		o.Expect(istag.Image.DockerImageLayers).To(o.HaveLen(2))
 		o.Expect(istag.Image.DockerImageLayers[0].Name).To(o.Equal(busyboxLayer))
 		o.Expect(istag.Image.DockerImageLayers[1].LayerSize).NotTo(o.Equal(0))
-		o.Expect(istag.Image.DockerImageMetadata.Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
+		o.Expect(istag.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
 	})
 })

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[Feature:ImageExtract] Image extract", func() {
 	oc = exutil.NewCLI("image-extract", exutil.KubeConfigPath())
 
 	g.It("should extract content from an image", func() {
-		is, err := oc.ImageClient().Image().ImageStreams("openshift").Get("php", metav1.GetOptions{})
+		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get("php", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")
 		registry := strings.Split(is.Status.DockerImageRepository, "/")[0]

--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -255,7 +255,7 @@ RUN echo %s > /3
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	g.By(fmt.Sprintf("checking for the imported tag: %s", istName))
-	ist, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get(istName, metav1.GetOptions{})
+	ist, err := oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(istName, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	return isName, ist.Image.Name

--- a/test/extended/images/resolve.go
+++ b/test/extended/images/resolve.go
@@ -21,7 +21,7 @@ var _ = g.Describe("[Feature:ImageLookup][registry][Conformance] Image policy", 
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("set", "image-lookup").Args("busybox").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		tag, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("busybox:latest", metav1.GetOptions{})
+		tag, err := oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get("busybox:latest", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(tag.LookupPolicy.Local).To(o.BeTrue())
 
@@ -73,7 +73,7 @@ var _ = g.Describe("[Feature:ImageLookup][registry][Conformance] Image policy", 
 	g.It("should perform lookup when the pod has the resolve-names annotation", func() {
 		err := oc.Run("import-image").Args("busybox:latest", "--confirm").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		tag, err := oc.ImageClient().Image().ImageStreamTags(oc.Namespace()).Get("busybox:latest", metav1.GetOptions{})
+		tag, err := oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get("busybox:latest", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// pods should auto replace local references

--- a/test/extended/oauth/http1.go
+++ b/test/extended/oauth/http1.go
@@ -10,7 +10,8 @@ import (
 
 	"k8s.io/client-go/rest"
 
-	"github.com/openshift/origin/pkg/oauth/util"
+	"github.com/openshift/library-go/pkg/oauth/oauthdiscovery"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -23,7 +24,7 @@ var _ = g.Describe("The OAuth server", func() {
 		metadataJSON, err := oc.Run("get").Args("--raw", "/.well-known/oauth-authorization-server").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		metadata := &util.OauthAuthorizationServerMetadata{}
+		metadata := &oauthdiscovery.OauthAuthorizationServerMetadata{}
 		err = json.Unmarshal([]byte(metadataJSON), metadata)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/well_known.go
+++ b/test/extended/oauth/well_known.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[Suite:openshift/oauth] The OAuth server well-known endpoint
 		err = json.Unmarshal([]byte(metadataJSON), metadata)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		// compare to openshift-authentication route
-		route, err := oc.AdminRouteClient().Route().Routes(oauthNamespace).Get(oauthRoute, metav1.GetOptions{})
+		route, err := oc.AdminRouteClient().RouteV1().Routes(oauthNamespace).Get(oauthRoute, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		u, err := url.Parse("https://" + route.Spec.Host)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -67,7 +67,7 @@ var _ = g.Describe("[Feature:Platform] Managed cluster should", func() {
 			g.By(fmt.Sprintf("verifying the %s/%s route has an ingress host", r.ns, r.name))
 			var hostname string
 			err := wait.Poll(time.Second, routeHostWait, func() (bool, error) {
-				route, err := oc.AdminRouteClient().Route().Routes(r.ns).Get(r.name, metav1.GetOptions{})
+				route, err := oc.AdminRouteClient().RouteV1().Routes(r.ns).Get(r.name, metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 			var hostname string
 			err = wait.Poll(time.Second, changeTimeoutSeconds*time.Second, func() (bool, error) {
-				route, err := oc.RouteClient().Route().Routes(ns).Get("serving-cert", metav1.GetOptions{})
+				route, err := oc.RouteClient().RouteV1().Routes(ns).Get("serving-cert", metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -15,11 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
+	routeapi "github.com/openshift/api/route/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
-	routedisplayhelpers "github.com/openshift/oc/pkg/helpers/route"
-	routeapi "github.com/openshift/origin/pkg/route/apis/route"
-	routev1conversions "github.com/openshift/origin/pkg/route/apis/route/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -155,16 +153,13 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			}
 
 			g.By("checking that the router reported the correct ingress and override")
-			r, err := oc.RouteClient().Route().Routes(ns).Get("route-1", metav1.GetOptions{})
+			r, err := oc.RouteClient().RouteV1().Routes(ns).Get("route-1", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			ingress := ingressForName(r, "test-override")
 			e2e.Logf("Selected: %#v, All: %#v", ingress, r.Status.Ingress)
 			o.Expect(ingress).NotTo(o.BeNil())
 			o.Expect(ingress.Host).To(o.Equal(fmt.Sprintf(pattern, "route-1", ns)))
-			external := routev1.RouteIngress{}
-			err = routev1conversions.Convert_route_RouteIngress_To_v1_RouteIngress(ingress, &external, nil)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			status, condition := routedisplayhelpers.IngressConditionStatus(&external, routev1.RouteAdmitted)
+			status, condition := ingressConditionStatus(ingress, routev1.RouteAdmitted)
 			o.Expect(status).To(o.Equal(corev1.ConditionTrue))
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})
@@ -223,20 +218,27 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			}
 
 			g.By("checking that the router reported the correct ingress and override")
-			r, err := oc.RouteClient().Route().Routes(ns).Get("route-override-domain-2", metav1.GetOptions{})
+			r, err := oc.RouteClient().RouteV1().Routes(ns).Get("route-override-domain-2", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			ingress := ingressForName(r, "test-override-domains")
 			o.Expect(ingress).NotTo(o.BeNil())
 			o.Expect(ingress.Host).To(o.Equal(fmt.Sprintf(pattern, "route-override-domain-2", ns)))
-			external := routev1.RouteIngress{}
-			err = routev1conversions.Convert_route_RouteIngress_To_v1_RouteIngress(ingress, &external, nil)
-			o.Expect(err).NotTo(o.HaveOccurred())
-			status, condition := routedisplayhelpers.IngressConditionStatus(&external, routev1.RouteAdmitted)
+			status, condition := ingressConditionStatus(ingress, routev1.RouteAdmitted)
 			o.Expect(status).To(o.Equal(corev1.ConditionTrue))
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})
 	})
 })
+
+func ingressConditionStatus(ingress *routev1.RouteIngress, t routev1.RouteIngressConditionType) (corev1.ConditionStatus, routev1.RouteIngressCondition) {
+	for _, condition := range ingress.Conditions {
+		if t != condition.Type {
+			continue
+		}
+		return condition.Status, condition
+	}
+	return corev1.ConditionUnknown, routev1.RouteIngressCondition{}
+}
 
 func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSeconds int) error {
 	cmd := fmt.Sprintf(`

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -97,7 +97,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			}
 
 			g.By("checking that the route doesn't have an ingress status")
-			r, err := oc.RouteClient().Route().Routes(ns).Get("route-1", metav1.GetOptions{})
+			r, err := oc.RouteClient().RouteV1().Routes(ns).Get("route-1", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			ingress := ingressForName(r, "test-unprivileged")
 			o.Expect(ingress).To(o.BeNil())

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -6,16 +6,16 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	kapi "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	templateapi "github.com/openshift/origin/pkg/template/apis/template"
-	userapi "github.com/openshift/origin/pkg/user/apis/user"
+	authorizationapi "github.com/openshift/api/authorization/v1"
+	templateapi "github.com/openshift/api/template/v1"
+	userapi "github.com/openshift/api/user/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -65,21 +65,21 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 		addUserToGroup(cli, impersonatebygroupuser.Name, impersonategroup.Name)
 
 		// additional plumbing to enable impersonateuser to impersonate edituser1
-		role, err := cli.AdminAuthorizationClient().Authorization().Roles(cli.Namespace()).Create(&authorizationapi.Role{
+		role, err := cli.AdminAuthorizationClient().AuthorizationV1().Roles(cli.Namespace()).Create(&authorizationapi.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "impersonater",
 			},
 			Rules: []authorizationapi.PolicyRule{
 				{
-					Verbs:     sets.NewString("assign"),
+					Verbs:     sets.NewString("assign").List(),
 					APIGroups: []string{templateapi.GroupName},
-					Resources: sets.NewString("templateinstances"),
+					Resources: sets.NewString("templateinstances").List(),
 				},
 			},
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.AdminAuthorizationClient().Authorization().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
+		_, err = cli.AdminAuthorizationClient().AuthorizationV1().RoleBindings(cli.Namespace()).Create(&authorizationapi.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "impersonater-binding",
 			},
@@ -89,11 +89,11 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 			},
 			Subjects: []kapi.ObjectReference{
 				{
-					Kind: authorizationapi.UserKind,
+					Kind: "User",
 					Name: impersonateuser.Name,
 				},
 				{
-					Kind: authorizationapi.GroupKind,
+					Kind: "Group",
 					Name: impersonategroup.Name,
 				},
 			},
@@ -106,7 +106,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 		err = wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
 			for _, user := range []*userapi.User{adminuser, impersonateuser, impersonatebygroupuser, edituser1, edituser2, viewuser} {
 				cli.ChangeUser(user.Name)
-				sar, err := cli.AuthorizationClient().Authorization().LocalSubjectAccessReviews(cli.Namespace()).Create(&authorizationapi.LocalSubjectAccessReview{
+				sar, err := cli.AuthorizationClient().AuthorizationV1().LocalSubjectAccessReviews(cli.Namespace()).Create(&authorizationapi.LocalSubjectAccessReview{
 					Action: authorizationapi.Action{
 						Verb:     "get",
 						Resource: "pods",
@@ -121,7 +121,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 			}
 
 			cli.ChangeUser(impersonatebygroupuser.Name)
-			sar, err := cli.AuthorizationClient().Authorization().LocalSubjectAccessReviews(cli.Namespace()).Create(&authorizationapi.LocalSubjectAccessReview{
+			sar, err := cli.AuthorizationClient().AuthorizationV1().LocalSubjectAccessReviews(cli.Namespace()).Create(&authorizationapi.LocalSubjectAccessReview{
 				Action: authorizationapi.Action{
 					Verb:     "assign",
 					Group:    templateapi.GroupName,
@@ -234,7 +234,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 			setUser(cli, test.user)
 
 			templateinstancecopy := dummytemplateinstance.DeepCopy()
-			templateinstance, err := cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstancecopy)
+			templateinstance, err := cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Create(templateinstancecopy)
 
 			if !test.expectCreateSuccess {
 				o.Expect(err).To(o.HaveOccurred())
@@ -242,7 +242,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 			} else {
 				o.Expect(err).NotTo(o.HaveOccurred())
 
-				err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
+				err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 		}
@@ -260,30 +260,30 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 			var templateinstancecopy *templateapi.TemplateInstance
 			setUser(cli, test.user)
 
-			templateinstance, err := cli.AdminInternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Create(dummytemplateinstance)
+			templateinstance, err := cli.AdminTemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Create(dummytemplateinstance)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// ensure spec (particularly including spec.requester.username and groups) are
 			// immutable via Update()
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				templateinstancecopy.Spec.Requester.Username = edituser2.Name
 
-				_, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Update(templateinstancecopy)
+				_, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Update(templateinstancecopy)
 				return err
 			})
 			o.Expect(err).To(o.HaveOccurred())
 			o.Expect(kerrors.IsInvalid(err) || kerrors.IsForbidden(err)).To(o.BeTrue())
 
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				templateinstancecopy.Spec.Requester.Groups = append(templateinstancecopy.Spec.Requester.Groups, "foo")
 
-				_, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Update(templateinstancecopy)
+				_, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Update(templateinstancecopy)
 				return err
 			})
 			o.Expect(err).To(o.HaveOccurred())
@@ -291,12 +291,12 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 
 			// ensure status changes are ignored via Update()
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				templateinstancecopy.Status.Conditions = append(templateinstancecopy.Status.Conditions, dummycondition)
 
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Update(templateinstancecopy)
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Update(templateinstancecopy)
 				return err
 			})
 			if !test.hasUpdatePermission {
@@ -309,12 +309,12 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 
 			// ensure spec changes are ignored via UpdateStatus()
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				templateinstancecopy.Spec.Requester.Username = edituser2.Name
 
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).UpdateStatus(templateinstancecopy)
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).UpdateStatus(templateinstancecopy)
 				return err
 			})
 			if !test.hasUpdateStatusPermission {
@@ -327,12 +327,12 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 
 			// ensure status changes are allowed via UpdateStatus()
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				templateinstancecopy.Status.Conditions = []templateapi.TemplateInstanceCondition{dummycondition}
 
-				templateinstancecopy, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).UpdateStatus(templateinstancecopy)
+				templateinstancecopy, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).UpdateStatus(templateinstancecopy)
 				return err
 			})
 			if !test.hasUpdateStatusPermission {
@@ -343,7 +343,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 				o.Expect(templateinstancecopy.Status.Conditions).To(o.ContainElement(dummycondition))
 			}
 
-			err = cli.AdminInternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
+			err = cli.AdminTemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
 	})
@@ -354,17 +354,17 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 			setUser(cli, test.user)
 
 			templateinstancecopy := dummytemplateinstance.DeepCopy()
-			templateinstance, err := cli.AdminInternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Create(templateinstancecopy)
+			templateinstance, err := cli.AdminTemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Create(templateinstancecopy)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
+			err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
 			if test.expectDeleteSuccess {
 				o.Expect(err).NotTo(o.HaveOccurred())
 			} else {
 				o.Expect(err).To(o.HaveOccurred())
 				o.Expect(kerrors.IsForbidden(err)).To(o.BeTrue())
 
-				err = cli.AdminInternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
+				err = cli.AdminTemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, nil)
 				o.Expect(err).NotTo(o.HaveOccurred())
 			}
 		}

--- a/test/extended/templates/templateinstance_objectkinds.go
+++ b/test/extended/templates/templateinstance_objectkinds.go
@@ -7,10 +7,10 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	kapi "k8s.io/api/core/v1"
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -32,7 +32,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance object kinds test"
 
 		// wait for templateinstance controller to do its thing
 		err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
-			templateinstance, err := cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get("templateinstance", metav1.GetOptions{})
+			templateinstance, err := cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get("templateinstance", metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -57,18 +57,18 @@ var _ = g.Describe("[Conformance][templates] templateinstance object kinds test"
 		_, err = cli.KubeClient().AppsV1beta1().Deployments(cli.Namespace()).Get("deployment", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.RouteClient().Route().Routes(cli.Namespace()).Get("route", metav1.GetOptions{})
+		_, err = cli.RouteClient().RouteV1().Routes(cli.Namespace()).Get("route", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err = cli.RouteClient().Route().Routes(cli.Namespace()).Get("newroute", metav1.GetOptions{})
+		_, err = cli.RouteClient().RouteV1().Routes(cli.Namespace()).Get("newroute", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Delete("templateinstance", nil)
+		err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Delete("templateinstance", nil)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("deleting the template instance")
 		err = wait.Poll(time.Second, time.Minute, func() (bool, error) {
-			_, err := cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get("templateinstance", metav1.GetOptions{})
+			_, err := cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get("templateinstance", metav1.GetOptions{})
 			if kapierrs.IsNotFound(err) {
 				return true, nil
 			}
@@ -87,12 +87,12 @@ var _ = g.Describe("[Conformance][templates] templateinstance object kinds test"
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
 
-		_, err = cli.RouteClient().Route().Routes(cli.Namespace()).Get("route", metav1.GetOptions{})
+		_, err = cli.RouteClient().RouteV1().Routes(cli.Namespace()).Get("route", metav1.GetOptions{})
 		if !kapierrs.IsNotFound(err) {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
 
-		_, err = cli.RouteClient().Route().Routes(cli.Namespace()).Get("newroute", metav1.GetOptions{})
+		_, err = cli.RouteClient().RouteV1().Routes(cli.Namespace()).Get("newroute", metav1.GetOptions{})
 		if !kapierrs.IsNotFound(err) {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}

--- a/test/extended/templates/templateinstance_security.go
+++ b/test/extended/templates/templateinstance_security.go
@@ -13,17 +13,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/storage"
 
+	authorizationapi "github.com/openshift/api/authorization/v1"
+	routeapi "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
-
+	userapi "github.com/openshift/api/user/v1"
 	templatecontroller "github.com/openshift/openshift-controller-manager/pkg/template/controller"
-	authorizationapi "github.com/openshift/origin/pkg/authorization/apis/authorization"
-	routeapi "github.com/openshift/origin/pkg/route/apis/route"
-	userapi "github.com/openshift/origin/pkg/user/apis/user"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -55,7 +55,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 				Name:      "rolebinding",
 				Namespace: "${NAMESPACE}",
 			},
-			RoleRef: kapi.ObjectReference{
+			RoleRef: corev1.ObjectReference{
 				Name: "admin",
 			},
 		}
@@ -83,7 +83,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 			err := wait.PollImmediate(time.Second, 30*time.Second, func() (done bool, err error) {
 				for _, user := range []*userapi.User{adminuser, edituser, editbygroupuser} {
 					cli.ChangeUser(user.Name)
-					sar, err := cli.AuthorizationClient().Authorization().LocalSubjectAccessReviews(cli.Namespace()).Create(&authorizationapi.LocalSubjectAccessReview{
+					sar, err := cli.AuthorizationClient().AuthorizationV1().LocalSubjectAccessReviews(cli.Namespace()).Create(&authorizationapi.LocalSubjectAccessReview{
 						Action: authorizationapi.Action{
 							Verb:     "get",
 							Resource: "pods",
@@ -103,7 +103,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 
 		g.AfterEach(func() {
 			if g.CurrentGinkgoTestDescription().Failed {
-				templateinstances, err := cli.AdminInternalTemplateClient().Template().TemplateInstances(cli.Namespace()).List(metav1.ListOptions{})
+				templateinstances, err := cli.AdminTemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).List(metav1.ListOptions{})
 				if err == nil {
 					fmt.Fprintf(g.GinkgoWriter, "TemplateInstances: %#v", templateinstances.Items)
 				}
@@ -132,7 +132,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyroute},
 					expectCondition: templatev1.TemplateInstanceReady,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminRouteClient().Route().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
+						_, err := cli.AdminRouteClient().RouteV1().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
 						return err == nil
 					},
 				},
@@ -143,7 +143,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyroute},
 					expectCondition: templatev1.TemplateInstanceReady,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminRouteClient().Route().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
+						_, err := cli.AdminRouteClient().RouteV1().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
 						return err == nil
 					},
 				},
@@ -154,7 +154,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyroute},
 					expectCondition: templatev1.TemplateInstanceInstantiateFailure,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminRouteClient().Route().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
+						_, err := cli.AdminRouteClient().RouteV1().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
 						return err != nil && kerrors.IsNotFound(err)
 					},
 				},
@@ -165,7 +165,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyroute},
 					expectCondition: templatev1.TemplateInstanceInstantiateFailure,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminRouteClient().Route().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
+						_, err := cli.AdminRouteClient().RouteV1().Routes(namespace).Get(dummyroute.Name, metav1.GetOptions{})
 						return err != nil && kerrors.IsNotFound(err)
 					},
 				},
@@ -176,7 +176,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyrolebinding},
 					expectCondition: templatev1.TemplateInstanceInstantiateFailure,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminAuthorizationClient().Authorization().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
+						_, err := cli.AdminAuthorizationClient().AuthorizationV1().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
 						return err != nil && kerrors.IsNotFound(err)
 					},
 				},
@@ -187,7 +187,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyrolebinding},
 					expectCondition: templatev1.TemplateInstanceInstantiateFailure,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminAuthorizationClient().Authorization().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
+						_, err := cli.AdminAuthorizationClient().AuthorizationV1().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
 						return err != nil && kerrors.IsNotFound(err)
 					},
 				},
@@ -198,7 +198,7 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					objects:         []runtime.Object{dummyrolebinding},
 					expectCondition: templatev1.TemplateInstanceReady,
 					checkOK: func(namespace string) bool {
-						_, err := cli.AdminAuthorizationClient().Authorization().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
+						_, err := cli.AdminAuthorizationClient().AuthorizationV1().RoleBindings(namespace).Get(dummyrolebinding.Name, metav1.GetOptions{})
 						return err == nil
 					},
 				},
@@ -255,9 +255,17 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 					},
 				}
 
+				testScheme := runtime.NewScheme()
+				utilruntime.Must(routeapi.Install(testScheme))
+				utilruntime.Must(authorizationapi.Install(testScheme))
+				utilruntime.Must(storage.AddToScheme(testScheme))
+
+				testCodecFactory := serializer.NewCodecFactory(testScheme)
+				testCodec := testCodecFactory.LegacyCodec(routeapi.GroupVersion, authorizationapi.SchemeGroupVersion, storage.SchemeGroupVersion)
+
 				for i := range test.objects {
 					templateinstance.Spec.Template.Objects = append(templateinstance.Spec.Template.Objects, runtime.RawExtension{
-						Raw: []byte(runtime.EncodeOrDie(legacyscheme.Codecs.LegacyCodec(legacyscheme.Scheme.PrioritizedVersionsAllGroups()...), test.objects[i])),
+						Raw: []byte(runtime.EncodeOrDie(testCodec, test.objects[i])),
 					})
 				}
 
@@ -277,12 +285,12 @@ var _ = g.Describe("[Conformance][templates] templateinstance security tests", f
 				o.Expect(test.checkOK(test.namespace)).To(o.BeTrue())
 
 				foreground := metav1.DeletePropagationForeground
-				err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, &metav1.DeleteOptions{PropagationPolicy: &foreground})
+				err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Delete(templateinstance.Name, &metav1.DeleteOptions{PropagationPolicy: &foreground})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				// wait for garbage collector to do its thing
 				err = wait.Poll(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-					_, err = cli.InternalTemplateClient().Template().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
+					_, err = cli.TemplateClient().TemplateV1().TemplateInstances(cli.Namespace()).Get(templateinstance.Name, metav1.GetOptions{})
 					if kerrors.IsNotFound(err) {
 						return true, nil
 					}

--- a/test/extended/util/auth_rule_resolver.go
+++ b/test/extended/util/auth_rule_resolver.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	rbacinformers "k8s.io/client-go/informers/rbac/v1"
+	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
+)
+
+func NewRuleResolver(informers rbacinformers.Interface) rbacregistryvalidation.AuthorizationRuleResolver {
+	return rbacregistryvalidation.NewDefaultRuleResolver(
+		&rbacauthorizer.RoleGetter{Lister: informers.Roles().Lister()},
+		&rbacauthorizer.RoleBindingLister{Lister: informers.RoleBindings().Lister()},
+		&rbacauthorizer.ClusterRoleGetter{Lister: informers.ClusterRoles().Lister()},
+		&rbacauthorizer.ClusterRoleBindingLister{Lister: informers.ClusterRoleBindings().Lister()},
+	)
+}

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -14,6 +14,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	authorizationapi "k8s.io/api/authorization/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	kapiv1 "k8s.io/api/core/v1"
@@ -29,20 +30,20 @@ import (
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/apis/authorization"
 	quota "k8s.io/kubernetes/pkg/quota/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
+	imageapi "github.com/openshift/api/image/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	appsv1clienttyped "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	buildv1clienttyped "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
+	imagetypeclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	"github.com/openshift/library-go/pkg/apps/appsutil"
 	"github.com/openshift/library-go/pkg/build/naming"
 	"github.com/openshift/library-go/pkg/git"
-	imageapi "github.com/openshift/origin/pkg/image/apis/image"
-	imagetypeclientset "github.com/openshift/origin/pkg/image/generated/internalclientset/typed/image/internalversion"
+
 	"github.com/openshift/origin/test/extended/testdata"
 )
 
@@ -90,7 +91,7 @@ func WaitForOpenShiftNamespaceImageStreams(oc *CLI) error {
 	scan := func() bool {
 		for _, lang := range langs {
 			e2e.Logf("Checking language %v \n", lang)
-			is, err := oc.ImageClient().Image().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
+			is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(lang, metav1.GetOptions{})
 			if err != nil {
 				e2e.Logf("ImageStream Error: %#v \n", err)
 				return false
@@ -101,8 +102,8 @@ func WaitForOpenShiftNamespaceImageStreams(oc *CLI) error {
 			}
 			for tag := range is.Spec.Tags {
 				e2e.Logf("Checking tag %v \n", tag)
-				if _, ok := is.Status.Tags[tag]; !ok {
-					e2e.Logf("Tag Error: %#v \n", ok)
+				if len(GetTagEvents(is.Status.Tags, is.Spec.Tags[tag].Name)) == 0 {
+					e2e.Logf("Tag Error: %#v \n", is.Status.Tags)
 					return false
 				}
 			}
@@ -539,7 +540,7 @@ func (t *BuildResult) dumpRegistryLogs() {
 	if t.Build != nil && !t.Build.CreationTimestamp.IsZero() {
 		buildStarted = &t.Build.CreationTimestamp.Time
 	} else {
-		proj, err := oc.ProjectClient().Project().Projects().Get(oc.Namespace(), metav1.GetOptions{})
+		proj, err := oc.ProjectClient().ProjectV1().Projects().Get(oc.Namespace(), metav1.GetOptions{})
 		if err != nil {
 			e2e.Logf("Failed to get project %s: %v\n", oc.Namespace(), err)
 		} else {
@@ -866,13 +867,10 @@ func TimedWaitForAnImageStreamTag(oc *CLI, namespace, name, tag string, waitTime
 	c := make(chan error)
 	go func() {
 		err := WaitForAnImageStream(
-			oc.ImageClient().Image().ImageStreams(namespace),
+			oc.ImageClient().ImageV1().ImageStreams(namespace),
 			name,
 			func(is *imageapi.ImageStream) bool {
-				if history, exists := is.Status.Tags[tag]; !exists || len(history.Items) == 0 {
-					return false
-				}
-				return true
+				return len(GetTagEvents(is.Status.Tags, tag)) > 0
 			},
 			func(is *imageapi.ImageStream) bool {
 				return time.Now().After(start.Add(waitTimeout))
@@ -890,8 +888,7 @@ func TimedWaitForAnImageStreamTag(oc *CLI, namespace, name, tag string, waitTime
 
 // CheckImageStreamLatestTagPopulated returns true if the imagestream has a ':latest' tag filed
 func CheckImageStreamLatestTagPopulated(i *imageapi.ImageStream) bool {
-	_, ok := i.Status.Tags["latest"]
-	return ok
+	return len(GetTagEvents(i.Status.Tags, "latest")) != 0
 }
 
 // CheckImageStreamTagNotFound return true if the imagestream update was not successful
@@ -1152,14 +1149,11 @@ func GetDockerImageReference(c imagetypeclientset.ImageStreamInterface, name, ta
 	if err != nil {
 		return "", err
 	}
-	isTag, ok := imageStream.Status.Tags[tag]
-	if !ok {
+	tagEvents := GetTagEvents(imageStream.Status.Tags, tag)
+	if len(tagEvents) == 0 {
 		return "", fmt.Errorf("ImageStream %q does not have tag %q", name, tag)
 	}
-	if len(isTag.Items) == 0 {
-		return "", fmt.Errorf("ImageStreamTag %q is empty", tag)
-	}
-	return isTag.Items[0].DockerImageReference, nil
+	return tagEvents[0].DockerImageReference, nil
 }
 
 // GetPodForContainer creates a new Pod that runs specified container
@@ -1459,9 +1453,9 @@ func NewGitRepo(repoName string) (GitRepo, error) {
 // WaitForUserBeAuthorized waits a minute until the cluster bootstrap roles are available
 // and the provided user is authorized to perform the action on the resource.
 func WaitForUserBeAuthorized(oc *CLI, user, verb, resource string) error {
-	sar := &authorization.SubjectAccessReview{
-		Spec: authorization.SubjectAccessReviewSpec{
-			ResourceAttributes: &authorization.ResourceAttributes{
+	sar := &authorizationapi.SubjectAccessReview{
+		Spec: authorizationapi.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
 				Namespace: oc.Namespace(),
 				Verb:      verb,
 				Resource:  resource,
@@ -1470,7 +1464,7 @@ func WaitForUserBeAuthorized(oc *CLI, user, verb, resource string) error {
 		},
 	}
 	return wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		resp, err := oc.InternalAdminKubeClient().Authorization().SubjectAccessReviews().Create(sar)
+		resp, err := oc.AdminKubeClient().AuthorizationV1().SubjectAccessReviews().Create(sar)
 		if err == nil && resp != nil && resp.Status.Allowed {
 			return true, nil
 		}

--- a/test/extended/util/image_helpers.go
+++ b/test/extended/util/image_helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	g "github.com/onsi/ginkgo"
+
+	imagev1 "github.com/openshift/api/image/v1"
 )
 
 //DumpAndReturnTagging takes and array of tags and obtains the hex image IDs, dumps them to ginkgo for printing, and then returns them
@@ -22,4 +24,15 @@ func DumpAndReturnTagging(tags []string) ([]string, error) {
 func CreateResource(jsonFilePath string, oc *CLI) error {
 	err := oc.Run("create").Args("-f", jsonFilePath).Execute()
 	return err
+}
+
+func GetTagEvents(tagEventList []imagev1.NamedTagEventList, tagName string) []imagev1.TagEvent {
+	result := []imagev1.TagEvent{}
+	for i := range tagEventList {
+		if tagEventList[i].Tag != tagName {
+			continue
+		}
+		result = append(result, tagEventList[i].Items...)
+	}
+	return result
 }

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/generated"
 
+	securityclient "github.com/openshift/client-go/security/clientset/versioned"
 	"github.com/openshift/origin/pkg/oc/cli/admin/policy"
-	securityclient "github.com/openshift/origin/pkg/security/generated/internalclientset"
 	"github.com/openshift/origin/pkg/version"
 	testutil "github.com/openshift/origin/test/util"
 )
@@ -495,7 +495,7 @@ func addE2EServiceAccountsToSCC(securityClient securityclient.Interface, namespa
 	// Because updates can race, we need to set the backoff retries to be > than the number of possible
 	// parallel jobs starting at once. Set very high to allow future high parallelism.
 	err := retry.RetryOnConflict(longRetry, func() error {
-		scc, err := securityClient.Security().SecurityContextConstraints().Get(sccName, metav1.GetOptions{})
+		scc, err := securityClient.SecurityV1().SecurityContextConstraints().Get(sccName, metav1.GetOptions{})
 		if err != nil {
 			if apierrs.IsNotFound(err) {
 				return nil
@@ -508,7 +508,7 @@ func addE2EServiceAccountsToSCC(securityClient securityclient.Interface, namespa
 				scc.Groups = append(scc.Groups, fmt.Sprintf("system:serviceaccounts:%s", ns.Name))
 			}
 		}
-		if _, err := securityClient.Security().SecurityContextConstraints().Update(scc); err != nil {
+		if _, err := securityClient.SecurityV1().SecurityContextConstraints().Update(scc); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
Summary of changes:

* Move away from internal clientsets (which should allow to delete some in origin)
* Switch to external API in tests
* Move some image helpers around
* Remove internal client helpers from util

/cc @deads2k 
/cc @soltysh 