### PR TITLE
Bug 1731278: Always restore kube:admin secret

### DIFF
--- a/test/extended/bootstrap_user/bootstrap_user_login.go
+++ b/test/extended/bootstrap_user/bootstrap_user_login.go
@@ -33,6 +33,20 @@ var _ = g.Describe("The bootstrap user", func() {
 		secretExists := true
 		recorder := events.NewInMemoryRecorder("")
 
+		// always restore cluster to original state at the end
+		defer func() {
+			if secretExists {
+				originalKubeadminSecret := generateSecret(originalPasswordHash)
+				e2e.Logf("restoring original kubeadmin user")
+				_, _, err := resourceapply.ApplySecret(oc.AsAdmin().KubeClient().CoreV1(), recorder, originalKubeadminSecret)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				return
+			}
+
+			err := oc.AsAdmin().KubeClient().CoreV1().Secrets("kube-system").Delete("kubeadmin", &metav1.DeleteOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}()
+
 		// We aren't testing that the installer has created this secret here, instead,
 		// we create it/apply new data/restore it after (if it existed, or delete it if
 		// it didn't.  Here, we are only testing the oauth flow
@@ -40,22 +54,22 @@ var _ = g.Describe("The bootstrap user", func() {
 		// Testing that the installer properly generated the password/secret is the
 		// responsibility of the installer.
 		secret, err := oc.AsAdmin().KubeClient().CoreV1().Secrets("kube-system").Get("kubeadmin", metav1.GetOptions{})
-		if err != nil {
-			if !kerrors.IsNotFound(err) {
-				o.Expect(err).NotTo(o.HaveOccurred())
-			} else {
-				secretExists = false
-			}
+		if kerrors.IsNotFound(err) {
+			secretExists = false
+			err = nil // ignore not found
 		}
+		o.Expect(err).NotTo(o.HaveOccurred())
 		if secretExists {
 			// not validating secret here, but it should have this if it's there
 			originalPasswordHash = secret.Data["kubeadmin"]
 		}
+
 		password, passwordHash, err := generatePassword()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		kubeadminSecret := generateSecret(passwordHash)
 		_, _, err = resourceapply.ApplySecret(oc.AsAdmin().KubeClient().CoreV1(), recorder, kubeadminSecret)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
 		e2e.Logf("logging in as kubeadmin user")
 		err = wait.Poll(10*time.Second, 5*time.Minute, func() (done bool, err error) {
 			out, err := oc.Run("login").Args("-u", "kubeadmin").InputString(password + "\n").Output()
@@ -70,19 +84,10 @@ var _ = g.Describe("The bootstrap user", func() {
 			return true, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
+
 		user, err := oc.Run("whoami").Args().Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(user).To(o.ContainSubstring("kube:admin"))
-		//Now, restore cluster to original state
-		if secretExists {
-			originalKubeadminSecret := generateSecret(originalPasswordHash)
-			e2e.Logf("restoring original kubeadmin user")
-			_, _, err = resourceapply.ApplySecret(oc.AsAdmin().KubeClient().CoreV1(), recorder, originalKubeadminSecret)
-			o.Expect(err).NotTo(o.HaveOccurred())
-		} else {
-			err := oc.AsAdmin().KubeClient().CoreV1().Secrets("kube-system").Delete("kubeadmin", &metav1.DeleteOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
 	})
 })
 


### PR DESCRIPTION
Even if the bootstrap user test fails, we must restore the cluster back to its original state.

Signed-off-by: Monis Khan <mkhan@redhat.com>

/assign @sallyom