### PR TITLE
Load testPerson schema for ldap tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -12960,6 +12960,7 @@ data:
             ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/cosine.ldif -d $OPENLDAP_DEBUG_LEVEL
             ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/nis.ldif -d $OPENLDAP_DEBUG_LEVEL
             ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/inetorgperson.ldif -d $OPENLDAP_DEBUG_LEVEL
+            ldapadd -Y EXTERNAL -H ldapi:/// -f /usr/local/etc/openldap/testPerson.ldif -d $OPENLDAP_DEBUG_LEVEL
 
             # domain and TLS setup
             ldapmodify -Y EXTERNAL -H ldapi:/// -f /usr/local/etc/ldapconf/domain_conf.ldif -d $OPENLDAP_DEBUG_LEVEL

--- a/test/extended/testdata/ldap/ldapserver-scripts-cm.yaml
+++ b/test/extended/testdata/ldap/ldapserver-scripts-cm.yaml
@@ -49,6 +49,7 @@ data:
             ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/cosine.ldif -d $OPENLDAP_DEBUG_LEVEL
             ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/nis.ldif -d $OPENLDAP_DEBUG_LEVEL
             ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/inetorgperson.ldif -d $OPENLDAP_DEBUG_LEVEL
+            ldapadd -Y EXTERNAL -H ldapi:/// -f /usr/local/etc/openldap/testPerson.ldif -d $OPENLDAP_DEBUG_LEVEL
 
             # domain and TLS setup
             ldapmodify -Y EXTERNAL -H ldapi:/// -f /usr/local/etc/ldapconf/domain_conf.ldif -d $OPENLDAP_DEBUG_LEVEL


### PR DESCRIPTION
The groupsync test data was failing to load completely since the testPerson schema was missing. 