### PR TITLE
UPSTREAM: 79221: Ensure that OpenStack cloud provider is initialized before making a call

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/metadata.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/metadata.go
@@ -51,6 +51,18 @@ const (
 
 	// configDriveID is used as an identifier on the metadata search order configuration.
 	configDriveID = "configDrive"
+
+	// We have to use AWS compatible metadata for the next urls, because OpenStack doesn't
+	// provide this information.
+
+	// instanceTypeURL contains url to get the instance type from metadata server.
+	instanceTypeURL = "http://169.254.169.254/2009-04-04/meta-data/instance-type"
+
+	// localAddressURL contains url to get the instance local ip address from metadata server.
+	localAddressURL = "http://169.254.169.254/2009-04-04/meta-data/local-ipv4"
+
+	// publicAddressURL contains url to get the instance public ip address from metadata server.
+	publicAddressURL = "http://169.254.169.254/2009-04-04/meta-data/public-ipv4"
 )
 
 // ErrBadMetadata is used to indicate a problem parsing data from metadata server
@@ -162,6 +174,60 @@ func getMetadataFromMetadataService(metadataVersion string) (*Metadata, error) {
 	}
 
 	return parseMetadata(resp.Body)
+}
+
+func getIntanceType() (string, error) {
+	klog.V(4).Infof("Attempting to fetch instance type from %s", instanceTypeURL)
+	resp, err := http.Get(instanceTypeURL)
+	if err != nil {
+		return "", fmt.Errorf("error fetching %s: %v", instanceTypeURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("unexpected status code when reading instance type from %s: %s", instanceTypeURL, resp.Status)
+		return "", err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cannot read the response body %s: %v", instanceTypeURL, err)
+	}
+
+	return string(body), nil
+}
+
+func getNodeAddress(url string) (string, error) {
+	klog.V(4).Infof("Attempting to fetch instance address from %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("error fetching %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("unexpected status code when reading instance address from %s: %s", url, resp.Status)
+		return "", err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cannot read the response body %s: %v", url, err)
+	}
+
+	return string(body), nil
+}
+
+func getNodeAddresses() (string, string, error) {
+	localAddess, err := getNodeAddress(localAddressURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	publicAddress, err := getNodeAddress(publicAddressURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	return localAddess, publicAddress, nil
 }
 
 // Metadata is fixed for the current host, so cache the value process-wide

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
@@ -143,6 +143,10 @@ type OpenStack struct {
 	metadataOpts MetadataOpts
 	// InstanceID of the server where this OpenStack object is instantiated.
 	localInstanceID string
+	// Options for reading config data from a secret
+	secretName      string
+	secretNamespace string
+	kubeconfigPath  string
 }
 
 // Config is used to read and store information from the cloud configuration file
@@ -278,10 +282,10 @@ func createKubernetesClient(kubeconfigPath string) (*kubernetes.Clientset, error
 }
 
 // setConfigFromSecret allows setting up the config from k8s secret
-func setConfigFromSecret(cfg *Config) error {
-	secretName := cfg.Global.SecretName
-	secretNamespace := cfg.Global.SecretNamespace
-	kubeconfigPath := cfg.Global.KubeconfigPath
+func (os *OpenStack) setConfigFromSecret() error {
+	secretName := os.secretName
+	secretNamespace := os.secretNamespace
+	kubeconfigPath := os.kubeconfigPath
 
 	k8sClient, err := createKubernetesClient(kubeconfigPath)
 	if err != nil {
@@ -290,9 +294,11 @@ func setConfigFromSecret(cfg *Config) error {
 
 	secret, err := k8sClient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
-		klog.Warningf("Cannot get secret %s in namespace %s. error: %q", secretName, secretNamespace, err)
+		klog.Errorf("Cannot get secret %s in namespace %s. error: %q", secretName, secretNamespace, err)
 		return err
 	}
+
+	cfg := &Config{}
 
 	if content, ok := secret.Data["clouds.conf"]; ok {
 		err = gcfg.ReadStringInto(cfg, string(content))
@@ -300,6 +306,14 @@ func setConfigFromSecret(cfg *Config) error {
 			klog.Errorf("Cannot parse data from the secret.")
 			return fmt.Errorf("cannot parse data from the secret")
 		}
+		provider, err := newProvider(*cfg)
+		if err != nil {
+			klog.Errorf("Cannot initialize cloud provider using data from the secret.")
+			return fmt.Errorf("cannot initialize cloud provider using data from the secret")
+		}
+		os.provider = provider
+		os.region = cfg.Global.Region
+		klog.Info("OpenStack cloud provider was initialized using data from the secret.")
 		return nil
 	}
 
@@ -307,7 +321,20 @@ func setConfigFromSecret(cfg *Config) error {
 	return fmt.Errorf("cannot find \"clouds.conf\" key in the secret")
 }
 
+func (os *OpenStack) ensureCloudProviderWasInitialized() error {
+	if os.provider != nil {
+		return nil
+	}
 
+	if os.secretName != "" && os.secretNamespace != "" {
+		err := os.setConfigFromSecret()
+		if err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cloud provider is not initialized")
+}
 
 func readConfig(config io.Reader) (Config, error) {
 	if config == nil {
@@ -325,14 +352,6 @@ func readConfig(config io.Reader) (Config, error) {
 	err := gcfg.ReadInto(&cfg, config)
 	if err != nil {
 		return cfg, err
-	}
-
-	if cfg.Global.SecretName != "" && cfg.Global.SecretNamespace != "" {
-		klog.Infof("Set credentials from secret %s in namespace %s", cfg.Global.SecretName, cfg.Global.SecretNamespace)
-		err = setConfigFromSecret(&cfg)
-		if err != nil {
-			return cfg, err
-		}
 	}
 
 	return cfg, nil
@@ -393,7 +412,7 @@ func checkOpenStackOpts(openstackOpts *OpenStack) error {
 	return checkMetadataSearchOrder(openstackOpts.metadataOpts.SearchOrder)
 }
 
-func newOpenStack(cfg Config) (*OpenStack, error) {
+func newProvider(cfg Config) (*gophercloud.ProviderClient, error) {
 	provider, err := openstack.NewClient(cfg.Global.AuthURL)
 	if err != nil {
 		return nil, err
@@ -423,22 +442,38 @@ func newOpenStack(cfg Config) (*OpenStack, error) {
 		return nil, err
 	}
 
+	provider.HTTPClient.Timeout = cfg.Metadata.RequestTimeout.Duration
+
+	return provider, nil
+}
+
+func newOpenStack(cfg Config) (*OpenStack, error) {
 	emptyDuration := MyDuration{}
 	if cfg.Metadata.RequestTimeout == emptyDuration {
 		cfg.Metadata.RequestTimeout.Duration = time.Duration(defaultTimeOut)
 	}
-	provider.HTTPClient.Timeout = cfg.Metadata.RequestTimeout.Duration
 
 	os := OpenStack{
-		provider:     provider,
-		region:       cfg.Global.Region,
-		lbOpts:       cfg.LoadBalancer,
-		bsOpts:       cfg.BlockStorage,
-		routeOpts:    cfg.Route,
-		metadataOpts: cfg.Metadata,
+		secretName:      cfg.Global.SecretName,
+		secretNamespace: cfg.Global.SecretNamespace,
+		kubeconfigPath:  cfg.Global.KubeconfigPath,
+		region:          cfg.Global.Region,
+		lbOpts:          cfg.LoadBalancer,
+		bsOpts:          cfg.BlockStorage,
+		routeOpts:       cfg.Route,
+		metadataOpts:    cfg.Metadata,
 	}
 
-	err = checkOpenStackOpts(&os)
+	// Skip provider initialization if we're going to read auth data from a secret.
+	if cfg.Global.SecretName == "" || cfg.Global.SecretNamespace == "" {
+		provider, err := newProvider(cfg)
+		if err != nil {
+			return nil, err
+		}
+		os.provider = provider
+	}
+
+	err := checkOpenStackOpts(&os)
 	if err != nil {
 		return nil, err
 	}
@@ -474,6 +509,7 @@ func NewFakeOpenStackCloud(cfg Config) (*OpenStack, error) {
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (os *OpenStack) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+	os.ensureCloudProviderWasInitialized()
 }
 
 // mapNodeNameToServerName maps a k8s NodeName to an OpenStack Server Name
@@ -675,6 +711,11 @@ func getAttachedInterfacesByID(client *gophercloud.ServiceClient, serviceID stri
 
 // Clusters is a no-op
 func (os *OpenStack) Clusters() (cloudprovider.Clusters, bool) {
+	err := os.ensureCloudProviderWasInitialized()
+	if err != nil {
+		return nil, false
+	}
+
 	return nil, false
 }
 
@@ -691,6 +732,11 @@ func (os *OpenStack) HasClusterID() bool {
 // LoadBalancer initializes a LbaasV2 object
 func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	klog.V(4).Info("openstack.LoadBalancer() called")
+
+	err := os.ensureCloudProviderWasInitialized()
+	if err != nil {
+		return nil, false
+	}
 
 	if reflect.DeepEqual(os.lbOpts, LoadBalancerOpts{}) {
 		klog.V(4).Info("LoadBalancer section is empty/not defined in cloud-config")
@@ -815,6 +861,11 @@ func (os *OpenStack) GetZoneByNodeName(ctx context.Context, nodeName types.NodeN
 // Routes initializes routes support
 func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 	klog.V(4).Info("openstack.Routes() called")
+
+	err := os.ensureCloudProviderWasInitialized()
+	if err != nil {
+		return nil, false
+	}
 
 	network, err := os.NewNetworkV2()
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -42,9 +42,35 @@ const (
 	instanceShutoff = "SHUTOFF"
 )
 
+func (os *OpenStack) getCompute() *gophercloud.ServiceClient {
+	err := os.ensureCloudProviderWasInitialized()
+	if err != nil {
+		klog.Errorf("unable to access compute v2 API : %v", err)
+		return nil
+	}
+
+	compute, err := os.NewComputeV2()
+	if err != nil {
+		klog.Errorf("unable to access compute v2 API : %v", err)
+		return nil
+	}
+
+	return compute
+}
+
 // Instances returns an implementation of Instances for OpenStack.
 func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
 	klog.V(4).Info("openstack.Instances() called")
+
+	err := os.ensureCloudProviderWasInitialized()
+	if err != nil {
+		// cannot initialize cloud provider - return empty instances without compute instance,
+		// it will be generated later with any call of an Instances' receiver.
+		klog.Errorf("cannot initialize cloud provider, only limited functionality is available : %v", err)
+		return &Instances{
+			opts: os.metadataOpts,
+		}, true
+	}
 
 	compute, err := os.NewComputeV2()
 	if err != nil {
@@ -78,6 +104,44 @@ func (i *Instances) AddSSHKeyToAllInstances(ctx context.Context, user string, ke
 // NodeAddresses implements Instances.NodeAddresses
 func (i *Instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
 	klog.V(4).Infof("NodeAddresses(%v) called", name)
+
+	// check if the node is local, in this case we can get its addresses from the metadata service
+	// without additional requests to Nova.
+	md, err := getMetadata(i.opts.SearchOrder)
+	if err != nil {
+		return nil, err
+	}
+	localName := types.NodeName(md.Name)
+	if localName == name {
+		localAddress, publicAddress, err := getNodeAddresses()
+		if err != nil {
+			return nil, err
+		}
+
+		addrs := []v1.NodeAddress{
+			{
+				Type:    v1.NodeHostName,
+				Address: md.Name,
+			},
+		}
+
+		if localAddress != "" {
+			addrs = append(addrs, v1.NodeAddress{
+				Type:    v1.NodeInternalIP,
+				Address: localAddress,
+			})
+		}
+
+		if publicAddress != "" {
+			addrs = append(addrs, v1.NodeAddress{
+				Type:    v1.NodeExternalIP,
+				Address: publicAddress,
+			})
+		}
+
+		klog.V(4).Infof("NodeAddresses(%v) => %v", name, addrs)
+		return addrs, nil
+	}
 
 	addrs, err := getAddressesByName(i.compute, name)
 	if err != nil {
@@ -164,6 +228,17 @@ func (os *OpenStack) InstanceID() (string, error) {
 
 // InstanceID returns the cloud provider ID of the specified instance.
 func (i *Instances) InstanceID(ctx context.Context, name types.NodeName) (string, error) {
+	// check if the node is local, in this case we can get its ID from the metadata service
+	// without additional requests to Nova.
+	md, err := getMetadata(i.opts.SearchOrder)
+	if err != nil {
+		return "", err
+	}
+	localName := types.NodeName(md.Name)
+	if localName == name {
+		return md.UUID, nil
+	}
+
 	srv, err := getServerByName(i.compute, name)
 	if err != nil {
 		if err == ErrNotFound {
@@ -197,6 +272,17 @@ func (i *Instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 
 // InstanceType returns the type of the specified instance.
 func (i *Instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
+	// check if the node is local, in this case we can get its type from the metadata service
+	// without additional requests to Nova.
+	md, err := getMetadata(i.opts.SearchOrder)
+	if err != nil {
+		return "", err
+	}
+	localName := types.NodeName(md.Name)
+	if localName == name {
+		return getIntanceType()
+	}
+
 	srv, err := getServerByName(i.compute, name)
 
 	if err != nil {


### PR DESCRIPTION
This commit improves the reading of OpenStack's cloud provider configuration from a secret. In some cases, if kubeConfigPath parameter specifies a configuration file, which is created by kubelet itself as a result of bootstrap (i.e. /var/lib/kubelet/kubeconfig), then the initialization of the cloud provider fails, because this file has not yet been created on the local file system.
https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#bootstrap-initialization
To solve this problem we transfer the real initialization of the provider from the init() function, which is called at the stage of modules import, to the functions from the Provider's top-level interface. https://github.com/kubernetes/cloud-provider/blob/master/cloud.go#L42-L62
This allows to initialize the provider not at the stage of modules import, but later, when the requests to the functions occur, and the kubeconfig file is already created.

Another peculiarity of the provider is that in order to get the node names it needs to execute a request to OpenStack at the initial stage, when kubeconfig file is not created yet. As a solution, it is suggested not to make a request to OpenStack when reading the configuration from the secret and to give the nodes names that coincide with the hostnames. This approach is used by all other cloud providers, as well as the external provider for OpenStack. This solution will make it easier to migrate users from in-tree to external, as the node names will be the same in both cases.