### PR TITLE
Bug 1731191: Flaky htpasswd e2e

### DIFF
--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -29,7 +29,7 @@ func init() {
 var _ = g.Describe("[Suite:openshift/oauth/htpasswd] HTPasswd IDP", func() {
 	var oc = exutil.NewCLI("htpasswd-idp", exutil.KubeConfigPath())
 
-	g.It("[Flaky] should successfully configure htpasswd and be responsive", func() {
+	g.It("should successfully configure htpasswd and be responsive", func() {
 		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)
 		defer cleanup()
 		o.Expect(err).ToNot(o.HaveOccurred())


### PR DESCRIPTION
Removing 'Flaky' from htpasswd e2e, running through CI - should not require retry 

testing flakiness with this merge: https://github.com/openshift/origin/commit/111a801fddf9ca7ec9c11a454e9436ad3ea0531e

/assign @deads2k 

