### PR TITLE
Add suite for CSI tests

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -143,6 +143,14 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool { return strings.Contains(name, "[Suite:openshift/test-cmd]") },
 	},
 	{
+		Name: "openshift/csi",
+		Description: templates.LongDesc(`
+		Run tests for an installed CSI driver. TEST_CSI_DRIVER_FILES env. variable must be set and it must be a comma separated list of CSI driver definition files.
+        See https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/external/README.md for required format of the files.
+		`),
+		Matches: func(name string) bool { return strings.Contains(name, "[Suite:openshift/csi") },
+	},
+	{
 		Name: "all",
 		Description: templates.LongDesc(`
 		Run all tests.

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -484,6 +484,9 @@ var (
 		"[Suite:openshift/test-cmd]": {
 			`\[Suite:openshift/test-cmd\]`,
 		},
+		"[Suite:openshift/csi]": {
+			`External Storage \[Driver:`,
+		},
 	}
 
 	// labelExcludes temporarily block tests out of a specific suite

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/external/external.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/external/external.go
@@ -66,7 +66,14 @@ func (t testDriverParameter) String() string {
 }
 
 func (t testDriverParameter) Set(filename string) error {
-	driver, err := t.loadDriverDefinition(filename)
+	return AddDriverDefinition(filename)
+}
+
+// AddDriverDefinition defines ginkgo tests for CSI driver definition file.
+// Either --storage.testdriver cmdline argument or AddDriverDefinition can be used
+// to define the tests.
+func AddDriverDefinition(filename string) error {
+	driver, err := loadDriverDefinition(filename)
 	if err != nil {
 		return err
 	}
@@ -82,7 +89,7 @@ func (t testDriverParameter) Set(filename string) error {
 	return nil
 }
 
-func (t testDriverParameter) loadDriverDefinition(filename string) (*driverDefinition, error) {
+func loadDriverDefinition(filename string) (*driverDefinition, error) {
 	if filename == "" {
 		return nil, errors.New("missing file name")
 	}

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/external/external_test.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/external/external_test.go
@@ -64,7 +64,7 @@ func TestDriverParameter(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		actual, err := testDriverParameter{}.loadDriverDefinition(testcase.filename)
+		actual, err := loadDriverDefinition(testcase.filename)
 		if testcase.err == "" {
 			assert.NoError(t, err, testcase.name)
 		} else {


### PR DESCRIPTION
Goal: create test definitions for installed CSI driver.

Usage: `TEST_CSI_DRIVER_FILES=my-csi-driver.yaml openshift-tests run openshift/csi` in a custom prow job.

See  k8s.io/kubernetes/test/e2e/storage/external for yaml file definition and upstream usage
