### PR TITLE
Re-enable crd-discovery-available hook and ignore some resources for bootstrap

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -227,9 +227,6 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		return nil
 	})
 	s.GenericAPIServer.AddPostStartHookOrDie("crd-discovery-available", func(context genericapiserver.PostStartHookContext) error {
-		if true {
-			return nil
-		}
 		return wait.PollImmediateUntil(100*time.Millisecond, func() (bool, error) {
 			// only check if we have a valid list for a given resourceversion
 			if !s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions().Informer().HasSynced() {


### PR DESCRIPTION
Follow-up for https://github.com/openshift/origin/pull/23366

In three cases we can't wait for the CRD's being available because these are installed later by the config operator. Relying on them being available means the bootstrap kube apiserver will fail.

An alternative would be to disable this hook for the bootstrap apiserver (but that looks like much more wiring).

/cc @sttts 
/cc @deads2k 