### PR TITLE
UPSTREAM: 80393: Prevent a flake in a pod e2e test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/kubectl/kubectl.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/kubectl/kubectl.go
@@ -578,7 +578,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			ginkgo.By("executing a command with run")
 			framework.RunKubectlOrDie("run", podName, "--generator=run-pod/v1", "--image="+busyboxImage, "--restart=OnFailure", nsFlag, "--", "sh", "-c", "sleep 10; seq 100 | while read i; do echo $i; sleep 0.01; done; echo EOF")
 
-			if !framework.CheckPodsRunningReady(c, ns, []string{podName}, framework.PodStartTimeout) {
+			if !framework.CheckPodsRunningReadyOrSucceeded(c, ns, []string{podName}, framework.PodStartTimeout) {
 				framework.Failf("Pod for run-log-test was not ready")
 			}
 


### PR DESCRIPTION
We can fail to observe ready because pod completes so fast.

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1/978