### PR TITLE
test: Ensure e2e tests create a namespace prefixed with e2e-

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -274,6 +274,9 @@ func skipTestNamespaceCustomization() bool {
 
 // createTestingNS ensures that kubernetes e2e tests have their service accounts in the privileged and anyuid SCCs
 func createTestingNS(baseName string, c kclientset.Interface, labels map[string]string) (*kapiv1.Namespace, error) {
+	if !strings.HasPrefix(baseName, "e2e-") {
+		baseName = "e2e-" + baseName
+	}
 	ns, err := e2e.CreateTestingNS(baseName, c, labels)
 	if err != nil {
 		return ns, err


### PR DESCRIPTION
Allows better filtering during debug, this is a regression from previous code (not sure when this regressed, it's at least 1 week old).