### PR TITLE
test/e2e: add deploying separate OAuth server to util

### DIFF
--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -1,0 +1,80 @@
+package oauth
+
+import (
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	osinv1 "github.com/openshift/api/osin/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	utiloauth "github.com/openshift/origin/test/extended/util/oauthserver"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	scheme  = runtime.NewScheme()
+	codecs  = serializer.NewCodecFactory(scheme)
+	encoder = codecs.LegacyCodec(osinv1.GroupVersion) // TODO I think there is a better way to do this
+)
+
+func init() {
+	utilruntime.Must(osinv1.Install(scheme))
+}
+
+var _ = g.Describe("[Suite:openshift/oauth/htpasswd] HTPasswd IDP", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLI("htpasswd-idp", exutil.KubeConfigPath())
+	)
+
+	g.It("should successfully configure htpasswd and be responsive", func() {
+		secrets := []corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "htpasswd-secret",
+			},
+			Data: map[string][]byte{
+				"htpasswd": []byte("testuser:$2y$05$pOYBCbJ1RXr.vDzPXdyTxuE96Nojc9dNI9R3QjkWUj2t/Ae/jmFy."), // userinfo testuser:password
+			},
+		}}
+
+		htpasswdProvider, err := utiloauth.GetRawExtensionForOsinProvider(
+			&osinv1.HTPasswdPasswordIdentityProvider{File: utiloauth.GetPathFromConfigMapSecretName("htpasswd-secret", "htpasswd")},
+		)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		htpasswdConfig := osinv1.IdentityProvider{
+			Name:            "htpasswd",
+			UseAsChallenger: true,
+			UseAsLogin:      true,
+			MappingMethod:   "claim",
+			Provider:        *htpasswdProvider,
+		}
+		tokenReqOpts, cleanup, err := utiloauth.DeployOAuthServer(oc, []osinv1.IdentityProvider{htpasswdConfig}, nil, secrets)
+		defer cleanup()
+		o.Expect(err).ToNot(o.HaveOccurred())
+		e2e.Logf("got the OAuth server address: %s", tokenReqOpts.Issuer)
+
+		token, err := utiloauth.RequestTokenForUser(tokenReqOpts, "testuser", "password")
+		defer func() {
+			oc.AdminUserClient().UserV1().Users().Delete("testuser", &metav1.DeleteOptions{})
+			oc.AdminUserClient().UserV1().Identities().Delete("htpasswd:testuser", &metav1.DeleteOptions{})
+		}()
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		tokenUser, err := utiloauth.GetUserForToken(oc.AdminConfig(), token, "testuser")
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(tokenUser.Name).To(o.Equal("testuser"))
+	})
+})
+
+func encodeOrDie(obj runtime.Object) []byte {
+	bytes, err := runtime.Encode(encoder, obj)
+	if err != nil {
+		panic(err) // indicates static generated code is broken, unrecoverable
+	}
+	return bytes
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -183,6 +183,10 @@
 // test/extended/testdata/long_names/fixture.json
 // test/extended/testdata/multi-namespace-pipeline.yaml
 // test/extended/testdata/multi-namespace-template.yaml
+// test/extended/testdata/oauthserver/cabundle-cm.yaml
+// test/extended/testdata/oauthserver/oauth-network.yaml
+// test/extended/testdata/oauthserver/oauth-pod.yaml
+// test/extended/testdata/oauthserver/oauth-sa.yaml
 // test/extended/testdata/openshift-secret-to-jenkins-credential.yaml
 // test/extended/testdata/reencrypt-serving-cert.yaml
 // test/extended/testdata/releases/payload-1/etcd-operator/image-references
@@ -10507,6 +10511,218 @@ func testExtendedTestdataMultiNamespaceTemplateYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/multi-namespace-template.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauthserverCabundleCmYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app: test-oauth-server
+  name: service-ca
+`)
+
+func testExtendedTestdataOauthserverCabundleCmYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauthserverCabundleCmYaml, nil
+}
+
+func testExtendedTestdataOauthserverCabundleCmYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauthserverCabundleCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauthserver/cabundle-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauthserverOauthNetworkYaml = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+  labels:
+    app: test-oauth-server
+  name: test-oauth-svc
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: test-oauth-server
+  type: ClusterIP
+  serviceAffinitiy: None
+---
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: test-oauth-server
+  name: test-oauth-route
+spec:
+  port:
+    targetPort: 6443
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: passthrough
+  to:
+    kind: Service
+    name: test-oauth-svc
+    weight: 100
+  wildcardPolicy: None
+
+`)
+
+func testExtendedTestdataOauthserverOauthNetworkYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauthserverOauthNetworkYaml, nil
+}
+
+func testExtendedTestdataOauthserverOauthNetworkYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauthserverOauthNetworkYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauthserver/oauth-network.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauthserverOauthPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: test-oauth-server
+  name: test-oauth-server
+spec:
+  containers:
+  - command:
+    - oauth-server
+    - osinserver
+    - --config=/var/config/system/configmaps/oauth-config/oauth.conf
+    - --v=100
+    image: quay.io/openshift/origin-oauth-server:latest
+    imagePullPolicy: IfNotPresent
+    name: oauth-server
+    ports:
+    - containerPort: 6443
+      name: https
+      protocol: TCP
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext:
+      capabilities:
+        drop:
+        - MKNOD
+      procMount: Default
+    volumeMounts:
+    - mountPath: /var/config/system/secrets/session-secret
+      name: session-secret
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/oauth-config
+      name: oauth-config
+      readOnly: true
+    - mountPath: /var/config/system/secrets/serving-cert
+      name: serving-cert
+      readOnly: true
+    - mountPath: /var/config/system/secrets/router-certs
+      name: router-certs
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/service-ca
+      name: service-ca
+      readOnly: true
+  serviceAccountName: e2e-oauth
+  volumes:
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: oauth.conf
+        path: oauth.conf
+      name: oauth-config
+    name: oauth-config
+  - name: session-secret
+    secret:
+      defaultMode: 420
+      items:
+      - key: session
+        path: session
+      secretName: session-secret
+  - name: serving-cert
+    secret:
+      defaultMode: 420
+      items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+      secretName: serving-cert
+  - name: router-certs
+    secret:
+      defaultMode: 420
+      secretName: router-certs
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: service-ca.crt
+      name: service-ca
+    name: service-ca
+
+`)
+
+func testExtendedTestdataOauthserverOauthPodYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauthserverOauthPodYaml, nil
+}
+
+func testExtendedTestdataOauthserverOauthPodYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauthserverOauthPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauthserver/oauth-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOauthserverOauthSaYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-oauth
+  labels:
+    app: test-oauth-server
+`)
+
+func testExtendedTestdataOauthserverOauthSaYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOauthserverOauthSaYaml, nil
+}
+
+func testExtendedTestdataOauthserverOauthSaYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOauthserverOauthSaYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/oauthserver/oauth-sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -33545,6 +33761,10 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/long_names/fixture.json": testExtendedTestdataLong_namesFixtureJson,
 	"test/extended/testdata/multi-namespace-pipeline.yaml": testExtendedTestdataMultiNamespacePipelineYaml,
 	"test/extended/testdata/multi-namespace-template.yaml": testExtendedTestdataMultiNamespaceTemplateYaml,
+	"test/extended/testdata/oauthserver/cabundle-cm.yaml": testExtendedTestdataOauthserverCabundleCmYaml,
+	"test/extended/testdata/oauthserver/oauth-network.yaml": testExtendedTestdataOauthserverOauthNetworkYaml,
+	"test/extended/testdata/oauthserver/oauth-pod.yaml": testExtendedTestdataOauthserverOauthPodYaml,
+	"test/extended/testdata/oauthserver/oauth-sa.yaml": testExtendedTestdataOauthserverOauthSaYaml,
 	"test/extended/testdata/openshift-secret-to-jenkins-credential.yaml": testExtendedTestdataOpenshiftSecretToJenkinsCredentialYaml,
 	"test/extended/testdata/reencrypt-serving-cert.yaml": testExtendedTestdataReencryptServingCertYaml,
 	"test/extended/testdata/releases/payload-1/etcd-operator/image-references": testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences,
@@ -34041,6 +34261,12 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				}},
 				"multi-namespace-pipeline.yaml": &bintree{testExtendedTestdataMultiNamespacePipelineYaml, map[string]*bintree{}},
 				"multi-namespace-template.yaml": &bintree{testExtendedTestdataMultiNamespaceTemplateYaml, map[string]*bintree{}},
+				"oauthserver": &bintree{nil, map[string]*bintree{
+					"cabundle-cm.yaml": &bintree{testExtendedTestdataOauthserverCabundleCmYaml, map[string]*bintree{}},
+					"oauth-network.yaml": &bintree{testExtendedTestdataOauthserverOauthNetworkYaml, map[string]*bintree{}},
+					"oauth-pod.yaml": &bintree{testExtendedTestdataOauthserverOauthPodYaml, map[string]*bintree{}},
+					"oauth-sa.yaml": &bintree{testExtendedTestdataOauthserverOauthSaYaml, map[string]*bintree{}},
+				}},
 				"openshift-secret-to-jenkins-credential.yaml": &bintree{testExtendedTestdataOpenshiftSecretToJenkinsCredentialYaml, map[string]*bintree{}},
 				"reencrypt-serving-cert.yaml": &bintree{testExtendedTestdataReencryptServingCertYaml, map[string]*bintree{}},
 				"releases": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/oauthserver/cabundle-cm.yaml
+++ b/test/extended/testdata/oauthserver/cabundle-cm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app: test-oauth-server
+  name: service-ca

--- a/test/extended/testdata/oauthserver/oauth-network.yaml
+++ b/test/extended/testdata/oauthserver/oauth-network.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+  labels:
+    app: test-oauth-server
+  name: test-oauth-svc
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 6443
+  selector:
+    app: test-oauth-server
+  type: ClusterIP
+  serviceAffinitiy: None
+---
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: test-oauth-server
+  name: test-oauth-route
+spec:
+  port:
+    targetPort: 6443
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: passthrough
+  to:
+    kind: Service
+    name: test-oauth-svc
+    weight: 100
+  wildcardPolicy: None
+

--- a/test/extended/testdata/oauthserver/oauth-pod.yaml
+++ b/test/extended/testdata/oauthserver/oauth-pod.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: test-oauth-server
+  name: test-oauth-server
+spec:
+  containers:
+  - command:
+    - oauth-server
+    - osinserver
+    - --config=/var/config/system/configmaps/oauth-config/oauth.conf
+    - --v=100
+    image: quay.io/openshift/origin-oauth-server:latest
+    imagePullPolicy: IfNotPresent
+    name: oauth-server
+    ports:
+    - containerPort: 6443
+      name: https
+      protocol: TCP
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext:
+      capabilities:
+        drop:
+        - MKNOD
+      procMount: Default
+    volumeMounts:
+    - mountPath: /var/config/system/secrets/session-secret
+      name: session-secret
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/oauth-config
+      name: oauth-config
+      readOnly: true
+    - mountPath: /var/config/system/secrets/serving-cert
+      name: serving-cert
+      readOnly: true
+    - mountPath: /var/config/system/secrets/router-certs
+      name: router-certs
+      readOnly: true
+    - mountPath: /var/config/system/configmaps/service-ca
+      name: service-ca
+      readOnly: true
+  serviceAccountName: e2e-oauth
+  volumes:
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: oauth.conf
+        path: oauth.conf
+      name: oauth-config
+    name: oauth-config
+  - name: session-secret
+    secret:
+      defaultMode: 420
+      items:
+      - key: session
+        path: session
+      secretName: session-secret
+  - name: serving-cert
+    secret:
+      defaultMode: 420
+      items:
+      - key: tls.crt
+        path: tls.crt
+      - key: tls.key
+        path: tls.key
+      secretName: serving-cert
+  - name: router-certs
+    secret:
+      defaultMode: 420
+      secretName: router-certs
+  - configMap:
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: service-ca.crt
+      name: service-ca
+    name: service-ca
+

--- a/test/extended/testdata/oauthserver/oauth-sa.yaml
+++ b/test/extended/testdata/oauthserver/oauth-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-oauth
+  labels:
+    app: test-oauth-server

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage/names"
-	"k8s.io/client-go/discovery/cached"
+	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
@@ -403,6 +403,10 @@ func (c *CLI) AdminProjectClient() projectv1client.Interface {
 
 func (c *CLI) AdminQuotaClient() quotav1client.Interface {
 	return quotav1client.NewForConfigOrDie(c.AdminConfig())
+}
+
+func (c *CLI) AdminOAuthClient() oauthv1client.Interface {
+	return oauthv1client.NewForConfigOrDie(c.AdminConfig())
 }
 
 func (c *CLI) AdminRouteClient() routev1client.Interface {

--- a/test/extended/util/oauthserver/helpers.go
+++ b/test/extended/util/oauthserver/helpers.go
@@ -1,0 +1,76 @@
+package oauthserver
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	restclient "k8s.io/client-go/rest"
+
+	osinv1 "github.com/openshift/api/osin/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+	"github.com/openshift/oc/pkg/helpers/tokencmd"
+)
+
+var (
+	osinScheme = runtime.NewScheme()
+	codecs     = serializer.NewCodecFactory(osinScheme)
+	encoder    = codecs.LegacyCodec(osinv1.GroupVersion)
+)
+
+func init() {
+	utilruntime.Must(osinv1.Install(osinScheme))
+}
+
+func RequestTokenForUser(reqOpts *tokencmd.RequestTokenOptions, username, password string) (string, error) {
+	reqOpts.Handler = &tokencmd.BasicChallengeHandler{
+		Host:     reqOpts.ClientConfig.Host,
+		Username: username,
+		Password: password,
+	}
+
+	return reqOpts.RequestToken()
+}
+
+func GetRawExtensionForOsinProvider(obj runtime.Object) (*runtime.RawExtension, error) {
+	objBytes := encode(obj)
+	if objBytes == nil {
+		return nil, fmt.Errorf("unable to encode the object: %v", obj)
+	}
+	return &runtime.RawExtension{Raw: objBytes}, nil
+}
+
+func GetUserForToken(config *restclient.Config, token, expectedUsername string) (*userv1.User, error) {
+	userConfig := restclient.AnonymousClientConfig(config)
+	userConfig.BearerToken = token
+	userClient, err := userv1client.NewForConfig(userConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := userClient.Users().Get("~", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return user, err
+}
+
+func GetDirPathFromConfigMapSecretName(name string) string {
+	return fmt.Sprintf("%s/%s", configObjectsDir, name) // always concat with / in case this is run on windows
+}
+
+func GetPathFromConfigMapSecretName(name, key string) string {
+	return fmt.Sprintf("%s/%s/%s", configObjectsDir, name, key)
+}
+
+func encode(obj runtime.Object) []byte {
+	bytes, err := runtime.Encode(encoder, obj)
+	if err != nil {
+		return nil
+	}
+	return bytes
+}

--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -1,0 +1,464 @@
+package oauthserver
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"path"
+	"time"
+
+	"github.com/RangelReale/osincli"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	restclient "k8s.io/client-go/rest"
+
+	configv1 "github.com/openshift/api/config/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	osinv1 "github.com/openshift/api/osin/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/config/helpers"
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/oc/pkg/helpers/tokencmd"
+	"github.com/openshift/origin/test/extended/testdata"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	serviceURLFmt = "https://test-oauth-svc.%s.svc" // fill in the namespace
+
+	servingCertDirPath  = "/var/config/system/secrets/serving-cert"
+	servingCertPathCert = "/var/config/system/secrets/serving-cert/tls.crt"
+	servingCertPathKey  = "/var/config/system/secrets/serving-cert/tls.key"
+
+	routerCertsDirPath = "/var/config/system/secrets/router-certs"
+
+	sessionSecretDirPath = "/var/config/system/secrets/session-secret"
+	sessionSecretPath    = "/var/config/system/secrets/session-secret/session"
+
+	oauthConfigPath  = "/var/config/system/configmaps/oauth-config"
+	serviceCADirPath = "/var/config/system/configmaps/service-ca"
+
+	configObjectsDir = "/var/oauth/configobjects/"
+
+	RouteName = "test-oauth-route"
+	SAName    = "e2e-oauth"
+)
+
+var (
+	serviceCAPath = "/var/config/system/configmaps/service-ca/service-ca.crt" // has to be var so that we can use its address
+
+	defaultProcMount         = corev1.DefaultProcMount
+	volumesDefaultMode int32 = 420
+)
+
+// DeployOAuthServer - deployes an instance of an OpenShift OAuth server
+// very simplified for now
+// returns OAuth server url, cleanup function, error
+func DeployOAuthServer(oc *exutil.CLI, idps []osinv1.IdentityProvider, configMaps []corev1.ConfigMap, secrets []corev1.Secret) (*tokencmd.RequestTokenOptions, func(), error) {
+	oauthServerDataDir := exutil.FixturePath("testdata", "oauthserver")
+	cleanups := func() {
+		oc.AsAdmin().Run("delete").Args("clusterrolebinding", oc.Namespace()).Execute()
+		oc.AsAdmin().Run("delete").Args("oauthclient", oc.Namespace()).Execute()
+	}
+
+	// create the CA bundle, Service, Route and SA
+	for _, res := range []string{"cabundle-cm.yaml", "oauth-sa.yaml", "oauth-network.yaml"} {
+		if err := oc.AsAdmin().Run("create").Args("-f", path.Join(oauthServerDataDir, res)).Execute(); err != nil {
+			return nil, cleanups, err
+		}
+	}
+
+	// the oauth server needs access to kube-system configmaps/extension-apiserver-authentication
+	oauthSARolebinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: oc.Namespace(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      SAName,
+				Namespace: oc.Namespace(),
+			},
+		},
+	}
+	if _, err := oc.AdminKubeClient().RbacV1().ClusterRoleBindings().Create(oauthSARolebinding); err != nil {
+		return nil, cleanups, err
+	}
+
+	// create the secrets and configmaps the OAuth server config requires to get the server going
+	coreClient := oc.AdminKubeClient().CoreV1()
+	cmClient := coreClient.ConfigMaps(oc.Namespace())
+	secretsClient := coreClient.Secrets(oc.Namespace())
+
+	for _, cm := range configMaps {
+		if _, err := cmClient.Create(&cm); err != nil {
+			return nil, cleanups, err
+		}
+	}
+
+	for _, secret := range secrets {
+		if _, err := secretsClient.Create(&secret); err != nil {
+			return nil, cleanups, err
+		}
+	}
+
+	// generate a session secret for the oauth server
+	sessionSecret, err := randomSessionSecret()
+	if err != nil {
+		return nil, cleanups, err
+	}
+	if _, err := secretsClient.Create(sessionSecret); err != nil {
+		return nil, cleanups, err
+	}
+
+	// get the route of the future OAuth server
+	route, err := oc.AdminRouteClient().RouteV1().Routes(oc.Namespace()).Get(RouteName, metav1.GetOptions{})
+	if err != nil {
+		return nil, cleanups, err
+	}
+	routeURL := fmt.Sprintf("https://%s", route.Spec.Host)
+
+	// prepare the config, inject it with the route URL and the IdP config we got
+	config, err := oauthServerConfig(oc, routeURL, idps)
+	if err != nil {
+		return nil, cleanups, err
+	}
+
+	configBytes := encode(config)
+	if configBytes == nil {
+		return nil, cleanups, fmt.Errorf("error encoding the OSIN config")
+	}
+
+	// store the config in a ConfigMap that's to be mounted into the server's pod
+	_, err = cmClient.Create(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "oauth-config",
+		},
+		Data: map[string]string{
+			"oauth.conf": string(configBytes),
+		},
+	})
+	if err != nil {
+		return nil, cleanups, err
+	}
+
+	// get the OAuth server image that's used in the cluster
+	image, err := getImage(oc)
+	if err != nil {
+		return nil, cleanups, err
+	}
+
+	// prepare the pod def, create secrets and CMs
+	oauthServerPod, err := oauthServerPod(configMaps, secrets, image)
+	if err != nil {
+		return nil, cleanups, err
+	}
+
+	// finally create the oauth server, wait till it starts running
+	if _, err := coreClient.Pods(oc.Namespace()).Create(oauthServerPod); err != nil {
+		return nil, cleanups, err
+	}
+
+	err = wait.PollImmediate(1*time.Second, 45*time.Second, func() (bool, error) {
+		pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get("test-oauth-server", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if !exutil.CheckPodIsReady(*pod) {
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, cleanups, err
+	}
+
+	if err = createOAuthClient(oc, routeURL); err != nil {
+		return nil, cleanups, err
+	}
+	tokenReqOptions, err := getTokenOpts(oc.AdminConfig(), routeURL, oc.Namespace())
+	if err != nil {
+		return nil, cleanups, err
+	}
+
+	return tokenReqOptions, cleanups, nil
+}
+
+func oauthServerPod(configMaps []corev1.ConfigMap, secrets []corev1.Secret, image string) (*corev1.Pod, error) {
+	oauthServerAsset := testdata.MustAsset("test/extended/testdata/oauthserver/oauth-pod.yaml")
+
+	obj, err := helpers.ReadYAML(bytes.NewBuffer(oauthServerAsset), corev1.AddToScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	oauthServerPod, ok := obj.(*corev1.Pod)
+	if ok != true {
+		return nil, err
+	}
+
+	volumes := oauthServerPod.Spec.Volumes
+	volumeMounts := oauthServerPod.Spec.Containers[0].VolumeMounts
+
+	for _, cm := range configMaps {
+		volumes, volumeMounts = addCMMount(volumes, volumeMounts, &cm)
+	}
+
+	for _, sec := range secrets {
+		volumes, volumeMounts = addSecretMount(volumes, volumeMounts, &sec)
+	}
+
+	oauthServerPod.Spec.Volumes = volumes
+	oauthServerPod.Spec.Containers[0].VolumeMounts = volumeMounts
+	oauthServerPod.Spec.Containers[0].Image = image
+
+	return oauthServerPod, nil
+}
+
+func addCMMount(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, cm *corev1.ConfigMap) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes = append(volumes, corev1.Volume{
+		Name: cm.ObjectMeta.Name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: cm.ObjectMeta.Name},
+				DefaultMode:          &volumesDefaultMode,
+			},
+		},
+	})
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      cm.ObjectMeta.Name,
+		MountPath: GetDirPathFromConfigMapSecretName(cm.ObjectMeta.Name),
+		ReadOnly:  true,
+	})
+
+	return volumes, volumeMounts
+}
+
+func addSecretMount(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, secret *corev1.Secret) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes = append(volumes, corev1.Volume{
+		Name: secret.ObjectMeta.Name,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  secret.ObjectMeta.Name,
+				DefaultMode: &volumesDefaultMode,
+			},
+		},
+	})
+
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      secret.ObjectMeta.Name,
+		MountPath: GetDirPathFromConfigMapSecretName(secret.ObjectMeta.Name),
+		ReadOnly:  true,
+	})
+
+	return volumes, volumeMounts
+}
+
+func oauthServerConfig(oc *exutil.CLI, routeURL string, idps []osinv1.IdentityProvider) (*osinv1.OsinServerConfig, error) {
+	adminConfigClient := configclient.NewForConfigOrDie(oc.AdminConfig()).ConfigV1()
+
+	infrastructure, err := adminConfigClient.Infrastructures().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	console, err := adminConfigClient.Consoles().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	namedRouterCerts, err := routerCertsToSNIConfig(oc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &osinv1.OsinServerConfig{
+		GenericAPIServerConfig: configv1.GenericAPIServerConfig{
+			ServingInfo: configv1.HTTPServingInfo{
+				ServingInfo: configv1.ServingInfo{
+					BindAddress: "0.0.0.0:6443",
+					BindNetwork: "tcp4",
+					// we have valid serving certs provided by service-ca
+					// this is our main server cert which is used if SNI does not match
+					CertInfo: configv1.CertInfo{
+						CertFile: servingCertPathCert,
+						KeyFile:  servingCertPathKey,
+					},
+					ClientCA:          "",
+					NamedCertificates: namedRouterCerts,
+					MinTLSVersion:     crypto.TLSVersionToNameOrDie(crypto.DefaultTLSVersion()),
+					CipherSuites:      crypto.CipherSuitesToNamesOrDie(crypto.DefaultCiphers()),
+				},
+				MaxRequestsInFlight:   1000,
+				RequestTimeoutSeconds: 5 * 60, // 5 minutes
+			},
+			AuditConfig: configv1.AuditConfig{},
+			KubeClientConfig: configv1.KubeClientConfig{
+				KubeConfig: "",
+				ConnectionOverrides: configv1.ClientConnectionOverrides{
+					QPS:   400,
+					Burst: 400,
+				},
+			},
+		},
+		OAuthConfig: osinv1.OAuthConfig{
+			MasterCA:                    &serviceCAPath, // we have valid serving certs provided by service-ca so we can use the service for loopback
+			MasterURL:                   fmt.Sprintf(serviceURLFmt, oc.Namespace()),
+			MasterPublicURL:             routeURL,
+			LoginURL:                    infrastructure.Status.APIServerURL,
+			AssetPublicURL:              console.Status.ConsoleURL, // set console route as valid 302 redirect for logout
+			AlwaysShowProviderSelection: false,
+			IdentityProviders:           idps,
+			GrantConfig: osinv1.GrantConfig{
+				Method:               osinv1.GrantHandlerDeny, // force denial as this field must be set per OAuth client
+				ServiceAccountMethod: osinv1.GrantHandlerPrompt,
+			},
+			SessionConfig: &osinv1.SessionConfig{
+				SessionSecretsFile:   sessionSecretPath,
+				SessionMaxAgeSeconds: 5 * 60, // 5 minutes
+				SessionName:          "ssn",
+			},
+			TokenConfig: osinv1.TokenConfig{
+				AuthorizeTokenMaxAgeSeconds: 5 * 60,       // 5 minutes
+				AccessTokenMaxAgeSeconds:    24 * 60 * 60, // 1 day
+			},
+		},
+	}, nil
+}
+
+func routerCertsToSNIConfig(oc *exutil.CLI) ([]configv1.NamedCertificate, error) {
+	routerSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config-managed").Get("router-certs", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	localRouterSecret := routerSecret.DeepCopy()
+	localRouterSecret.ResourceVersion = ""
+	localRouterSecret.Namespace = oc.Namespace()
+	if _, err := oc.AdminKubeClient().CoreV1().Secrets(oc.Namespace()).Create(localRouterSecret); err != nil {
+		return nil, err
+	}
+
+	var out []configv1.NamedCertificate
+	for domain := range localRouterSecret.Data {
+		out = append(out, configv1.NamedCertificate{
+			Names: []string{"*." + domain}, // ingress domain is always a wildcard
+			CertInfo: configv1.CertInfo{ // the cert and key are appended together
+				CertFile: routerCertsDirPath + "/" + domain,
+				KeyFile:  routerCertsDirPath + "/" + domain,
+			},
+		})
+	}
+	return out, nil
+}
+
+func randomSessionSecret() (*corev1.Secret, error) {
+	skey, err := newSessionSecretsJSON()
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "session-secret",
+			Labels: map[string]string{
+				"app": "test-oauth-server",
+			},
+		},
+		Data: map[string][]byte{
+			"session": skey,
+		},
+	}, nil
+}
+
+// this is less random than the actual secret generated in cluster-authentication-operator
+func newSessionSecretsJSON() ([]byte, error) {
+	const (
+		sha256KeyLenBytes = sha256.BlockSize // max key size with HMAC SHA256
+		aes256KeyLenBytes = 32               // max key size with AES (AES-256)
+	)
+
+	secrets := &legacyconfigv1.SessionSecrets{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SessionSecrets",
+			APIVersion: "v1",
+		},
+		Secrets: []legacyconfigv1.SessionSecret{
+			{
+				Authentication: randomString(sha256KeyLenBytes), // 64 chars
+				Encryption:     randomString(aes256KeyLenBytes), // 32 chars
+			},
+		},
+	}
+	secretsBytes, err := json.Marshal(secrets)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling the session secret: %v", err) // should never happen
+	}
+
+	return secretsBytes, nil
+}
+
+//randomString - random string of A-Z chars with len size
+func randomString(size int) string {
+	bytes := make([]byte, size)
+	for i := 0; i < size; i++ {
+		bytes[i] = byte(65 + rand.Intn(25))
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes)
+}
+
+// getImage will grab the hypershift image version from openshift-authentication ns
+func getImage(oc *exutil.CLI) (string, error) {
+	selector, _ := labels.Parse("app=oauth-openshift")
+	pods, err := oc.AdminKubeClient().CoreV1().Pods("openshift-authentication").List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return "", err
+	}
+	return pods.Items[0].Spec.Containers[0].Image, nil
+}
+
+func getTokenOpts(config *restclient.Config, oauthServerURL, oauthClientName string) (*tokencmd.RequestTokenOptions, error) {
+	tokenReqOptions := tokencmd.NewRequestTokenOptions(config, nil, "", "", false)
+	// supply the info the client would otherwise ask from .well-known/oauth-authorization-server
+	oauthClientConfig := &osincli.ClientConfig{
+		ClientId:     oauthClientName,
+		AuthorizeUrl: fmt.Sprintf("%s/oauth/authorize", oauthServerURL), // TODO: the endpoints are defined in vendor/github.com/openshift/library-go/pkg/oauth/oauthdiscovery/urls.go
+		TokenUrl:     fmt.Sprintf("%s/oauth/token", oauthServerURL),
+		RedirectUrl:  fmt.Sprintf("%s/oauth/token/implicit", oauthServerURL),
+	}
+
+	if err := osincli.PopulatePKCE(oauthClientConfig); err != nil {
+		return nil, err
+	}
+	tokenReqOptions.OsinConfig = oauthClientConfig
+	tokenReqOptions.Issuer = oauthServerURL
+
+	return tokenReqOptions, nil
+}
+
+func createOAuthClient(oc *exutil.CLI, routeURL string) error {
+	_, err := oc.AdminOAuthClient().OauthV1().OAuthClients().
+		Create(&oauthv1.OAuthClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: oc.Namespace(),
+			},
+			GrantMethod:           oauthv1.GrantHandlerAuto,
+			RedirectURIs:          []string{fmt.Sprintf("%s/oauth/token/implicit", routeURL)},
+			RespondWithChallenges: true,
+		})
+	return err
+}


### PR DESCRIPTION
This PR makes it possible to allow deploying a separate OAuth server for e2e tests

/assign @sallyom 

It ss a part of https://github.com/openshift/origin/issues/23258