### PR TITLE
images/kube-proxy/Dockerfile.rhel: COPY relative

### DIFF
--- a/images/kube-proxy/Dockerfile.rhel
+++ b/images/kube-proxy/Dockerfile.rhel
@@ -4,13 +4,13 @@ RUN INSTALL_PKGS="conntrack-tools" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*
 
-COPY ./images/kube-proxy/scripts/iptables /usr/sbin/
-COPY ./images/kube-proxy/scripts/iptables-save /usr/sbin/
-COPY ./images/kube-proxy/scripts/iptables-restore /usr/sbin/
-COPY ./images/kube-proxy/scripts/ip6tables /usr/sbin/
-COPY ./images/kube-proxy/scripts/ip6tables-save /usr/sbin/
-COPY ./images/kube-proxy/scripts/ip6tables-restore /usr/sbin/
-COPY ./images/kube-proxy/scripts/iptables /usr/sbin/
+COPY ./scripts/iptables /usr/sbin/
+COPY ./scripts/iptables-save /usr/sbin/
+COPY ./scripts/iptables-restore /usr/sbin/
+COPY ./scripts/ip6tables /usr/sbin/
+COPY ./scripts/ip6tables-save /usr/sbin/
+COPY ./scripts/ip6tables-restore /usr/sbin/
+COPY ./scripts/iptables /usr/sbin/
 
 LABEL io.k8s.display-name="Kubernetes kube-proxy" \
       io.k8s.description="Provides kube-proxy for external CNI plugins" \


### PR DESCRIPTION
There is no need to refer to the whole repo when only using the contents from the same directory.

Of course you can expect this to fail tests until CI config is adjusted to match.