### PR TITLE
Bug 1711569: reenable node lease tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -396,10 +396,6 @@ var (
 			`\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\] provisioning should access volume from different nodes`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711688
 
 			`Probing container should \*not\* be restarted with a non-local redirect http liveness probe`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711687
-
-			// requires a 1.14 kubelet, enable when rhcos is built for 4.2
-			"when the NodeLease feature is enabled",
-			"RuntimeClass should reject",
 		},
 		// tests too slow to be part of conformance
 		"[Slow]": {


### PR DESCRIPTION
Reenable node lease tests since we have a 1.14 kubelet now.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1711569

/cc @sjenning 