### PR TITLE
Bugzilla 1693023: Add CSRF to token request endpoint [3.9] 

### DIFF
--- a/pkg/oauth/util/url.go
+++ b/pkg/oauth/util/url.go
@@ -5,10 +5,14 @@ import (
 	"strings"
 
 	"github.com/openshift/origin/pkg/oauthserver/osinserver"
-	"github.com/openshift/origin/pkg/oauthserver/server/tokenrequest"
 )
 
-const OpenShiftOAuthAPIPrefix = "/oauth"
+const (
+	OpenShiftOAuthAPIPrefix = "/oauth"
+	RequestTokenEndpoint    = "/token/request"
+	DisplayTokenEndpoint    = "/token/display"
+	ImplicitTokenEndpoint   = "/token/implicit"
+)
 
 func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
 	return openShiftOAuthURL(masterAddr, osinserver.AuthorizePath)
@@ -17,13 +21,13 @@ func OpenShiftOAuthTokenURL(masterAddr string) string {
 	return openShiftOAuthURL(masterAddr, osinserver.TokenPath)
 }
 func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
-	return openShiftOAuthURL(masterAddr, tokenrequest.RequestTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, RequestTokenEndpoint)
 }
 func OpenShiftOAuthTokenDisplayURL(masterAddr string) string {
-	return openShiftOAuthURL(masterAddr, tokenrequest.DisplayTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, DisplayTokenEndpoint)
 }
 func OpenShiftOAuthTokenImplicitURL(masterAddr string) string {
-	return openShiftOAuthURL(masterAddr, tokenrequest.ImplicitTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, ImplicitTokenEndpoint)
 }
 func openShiftOAuthURL(masterAddr, oauthEndpoint string) string {
 	return strings.TrimRight(masterAddr, "/") + path.Join(OpenShiftOAuthAPIPrefix, oauthEndpoint)

--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -138,7 +138,7 @@ func (c *OAuthServerConfig) WithOAuth(handler http.Handler, requestContextMapper
 	)
 	server.Install(mux, oauthutil.OpenShiftOAuthAPIPrefix)
 
-	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.ExtraOAuthConfig.Options.MasterPublicURL, c.getOsinOAuthClient)
+	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.ExtraOAuthConfig.Options.MasterPublicURL, c.getOsinOAuthClient, c.getCSRF())
 	tokenRequestEndpoints.Install(mux, oauthutil.OpenShiftOAuthAPIPrefix)
 
 	// glog.Infof("oauth server configured as: %#v", server)

--- a/pkg/oauthserver/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauthserver/oauth_apiserver.go
@@ -27,6 +27,7 @@ import (
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
 	"github.com/openshift/origin/pkg/cmd/server/apis/config/latest"
 	oauthutil "github.com/openshift/origin/pkg/oauth/util"
+	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 	"github.com/openshift/origin/pkg/oauthserver/server/session"
 	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset"
 )
@@ -218,6 +219,7 @@ func (c *OAuthServerConfig) buildHandlerChainForOAuth(startingHandler http.Handl
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, genericConfig.RequestContextMapper, genericConfig.LongRunningFunc, genericConfig.RequestTimeout)
 	handler = genericapifilters.WithRequestInfo(handler, genericapiserver.NewRequestInfoResolver(genericConfig), genericConfig.RequestContextMapper)
 	handler = apirequest.WithRequestContext(handler, genericConfig.RequestContextMapper)
+	handler = headers.WithStandardHeaders(handler)
 	handler = genericfilters.WithPanicRecovery(handler)
 	return handler
 }

--- a/pkg/oauthserver/server/grant/grant.go
+++ b/pkg/oauthserver/server/grant/grant.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclientauthorization"
 	"github.com/openshift/origin/pkg/oauth/scope"
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
-	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 )
 
 const (
@@ -108,8 +107,6 @@ func (l *Grant) Install(mux Mux, paths ...string) {
 }
 
 func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
-
 	user, ok, err := l.auth.AuthenticateRequest(req)
 	if err != nil || !ok {
 		l.redirect("You must reauthenticate before continuing", w, req)

--- a/pkg/oauthserver/server/headers/headers.go
+++ b/pkg/oauthserver/server/headers/headers.go
@@ -1,28 +1,32 @@
 package headers
 
-import (
-	"net/http"
-)
+import "net/http"
 
-func SetStandardHeaders(w http.ResponseWriter) {
-	// We cannot set HSTS by default, it has too many drawbacks in environments
-	// that use self-signed certs
-	standardHeaders := map[string]string{
-		// Turn off caching, it never makes sense for authorization pages
-		"Cache-Control": "no-cache, no-store",
-		"Pragma":        "no-cache",
-		"Expires":       "0",
-		// Use a reasonably strict Referer policy by default
-		"Referrer-Policy": "strict-origin-when-cross-origin",
-		// Do not allow embedding as that can lead to clickjacking attacks
-		"X-Frame-Options": "DENY",
-		// Add other basic scurity hygiene headers
-		"X-Content-Type-Options": "nosniff",
-		"X-DNS-Prefetch-Control": "off",
-		"X-XSS-Protection":       "1; mode=block",
-	}
+// We cannot set HSTS by default, it has too many drawbacks in environments
+// that use self-signed certs
+var standardHeaders = map[string]string{
+	// Turn off caching, it never makes sense for authorization pages
+	"Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+	"Pragma":        "no-cache",
+	"Expires":       "0",
+	// Use a reasonably strict Referer policy by default
+	"Referrer-Policy": "strict-origin-when-cross-origin",
+	// Do not allow embedding as that can lead to clickjacking attacks
+	"X-Frame-Options": "DENY",
+	// Add other basic security hygiene headers
+	"X-Content-Type-Options": "nosniff",
+	"X-DNS-Prefetch-Control": "off",
+	"X-XSS-Protection":       "1; mode=block",
+}
 
-	for key, val := range standardHeaders {
-		w.Header().Set(key, val)
-	}
+func WithStandardHeaders(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// force every request into the OAuth server to have our standard headers
+		h := w.Header()
+		for k, v := range standardHeaders {
+			h.Set(k, v)
+		}
+
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/pkg/oauthserver/server/login/login.go
+++ b/pkg/oauthserver/server/login/login.go
@@ -15,10 +15,9 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 
 	"github.com/openshift/origin/pkg/oauthserver/oauth/handlers"
-	"github.com/openshift/origin/pkg/oauthserver/prometheus"
+	metrics "github.com/openshift/origin/pkg/oauthserver/prometheus"
 	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
 	"github.com/openshift/origin/pkg/oauthserver/server/errorpage"
-	"github.com/openshift/origin/pkg/oauthserver/server/headers"
 )
 
 const (
@@ -97,7 +96,6 @@ func (l *Login) Install(mux Mux, paths ...string) {
 }
 
 func (l *Login) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
 	switch req.Method {
 	case "GET":
 		l.handleLoginForm(w, req)

--- a/pkg/oauthserver/server/tokenrequest/endpoints.go
+++ b/pkg/oauthserver/server/tokenrequest/endpoints.go
@@ -5,36 +5,39 @@ import (
 	"html/template"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 
 	"github.com/RangelReale/osincli"
+	"github.com/golang/glog"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
+	oauthutil "github.com/openshift/origin/pkg/oauth/util"
+	"github.com/openshift/origin/pkg/oauthserver/server/csrf"
 	"github.com/openshift/origin/pkg/oauthserver/server/login"
 )
 
-const (
-	RequestTokenEndpoint  = "/token/request"
-	DisplayTokenEndpoint  = "/token/display"
-	ImplicitTokenEndpoint = "/token/implicit"
-)
+const csrfParam = "csrf"
 
 type endpointDetails struct {
 	publicMasterURL string
 	// osinOAuthClientGetter is used to initialize osinOAuthClient.
 	// Since it can return an error, it may be called multiple times.
 	osinOAuthClientGetter func() (*osincli.Client, error)
+
+	csrf csrf.CSRF
 }
 
 type Endpoints interface {
 	Install(mux login.Mux, paths ...string)
 }
 
-func NewEndpoints(publicMasterURL string, osinOAuthClientGetter func() (*osincli.Client, error)) Endpoints {
+func NewEndpoints(publicMasterURL string, osinOAuthClientGetter func() (*osincli.Client, error), csrf csrf.CSRF) Endpoints {
 	return &endpointDetails{
 		publicMasterURL:       publicMasterURL,
 		osinOAuthClientGetter: osinOAuthClientGetter,
+		csrf:                  csrf,
 	}
 }
 
@@ -42,9 +45,9 @@ func NewEndpoints(publicMasterURL string, osinOAuthClientGetter func() (*osincli
 // provided prefix will serve all operations
 func (endpoints *endpointDetails) Install(mux login.Mux, paths ...string) {
 	for _, prefix := range paths {
-		mux.HandleFunc(path.Join(prefix, RequestTokenEndpoint), endpoints.oauthClientHandler(endpoints.requestToken))
-		mux.HandleFunc(path.Join(prefix, DisplayTokenEndpoint), endpoints.oauthClientHandler(endpoints.displayToken))
-		mux.HandleFunc(path.Join(prefix, ImplicitTokenEndpoint), endpoints.implicitToken)
+		mux.HandleFunc(path.Join(prefix, oauthutil.RequestTokenEndpoint), endpoints.oauthClientHandler(endpoints.requestToken))
+		mux.HandleFunc(path.Join(prefix, oauthutil.DisplayTokenEndpoint), endpoints.oauthClientHandler(endpoints.displayToken))
+		mux.HandleFunc(path.Join(prefix, oauthutil.ImplicitTokenEndpoint), endpoints.implicitToken)
 	}
 }
 
@@ -69,14 +72,53 @@ func (endpoints *endpointDetails) requestToken(osinOAuthClient *osincli.Client, 
 }
 
 func (endpoints *endpointDetails) displayToken(osinOAuthClient *osincli.Client, w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
-	data := tokenData{RequestURL: "request", PublicMasterURL: endpoints.publicMasterURL}
+	switch req.Method {
+	case http.MethodGet:
+		endpoints.displayTokenGet(osinOAuthClient, w, req)
+	case http.MethodPost:
+		endpoints.displayTokenPost(osinOAuthClient, w, req)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
 
-	authorizeReq := osinOAuthClient.NewAuthorizeRequest(osincli.CODE)
-	authorizeData, err := authorizeReq.HandleRequest(req)
+func (endpoints *endpointDetails) displayTokenGet(osinOAuthClient *osincli.Client, w http.ResponseWriter, req *http.Request) {
+	data := formData{}
+	authorizeData, ok := displayTokenStart(osinOAuthClient, w, req, &data.sharedData)
+	if !ok {
+		renderForm(w, data)
+		return
+	}
+
+	uri, err := getBaseURL(req)
 	if err != nil {
-		data.Error = fmt.Sprintf("Error handling auth request: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
+		utilruntime.HandleError(fmt.Errorf("unable to generate base URL: %v", err))
+		http.Error(w, "Unable to determine URL", http.StatusInternalServerError)
+		return
+	}
+
+	data.Action = uri.String()
+	data.Code = authorizeData.Code
+	data.CSRF, err = endpoints.csrf.Generate(w, req)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to generate csrf token: %v", err))
+		http.Error(w, "Unable to generate csrf token", http.StatusInternalServerError)
+		return
+	}
+
+	renderForm(w, data)
+}
+
+func (endpoints *endpointDetails) displayTokenPost(osinOAuthClient *osincli.Client, w http.ResponseWriter, req *http.Request) {
+	if ok, _ := endpoints.csrf.Check(req, req.FormValue(csrfParam)); !ok {
+		glog.V(4).Infof("Invalid CSRF token: %s", req.FormValue(csrfParam))
+		http.Error(w, "Could not check CSRF token. Please try again.", http.StatusBadRequest)
+		return
+	}
+
+	data := tokenData{PublicMasterURL: endpoints.publicMasterURL}
+	authorizeData, ok := displayTokenStart(osinOAuthClient, w, req, &data.sharedData)
+	if !ok {
 		renderToken(w, data)
 		return
 	}
@@ -94,21 +136,65 @@ func (endpoints *endpointDetails) displayToken(osinOAuthClient *osincli.Client, 
 	renderToken(w, data)
 }
 
+func displayTokenStart(osinOAuthClient *osincli.Client, w http.ResponseWriter, req *http.Request, data *sharedData) (*osincli.AuthorizeData, bool) {
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+
+	requestURL := oauthutil.OpenShiftOAuthTokenRequestURL("") // relative url to token request endpoint
+	data.RequestURL = requestURL                              // always set this field even on error cases
+
+	authorizeReq := osinOAuthClient.NewAuthorizeRequest(osincli.CODE)
+	authorizeData, err := authorizeReq.HandleRequest(req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		data.Error = fmt.Sprintf("Error handling auth request: %v", err)
+		return nil, false
+	}
+
+	return authorizeData, true
+}
+
 func renderToken(w io.Writer, data tokenData) {
 	if err := tokenTemplate.Execute(w, data); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to render token template: %v", err))
 	}
 }
 
+type sharedData struct {
+	Error      string
+	RequestURL string
+}
+
 type tokenData struct {
-	Error           string
+	sharedData
+
 	AccessToken     string
-	RequestURL      string
 	PublicMasterURL string
 }
 
-// TODO: allow template to be read from an external file
-var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(`
+func getBaseURL(req *http.Request) (*url.URL, error) {
+	uri, err := url.Parse(req.RequestURI)
+	if err != nil {
+		return nil, err
+	}
+	uri.Scheme, uri.Host, uri.RawQuery, uri.Fragment = req.URL.Scheme, req.URL.Host, "", ""
+	return uri, nil
+}
+
+type formData struct {
+	sharedData
+
+	Action string
+	Code   string
+	CSRF   string
+}
+
+func renderForm(w io.Writer, data formData) {
+	if err := formTemplate.Execute(w, data); err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to render form template: %v", err))
+	}
+}
+
+const cssStyle = `
 <style>
 	body     { font-family: sans-serif; font-size: 14px; margin: 2em 2%; background-color: #F9F9F9; }
 	h2       { font-size: 1.4em;}
@@ -122,7 +208,10 @@ var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(`
 		.nowrap { white-space: nowrap; }
 	}
 </style>
+`
 
+var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(
+	cssStyle + `
 {{ if .Error }}
   {{ .Error }}
 {{ else }}
@@ -138,6 +227,23 @@ var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(`
 
 <br><br>
 <a href="{{.RequestURL}}">Request another token</a>
+`))
+
+var formTemplate = template.Must(template.New("formTemplate").Parse(
+	cssStyle + `
+{{ if .Error }}
+  {{ .Error }}
+  <br><br>
+  <a href="{{.RequestURL}}">Request another token</a>
+{{ else }}
+  <form method="post" action="{{.Action}}">
+    <input type="hidden" name="code" value="{{.Code}}">
+    <input type="hidden" name="csrf" value="{{.CSRF}}">
+    <button type="submit">
+      Display Token
+    </button>
+  </form>
+{{ end }}
 `))
 
 func (endpoints *endpointDetails) implicitToken(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
This is a 3.9 backport of #22767 which adds CSRF validation to OAuth server token requests created from its web console.

cc @enj

csrf check tested with openshift start master
contains only necessary changes to wrap the token request with csrf and set the standard security headers