### PR TITLE
Ignore ssh bastion namespace when checking for images

### DIFF
--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -28,7 +28,7 @@ var _ = Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 		// a pod in a namespace that begins with kube-* or openshift-* must come from our release payload
 		// TODO components in openshift-operators may not come from our payload, may want to weaken restriction
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
-		excludeNamespaces := sets.NewString("openshift-marketplace", "openshift-operator-lifecycle-manager")
+		excludeNamespaces := sets.NewString("openshift-marketplace", "openshift-operator-lifecycle-manager", sshBastionNamespace)
 		excludePodPrefix := sets.NewString("revision-pruner-", "installer-")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces


### PR DESCRIPTION
Some tests need ssh bastion and they set KUBE_SSH_BASTION env. variable. The bastion uses image from quay.io/eparis and thus it should be skipped.

Fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=1711600

Related to https://github.com/openshift/release/pull/4161, https://github.com/openshift/origin/pull/22966.

@derekwaynecarr, PTAL