### PR TITLE
prevent test references to controller-manager

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -175,7 +175,8 @@
 
   {
     "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
+      "github.com/openshift/origin/pkg",
+      "github.com/openshift/origin/test"
     ],
     "ignoredSubTrees": [],
     "forbiddenImportPackageRoots": [


### PR DESCRIPTION
I haven't dug into what or why, but it's red


/assign @mfojtik 