### PR TITLE
Don't assume instances of OLM kinds exist

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -1,12 +1,10 @@
 package operators
 
 import (
-	"reflect"
+	"fmt"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	yaml "gopkg.in/yaml.v2"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -16,37 +14,60 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 
 	var oc = exutil.NewCLI("olm", exutil.KubeConfigPath())
 
-	// The list of all available OLM resources
-	olmResources := []string{
-		"packagemanifests", "catalogsources", "clusterserviceversions",
-		"installplans", "operatorgroups", "subscriptions",
+	operators := "operators.coreos.com"
+	providedAPIs := []struct {
+		fromAPIService bool
+		group          string
+		version        string
+		plural         string
+	}{
+		{
+			fromAPIService: true,
+			group:          "packages." + operators,
+			version:        "v1",
+			plural:         "packagemanifests",
+		},
+		{
+			group:   operators,
+			version: "v1",
+			plural:  "operatorgroups",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "clusterserviceversions",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "catalogsources",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "installplans",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "subscriptions",
+		},
 	}
 
-	for i := range olmResources {
-		g.It("list "+olmResources[i], func() {
-			var resourceList map[string]interface{}
-			// Get resource yaml and parse
-			output, err := oc.AsAdmin().Run("get").Args(olmResources[i], "--all-namespaces", "-o", "yaml").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			err = yaml.Unmarshal([]byte(output), &resourceList)
-			if err != nil {
-				e2e.Logf("Unable to parse %s yaml list", olmResources[i])
+	for _, api := range providedAPIs {
+		g.It(fmt.Sprintf("be installed with %s at version %s", api.plural, api.version), func() {
+			if api.fromAPIService {
+				// Ensure spec.version matches expected
+				raw, err := oc.AsAdmin().Run("get").Args("apiservices", fmt.Sprintf("%s.%s", api.version, api.group), "-o=jsonpath='{.spec.version}'").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(raw).To(o.Equal(api.version))
+			} else {
+				// Ensure expected version exists in spec.versions and is both served and stored
+				raw, err := oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath='{.spec.versions[?(@.name==\"%s\")]}'", api.version)).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(raw).To(o.ContainSubstring("served:true"))
+				o.Expect(raw).To(o.ContainSubstring("storage:true"))
 			}
-			// Verify resource items list has at least one item
-			o.Expect(isResourceItemsEmpty(resourceList)).To(o.BeFalse(), olmResources[i]+" list should have at least one item")
-			e2e.Logf("Successfully list %s", olmResources[i])
 		})
 	}
 })
-
-func isResourceItemsEmpty(resourceList map[string]interface{}) bool {
-	// Get resource items and check if it is empty
-	items, err := resourceList["items"].([]interface{})
-	o.Expect(err).To(o.BeTrue(), "Unable to verify items is a slice")
-
-	if reflect.ValueOf(items).Len() > 0 {
-		return false
-	} else {
-		return true
-	}
-}


### PR DESCRIPTION
Removes the assumption that at least one instance of each OLM kind exists on a cluster for OLM tests.

This borrows code from @jianzhangbjz's PR (#23224).