### PR TITLE
Add ConsoleLogLinks to exceptions list for Console CRDs

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -116,7 +116,7 @@ var (
 
 			// These custom resources are used to extend console functionality
 			// The console team is working on eliminating this exception in the near future
-			rbacv1helpers.NewRule(read...).Groups(consoleGroup).Resources("consoleclidownloads", "consolelinks", "consolenotifications").RuleOrDie(),
+			rbacv1helpers.NewRule(read...).Groups(consoleGroup).Resources("consoleclidownloads", "consolelinks", "consoleexternalloglinks", "consolenotifications").RuleOrDie(),
 		},
 		allUnauthenticatedRules...,
 	)


### PR DESCRIPTION
RE https://github.com/openshift/console-operator/pull/246
Extending initial exceptions in #23231 

