### PR TITLE
automate OLM test case OCP-24074

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -1,13 +1,13 @@
 package operators
 
 import (
-	"reflect"
-	"strings"
-
+	"fmt"
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	yaml "gopkg.in/yaml.v2"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"reflect"
+	"strings"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -61,6 +61,26 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 				e2e.Logf("%s apiVersion is correct.", k)
 			} else {
 				e2e.Failf("%s apiVersion is incorrect!", k)
+			}
+		})
+		g.It("check OLM's CRDs' version: "+k, func() {
+			var output string
+			var err error
+
+			if k == "packagemanifests" {
+				// packagemanifests is a resource created by Aggregation layer, not CRD.
+				output, err = oc.AsAdmin().Run("get").Args("apiservice", "v1.packages.operators.coreos.com", "-o=jsonpath={.spec.version}").Output()
+			} else {
+				output, err = oc.AsAdmin().Run("get").Args("crd", fmt.Sprintf("%s.operators.coreos.com", k), "-o=jsonpath={.spec.version}").Output()
+			}
+			if err != nil {
+				e2e.Failf("Unable to check %s CRD version, errors:%v", k, err)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if strings.HasSuffix(output, v) {
+				e2e.Logf("%s CRD version is correct.", k)
+			} else {
+				e2e.Failf("%s CRD version is incorrect!", k)
 			}
 		})
 	}


### PR DESCRIPTION
As title, automate [test case OCP-24074](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-24074).
@ecordell @njhale Could you help take a look at it? And, could you give approve if it looks good to you? Thanks!
cc @bandrade @scolange @cuipinghuo @emmajiafan @chengzhang1016 @zihantang-rh 
Logs as below:
```console
mac:origin jianzhang$ openshift-tests run all --dry-run | grep "\[Feature:Platform\] OLM should"  | openshift-tests run --junit-dir=./ -f -
I0620 18:05:02.132668   73378 trace.go:81] Trace[939984059]: "Reflector k8s.io/client-go/informers/factory.go:133 ListAndWatch" (started: 2019-06-20 18:04:51.05113 +0800 CST m=+0.645920637) (total time: 11.08123279s):
Trace[939984059]: [11.081046228s] [11.081046228s] Objects listed
started: (0/1/12) "[Feature:Platform] OLM should check API version: operatorgroups [Suite:openshift/conformance/parallel]"

started: (0/2/12) "[Feature:Platform] OLM should check API version: catalogsources [Suite:openshift/conformance/parallel]"

started: (0/3/12) "[Feature:Platform] OLM should list catalogsources [Suite:openshift/conformance/parallel]"

started: (0/4/12) "[Feature:Platform] OLM should check API version: subscriptions [Suite:openshift/conformance/parallel]"

started: (0/5/12) "[Feature:Platform] OLM should list subscriptions [Suite:openshift/conformance/parallel]"

started: (0/6/12) "[Feature:Platform] OLM should check API version: packagemanifests [Suite:openshift/conformance/parallel]"

started: (0/7/12) "[Feature:Platform] OLM should list clusterserviceversions [Suite:openshift/conformance/parallel]"

started: (0/8/12) "[Feature:Platform] OLM should list packagemanifests [Suite:openshift/conformance/parallel]"

started: (0/9/12) "[Feature:Platform] OLM should list operatorgroups [Suite:openshift/conformance/parallel]"

started: (0/10/12) "[Feature:Platform] OLM should check API version: installplans [Suite:openshift/conformance/parallel]"

passed: (28.2s) 2019-06-20T10:05:31 "[Feature:Platform] OLM should check API version: installplans [Suite:openshift/conformance/parallel]"

started: (0/11/12) "[Feature:Platform] OLM should check API version: clusterserviceversions [Suite:openshift/conformance/parallel]"

passed: (28.5s) 2019-06-20T10:05:31 "[Feature:Platform] OLM should list catalogsources [Suite:openshift/conformance/parallel]"

started: (0/12/12) "[Feature:Platform] OLM should list installplans [Suite:openshift/conformance/parallel]"

passed: (30s) 2019-06-20T10:05:32 "[Feature:Platform] OLM should check API version: subscriptions [Suite:openshift/conformance/parallel]"

passed: (32.1s) 2019-06-20T10:05:34 "[Feature:Platform] OLM should list packagemanifests [Suite:openshift/conformance/parallel]"

passed: (32.9s) 2019-06-20T10:05:35 "[Feature:Platform] OLM should check API version: catalogsources [Suite:openshift/conformance/parallel]"

passed: (33.4s) 2019-06-20T10:05:36 "[Feature:Platform] OLM should check API version: operatorgroups [Suite:openshift/conformance/parallel]"

passed: (34.5s) 2019-06-20T10:05:37 "[Feature:Platform] OLM should list subscriptions [Suite:openshift/conformance/parallel]"

passed: (34.8s) 2019-06-20T10:05:37 "[Feature:Platform] OLM should list clusterserviceversions [Suite:openshift/conformance/parallel]"

passed: (35.2s) 2019-06-20T10:05:38 "[Feature:Platform] OLM should list operatorgroups [Suite:openshift/conformance/parallel]"

passed: (39.4s) 2019-06-20T10:05:42 "[Feature:Platform] OLM should check API version: packagemanifests [Suite:openshift/conformance/parallel]"

passed: (36.3s) 2019-06-20T10:06:07 "[Feature:Platform] OLM should check API version: clusterserviceversions [Suite:openshift/conformance/parallel]"

passed: (36.6s) 2019-06-20T10:06:07 "[Feature:Platform] OLM should list installplans [Suite:openshift/conformance/parallel]"

Writing JUnit report to junit_e2e_20190620-100607.xml

12 pass, 0 skip (1m5s)
```