### PR TITLE
apiextensions: don't mutate input schema on OpenAPI publishing

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion.go
@@ -33,9 +33,10 @@ func ConvertJSONSchemaPropsToOpenAPIv2Schema(in *apiextensions.JSONSchemaProps) 
 	}
 
 	// dirty hack to temporarily set the type at the root. See continuation at the func bottom.
-	// TODO: remove for Kubernetes 1.15
 	oldRootType := in.Type
 	if len(in.Type) == 0 {
+		shallowClone := *in
+		in = &shallowClone
 		in.Type = "object"
 	}
 
@@ -111,9 +112,6 @@ func ConvertJSONSchemaPropsToOpenAPIv2Schema(in *apiextensions.JSONSchemaProps) 
 		return nil
 	})
 
-	// restore root level type in input, and remove it in output if we had added it
-	// TODO: remove with Kubernetes 1.15
-	in.Type = oldRootType
 	if len(oldRootType) == 0 {
 		out.Type = nil
 	}


### PR DESCRIPTION
We mutated the input OpenAPI schema in-place while building the go-openapi output schema. We assumed that we own that input object, but it comes from a lister. Hence, the mutation made the cache inconcistent for a short time and produced races.