### PR TITLE
Modify SetNamespace() to fix multithreaded use

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -183,11 +183,14 @@ func (c *CLI) ChangeUser(name string) *CLI {
 
 // SetNamespace sets a new namespace
 func (c *CLI) SetNamespace(ns string) *CLI {
-	c.kubeFramework.Namespace = &corev1.Namespace{
+	// This copy is to fix SetNamespace() when used multithreaded
+	newKubeFramework := *c.kubeFramework
+	newKubeFramework.Namespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		},
 	}
+	c.kubeFramework = &newKubeFramework
 	return c
 }
 


### PR DESCRIPTION
When using a single oc CLI client in extended test in multiple threads, `SetNamespace()` breaks thread safety.

This is a proposed fix that solves the issue with a shallow copy.

However this copy breaks `govet`:
```
# github.com/openshift/origin/test/extended/util
test/extended/util/client.go:187:22: assignment copies lock value to newKubeFramework: github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.Framework contains sync.WaitGroup contains sync.noCopy
[FATAL] FAILURE: go vet failed!
```

Would this be possible to fix upstream? 