### PR TITLE
hack/lib/constants.sh: remove no_openssl flag

### DIFF
--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -10,7 +10,7 @@ readonly OS_REQUIRED_GO_VERSION="go${OS_BUILD_ENV_GOLANG}"
 readonly OS_GLIDE_MINOR_VERSION="13"
 readonly OS_REQUIRED_GLIDE_VERSION="0.$OS_GLIDE_MINOR_VERSION"
 
-readonly OS_GOFLAGS_TAGS="include_gcs include_oss containers_image_openpgp no_openssl"
+readonly OS_GOFLAGS_TAGS="include_gcs include_oss containers_image_openpgp"
 readonly OS_GOFLAGS_TAGS_LINUX_AMD64="gssapi"
 readonly OS_GOFLAGS_TAGS_LINUX_S390X="gssapi"
 readonly OS_GOFLAGS_TAGS_LINUX_ARM64="gssapi"


### PR DESCRIPTION
Per https://jira.coreos.com/browse/ART-666 4.2 should no longer be disabling openssl linking.

@stevekuznetsov @smarterclayton I am guessing you will probably not want to do this until the latest golang-builder is being used in CI so that dynamic linking of openssl fails over as intended to static linked crypto. That builder is ready when you are.