### PR TITLE
Let the authentication operator manage OAuth clients in 4.x

### DIFF
--- a/staging/src/github.com/openshift/oauth-server/pkg/oauthserver/oauth_apiserver.go
+++ b/staging/src/github.com/openshift/oauth-server/pkg/oauthserver/oauth_apiserver.go
@@ -316,6 +316,11 @@ func (c *OAuthServerConfig) buildHandlerChainForOAuth(startingHandler http.Handl
 // TODO TODO, this actually looks a lot like a controller or an add-on manager style thing.  Seems like we'd want to do this outside
 // EnsureBootstrapOAuthClients creates or updates the bootstrap oauth clients that openshift relies upon.
 func (c *OAuthServerConfig) StartOAuthClientsBootstrapping(context genericapiserver.PostStartHookContext) error {
+	// if we are running an external OAuth server, let the operator manage these OAuth clients
+	if len(c.ExtraOAuthConfig.Options.LoginURL) != 0 {
+		return nil
+	}
+
 	// the TODO above still applies, but this makes it possible for this poststarthook to do its job with a split kubeapiserver and not run forever
 	go func() {
 		// error is guaranteed to be nil


### PR DESCRIPTION
This disables the post start hook in the 4.x code paths.  All of this code should be deleted but this unblocks the various efforts to move integration to e2e.

Signed-off-by: Monis Khan <mkhan@redhat.com>