### PR TITLE
images/kube-proxy: copy iptables wrapper scripts from sdn

### DIFF
--- a/images/kube-proxy/Dockerfile.rhel
+++ b/images/kube-proxy/Dockerfile.rhel
@@ -4,13 +4,13 @@ RUN INSTALL_PKGS="conntrack-tools" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*
 
-COPY ./images/sdn/scripts/iptables /usr/sbin/
-COPY ./images/sdn/scripts/iptables-save /usr/sbin/
-COPY ./images/sdn/scripts/iptables-restore /usr/sbin/
-COPY ./images/sdn/scripts/ip6tables /usr/sbin/
-COPY ./images/sdn/scripts/ip6tables-save /usr/sbin/
-COPY ./images/sdn/scripts/ip6tables-restore /usr/sbin/
-COPY ./images/sdn/scripts/iptables /usr/sbin/
+COPY ./images/kube-proxy/scripts/iptables /usr/sbin/
+COPY ./images/kube-proxy/scripts/iptables-save /usr/sbin/
+COPY ./images/kube-proxy/scripts/iptables-restore /usr/sbin/
+COPY ./images/kube-proxy/scripts/ip6tables /usr/sbin/
+COPY ./images/kube-proxy/scripts/ip6tables-save /usr/sbin/
+COPY ./images/kube-proxy/scripts/ip6tables-restore /usr/sbin/
+COPY ./images/kube-proxy/scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="Kubernetes kube-proxy" \
       io.k8s.description="Provides kube-proxy for external CNI plugins" \

--- a/images/kube-proxy/scripts/ip6tables
+++ b/images/kube-proxy/scripts/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables "$@"

--- a/images/kube-proxy/scripts/ip6tables-restore
+++ b/images/kube-proxy/scripts/ip6tables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/images/kube-proxy/scripts/ip6tables-save
+++ b/images/kube-proxy/scripts/ip6tables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/images/kube-proxy/scripts/iptables
+++ b/images/kube-proxy/scripts/iptables
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables "$@"

--- a/images/kube-proxy/scripts/iptables-restore
+++ b/images/kube-proxy/scripts/iptables-restore
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/images/kube-proxy/scripts/iptables-save
+++ b/images/kube-proxy/scripts/iptables-save
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
Turns out using the scripts from sdn works in OSBS but not ART, huh.