### PR TITLE
Add CL simple concurrency test for template creation

### DIFF
--- a/test/extended/cluster/clt.go
+++ b/test/extended/cluster/clt.go
@@ -1,0 +1,126 @@
+package cluster
+
+import (
+	"fmt"
+	"sync"
+
+	g "github.com/onsi/ginkgo"
+
+	reale2e "k8s.io/kubernetes/test/e2e"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var viperConfig string
+
+const (
+	defaultThreadCount int = 10
+	channelSize        int = 1024
+)
+
+var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
+	defer g.GinkgoRecover()
+	var oc = exutil.NewCLIWithoutNamespace("cl")
+
+	g.BeforeEach(func() {
+		var err error
+		viperConfig = reale2e.GetViperConfig()
+		e2e.Logf("Using config %v", viperConfig)
+		err = ParseConfig(viperConfig, false)
+		if err != nil {
+			e2e.Failf("Error parsing config: %v", err)
+		}
+	})
+
+	g.It("concurrently with templates", func() {
+		project := ConfigContext.ClusterLoader.Projects
+		if project == nil {
+			e2e.Failf("Invalid config file.\nFile: %v", project)
+		}
+
+		numWorkers := ConfigContext.ClusterLoader.Threads
+		if numWorkers == 0 {
+			numWorkers = defaultThreadCount
+		}
+
+		work := make(chan ProjectMeta, channelSize)
+		var wg sync.WaitGroup
+
+		for i := 0; i < numWorkers; i++ {
+			go clWorker(work, &wg, oc)
+		}
+
+		for _, p := range project {
+			for j := 0; j < p.Number; j++ {
+				wg.Add(1)
+				unit := ProjectMeta{j, p, viperConfig}
+				work <- unit
+			}
+		}
+
+		wg.Wait()
+		e2e.Logf("Closing channel")
+		close(work)
+	})
+})
+
+func clWorker(in <-chan ProjectMeta, wg *sync.WaitGroup, oc *exutil.CLI) {
+	for {
+		p, ok := <-in
+		if !ok {
+			e2e.Logf("Channel closed")
+			return
+		}
+		var allArgs []string
+		if p.NodeSelector != "" {
+			allArgs = append(allArgs, "--node-selector")
+			allArgs = append(allArgs, p.NodeSelector)
+		}
+		nsName := fmt.Sprintf("%s%d", p.Basename, p.Counter)
+		allArgs = append(allArgs, nsName)
+
+		// Check to see if the project exists
+		projectExists, _ := ProjectExists(oc, nsName)
+		if !projectExists {
+			e2e.Logf("Project %s does not exist.", nsName)
+		}
+
+		// Based on configuration handle project existance
+		switch p.IfExists {
+		case IF_EXISTS_REUSE:
+			e2e.Logf("Configuration requested reuse of project %v", nsName)
+		case IF_EXISTS_DELETE:
+			e2e.Logf("Configuration requested deletion of project %v", nsName)
+			if projectExists {
+				err := DeleteProject(oc, nsName, checkDeleteProjectInterval, checkDeleteProjectTimeout)
+				e2e.Logf("Error deleting project: %v", err)
+			}
+		default:
+			e2e.Failf("Unsupported ifexists value '%v' for project %v", p.IfExists, p)
+		}
+
+		if p.IfExists == IF_EXISTS_REUSE && projectExists {
+			// do nothing
+		} else {
+			// Create namespaces as defined in Cluster Loader config
+			err := oc.Run("adm", "new-project").Args(allArgs...).Execute()
+			if err != nil {
+				e2e.Logf("Error creating project: %v", err)
+
+			} else {
+				e2e.Logf("Created new namespace: %v", nsName)
+			}
+		}
+
+		// Create templates as defined
+		for _, template := range p.Templates {
+			err := CreateSimpleTemplates(oc, nsName, p.ViperConfig, template)
+			if err != nil {
+				e2e.Logf("Error creating template: %v", err)
+			}
+		}
+
+		wg.Done()
+	}
+}

--- a/test/extended/cluster/context.go
+++ b/test/extended/cluster/context.go
@@ -17,10 +17,17 @@ const (
 type ContextType struct {
 	ClusterLoader struct {
 		Cleanup    bool
+		Threads    int
 		Projects   []ClusterLoaderType
 		Sync       SyncObjectType  `yaml:",omitempty"`
 		TuningSets []TuningSetType `yaml:",omitempty"`
 	}
+}
+
+type ProjectMeta struct {
+	Counter int
+	ClusterLoaderType
+	ViperConfig string
 }
 
 // ClusterLoaderType struct only used for Cluster Loader test config

--- a/test/extended/cluster/utils.go
+++ b/test/extended/cluster/utils.go
@@ -16,12 +16,16 @@ import (
 	"github.com/ghodss/yaml"
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	kclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
+	"github.com/openshift/library-go/pkg/template/templateprocessingclient"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -550,10 +554,85 @@ func CreateTemplates(oc *exutil.CLI, c kclientset.Interface, nsName, config stri
 	return nil
 }
 
+// CreateSimpleTemplates creates templates in user defined namespaces without tuningsets
+func CreateSimpleTemplates(oc *exutil.CLI, nsName, config string, template ClusterLoaderObjectType) error {
+	clusterAdminClientConfig := oc.AdminConfig()
+	restmapper := oc.AsAdmin().RESTMapper()
+
+	templateFile, err := mkPath(template.File, config)
+	if err != nil {
+		return err
+	}
+	e2e.Logf("We're loading file %v: ", templateFile)
+
+	data, err := ioutil.ReadFile(templateFile)
+	if err != nil {
+		return err
+	}
+
+	templateObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, data)
+	if err != nil {
+		return err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(clusterAdminClientConfig)
+	if err != nil {
+		return err
+	}
+
+	temp := templateObj.(*unstructured.Unstructured)
+	parameters, ok := temp.Object["parameters"]
+	if !ok {
+		e2e.Logf("Template has no parameters")
+	}
+	params := parameters.([]interface{})
+
+	for count := 0; count < template.Number; count++ {
+		for _, p := range params {
+			field := p.(map[string]interface{})
+			if field["name"] == "IDENTIFIER" {
+				field["value"] = fmt.Sprintf("%d", count)
+				break
+			}
+		}
+		e2e.Logf("New Parameters: %v", params)
+
+		processedList, err := templateprocessingclient.NewDynamicTemplateProcessor(dynamicClient).ProcessToListFromUnstructured(templateObj.(*unstructured.Unstructured))
+		if err != nil {
+			return err
+		}
+
+		processedItems := len(processedList.Items)
+		if processedItems == 0 {
+			return err
+		}
+		e2e.Logf("Processed template list (items %d): %v\n", processedItems, templateObj)
+
+		for _, v := range processedList.Items {
+			var err error
+			unstructuredObj := &unstructured.Unstructured{}
+			unstructuredObj.Object = v.Object
+			if err != nil {
+				return err
+			}
+
+			mapping, err := restmapper.RESTMapping(unstructuredObj.GroupVersionKind().GroupKind(), unstructuredObj.GroupVersionKind().Version)
+			createdObj, err := dynamicClient.Resource(mapping.Resource).Namespace(nsName).Create(unstructuredObj, metav1.CreateOptions{})
+			if err != nil {
+				return err
+			}
+			e2e.Logf("Created object: %v\n", createdObj)
+		}
+	}
+
+	return nil
+}
+
 func getNsCmdFlag(name string) string {
 	return fmt.Sprintf("--namespace=%v", name)
 }
 
+// SetNamespaceLabels sets the labels of a namespace
 func SetNamespaceLabels(c kclientset.Interface, name string, labels map[string]string) (*kapiv1.Namespace, error) {
 	if len(labels) == 0 {
 		return nil, nil
@@ -566,6 +645,7 @@ func SetNamespaceLabels(c kclientset.Interface, name string, labels map[string]s
 	return c.CoreV1().Namespaces().Update(ns)
 }
 
+// ProjectExists checks to see if a namespace exists, returns boolean
 func ProjectExists(oc *exutil.CLI, name string) (bool, error) {
 	p, err := oc.AdminProjectClient().ProjectV1().Projects().Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -580,6 +660,7 @@ func ProjectExists(oc *exutil.CLI, name string) (bool, error) {
 	return false, nil
 }
 
+// DeleteProject deletes a namespace with timeout
 func DeleteProject(oc *exutil.CLI, name string, interval, timeout time.Duration) error {
 	e2e.Logf("Deleting project %v ...", name)
 	err := oc.AdminProjectClient().ProjectV1().Projects().Delete(name, &metav1.DeleteOptions{})


### PR DESCRIPTION
This tests exists to speed up tests like master vertical which have a large number of projects and large number of templates within them.