### PR TITLE
Bug 1690087: Increase the wait for the service upgrade e2e test for LB

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/upgrades/services.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/upgrades/services.go
@@ -17,6 +17,8 @@ limitations under the License.
 package upgrades
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -66,7 +68,8 @@ func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 
 	// Hit it once before considering ourselves ready
 	By("hitting the pod through the service's LoadBalancer")
-	jig.TestReachableHTTP(tcpIngressIP, svcPort, framework.LoadBalancerLagTimeoutDefault)
+	// Load balancers can take more than 2 minutes in heavily contended AWS accounts
+	jig.TestReachableHTTP(tcpIngressIP, svcPort, 3*time.Minute)
 
 	t.jig = jig
 	t.tcpService = tcpService


### PR DESCRIPTION
In heavily contended AWS accounts, it can take more than 2m for an
LB to get created and pick up entries.

Cherrypicked from #23160