### PR TITLE
Bugzilla 1693022: Add CSRF to token request endpoint [3.7]

### DIFF
--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -15,7 +15,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
-	"github.com/openshift/origin/pkg/auth/server/headers"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
@@ -107,8 +106,6 @@ func (l *Grant) Install(mux Mux, paths ...string) {
 }
 
 func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
-
 	user, ok, err := l.auth.AuthenticateRequest(req)
 	if err != nil || !ok {
 		l.redirect("You must reauthenticate before continuing", w, req)

--- a/pkg/auth/server/headers/headers.go
+++ b/pkg/auth/server/headers/headers.go
@@ -1,29 +1,32 @@
 package headers
 
-import (
-	"net/http"
-)
+import "net/http"
 
-func SetStandardHeaders(w http.ResponseWriter) {
+// We cannot set HSTS by default, it has too many drawbacks in environments
+// that use self-signed certs
+var standardHeaders = map[string]string{
+	// Turn off caching, it never makes sense for authorization pages
+	"Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+	"Pragma":        "no-cache",
+	"Expires":       "0",
+	// Use a reasonably strict Referer policy by default
+	"Referrer-Policy": "strict-origin-when-cross-origin",
+	// Do not allow embedding as that can lead to clickjacking attacks
+	"X-Frame-Options": "DENY",
+	// Add other basic security hygiene headers
+	"X-Content-Type-Options": "nosniff",
+	"X-DNS-Prefetch-Control": "off",
+	"X-XSS-Protection":       "1; mode=block",
+}
 
-	// We cannot set HSTS by default, it has too many drawbacks in environments
-	// that use self-signed certs
-	standardHeaders := map[string]string{
-		// Turn off caching, it never makes sense for authorization pages
-		"Cache-Control": "no-cache, no-store",
-		"Pragma":        "no-cache",
-		"Expires":       "0",
-		// Use a reasonably strict Referer policy by default
-		"Referrer-Policy": "strict-origin-when-cross-origin",
-		// Do not allow embedding as that can lead to clickjacking attacks
-		"X-Frame-Options": "DENY",
-		// Add other basic scurity hygiene headers
-		"X-Content-Type-Options": "nosniff",
-		"X-DNS-Prefetch-Control": "off",
-		"X-XSS-Protection":       "1; mode=block",
-	}
+func WithStandardHeaders(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// force every request into the OAuth server to have our standard headers
+		h := w.Header()
+		for k, v := range standardHeaders {
+			h.Set(k, v)
+		}
 
-	for key, val := range standardHeaders {
-		w.Header().Set(key, val)
-	}
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/pkg/auth/server/login/login.go
+++ b/pkg/auth/server/login/login.go
@@ -14,10 +14,9 @@ import (
 
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
-	"github.com/openshift/origin/pkg/auth/prometheus"
+	metrics "github.com/openshift/origin/pkg/auth/prometheus"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
 	"github.com/openshift/origin/pkg/auth/server/errorpage"
-	"github.com/openshift/origin/pkg/auth/server/headers"
 )
 
 const (
@@ -96,7 +95,6 @@ func (l *Login) Install(mux Mux, paths ...string) {
 }
 
 func (l *Login) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
 	switch req.Method {
 	case "GET":
 		l.handleLoginForm(w, req)

--- a/pkg/oauth/apiserver/auth.go
+++ b/pkg/oauth/apiserver/auth.go
@@ -134,7 +134,7 @@ func (c *OAuthServerConfig) WithOAuth(handler http.Handler, requestContextMapper
 	)
 	server.Install(mux, oauthutil.OpenShiftOAuthAPIPrefix)
 
-	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.Options.MasterPublicURL, c.getOsinOAuthClient)
+	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.Options.MasterPublicURL, c.getOsinOAuthClient, c.getCSRF())
 	tokenRequestEndpoints.Install(mux, oauthutil.OpenShiftOAuthAPIPrefix)
 
 	// glog.Infof("oauth server configured as: %#v", server)

--- a/pkg/oauth/apiserver/oauth_apiserver.go
+++ b/pkg/oauth/apiserver/oauth_apiserver.go
@@ -20,6 +20,7 @@ import (
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 
+	"github.com/openshift/origin/pkg/auth/server/headers"
 	"github.com/openshift/origin/pkg/auth/server/session"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	"github.com/openshift/origin/pkg/cmd/server/api/latest"
@@ -203,6 +204,7 @@ func (c *OAuthServerConfig) buildHandlerChainForOAuth(startingHandler http.Handl
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, genericConfig.RequestContextMapper, genericConfig.LongRunningFunc, genericConfig.RequestTimeout)
 	handler = genericapifilters.WithRequestInfo(handler, genericapiserver.NewRequestInfoResolver(genericConfig), genericConfig.RequestContextMapper)
 	handler = apirequest.WithRequestContext(handler, genericConfig.RequestContextMapper)
+	handler = headers.WithStandardHeaders(handler)
 	handler = genericfilters.WithPanicRecovery(handler)
 	return handler
 }

--- a/pkg/oauth/urls/urls.go
+++ b/pkg/oauth/urls/urls.go
@@ -1,0 +1,37 @@
+package urls
+
+import (
+	"path"
+	"strings"
+)
+
+const (
+	AuthorizePath = "/authorize"
+	TokenPath     = "/token"
+	InfoPath      = "/info"
+
+	RequestTokenEndpoint  = "/token/request"
+	DisplayTokenEndpoint  = "/token/display"
+	ImplicitTokenEndpoint = "/token/implicit"
+)
+
+const OpenShiftOAuthAPIPrefix = "/oauth"
+
+func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, AuthorizePath)
+}
+func OpenShiftOAuthTokenURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, TokenPath)
+}
+func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, RequestTokenEndpoint)
+}
+func OpenShiftOAuthTokenDisplayURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, DisplayTokenEndpoint)
+}
+func OpenShiftOAuthTokenImplicitURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, ImplicitTokenEndpoint)
+}
+func openShiftOAuthURL(masterAddr, oauthEndpoint string) string {
+	return strings.TrimRight(masterAddr, "/") + path.Join(OpenShiftOAuthAPIPrefix, oauthEndpoint)
+}

--- a/pkg/oauth/util/url.go
+++ b/pkg/oauth/util/url.go
@@ -4,11 +4,15 @@ import (
 	"path"
 	"strings"
 
-	"github.com/openshift/origin/pkg/auth/server/tokenrequest"
 	"github.com/openshift/origin/pkg/oauth/server/osinserver"
 )
 
-const OpenShiftOAuthAPIPrefix = "/oauth"
+const (
+	OpenShiftOAuthAPIPrefix = "/oauth"
+	RequestTokenEndpoint    = "/token/request"
+	DisplayTokenEndpoint    = "/token/display"
+	ImplicitTokenEndpoint   = "/token/implicit"
+)
 
 func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
 	return openShiftOAuthURL(masterAddr, osinserver.AuthorizePath)
@@ -17,13 +21,13 @@ func OpenShiftOAuthTokenURL(masterAddr string) string {
 	return openShiftOAuthURL(masterAddr, osinserver.TokenPath)
 }
 func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
-	return openShiftOAuthURL(masterAddr, tokenrequest.RequestTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, RequestTokenEndpoint)
 }
 func OpenShiftOAuthTokenDisplayURL(masterAddr string) string {
-	return openShiftOAuthURL(masterAddr, tokenrequest.DisplayTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, DisplayTokenEndpoint)
 }
 func OpenShiftOAuthTokenImplicitURL(masterAddr string) string {
-	return openShiftOAuthURL(masterAddr, tokenrequest.ImplicitTokenEndpoint)
+	return openShiftOAuthURL(masterAddr, ImplicitTokenEndpoint)
 }
 func openShiftOAuthURL(masterAddr, oauthEndpoint string) string {
 	return strings.TrimRight(masterAddr, "/") + path.Join(OpenShiftOAuthAPIPrefix, oauthEndpoint)


### PR DESCRIPTION
This is a 3.7 backport of #22767 which adds CSRF validation to OAuth server token requests created from its web console.

`openshift start master` fails while trying to list roles, there seem to be a cert problem for whatever reason -> did not test it yet