### PR TITLE
snip easy openshift-apiserver test deps

### DIFF
--- a/test/extended/authorization/rolebinding_restrictions.go
+++ b/test/extended/authorization/rolebinding_restrictions.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	authorizationv1 "github.com/openshift/api/authorization/v1"
-	authorizationapi "github.com/openshift/openshift-apiserver/pkg/authorization/apis/authorization"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -150,7 +149,7 @@ func generateRolebinding(ns, user, rb string) *authorizationv1.RoleBinding {
 		},
 		Subjects: []corev1.ObjectReference{
 			{
-				Kind:      authorizationapi.UserKind,
+				Kind:      authorizationv1.UserKind,
 				Namespace: ns,
 				Name:      user,
 			},

--- a/test/integration/authorization_test.go
+++ b/test/integration/authorization_test.go
@@ -34,7 +34,6 @@ import (
 	authorizationv1typedclient "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
 	projectv1client "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/oc/pkg/cli/admin/policy"
-	"github.com/openshift/openshift-apiserver/pkg/api/legacy"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -128,20 +127,20 @@ func TestClusterReaderCoverage(t *testing.T) {
 	}
 
 	escalatingResources := map[schema.GroupResource]bool{
-		oauth.Resource("oauthauthorizetokens"):  true,
-		oauth.Resource("oauthaccesstokens"):     true,
-		oauth.Resource("oauthclients"):          true,
-		image.Resource("imagestreams/secrets"):  true,
-		corev1.Resource("secrets"):              true,
-		corev1.Resource("pods/exec"):            true,
-		corev1.Resource("pods/proxy"):           true,
-		corev1.Resource("pods/portforward"):     true,
-		corev1.Resource("nodes/proxy"):          true,
-		corev1.Resource("services/proxy"):       true,
-		legacy.Resource("oauthauthorizetokens"): true,
-		legacy.Resource("oauthaccesstokens"):    true,
-		legacy.Resource("oauthclients"):         true,
-		legacy.Resource("imagestreams/secrets"): true,
+		oauth.Resource("oauthauthorizetokens"): true,
+		oauth.Resource("oauthaccesstokens"):    true,
+		oauth.Resource("oauthclients"):         true,
+		image.Resource("imagestreams/secrets"): true,
+		corev1.Resource("secrets"):             true,
+		corev1.Resource("pods/exec"):           true,
+		corev1.Resource("pods/proxy"):          true,
+		corev1.Resource("pods/portforward"):    true,
+		corev1.Resource("nodes/proxy"):         true,
+		corev1.Resource("services/proxy"):      true,
+		{Resource: "oauthauthorizetokens"}:     true,
+		{Resource: "oauthaccesstokens"}:        true,
+		{Resource: "oauthclients"}:             true,
+		{Resource: "imagestreams/secrets"}:     true,
 	}
 
 	readerRole, err := rbacv1client.NewForConfigOrDie(clusterAdminClientConfig).ClusterRoles().Get("cluster-reader", metav1.GetOptions{})

--- a/test/integration/deploy_defaults_test.go
+++ b/test/integration/deploy_defaults_test.go
@@ -13,8 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	_ "github.com/openshift/openshift-apiserver/pkg/apps/apis/apps/install"
 )
 
 var (

--- a/test/integration/front_proxy_test.go
+++ b/test/integration/front_proxy_test.go
@@ -23,7 +23,6 @@ import (
 	authorizationv1client "github.com/openshift/client-go/authorization/clientset/versioned"
 	projectv1client "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/library-go/pkg/crypto"
-	authorizationapi "github.com/openshift/openshift-apiserver/pkg/authorization/apis/authorization"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 	"github.com/openshift/origin/test/util/server/deprecated_openshift/apis/config"
@@ -117,7 +116,7 @@ func TestFrontProxy(t *testing.T) {
 			&authorizationv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: username + "-clusterrolebinding"},
 				Subjects: []corev1.ObjectReference{
-					{Kind: authorizationapi.UserKind, Name: username},
+					{Kind: authorizationv1.UserKind, Name: username},
 				},
 				RoleRef: corev1.ObjectReference{Name: listProjectsRoleName},
 			},

--- a/test/integration/image_layers_mocks.go
+++ b/test/integration/image_layers_mocks.go
@@ -1,0 +1,175 @@
+package integration
+
+import (
+	"fmt"
+)
+
+// InternalRegistryURL is an url of internal docker registry for testing purposes.
+const InternalRegistryURL = "172.30.12.34:5000"
+
+// MakeDockerImageReference makes a docker image reference string referencing testing internal docker
+// registry.
+func MakeDockerImageReference(ns, isName, imageID string) string {
+	return fmt.Sprintf("%s/%s/%s@%s", InternalRegistryURL, ns, isName, imageID)
+}
+
+// 1 data layer of 128 B
+const BaseImageWith1LayerDigest = `sha256:c5207ce0f38da269ad2e58f143b5ea4b314c75ce1121384369f0db9015e10e82`
+const BaseImageWith1Layer = `{
+   "schemaVersion": 1,
+   "name": "miminar/baseImageWith1Layer",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+		  "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:d4994ff5bda31913c54af389d68d27418b294cde415cb41282b513900bd11f1e\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"container\":\"99664df33257d325a5d3c082e72a5b6bf86adf1d4e75af6c5a5c4cdaab1fac58\",\"container_config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"],\"Image\":\"sha256:d4994ff5bda31913c54af389d68d27418b294cde415cb41282b513900bd11f1e\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"created\":\"2016-02-15T07:30:37.655693399Z\",\"docker_version\":\"1.10.0\",\"id\":\"3303329125f4954da646b116f6e4a7e40d03656d4802340d46aca8a473d9c3e4\",\"os\":\"linux\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// 2 data layers, the first is shared with baseImageWith1Layer, total size of 240 B
+const BaseImageWith2LayersDigest = "sha256:77371f61c054608a4bb1a96b99f9be69f0868340f5c924ecd8813172f7cf853d"
+const BaseImageWith2Layers = `{
+   "schemaVersion": 1,
+   "name": "miminar/baseImageWith2Layers",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:e7900a2e6943680b384950859a0616089757cae4d8c6e98db9cfec6c41fe2834"
+      },
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+          "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:356b1cbd1af67cfa316c7066895954a69865b972abe680942c123e8bfbbd7458\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"container\":\"686b99d75c4a744420c9a6bf9d3ba2548e72462e4719c8202878315f48083b2c\",\"container_config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:23d2e6ff1c67ff4caee900c71d58df6e37bfb9defe46085018c4ba29c3d2de5a in /data2\"],\"Image\":\"sha256:356b1cbd1af67cfa316c7066895954a69865b972abe680942c123e8bfbbd7458\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"created\":\"2016-02-15T07:31:50.390272025Z\",\"docker_version\":\"1.10.0\",\"id\":\"61c8a7f2be3a9b6fcd46f24da46eedfd37200b0d067d487595942b5b8bacbce7\",\"os\":\"linux\",\"parent\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"size\":112}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.655693399Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"]},\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// based on baseImageWith1Layer, it adds a new data layer of 126 B
+const ChildImageWith2LayersDigest = "sha256:a9f073fbf2c9835711acd09081d87f5b7129ac6269e0df834240000f48abecd4"
+const ChildImageWith2Layers = `{
+   "schemaVersion": 1,
+   "name": "miminar/childImageWith2Layers",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:766b6e9134dc2819fae9c5e67d39e14272948bc8967df9a119418cca84cab089"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+          "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:27bc5bf237c48c2b41b0636a3876960a9adb6c2ac9ff95ac879d56b1046ba5a1\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"container\":\"c2d2505e43f4fd479aa21d356270d0791633e838284d7010cba1f61992907c69\",\"container_config\":{\"Hostname\":\"d7b63ae1152b\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:859e4175fd5743f276905245e351272b425232cfd3b30a3fc6bff351da308996 in /data3\"],\"Image\":\"sha256:27bc5bf237c48c2b41b0636a3876960a9adb6c2ac9ff95ac879d56b1046ba5a1\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"created\":\"2016-02-15T07:33:17.59074814Z\",\"docker_version\":\"1.10.0\",\"id\":\"e6a8e2793d6cad7d503aa5a3b55fd2c19b3b190d480a175b21d5f7b50c86d27b\",\"os\":\"linux\",\"parent\":\"84dc393745ff2631760c4bdbf1168af188fcd4606c1400c6900487fdc75a9ed5\",\"size\":126}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"84dc393745ff2631760c4bdbf1168af188fcd4606c1400c6900487fdc75a9ed5\",\"parent\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"created\":\"2016-02-15T07:33:17.454934648Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.655693399Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"]},\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// based on baseImageWith2Layers, it adds a new data layer of 70 B
+const ChildImageWith3LayersDigest = "sha256:2282a6d553353756fa43ba8672807d3fe81f8fdef54b0f6a360d64aaef2f243a"
+const ChildImageWith3Layers = `{
+   "schemaVersion": 1,
+   "name": "miminar/childImageWith3Layers",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:77ef66f4abb43c5e17bcacdfe744f6959365f6244b66a6565470083fbdd15178"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:e7900a2e6943680b384950859a0616089757cae4d8c6e98db9cfec6c41fe2834"
+      },
+      {
+         "blobSum": "sha256:2d099e04ef6c850542d8ab916df2e9417cc799d39b78f64440e51402f1261a36"
+      },
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"architecture\":\"amd64\",\"author\":\"miminar@redhat.com\",\"config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":null,\"Image\":\"sha256:8b0241d44c66c1bcf48c66d0465ee6bf6ac2117e9936a9ec2337122e08d109ef\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"container\":\"61c9522f27b7052081b61b72d70dd71ce7050566812f050158e03954b493e446\",\"container_config\":{\"Hostname\":\"686b99d75c4a\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) COPY file:7781db9ed3a36b0607009b073a99802a9ad834bbb5e3bcbcf83a7d27146a1a5b in /data4\"],\"Image\":\"sha256:8b0241d44c66c1bcf48c66d0465ee6bf6ac2117e9936a9ec2337122e08d109ef\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":[],\"Labels\":{}},\"created\":\"2016-02-15T07:36:13.703778299Z\",\"docker_version\":\"1.10.0\",\"id\":\"8e7b1ec73ed1d21747991c2101d1db51e97c4f62931bbaa575aeba11286d6748\",\"os\":\"linux\",\"parent\":\"fbe31426cd0e8c5545ddc5c8318499682d52ff96118e36e49616ac3aee32c47c\",\"size\":70}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"fbe31426cd0e8c5545ddc5c8318499682d52ff96118e36e49616ac3aee32c47c\",\"parent\":\"9b1154060650718a3850e625464addb217c1064f18dd693cf635dfcabdc9de50\",\"created\":\"2016-02-15T07:36:13.585345649Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"9b1154060650718a3850e625464addb217c1064f18dd693cf635dfcabdc9de50\",\"parent\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"created\":\"2016-02-15T07:31:50.390272025Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:23d2e6ff1c67ff4caee900c71d58df6e37bfb9defe46085018c4ba29c3d2de5a in /data2\"]},\"size\":112}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"1620fdccc2424391c3422467cec611bc32767d5bfae5bd8a2fb53c795e2a3e86\",\"parent\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.655693399Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:90583fd8c765e40f7f2070c55da446e138b019b0712dee898d8193b66b05d48d in /data1\"]},\"size\":128}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"3690474eb5b4b26fdfbd89c6e159e8cc376ca76ef48032a30fa6aafd56337880\",\"created\":\"2016-02-15T07:30:37.531741167Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) MAINTAINER miminar@redhat.com\"]},\"throwaway\":true}"
+      }
+   ]
+}`
+
+// another base image with unique data layer of 554 B
+const MiscImageDigest = "sha256:2643199e5ed5047eeed22da854748ed88b3a63ba0497601ba75852f7b92d4640"
+const MiscImage = `{
+   "schemaVersion": 1,
+   "name": "miminar/misc",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {
+         "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+      },
+      {
+         "blobSum": "sha256:eeee0535bf3cec7a24bff2c6e97481afa3d37e2cdeff277c57cb5cbdb2fa9e92"
+      }
+   ],
+   "history": [
+      {
+         "v1Compatibility": "{\"id\":\"964092b7f3e54185d3f425880be0b022bfc9a706701390e0ceab527c84dea3e3\",\"parent\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"created\":\"2016-01-15T18:06:41.282540103Z\",\"container\":\"4e937d31f242d087cce0ec5b9fdbceaf1a13b40704e9147962cc80947e4ab86b\",\"container_config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) CMD [\\\"sh\\\"]\"],\"Image\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.3\",\"config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"sh\"],\"Image\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\"}"
+      },
+      {
+         "v1Compatibility": "{\"id\":\"9e77fef7a1c9f989988c06620dabc4020c607885b959a2cbd7c2283c91da3e33\",\"created\":\"2016-01-15T18:06:40.707908287Z\",\"container\":\"aded96b43f48d94eb80642c210b89f119ab2a233c1c7c7055104fb052937f12c\",\"container_config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) ADD file:a62b361be92f978752150570261ddc6fc21b025e3a28418820a1f39b7db7498c in /\"],\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"docker_version\":\"1.8.3\",\"config\":{\"Hostname\":\"aded96b43f48\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":null,\"Cmd\":null,\"Image\":\"\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"architecture\":\"amd64\",\"os\":\"linux\",\"Size\":554}"
+      }
+   ]
+}`

--- a/test/integration/imagestream_admission_test.go
+++ b/test/integration/imagestream_admission_test.go
@@ -19,7 +19,6 @@ import (
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned"
 	"github.com/openshift/library-go/pkg/quota/quotautil"
 
-	imagetest "github.com/openshift/openshift-apiserver/pkg/image/apiserver/testutil"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -38,7 +37,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 	kClient, client, fn := setupImageStreamAdmissionTest(t)
 	defer fn()
 
-	for i, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest, imagetest.MiscImageDigest} {
+	for i, name := range []string{BaseImageWith1LayerDigest, BaseImageWith2LayersDigest, MiscImageDigest} {
 		imageReference := fmt.Sprintf("openshift/test@%s", name)
 		image := &imagev1.Image{
 			ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +72,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 			Name: "1",
 			From: &corev1.ObjectReference{
 				Kind: "ImageStreamImage",
-				Name: "src@" + imagetest.BaseImageWith1LayerDigest,
+				Name: "src@" + BaseImageWith1LayerDigest,
 			},
 		},
 	}
@@ -96,7 +95,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 			Name: "1",
 			From: &corev1.ObjectReference{
 				Kind: "ImageStreamImage",
-				Name: "src@" + imagetest.BaseImageWith1LayerDigest,
+				Name: "src@" + BaseImageWith1LayerDigest,
 			},
 		},
 	}
@@ -121,7 +120,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 			Name: "2",
 			From: &corev1.ObjectReference{
 				Kind: "ImageStreamImage",
-				Name: "src@" + imagetest.BaseImageWith2LayersDigest,
+				Name: "src@" + BaseImageWith2LayersDigest,
 			},
 		},
 	}
@@ -142,7 +141,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 			Name: "tag1again",
 			From: &corev1.ObjectReference{
 				Kind: "ImageStreamImage",
-				Name: "src@" + imagetest.BaseImageWith1LayerDigest,
+				Name: "src@" + BaseImageWith1LayerDigest,
 			},
 		},
 	}
@@ -160,7 +159,7 @@ func TestImageStreamTagsAdmission(t *testing.T) {
 			Name: "misc",
 			From: &corev1.ObjectReference{
 				Kind: "ImageStreamImage",
-				Name: "src@" + imagetest.MiscImageDigest,
+				Name: "src@" + MiscImageDigest,
 			},
 		},
 	}
@@ -240,7 +239,7 @@ func TestImageStreamAdmitSpecUpdate(t *testing.T) {
 	kClient, client, fn := setupImageStreamAdmissionTest(t)
 	defer fn()
 
-	for i, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest} {
+	for i, name := range []string{BaseImageWith1LayerDigest, BaseImageWith2LayersDigest} {
 		imageReference := fmt.Sprintf("openshift/test@%s", name)
 		image := &imagev1.Image{
 			ObjectMeta: metav1.ObjectMeta{
@@ -377,7 +376,7 @@ func TestImageStreamAdmitStatusUpdate(t *testing.T) {
 	defer fn()
 	images := []*imagev1.Image{}
 
-	for _, name := range []string{imagetest.BaseImageWith1LayerDigest, imagetest.BaseImageWith2LayersDigest} {
+	for _, name := range []string{BaseImageWith1LayerDigest, BaseImageWith2LayersDigest} {
 		imageReference := fmt.Sprintf("openshift/test@%s", name)
 		image := &imagev1.Image{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/imagestream_test.go
+++ b/test/integration/imagestream_test.go
@@ -20,7 +20,6 @@ import (
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned"
 	"github.com/openshift/library-go/pkg/image/imageutil"
 	stratsupport "github.com/openshift/oc/pkg/cli/deployer/strategy/support"
-	imagetest "github.com/openshift/openshift-apiserver/pkg/image/apiserver/testutil"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -258,7 +257,7 @@ func TestImageStreamWithoutDockerImageConfig(t *testing.T) {
 
 	image := imagev1.Image{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: imagetest.BaseImageWith1LayerDigest,
+			Name: BaseImageWith1LayerDigest,
 		},
 		DockerImageMetadata: runtime.RawExtension{
 			Object: &docker10.DockerImage{
@@ -306,7 +305,7 @@ func TestImageStreamWithoutDockerImageConfig(t *testing.T) {
 		t.Errorf("image has a not empty config: %#v", ist)
 	}
 
-	isi, err := clusterAdminImageClient.ImageStreamImages(testutil.Namespace()).Get(imageutil.JoinImageStreamImage(stream.Name, imagetest.BaseImageWith1LayerDigest), metav1.GetOptions{})
+	isi, err := clusterAdminImageClient.ImageStreamImages(testutil.Namespace()).Get(imageutil.JoinImageStreamImage(stream.Name, BaseImageWith1LayerDigest), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/test/integration/newapp_test.go
+++ b/test/integration/newapp_test.go
@@ -52,9 +52,7 @@ import (
 	"github.com/openshift/oc/pkg/helpers/newapp/dockerfile"
 	"github.com/openshift/oc/pkg/helpers/newapp/jenkinsfile"
 	"github.com/openshift/oc/pkg/helpers/newapp/source"
-	templateapi "github.com/openshift/openshift-apiserver/pkg/template/apis/template"
 
-	_ "github.com/openshift/openshift-apiserver/pkg/api/install"
 	"github.com/openshift/origin/test/util"
 
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
@@ -2249,32 +2247,6 @@ func fakeImageStreamSearcher() app.Searcher {
 	return app.ImageStreamSearcher{
 		Client:     client.ImageV1(),
 		Namespaces: []string{"default"},
-	}
-}
-
-func fakeTemplateSearcher() app.Searcher {
-	client := faketemplatev1client.NewSimpleClientset()
-	client.AddReactor("list", "templates", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, templateList(), nil
-	})
-
-	return app.TemplateSearcher{
-		Client:     client.TemplateV1(),
-		Namespaces: []string{"default"},
-	}
-}
-
-func templateList() *templateapi.TemplateList {
-	return &templateapi.TemplateList{
-		Items: []templateapi.Template{
-			{
-				Objects: []runtime.Object{},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "first-stored-template",
-					Namespace: "default",
-				},
-			},
-		},
 	}
 }
 

--- a/test/integration/oauth_external_test.go
+++ b/test/integration/oauth_external_test.go
@@ -18,10 +18,10 @@ import (
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	authorizationv1 "github.com/openshift/api/authorization/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 	"github.com/openshift/library-go/pkg/oauth/oauthdiscovery"
 	"github.com/openshift/oc/pkg/helpers/tokencmd"
-	authorizationapi "github.com/openshift/openshift-apiserver/pkg/authorization/apis/authorization"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 	configapi "github.com/openshift/origin/test/util/server/deprecated_openshift/apis/config"
@@ -55,7 +55,7 @@ func TestOauthExternal(t *testing.T) {
 				UID:      authTestUID,
 				Groups:   authTestGroups,
 				Extra: map[string]kauthn.ExtraValue{
-					authorizationapi.ScopesKey: []string{
+					authorizationv1.ScopesKey: []string{
 						"user:info",
 					},
 				},

--- a/test/integration/project_test.go
+++ b/test/integration/project_test.go
@@ -15,12 +15,12 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 
+	"github.com/openshift/api/annotations"
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	authorizationv1client "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
 	projectv1client "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	"github.com/openshift/oc/pkg/cli/admin/policy"
-	oapi "github.com/openshift/openshift-apiserver/pkg/api"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 	"k8s.io/kubernetes/openshift-kube-apiserver/authorization/scope"
@@ -67,8 +67,8 @@ func TestProjectIsNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "new-project",
 			Annotations: map[string]string{
-				oapi.OpenShiftDisplayName:    "Hello World",
-				"openshift.io/node-selector": "env=test",
+				annotations.OpenShiftDisplayName: "Hello World",
+				"openshift.io/node-selector":     "env=test",
 			},
 		},
 	}
@@ -85,8 +85,8 @@ func TestProjectIsNamespace(t *testing.T) {
 	if project.Name != namespace.Name {
 		t.Fatalf("Project name did not match namespace name, project %v, namespace %v", project.Name, namespace.Name)
 	}
-	if project.Annotations[oapi.OpenShiftDisplayName] != namespace.Annotations[oapi.OpenShiftDisplayName] {
-		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations[oapi.OpenShiftDisplayName], namespace.Annotations[oapi.OpenShiftDisplayName])
+	if project.Annotations[annotations.OpenShiftDisplayName] != namespace.Annotations[annotations.OpenShiftDisplayName] {
+		t.Fatalf("Project display name did not match namespace annotation, project %v, namespace %v", project.Annotations[annotations.OpenShiftDisplayName], namespace.Annotations[annotations.OpenShiftDisplayName])
 	}
 	if project.Annotations["openshift.io/node-selector"] != namespace.Annotations["openshift.io/node-selector"] {
 		t.Fatalf("Project node selector did not match namespace node selector, project %v, namespace %v", project.Annotations["openshift.io/node-selector"], namespace.Annotations["openshift.io/node-selector"])

--- a/test/integration/restrictusers_test.go
+++ b/test/integration/restrictusers_test.go
@@ -10,7 +10,6 @@ import (
 
 	authorizationv1 "github.com/openshift/api/authorization/v1"
 	authorizationclient "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
-	authorizationapi "github.com/openshift/openshift-apiserver/pkg/authorization/apis/authorization"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
@@ -58,7 +57,7 @@ func TestRestrictUsers(t *testing.T) {
 		},
 		Subjects: []kapi.ObjectReference{
 			{
-				Kind:      authorizationapi.UserKind,
+				Kind:      authorizationv1.UserKind,
 				Namespace: "namespace",
 				Name:      "alice",
 			},
@@ -94,7 +93,7 @@ func TestRestrictUsers(t *testing.T) {
 		},
 		Subjects: []kapi.ObjectReference{
 			{
-				Kind:      authorizationapi.UserKind,
+				Kind:      authorizationv1.UserKind,
 				Namespace: "namespace",
 				Name:      "alice",
 			},
@@ -114,7 +113,7 @@ func TestRestrictUsers(t *testing.T) {
 		},
 		Subjects: []kapi.ObjectReference{
 			{
-				Kind:      authorizationapi.UserKind,
+				Kind:      authorizationv1.UserKind,
 				Namespace: "namespace",
 				Name:      "bob",
 			},
@@ -195,7 +194,7 @@ func TestRestrictUsers(t *testing.T) {
 		},
 		Subjects: []kapi.ObjectReference{
 			{
-				Kind:      authorizationapi.UserKind,
+				Kind:      authorizationv1.UserKind,
 				Namespace: "namespace",
 				Name:      "eve",
 			},
@@ -214,7 +213,7 @@ func TestRestrictUsers(t *testing.T) {
 		},
 		Subjects: []kapi.ObjectReference{
 			{
-				Kind:      authorizationapi.UserKind,
+				Kind:      authorizationv1.UserKind,
 				Namespace: "namespace",
 				Name:      "system:non-existing",
 			},

--- a/test/integration/scopes_test.go
+++ b/test/integration/scopes_test.go
@@ -122,7 +122,7 @@ func TestScopedImpersonation(t *testing.T) {
 
 	err = clusterAdminBuildClient.BuildV1().RESTClient().Get().
 		SetHeader(authenticationv1.ImpersonateUserHeader, "harold").
-		SetHeader(authenticationv1.ImpersonateUserExtraHeaderPrefix+authorizationapi.ScopesKey, "user:info").
+		SetHeader(authenticationv1.ImpersonateUserExtraHeaderPrefix+authorizationv1.ScopesKey, "user:info").
 		Namespace(projectName).Resource("builds").Name("name").Do().Into(&buildapi.Build{})
 	if !kapierrors.IsForbidden(err) {
 		t.Fatalf("unexpected error: %v", err)
@@ -131,7 +131,7 @@ func TestScopedImpersonation(t *testing.T) {
 	user := &userv1.User{}
 	err = userv1client.NewForConfigOrDie(clusterAdminClientConfig).RESTClient().Get().
 		SetHeader(authenticationv1.ImpersonateUserHeader, "harold").
-		SetHeader(authenticationv1.ImpersonateUserExtraHeaderPrefix+authorizationapi.ScopesKey, "user:info").
+		SetHeader(authenticationv1.ImpersonateUserExtraHeaderPrefix+authorizationv1.ScopesKey, "user:info").
 		Resource("users").Name("~").Do().Into(user)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -466,7 +466,7 @@ func TestUnknownScopes(t *testing.T) {
 	userInfo := apiserveruser.DefaultInfo{
 		Name: userName,
 		Extra: map[string][]string{
-			authorizationapi.ScopesKey: {"user:list-projects", "bad"}}}
+			authorizationv1.ScopesKey: {"user:list-projects", "bad"}}}
 	impersonatingConfig := impersonatingclient.NewImpersonatingConfig(&userInfo, *clusterAdminClientConfig)
 	projectClient := projectv1client.NewForConfigOrDie(&impersonatingConfig)
 
@@ -495,7 +495,7 @@ func TestUnknownScopes(t *testing.T) {
 	badScopesUserInfo := apiserveruser.DefaultInfo{
 		Name: userName,
 		Extra: map[string][]string{
-			authorizationapi.ScopesKey: {"bad"}}}
+			authorizationv1.ScopesKey: {"bad"}}}
 	badScopesImpersonatingConfig := impersonatingclient.NewImpersonatingConfig(
 		&badScopesUserInfo, *clusterAdminClientConfig)
 	badScopesProjectClient := projectv1client.NewForConfigOrDie(&badScopesImpersonatingConfig)

--- a/test/integration/webhook_token_auth_test.go
+++ b/test/integration/webhook_token_auth_test.go
@@ -20,10 +20,10 @@ import (
 	kclientcmd "k8s.io/client-go/tools/clientcmd"
 	kclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	authorizationv1 "github.com/openshift/api/authorization/v1"
 	oauthv1typedclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
 	"github.com/openshift/oc/pkg/cli/whoami"
-	authorizationapi "github.com/openshift/openshift-apiserver/pkg/authorization/apis/authorization"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 	configapi "github.com/openshift/origin/test/util/server/deprecated_openshift/apis/config"
@@ -61,7 +61,7 @@ func TestWebhookTokenAuthn(t *testing.T) {
 				UID:      authTestUID,
 				Groups:   authTestGroups,
 				Extra: map[string]kauthn.ExtraValue{
-					authorizationapi.ScopesKey: []string{
+					authorizationv1.ScopesKey: []string{
 						"user:info",
 					},
 				},

--- a/tools/buildanalyzer/cmd/buildanalyzer.go
+++ b/tools/buildanalyzer/cmd/buildanalyzer.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	buildv1 "github.com/openshift/api/build/v1"
-	buildinternalapi "github.com/openshift/openshift-apiserver/pkg/build/apis/build"
 )
 
 type BuildAnalyzerOptions struct {
@@ -164,7 +163,7 @@ func (o *BuildAnalyzerOptions) Run() error {
 						failcnt += 1
 						failedReasons[string(build.Status.Reason)+":"+string(build.Status.Message)] += 1
 						if o.TestClone {
-							if string(build.Status.Reason) == string(buildinternalapi.StatusReasonFetchSourceFailed) {
+							if string(build.Status.Reason) == string(buildv1.StatusReasonFetchSourceFailed) {
 								//fmt.Printf("Attempting to clone %s\n", build.Spec.Source.Git.URI)
 								err := exec.Command("/bin/sh", "-c", "GIT_TERMINAL_PROMPT=0 git clone -q "+build.Spec.Source.Git.URI).Run()
 								if err == nil {

--- a/tools/etcdhelper/etcdhelper.go
+++ b/tools/etcdhelper/etcdhelper.go
@@ -16,15 +16,12 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
 
-	// install all APIs
-	install "github.com/openshift/openshift-apiserver/pkg/api/install"
-	"github.com/openshift/openshift-apiserver/pkg/api/legacy"
+	"github.com/openshift/api"
 )
 
 func init() {
-	install.InstallInternalOpenShift(scheme.Scheme)
-	install.InstallInternalKube(scheme.Scheme)
-	legacy.InstallInternalLegacyAll(scheme.Scheme)
+	api.Install(scheme.Scheme)
+	api.InstallKube(scheme.Scheme)
 }
 
 func main() {


### PR DESCRIPTION
To avoid unpleasant rebase dependencies, we need to move openshift-apiserver usage from e2e tests.