### PR TITLE
UPSTREAM: 70286: Use pvc uid instead of pvc name in glusterfs endpoint name

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/glusterfs/glusterfs.go
@@ -781,11 +781,11 @@ func (p *glusterfsVolumeProvisioner) CreateVolume(gid int) (r *v1.GlusterfsVolum
 		return nil, 0, "", fmt.Errorf("failed to get cluster nodes for volume %s: %v", volume, err)
 	}
 
-	// The 'endpointname' is created in form of 'glusterfs-dynamic-<claimname>'.
+	// The 'endpointname' is created in form of 'glusterfs-dynamic-<PVC UID>'.
 	// createEndpointService() checks for this 'endpoint' existence in PVC's namespace and
-	// If not found, it create an endpoint and service using the IPs we dynamically picked at time
+	// if not found, it create an endpoint and service using the IPs we dynamically picked at time
 	// of volume creation.
-	epServiceName := dynamicEpSvcPrefix + p.options.PVC.Name
+	epServiceName := dynamicEpSvcPrefix + string(p.options.PVC.UID)
 	epNamespace := p.options.PVC.Namespace
 	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)
 	if err != nil {


### PR DESCRIPTION


Bug # https://bugzilla.redhat.com/show_bug.cgi?id=1714609

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>