### PR TITLE
Bug 1683057: fix flaky router metrics test

### DIFF
--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.BeforeEach(func() {
 		var err error
-		routerIP, err = exutil.WaitForRouterServiceIP(oc)
+		routerIP, err = exutil.WaitForDefaultIngressControllerRoutableEndpoint(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		metricsIP, err = exutil.WaitForRouterInternalIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -39,7 +39,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.BeforeEach(func() {
 		var err error
-		ip, err = exutil.WaitForRouterServiceIP(oc)
+		ip, err = exutil.WaitForDefaultIngressControllerRoutableEndpoint(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -49,7 +49,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.BeforeEach(func() {
 		var err error
-		host, err = exutil.WaitForRouterServiceIP(oc)
+		host, err = exutil.WaitForDefaultIngressControllerRoutableEndpoint(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name


### PR DESCRIPTION
In v4, there are two ingress controller replicas by default. The ingress
controllers have their own uncoordinated metrics state. The metrics test was
refactored to speak to the metrics endpoint via a Service in front of the
ingress controllers. This means the metrics requests are getting load balanced
to different Service endpoints. The test was originally designed in v3 to assume
communication with a single ingress controller endpoint and makes assertions
about the metrics state of the single ingress controller. By abstracting
communication through the Service, the test no longer knows which ingress
controller it's talking to, and so sometimes gets the answers it expects, and
sometimes not, resulting in flakiness.

Refactor the test to communicate with ingress controller endpoints directly as
appropriate rather than through a Service.