### PR TITLE
Revert "pkg/oc/cli/admin/release/git: Case-insensitive bug regexp allowing prefixes"

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/admin/release/git.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/admin/release/git.go
@@ -152,7 +152,7 @@ func mergeLogForRepo(g *git, repo string, from, to string) ([]MergeCommit, error
 	if err != nil {
 		return nil, err
 	}
-	reBug, err := regexp.Compile(`^(?i)^.*?Bug (\d+)\s*(-|:)\s*`)
+	reBug, err := regexp.Compile(`^Bug (\d+)\s*(-|:)\s*`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts openshift/origin#23051