### PR TITLE
build oauth-server binary into a separate image, split from hypershift

### DIFF
--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -336,6 +336,7 @@ readonly OS_ALL_IMAGES=(
   origin-recycler
   origin-template-service-broker
   origin-tests
+  origin-oauth-server
 )
 
 # os::build::check_binaries ensures that binary sizes do not grow without approval.
@@ -396,6 +397,7 @@ function os::build::images() {
   ( os::build::image "${tag_prefix}-hyperkube"               images/hyperkube ) &
   ( os::build::image "${tag_prefix}-hypershift"              images/hypershift ) &
   ( os::build::image "${tag_prefix}-sdn"                     images/sdn ) &
+  ( os::build::image "${tag_prefix}-oauth-server"            images/oauth-server ) &
 
   for i in `jobs -p`; do wait $i; done
 

--- a/images/oauth-server/Dockerfile.rhel
+++ b/images/oauth-server/Dockerfile.rhel
@@ -1,0 +1,13 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/origin
+COPY . .
+RUN make build WHAT=vendor/github.com/openshift/oauth-server/cmd/oauth-server; \
+    mkdir -p /tmp/build; \
+    cp /go/src/github.com/openshift/origin/_output/local/bin/linux/$(go env GOARCH)/oauth-server /tmp/build/oauth-server
+
+FROM registry.svc.ci.openshift.org/ocp/4.2:base
+COPY --from=builder /tmp/build/oauth-server /usr/bin/
+LABEL io.k8s.display-name="OpenShift OAuth Server" \
+      io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
+      io.openshift.tags="openshift"
+CMD [ "/usr/bin/oauth-server" ]


### PR DESCRIPTION
This is in preparation of migrating oauth-server out of staging

/cc @tnozicka