### PR TITLE
Bug 1717640: include cluster-storage-operator when testing status.relatedObjects

### DIFF
--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -26,7 +26,6 @@ var _ = g.Describe("[Feature:Platform] ClusterOperators", func() {
 		"network",
 		"operator-lifecycle-manager",
 		"operator-lifecycle-manager-catalog",
-		"storage",
 		"support",
 	)
 	whitelistNoOperatorConfig := sets.NewString(
@@ -39,7 +38,6 @@ var _ = g.Describe("[Feature:Platform] ClusterOperators", func() {
 		"node-tuning",
 		"operator-lifecycle-manager",
 		"operator-lifecycle-manager-catalog",
-		"storage",
 		"support",
 	)
 


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1717640
Related: https://github.com/openshift/cluster-storage-operator/pull/37

