### PR TITLE
Fix openshift-sdn --proxy-config parsing

### DIFF
--- a/staging/src/github.com/openshift/sdn/pkg/openshift-sdn/config.go
+++ b/staging/src/github.com/openshift/sdn/pkg/openshift-sdn/config.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 
-	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
-
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/openshift/library-go/pkg/config/helpers"
 )
@@ -38,19 +36,4 @@ func setDefaults_NodeConfig(obj *legacyconfigv1.NodeConfig) {
 		v := true
 		obj.EnableUnidling = &v
 	}
-}
-
-func readProxyConfig(filename string) (*kubeproxyconfig.KubeProxyConfiguration, error) {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	uncast, err := helpers.ReadYAML(bytes.NewBuffer(data), kubeproxyconfig.AddToScheme)
-	if err != nil {
-		return nil, err
-	}
-
-	ret := uncast.(*kubeproxyconfig.KubeProxyConfiguration)
-	return ret, nil
 }

--- a/staging/src/github.com/openshift/sdn/pkg/openshift-sdn/proxy.go
+++ b/staging/src/github.com/openshift/sdn/pkg/openshift-sdn/proxy.go
@@ -41,6 +41,16 @@ import (
 	"k8s.io/klog"
 )
 
+// readProxyConfig reads the proxy config from a file
+func readProxyConfig(filename string) (*kubeproxyconfig.KubeProxyConfiguration, error) {
+	o := kubeproxyoptions.NewOptions()
+	o.ConfigFile = filename
+	if err := o.Complete(); err != nil {
+		return nil, err
+	}
+	return o.GetConfig(), nil
+}
+
 // ProxyConfigFromNodeConfig builds the kube-proxy configuration from the already-parsed nodeconfig.
 func ProxyConfigFromNodeConfig(nodeName, bindAddress, iptablesSyncPeriod string, proxyArguments map[string][]string) (*kubeproxyconfig.KubeProxyConfiguration, error) {
 	proxyOptions := kubeproxyoptions.NewOptions()


### PR DESCRIPTION
We were trying to read an `apiVersion: kubeproxy.config.k8s.io/v1alpha1` file into an internal-type `KubeProxyConfiguration`. We need to read in the external type and then convert. Fortunately there was already code in kube-proxy for doing this, we just weren't using it because I'd copied the `node-config.yaml`-reading code instead.

(Tested this time; since reading the command-line is the first thing it does, you can just run the binary locally to test that part...)

/assign @squeed