### PR TITLE
Bugzilla 1693021: Add CSRF to token request endpoint [3.6]

### DIFF
--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -16,7 +16,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
-	"github.com/openshift/origin/pkg/auth/server/headers"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
@@ -107,8 +106,6 @@ func (l *Grant) Install(mux Mux, paths ...string) {
 }
 
 func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
-
 	user, ok, err := l.auth.AuthenticateRequest(req)
 	if err != nil || !ok {
 		l.redirect("You must reauthenticate before continuing", w, req)

--- a/pkg/auth/server/grant/grant.go
+++ b/pkg/auth/server/grant/grant.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift/origin/pkg/auth/authenticator"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
+	"github.com/openshift/origin/pkg/auth/server/headers"
 	scopeauthorizer "github.com/openshift/origin/pkg/authorization/authorizer/scope"
 	oapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
 	"github.com/openshift/origin/pkg/oauth/registry/oauthclient"
@@ -106,12 +107,13 @@ func (l *Grant) Install(mux Mux, paths ...string) {
 }
 
 func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	headers.SetStandardHeaders(w)
+
 	user, ok, err := l.auth.AuthenticateRequest(req)
 	if err != nil || !ok {
 		l.redirect("You must reauthenticate before continuing", w, req)
 		return
 	}
-
 	switch req.Method {
 	case "GET":
 		l.handleForm(user, w, req)

--- a/pkg/auth/server/headers/headers.go
+++ b/pkg/auth/server/headers/headers.go
@@ -1,0 +1,29 @@
+package headers
+
+import (
+	"net/http"
+)
+
+func SetStandardHeaders(w http.ResponseWriter) {
+
+	// We cannot set HSTS by default, it has too many drawbacks in environments
+	// that use self-signed certs
+	standardHeaders := map[string]string{
+		// Turn off caching, it never makes sense for authorization pages
+		"Cache-Control": "no-cache, no-store",
+		"Pragma":        "no-cache",
+		"Expires":       "0",
+		// Use a reasonably strict Referer policy by default
+		"Referrer-Policy": "strict-origin-when-cross-origin",
+		// Do not allow embedding as that can lead to clickjacking attacks
+		"X-Frame-Options": "DENY",
+		// Add other basic scurity hygiene headers
+		"X-Content-Type-Options": "nosniff",
+		"X-DNS-Prefetch-Control": "off",
+		"X-XSS-Protection":       "1; mode=block",
+	}
+
+	for key, val := range standardHeaders {
+		w.Header().Set(key, val)
+	}
+}

--- a/pkg/auth/server/headers/headers.go
+++ b/pkg/auth/server/headers/headers.go
@@ -1,29 +1,32 @@
 package headers
 
-import (
-	"net/http"
-)
+import "net/http"
 
-func SetStandardHeaders(w http.ResponseWriter) {
+// We cannot set HSTS by default, it has too many drawbacks in environments
+// that use self-signed certs
+var standardHeaders = map[string]string{
+	// Turn off caching, it never makes sense for authorization pages
+	"Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+	"Pragma":        "no-cache",
+	"Expires":       "0",
+	// Use a reasonably strict Referer policy by default
+	"Referrer-Policy": "strict-origin-when-cross-origin",
+	// Do not allow embedding as that can lead to clickjacking attacks
+	"X-Frame-Options": "DENY",
+	// Add other basic security hygiene headers
+	"X-Content-Type-Options": "nosniff",
+	"X-DNS-Prefetch-Control": "off",
+	"X-XSS-Protection":       "1; mode=block",
+}
 
-	// We cannot set HSTS by default, it has too many drawbacks in environments
-	// that use self-signed certs
-	standardHeaders := map[string]string{
-		// Turn off caching, it never makes sense for authorization pages
-		"Cache-Control": "no-cache, no-store",
-		"Pragma":        "no-cache",
-		"Expires":       "0",
-		// Use a reasonably strict Referer policy by default
-		"Referrer-Policy": "strict-origin-when-cross-origin",
-		// Do not allow embedding as that can lead to clickjacking attacks
-		"X-Frame-Options": "DENY",
-		// Add other basic scurity hygiene headers
-		"X-Content-Type-Options": "nosniff",
-		"X-DNS-Prefetch-Control": "off",
-		"X-XSS-Protection":       "1; mode=block",
-	}
+func WithStandardHeaders(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// force every request into the OAuth server to have our standard headers
+		h := w.Header()
+		for k, v := range standardHeaders {
+			h.Set(k, v)
+		}
 
-	for key, val := range standardHeaders {
-		w.Header().Set(key, val)
-	}
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/pkg/auth/server/login/login.go
+++ b/pkg/auth/server/login/login.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
 	"github.com/openshift/origin/pkg/auth/server/errorpage"
+	"github.com/openshift/origin/pkg/auth/server/headers"
 )
 
 const (
@@ -94,6 +95,7 @@ func (l *Login) Install(mux Mux, paths ...string) {
 }
 
 func (l *Login) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	headers.SetStandardHeaders(w)
 	switch req.Method {
 	case "GET":
 		l.handleLoginForm(w, req)

--- a/pkg/auth/server/login/login.go
+++ b/pkg/auth/server/login/login.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift/origin/pkg/auth/oauth/handlers"
 	"github.com/openshift/origin/pkg/auth/server/csrf"
 	"github.com/openshift/origin/pkg/auth/server/errorpage"
-	"github.com/openshift/origin/pkg/auth/server/headers"
 )
 
 const (
@@ -95,7 +94,6 @@ func (l *Login) Install(mux Mux, paths ...string) {
 }
 
 func (l *Login) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	headers.SetStandardHeaders(w)
 	switch req.Method {
 	case "GET":
 		l.handleLoginForm(w, req)

--- a/pkg/cmd/server/origin/auth.go
+++ b/pkg/cmd/server/origin/auth.go
@@ -161,7 +161,7 @@ func (c *AuthConfig) WithOAuth(handler http.Handler) (http.Handler, error) {
 		glog.Fatal(err)
 	}
 
-	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.Options.MasterPublicURL, c.getOsinOAuthClient)
+	tokenRequestEndpoints := tokenrequest.NewEndpoints(c.Options.MasterPublicURL, c.getOsinOAuthClient, c.getCSRF())
 	tokenRequestEndpoints.Install(mux, oauthutil.OpenShiftOAuthAPIPrefix)
 
 	// glog.Infof("oauth server configured as: %#v", server)
@@ -185,7 +185,7 @@ func (c *AuthConfig) getOsinOAuthClient() (*osincli.Client, error) {
 		return nil, err
 	}
 	osOAuthClientConfig := c.NewOpenShiftOAuthClientConfig(browserClient)
-	osOAuthClientConfig.RedirectUrl = c.Options.MasterPublicURL + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, tokenrequest.DisplayTokenEndpoint)
+	osOAuthClientConfig.RedirectUrl = c.Options.MasterPublicURL + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, oauthutil.DisplayTokenEndpoint)
 
 	osOAuthClient, _ := osincli.NewClient(osOAuthClientConfig)
 	if len(*c.Options.MasterCA) > 0 {
@@ -307,7 +307,7 @@ func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddre
 			ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftBrowserClientID},
 			Secret:                uuid.New(),
 			RespondWithChallenges: false,
-			RedirectURIs:          []string{masterPublicAddr + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, tokenrequest.DisplayTokenEndpoint)},
+			RedirectURIs:          []string{masterPublicAddr + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, oauthutil.DisplayTokenEndpoint)},
 			GrantMethod:           oauthapi.GrantHandlerAuto,
 		}
 		if err := ensureOAuthClient(browserClient, clientRegistry, true, true); err != nil {
@@ -320,7 +320,7 @@ func CreateOrUpdateDefaultOAuthClients(masterPublicAddr string, assetPublicAddre
 			ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftCLIClientID},
 			Secret:                "",
 			RespondWithChallenges: true,
-			RedirectURIs:          []string{masterPublicAddr + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, tokenrequest.ImplicitTokenEndpoint)},
+			RedirectURIs:          []string{masterPublicAddr + path.Join(oauthutil.OpenShiftOAuthAPIPrefix, oauthutil.ImplicitTokenEndpoint)},
 			GrantMethod:           oauthapi.GrantHandlerAuto,
 		}
 		if err := ensureOAuthClient(cliClient, clientRegistry, false, false); err != nil {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -25,6 +25,8 @@ import (
 	kcorestorage "k8s.io/kubernetes/pkg/registry/core/rest"
 
 	"crypto/x509"
+
+	authheaders "github.com/openshift/origin/pkg/auth/server/headers"
 	"github.com/openshift/origin/pkg/authorization/authorizer"
 	configapi "github.com/openshift/origin/pkg/cmd/server/api"
 	serverauthenticator "github.com/openshift/origin/pkg/cmd/server/authenticator"
@@ -249,6 +251,7 @@ func (c *MasterConfig) buildHandlerChain(assetConfig *AssetConfig) (func(http.Ha
 		handler = apiserverfilters.WithMaxInFlightLimit(handler, kc.MaxRequestsInFlight, kc.MaxMutatingRequestsInFlight, contextMapper, kc.LongRunningFunc)
 		handler = apifilters.WithRequestInfo(handler, apiserver.NewRequestInfoResolver(kc), contextMapper)
 		handler = apirequest.WithRequestContext(handler, contextMapper)
+		handler = authheaders.WithStandardHeaders(handler)
 		handler = apiserverfilters.WithPanicRecovery(handler)
 
 		return handler

--- a/pkg/oauth/apiserver/oauth_apiserver.go
+++ b/pkg/oauth/apiserver/oauth_apiserver.go
@@ -1,0 +1,250 @@
+package apiserver
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pborman/uuid"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+
+	"github.com/openshift/origin/pkg/auth/server/headers"
+	"github.com/openshift/origin/pkg/auth/server/session"
+	configapi "github.com/openshift/origin/pkg/cmd/server/api"
+	"github.com/openshift/origin/pkg/cmd/server/api/latest"
+	oauthapi "github.com/openshift/origin/pkg/oauth/apis/oauth"
+	oauthclient "github.com/openshift/origin/pkg/oauth/generated/internalclientset/typed/oauth/internalversion"
+	oauthutil "github.com/openshift/origin/pkg/oauth/util"
+	routeclient "github.com/openshift/origin/pkg/route/generated/internalclientset"
+	userclient "github.com/openshift/origin/pkg/user/generated/internalclientset/typed/user/internalversion"
+)
+
+type OAuthServerConfig struct {
+	GenericConfig *genericapiserver.Config
+
+	Options configapi.OAuthConfig
+
+	// AssetPublicAddresses contains valid redirectURI prefixes to direct browsers to the web console
+	AssetPublicAddresses []string
+
+	// KubeClient is kubeclient with enough permission for the auth API
+	KubeClient kclientset.Interface
+
+	// EventsClient is for creating user events
+	EventsClient corev1.EventInterface
+
+	// RouteClient provides a client for OpenShift routes API.
+	RouteClient routeclient.Interface
+
+	UserClient                userclient.UserResourceInterface
+	IdentityClient            userclient.IdentityInterface
+	UserIdentityMappingClient userclient.UserIdentityMappingInterface
+
+	OAuthAccessTokenClient         oauthclient.OAuthAccessTokenInterface
+	OAuthAuthorizeTokenClient      oauthclient.OAuthAuthorizeTokenInterface
+	OAuthClientClient              oauthclient.OAuthClientInterface
+	OAuthClientAuthorizationClient oauthclient.OAuthClientAuthorizationInterface
+
+	SessionAuth *session.Authenticator
+
+	HandlerWrapper handlerWrapper
+}
+
+func NewOAuthServerConfig(oauthConfig configapi.OAuthConfig, userClientConfig *rest.Config) (*OAuthServerConfig, error) {
+	genericConfig := genericapiserver.NewConfig(kapi.Codecs)
+
+	var sessionAuth *session.Authenticator
+	var sessionHandlerWrapper handlerWrapper
+	if oauthConfig.SessionConfig != nil {
+		secure := isHTTPS(oauthConfig.MasterPublicURL)
+		auth, wrapper, err := buildSessionAuth(secure, oauthConfig.SessionConfig)
+		if err != nil {
+			return nil, err
+		}
+		sessionAuth = auth
+		sessionHandlerWrapper = wrapper
+	}
+
+	userClient, err := userclient.NewForConfig(userClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	oauthClient, err := oauthclient.NewForConfig(userClientConfig)
+	if err != nil {
+		return nil, err
+	}
+	eventsClient, err := corev1.NewForConfig(userClientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &OAuthServerConfig{
+		GenericConfig:                  genericConfig,
+		Options:                        oauthConfig,
+		SessionAuth:                    sessionAuth,
+		EventsClient:                   eventsClient.Events(""),
+		IdentityClient:                 userClient.Identities(),
+		UserClient:                     userClient.Users(),
+		UserIdentityMappingClient:      userClient.UserIdentityMappings(),
+		OAuthAccessTokenClient:         oauthClient.OAuthAccessTokens(),
+		OAuthAuthorizeTokenClient:      oauthClient.OAuthAuthorizeTokens(),
+		OAuthClientClient:              oauthClient.OAuthClients(),
+		OAuthClientAuthorizationClient: oauthClient.OAuthClientAuthorizations(),
+		HandlerWrapper:                 sessionHandlerWrapper,
+	}
+	genericConfig.BuildHandlerChainFunc = ret.buildHandlerChainForOAuth
+
+	return ret, nil
+}
+
+func buildSessionAuth(secure bool, config *configapi.SessionConfig) (*session.Authenticator, handlerWrapper, error) {
+	secrets, err := getSessionSecrets(config.SessionSecretsFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	sessionStore := session.NewStore(secure, secrets...)
+	return session.NewAuthenticator(sessionStore, config.SessionName, int(config.SessionMaxAgeSeconds)), sessionStore, nil
+}
+
+func getSessionSecrets(filename string) ([]string, error) {
+	// Build secrets list
+	secrets := []string{}
+
+	if len(filename) != 0 {
+		sessionSecrets, err := latest.ReadSessionSecrets(filename)
+		if err != nil {
+			return nil, fmt.Errorf("error reading sessionSecretsFile %s: %v", filename, err)
+		}
+
+		if len(sessionSecrets.Secrets) == 0 {
+			return nil, fmt.Errorf("sessionSecretsFile %s contained no secrets", filename)
+		}
+
+		for _, s := range sessionSecrets.Secrets {
+			secrets = append(secrets, s.Authentication)
+			secrets = append(secrets, s.Encryption)
+		}
+	} else {
+		// Generate random signing and encryption secrets if none are specified in config
+		secrets = append(secrets, fmt.Sprintf("%x", md5.Sum([]byte(uuid.NewRandom().String()))))
+		secrets = append(secrets, fmt.Sprintf("%x", md5.Sum([]byte(uuid.NewRandom().String()))))
+	}
+
+	return secrets, nil
+}
+
+// isHTTPS returns true if the given URL is a valid https URL
+func isHTTPS(u string) bool {
+	parsedURL, err := url.Parse(u)
+	return err == nil && parsedURL.Scheme == "https"
+}
+
+// OAuthServer serves non-API endpoints for openshift.
+type OAuthServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+
+	PublicURL url.URL
+}
+
+type completedOAuthServerConfig struct {
+	*OAuthServerConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *OAuthServerConfig) Complete() completedOAuthServerConfig {
+	c.GenericConfig.Complete()
+
+	return completedOAuthServerConfig{c}
+}
+
+// SkipComplete provides a way to construct a server instance without config completion.
+func (c *OAuthServerConfig) SkipComplete() completedOAuthServerConfig {
+	return completedOAuthServerConfig{c}
+}
+
+// this server is odd.  It doesn't delegate.  We mostly leave it alone, so I don't plan to make it look "normal".  We'll
+// model it as a separate API server to reason about its handling chain, but otherwise, just let it be
+func (c completedOAuthServerConfig) New(delegationTarget genericapiserver.DelegationTarget) (*OAuthServer, error) {
+	genericServer, err := c.OAuthServerConfig.GenericConfig.SkipComplete().New("openshift-oauth", delegationTarget) // completion is done in Complete, no need for a second time
+	if err != nil {
+		return nil, err
+	}
+
+	s := &OAuthServer{
+		GenericAPIServer: genericServer,
+	}
+
+	return s, nil
+}
+
+func (c *OAuthServerConfig) buildHandlerChainForOAuth(startingHandler http.Handler, genericConfig *genericapiserver.Config) http.Handler {
+	handler, err := c.WithOAuth(startingHandler, genericConfig.RequestContextMapper)
+	if err != nil {
+		// the existing errors all cause the server to die anyway
+		panic(err)
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.AdvancedAuditing) {
+		handler = genericapifilters.WithAudit(handler, genericConfig.RequestContextMapper, genericConfig.AuditBackend, genericConfig.AuditPolicyChecker, genericConfig.LongRunningFunc)
+	}
+
+	handler = genericfilters.WithMaxInFlightLimit(handler, genericConfig.MaxRequestsInFlight, genericConfig.MaxMutatingRequestsInFlight, genericConfig.RequestContextMapper, genericConfig.LongRunningFunc)
+	handler = genericfilters.WithCORS(handler, genericConfig.CorsAllowedOriginList, nil, nil, nil, "true")
+	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, genericConfig.RequestContextMapper, genericConfig.LongRunningFunc, genericConfig.RequestTimeout)
+	handler = genericapifilters.WithRequestInfo(handler, genericapiserver.NewRequestInfoResolver(genericConfig), genericConfig.RequestContextMapper)
+	handler = apirequest.WithRequestContext(handler, genericConfig.RequestContextMapper)
+	handler = headers.WithStandardHeaders(handler)
+	handler = genericfilters.WithPanicRecovery(handler)
+	return handler
+}
+
+// TODO, this moves to the `apiserver.go` when we have it for this group
+// TODO TODO, this actually looks a lot like a controller or an add-on manager style thing.  Seems like we'd want to do this outside
+// EnsureBootstrapOAuthClients creates or updates the bootstrap oauth clients that openshift relies upon.
+func (c *OAuthServerConfig) EnsureBootstrapOAuthClients(context genericapiserver.PostStartHookContext) error {
+	webConsoleClient := oauthapi.OAuthClient{
+		ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftWebConsoleClientID},
+		Secret:                "",
+		RespondWithChallenges: false,
+		RedirectURIs:          c.AssetPublicAddresses,
+		GrantMethod:           oauthapi.GrantHandlerAuto,
+	}
+	if err := ensureOAuthClient(webConsoleClient, c.OAuthClientClient, true, false); err != nil {
+		return err
+	}
+
+	browserClient := oauthapi.OAuthClient{
+		ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftBrowserClientID},
+		Secret:                uuid.New(),
+		RespondWithChallenges: false,
+		RedirectURIs:          []string{oauthutil.OpenShiftOAuthTokenDisplayURL(c.Options.MasterPublicURL)},
+		GrantMethod:           oauthapi.GrantHandlerAuto,
+	}
+	if err := ensureOAuthClient(browserClient, c.OAuthClientClient, true, true); err != nil {
+		return err
+	}
+
+	cliClient := oauthapi.OAuthClient{
+		ObjectMeta:            metav1.ObjectMeta{Name: OpenShiftCLIClientID},
+		Secret:                "",
+		RespondWithChallenges: true,
+		RedirectURIs:          []string{oauthutil.OpenShiftOAuthTokenImplicitURL(c.Options.MasterPublicURL)},
+		GrantMethod:           oauthapi.GrantHandlerAuto,
+	}
+	if err := ensureOAuthClient(cliClient, c.OAuthClientClient, false, false); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/oauth/urls/urls.go
+++ b/pkg/oauth/urls/urls.go
@@ -1,0 +1,37 @@
+package urls
+
+import (
+	"path"
+	"strings"
+)
+
+const (
+	AuthorizePath = "/authorize"
+	TokenPath     = "/token"
+	InfoPath      = "/info"
+
+	RequestTokenEndpoint  = "/token/request"
+	DisplayTokenEndpoint  = "/token/display"
+	ImplicitTokenEndpoint = "/token/implicit"
+)
+
+const OpenShiftOAuthAPIPrefix = "/oauth"
+
+func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, AuthorizePath)
+}
+func OpenShiftOAuthTokenURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, TokenPath)
+}
+func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, RequestTokenEndpoint)
+}
+func OpenShiftOAuthTokenDisplayURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, DisplayTokenEndpoint)
+}
+func OpenShiftOAuthTokenImplicitURL(masterAddr string) string {
+	return openShiftOAuthURL(masterAddr, ImplicitTokenEndpoint)
+}
+func openShiftOAuthURL(masterAddr, oauthEndpoint string) string {
+	return strings.TrimRight(masterAddr, "/") + path.Join(OpenShiftOAuthAPIPrefix, oauthEndpoint)
+}

--- a/pkg/oauth/util/url.go
+++ b/pkg/oauth/util/url.go
@@ -3,12 +3,14 @@ package util
 import (
 	"path"
 
-	"github.com/openshift/origin/pkg/auth/server/tokenrequest"
 	"github.com/openshift/origin/pkg/oauth/server/osinserver"
 )
 
 const (
 	OpenShiftOAuthAPIPrefix = "/oauth"
+	RequestTokenEndpoint    = "/token/request"
+	DisplayTokenEndpoint    = "/token/display"
+	ImplicitTokenEndpoint   = "/token/implicit"
 )
 
 func OpenShiftOAuthAuthorizeURL(masterAddr string) string {
@@ -18,5 +20,5 @@ func OpenShiftOAuthTokenURL(masterAddr string) string {
 	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, osinserver.TokenPath)
 }
 func OpenShiftOAuthTokenRequestURL(masterAddr string) string {
-	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, tokenrequest.RequestTokenEndpoint)
+	return masterAddr + path.Join(OpenShiftOAuthAPIPrefix, RequestTokenEndpoint)
 }

--- a/test/integration/oauth_server_headers_test.go
+++ b/test/integration/oauth_server_headers_test.go
@@ -1,0 +1,85 @@
+package integration
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	restclient "k8s.io/client-go/rest"
+
+	testutil "github.com/openshift/origin/test/util"
+	testserver "github.com/openshift/origin/test/util/server"
+)
+
+// TestOAuthServerHeaders tests that the Oauth Server pages that return
+// browser relevant stuff (HTML) are served with appropriate headers
+func TestOAuthServerHeaders(t *testing.T) {
+	// Set up server
+	masterOptions, err := testserver.DefaultMasterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	defer testserver.CleanupMasterEtcd(t, masterOptions)
+
+	clusterAdminKubeConfig, err := testserver.StartConfiguredMaster(masterOptions)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	clientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	anonConfig := restclient.AnonymousClientConfig(clientConfig)
+	transport, err := restclient.TransportFor(anonConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	baseURL, err := url.Parse(clientConfig.Host)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Hit the login URL
+	loginURL := *baseURL
+	loginURL.Path = "/login"
+	checkNewReqHeaders(t, transport, loginURL.String())
+
+	// Hit the grant URL
+	grantURL := *baseURL
+	grantURL.Path = "/oauth/authorize/approve"
+	checkNewReqHeaders(t, transport, grantURL.String())
+
+}
+
+func checkNewReqHeaders(t *testing.T, rt http.RoundTripper, check_url string) {
+	req, err := http.NewRequest("GET", check_url, nil)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	req.Header.Set("Accept", "text/html; charset=UTF-8")
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	checkImportantHeaders := map[string]string{
+		"Referrer-Policy":        "strict-origin-when-cross-origin",
+		"X-Frame-Options":        "DENY",
+		"X-Content-Type-Options": "nosniff",
+		"X-DNS-Prefetch-Control": "off",
+		"X-XSS-Protection":       "1; mode=block",
+	}
+
+	for key, val := range checkImportantHeaders {
+		header := resp.Header.Get(key)
+		if header != val {
+			t.Errorf("While probing %s expected header %s: %s, got {%v}", check_url, key, val, header)
+		}
+	}
+}


### PR DESCRIPTION
This is a 3.6 backport of #22767 which adds CSRF validation to OAuth server token requests created from its web console.

`openshift start master` fails while trying to list roles coz:
`no kind "ClusterRoleBinding" is registered for version "rbac.authorization.k8s.io/v1"` which I don't know has workarounds in this old version;
There seems to be an etcd cert problem for whatever reason during startup:
`2019-06-14 12:41:39.502902 I | etcdserver/api/v3rpc: Failed to dial [::]:4001: connection error: desc = "transport: remote error: tls: bad certificate"; please retry.`
-> did not test it yet, not sure how to get `openshift start master` running