### PR TITLE
Fix APIServer CRD admission

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validation_wrapper.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/apiserver/validation_wrapper.go
@@ -25,7 +25,7 @@ func Register(plugins *admission.Plugins) {
 }
 
 type validateCustomResourceWithClient struct {
-	admission.Interface
+	admission.ValidationInterface
 
 	infrastructureGetter configv1client.InfrastructuresGetter
 }
@@ -43,7 +43,7 @@ func NewValidateAPIServer() (admission.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	ret.Interface = delegate
+	ret.ValidationInterface = delegate
 
 	return ret, nil
 }
@@ -68,7 +68,7 @@ func (a *validateCustomResourceWithClient) ValidateInitialization() error {
 		return fmt.Errorf(PluginName + " needs an infrastructureGetter")
 	}
 
-	if initializationValidator, ok := a.Interface.(admission.InitializationValidator); ok {
+	if initializationValidator, ok := a.ValidationInterface.(admission.InitializationValidator); ok {
 		return initializationValidator.ValidateInitialization()
 	}
 

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidator.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidator.go
@@ -25,7 +25,7 @@ type validateCustomResource struct {
 	validators map[schema.GroupVersionKind]ObjectValidator
 }
 
-func NewValidator(resources map[schema.GroupResource]bool, validators map[schema.GroupVersionKind]ObjectValidator) (admission.Interface, error) {
+func NewValidator(resources map[schema.GroupResource]bool, validators map[schema.GroupVersionKind]ObjectValidator) (admission.ValidationInterface, error) {
 	return &validateCustomResource{
 		Handler:    admission.NewHandler(admission.Create, admission.Update),
 		resources:  resources,


### PR DESCRIPTION
The admission stack was never calling the `Validate` method of the embedded plugin.