### PR TITLE
remove TSB dependency from origin

### DIFF
--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -1,155 +1,124 @@
 [
   {
     "checkedPackageRoots": [
+      "github.com/openshift/origin/cmd",
       "github.com/openshift/origin/pkg"
     ],
     "ignoredSubTrees": [
-      "github.com/openshift/origin/pkg/cmd/server/start"
+      "github.com/openshift/origin/cmd/openshift-tests"
     ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-  {
-    "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-  {
-    "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
-    "ignoredSubTrees": [],
     "forbiddenImportPackageRoots": [
       "github.com/openshift/origin/test"
     ],
     "allowedImportPackageRoots": [
-      "vendor",
-      ""
+      "vendor"
     ]
   },
 
   {
     "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
+      "github.com/openshift/origin/cmd",
+      "github.com/openshift/origin/pkg",
+      "github.com/openshift/origin/test"
     ],
     "ignoredSubTrees": [
-      "github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver"
-    ],
-    "forbiddenImportPackageRoots": [
-      "github.com/openshift/openshift-apiserver"
-    ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-  {
-    "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
-    "ignoredSubTrees": [
-      "github.com/openshift/origin/pkg/authorization/apiserver/registry/subjectrulesreview",
-      "github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver",
-      "github.com/openshift/origin/pkg/cmd/openshift-apiserver/openshiftadmission",
-      "github.com/openshift/origin/pkg/cmd/openshift-apiserver/openshiftapiserver",
-      "github.com/openshift/origin/pkg/cmd/server/admission",
-      "github.com/openshift/origin/pkg/image/apiserver/admission/imagepolicy",
-      "github.com/openshift/origin/pkg/oauth/apiserver/registry/oauthclientauthorization",
-      "github.com/openshift/origin/pkg/project/apiserver/registry/project/proxy",
-      "github.com/openshift/origin/pkg/project/auth",
-      "github.com/openshift/origin/pkg/security/apis/security/v1",
-      "github.com/openshift/origin/pkg/security/apiserver"
-    ],
-    "forbiddenImportPackageRoots": [
-      "github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver"
-    ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-
-  {
-    "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-
-  {
-    "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
-    "ignoredSubTrees": [
-      "github.com/openshift/origin/pkg/cmd/openshift-kube-apiserver/openshiftkubeapiserver"
+      "github.com/openshift/origin/cmd/hypershift",
+      "github.com/openshift/origin/test/integration",
+      "github.com/openshift/origin/test/extended/bootstrap_user"
     ],
     "forbiddenImportPackageRoots": [
       "vendor/github.com/openshift/oauth-server"
     ],
     "allowedImportPackageRoots": [
-      "vendor",
-      ""
+      "vendor"
     ]
   },
 
   {
     "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
-    "ignoredSubTrees": [],
-    "forbiddenImportPackageRoots": [
-      "vendor/github.com/openshift/openshift-controller-manager"
-    ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-  {
-    "checkedPackageRoots": [
+      "github.com/openshift/origin/cmd",
       "github.com/openshift/origin/pkg",
       "github.com/openshift/origin/test"
     ],
-    "ignoredSubTrees": [],
-    "forbiddenImportPackageRoots": [
-      "vendor/github.com/openshift/sdn"
-    ],
-    "allowedImportPackageRoots": [
-      "vendor",
-      ""
-    ]
-  },
-
-  {
-    "checkedPackageRoots": [
-      "github.com/openshift/origin/pkg"
-    ],
     "ignoredSubTrees": [
-      "github.com/openshift/origin/pkg/cmd/openshift",
-      "github.com/openshift/origin/pkg/cmd/server/admin",
-      "github.com/openshift/origin/pkg/cmd/templates"
+      "github.com/openshift/origin/cmd/oc",
+      "github.com/openshift/origin/cmd/openshift-tests",
+      "github.com/openshift/origin/test/common/build",
+      "github.com/openshift/origin/test/extended",
+      "github.com/openshift/origin/test/integration",
+      "github.com/openshift/origin/test/util"
     ],
     "forbiddenImportPackageRoots": [
       "vendor/github.com/openshift/oc"
     ],
     "allowedImportPackageRoots": [
-      "vendor",
-      ""
+      "vendor"
+    ]
+  },
+
+  {
+    "checkedPackageRoots": [
+      "github.com/openshift/origin/cmd",
+      "github.com/openshift/origin/pkg",
+      "github.com/openshift/origin/test"
+    ],
+    "ignoredSubTrees": [
+      "github.com/openshift/origin/cmd/hypershift"
+    ],
+    "forbiddenImportPackageRoots": [
+      "github.com/openshift/openshift-apiserver"
+    ],
+    "allowedImportPackageRoots": [
+      "vendor"
+    ]
+  },
+
+  {
+    "checkedPackageRoots": [
+      "github.com/openshift/origin/cmd",
+      "github.com/openshift/origin/pkg"
+    ],
+    "ignoredSubTrees": [
+      "github.com/openshift/origin/cmd/hypershift",
+      "github.com/openshift/origin/cmd/openshift-tests"
+    ],
+    "forbiddenImportPackageRoots": [
+      "vendor/github.com/openshift/openshift-controller-manager"
+    ],
+    "allowedImportPackageRoots": [
+      "vendor"
+    ]
+  },
+
+  {
+    "checkedPackageRoots": [
+      "github.com/openshift/origin/cmd",
+      "github.com/openshift/origin/pkg",
+      "github.com/openshift/origin/test"
+    ],
+    "ignoredSubTrees": [
+      "github.com/openshift/origin/cmd/hypershift"
+    ],
+    "forbiddenImportPackageRoots": [
+      "vendor/github.com/openshift/sdn"
+    ],
+    "allowedImportPackageRoots": [
+      "vendor"
+    ]
+  },
+
+  {
+    "checkedPackageRoots": [
+      "github.com/openshift/origin/cmd",
+      "github.com/openshift/origin/pkg",
+      "github.com/openshift/origin/test"
+    ],
+    "ignoredSubTrees": [],
+    "forbiddenImportPackageRoots": [
+      "github.com/openshift/template-service-broker"
+    ],
+    "allowedImportPackageRoots": [
+      "vendor"
     ]
   },
 

--- a/hack/import-restrictions.json
+++ b/hack/import-restrictions.json
@@ -23,8 +23,7 @@
     ],
     "ignoredSubTrees": [
       "github.com/openshift/origin/cmd/hypershift",
-      "github.com/openshift/origin/test/integration",
-      "github.com/openshift/origin/test/extended/bootstrap_user"
+      "github.com/openshift/origin/test/integration"
     ],
     "forbiddenImportPackageRoots": [
       "vendor/github.com/openshift/oauth-server"

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -17,7 +17,7 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/openshift/openshift-controller-manager/pkg/template/controller"
-	osbclient "github.com/openshift/template-service-broker/pkg/openservicebroker/client"
+	osbclient "github.com/openshift/origin/test/extended/templates/openservicebroker/client"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )

--- a/test/extended/templates/openservicebroker/api/helpers.go
+++ b/test/extended/templates/openservicebroker/api/helpers.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func NewResponse(code int, body interface{}, err error) *Response {
+	return &Response{Code: code, Body: body, Err: err}
+}
+
+func BadRequest(err error) *Response {
+	return NewResponse(http.StatusBadRequest, nil, err)
+}
+
+func Forbidden(err error) *Response {
+	return NewResponse(http.StatusForbidden, nil, err)
+}
+
+func InternalServerError(err error) *Response {
+	return NewResponse(http.StatusInternalServerError, nil, err)
+}
+
+// TemplateInstanceRequester holds the identity of an agent requesting a
+// template instantiation.
+type TemplateInstanceRequester struct {
+	// username uniquely identifies this user among all active users.
+	Username string
+
+	// uid is a unique value that identifies this user across time; if this user is
+	// deleted and another user by the same name is added, they will have
+	// different UIDs.
+	UID string
+
+	// groups represent the groups this user is a part of.
+	Groups []string
+
+	// extra holds additional information provided by the authenticator.
+	Extra map[string]ExtraValue
+}
+
+// ExtraValue masks the value so protobuf can generate
+type ExtraValue []string
+
+// ConvertUserToTemplateInstanceRequester copies analogous fields from user.Info to TemplateInstanceRequester
+func ConvertUserToTemplateInstanceRequester(u user.Info) TemplateInstanceRequester {
+	templatereq := TemplateInstanceRequester{}
+
+	if u != nil {
+		extra := map[string]ExtraValue{}
+		if u.GetExtra() != nil {
+			for k, v := range u.GetExtra() {
+				extra[k] = ExtraValue(v)
+			}
+		}
+
+		templatereq.Username = u.GetName()
+		templatereq.UID = u.GetUID()
+		templatereq.Groups = u.GetGroups()
+		templatereq.Extra = extra
+	}
+
+	return templatereq
+}

--- a/test/extended/templates/openservicebroker/api/types.go
+++ b/test/extended/templates/openservicebroker/api/types.go
@@ -1,0 +1,208 @@
+package api
+
+// from https://github.com/openservicebrokerapi/servicebroker/blob/b33070e07cea53b9540b1d5ab8d1f62ddc556eb5/spec.md
+// and https://github.com/openservicebrokerapi/servicebroker/blob/b33070e07cea53b9540b1d5ab8d1f62ddc556eb5/profile.md
+// and https://github.com/avade/servicebroker/blob/9165f14ce6c54c3f81fba760cca53bd781febd6f/spec.md
+
+import (
+	jsschema "github.com/lestrrat/go-jsschema"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const (
+	XBrokerAPIVersion                   = "X-Broker-Api-Version"
+	APIVersion                          = "2.11"
+	XBrokerAPIOriginatingIdentity       = "X-Broker-API-Originating-Identity"
+	OriginatingIdentitySchemeKubernetes = "kubernetes"
+)
+
+type Service struct {
+	Name            string                 `json:"name"`
+	ID              string                 `json:"id"`
+	Description     string                 `json:"description"`
+	Tags            []string               `json:"tags,omitempty"`
+	Requires        []string               `json:"requires,omitempty"`
+	Bindable        bool                   `json:"bindable"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	DashboardClient *DashboardClient       `json:"dashboard_client,omitempty"`
+	PlanUpdatable   bool                   `json:"plan_updateable,omitempty"`
+	Plans           []Plan                 `json:"plans"`
+}
+
+type DashboardClient struct {
+	ID          string `json:"id"`
+	Secret      string `json:"secret"`
+	RedirectURI string `json:"redirect_uri"`
+}
+
+type Plan struct {
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	Free        bool                   `json:"free,omitempty"`
+	Bindable    bool                   `json:"bindable,omitempty"`
+	Schemas     Schema                 `json:"schemas,omitempty"`
+}
+
+type Schema struct {
+	ServiceInstance ServiceInstances `json:"service_instance,omitempty"`
+	ServiceBinding  ServiceBindings  `json:"service_binding,omitempty"`
+}
+
+type ServiceInstances struct {
+	Create map[string]*jsschema.Schema `json:"create,omitempty"`
+	Update map[string]*jsschema.Schema `json:"update,omitempty"`
+}
+
+type ServiceBindings struct {
+	Create map[string]*jsschema.Schema `json:"create,omitempty"`
+}
+
+// ParameterSchemas is an OpenShift extension to allow for form building
+// for provision/bind parameters.
+type ParameterSchemas struct {
+	ServiceInstance ParameterSchema `json:"service_instance,omitempty"`
+}
+
+type ParameterSchema struct {
+	Create OpenShiftMetadata `json:"create,omitempty"`
+}
+
+type OpenShiftMetadata struct {
+	OpenShiftFormDefinition []string `json:"openshift_form_definition,omitempty"`
+}
+
+type CatalogResponse struct {
+	Services []*Service `json:"services"`
+}
+
+type LastOperationResponse struct {
+	State       LastOperationState `json:"state"`
+	Description string             `json:"description,omitempty"`
+}
+
+type LastOperationState string
+
+const (
+	LastOperationStateInProgress LastOperationState = "in progress"
+	LastOperationStateSucceeded  LastOperationState = "succeeded"
+	LastOperationStateFailed     LastOperationState = "failed"
+)
+
+type ProvisionRequest struct {
+	ServiceID      string            `json:"service_id"`
+	PlanID         string            `json:"plan_id"`
+	Context        KubernetesContext `json:"context,omitempty"`
+	OrganizationID string            `json:"organization_guid"`
+	SpaceID        string            `json:"space_guid"`
+	Parameters     map[string]string `json:"parameters,omitempty"`
+}
+
+type KubernetesContext struct {
+	Platform  string `json:"platform"`
+	Namespace string `json:"namespace"`
+}
+
+const ContextPlatformKubernetes = "kubernetes"
+
+type ProvisionResponse struct {
+	DashboardURL string    `json:"dashboard_url,omitempty"`
+	Operation    Operation `json:"operation,omitempty"`
+}
+
+type Operation string
+
+type UpdateRequest struct {
+	Context        KubernetesContext `json:"context,omitempty"`
+	ServiceID      string            `json:"service_id"`
+	PlanID         string            `json:"plan_id,omitempty"`
+	Parameters     map[string]string `json:"parameters,omitempty"`
+	PreviousValues struct {
+		ServiceID      string `json:"service_id,omitempty"`
+		PlanID         string `json:"plan_id,omitempty"`
+		OrganizationID string `json:"organization_id,omitempty"`
+		SpaceID        string `json:"space_id,omitempty"`
+	} `json:"previous_values,omitempty"`
+}
+
+type UpdateResponse struct {
+	Operation Operation `json:"operation,omitempty"`
+}
+
+type BindRequest struct {
+	ServiceID    string `json:"service_id"`
+	PlanID       string `json:"plan_id"`
+	AppGUID      string `json:"app_guid,omitempty"`
+	BindResource struct {
+		AppGUID string `json:"app_guid,omitempty"`
+		Route   string `json:"route,omitempty"`
+	} `json:"bind_resource,omitempty"`
+	Parameters map[string]string `json:"parameters,omitempty"`
+}
+
+type BindResponse struct {
+	Credentials     map[string]interface{} `json:"credentials,omitempty"`
+	SyslogDrainURL  string                 `json:"syslog_drain_url,omitempty"`
+	RouteServiceURL string                 `json:"route_service_url,omitempty"`
+	VolumeMounts    []interface{}          `json:"volume_mounts,omitempty"`
+}
+
+type UnbindResponse struct {
+}
+
+type DeprovisionResponse struct {
+	Operation Operation `json:"operation,omitempty"`
+}
+
+type ErrorResponse struct {
+	Error       string `json:"error,omitempty"`
+	Description string `json:"description"`
+}
+
+var AsyncRequired = ErrorResponse{
+	Error:       "AsyncRequired",
+	Description: "This request requires client support for asynchronous service operations.",
+}
+
+var ConcurrencyError = ErrorResponse{
+	Error:       "ConcurrencyError",
+	Description: "Another operation for this Service Instance is in progress.",
+}
+
+// from http://docs.cloudfoundry.org/services/catalog-metadata.html#services-metadata-fields
+
+const (
+	ServiceMetadataDisplayName         = "displayName"
+	ServiceMetadataImageURL            = "imageUrl"
+	ServiceMetadataLongDescription     = "longDescription"
+	ServiceMetadataProviderDisplayName = "providerDisplayName"
+	ServiceMetadataDocumentationURL    = "documentationUrl"
+	ServiceMetadataSupportURL          = "supportUrl"
+)
+
+// the types below are not specified in the openservicebrokerapi spec
+
+type Response struct {
+	Code int
+	Body interface{}
+	Err  error
+}
+
+type Broker interface {
+	Catalog() *Response
+	Provision(u user.Info, instanceID string, preq *ProvisionRequest) *Response
+	Deprovision(u user.Info, instanceID string) *Response
+	Bind(u user.Info, instanceID string, bindingID string, breq *BindRequest) *Response
+	Unbind(u user.Info, instanceID string, bindingID string) *Response
+	LastOperation(u user.Info, instanceID string, operation Operation) *Response
+}
+
+const (
+	OperationProvisioning   Operation = "provisioning"
+	OperationUpdating       Operation = "updating"
+	OperationDeprovisioning Operation = "deprovisioning"
+)
+
+// OpenServiceBrokerInstanceExternalID is a common, optional annotation that stores the OSBAPI instance (UU)ID associated with an object.
+const OpenServiceBrokerInstanceExternalID = "openservicebroker.openshift.io/instance-external-id"

--- a/test/extended/templates/openservicebroker/api/validation.go
+++ b/test/extended/templates/openservicebroker/api/validation.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var uuidRegex = regexp.MustCompile("^(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+func ValidateUUID(path *field.Path, uuid string) field.ErrorList {
+	if uuidRegex.MatchString(uuid) {
+		return nil
+	}
+	return field.ErrorList{field.Invalid(path, uuid, "must be a valid UUID")}
+}

--- a/test/extended/templates/openservicebroker/api/validation_test.go
+++ b/test/extended/templates/openservicebroker/api/validation_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const validUUID = "fe6e44ea-377a-457c-9fa1-ba06ad356839"
+
+func TestValidateUUID(t *testing.T) {
+	tests := []struct {
+		name        string
+		uuid        string
+		expectError string
+	}{
+		{
+			name:        "empty UUID",
+			uuid:        "",
+			expectError: `uuid: Invalid value: "": must be a valid UUID`,
+		},
+		{
+			name:        "bad UUID",
+			uuid:        "bad",
+			expectError: `uuid: Invalid value: "bad": must be a valid UUID`,
+		},
+		{
+			name:        "good",
+			uuid:        validUUID,
+			expectError: ``,
+		},
+	}
+
+	for _, test := range tests {
+		errors := ValidateUUID(field.NewPath("uuid"), test.uuid)
+		if test.expectError == "" {
+			if len(errors) > 0 {
+				t.Errorf("%q: expectError was %q but errors was %q", test.name, test.expectError, errors)
+			}
+		} else {
+			found := false
+			for _, err := range errors {
+				if err.Error() == test.expectError {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%q: expectError was %q but errors was %q", test.name, test.expectError, errors)
+			}
+		}
+	}
+}

--- a/test/extended/templates/openservicebroker/client/client.go
+++ b/test/extended/templates/openservicebroker/client/client.go
@@ -1,0 +1,402 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	openservicebrokerapi "github.com/openshift/origin/test/extended/templates/openservicebroker/api"
+)
+
+type Client interface {
+	Client() *http.Client
+
+	Catalog(ctx context.Context) (*openservicebrokerapi.CatalogResponse, error)
+	Provision(ctx context.Context, u user.Info, instanceID string, preq *openservicebrokerapi.ProvisionRequest) (*openservicebrokerapi.ProvisionResponse, error)
+	Deprovision(ctx context.Context, u user.Info, instanceID string) error
+	Bind(ctx context.Context, u user.Info, instanceID, bindingID string, breq *openservicebrokerapi.BindRequest) (*openservicebrokerapi.BindResponse, error)
+	Unbind(ctx context.Context, u user.Info, instanceID, bindingID string) error
+}
+
+type client struct {
+	cli  *http.Client
+	root string
+}
+
+func NewClient(cli *http.Client, root string) Client {
+	return &client{cli: cli, root: root}
+}
+
+type ServerError struct {
+	StatusCode  int
+	Description string
+}
+
+func (e *ServerError) Error() string {
+	return fmt.Sprintf("%s: %s", http.StatusText(e.StatusCode), e.Description)
+}
+
+func newServerError(statusCode int, description string) error {
+	return &ServerError{StatusCode: statusCode, Description: description}
+}
+
+func (c *client) Client() *http.Client {
+	return c.cli
+}
+
+func OriginatingIdentityHeader(u user.Info) (string, error) {
+	templatereq := openservicebrokerapi.ConvertUserToTemplateInstanceRequester(u)
+
+	b, err := json.Marshal(&templatereq)
+	if err != nil {
+		return "", err
+	}
+	encodeVal := base64.StdEncoding.EncodeToString(b)
+	return openservicebrokerapi.OriginatingIdentitySchemeKubernetes + " " + encodeVal, nil
+}
+
+func (c *client) Catalog(ctx context.Context) (*openservicebrokerapi.CatalogResponse, error) {
+	req, err := http.NewRequest(http.MethodGet, c.root+"/v2/catalog", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add(openservicebrokerapi.XBrokerAPIVersion, openservicebrokerapi.APIVersion)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return nil, newServerError(resp.StatusCode, "invalid content type")
+	}
+
+	d := json.NewDecoder(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		var r *openservicebrokerapi.CatalogResponse
+		err = d.Decode(&r)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	var r *openservicebrokerapi.ErrorResponse
+	err = d.Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+	return nil, newServerError(resp.StatusCode, r.Description)
+}
+
+func (c *client) Provision(ctx context.Context, u user.Info, instanceID string, preq *openservicebrokerapi.ProvisionRequest) (*openservicebrokerapi.ProvisionResponse, error) {
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("instanceID"), instanceID); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		e := json.NewEncoder(pw)
+		pw.CloseWithError(e.Encode(preq))
+	}()
+
+	req, err := http.NewRequest(http.MethodPut, c.root+"/v2/service_instances/"+instanceID+"?accepts_incomplete=true", pr)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add(openservicebrokerapi.XBrokerAPIVersion, openservicebrokerapi.APIVersion)
+	req.Header.Add("Content-Type", "application/json")
+
+	identity, err := OriginatingIdentityHeader(u)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(openservicebrokerapi.XBrokerAPIOriginatingIdentity, identity)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return nil, newServerError(resp.StatusCode, "invalid content type")
+	}
+
+	d := json.NewDecoder(resp.Body)
+	if resp.StatusCode == http.StatusCreated ||
+		resp.StatusCode == http.StatusOK ||
+		resp.StatusCode == http.StatusAccepted {
+		var r *openservicebrokerapi.ProvisionResponse
+		err = d.Decode(&r)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusAccepted {
+			var state openservicebrokerapi.LastOperationState
+			state, err = c.WaitForOperation(ctx, u, instanceID, r.Operation)
+			if err != nil {
+				return nil, err
+			}
+			if state != openservicebrokerapi.LastOperationStateSucceeded {
+				return nil, fmt.Errorf("operation returned state %s", string(state))
+			}
+		}
+
+		return r, nil
+	}
+
+	var r *openservicebrokerapi.ErrorResponse
+	err = d.Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+	return nil, newServerError(resp.StatusCode, r.Description)
+}
+
+func (c *client) Deprovision(ctx context.Context, u user.Info, instanceID string) error {
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("instanceID"), instanceID); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, c.root+"/v2/service_instances/"+instanceID+"?accepts_incomplete=true", nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add(openservicebrokerapi.XBrokerAPIVersion, openservicebrokerapi.APIVersion)
+
+	identity, err := OriginatingIdentityHeader(u)
+	if err != nil {
+		return err
+	}
+	req.Header.Add(openservicebrokerapi.XBrokerAPIOriginatingIdentity, identity)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return newServerError(resp.StatusCode, "invalid content type")
+	}
+
+	d := json.NewDecoder(resp.Body)
+	if resp.StatusCode == http.StatusOK ||
+		resp.StatusCode == http.StatusAccepted ||
+		resp.StatusCode == http.StatusGone {
+		var r *openservicebrokerapi.DeprovisionResponse
+		err = d.Decode(&r)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode == http.StatusAccepted {
+			var state openservicebrokerapi.LastOperationState
+			state, err = c.WaitForOperation(ctx, u, instanceID, r.Operation)
+			if err != nil {
+				return err
+			}
+			if state != openservicebrokerapi.LastOperationStateSucceeded {
+				return fmt.Errorf("operation returned state %s", string(state))
+			}
+		}
+
+		return nil
+	}
+
+	var r *openservicebrokerapi.ErrorResponse
+	err = d.Decode(&r)
+	if err != nil {
+		return err
+	}
+	return newServerError(resp.StatusCode, r.Description)
+}
+
+func (c *client) LastOperation(ctx context.Context, u user.Info, instanceID string, operation openservicebrokerapi.Operation) (*openservicebrokerapi.LastOperationResponse, error) {
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("instanceID"), instanceID); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.root+"/v2/service_instances/"+instanceID+"/last_operation?operation="+string(operation), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add(openservicebrokerapi.XBrokerAPIVersion, openservicebrokerapi.APIVersion)
+
+	identity, err := OriginatingIdentityHeader(u)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(openservicebrokerapi.XBrokerAPIOriginatingIdentity, identity)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return nil, newServerError(resp.StatusCode, "invalid content type")
+	}
+
+	d := json.NewDecoder(resp.Body)
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusGone {
+		var r *openservicebrokerapi.LastOperationResponse
+		err = d.Decode(&r)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	var r *openservicebrokerapi.ErrorResponse
+	err = d.Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+	return nil, newServerError(resp.StatusCode, r.Description)
+}
+
+func (c *client) WaitForOperation(ctx context.Context, u user.Info, instanceID string, operation openservicebrokerapi.Operation) (openservicebrokerapi.LastOperationState, error) {
+	done := ctx.Done()
+	for {
+		op, err := c.LastOperation(ctx, u, instanceID, operation)
+		if err != nil {
+			return openservicebrokerapi.LastOperationStateFailed, err
+		}
+
+		if op.State != openservicebrokerapi.LastOperationStateInProgress {
+			return op.State, nil
+		}
+
+		select {
+		case <-done:
+			return openservicebrokerapi.LastOperationStateFailed, ctx.Err()
+		default:
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (c *client) Bind(ctx context.Context, u user.Info, instanceID, bindingID string, breq *openservicebrokerapi.BindRequest) (*openservicebrokerapi.BindResponse, error) {
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("instanceID"), instanceID); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("bindingID"), bindingID); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		e := json.NewEncoder(pw)
+		pw.CloseWithError(e.Encode(breq))
+	}()
+
+	req, err := http.NewRequest(http.MethodPut, c.root+"/v2/service_instances/"+instanceID+"/service_bindings/"+bindingID, pr)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add(openservicebrokerapi.XBrokerAPIVersion, openservicebrokerapi.APIVersion)
+	req.Header.Add("Content-Type", "application/json")
+
+	identity, err := OriginatingIdentityHeader(u)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(openservicebrokerapi.XBrokerAPIOriginatingIdentity, identity)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return nil, newServerError(resp.StatusCode, "invalid content type")
+	}
+
+	d := json.NewDecoder(resp.Body)
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		var r *openservicebrokerapi.BindResponse
+		err = d.Decode(&r)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	var r *openservicebrokerapi.ErrorResponse
+	err = d.Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+	return nil, newServerError(resp.StatusCode, r.Description)
+}
+
+func (c *client) Unbind(ctx context.Context, u user.Info, instanceID, bindingID string) error {
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("instanceID"), instanceID); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+
+	if errs := openservicebrokerapi.ValidateUUID(field.NewPath("bindingID"), bindingID); len(errs) > 0 {
+		return errs.ToAggregate()
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, c.root+"/v2/service_instances/"+instanceID+"/service_bindings/"+bindingID, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add(openservicebrokerapi.XBrokerAPIVersion, openservicebrokerapi.APIVersion)
+
+	identity, err := OriginatingIdentityHeader(u)
+	if err != nil {
+		return err
+	}
+	req.Header.Add(openservicebrokerapi.XBrokerAPIOriginatingIdentity, identity)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return newServerError(resp.StatusCode, "invalid content type")
+	}
+
+	d := json.NewDecoder(resp.Body)
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusGone {
+		var r *openservicebrokerapi.UnbindResponse
+		err = d.Decode(&r)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	var r *openservicebrokerapi.ErrorResponse
+	err = d.Decode(&r)
+	if err != nil {
+		return err
+	}
+	return newServerError(resp.StatusCode, r.Description)
+}

--- a/test/extended/templates/templateservicebroker_bind.go
+++ b/test/extended/templates/templateservicebroker_bind.go
@@ -17,8 +17,8 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	authorizationv1 "github.com/openshift/api/authorization/v1"
-	"github.com/openshift/template-service-broker/pkg/openservicebroker/api"
-	"github.com/openshift/template-service-broker/pkg/openservicebroker/client"
+	"github.com/openshift/origin/test/extended/templates/openservicebroker/api"
+	"github.com/openshift/origin/test/extended/templates/openservicebroker/client"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )

--- a/test/extended/templates/templateservicebroker_e2e.go
+++ b/test/extended/templates/templateservicebroker_e2e.go
@@ -28,8 +28,8 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/openshift/library-go/pkg/template/templateprocessingclient"
 	templatecontroller "github.com/openshift/openshift-controller-manager/pkg/template/controller"
-	"github.com/openshift/template-service-broker/pkg/openservicebroker/api"
-	"github.com/openshift/template-service-broker/pkg/openservicebroker/client"
+	"github.com/openshift/origin/test/extended/templates/openservicebroker/api"
+	"github.com/openshift/origin/test/extended/templates/openservicebroker/client"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/util/server/deprecated_openshift/deprecatedclient"

--- a/test/extended/templates/templateservicebroker_security.go
+++ b/test/extended/templates/templateservicebroker_security.go
@@ -19,8 +19,8 @@ import (
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	userv1 "github.com/openshift/api/user/v1"
-	"github.com/openshift/template-service-broker/pkg/openservicebroker/api"
-	"github.com/openshift/template-service-broker/pkg/openservicebroker/client"
+	"github.com/openshift/origin/test/extended/templates/openservicebroker/api"
+	"github.com/openshift/origin/test/extended/templates/openservicebroker/client"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )


### PR DESCRIPTION
this copies an API and client to the e2e tests so that we no longer carry a direct TSB dependency.  It tightens and simplifies the verify-imports further to continue restricting what we can rely upon.

/assign @mfojtik 