### PR TITLE
Making 'oc adm prune auth' can prune specific serviceaccount

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/admin/prune/auth/serviceaccount.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/admin/prune/auth/serviceaccount.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	authv1client "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
+	securityv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
+)
+
+func reapForServiceAccount(
+	authorizationClient authv1client.AuthorizationV1Interface,
+	securityClient securityv1client.SecurityContextConstraintsInterface,
+	nsname string,
+	name string,
+	out io.Writer) error {
+
+	errors := []error{}
+
+	removedSubject := corev1.ObjectReference{Kind: "ServiceAccount", Name: name, Namespace: nsname}
+	errors = append(errors, reapClusterBindings(removedSubject, authorizationClient, out)...)
+	errors = append(errors, reapNamespacedBindings(removedSubject, authorizationClient, out)...)
+
+	// Remove the sa from sccs
+	sccs, err := securityClient.List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	saname := "system:serviceaccount:" + nsname + ":" + name
+	for _, scc := range sccs.Items {
+		retainedUsers := []string{}
+		for _, user := range scc.Users {
+			if user != saname {
+				retainedUsers = append(retainedUsers, user)
+			}
+		}
+		if len(retainedUsers) != len(scc.Users) {
+			updatedSCC := scc
+			updatedSCC.Users = retainedUsers
+			if _, err := securityClient.Update(&updatedSCC); err != nil && !kerrors.IsNotFound(err) {
+				errors = append(errors, err)
+			} else {
+				fmt.Fprintf(out, "securitycontextconstraints.security.openshift.io/"+updatedSCC.Name+" updated\n")
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}

--- a/staging/src/github.com/openshift/oc/pkg/cli/admin/prune/auth/serviceaccount_test.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/admin/prune/auth/serviceaccount_test.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+
+	authv1 "github.com/openshift/api/authorization/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	fakeauthclient "github.com/openshift/client-go/authorization/clientset/versioned/fake"
+	fakeauthv1client "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1/fake"
+	fakesecurityclient "github.com/openshift/client-go/security/clientset/versioned/fake"
+	fakesecurityv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1/fake"
+)
+
+func TestServiceAccountReaper(t *testing.T) {
+	tests := []struct {
+		name           string
+		serviceaccount string
+		namespace      string
+		authObjects    []runtime.Object
+		sccs           []runtime.Object
+		expected       []interface{}
+	}{
+		{
+			name:           "no objects",
+			serviceaccount: "foosa",
+			namespace:      "foons",
+			expected:       []interface{}{},
+		},
+		{
+			name:           "cluster bindings",
+			serviceaccount: "foosa",
+			namespace:      "foons",
+			authObjects: []runtime.Object{
+				&authv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-no-subjects"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{},
+				},
+				&authv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-one-subject"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{{Name: "foosa", Kind: "ServiceAccount", Namespace: "foons"}},
+				},
+				&authv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-mismatched-subject"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{{Name: "foosa"}, {Name: "foosa", Kind: "Group"}, {Name: "foosa", Kind: "Other"}},
+				},
+			},
+			expected: []interface{}{
+				clienttesting.UpdateActionImpl{ActionImpl: clienttesting.ActionImpl{Verb: "update", Resource: clusterRoleBindingsResource}, Object: &authv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-one-subject"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{},
+				}},
+			},
+		},
+		{
+			name:           "namespaced bindings",
+			serviceaccount: "foosa",
+			namespace:      "foons",
+			authObjects: []runtime.Object{
+				&authv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-no-subjects", Namespace: "ns1"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{},
+				},
+				&authv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-one-subject", Namespace: "ns2"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{{Name: "foosa", Kind: "ServiceAccount", Namespace: "foons"}},
+				},
+				&authv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-mismatched-subject", Namespace: "ns3"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{{Name: "foosa"}, {Name: "foosa", Kind: "Group"}, {Name: "foosa", Kind: "Other"}},
+				},
+			},
+			expected: []interface{}{
+				clienttesting.UpdateActionImpl{ActionImpl: clienttesting.ActionImpl{Verb: "update", Resource: roleBindingsResource, Namespace: "ns2"}, Object: &authv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "binding-one-subject", Namespace: "ns2"},
+					RoleRef:    corev1.ObjectReference{Name: "role"},
+					Subjects:   []corev1.ObjectReference{},
+				}},
+			},
+		},
+		{
+			name:           "sccs",
+			serviceaccount: "foosa",
+			namespace:      "foons",
+			sccs: []runtime.Object{
+				&securityv1.SecurityContextConstraints{
+					ObjectMeta: metav1.ObjectMeta{Name: "scc-no-subjects"},
+					Users:      []string{},
+				},
+				&securityv1.SecurityContextConstraints{
+					ObjectMeta: metav1.ObjectMeta{Name: "scc-one-subject"},
+					Users:      []string{"system:serviceaccount:foons:foosa"},
+				},
+				&securityv1.SecurityContextConstraints{
+					ObjectMeta: metav1.ObjectMeta{Name: "scc-mismatched-subjects"},
+					Users:      []string{"foouser"},
+					Groups:     []string{"foogroup"},
+				},
+			},
+			expected: []interface{}{
+				clienttesting.UpdateActionImpl{ActionImpl: clienttesting.ActionImpl{Verb: "update", Resource: securityContextContraintsResource}, Object: &securityv1.SecurityContextConstraints{
+					ObjectMeta: metav1.ObjectMeta{Name: "scc-one-subject"},
+					Users:      []string{},
+				}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authFake := &fakeauthv1client.FakeAuthorizationV1{Fake: &(fakeauthclient.NewSimpleClientset(test.authObjects...).Fake)}
+			securityFake := &fakesecurityv1client.FakeSecurityV1{Fake: &(fakesecurityclient.NewSimpleClientset(test.sccs...).Fake)}
+
+			actual := []interface{}{}
+			oreactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+				actual = append(actual, action)
+				return false, nil, nil
+			}
+			kreactor := func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+				actual = append(actual, action)
+				return false, nil, nil
+			}
+
+			authFake.PrependReactor("update", "*", oreactor)
+			authFake.PrependReactor("delete", "*", oreactor)
+			securityFake.Fake.PrependReactor("update", "*", kreactor)
+			securityFake.Fake.PrependReactor("delete", "*", kreactor)
+
+			err := reapForServiceAccount(authFake, securityFake.SecurityContextConstraints(), test.namespace, test.serviceaccount, ioutil.Discard)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(test.expected, actual) {
+				for i, x := range test.expected {
+					t.Logf("Expected %d: %s", i, spew.Sprint(x))
+				}
+				for i, x := range actual {
+					t.Logf("Actual %d:   %s", i, spew.Sprint(x))
+				}
+				t.Errorf("unexpected actions")
+			}
+		})
+	}
+}

--- a/staging/src/github.com/openshift/oc/pkg/cli/admin/prune/prune.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/admin/prune/prune.go
@@ -38,6 +38,6 @@ func NewCommandPrune(name, fullName string, f kcmdutil.Factory, streams genericc
 	cmds.AddCommand(deployments.NewCmdPruneDeployments(f, fullName, deployments.PruneDeploymentsRecommendedName, streams))
 	cmds.AddCommand(images.NewCmdPruneImages(f, fullName, images.PruneImagesRecommendedName, streams))
 	cmds.AddCommand(groups.NewCmdPrune(PruneGroupsRecommendedName, fullName+" "+PruneGroupsRecommendedName, f, streams))
-	cmds.AddCommand(auth.NewCmdPruneAuth(f, "auth", streams))
+	cmds.AddCommand(auth.NewCmdPruneAuth(f, fullName, "auth", streams))
 	return cmds
 }


### PR DESCRIPTION
As title,since this **[BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1724596)**,I think this PR can make some sense.

This can prune scc,clusterrolebinding and rolebinding of sa; you can use  `oc adm prune auth sa " " -n " "` to prune specific sa.