### PR TITLE
UPSTREAM: 1679612: kubelet_stats: fix potential e2e crash dereferencing CPU

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/kubelet_stats.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/kubelet_stats.go
@@ -590,6 +590,9 @@ func (r *resourceCollector) collectStats(oldStatsMap map[string]*stats.Container
 		}
 
 		if oldStats, ok := oldStatsMap[name]; ok {
+			if oldStats.CPU == nil || cStats.CPU == nil || oldStats.Memory == nil || cStats.Memory == nil {
+				continue
+			}
 			if oldStats.CPU.Time.Equal(&cStats.CPU.Time) {
 				// No change -> skip this stat.
 				continue


### PR DESCRIPTION
Fixes a flake in kubelet_stats.go

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1679612