### PR TITLE
build stand-alone openshift-apiserver binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ all build:
 # Example:
 #   make build-all
 build-all:
-	hack/build-go.sh cmd/hypershift vendor/k8s.io/kubernetes/cmd/hyperkube vendor/github.com/openshift/oc/cmd/oc vendor/github.com/openshift/sdn/cmd/openshift-sdn vendor/github.com/openshift/oauth-server/cmd/oauth-server cmd/openshift-tests
+	hack/build-go.sh cmd/hypershift vendor/k8s.io/kubernetes/cmd/hyperkube vendor/github.com/openshift/oc/cmd/oc vendor/github.com/openshift/sdn/cmd/openshift-sdn vendor/github.com/openshift/oauth-server/cmd/oauth-server\
+	 vendor/github.com/openshift/openshift-apiserver/cmd/openshift-apiserver\
+	 cmd/openshift-tests
 .PHONY: build-all
 
 # Build the test binaries.

--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -19,8 +19,9 @@ import (
 	openshift_integrated_oauth_server "github.com/openshift/oauth-server/pkg/cmd/oauth-server"
 	"github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver"
 	"github.com/openshift/openshift-controller-manager/pkg/cmd/openshift-controller-manager"
-	"github.com/openshift/origin/pkg/version"
 	"github.com/openshift/sdn/pkg/openshift-network-controller"
+
+	"github.com/openshift/origin/pkg/version"
 )
 
 func main() {
@@ -57,7 +58,9 @@ func NewHyperShiftCommand(stopCh <-chan struct{}) *cobra.Command {
 		},
 	}
 
-	startOpenShiftAPIServer := openshift_apiserver.NewOpenShiftAPIServerCommand(openshift_apiserver.RecommendedStartAPIServerName, "hypershift", os.Stdout, os.Stderr, stopCh)
+	startOpenShiftAPIServer := openshift_apiserver.NewOpenShiftAPIServerCommand(openshift_apiserver.RecommendedStartAPIServerName, os.Stdout, os.Stderr, stopCh)
+	startOpenShiftAPIServer.Deprecated = "will be removed in 4.2"
+	startOpenShiftAPIServer.Hidden = true
 	cmd.AddCommand(startOpenShiftAPIServer)
 
 	startOpenShiftControllerManager := openshift_controller_manager.NewOpenShiftControllerManagerCommand(openshift_controller_manager.RecommendedStartControllerManagerName, "hypershift", os.Stdout, os.Stderr)

--- a/staging/src/github.com/openshift/openshift-apiserver/cmd/openshift-apiserver/main.go
+++ b/staging/src/github.com/openshift/openshift-apiserver/cmd/openshift-apiserver/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	goflag "flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+
+	"github.com/openshift/library-go/pkg/serviceability"
+
+	"github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver"
+	"github.com/openshift/openshift-apiserver/pkg/version"
+)
+
+func main() {
+	stopCh := genericapiserver.SetupSignalHandler()
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), version.Get())()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	command := NewOpenshiftApiServerCommand(stopCh)
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func NewOpenshiftApiServerCommand(stopCh <-chan struct{}) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openshift-apiserver",
+		Short: "Command for the OpenShift API Server",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+	start := openshift_apiserver.NewOpenShiftAPIServerCommand("start", os.Stdout, os.Stderr, stopCh)
+	cmd.AddCommand(start)
+
+	return cmd
+}

--- a/staging/src/github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver/cmd.go
+++ b/staging/src/github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver/cmd.go
@@ -38,7 +38,7 @@ type OpenShiftAPIServer struct {
 var longDescription = templates.LongDesc(`
 	Start an apiserver that contains the OpenShift resources`)
 
-func NewOpenShiftAPIServerCommand(name, basename string, out, errout io.Writer, stopCh <-chan struct{}) *cobra.Command {
+func NewOpenShiftAPIServerCommand(name string, out, errout io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	options := &OpenShiftAPIServer{Output: out}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
* Added new `openshift-apiserver` binary.
* `hypershift openshift-apiserver` equivalent is `openshift-apiserver start`
* `hypershift openshift-apiserver` deprecated & hidden