### PR TITLE
convert ldap group sync tests to e2e

### DIFF
--- a/test/extended/authentication/ldap/ad/sync-config-dn-everywhere.yaml
+++ b/test/extended/authentication/ldap/ad/sync-config-dn-everywhere.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 activeDirectory:
     usersQuery:
         baseDN: "ou=people,ou=ad,dc=example,dc=com"

--- a/test/extended/authentication/ldap/ad/sync-config-paging.yaml
+++ b/test/extended/authentication/ldap/ad/sync-config-paging.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 activeDirectory:
     usersQuery:
         baseDN: "ou=people,ou=ad,dc=example,dc=com"

--- a/test/extended/authentication/ldap/ad/sync-config-partially-user-defined.yaml
+++ b/test/extended/authentication/ldap/ad/sync-config-partially-user-defined.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 groupUIDNameMapping:
   group1: firstgroup
   group3: thirdgroup

--- a/test/extended/authentication/ldap/ad/sync-config-user-defined.yaml
+++ b/test/extended/authentication/ldap/ad/sync-config-user-defined.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 groupUIDNameMapping:
   group1: firstgroup
   group2: secondgroup

--- a/test/extended/authentication/ldap/ad/sync-config.yaml
+++ b/test/extended/authentication/ldap/ad/sync-config.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 activeDirectory:
     usersQuery:
         baseDN: "ou=people,ou=ad,dc=example,dc=com"

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-dn-everywhere.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-dn-everywhere.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 augmentedActiveDirectory:
     usersQuery:
         baseDN: "ou=people,ou=adextended,dc=example,dc=com"

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-paging.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-paging.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 augmentedActiveDirectory:
     usersQuery:
         baseDN: "ou=people,ou=adextended,dc=example,dc=com"

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-partially-user-defined.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-partially-user-defined.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 groupUIDNameMapping:
   cn=group1,ou=groups,ou=adextended,dc=example,dc=com: firstgroup
   cn=group3,ou=groups,ou=adextended,dc=example,dc=com: thirdgroup

--- a/test/extended/authentication/ldap/augmented-ad/sync-config-user-defined.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config-user-defined.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 groupUIDNameMapping:
   cn=group1,ou=groups,ou=adextended,dc=example,dc=com: firstgroup
   cn=group2,ou=groups,ou=adextended,dc=example,dc=com: secondgroup

--- a/test/extended/authentication/ldap/augmented-ad/sync-config.yaml
+++ b/test/extended/authentication/ldap/augmented-ad/sync-config.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 augmentedActiveDirectory:
     usersQuery:
         baseDN: "ou=people,ou=adextended,dc=example,dc=com"

--- a/test/extended/authentication/ldap/rfc2307/sync-config-dn-everywhere.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-dn-everywhere.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 rfc2307:
     groupsQuery:
         baseDN: "ou=groups,ou=rfc2307,dc=example,dc=com"

--- a/test/extended/authentication/ldap/rfc2307/sync-config-paging.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-paging.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 rfc2307:
     groupsQuery:
         baseDN: "ou=groups,ou=rfc2307,dc=example,dc=com"

--- a/test/extended/authentication/ldap/rfc2307/sync-config-partially-user-defined.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-partially-user-defined.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 groupUIDNameMapping:
   "cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com": firstgroup
   "cn=group3,ou=groups,ou=rfc2307,dc=example,dc=com": thirdgroup

--- a/test/extended/authentication/ldap/rfc2307/sync-config-tolerating.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-tolerating.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 rfc2307:
     groupsQuery:
         baseDN: "ou=groups,ou=incomplete-rfc2307,dc=example,dc=com"

--- a/test/extended/authentication/ldap/rfc2307/sync-config-user-defined.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config-user-defined.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 groupUIDNameMapping:
   "cn=group1,ou=groups,ou=rfc2307,dc=example,dc=com": firstgroup
   "cn=group2,ou=groups,ou=rfc2307,dc=example,dc=com": secondgroup

--- a/test/extended/authentication/ldap/rfc2307/sync-config.yaml
+++ b/test/extended/authentication/ldap/rfc2307/sync-config.yaml
@@ -1,7 +1,8 @@
 kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389
-insecure: true
+insecure: false
+ca: LDAP_CA
 rfc2307:
     groupsQuery:
         baseDN: "ou=groups,ou=rfc2307,dc=example,dc=com"

--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -1,0 +1,88 @@
+package oauth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	"github.com/openshift/origin/test/extended/testdata"
+	testutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Suite:openshift/oauth][Serial] ldap group sync", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc                 = testutil.NewCLI("ldap-group-sync", testutil.KubeConfigPath())
+		remoteTmp          = "/tmp/"
+		caFileName         = "ca"
+		kubeConfigFileName = "kubeconfig"
+	)
+	g.It("can sync groups from ldap", func() {
+		g.By("starting an openldap server")
+		ldapService, ca, err := testutil.CreateLDAPTestServer(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("running oc adm groups sync against the ldap server")
+		_, err = oc.AsAdmin().Run("adm").Args("policy", "add-scc-to-user", "anyuid", oc.Username()).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		pod, err := testutil.NewPodExecutor(oc, "groupsync", "fedora:29")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Install stuff needed for the exec pod to run groupsync.sh and hack/lib
+		_, err = pod.Exec("dnf install findutils golang docker which bc openldap-clients -y")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Copy oc
+		ocAbsPath, err := exec.LookPath("oc")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = pod.CopyFromHost(ocAbsPath, path.Join("/usr", "bin")+"/")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Copy groupsync test data
+		err = pod.CopyFromHost(path.Join("test", "extended", "authentication", "ldap"), remoteTmp)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Copy hack lib needed by groupsync.sh
+		err = pod.CopyFromHost("hack", path.Join("/usr", "hack"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Write ldap CA and kubeconfig to temporary files, and copy them in.
+		tmpDir, err := ioutil.TempDir("", "staging")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer os.Remove(tmpDir)
+
+		ldapCAPath := path.Join(tmpDir, caFileName)
+		err = ioutil.WriteFile(ldapCAPath, ca, 0644)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = pod.CopyFromHost(ldapCAPath, remoteTmp)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = pod.CopyFromHost(testutil.KubeConfigPath(), remoteTmp)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		groupSyncScriptPath := path.Join(tmpDir, "groupsync.sh")
+		groupSyncScript := testdata.MustAsset("test/extended/testdata/ldap/groupsync.sh")
+		err = ioutil.WriteFile(groupSyncScriptPath, groupSyncScript, 0644)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Copy groupsync script
+		err = pod.CopyFromHost(groupSyncScriptPath, path.Join("/usr", "bin", "groupsync.sh"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Make it executable
+		_, err = pod.Exec("chmod +x /usr/bin/groupsync.sh")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Execute groupsync.sh
+		_, err = pod.Exec(fmt.Sprintf("export LDAP_SERVICE=%s LDAP_CA=%s ADMIN_KUBECONFIG=%s; groupsync.sh",
+			ldapService, path.Join(remoteTmp, caFileName), path.Join(remoteTmp, kubeConfigFileName)))
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -390,6 +390,7 @@
 // test/extended/testdata/jenkins-plugin/shared-resources-template.json
 // test/extended/testdata/jenkins-slave-template.yaml
 // test/extended/testdata/jobs/v1.yaml
+// test/extended/testdata/ldap/groupsync.sh
 // test/extended/testdata/ldap/ldapserver-config-cm.yaml
 // test/extended/testdata/ldap/ldapserver-deployment.yaml
 // test/extended/testdata/ldap/ldapserver-scripts-cm.yaml
@@ -51231,6 +51232,224 @@ func testExtendedTestdataJobsV1Yaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataLdapGroupsyncSh = []byte(`#!/bin/bash
+#
+# This scripts starts the OpenShift server with a default configuration.
+# The OpenShift Docker registry and router are installed.
+# It will run all tests that are imported into test/extended.
+source "/usr/hack/lib/init.sh"
+os::util::environment::setup_time_vars
+os::build::setup_env
+
+export KUBECONFIG="${ADMIN_KUBECONFIG}"
+LDAP_SERVICE_IP="${LDAP_SERVICE}"
+
+function cleanup() {
+       return_code=$?
+       os::test::junit::generate_report
+       os::cleanup::all
+       os::util::describe_return_code "${return_code}"
+       exit "${return_code}"
+}
+trap "cleanup" EXIT
+
+function compare_and_cleanup() {
+       validation_file=$1
+       actual_file=actual-${validation_file}
+       rm -f ${WORKINGDIR}/${actual_file}
+       oc get groups --no-headers | awk '{print $1}' | sort | xargs -I{} oc get --export group {} -o yaml >> ${WORKINGDIR}/${actual_file}
+       os::util::sed '/sync-time/d' ${WORKINGDIR}/${actual_file}
+       diff ${validation_file} ${WORKINGDIR}/${actual_file}
+       oc delete groups --all
+       echo -e "\tSUCCESS"
+}
+
+os::log::info "Running extended tests"
+
+schema=('rfc2307' 'ad' 'augmented-ad')
+
+for (( i=0; i<${#schema[@]}; i++ )); do
+       current_schema=${schema[$i]}
+       os::log::info "Testing schema: ${current_schema}"
+       os::test::junit::declare_suite_start "extended/ldap-groups/${current_schema}"
+
+       WORKINGDIR=${BASETMPDIR}/${current_schema}
+       mkdir ${WORKINGDIR}
+
+       os::log::info "working dir ${WORKINGDIR}"
+       # create a temp copy of the test files
+       cp /tmp/ldap/${current_schema}/* ${WORKINGDIR}
+       pushd ${WORKINGDIR} > /dev/null
+
+       # load OpenShift and LDAP group UIDs, needed for literal whitelists
+       # use awk instead of sed for compatibility (see os::util::sed)
+       group1_ldapuid=$(awk 'NR == 1 {print $0}' ldapgroupuids.txt)
+       group2_ldapuid=$(awk 'NR == 2 {print $0}' ldapgroupuids.txt)
+       group3_ldapuid=$(awk 'NR == 3 {print $0}' ldapgroupuids.txt)
+
+       group1_osuid=$(awk 'NR == 1 {print $0}' osgroupuids.txt)
+       group2_osuid=$(awk 'NR == 2 {print $0}' osgroupuids.txt)
+       group3_osuid=$(awk 'NR == 3 {print $0}' osgroupuids.txt)
+
+       # update sync-configs and validation files with the LDAP server's IP
+       config_files=sync-config*.yaml
+       validation_files=valid*.yaml
+       for config in ${config_files} ${validation_files}
+       do
+               os::util::sed "s/LDAP_SERVICE_IP/${LDAP_SERVICE_IP}/g" ${config}
+               os::util::sed "s@LDAP_CA@${LDAP_CA}@g" ${config}
+       done
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server"
+       oc adm groups sync --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync.yaml
+
+
+       # WHITELISTS
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using whitelist file"
+       oc adm groups sync --whitelist=whitelist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using literal whitelist"
+       oc adm groups sync ${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using union of literal whitelist and whitelist file"
+       oc adm groups sync ${group2_ldapuid} --whitelist=whitelist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_union_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using whitelist file"
+       oc adm groups sync ${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc patch group ${group1_osuid} -p 'users: []'
+       oc adm groups sync --type=openshift --whitelist=whitelist_openshift.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using literal whitelist"
+       # sync group from LDAP
+       oc adm groups sync ${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc patch group ${group1_osuid} -p 'users: []'
+       oc adm groups sync --type=openshift ${group1_osuid} --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using union of literal whitelist and whitelist file"
+       # sync groups from LDAP
+       oc adm groups sync ${group1_ldapuid} ${group2_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc patch group ${group1_osuid} -p 'users: []'
+       oc patch group ${group2_osuid} -p 'users: []'
+       oc adm groups sync --type=openshift group/${group2_osuid} --whitelist=whitelist_openshift.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_union_sync.yaml
+
+
+       # BLACKLISTS
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using whitelist and blacklist file"
+       # oc adm groups sync --whitelist=ldapgroupuids.txt --blacklist=blacklist_ldap.txt --blacklist-group="${group1_ldapuid}" --sync-config=sync-config.yaml --confirm
+       oc adm groups sync --whitelist=ldapgroupuids.txt --blacklist=blacklist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_blacklist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using blacklist"
+       # oc adm groups sync --blacklist=blacklist_ldap.txt --blacklist-group=${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc adm groups sync --blacklist=blacklist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_blacklist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using whitelist and blacklist file"
+       oc adm groups sync --sync-config=sync-config.yaml --confirm
+       oc get group -o name --no-headers | xargs -n 1 oc patch -p 'users: []'
+       # oc adm groups sync --type=openshift --whitelist=osgroupuids.txt --blacklist=blacklist_openshift.txt --blacklist-group=${group1_osuid} --sync-config=sync-config.yaml --confirm
+       oc adm groups sync --type=openshift --whitelist=osgroupuids.txt --blacklist=blacklist_openshift.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_openshift_blacklist_sync.yaml
+
+
+       # MAPPINGS
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using a user-defined mapping"
+       oc adm groups sync --sync-config=sync-config-user-defined.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_user_defined.yaml
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using a partially user-defined mapping"
+       oc adm groups sync --sync-config=sync-config-partially-user-defined.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_partially_user_defined.yaml
+
+       echo -e "\tTEST: Sync based on OpenShift groups respecting OpenShift mappings"
+       oc adm groups sync --sync-config=sync-config-user-defined.yaml --confirm
+       oc get group -o name --no-headers | xargs -n 1 oc patch -p 'users: []'
+       oc adm groups sync --type=openshift --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_user_defined.yaml
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using DN as attribute whenever possible"
+    oc adm groups sync --sync-config=sync-config-dn-everywhere.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_dn_everywhere.yaml
+
+       echo -e "\tTEST: Sync based on OpenShift groups respecting OpenShift mappings and whitelist file"
+       os::cmd::expect_success_and_text 'oc adm groups sync --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc adm groups sync --type=openshift --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc delete groups --all' 'deleted'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name} | wc -l' '0'
+
+       # PRUNING
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server, change LDAP UID, then prune OpenShift groups"
+       oc adm groups sync --sync-config=sync-config.yaml --confirm
+       oc patch group ${group2_osuid} -p "{\"metadata\":{\"annotations\":{\"openshift.io/ldap.uid\":\"cn=garbage,${group2_ldapuid}\"}}}"
+       oc adm groups prune --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_prune.yaml
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using whitelist file, then prune OpenShift groups using the same whitelist file"
+       os::cmd::expect_success_and_text 'oc adm groups sync --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc adm groups prune --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm | wc -l' '0'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc patch group secondgroup -p "{\"metadata\":{\"annotations\":{\"openshift.io/ldap.uid\":\"cn=garbage\"}}}"' 'group.user.openshift.io/secondgroup patched'
+       os::cmd::expect_success_and_text 'oc adm groups prune --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/secondgroup'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc delete groups --all' 'deleted'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name} | wc -l' '0'
+
+
+       # PAGING
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using paged queries"
+       oc adm groups sync --sync-config=sync-config-paging.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync.yaml
+
+
+       os::test::junit::declare_suite_end
+    popd > /dev/null
+done
+
+# special test for RFC2307
+pushd ${BASETMPDIR}/rfc2307 > /dev/null
+echo -e "\tTEST: Sync groups from LDAP server, tolerating errors"
+oc adm groups sync --sync-config=sync-config-tolerating.yaml --confirm 2>"${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group1,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=INVALID,ou=people,ou=rfc2307,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group2,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=OUTOFSCOPE,ou=people,ou=OUTOFSCOPE,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group3,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=INVALID,ou=people,ou=rfc2307,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group3,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=OUTOFSCOPE,ou=people,ou=OUTOFSCOPE,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+compare_and_cleanup valid_all_ldap_sync_tolerating.yaml
+popd > /dev/null
+
+# special test for augmented-ad
+pushd ${BASETMPDIR}/augmented-ad > /dev/null
+echo -e "\tTEST: Sync all LDAP groups from LDAP server, remove LDAP group metadata entry, then prune OpenShift groups"
+oc adm groups sync --sync-config=sync-config.yaml --confirm
+ldapdelete -x -h $LDAP_SERVICE_IP -p 389 -D cn=Manager,dc=example,dc=com -w admin "${group1_ldapuid}"
+oc adm groups prune --sync-config=sync-config.yaml --confirm
+compare_and_cleanup valid_all_ldap_sync_delete_prune.yaml
+popd > /dev/null`)
+
+func testExtendedTestdataLdapGroupsyncShBytes() ([]byte, error) {
+	return _testExtendedTestdataLdapGroupsyncSh, nil
+}
+
+func testExtendedTestdataLdapGroupsyncSh() (*asset, error) {
+	bytes, err := testExtendedTestdataLdapGroupsyncShBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/ldap/groupsync.sh", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataLdapLdapserverConfigCmYaml = []byte(`---
 apiVersion: v1
 kind: ConfigMap
@@ -57181,6 +57400,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/jenkins-plugin/shared-resources-template.json": testExtendedTestdataJenkinsPluginSharedResourcesTemplateJson,
 	"test/extended/testdata/jenkins-slave-template.yaml": testExtendedTestdataJenkinsSlaveTemplateYaml,
 	"test/extended/testdata/jobs/v1.yaml": testExtendedTestdataJobsV1Yaml,
+	"test/extended/testdata/ldap/groupsync.sh": testExtendedTestdataLdapGroupsyncSh,
 	"test/extended/testdata/ldap/ldapserver-config-cm.yaml": testExtendedTestdataLdapLdapserverConfigCmYaml,
 	"test/extended/testdata/ldap/ldapserver-deployment.yaml": testExtendedTestdataLdapLdapserverDeploymentYaml,
 	"test/extended/testdata/ldap/ldapserver-scripts-cm.yaml": testExtendedTestdataLdapLdapserverScriptsCmYaml,
@@ -57872,6 +58092,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"v1.yaml": &bintree{testExtendedTestdataJobsV1Yaml, map[string]*bintree{}},
 				}},
 				"ldap": &bintree{nil, map[string]*bintree{
+					"groupsync.sh": &bintree{testExtendedTestdataLdapGroupsyncSh, map[string]*bintree{}},
 					"ldapserver-config-cm.yaml": &bintree{testExtendedTestdataLdapLdapserverConfigCmYaml, map[string]*bintree{}},
 					"ldapserver-deployment.yaml": &bintree{testExtendedTestdataLdapLdapserverDeploymentYaml, map[string]*bintree{}},
 					"ldapserver-scripts-cm.yaml": &bintree{testExtendedTestdataLdapLdapserverScriptsCmYaml, map[string]*bintree{}},

--- a/test/extended/testdata/ldap/groupsync.sh
+++ b/test/extended/testdata/ldap/groupsync.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#
+# This scripts starts the OpenShift server with a default configuration.
+# The OpenShift Docker registry and router are installed.
+# It will run all tests that are imported into test/extended.
+source "/usr/hack/lib/init.sh"
+os::util::environment::setup_time_vars
+os::build::setup_env
+
+export KUBECONFIG="${ADMIN_KUBECONFIG}"
+LDAP_SERVICE_IP="${LDAP_SERVICE}"
+
+function cleanup() {
+       return_code=$?
+       os::test::junit::generate_report
+       os::cleanup::all
+       os::util::describe_return_code "${return_code}"
+       exit "${return_code}"
+}
+trap "cleanup" EXIT
+
+function compare_and_cleanup() {
+       validation_file=$1
+       actual_file=actual-${validation_file}
+       rm -f ${WORKINGDIR}/${actual_file}
+       oc get groups --no-headers | awk '{print $1}' | sort | xargs -I{} oc get --export group {} -o yaml >> ${WORKINGDIR}/${actual_file}
+       os::util::sed '/sync-time/d' ${WORKINGDIR}/${actual_file}
+       diff ${validation_file} ${WORKINGDIR}/${actual_file}
+       oc delete groups --all
+       echo -e "\tSUCCESS"
+}
+
+os::log::info "Running extended tests"
+
+schema=('rfc2307' 'ad' 'augmented-ad')
+
+for (( i=0; i<${#schema[@]}; i++ )); do
+       current_schema=${schema[$i]}
+       os::log::info "Testing schema: ${current_schema}"
+       os::test::junit::declare_suite_start "extended/ldap-groups/${current_schema}"
+
+       WORKINGDIR=${BASETMPDIR}/${current_schema}
+       mkdir ${WORKINGDIR}
+
+       os::log::info "working dir ${WORKINGDIR}"
+       # create a temp copy of the test files
+       cp /tmp/ldap/${current_schema}/* ${WORKINGDIR}
+       pushd ${WORKINGDIR} > /dev/null
+
+       # load OpenShift and LDAP group UIDs, needed for literal whitelists
+       # use awk instead of sed for compatibility (see os::util::sed)
+       group1_ldapuid=$(awk 'NR == 1 {print $0}' ldapgroupuids.txt)
+       group2_ldapuid=$(awk 'NR == 2 {print $0}' ldapgroupuids.txt)
+       group3_ldapuid=$(awk 'NR == 3 {print $0}' ldapgroupuids.txt)
+
+       group1_osuid=$(awk 'NR == 1 {print $0}' osgroupuids.txt)
+       group2_osuid=$(awk 'NR == 2 {print $0}' osgroupuids.txt)
+       group3_osuid=$(awk 'NR == 3 {print $0}' osgroupuids.txt)
+
+       # update sync-configs and validation files with the LDAP server's IP
+       config_files=sync-config*.yaml
+       validation_files=valid*.yaml
+       for config in ${config_files} ${validation_files}
+       do
+               os::util::sed "s/LDAP_SERVICE_IP/${LDAP_SERVICE_IP}/g" ${config}
+               os::util::sed "s@LDAP_CA@${LDAP_CA}@g" ${config}
+       done
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server"
+       oc adm groups sync --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync.yaml
+
+
+       # WHITELISTS
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using whitelist file"
+       oc adm groups sync --whitelist=whitelist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using literal whitelist"
+       oc adm groups sync ${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using union of literal whitelist and whitelist file"
+       oc adm groups sync ${group2_ldapuid} --whitelist=whitelist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_union_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using whitelist file"
+       oc adm groups sync ${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc patch group ${group1_osuid} -p 'users: []'
+       oc adm groups sync --type=openshift --whitelist=whitelist_openshift.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using literal whitelist"
+       # sync group from LDAP
+       oc adm groups sync ${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc patch group ${group1_osuid} -p 'users: []'
+       oc adm groups sync --type=openshift ${group1_osuid} --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using union of literal whitelist and whitelist file"
+       # sync groups from LDAP
+       oc adm groups sync ${group1_ldapuid} ${group2_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc patch group ${group1_osuid} -p 'users: []'
+       oc patch group ${group2_osuid} -p 'users: []'
+       oc adm groups sync --type=openshift group/${group2_osuid} --whitelist=whitelist_openshift.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_whitelist_union_sync.yaml
+
+
+       # BLACKLISTS
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using whitelist and blacklist file"
+       # oc adm groups sync --whitelist=ldapgroupuids.txt --blacklist=blacklist_ldap.txt --blacklist-group="${group1_ldapuid}" --sync-config=sync-config.yaml --confirm
+       oc adm groups sync --whitelist=ldapgroupuids.txt --blacklist=blacklist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_blacklist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of LDAP groups from LDAP server using blacklist"
+       # oc adm groups sync --blacklist=blacklist_ldap.txt --blacklist-group=${group1_ldapuid} --sync-config=sync-config.yaml --confirm
+       oc adm groups sync --blacklist=blacklist_ldap.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_blacklist_sync.yaml
+
+       echo -e "\tTEST: Sync subset of OpenShift groups from LDAP server using whitelist and blacklist file"
+       oc adm groups sync --sync-config=sync-config.yaml --confirm
+       oc get group -o name --no-headers | xargs -n 1 oc patch -p 'users: []'
+       # oc adm groups sync --type=openshift --whitelist=osgroupuids.txt --blacklist=blacklist_openshift.txt --blacklist-group=${group1_osuid} --sync-config=sync-config.yaml --confirm
+       oc adm groups sync --type=openshift --whitelist=osgroupuids.txt --blacklist=blacklist_openshift.txt --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_openshift_blacklist_sync.yaml
+
+
+       # MAPPINGS
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using a user-defined mapping"
+       oc adm groups sync --sync-config=sync-config-user-defined.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_user_defined.yaml
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using a partially user-defined mapping"
+       oc adm groups sync --sync-config=sync-config-partially-user-defined.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_partially_user_defined.yaml
+
+       echo -e "\tTEST: Sync based on OpenShift groups respecting OpenShift mappings"
+       oc adm groups sync --sync-config=sync-config-user-defined.yaml --confirm
+       oc get group -o name --no-headers | xargs -n 1 oc patch -p 'users: []'
+       oc adm groups sync --type=openshift --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_user_defined.yaml
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using DN as attribute whenever possible"
+    oc adm groups sync --sync-config=sync-config-dn-everywhere.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_dn_everywhere.yaml
+
+       echo -e "\tTEST: Sync based on OpenShift groups respecting OpenShift mappings and whitelist file"
+       os::cmd::expect_success_and_text 'oc adm groups sync --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc adm groups sync --type=openshift --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc delete groups --all' 'deleted'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name} | wc -l' '0'
+
+       # PRUNING
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server, change LDAP UID, then prune OpenShift groups"
+       oc adm groups sync --sync-config=sync-config.yaml --confirm
+       oc patch group ${group2_osuid} -p "{\"metadata\":{\"annotations\":{\"openshift.io/ldap.uid\":\"cn=garbage,${group2_ldapuid}\"}}}"
+       oc adm groups prune --sync-config=sync-config.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync_prune.yaml
+
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using whitelist file, then prune OpenShift groups using the same whitelist file"
+       os::cmd::expect_success_and_text 'oc adm groups sync --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc adm groups prune --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm | wc -l' '0'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup secondgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc patch group secondgroup -p "{\"metadata\":{\"annotations\":{\"openshift.io/ldap.uid\":\"cn=garbage\"}}}"' 'group.user.openshift.io/secondgroup patched'
+       os::cmd::expect_success_and_text 'oc adm groups prune --whitelist=ldapgroupuids.txt --sync-config=sync-config-user-defined.yaml --confirm' 'group/secondgroup'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name}' 'firstgroup thirdgroup'
+       os::cmd::expect_success_and_text 'oc delete groups --all' 'deleted'
+       os::cmd::expect_success_and_text 'oc get group -o jsonpath={.items[*].metadata.name} | wc -l' '0'
+
+
+       # PAGING
+       echo -e "\tTEST: Sync all LDAP groups from LDAP server using paged queries"
+       oc adm groups sync --sync-config=sync-config-paging.yaml --confirm
+       compare_and_cleanup valid_all_ldap_sync.yaml
+
+
+       os::test::junit::declare_suite_end
+    popd > /dev/null
+done
+
+# special test for RFC2307
+pushd ${BASETMPDIR}/rfc2307 > /dev/null
+echo -e "\tTEST: Sync groups from LDAP server, tolerating errors"
+oc adm groups sync --sync-config=sync-config-tolerating.yaml --confirm 2>"${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group1,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=INVALID,ou=people,ou=rfc2307,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group2,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=OUTOFSCOPE,ou=people,ou=OUTOFSCOPE,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group3,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=INVALID,ou=people,ou=rfc2307,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+grep 'For group "cn=group3,ou=groups,ou=incomplete\-rfc2307,dc=example,dc=com", ignoring member "cn=OUTOFSCOPE,ou=people,ou=OUTOFSCOPE,dc=example,dc=com"' "${LOG_DIR}/tolerated-output.txt"
+compare_and_cleanup valid_all_ldap_sync_tolerating.yaml
+popd > /dev/null
+
+# special test for augmented-ad
+pushd ${BASETMPDIR}/augmented-ad > /dev/null
+echo -e "\tTEST: Sync all LDAP groups from LDAP server, remove LDAP group metadata entry, then prune OpenShift groups"
+oc adm groups sync --sync-config=sync-config.yaml --confirm
+ldapdelete -x -h $LDAP_SERVICE_IP -p 389 -D cn=Manager,dc=example,dc=com -w admin "${group1_ldapuid}"
+oc adm groups prune --sync-config=sync-config.yaml --confirm
+compare_and_cleanup valid_all_ldap_sync_delete_prune.yaml
+popd > /dev/null


### PR DESCRIPTION
This restores the old ldap_groups.sh extended test to run in a container.  
Depends on https://github.com/openshift/origin/pull/23347 (will drop commit and rebase when it merges)
