### PR TITLE
UPSTREAM: <carry>: add apiserver.config.openshift.io validation to prevent overriding internal LB SNI settings

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/OWNERS
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - deads2k
+  - sttts
+approvers:
+  - deads2k
+  - sttts

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validate_apiserver.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validate_apiserver.go
@@ -1,0 +1,145 @@
+package apiserver
+
+import (
+	"fmt"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation"
+)
+
+func toAPIServerV1(uncastObj runtime.Object) (*configv1.APIServer, field.ErrorList) {
+	if uncastObj == nil {
+		return nil, nil
+	}
+
+	errs := field.ErrorList{}
+
+	obj, ok := uncastObj.(*configv1.APIServer)
+	if !ok {
+		return nil, append(errs,
+			field.NotSupported(field.NewPath("kind"), fmt.Sprintf("%T", uncastObj), []string{"APIServer"}),
+			field.NotSupported(field.NewPath("apiVersion"), fmt.Sprintf("%T", uncastObj), []string{"config.openshift.io/v1"}))
+	}
+
+	return obj, nil
+}
+
+type apiserverV1 struct {
+	infrastructureGetter func() configv1client.InfrastructuresGetter
+}
+
+func (a apiserverV1) ValidateCreate(uncastObj runtime.Object) field.ErrorList {
+	obj, errs := toAPIServerV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMeta(&obj.ObjectMeta, false, customresourcevalidation.RequireNameCluster, field.NewPath("metadata"))...)
+	errs = append(errs, validateAPIServerSpecCreate(obj.Spec)...)
+	errs = append(errs, a.validateSNINames(obj)...)
+
+	return errs
+}
+
+func (a apiserverV1) validateSNINames(obj *configv1.APIServer) field.ErrorList {
+	errs := field.ErrorList{}
+	if len(obj.Spec.ServingCerts.NamedCertificates) == 0 {
+		return errs
+	}
+
+	infrastructure, err := a.infrastructureGetter().Infrastructures().Get("cluster", metav1.GetOptions{})
+	if err != nil {
+		errs = append(errs, field.InternalError(field.NewPath("metadata"), err))
+	}
+	for i, currSNI := range obj.Spec.ServingCerts.NamedCertificates {
+		// if names are specified, confirm they do not match
+		// if names are not specified, the cert can still match, but only the operator resolves the secrets down.  We gain a lot of benefit by being sure
+		// we don't allow an explicit override of these values
+		for j, currName := range currSNI.Names {
+			path := field.NewPath("spec").Child("servingCerts").Index(i).Child("names").Index(j)
+			if currName == infrastructure.Status.APIServerInternalURL {
+				errs = append(errs, field.Invalid(path, currName, fmt.Sprintf("may not match internal loadbalancer: %q", infrastructure.Status.APIServerInternalURL)))
+				continue
+			}
+			if strings.HasSuffix(currName, ".*") {
+				withoutSuffix := currName[0 : len(currName)-2]
+				if strings.HasPrefix(infrastructure.Status.APIServerInternalURL, withoutSuffix) {
+					errs = append(errs, field.Invalid(path, currName, fmt.Sprintf("may not match internal loadbalancer: %q", infrastructure.Status.APIServerInternalURL)))
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
+func (a apiserverV1) ValidateUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toAPIServerV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toAPIServerV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	errs = append(errs, validateAPIServerSpecUpdate(obj.Spec, oldObj.Spec)...)
+	errs = append(errs, a.validateSNINames(obj)...)
+
+	return errs
+}
+
+func (apiserverV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj runtime.Object) field.ErrorList {
+	obj, errs := toAPIServerV1(uncastObj)
+	if len(errs) > 0 {
+		return errs
+	}
+	oldObj, errs := toAPIServerV1(uncastOldObj)
+	if len(errs) > 0 {
+		return errs
+	}
+
+	// TODO validate the obj.  remember that status validation should *never* fail on spec validation errors.
+	errs = append(errs, validation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldObj.ObjectMeta, field.NewPath("metadata"))...)
+	errs = append(errs, validateAPIServerStatus(obj.Status)...)
+
+	return errs
+}
+
+func validateAPIServerSpecCreate(spec configv1.APIServerSpec) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// we rely on fall through for the service network
+	if len(spec.ServingCerts.DefaultServingCertificate.Name) > 0 {
+		errs = append(errs, field.Forbidden(field.NewPath("spec").Child("servingCerts").Child("defaultServingCertificate").Child("name"), "may not be set"))
+	}
+
+	return errs
+}
+
+func validateAPIServerSpecUpdate(newSpec, oldSpec configv1.APIServerSpec) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// we rely on fall through for the service network
+	if len(newSpec.ServingCerts.DefaultServingCertificate.Name) > 0 {
+		errs = append(errs, field.Forbidden(field.NewPath("spec").Child("servingCerts").Child("defaultServingCertificate").Child("name"), "may not be set"))
+	}
+
+	return errs
+}
+
+func validateAPIServerStatus(status configv1.APIServerStatus) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// TODO
+
+	return errs
+}

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validate_apiserver_test.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validate_apiserver_test.go
@@ -1,0 +1,117 @@
+package apiserver
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclientfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateSNINames(t *testing.T) {
+	expectNoErrors := func(t *testing.T, errs field.ErrorList) {
+		t.Helper()
+		if len(errs) > 0 {
+			t.Fatal(errs)
+		}
+	}
+
+	tests := []struct {
+		name string
+
+		internalName string
+		apiserver    *configv1.APIServer
+
+		validateErrors func(t *testing.T, errs field.ErrorList)
+	}{
+		{
+			name:           "no sni",
+			internalName:   "internal.host.com",
+			apiserver:      &configv1.APIServer{},
+			validateErrors: expectNoErrors,
+		},
+		{
+			name:         "allowed sni",
+			internalName: "internal.host.com",
+			apiserver: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					ServingCerts: configv1.APIServerServingCerts{
+						NamedCertificates: []configv1.APIServerNamedServingCert{
+							{
+								Names: []string{"external.host.com", "somwhere.else.*"},
+							},
+						},
+					},
+				},
+			},
+			validateErrors: expectNoErrors,
+		},
+		{
+			name:         "directly invalid sni",
+			internalName: "internal.host.com",
+			apiserver: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					ServingCerts: configv1.APIServerServingCerts{
+						NamedCertificates: []configv1.APIServerNamedServingCert{
+							{Names: []string{"external.host.com", "somwhere.else.*"}},
+							{Names: []string{"foo.bar", "internal.host.com"}},
+						},
+					},
+				},
+			},
+			validateErrors: func(t *testing.T, errs field.ErrorList) {
+				t.Helper()
+				if len(errs) != 1 {
+					t.Fatal(errs)
+				}
+				if errs[0].Error() != `spec.servingCerts[1].names[1]: Invalid value: "internal.host.com": may not match internal loadbalancer: "internal.host.com"` {
+					t.Error(errs[0])
+				}
+			},
+		},
+		{
+			name:         "wildcard invalid sni",
+			internalName: "internal.host.com",
+			apiserver: &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					ServingCerts: configv1.APIServerServingCerts{
+						NamedCertificates: []configv1.APIServerNamedServingCert{
+							{Names: []string{"internal.*"}},
+						},
+					},
+				},
+			},
+			validateErrors: func(t *testing.T, errs field.ErrorList) {
+				t.Helper()
+				if len(errs) != 1 {
+					t.Fatal(errs)
+				}
+				if errs[0].Error() != `spec.servingCerts[0].names[0]: Invalid value: "internal.*": may not match internal loadbalancer: "internal.host.com"` {
+					t.Error(errs[0])
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeclient := configclientfake.NewSimpleClientset(&configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: configv1.InfrastructureStatus{
+					APIServerInternalURL: test.internalName,
+				},
+			})
+
+			instance := apiserverV1{
+				infrastructureGetter: func() configv1client.InfrastructuresGetter {
+					return fakeclient.ConfigV1()
+				},
+			}
+			test.validateErrors(t, instance.validateSNINames(test.apiserver))
+		})
+
+	}
+}

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validation_wrapper.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validation_wrapper.go
@@ -1,0 +1,76 @@
+package apiserver
+
+import (
+	"fmt"
+	"io"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/rest"
+)
+
+const PluginName = "config.openshift.io/ValidateAPIServer"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewValidateAPIServer()
+	})
+}
+
+type validateCustomResourceWithClient struct {
+	admission.Interface
+
+	infrastructureGetter configv1client.InfrastructuresGetter
+}
+
+func NewValidateAPIServer() (admission.Interface, error) {
+	ret := &validateCustomResourceWithClient{}
+
+	delegate, err := customresourcevalidation.NewValidator(
+		map[schema.GroupResource]bool{
+			configv1.GroupVersion.WithResource("apiservers").GroupResource(): true,
+		},
+		map[schema.GroupVersionKind]customresourcevalidation.ObjectValidator{
+			configv1.GroupVersion.WithKind("APIServer"): apiserverV1{infrastructureGetter: ret.getInfrastructureGetter},
+		})
+	if err != nil {
+		return nil, err
+	}
+	ret.Interface = delegate
+
+	return ret, nil
+}
+
+var _ admissionrestconfig.WantsRESTClientConfig = &validateCustomResourceWithClient{}
+
+func (a *validateCustomResourceWithClient) getInfrastructureGetter() configv1client.InfrastructuresGetter {
+	return a.infrastructureGetter
+}
+
+func (a *validateCustomResourceWithClient) SetRESTClientConfig(restClientConfig rest.Config) {
+	var err error
+	a.infrastructureGetter, err = configv1client.NewForConfig(&restClientConfig)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+}
+
+func (a *validateCustomResourceWithClient) ValidateInitialization() error {
+	if a.infrastructureGetter == nil {
+		return fmt.Errorf(PluginName + " needs an infrastructureGetter")
+	}
+
+	if initializationValidator, ok := a.Interface.(admission.InitializationValidator); ok {
+		return initializationValidator.ValidateInitialization()
+	}
+
+	return nil
+}

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration/cr_validation_registration.go
@@ -3,6 +3,7 @@ package customresourcevalidationregistration
 import (
 	"k8s.io/apiserver/pkg/admission"
 
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/authentication"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/clusterresourcequota"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/config"
@@ -18,6 +19,7 @@ import (
 
 // AllCustomResourceValidators are the names of all custom resource validators that should be registered
 var AllCustomResourceValidators = []string{
+	apiserver.PluginName,
 	authentication.PluginName,
 	features.PluginName,
 	console.PluginName,
@@ -35,6 +37,7 @@ var AllCustomResourceValidators = []string{
 }
 
 func RegisterCustomResourceValidation(plugins *admission.Plugins) {
+	apiserver.Register(plugins)
 	authentication.Register(plugins)
 	features.Register(plugins)
 	console.Register(plugins)


### PR DESCRIPTION
UPSTREAM: <carry>: add apiserver.config.openshift.io validation to prevent overriding internal LB SNI settings

The internal LB is used by kubelets which cannot update their trust. This means that if the internal LB certificate is changed, the cluster loses connectivity.  We auto-rotate the serving cert, but not the corresponding trust for it.

/assign @sttts 