### PR TITLE
build stand-alone openshift-controller-manager binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ all build:
 build-all:
 	hack/build-go.sh cmd/hypershift vendor/k8s.io/kubernetes/cmd/hyperkube vendor/github.com/openshift/oc/cmd/oc vendor/github.com/openshift/sdn/cmd/openshift-sdn vendor/github.com/openshift/oauth-server/cmd/oauth-server\
 	 vendor/github.com/openshift/openshift-apiserver/cmd/openshift-apiserver\
+	 vendor/github.com/openshift/openshift-controller-manager/cmd/openshift-controller-manager\
 	 cmd/openshift-tests
 .PHONY: build-all
 

--- a/cmd/hypershift/main.go
+++ b/cmd/hypershift/main.go
@@ -63,7 +63,9 @@ func NewHyperShiftCommand(stopCh <-chan struct{}) *cobra.Command {
 	startOpenShiftAPIServer.Hidden = true
 	cmd.AddCommand(startOpenShiftAPIServer)
 
-	startOpenShiftControllerManager := openshift_controller_manager.NewOpenShiftControllerManagerCommand(openshift_controller_manager.RecommendedStartControllerManagerName, "hypershift", os.Stdout, os.Stderr)
+	startOpenShiftControllerManager := openshift_controller_manager.NewOpenShiftControllerManagerCommand(openshift_controller_manager.RecommendedStartControllerManagerName, os.Stdout, os.Stderr)
+	startOpenShiftControllerManager.Deprecated = "will be removed in 4.2"
+	startOpenShiftControllerManager.Hidden = true
 	cmd.AddCommand(startOpenShiftControllerManager)
 
 	startOpenShiftNetworkController := openshift_network_controller.NewOpenShiftNetworkControllerCommand(openshift_network_controller.RecommendedStartNetworkControllerName, "hypershift", os.Stdout, os.Stderr)

--- a/staging/src/github.com/openshift/openshift-controller-manager/cmd/openshift-controller-manager/main.go
+++ b/staging/src/github.com/openshift/openshift-controller-manager/cmd/openshift-controller-manager/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	goflag "flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+
+	"github.com/openshift/library-go/pkg/serviceability"
+	openshift_controller_manager "github.com/openshift/openshift-controller-manager/pkg/cmd/openshift-controller-manager"
+	"github.com/openshift/openshift-controller-manager/pkg/version"
+)
+
+func main() {
+	stopCh := genericapiserver.SetupSignalHandler()
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), version.Get())()
+	defer serviceability.Profile(os.Getenv("OPENSHIFT_PROFILE")).Stop()
+
+	if len(os.Getenv("GOMAXPROCS")) == 0 {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	command := NewOpenShiftControllerManagerCommand(stopCh)
+	if err := command.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func NewOpenShiftControllerManagerCommand(stopCh <-chan struct{}) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openshift-controller-manager",
+		Short: "Command for the OpenShift Controllers",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+	start := openshift_controller_manager.NewOpenShiftControllerManagerCommand("start", os.Stdout, os.Stderr)
+	cmd.AddCommand(start)
+
+	return cmd
+}

--- a/staging/src/github.com/openshift/openshift-controller-manager/pkg/cmd/openshift-controller-manager/cmd.go
+++ b/staging/src/github.com/openshift/openshift-controller-manager/pkg/cmd/openshift-controller-manager/cmd.go
@@ -37,7 +37,7 @@ type OpenShiftControllerManager struct {
 var longDescription = templates.LongDesc(`
 	Start the OpenShift controllers`)
 
-func NewOpenShiftControllerManagerCommand(name, basename string, out, errout io.Writer) *cobra.Command {
+func NewOpenShiftControllerManagerCommand(name string, out, errout io.Writer) *cobra.Command {
 	options := &OpenShiftControllerManager{Output: out}
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
* Added new `openshift-controller-manager` binary.
* `hypershift openshift-controller-manager` equivalent is `openshift-controller-manager start`
* `hypershift openshift-controller-manager` deprecated & hidden