### PR TITLE
Do not panic when running openshift-tests without KUBECONFIG set

### DIFF
--- a/test/extended/util/cli.go
+++ b/test/extended/util/cli.go
@@ -90,9 +90,6 @@ func NewCLI(project, adminConfigPath string) *CLI {
 	client.kubeFramework.SkipNamespaceCreation = true
 	client.username = "admin"
 	client.execPath = "oc"
-	if len(adminConfigPath) == 0 {
-		FatalErr(fmt.Errorf("you must set the KUBECONFIG variable to admin kubeconfig"))
-	}
 	client.adminConfigPath = adminConfigPath
 
 	g.BeforeEach(client.SetupProject)


### PR DESCRIPTION
This check is inconsistent with the behavior of the e2e framework
when running in a container (it uses in cluster config). Remove
the check so that `openshift-tests -h` does not panic when KUBECONFIG
is unset.

/assign @soltysh