### PR TITLE
UPSTREAM: 79156: cache mutation detector: improve diff readability

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
@@ -24,10 +24,9 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/klog"
+	"k8s.io/utils/diff"
 )
 
 var mutationDetectionEnabled = false
@@ -75,8 +74,8 @@ type defaultCacheMutationDetector struct {
 
 // cacheObj holds the actual object and a copy
 type cacheObj struct {
-	cached interface{}
-	copied interface{}
+	cached runtime.Object
+	copied runtime.Object
 }
 
 func (d *defaultCacheMutationDetector) Run(stopCh <-chan struct{}) {
@@ -113,8 +112,12 @@ func (d *defaultCacheMutationDetector) CompareObjects() {
 
 	altered := false
 	for i, obj := range d.cachedObjs {
-		if !reflect.DeepEqual(obj.cached, obj.copied) {
-			fmt.Printf("CACHE %s[%d] ALTERED!\n%v\n", d.name, i, diff.ObjectGoPrintSideBySide(obj.cached, obj.copied))
+		// make sure that we have a stable view of the cached object
+		// sometimes code will modify an object and then reset it back to the original state
+		// this can result in reflect.DeepEqual returning false while diff.ObjectGoPrintDiff prints an empty diff
+		cached := obj.cached.DeepCopyObject()
+		if !reflect.DeepEqual(cached, obj.copied) {
+			fmt.Printf("CACHE %s[%d] ALTERED!\n%v\n", d.name, i, diff.ObjectGoPrintDiff(obj.copied, cached))
 			altered = true
 		}
 	}


### PR DESCRIPTION
The output from ObjectGoPrintSideBySide is not readable and upstream has dropped the other diff functions.

Signed-off-by: Monis Khan <mkhan@redhat.com>