### PR TITLE
move project request tests to e2e

### DIFF
--- a/test/extended/project/unprivileged_newproject.go
+++ b/test/extended/project/unprivileged_newproject.go
@@ -1,0 +1,122 @@
+package project
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/retry"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	authorizationv1 "github.com/openshift/api/authorization/v1"
+	projectv1 "github.com/openshift/api/project/v1"
+	projectv1client "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
+	projectapi "github.com/openshift/openshift-apiserver/pkg/project/apis/project"
+	exutil "github.com/openshift/origin/test/extended/util"
+	kubeauthorizationv1 "k8s.io/api/authorization/v1"
+	kapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = g.Describe("[Feature:ProjectAPI] ", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("project-api", exutil.KubeConfigPath())
+
+	g.It("TestUnprivilegedNewProject", func() {
+		t := g.GinkgoT()
+
+		valerieProjectClient := oc.ProjectClient()
+
+		// confirm that we have access to request the project
+		allowed := &metav1.Status{}
+		if err := valerieProjectClient.ProjectV1().RESTClient().Get().Resource("projectrequests").Do().Into(allowed); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if allowed.Status != metav1.StatusSuccess {
+			t.Fatalf("expected %v, got %v", metav1.StatusSuccess, allowed.Status)
+		}
+
+		projectRequest := &projectv1.ProjectRequest{}
+		projectRequest.Name = "new-project-" + oc.Namespace()
+		projectRequest.DisplayName = "display name here"
+		projectRequest.Description = "the special description"
+		projectRequest.Annotations = make(map[string]string)
+
+		project, err := valerieProjectClient.ProjectV1().ProjectRequests().Create(projectRequest)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		oc.AddResourceToDelete(projectv1.GroupVersion.WithResource("projects"), project)
+
+		waitForProject(t, valerieProjectClient.ProjectV1(), projectRequest.Name, 5*time.Second, 10)
+
+		actualProject, err := valerieProjectClient.ProjectV1().Projects().Get(projectRequest.Name, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if e, a := oc.Username(), actualProject.Annotations[projectapi.ProjectRequester]; e != a {
+			t.Errorf("incorrect project requester: expected %v, got %v", e, a)
+		}
+
+		if _, err := valerieProjectClient.ProjectV1().ProjectRequests().Create(projectRequest); !kapierrors.IsAlreadyExists(err) {
+			t.Fatalf("expected an already exists error, but got %v", err)
+		}
+
+	})
+})
+
+var _ = g.Describe("[Feature:ProjectAPI][Serial] ", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("project-api", exutil.KubeConfigPath())
+
+	g.It("TestUnprivilegedNewProjectDenied", func() {
+		t := g.GinkgoT()
+
+		clusterAdminAuthorizationConfig := oc.AdminAuthorizationClient().AuthorizationV1()
+		role, err := clusterAdminAuthorizationConfig.ClusterRoles().Get("self-provisioner", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		existingRole := role.DeepCopy()
+		defer func() {
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				currentRole, err := clusterAdminAuthorizationConfig.ClusterRoles().Get("self-provisioner", metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				currentRole.Rules = existingRole.Rules
+				_, err = clusterAdminAuthorizationConfig.ClusterRoles().Update(currentRole)
+				return err
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}()
+
+		role.Rules = []authorizationv1.PolicyRule{}
+		_, err = clusterAdminAuthorizationConfig.ClusterRoles().Update(role)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		valerieProjectClient := oc.ProjectClient()
+		err = oc.WaitForAccessDenied(&kubeauthorizationv1.SelfSubjectAccessReview{
+			Spec: kubeauthorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &kubeauthorizationv1.ResourceAttributes{
+					Verb:     "create",
+					Group:    "project.openshift.io",
+					Resource: "projectrequests",
+				},
+			},
+		}, oc.Username())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// confirm that we have access to request the project
+		err = valerieProjectClient.ProjectV1().RESTClient().Get().Resource("projectrequests").Do().Into(&metav1.Status{})
+		o.Expect(err).To(o.HaveOccurred())
+		expectedError := `You may not request a new project via this API.`
+		if (err != nil) && (err.Error() != expectedError) {
+			t.Fatalf("expected\n\t%v\ngot\n\t%v", expectedError, err.Error())
+		}
+	})
+})
+
+// waitForProject will execute a client list of projects looking for the project with specified name
+// if not found, it will retry up to numRetries at the specified delayInterval
+func waitForProject(t g.GinkgoTInterface, client projectv1client.ProjectV1Interface, projectName string, delayInterval time.Duration, numRetries int) {
+	for i := 0; i <= numRetries; i++ {
+		_, err := client.Projects().Get(projectName, metav1.GetOptions{})
+		if err == nil {
+			return
+		}
+		time.Sleep(delayInterval)
+	}
+	t.Errorf("expected project %v not found", projectName)
+}

--- a/test/integration/unprivileged_newproject_test.go
+++ b/test/integration/unprivileged_newproject_test.go
@@ -8,89 +8,16 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
-	authorizationv1 "github.com/openshift/api/authorization/v1"
-	"github.com/openshift/api/project"
 	projectv1 "github.com/openshift/api/project/v1"
-	authorizationv1client "github.com/openshift/client-go/authorization/clientset/versioned"
 	projectv1client "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	templatev1client "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 	"github.com/openshift/oc/pkg/cli/requestproject"
 	"github.com/openshift/oc/pkg/helpers/tokencmd"
-	projectapi "github.com/openshift/openshift-apiserver/pkg/project/apis/project"
 	testutil "github.com/openshift/origin/test/util"
 	testserver "github.com/openshift/origin/test/util/server"
 )
 
-func TestUnprivilegedNewProject(t *testing.T) {
-	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer testserver.CleanupMasterEtcd(t, masterConfig)
-
-	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	valerieClientConfig := *clusterAdminClientConfig
-	valerieClientConfig.Username = ""
-	valerieClientConfig.Password = ""
-	valerieClientConfig.BearerToken = ""
-	valerieClientConfig.CertFile = ""
-	valerieClientConfig.KeyFile = ""
-	valerieClientConfig.CertData = nil
-	valerieClientConfig.KeyData = nil
-
-	accessToken, err := tokencmd.RequestToken(&valerieClientConfig, nil, "valerie", "security!")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	valerieClientConfig.BearerToken = accessToken
-	valerieProjectClient := projectv1client.NewForConfigOrDie(&valerieClientConfig)
-
-	// confirm that we have access to request the project
-
-	allowed := &metav1.Status{}
-	if err := valerieProjectClient.RESTClient().Get().Resource("projectrequests").Do().Into(allowed); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if allowed.Status != metav1.StatusSuccess {
-		t.Fatalf("expected %v, got %v", metav1.StatusSuccess, allowed.Status)
-	}
-
-	requestProject := requestproject.RequestProjectOptions{
-		ProjectName: "new-project",
-		DisplayName: "display name here",
-		Description: "the special description",
-
-		Client:    valerieProjectClient,
-		IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
-	}
-
-	if err := requestProject.Run(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	waitForProject(t, valerieProjectClient, "new-project", 5*time.Second, 10)
-
-	actualProject, err := valerieProjectClient.Projects().Get("new-project", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if e, a := "valerie", actualProject.Annotations[projectapi.ProjectRequester]; e != a {
-		t.Errorf("incorrect project requester: expected %v, got %v", e, a)
-	}
-
-	if err := requestProject.Run(); !kapierrors.IsAlreadyExists(err) {
-		t.Fatalf("expected an already exists error, but got %v", err)
-	}
-
-}
 func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 	namespace := "foo"
 	templateName := "bar"
@@ -179,54 +106,6 @@ func TestUnprivilegedNewProjectFromTemplate(t *testing.T) {
 		t.Fatalf("expected a not found error, but got %v", err)
 	}
 
-}
-
-func TestUnprivilegedNewProjectDenied(t *testing.T) {
-	masterConfig, clusterAdminKubeConfig, err := testserver.StartTestMasterAPI()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	defer testserver.CleanupMasterEtcd(t, masterConfig)
-
-	clusterAdminClientConfig, err := testutil.GetClusterAdminClientConfig(clusterAdminKubeConfig)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	clusterAdminAuthorizationConfig := authorizationv1client.NewForConfigOrDie(clusterAdminClientConfig).AuthorizationV1()
-	role, err := clusterAdminAuthorizationConfig.ClusterRoles().Get("self-provisioner", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	role.Rules = []authorizationv1.PolicyRule{}
-	if _, err := clusterAdminAuthorizationConfig.ClusterRoles().Update(role); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	valerieClientConfig := rest.AnonymousClientConfig(clusterAdminClientConfig)
-
-	accessToken, err := tokencmd.RequestToken(valerieClientConfig, nil, "valerie", "security!")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	valerieClientConfig.BearerToken = accessToken
-
-	valerieProjectClient := projectv1client.NewForConfigOrDie(valerieClientConfig)
-	valerieKubeClient := kubernetes.NewForConfigOrDie(valerieClientConfig)
-
-	if err := testutil.WaitForClusterPolicyUpdate(valerieKubeClient.AuthorizationV1(), "create", project.Resource("projectrequests"), false); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// confirm that we have access to request the project
-	err = valerieProjectClient.RESTClient().Get().Resource("projectrequests").Do().Into(&metav1.Status{})
-	if err == nil {
-		t.Fatalf("expected error: %v", err)
-	}
-	expectedError := `You may not request a new project via this API.`
-	if (err != nil) && (err.Error() != expectedError) {
-		t.Fatalf("expected\n\t%v\ngot\n\t%v", expectedError, err.Error())
-	}
 }
 
 // waitForProject will execute a client list of projects looking for the project with specified name


### PR DESCRIPTION
part of #23320, splitting to find flake.