### PR TITLE
Fix documentation for cluster_up_down: host-data-dir => base-dir

### DIFF
--- a/docs/cluster_up_down.md
+++ b/docs/cluster_up_down.md
@@ -220,7 +220,7 @@ docker cp origin:/var/lib/origin/openshift.local.config .
 
 ## Etcd Data
 
-To persist data across restarts, specify a valid host directory in the `--host-data-dir` argument when starting your cluster
+To persist data across restarts, specify a valid host directory in the `--base-dir` argument when starting your cluster
 with `oc cluster up`. As long as the same value is specified every time, the data will be preserved across restarts.
 
 If a host data directory is not specified, the data directory used by OpenShift is discarded when the container is destroyed.


### PR DESCRIPTION
The --host-data-dir flag has been renamed to --base-dir. This commit
lets the documentation reflect that.