### PR TITLE
openshift-sdn: skip OPENSHIFT-MASQ for traffic already marked.

### DIFF
--- a/staging/src/github.com/openshift/sdn/pkg/network/node/node.go
+++ b/staging/src/github.com/openshift/sdn/pkg/network/node/node.go
@@ -94,6 +94,7 @@ type OsdnNode struct {
 	hostName           string
 	useConnTrack       bool
 	iptablesSyncPeriod time.Duration
+	masqueradeBit      uint32
 
 	// Synchronizes operations on egressPolicies
 	egressPoliciesLock sync.Mutex
@@ -152,6 +153,11 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 	}
 	oc := NewOVSController(ovsif, pluginId, useConnTrack, c.SelfIP)
 
+	masqBit := uint32(0)
+	if c.MasqueradeBit != nil {
+		masqBit = uint32(*c.MasqueradeBit)
+	}
+
 	plugin := &OsdnNode{
 		policy:             policy,
 		kClient:            c.KClient,
@@ -164,6 +170,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		hostName:           c.Hostname,
 		useConnTrack:       useConnTrack,
 		iptablesSyncPeriod: c.IPTablesSyncPeriod,
+		masqueradeBit:      masqBit,
 		egressPolicies:     make(map[uint32][]networkapi.EgressNetworkPolicy),
 		egressDNS:          common.NewEgressDNS(),
 		kubeInformers:      c.KubeInformers,
@@ -373,7 +380,7 @@ func (node *OsdnNode) Start() error {
 	for _, cn := range node.networkInfo.ClusterNetworks {
 		cidrList = append(cidrList, cn.ClusterCIDR.String())
 	}
-	nodeIPTables := newNodeIPTables(cidrList, node.iptablesSyncPeriod, !node.useConnTrack, node.networkInfo.VXLANPort)
+	nodeIPTables := newNodeIPTables(cidrList, node.iptablesSyncPeriod, !node.useConnTrack, node.networkInfo.VXLANPort, node.masqueradeBit)
 
 	if err = nodeIPTables.Setup(); err != nil {
 		return fmt.Errorf("failed to set up iptables: %v", err)


### PR DESCRIPTION
If a packet has already been marked by other kube-proxy rules for masquerade, don't run it through the OPENSHIFT-MASQUERADE chain for further twiddling.

Most notably, this chain is used for Egress IPs.

This change fixes a bug where egress IPs can't access services via their ExternalIP. (bz1726045)