### PR TITLE
 cmd/openshift-tests: load the configuration for test from cluster when provider is azure

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -6,6 +6,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/monitor"
 	testginkgo "github.com/openshift/origin/pkg/test/ginkgo"
 	exutil "github.com/openshift/origin/test/extended/util"
+	exutilazure "github.com/openshift/origin/test/extended/util/azure"
 )
 
 func main() {
@@ -295,6 +297,23 @@ func decodeProviderTo(provider string, testContext *e2e.TestContextType) error {
 			}
 		}
 		// TODO: detect which provider the cluster is running and use that as a default.
+	case "azure":
+		tmpFile, err := ioutil.TempFile("", "e2e-*")
+		if err != nil {
+			return err
+		}
+		data, err := exutilazure.LoadConfigFile()
+		if err != nil {
+			return err
+		}
+		if _, err := tmpFile.Write(data); err != nil {
+			return err
+		}
+		if err := tmpFile.Close(); err != nil {
+			return err
+		}
+		testContext.Provider = "azure"
+		testContext.CloudConfig = e2e.CloudConfig{ConfigFile: tmpFile.Name()}
 	default:
 		var providerInfo struct{ Type string }
 		if err := json.Unmarshal([]byte(provider), &providerInfo); err != nil {

--- a/test/extended/util/azure/config_file.go
+++ b/test/extended/util/azure/config_file.go
@@ -1,0 +1,91 @@
+package azure
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"sigs.k8s.io/yaml"
+)
+
+// LoadConfigFile uses the cluster to fetch the cloud provider config from `openshift-config/cloud-provider-config` config map's config key.
+// It then uses the `AZURE_AUTH_LOCATION` to load the credentials for Azure API and update the cloud provider config with the client secret. In-cluster cloud provider config
+// uses Azure Managed Identity attached to virtual machines to provide Azure API access, while the e2e tests are usually run from outside the cluster and therefore need explicit auth creds.
+func LoadConfigFile() ([]byte, error) {
+	client, err := e2e.LoadClientset()
+	if err != nil {
+		return nil, err
+	}
+	config, err := cloudProviderConfigFromCluster(client.CoreV1())
+	if err != nil {
+		return nil, err
+	}
+	settings, err := getAuthFile()
+	if err != nil {
+		return nil, err
+	}
+	config.AADClientID = settings.ClientID
+	config.AADClientSecret = settings.ClientSecret
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func cloudProviderConfigFromCluster(client clientcorev1.ConfigMapsGetter) (*azure.Config, error) {
+	cm, err := client.ConfigMaps("openshift-config").Get("cloud-provider-config", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	data, ok := cm.Data["config"]
+	if !ok {
+		return nil, errors.New("No cloud provider config was set in openshift-config/cloud-provider-config")
+	}
+	config := &azure.Config{}
+	if err := yaml.Unmarshal([]byte(data), config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+// loads the auth file using the file provided by AZURE_AUTH_LOCATION
+// this mimics the function https://godoc.org/github.com/Azure/go-autorest/autorest/azure/auth#GetSettingsFromFile which is not currently available with vendor Azure SDK.
+func getAuthFile() (*file, error) {
+	fileLocation := os.Getenv("AZURE_AUTH_LOCATION")
+	if fileLocation == "" {
+		return nil, errors.New("environment variable AZURE_AUTH_LOCATION is not set")
+	}
+
+	contents, err := ioutil.ReadFile(fileLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	authFile := file{}
+	err = json.Unmarshal(contents, &authFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &authFile, nil
+}
+
+// File represents the authentication file
+type file struct {
+	ClientID                string `json:"clientId,omitempty"`
+	ClientSecret            string `json:"clientSecret,omitempty"`
+	SubscriptionID          string `json:"subscriptionId,omitempty"`
+	TenantID                string `json:"tenantId,omitempty"`
+	ActiveDirectoryEndpoint string `json:"activeDirectoryEndpointUrl,omitempty"`
+	ResourceManagerEndpoint string `json:"resourceManagerEndpointUrl,omitempty"`
+	GraphResourceID         string `json:"activeDirectoryGraphResourceId,omitempty"`
+	SQLManagementEndpoint   string `json:"sqlManagementEndpointUrl,omitempty"`
+	GalleryEndpoint         string `json:"galleryEndpointUrl,omitempty"`
+	ManagementEndpoint      string `json:"managementEndpointUrl,omitempty"`
+}


### PR DESCRIPTION
Single test can be run with 
`TEST_PROVIDER='azure' _output/local/bin/linux/amd64/openshift-tests run-test "[sig-storage] Zone Support Verify dynamically created pv with multiple zones specified in the storage class, shows both the zones on its labels [Suite:openshift/conformance/parallel] [Suite:k8s]" --dry-run`
test suite can be run with
`_output/local/bin/linux/amd64/openshift-tests run openshift/conformance/parallel --provider='azure'`

The cloud config file is fetched from the cluster, and creds are also setup to run this test from outside the cluster.

/cc @smarterclayton 
