### PR TITLE
Add repo details for disconnected install/upgrade

### DIFF
--- a/staging/src/github.com/openshift/oc/pkg/cli/admin/release/mirror.go
+++ b/staging/src/github.com/openshift/oc/pkg/cli/admin/release/mirror.go
@@ -513,16 +513,3 @@ func printInstallInstructions(out io.Writer, from, to string, repos map[string]s
 
 	return nil
 }
-
-func sourceImageRef(is *imagev1.ImageStream, name string) (string, bool) {
-	for _, tag := range is.Spec.Tags {
-		if tag.Name != name {
-			continue
-		}
-		if tag.From == nil || tag.From.Kind != "DockerImage" {
-			return "", false
-		}
-		return tag.From.Name, true
-	}
-	return "", false
-}


### PR DESCRIPTION
When performing a release mirror, provide details of repos where images
have been mirrored from to be used for disconnected install or upgrade.

https://jira.coreos.com/browse/CORS-1105

Command:
```
oc adm release mirror --from=registry.svc.ci.openshift.org/ocp/release:4.2 --to=registry.svc.ci.openshift.org/rteague-1/mirror-test
```

Example output:
```
To use the new mirrored release-image to install, provide the following list of release-image sources to the installer using the install-config.yaml:

imageContentSources:
- sources:
  - registry.svc.ci.openshift.org/rteague-1/mirror-test
  - registry.svc.ci.openshift.org/ocp/release
  - quay.io/openshift-release-dev/ocp-v4.0-art-dev
```