### PR TITLE
Bugfix: fixup the following crash

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/secrets/sshauth.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/secrets/sshauth.go
@@ -146,6 +146,9 @@ func (o *CreateSSHAuthSecretOptions) NewSSHAuthSecret() (*corev1.Secret, error) 
 // Complete fills CreateSSHAuthSecretOptions fields with data and checks whether necessary
 // arguments were provided.
 func (o *CreateSSHAuthSecretOptions) Complete(f kcmdutil.Factory, args []string) error {
+	if len(args) != 1 {
+		return errors.New("must have exactly one argument: secret name")
+	}
 	o.SecretName = args[0]
 
 	clientConfig, err := f.ToRESTConfig()


### PR DESCRIPTION
$ oc secret new-sshauth
Command "new-sshauth" is deprecated, use oc create secret
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/openshift/origin/pkg/oc/cli/secrets.(*CreateSSHAuthSecretOptions).Complete(0xc420ee2c80, 0x3caf1a0, 0xc420b73860, 0x5303668, 0x0, 0x0, 0x23, 0x23)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/secrets/sshauth.go:149 +0x2ae
github.com/openshift/origin/pkg/oc/cli/secrets.NewCmdCreateSSHAuthSecret.func1(0xc4210e3180, 0x5303668, 0x0, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/pkg/oc/cli/secrets/sshauth.go:80 +0x7a
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc4210e3180, 0x5303668, 0x0, 0x0, 0xc4210e3180, 0x5303668)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:760 +0x2c1
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420b98000, 0xc4200d8000, 0xc4200d8010, 0xc420b98000)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:846 +0x30a
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420b98000, 0x2, 0xc420b98000)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:794 +0x2b
main.main()
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/oc/oc.go:70 +0x583

Signed-off-by: Zhou Peng <p@ctriple.cn>