### PR TITLE
Bug 1717739: ClusterOperators should specify related objects

### DIFF
--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -36,7 +36,6 @@ var _ = g.Describe("[Feature:Platform] ClusterOperators", func() {
 		"machine-config",
 		"marketplace",
 		"network",
-		"node-tuning",
 		"operator-lifecycle-manager",
 		"operator-lifecycle-manager-catalog",
 		"storage",


### PR DESCRIPTION
See: https://github.com/openshift/cluster-node-tuning-operator/pull/64
