### PR TITLE
project: improve error reported when template objects failed to create

### DIFF
--- a/staging/src/github.com/openshift/openshift-apiserver/pkg/project/apiserver/registry/projectrequest/delegated/delegated.go
+++ b/staging/src/github.com/openshift/openshift-apiserver/pkg/project/apiserver/registry/projectrequest/delegated/delegated.go
@@ -208,10 +208,13 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		var restMapping *meta.RESTMapping
 		var mappingErr error
 		for i := 0; i < 3; i++ {
-			restMapping, mappingErr = r.restMapper.RESTMapping(toCreate.GroupVersionKind().GroupKind(), toCreate.GroupVersionKind().Version)
-			if mappingErr == nil {
+			restMapping, err = r.restMapper.RESTMapping(toCreate.GroupVersionKind().GroupKind(), toCreate.GroupVersionKind().Version)
+			if err == nil {
+				mappingErr = nil
 				break
 			}
+			mappingErr = fmt.Errorf("mapping %s failed: %v", toCreate.GroupVersionKind(), err)
+
 			// the refresh is every 10 seconds
 			time.Sleep(11 * time.Second)
 		}


### PR DESCRIPTION
This change will help debugging problems like https://bugzilla.redhat.com/show_bug.cgi?id=1664638 where the resource failed to create because of mapping error but we don't know which resource it was.

/cc @deads2k 
/cc @sttts 