### PR TITLE
oc: fix describer for docker images

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/helpers/describe/describer.go
+++ b/staging/src/github.com/openshift/oc/pkg/helpers/describe/describer.go
@@ -719,7 +719,12 @@ func DescribeImage(image *imagev1.Image, imageName string) (string, error) {
 		formatString(out, "Image Created", fmt.Sprintf("%s ago", formatRelativeTime(dockerImage.Created.Time)))
 		formatString(out, "Author", dockerImage.Author)
 		formatString(out, "Arch", dockerImage.Architecture)
-		describeDockerImage(out, &dockerImage.ContainerConfig)
+
+		if dockerImage.Config != nil {
+			// Config is the configuration of the container received from the client.
+			// In most cases this field is always set for images.
+			describeDockerImage(out, dockerImage.Config)
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
In some cases the docker image metadata does not fill the ContainerConfig (possible bug in importer?). According to Docker API, the Config should be always set as received from the client.

This fix will return the later for describe but fallback when the Config is not set to ContainerConfig.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1726374

@soltysh @adambkaplan @dmage this need more investigation.

