### PR TITLE
APIServer CRD: add additionalCORSAllowedOrigins validation

### DIFF
--- a/test/extended/crdvalidation/apiserver.go
+++ b/test/extended/crdvalidation/apiserver.go
@@ -1,0 +1,29 @@
+package crdvalidation
+
+import (
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Suite:openshift/crdvalidation/apiserver] APIServer CR fields validation", func() {
+	var (
+		oc              = exutil.NewCLI("cluster-basic-auth", exutil.KubeConfigPath())
+		apiServerClient = oc.AdminConfigClient().ConfigV1().APIServers()
+	)
+	defer g.GinkgoRecover()
+
+	g.It("additionalCORSAllowedOrigins", func() {
+		apiServer, err := apiServerClient.Get("cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		apiServer.Spec.AdditionalCORSAllowedOrigins = []string{"no closing (parentheses"}
+		_, err = apiServerClient.Update(apiServer)
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(err.Error()).To(o.ContainSubstring("additionalCORSAllowedOrigins"))
+		o.Expect(err.Error()).To(o.ContainSubstring("not a valid regular expression"))
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/cluster"
 	_ "github.com/openshift/origin/test/extended/controller_manager"
+	_ "github.com/openshift/origin/test/extended/crdvalidation"
 	_ "github.com/openshift/origin/test/extended/csrapprover"
 	_ "github.com/openshift/origin/test/extended/deployments"
 	_ "github.com/openshift/origin/test/extended/dns"

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validate_apiserver.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validate_apiserver.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -115,18 +116,14 @@ func (apiserverV1) ValidateStatusUpdate(uncastObj runtime.Object, uncastOldObj r
 }
 
 func validateAPIServerSpecCreate(spec configv1.APIServerSpec) field.ErrorList {
-	errs := field.ErrorList{}
 
-	//TODO: Add validation code, if needed
-
+	errs := validateAdditionalCORSAllowedOrigins(field.NewPath("spec").Child("additionalCORSAllowedOrigins"), spec.AdditionalCORSAllowedOrigins)
 	return errs
 }
 
 func validateAPIServerSpecUpdate(newSpec, oldSpec configv1.APIServerSpec) field.ErrorList {
-	errs := field.ErrorList{}
 
-	// TODO: Add validation code, if needed
-
+	errs := validateAdditionalCORSAllowedOrigins(field.NewPath("spec").Child("additionalCORSAllowedOrigins"), newSpec.AdditionalCORSAllowedOrigins)
 	return errs
 }
 
@@ -134,6 +131,18 @@ func validateAPIServerStatus(status configv1.APIServerStatus) field.ErrorList {
 	errs := field.ErrorList{}
 
 	// TODO
+
+	return errs
+}
+
+func validateAdditionalCORSAllowedOrigins(fieldPath *field.Path, cors []string) field.ErrorList {
+	errs := field.ErrorList{}
+
+	for i, re := range cors {
+		if _, err := regexp.Compile(re); err != nil {
+			errs = append(errs, field.Invalid(fieldPath.Index(i), re, fmt.Sprintf("not a valid regular expression: %v", err)))
+		}
+	}
 
 	return errs
 }


### PR DESCRIPTION
Add validation for the new `additionalCORSAllowedOrigins` field in APIServer CRD

Running `glide update` always ended-up with a SIGSEGV for me so I just picked the API for the bump.