### PR TITLE
add well-known endpoint e2e

### DIFF
--- a/test/extended/oauth/well_known.go
+++ b/test/extended/oauth/well_known.go
@@ -1,0 +1,56 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/origin/pkg/oauth/util"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Suite:openshift/oauth] The OAuth server well-known endpoint", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc             = exutil.NewCLI("oauth-well-known", exutil.KubeConfigPath())
+		oauthRoute     = "oauth-openshift"
+		oauthNamespace = "openshift-authentication"
+	)
+
+	g.It("should be reachable", func() {
+		metadataJSON, err := oc.Run("get").Args("--raw", "/.well-known/oauth-authorization-server").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		metadata := &util.OauthAuthorizationServerMetadata{}
+		err = json.Unmarshal([]byte(metadataJSON), metadata)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		// compare to openshift-authentication route
+		route, err := oc.AdminRouteClient().Route().Routes(oauthNamespace).Get(oauthRoute, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		u, err := url.Parse("https://" + route.Spec.Host)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		u.Path = path.Join(u.Path, "oauth/authorize")
+		authEndpointFromRoute := u.String()
+		o.Expect(metadata.AuthorizationEndpoint).To(o.Equal(authEndpointFromRoute))
+		tlsClientConfig, err := rest.TLSConfigFor(oc.AdminConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		rt := http.Transport{
+			TLSClientConfig: tlsClientConfig,
+		}
+
+		req, err := http.NewRequest(http.MethodHead, metadata.Issuer, nil)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		resp, err := rt.RoundTrip(req)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(resp.StatusCode).To(o.Equal(200))
+	})
+})


### PR DESCRIPTION
This test checks that authorization_endpoint is
* accessible
* returns 200
* properly configured 
`oc get --raw /.well-known/oauth-authorization-server` authorization_endpoint matches 
openshift-authentication route/oauth-openshift spec.host + `oauth/authorize`

broke this out from https://github.com/openshift/origin/pull/23024 there are comments there regarding this test