### PR TITLE
e2e: add first e2e test for cluster logging.

### DIFF
--- a/test/extended/clusterlogging/deploy_logging.go
+++ b/test/extended/clusterlogging/deploy_logging.go
@@ -1,0 +1,130 @@
+package clusterlogging
+
+import (
+	"fmt"
+	"strconv"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var (
+	//CLO resource files to create subscription for cluster-logging-operator
+	CLO = OperatorObjects{
+		exutil.FixturePath("testdata", "clusterlogging", "deployment", "01-clo-project.yaml"),
+		exutil.FixturePath("testdata", "clusterlogging", "deployment", "02-clo-og.yaml"),
+		exutil.FixturePath("testdata", "clusterlogging", "deployment", "04-clo-sub.yaml")}
+	//EO resource files to create subscription for elasticsearch-operator
+	EO = OperatorObjects{
+		exutil.FixturePath("testdata", "clusterlogging", "deployment", "01-eo-project.yaml"),
+		exutil.FixturePath("testdata", "clusterlogging", "deployment", "02-eo-og.yaml"),
+		exutil.FixturePath("testdata", "clusterlogging", "deployment", "05-eo-sub.yaml")}
+	rbac = exutil.FixturePath("testdata", "clusterlogging", "deployment", "04-eo-rbac.yaml")
+)
+
+var _ = g.Describe("[Feature:Logging][Serial] Logging", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc            = exutil.NewCLIWithoutNamespace("logging")
+		loggingNs     = "openshift-logging"
+		eoNs          = "openshift-operators-redhat"
+		marketplaceNs = "openshift-marketplace"
+	)
+	g.Describe("Deploy Logging Via OLM: ", func() {
+		g.BeforeEach(func() {
+			g.By("Check packagemanifests", func() {
+				err := oc.AsAdmin().Run("get").Args("-n", marketplaceNs, "packagemanifests", "cluster-logging").Execute()
+				o.Expect(err).NotTo(o.HaveOccurred(), "Can't get packagemanifest cluster-logging")
+				err = oc.AsAdmin().Run("get").Args("-n", marketplaceNs, "packagemanifests", "elasticsearch-operator").Execute()
+				o.Expect(err).NotTo(o.HaveOccurred(), "Can't get packagemanifest elasticsearch-operator")
+			})
+
+			g.By("Creating subscription for cluster-logging-operator", func() {
+				err := createLoggingResources(oc, CLO)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+
+			g.By("Creating subscription for elasticsearch-operator", func() {
+				err := createLoggingResources(oc, EO)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				err = oc.AsAdmin().Run("create").Args("-f", rbac).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create RBAC")
+			})
+
+			g.By("Check if the cluster-logging-operator is ready or not", func() {
+				err := waitForDeployPodsToBeReady(oc, loggingNs, "cluster-logging-operator")
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+
+			g.By("Check if the elasticsearch-operator is ready or not", func() {
+				err := waitForDeployPodsToBeReady(oc, eoNs, "elasticsearch-operator")
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+		})
+
+		g.AfterEach(func() {
+			err := deleteNamespace(oc, loggingNs)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = deleteNamespace(oc, eoNs)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = e2e.WaitForNamespacesDeleted(oc.AdminKubeClient(), []string{loggingNs, eoNs}, timeout)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+		})
+
+		g.It("should deploy logging successfully when using fluentd as logcollector", func() {
+			instance := exutil.FixturePath("testdata", "clusterlogging", "instances", "example.yaml")
+			g.By("Creating clusterlogging instance", func() {
+				err := oc.AsAdmin().Run("create").Args("-f", instance).Execute()
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+
+			g.By("waiting for the fluentd pods to be ready...", func() {
+				err := waitForDaemonsetPodsToBeReady(oc, "fluentd", loggingNs)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+
+			g.By("waiting for the kibana pod to be ready...", func() {
+				err := waitForDeployPodsToBeReady(oc, loggingNs, "kibana")
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+
+			g.By("waiting for the elasticsearch pod to be ready...", func() {
+				output, err := oc.AsAdmin().Run("get").Args("-n", loggingNs, "clusterlogging", "instance", "-o=jsonpath={.spec.logStore.elasticsearch.nodeCount}").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				msg := fmt.Sprintf("%v", output)
+				escount, err := strconv.ParseInt(msg, 10, 0)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				deployName, err := getDeploymentsNameViaLabel(oc, loggingNs, "cluster-name=elasticsearch", int(escount))
+				o.Expect(err).NotTo(o.HaveOccurred())
+				for _, name := range deployName {
+					err = waitForDeployPodsToBeReady(oc, loggingNs, name)
+					o.Expect(err).NotTo(o.HaveOccurred())
+				}
+			})
+
+			g.By("check cronjob", func() {
+				err := checkCronJob(oc, "curator", loggingNs)
+				o.Expect(err).NotTo(o.HaveOccurred())
+			})
+
+			g.By("check CRDs", func() {
+				err := checkResourcesCreatedByOperators(oc, loggingNs, "clusterlogging", "instance")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				err = checkResourcesCreatedByOperators(oc, loggingNs, "elasticsearch", "elasticsearch")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				err = checkResourcesCreatedByOperators(oc, loggingNs, "servicemonitor", "fluentd")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				err = checkResourcesCreatedByOperators(oc, loggingNs, "servicemonitor", "monitor-elasticsearch-cluster")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				err = checkResourcesCreatedByOperators(oc, loggingNs, "prometheusrule", "elasticsearch-prometheus-rules")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				//err = checkResourcesCreatedByOperators(oc, loggingNs, "prometheusrule", "fluentd")
+				//o.Expect(err).NotTo(o.HaveOccurred())
+			})
+		})
+	})
+
+})

--- a/test/extended/clusterlogging/logging_utils.go
+++ b/test/extended/clusterlogging/logging_utils.go
@@ -1,0 +1,194 @@
+package clusterlogging
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	//"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	//apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var (
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 600
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
+)
+
+// OperatorObjects objects for creating operators via OLM
+type OperatorObjects struct {
+	Namepsace     string
+	Operatorgroup string
+	Sub           string
+}
+
+func createLoggingResources(oc *exutil.CLI, oo OperatorObjects) error {
+	filenames := reflect.ValueOf(oo)
+	t := reflect.TypeOf(oo)
+	num := filenames.NumField()
+	for i := 0; i < num; i++ {
+		filename := filenames.Field(i).Interface()
+		name := fmt.Sprint(filename)
+		fmt.Printf("Creating %s ...\n", t.Field(i).Name)
+		err := oc.AsAdmin().Run("create").Args("-f", name).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create %s \n", t.Field(i).Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitForDeployPodsToBeReady(oc *exutil.CLI, namespace string, name string) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		deployment, err := oc.AdminKubeClient().AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				e2e.Logf("Waiting for availability of %s deployment\n", name)
+				return false, nil
+			}
+			return false, err
+		}
+		if int(deployment.Status.AvailableReplicas) == int(deployment.Status.Replicas) {
+			replicas := int(deployment.Status.Replicas)
+			e2e.Logf("Deployment %s available (%d/%d)\n", name, replicas, replicas)
+			return true, nil
+		}
+		e2e.Logf("Waiting for full availability of %s deployment (%d/%d)\n", name, deployment.Status.AvailableReplicas, deployment.Status.Replicas)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForDaemonsetPodsToBeReady(oc *exutil.CLI, name string, ns string) error {
+	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	nodeCount := len(nodes.Items)
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		daemonset, err := oc.AdminKubeClient().AppsV1().DaemonSets(ns).Get(name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				e2e.Logf("Waiting for availability of %s daemonset\n", name)
+				return false, nil
+			}
+			return false, err
+		}
+		if int(daemonset.Status.NumberReady) == nodeCount {
+			return true, nil
+		}
+		e2e.Logf("Waiting for full availability of %s daemonset (%d/%d)\n", name, int(daemonset.Status.NumberReady), nodeCount)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	e2e.Logf("Daemonset %s available (%d/%d)\n", name, nodeCount, nodeCount)
+	return nil
+}
+
+func getDeploymentsNameViaLabel(oc *exutil.CLI, ns string, label string, count int) ([]string, error) {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		deployList, err := oc.AdminKubeClient().AppsV1().Deployments(ns).List(metav1.ListOptions{LabelSelector: label})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				e2e.Logf("Waiting for availability of deployment\n")
+				return false, nil
+			}
+			return false, err
+		}
+		if len(deployList.Items) == count {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err == nil {
+		deployList, err := oc.AdminKubeClient().AppsV1().Deployments(ns).List(metav1.ListOptions{LabelSelector: label})
+		if err != nil {
+			return nil, err
+		}
+		expectedDeployments := make([]string, 0, len(deployList.Items))
+		for _, deploy := range deployList.Items {
+			expectedDeployments = append(expectedDeployments, deploy.Name)
+		}
+		return expectedDeployments, nil
+	}
+	return nil, err
+}
+
+// delete objects in the cluster
+func clearResources(oc *exutil.CLI, resourcetype string, name string, ns string) error {
+	msg, err := oc.AsAdmin().Run("delete").Args("-n", ns, resourcetype, name).Output()
+	if err != nil {
+		errstring := fmt.Sprintf("%v", msg)
+		if strings.Contains(errstring, "NotFound") || strings.Contains(errstring, "the server doesn't have a resource type") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func deleteNamespace(oc *exutil.CLI, ns string) error {
+	// err := oc.AdminKubeClient().CoreV1().Namespaces().Delete(ns, nil)
+	err := oc.AdminKubeClient().CoreV1().Namespaces().Delete(ns, &metav1.DeleteOptions{})
+	//err := oc.AdminKubeClient().CoreV1().Namespaces().Delete(ns, metav1.NewDeleteOptions(0))
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func checkResourcesCreatedByOperators(oc *exutil.CLI, ns string, resourcetype string, name string) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		output, err := oc.AsAdmin().Run("get").Args("-n", ns, resourcetype, name).Output()
+		if err != nil {
+			msg := fmt.Sprintf(output)
+			if strings.Contains(msg, "NotFound") {
+				return false, nil
+			}
+			return false, err
+		}
+		e2e.Logf("Find %s %s", resourcetype, name)
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkCronJob(oc *exutil.CLI, name string, ns string) error {
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		_, err = oc.AdminKubeClient().BatchV1beta1().CronJobs(ns).Get(name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				e2e.Logf("Waiting for availability of cronjob %s \n", name)
+				return false, nil
+			}
+			return false, err
+		}
+		e2e.Logf("Find cronjob %s \n", name)
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/cluster"
+	_ "github.com/openshift/origin/test/extended/clusterlogging"
 	_ "github.com/openshift/origin/test/extended/cmd"
 	_ "github.com/openshift/origin/test/extended/controller_manager"
 	_ "github.com/openshift/origin/test/extended/crdvalidation"

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -160,6 +160,14 @@
 // test/extended/testdata/cluster/quickstarts/django-postgresql.json
 // test/extended/testdata/cluster/quickstarts/nodejs-mongodb.json
 // test/extended/testdata/cluster/quickstarts/rails-postgresql.json
+// test/extended/testdata/clusterlogging/deployment/01-clo-project.yaml
+// test/extended/testdata/clusterlogging/deployment/01-eo-project.yaml
+// test/extended/testdata/clusterlogging/deployment/02-clo-og.yaml
+// test/extended/testdata/clusterlogging/deployment/02-eo-og.yaml
+// test/extended/testdata/clusterlogging/deployment/04-clo-sub.yaml
+// test/extended/testdata/clusterlogging/deployment/04-eo-rbac.yaml
+// test/extended/testdata/clusterlogging/deployment/05-eo-sub.yaml
+// test/extended/testdata/clusterlogging/instances/example.yaml
 // test/extended/testdata/cmd/hack/lib/cmd.sh
 // test/extended/testdata/cmd/hack/lib/compress.awk
 // test/extended/testdata/cmd/hack/lib/constants.sh
@@ -27260,6 +27268,257 @@ func testExtendedTestdataClusterQuickstartsRailsPostgresqlJson() (*asset, error)
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/cluster/quickstarts/rails-postgresql.json", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment01CloProjectYaml = []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"
+`)
+
+func testExtendedTestdataClusterloggingDeployment01CloProjectYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment01CloProjectYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment01CloProjectYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment01CloProjectYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/01-clo-project.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment01EoProjectYaml = []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"
+`)
+
+func testExtendedTestdataClusterloggingDeployment01EoProjectYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment01EoProjectYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment01EoProjectYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment01EoProjectYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/01-eo-project.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment02CloOgYaml = []byte(`apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-logging-
+  namespace: openshift-logging
+  labels:
+    og_label: openshift-logging
+spec:
+  targetNamespaces:
+  - openshift-logging
+`)
+
+func testExtendedTestdataClusterloggingDeployment02CloOgYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment02CloOgYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment02CloOgYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment02CloOgYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/02-clo-og.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment02EoOgYaml = []byte(`apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-operators-redhat-
+  namespace: openshift-operators-redhat
+  spec: {}
+`)
+
+func testExtendedTestdataClusterloggingDeployment02EoOgYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment02EoOgYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment02EoOgYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment02EoOgYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/02-eo-og.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment04CloSubYaml = []byte(`apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging-operator
+  namespace: openshift-logging
+spec:
+  channel: preview
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+`)
+
+func testExtendedTestdataClusterloggingDeployment04CloSubYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment04CloSubYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment04CloSubYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment04CloSubYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/04-clo-sub.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment04EoRbacYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators-redhat
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators-redhat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+namespace: openshift-operators-redhat
+`)
+
+func testExtendedTestdataClusterloggingDeployment04EoRbacYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment04EoRbacYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment04EoRbacYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment04EoRbacYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/04-eo-rbac.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingDeployment05EoSubYaml = []byte(`apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: preview
+  installPlanApproval: Automatic
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  name: elasticsearch-operator
+`)
+
+func testExtendedTestdataClusterloggingDeployment05EoSubYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingDeployment05EoSubYaml, nil
+}
+
+func testExtendedTestdataClusterloggingDeployment05EoSubYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingDeployment05EoSubYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/deployment/05-eo-sub.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataClusterloggingInstancesExampleYaml = []byte(`apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: openshift-logging
+spec:
+  managementState: "Managed"
+  logStore:
+    type: "elasticsearch"
+    elasticsearch:
+      nodeCount: 1
+      resources:
+        requests:
+          cpu: 400m
+          memory: 2Gi
+      storage: {}
+      redundancyPolicy: "ZeroRedundancy"
+  visualization:
+    type: "kibana"
+    kibana:
+      replicas: 1
+  curation:
+    type: "curator"
+    curator:
+      schedule: "*/10 * * * *"
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd: {}
+`)
+
+func testExtendedTestdataClusterloggingInstancesExampleYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataClusterloggingInstancesExampleYaml, nil
+}
+
+func testExtendedTestdataClusterloggingInstancesExampleYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataClusterloggingInstancesExampleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/clusterlogging/instances/example.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -56403,6 +56662,14 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/cluster/quickstarts/django-postgresql.json": testExtendedTestdataClusterQuickstartsDjangoPostgresqlJson,
 	"test/extended/testdata/cluster/quickstarts/nodejs-mongodb.json": testExtendedTestdataClusterQuickstartsNodejsMongodbJson,
 	"test/extended/testdata/cluster/quickstarts/rails-postgresql.json": testExtendedTestdataClusterQuickstartsRailsPostgresqlJson,
+	"test/extended/testdata/clusterlogging/deployment/01-clo-project.yaml": testExtendedTestdataClusterloggingDeployment01CloProjectYaml,
+	"test/extended/testdata/clusterlogging/deployment/01-eo-project.yaml": testExtendedTestdataClusterloggingDeployment01EoProjectYaml,
+	"test/extended/testdata/clusterlogging/deployment/02-clo-og.yaml": testExtendedTestdataClusterloggingDeployment02CloOgYaml,
+	"test/extended/testdata/clusterlogging/deployment/02-eo-og.yaml": testExtendedTestdataClusterloggingDeployment02EoOgYaml,
+	"test/extended/testdata/clusterlogging/deployment/04-clo-sub.yaml": testExtendedTestdataClusterloggingDeployment04CloSubYaml,
+	"test/extended/testdata/clusterlogging/deployment/04-eo-rbac.yaml": testExtendedTestdataClusterloggingDeployment04EoRbacYaml,
+	"test/extended/testdata/clusterlogging/deployment/05-eo-sub.yaml": testExtendedTestdataClusterloggingDeployment05EoSubYaml,
+	"test/extended/testdata/clusterlogging/instances/example.yaml": testExtendedTestdataClusterloggingInstancesExampleYaml,
 	"test/extended/testdata/cmd/hack/lib/cmd.sh": testExtendedTestdataCmdHackLibCmdSh,
 	"test/extended/testdata/cmd/hack/lib/compress.awk": testExtendedTestdataCmdHackLibCompressAwk,
 	"test/extended/testdata/cmd/hack/lib/constants.sh": testExtendedTestdataCmdHackLibConstantsSh,
@@ -56976,6 +57243,20 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"django-postgresql.json": &bintree{testExtendedTestdataClusterQuickstartsDjangoPostgresqlJson, map[string]*bintree{}},
 						"nodejs-mongodb.json": &bintree{testExtendedTestdataClusterQuickstartsNodejsMongodbJson, map[string]*bintree{}},
 						"rails-postgresql.json": &bintree{testExtendedTestdataClusterQuickstartsRailsPostgresqlJson, map[string]*bintree{}},
+					}},
+				}},
+				"clusterlogging": &bintree{nil, map[string]*bintree{
+					"deployment": &bintree{nil, map[string]*bintree{
+						"01-clo-project.yaml": &bintree{testExtendedTestdataClusterloggingDeployment01CloProjectYaml, map[string]*bintree{}},
+						"01-eo-project.yaml": &bintree{testExtendedTestdataClusterloggingDeployment01EoProjectYaml, map[string]*bintree{}},
+						"02-clo-og.yaml": &bintree{testExtendedTestdataClusterloggingDeployment02CloOgYaml, map[string]*bintree{}},
+						"02-eo-og.yaml": &bintree{testExtendedTestdataClusterloggingDeployment02EoOgYaml, map[string]*bintree{}},
+						"04-clo-sub.yaml": &bintree{testExtendedTestdataClusterloggingDeployment04CloSubYaml, map[string]*bintree{}},
+						"04-eo-rbac.yaml": &bintree{testExtendedTestdataClusterloggingDeployment04EoRbacYaml, map[string]*bintree{}},
+						"05-eo-sub.yaml": &bintree{testExtendedTestdataClusterloggingDeployment05EoSubYaml, map[string]*bintree{}},
+					}},
+					"instances": &bintree{nil, map[string]*bintree{
+						"example.yaml": &bintree{testExtendedTestdataClusterloggingInstancesExampleYaml, map[string]*bintree{}},
 					}},
 				}},
 				"cmd": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/clusterlogging/deployment/01-clo-project.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/01-clo-project.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"

--- a/test/extended/testdata/clusterlogging/deployment/01-eo-project.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/01-eo-project.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"

--- a/test/extended/testdata/clusterlogging/deployment/02-clo-og.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/02-clo-og.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-logging-
+  namespace: openshift-logging
+  labels:
+    og_label: openshift-logging
+spec:
+  targetNamespaces:
+  - openshift-logging

--- a/test/extended/testdata/clusterlogging/deployment/02-eo-og.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/02-eo-og.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-operators-redhat-
+  namespace: openshift-operators-redhat
+  spec: {}

--- a/test/extended/testdata/clusterlogging/deployment/04-clo-sub.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/04-clo-sub.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging-operator
+  namespace: openshift-logging
+spec:
+  channel: preview
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/test/extended/testdata/clusterlogging/deployment/04-eo-rbac.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/04-eo-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators-redhat
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators-redhat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+namespace: openshift-operators-redhat

--- a/test/extended/testdata/clusterlogging/deployment/05-eo-sub.yaml
+++ b/test/extended/testdata/clusterlogging/deployment/05-eo-sub.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: preview
+  installPlanApproval: Automatic
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  name: elasticsearch-operator

--- a/test/extended/testdata/clusterlogging/instances/example.yaml
+++ b/test/extended/testdata/clusterlogging/instances/example.yaml
@@ -1,0 +1,29 @@
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: openshift-logging
+spec:
+  managementState: "Managed"
+  logStore:
+    type: "elasticsearch"
+    elasticsearch:
+      nodeCount: 1
+      resources:
+        requests:
+          cpu: 400m
+          memory: 2Gi
+      storage: {}
+      redundancyPolicy: "ZeroRedundancy"
+  visualization:
+    type: "kibana"
+    kibana:
+      replicas: 1
+  curation:
+    type: "curator"
+    curator:
+      schedule: "*/10 * * * *"
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd: {}


### PR DESCRIPTION
This PR is to add e2e test for cluster logging. @anpingli  @jcantrill @ewolinetz @richm  Could you please help to review it?

Logs:
started: (0/1/1) "[Feature:Logging][Serial] Logging Deploy Logging Via OLM:  should deploy logging successfully when using fluentd as logcollector [Suite:openshift/conformance/serial]"
......

passed: (5m19s) 2019-07-12T03:45:33 "[Feature:Logging][Serial] Logging Deploy Logging Via OLM:  should deploy logging successfully when using fluentd as logcollector [Suite:openshift/conformance/serial]"


Timeline:

Jul 12 03:40:31.320 I ns/openshift-logging clusterserviceversion/clusterlogging.4.1.4-201906271212 requirements not yet checked
Jul 12 03:40:31.357 I ns/openshift-logging clusterserviceversion/clusterlogging.4.1.4-201906271212 one or more requirements couldn't be found
Jul 12 03:40:31.468 I ns/openshift-logging clusterserviceversion/clusterlogging.4.1.4-201906271212 one or more requirements couldn't be found (2 times)
Jul 12 03:40:33.077 I ns/openshift-logging clusterserviceversion/clusterlogging.4.1.4-201906271212 all requirements found, attempting install
......
1 pass, 0 skip (5m19s)
