### PR TITLE
Wait for pods that have the correct label

### DIFF
--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -27,7 +27,7 @@ const checkDeleteProjectTimeout = 3 * time.Minute
 const checkPodRunningTimeout = 5 * time.Minute
 
 // TODO sjug: pass label via config
-var podLabels = map[string]string{"purpose": "test"}
+var podLabelMap = map[string]string{"purpose": "test"}
 var rootDir string
 
 var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
@@ -170,7 +170,7 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 							_ = c.CoreV1().ConfigMaps(nsName).Delete(configMapName, nil)
 						}()
 					}
-					err = pod.CreatePods(c, nsName, podLabels, config.Spec, tuning)
+					err = pod.CreatePods(c, nsName, podLabelMap, config.Spec, tuning)
 					o.Expect(err).NotTo(o.HaveOccurred())
 				}
 			}
@@ -222,14 +222,15 @@ var _ = g.Describe("[Feature:Performance][Serial][Slow] Load cluster", func() {
 				}
 			}
 
-			podList, err := oc.AdminKubeClient().CoreV1().Pods(ns).List(metav1.ListOptions{})
+			podLabels := exutil.ParseLabelsOrDie(mapToString(podLabelMap))
+			podList, err := oc.AdminKubeClient().CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: podLabels.String()})
 			if err != nil {
 				e2e.Failf("Error listing pods: %v", err)
 			}
 			podCount := len(podList.Items)
 			if podCount > 0 {
 				e2e.Logf("Waiting for %d pods in namespace %s", podCount, ns)
-				pods, err := exutil.WaitForPods(c.CoreV1().Pods(ns), exutil.ParseLabelsOrDie(mapToString(podLabels)), exutil.CheckPodIsRunning, podCount, checkPodRunningTimeout)
+				pods, err := exutil.WaitForPods(c.CoreV1().Pods(ns), podLabels, exutil.CheckPodIsRunning, podCount, checkPodRunningTimeout)
 				if err != nil {
 					e2e.Failf("Error in pod wait: %v", err)
 				} else if len(pods) < podCount {


### PR DESCRIPTION
Currently we are trying to compare all pods in a namespace to the count of running pods with a label. This fixed the expectation so that when we have other pods that are managed by higher level objects like builds or deployments they don't cause pod wait timeout.

