### PR TITLE
Bug 1725027: --output flag to release info does not include all options

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/admin/release/info.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/admin/release/info.go
@@ -103,7 +103,7 @@ func NewInfo(f kcmdutil.Factory, parentName string, streams genericclioptions.IO
 	flags.BoolVar(&o.ShowPullSpec, "pullspecs", o.ShowPullSpec, "Display the pull spec of each image instead of the digest.")
 	flags.BoolVar(&o.ShowSize, "size", o.ShowSize, "Display the size of each image including overlap.")
 	flags.StringVar(&o.ImageFor, "image-for", o.ImageFor, "Print the pull spec of the specified image or an error if it does not exist.")
-	flags.StringVarP(&o.Output, "output", "o", o.Output, "Display the release info in an alternative format: json")
+	flags.StringVarP(&o.Output, "output", "o", o.Output, "Display the release info in an alternative format: digest, json, name, pullspec.")
 	flags.StringVar(&o.ChangelogDir, "changelog", o.ChangelogDir, "Generate changelog output from the git directories extracted to this path.")
 	flags.StringVar(&o.BugsDir, "bugs", o.BugsDir, "Generate bug listings from the changelogs in the git repositories extracted to this path.")
 	flags.BoolVar(&o.IncludeImages, "include-images", o.IncludeImages, "When displaying JSON output of a release output the images the release references.")


### PR DESCRIPTION
fix bug: https://bugzilla.redhat.com/show_bug.cgi?id=1725027
@xingxingxia   @tnozicka  Please help review. thanks.

