### PR TITLE
Single layer images should still print layer digest

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/image/info/info.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/image/info/info.go
@@ -212,8 +212,6 @@ func describeImage(out io.Writer, image *Image) error {
 	case 0:
 		// legacy case, server does not know individual layers
 		fmt.Fprintf(w, "Layer Size:\t%s\n", units.HumanSize(float64(image.Config.Size)))
-	case 1:
-		fmt.Fprintf(w, "Image Size:\t%s\n", units.HumanSize(float64(image.Layers[0].Size)))
 	default:
 		imageSize := fmt.Sprintf("%s in %d layers", units.HumanSize(float64(image.Config.Size)), len(image.Layers))
 		if image.Config.Size == 0 {

--- a/staging/src/github.com/openshift/oc/pkg/helpers/describe/describer.go
+++ b/staging/src/github.com/openshift/oc/pkg/helpers/describe/describer.go
@@ -698,8 +698,6 @@ func DescribeImage(image *imagev1.Image, imageName string) (string, error) {
 		case 0:
 			// legacy case, server does not know individual layers
 			formatString(out, "Layer Size", units.HumanSize(float64(dockerImage.Size)))
-		case 1:
-			formatString(out, "Image Size", units.HumanSize(float64(dockerImage.Size)))
 		default:
 			formatString(out, "Image Size", fmt.Sprintf("%s in %d layers", units.HumanSize(float64(dockerImage.Size)), len(image.DockerImageLayers)))
 			var layers []string


### PR DESCRIPTION
Users may want to compare a single layer digest against another image,
but if we don't print the layer they can't do that. Fix the image
describer to show info about the single layer like we would with
multiple layers:

```
Image Size: 59.51MB in 1 layer
Layers:     59.5MB sha256:abcdef1434
```