### PR TITLE
remove e2e-test deps on oc

### DIFF
--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/openshift/api/image/docker10"
 	"github.com/openshift/library-go/pkg/image/imageutil"
-	"github.com/openshift/oc/pkg/helpers/image/dockerlayer"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -121,7 +120,7 @@ var _ = g.Describe("[Feature:ImageAppend] Image append", func() {
 		imageutil.ImageWithMetadataOrDie(&istag.Image)
 
 		o.Expect(istag.Image.DockerImageLayers).To(o.HaveLen(1))
-		o.Expect(istag.Image.DockerImageLayers[0].Name).To(o.Equal(dockerlayer.GzippedEmptyLayerDigest))
+		o.Expect(istag.Image.DockerImageLayers[0].Name).To(o.Equal(GzippedEmptyLayerDigest))
 		err = imageutil.ImageWithMetadata(&istag.Image)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(istag.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
@@ -136,7 +135,7 @@ var _ = g.Describe("[Feature:ImageAppend] Image append", func() {
 		o.Expect(istag.Image).NotTo(o.BeNil())
 		imageutil.ImageWithMetadataOrDie(&istag.Image)
 		o.Expect(istag.Image.DockerImageLayers).To(o.HaveLen(1))
-		o.Expect(istag.Image.DockerImageLayers[0].Name).NotTo(o.Equal(dockerlayer.GzippedEmptyLayerDigest))
+		o.Expect(istag.Image.DockerImageLayers[0].Name).NotTo(o.Equal(GzippedEmptyLayerDigest))
 		err = imageutil.ImageWithMetadata(&istag.Image)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(istag.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
@@ -154,3 +153,12 @@ var _ = g.Describe("[Feature:ImageAppend] Image append", func() {
 		o.Expect(istag.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.Cmd).To(o.Equal([]string{"/bin/sleep"}))
 	})
 })
+
+const (
+	// GzippedEmptyLayerDigest is a digest of GzippedEmptyLayer
+	GzippedEmptyLayerDigest = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+	// EmptyLayerDiffID is the tarsum of the GzippedEmptyLayer
+	EmptyLayerDiffID = "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)

--- a/test/extended/images/imagestream.go
+++ b/test/extended/images/imagestream.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/api/image/docker10"
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/library-go/pkg/image/imageutil"
-	stratsupport "github.com/openshift/oc/pkg/cli/deployer/strategy/support"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -310,7 +309,7 @@ func TestImageStreamTagLifecycleHook(t g.GinkgoTInterface, oc *exutil.CLI) {
 	coreClient := oc.AdminKubeClient()
 
 	// can tag to a stream that exists
-	exec := stratsupport.NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
+	exec := NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
 	err := exec.Execute(
 		&appsv1.LifecycleHook{
 			TagImages: []appsv1.TagImageHook{
@@ -349,7 +348,7 @@ func TestImageStreamTagLifecycleHook(t g.GinkgoTInterface, oc *exutil.CLI) {
 	}
 
 	// can execute a second time the same tag and it should work
-	exec = stratsupport.NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
+	exec = NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
 	err = exec.Execute(
 		&appsv1.LifecycleHook{
 			TagImages: []appsv1.TagImageHook{
@@ -381,7 +380,7 @@ func TestImageStreamTagLifecycleHook(t g.GinkgoTInterface, oc *exutil.CLI) {
 	}
 
 	// can lifecycle tag a new image stream
-	exec = stratsupport.NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
+	exec = NewHookExecutor(coreClient, imageClientset.ImageV1(), os.Stdout)
 	err = exec.Execute(
 		&appsv1.LifecycleHook{
 			TagImages: []appsv1.TagImageHook{

--- a/test/extended/images/oc_copy.go
+++ b/test/extended/images/oc_copy.go
@@ -1,0 +1,557 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/reference"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/klog"
+	kapi "k8s.io/kubernetes/pkg/apis/core"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	imageapiv1 "github.com/openshift/api/image/v1"
+	imageclienttyped "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	"github.com/openshift/library-go/pkg/build/naming"
+	"github.com/openshift/origin/test/extended/scheme"
+
+	"github.com/openshift/library-go/pkg/apps/appsserialization"
+	"github.com/openshift/library-go/pkg/apps/appsutil"
+)
+
+const (
+	// hookContainerName is the name used for the container that runs inside hook pods.
+	hookContainerName = "lifecycle"
+	// deploymentPodTypeLabel is a label with which contains a type of deployment pod.
+	deploymentPodTypeLabel = "openshift.io/deployer-pod.type"
+	// deploymentAnnotation is an annotation on a deployer Pod. The annotation value is the name
+	// of the deployment (a ReplicationController) on which the deployer Pod acts.
+	deploymentAnnotation = "openshift.io/deployment.name"
+)
+
+// HookExecutor knows how to execute a deployment lifecycle hook.
+type HookExecutor interface {
+	Execute(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error
+}
+
+// hookExecutor implements the HookExecutor interface.
+var _ HookExecutor = &hookExecutor{}
+
+// hookExecutor executes a deployment lifecycle hook.
+type hookExecutor struct {
+	// pods provides client to pods
+	pods corev1client.PodsGetter
+	// tags allows setting image stream tags
+	tags imageclienttyped.ImageStreamTagsGetter
+	// out is where hook pod logs should be written to.
+	out io.Writer
+	// recorder is used to emit events from hooks
+	events corev1client.EventsGetter
+	// getPodLogs knows how to get logs from a pod and is used for testing
+	getPodLogs func(*corev1.Pod) (io.ReadCloser, error)
+}
+
+// NewHookExecutor makes a HookExecutor from a client.
+func NewHookExecutor(kubeClient kubernetes.Interface, imageClient imageclienttyped.ImageStreamTagsGetter, out io.Writer) HookExecutor {
+	executor := &hookExecutor{
+		tags:   imageClient,
+		pods:   kubeClient.CoreV1(),
+		events: kubeClient.CoreV1(),
+		out:    out,
+	}
+	executor.getPodLogs = func(pod *corev1.Pod) (io.ReadCloser, error) {
+		opts := &corev1.PodLogOptions{
+			Container:  hookContainerName,
+			Follow:     true,
+			Timestamps: false,
+		}
+		return executor.pods.Pods(pod.Namespace).GetLogs(pod.Name, opts).Stream()
+	}
+	return executor
+}
+
+// Execute executes hook in the context of deployment. The suffix is used to
+// distinguish the kind of hook (e.g. pre, post).
+func (e *hookExecutor) Execute(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
+	var err error
+	switch {
+	case len(hook.TagImages) > 0:
+		tagEventMessages := []string{}
+		for _, t := range hook.TagImages {
+			image, ok := findContainerImage(rc, t.ContainerName)
+			if ok {
+				tagEventMessages = append(tagEventMessages, fmt.Sprintf("image %q as %q", image, t.To.Name))
+			}
+		}
+		RecordConfigEvent(e.events, rc, kapi.EventTypeNormal, "Started",
+			fmt.Sprintf("Running %s-hook (TagImages) %s for rc %s/%s", label, strings.Join(tagEventMessages, ","), rc.Namespace, rc.Name))
+		err = e.tagImages(hook, rc, suffix, label)
+	case hook.ExecNewPod != nil:
+		RecordConfigEvent(e.events, rc, kapi.EventTypeNormal, "Started",
+			fmt.Sprintf("Running %s-hook (%q) for rc %s/%s", label, strings.Join(hook.ExecNewPod.Command, " "), rc.Namespace, rc.Name))
+		err = e.executeExecNewPod(hook, rc, suffix, label)
+	}
+
+	if err == nil {
+		RecordConfigEvent(e.events, rc, kapi.EventTypeNormal, "Completed",
+			fmt.Sprintf("The %s-hook for rc %s/%s completed successfully", label, rc.Namespace, rc.Name))
+		return nil
+	}
+
+	// Retry failures are treated the same as Abort.
+	switch hook.FailurePolicy {
+	case appsv1.LifecycleHookFailurePolicyAbort, appsv1.LifecycleHookFailurePolicyRetry:
+		RecordConfigEvent(e.events, rc, kapi.EventTypeWarning, "Failed",
+			fmt.Sprintf("The %s-hook failed: %v, aborting rollout of %s/%s", label, err, rc.Namespace, rc.Name))
+		return fmt.Errorf("the %s hook failed: %v, aborting rollout of %s/%s", label, err, rc.Namespace, rc.Name)
+	case appsv1.LifecycleHookFailurePolicyIgnore:
+		RecordConfigEvent(e.events, rc, kapi.EventTypeWarning, "Failed",
+			fmt.Sprintf("The %s-hook failed: %v (ignore), rollout of %s/%s will continue", label, err, rc.Namespace, rc.Name))
+		return nil
+	default:
+		return err
+	}
+}
+
+// findContainerImage returns the image with the given container name from a replication controller.
+func findContainerImage(rc *corev1.ReplicationController, containerName string) (string, bool) {
+	if rc.Spec.Template == nil {
+		return "", false
+	}
+	for _, container := range rc.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			return container.Image, true
+		}
+	}
+	return "", false
+}
+
+// tagImages tags images as part of the lifecycle of a rc. It uses an ImageStreamTag client
+// which will provision an ImageStream if it doesn't already exist.
+func (e *hookExecutor) tagImages(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
+	var errs []error
+	for _, action := range hook.TagImages {
+		value, ok := findContainerImage(rc, action.ContainerName)
+		if !ok {
+			errs = append(errs, fmt.Errorf("unable to find image for container %q, container could not be found", action.ContainerName))
+			continue
+		}
+		namespace := action.To.Namespace
+		if len(namespace) == 0 {
+			namespace = rc.Namespace
+		}
+		if _, err := e.tags.ImageStreamTags(namespace).Update(&imageapiv1.ImageStreamTag{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      action.To.Name,
+				Namespace: namespace,
+			},
+			Tag: &imageapiv1.TagReference{
+				From: &corev1.ObjectReference{
+					Kind: "DockerImage",
+					Name: value,
+				},
+			},
+		}); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		fmt.Fprintf(e.out, "--> %s: Tagged %q into %s/%s\n", label, value, action.To.Namespace, action.To.Name)
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// executeExecNewPod executes a ExecNewPod hook by creating a new pod based on
+// the hook parameters and replication controller. The pod is then synchronously
+// watched until the pod completes, and if the pod failed, an error is returned.
+//
+// The hook pod inherits the following from the container the hook refers to:
+//
+//   * Environment (hook keys take precedence)
+//   * Working directory
+//   * Resources
+func (e *hookExecutor) executeExecNewPod(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, suffix, label string) error {
+	config, err := appsserialization.DecodeDeploymentConfig(rc)
+	if err != nil {
+		return err
+	}
+
+	deployerPod, err := e.pods.Pods(rc.Namespace).Get(appsutil.DeployerPodNameForDeployment(rc.Name), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var startTime time.Time
+	// if the deployer pod has not yet had its status updated, it means the execution of the pod is racing with the kubelet
+	// status update. Until kubernetes/kubernetes#36813 is implemented, this check will remain racy. Set to Now() expecting
+	// that the kubelet is unlikely to be very far behind.
+	if deployerPod.Status.StartTime != nil {
+		startTime = deployerPod.Status.StartTime.Time
+	} else {
+		startTime = time.Now()
+	}
+
+	// Build a pod spec from the hook config and replication controller.
+	podSpec, err := createHookPodManifest(hook, rc, &config.Spec.Strategy, suffix, startTime)
+	if err != nil {
+		return err
+	}
+
+	// Track whether the pod has already run to completion and avoid showing logs
+	// or the Success message twice.
+	completed, created := false, false
+
+	// Try to create the pod.
+	pod, err := e.pods.Pods(rc.Namespace).Create(podSpec)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("couldn't create lifecycle pod for %s: %v", rc.Name, err)
+		}
+		completed = true
+		pod = podSpec
+		pod.Namespace = rc.Namespace
+	} else {
+		created = true
+		fmt.Fprintf(e.out, "--> %s: Running hook pod ...\n", label)
+	}
+
+	var updatedPod *corev1.Pod
+	restarts := int32(0)
+	alreadyRead := false
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	listWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", pod.Name).String()
+			return e.pods.Pods(pod.Namespace).List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", pod.Name).String()
+			return e.pods.Pods(pod.Namespace).Watch(options)
+		},
+	}
+	// make sure that the pod exists and wasn't deleted early
+	preconditionFunc := func(store cache.Store) (bool, error) {
+		_, exists, err := store.Get(&metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name})
+		if err != nil {
+			return true, err
+		}
+		if !exists {
+			// We need to make sure we see the object in the cache before we start waiting for events
+			// or we would be waiting for the timeout if such object didn't exist.
+			return true, apierrors.NewNotFound(corev1.Resource("pods"), pod.Name)
+		}
+
+		return false, nil
+	}
+	// Wait for the hook pod to reach a terminal phase. Start reading logs as
+	// soon as the pod enters a usable phase.
+	_, err = watchtools.UntilWithSync(
+		context.TODO(),
+		listWatcher,
+		&corev1.Pod{},
+		preconditionFunc,
+		func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Error:
+				return false, apierrors.FromObject(event.Object)
+			case watch.Added, watch.Modified:
+				updatedPod = event.Object.(*corev1.Pod)
+			case watch.Deleted:
+				err := fmt.Errorf("%s: pod/%s[%s] unexpectedly deleted", label, pod.Name, pod.Namespace)
+				fmt.Fprintf(e.out, "%v\n", err)
+				return false, err
+
+			}
+
+			switch updatedPod.Status.Phase {
+			case corev1.PodRunning:
+				completed = false
+
+				// We should read only the first time or in any container restart when we want to retry.
+				canRetry, restartCount := canRetryReading(updatedPod, restarts)
+				if alreadyRead && !canRetry {
+					break
+				}
+				// The hook container has restarted; we need to notify that we are retrying in the logs.
+				// TODO: Maybe log the container id
+				if restarts != restartCount {
+					wg.Add(1)
+					restarts = restartCount
+					fmt.Fprintf(e.out, "--> %s: Retrying hook pod (retry #%d)\n", label, restartCount)
+				}
+				alreadyRead = true
+				go e.readPodLogs(pod, wg)
+
+			case corev1.PodSucceeded, corev1.PodFailed:
+				if completed {
+					if updatedPod.Status.Phase == corev1.PodSucceeded {
+						fmt.Fprintf(e.out, "--> %s: Hook pod already succeeded\n", label)
+					}
+					wg.Done()
+					return true, nil
+				}
+				if !created {
+					fmt.Fprintf(e.out, "--> %s: Hook pod is already running ...\n", label)
+				}
+				if !alreadyRead {
+					go e.readPodLogs(pod, wg)
+				}
+				return true, nil
+			default:
+				completed = false
+			}
+
+			return false, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// The pod is finished, wait for all logs to be consumed before returning.
+	wg.Wait()
+	if updatedPod.Status.Phase == corev1.PodFailed {
+		fmt.Fprintf(e.out, "--> %s: Failed\n", label)
+		return fmt.Errorf(updatedPod.Status.Message)
+	}
+	// Only show this message if we created the pod ourselves, or we saw
+	// the pod in a running or pending state.
+	if !completed {
+		fmt.Fprintf(e.out, "--> %s: Success\n", label)
+	}
+	return nil
+}
+
+// readPodLogs streams logs from pod to out. It signals wg when
+// done.
+func (e *hookExecutor) readPodLogs(pod *corev1.Pod, wg *sync.WaitGroup) {
+	defer wg.Done()
+	logStream, err := e.getPodLogs(pod)
+	if err != nil || logStream == nil {
+		fmt.Fprintf(e.out, "warning: Unable to retrieve hook logs from %s: %v\n", pod.Name, err)
+		return
+	}
+	// Read logs.
+	defer logStream.Close()
+	if _, err := io.Copy(e.out, logStream); err != nil {
+		fmt.Fprintf(e.out, "\nwarning: Unable to read all logs from %s, continuing: %v\n", pod.Name, err)
+	}
+}
+
+func createHookPodManifest(hook *appsv1.LifecycleHook, rc *corev1.ReplicationController, strategy *appsv1.DeploymentStrategy,
+	hookType string,
+	startTime time.Time) (*corev1.Pod, error) {
+
+	exec := hook.ExecNewPod
+
+	var baseContainer *corev1.Container
+
+	for _, container := range rc.Spec.Template.Spec.Containers {
+		if container.Name == exec.ContainerName {
+			baseContainer = &container
+			break
+		}
+	}
+	if baseContainer == nil {
+		return nil, fmt.Errorf("no container named '%s' found in rc template", exec.ContainerName)
+	}
+
+	// Build a merged environment; hook environment takes precedence over base
+	// container environment
+	envMap := map[string]corev1.EnvVar{}
+	mergedEnv := []corev1.EnvVar{}
+	for _, env := range baseContainer.Env {
+		envMap[env.Name] = env
+	}
+	for _, env := range exec.Env {
+		envMap[env.Name] = env
+	}
+	for k, v := range envMap {
+		mergedEnv = append(mergedEnv, corev1.EnvVar{Name: k, Value: v.Value, ValueFrom: v.ValueFrom})
+	}
+	mergedEnv = append(mergedEnv, corev1.EnvVar{Name: "OPENSHIFT_DEPLOYMENT_NAME", Value: rc.Name})
+	mergedEnv = append(mergedEnv, corev1.EnvVar{Name: "OPENSHIFT_DEPLOYMENT_NAMESPACE", Value: rc.Namespace})
+
+	// Assigning to a variable since its address is required
+	defaultActiveDeadline := appsutil.MaxDeploymentDurationSeconds
+	if strategy.ActiveDeadlineSeconds != nil {
+		defaultActiveDeadline = *(strategy.ActiveDeadlineSeconds)
+	}
+	maxDeploymentDurationSeconds := defaultActiveDeadline - int64(time.Since(startTime).Seconds())
+
+	// Let the kubelet manage retries if requested
+	restartPolicy := corev1.RestartPolicyNever
+	if hook.FailurePolicy == appsv1.LifecycleHookFailurePolicyRetry {
+		restartPolicy = corev1.RestartPolicyOnFailure
+	}
+
+	// Transfer any requested volumes to the hook pod.
+	volumes := []corev1.Volume{}
+	volumeNames := sets.NewString()
+	for _, volume := range rc.Spec.Template.Spec.Volumes {
+		for _, name := range exec.Volumes {
+			if volume.Name == name {
+				volumes = append(volumes, volume)
+				volumeNames.Insert(volume.Name)
+			}
+		}
+	}
+	// Transfer any volume mounts associated with transferred volumes.
+	volumeMounts := []corev1.VolumeMount{}
+	for _, mount := range baseContainer.VolumeMounts {
+		if volumeNames.Has(mount.Name) {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      mount.Name,
+				ReadOnly:  mount.ReadOnly,
+				MountPath: mount.MountPath,
+				SubPath:   mount.SubPath,
+			})
+		}
+	}
+
+	// Transfer image pull secrets from the pod spec.
+	imagePullSecrets := []corev1.LocalObjectReference{}
+	for _, pullSecret := range rc.Spec.Template.Spec.ImagePullSecrets {
+		imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: pullSecret.Name})
+	}
+
+	gracePeriod := int64(10)
+	podSecurityContextCopy := rc.Spec.Template.Spec.SecurityContext.DeepCopy()
+	securityContextCopy := baseContainer.SecurityContext.DeepCopy()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      naming.GetPodName(rc.Name, hookType),
+			Namespace: rc.Namespace,
+			Annotations: map[string]string{
+				deploymentAnnotation: rc.Name,
+			},
+			Labels: map[string]string{
+				appsv1.DeployerPodForDeploymentLabel: rc.Name,
+				deploymentPodTypeLabel:               hookType,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            hookContainerName,
+					Image:           baseContainer.Image,
+					ImagePullPolicy: baseContainer.ImagePullPolicy,
+					Command:         exec.Command,
+					WorkingDir:      baseContainer.WorkingDir,
+					Env:             mergedEnv,
+					Resources:       baseContainer.Resources,
+					VolumeMounts:    volumeMounts,
+					SecurityContext: securityContextCopy,
+				},
+			},
+			SecurityContext:       podSecurityContextCopy,
+			Volumes:               volumes,
+			ActiveDeadlineSeconds: &maxDeploymentDurationSeconds,
+			// Setting the node selector on the hook pod so that it is created
+			// on the same set of nodes as the rc pods.
+			NodeSelector:                  rc.Spec.Template.Spec.NodeSelector,
+			RestartPolicy:                 restartPolicy,
+			ImagePullSecrets:              imagePullSecrets,
+			TerminationGracePeriodSeconds: &gracePeriod,
+		},
+	}
+
+	// add in DC specified labels and annotations
+	for k, v := range strategy.Labels {
+		if _, ok := pod.Labels[k]; ok {
+			continue
+		}
+		pod.Labels[k] = v
+	}
+	for k, v := range strategy.Annotations {
+		if _, ok := pod.Annotations[k]; ok {
+			continue
+		}
+		pod.Annotations[k] = v
+	}
+
+	return pod, nil
+}
+
+// canRetryReading returns whether the deployment strategy can retry reading logs
+// from the given (hook) pod and the number of restarts that pod has.
+func canRetryReading(pod *corev1.Pod, restarts int32) (bool, int32) {
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false, int32(0)
+	}
+	restartCount := pod.Status.ContainerStatuses[0].RestartCount
+	return pod.Spec.RestartPolicy == corev1.RestartPolicyOnFailure && restartCount > restarts, restartCount
+}
+
+// deployment.
+func RecordConfigEvent(client corev1client.EventsGetter, deployment *corev1.ReplicationController, eventType, reason,
+	msg string) {
+	t := metav1.Time{Time: time.Now()}
+	var obj runtime.Object = deployment
+	if config, err := appsserialization.DecodeDeploymentConfig(deployment); err == nil {
+		obj = config
+	} else {
+		klog.Errorf("Unable to decode deployment config from %s/%s: %v", deployment.Namespace, deployment.Name, err)
+	}
+	ref, err := reference.GetReference(scheme.Scheme, obj)
+	if err != nil {
+		klog.Errorf("Unable to get reference for %#v: %v", obj, err)
+		return
+	}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			Namespace: ref.Namespace,
+		},
+		InvolvedObject: *ref,
+		Reason:         reason,
+		Message:        msg,
+		Source: corev1.EventSource{
+			Component: appsutil.DeployerPodNameFor(deployment),
+		},
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Type:           eventType,
+	}
+	if _, err := client.Events(ref.Namespace).Create(event); err != nil {
+		klog.Errorf("Could not create event '%#v': %v", event, err)
+	}
+}
+
+// RecordConfigWarnings records all warning events from the replication controller to the
+// associated deployment config.
+func RecordConfigWarnings(client corev1client.EventsGetter, rc *corev1.ReplicationController, out io.Writer) {
+	if rc == nil {
+		return
+	}
+	events, err := client.Events(rc.Namespace).Search(scheme.Scheme, rc)
+	if err != nil {
+		fmt.Fprintf(out, "--> Error listing events for replication controller %s: %v\n", rc.Name, err)
+		return
+	}
+	// TODO: Do we need to sort the events?
+	for _, e := range events.Items {
+		if e.Type == corev1.EventTypeWarning {
+			fmt.Fprintf(out, "-->  %s: %s %s\n", e.Reason, rc.Name, e.Message)
+			RecordConfigEvent(client, rc, e.Type, e.Reason, e.Message)
+		}
+	}
+}

--- a/test/extended/images/prune.go
+++ b/test/extended/images/prune.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/api/image/docker10"
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/library-go/pkg/image/imageutil"
-	"github.com/openshift/oc/pkg/helpers/image/dockerlayer"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -261,7 +260,7 @@ func testPruneImages(oc *exutil.CLI, schemaVersion int) {
 		o.Expect(output).To(o.ContainSubstring(imgPrune.DockerImageMetadata.Object.(*docker10.DockerImage).ID))
 	}
 	for _, layer := range imgPrune.DockerImageLayers {
-		if layer.Name == dockerlayer.GzippedEmptyLayerDigest {
+		if layer.Name == GzippedEmptyLayerDigest {
 			// Schema 1 manifests are known to have the widespread layer.
 			continue
 		}
@@ -293,7 +292,7 @@ func testPruneImages(oc *exutil.CLI, schemaVersion int) {
 		o.Expect(output).To(o.ContainSubstring(imgPrune.DockerImageMetadata.Object.(*docker10.DockerImage).ID))
 	}
 	for _, layer := range imgPrune.DockerImageLayers {
-		if layer.Name == dockerlayer.GzippedEmptyLayerDigest {
+		if layer.Name == GzippedEmptyLayerDigest {
 			// Schema 1 manifests are known to have the widespread layer.
 			continue
 		}

--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
-	"github.com/openshift/oc/pkg/cli/admin/release"
 	exutil "github.com/openshift/origin/test/extended/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +47,7 @@ var _ = Describe("[Feature:Platform][Smoke] Managed cluster", func() {
 			e2e.Logf("unable to read release payload with error: %v", err)
 			return
 		}
-		releaseInfo := &release.ReleaseInfo{}
+		releaseInfo := &ReleaseInfo{}
 		if err := json.Unmarshal([]byte(out), &releaseInfo); err != nil {
 			e2e.Failf("unable to decode release payload with error: %v", err)
 		}

--- a/test/extended/operators/oc_copy.go
+++ b/test/extended/operators/oc_copy.go
@@ -1,0 +1,75 @@
+package operators
+
+import (
+	"github.com/docker/distribution"
+	digest "github.com/opencontainers/go-digest"
+	imageapi "github.com/openshift/api/image/v1"
+	"github.com/openshift/library-go/pkg/image/dockerv1client"
+	imagereference "github.com/openshift/library-go/pkg/image/reference"
+)
+
+type CincinnatiMetadata struct {
+	Kind string `json:"kind"`
+
+	Version  string   `json:"version"`
+	Previous []string `json:"previous"`
+
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type ReleaseDiff struct {
+	From *ReleaseInfo `json:"from"`
+	To   *ReleaseInfo `json:"to"`
+
+	ChangedImages    map[string]*ImageReferenceDiff  `json:"changedImages"`
+	ChangedManifests map[string]*ReleaseManifestDiff `json:"changedManifests"`
+}
+
+type ImageReferenceDiff struct {
+	Name string `json:"name"`
+
+	From *imageapi.TagReference `json:"from"`
+	To   *imageapi.TagReference `json:"to"`
+}
+
+type ReleaseManifestDiff struct {
+	Filename string `json:"filename"`
+
+	From []byte `json:"from"`
+	To   []byte `json:"to"`
+}
+
+type ReleaseInfo struct {
+	Image         string                              `json:"image"`
+	ImageRef      imagereference.DockerImageReference `json:"-"`
+	Digest        digest.Digest                       `json:"digest"`
+	ContentDigest digest.Digest                       `json:"contentDigest"`
+	// TODO: return the list digest in the future
+	// ListDigest    digest.Digest                       `json:"listDigest"`
+	Config     *dockerv1client.DockerImageConfig `json:"config"`
+	Metadata   *CincinnatiMetadata               `json:"metadata"`
+	References *imageapi.ImageStream             `json:"references"`
+
+	ComponentVersions map[string]string `json:"versions"`
+
+	Images map[string]*Image `json:"images"`
+
+	RawMetadata   map[string][]byte `json:"-"`
+	ManifestFiles map[string][]byte `json:"-"`
+	UnknownFiles  []string          `json:"-"`
+
+	Warnings []string `json:"warnings"`
+}
+
+type Image struct {
+	Name          string                              `json:"name"`
+	Ref           imagereference.DockerImageReference `json:"-"`
+	Digest        digest.Digest                       `json:"digest"`
+	ContentDigest digest.Digest                       `json:"contentDigest"`
+	ListDigest    digest.Digest                       `json:"listDigest"`
+	MediaType     string                              `json:"mediaType"`
+	Layers        []distribution.Descriptor           `json:"layers"`
+	Config        *dockerv1client.DockerImageConfig   `json:"config"`
+
+	Manifest distribution.Manifest `json:"-"`
+}

--- a/test/extended/router/oc_copy.go
+++ b/test/extended/router/oc_copy.go
@@ -1,0 +1,17 @@
+package router
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+func IngressConditionStatus(ingress *routev1.RouteIngress, t routev1.RouteIngressConditionType) (corev1.ConditionStatus, routev1.RouteIngressCondition) {
+	for _, condition := range ingress.Conditions {
+		if t != condition.Type {
+			continue
+		}
+		return condition.Status, condition
+	}
+	return corev1.ConditionUnknown, routev1.RouteIngressCondition{}
+}

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -17,7 +17,6 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
-	routedisplayhelpers "github.com/openshift/oc/pkg/helpers/route"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -160,7 +159,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			e2e.Logf("Selected: %#v, All: %#v", ingress, r.Status.Ingress)
 			o.Expect(ingress).NotTo(o.BeNil())
 			o.Expect(ingress.Host).To(o.Equal(fmt.Sprintf(pattern, "route-1", ns)))
-			status, condition := routedisplayhelpers.IngressConditionStatus(ingress, routev1.RouteAdmitted)
+			status, condition := IngressConditionStatus(ingress, routev1.RouteAdmitted)
 			o.Expect(status).To(o.Equal(corev1.ConditionTrue))
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})
@@ -224,7 +223,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			ingress := ingressForName(r, "test-override-domains")
 			o.Expect(ingress).NotTo(o.BeNil())
 			o.Expect(ingress.Host).To(o.Equal(fmt.Sprintf(pattern, "route-override-domain-2", ns)))
-			status, condition := routedisplayhelpers.IngressConditionStatus(ingress, routev1.RouteAdmitted)
+			status, condition := IngressConditionStatus(ingress, routev1.RouteAdmitted)
 			o.Expect(status).To(o.Equal(corev1.ConditionTrue))
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -61,7 +61,6 @@ import (
 	securityv1client "github.com/openshift/client-go/security/clientset/versioned"
 	templatev1client "github.com/openshift/client-go/template/clientset/versioned"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned"
-	"github.com/openshift/oc/pkg/helpers/kubeconfig"
 )
 
 // CLI provides function to call the OpenShift CLI and Kubernetes and OpenShift
@@ -152,7 +151,7 @@ func (c *CLI) AsAdmin() *CLI {
 func (c *CLI) ChangeUser(name string) *CLI {
 	clientConfig := c.GetClientConfigForUser(name)
 
-	kubeConfig, err := kubeconfig.CreateConfig(c.Namespace(), clientConfig)
+	kubeConfig, err := createConfig(c.Namespace(), clientConfig)
 	if err != nil {
 		FatalErr(err)
 	}

--- a/test/extended/util/oauthserver/helpers.go
+++ b/test/extended/util/oauthserver/helpers.go
@@ -12,7 +12,7 @@ import (
 	osinv1 "github.com/openshift/api/osin/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
-	"github.com/openshift/oc/pkg/helpers/tokencmd"
+	"github.com/openshift/origin/test/extended/util/oauthserver/tokencmd"
 )
 
 var (

--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -26,9 +26,9 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/library-go/pkg/config/helpers"
 	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/openshift/oc/pkg/helpers/tokencmd"
 	"github.com/openshift/origin/test/extended/testdata"
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/oauthserver/tokencmd"
 )
 
 const (

--- a/test/extended/util/oauthserver/tokencmd/basicauth.go
+++ b/test/extended/util/oauthserver/tokencmd/basicauth.go
@@ -1,0 +1,110 @@
+package tokencmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+type BasicChallengeHandler struct {
+	// Host is the server being authenticated to. Used only for displaying messages when prompting for username/password
+	Host string
+
+	// Reader is used to prompt for username/password. If nil, no prompting is done
+	Reader io.Reader
+	// Writer is used to output prompts. If nil, stdout is used
+	Writer io.Writer
+
+	// Username is the username to use when challenged. If empty, a prompt is issued to a non-nil Reader
+	Username string
+	// Password is the password to use when challenged. If empty, a prompt is issued to a non-nil Reader
+	Password string
+
+	// handled tracks whether this handler has already handled a challenge.
+	handled bool
+	// prompted tracks whether this handler has already prompted for a username and/or password.
+	prompted bool
+}
+
+func (c *BasicChallengeHandler) CanHandle(headers http.Header) bool {
+	isBasic, _ := basicRealm(headers)
+	return isBasic
+}
+func (c *BasicChallengeHandler) HandleChallenge(requestURL string, headers http.Header) (http.Header, bool, error) {
+	if c.prompted {
+		klog.V(2).Info("already prompted for challenge, won't prompt again")
+		return nil, false, nil
+	}
+	if c.handled {
+		klog.V(2).Info("already handled basic challenge")
+		return nil, false, nil
+	}
+
+	username := c.Username
+	password := c.Password
+
+	missingUsername := len(username) == 0
+	missingPassword := len(password) == 0
+
+	if (missingUsername || missingPassword) && c.Reader != nil {
+		panic("unsupported")
+	}
+
+	if len(username) > 0 || len(password) > 0 {
+		// Basic auth does not support usernames containing colons
+		// http://tools.ietf.org/html/rfc2617#section-2
+		if strings.Contains(username, ":") {
+			return nil, false, fmt.Errorf("username %s is invalid for basic auth", username)
+		}
+		responseHeaders := http.Header{}
+		responseHeaders.Set("Authorization", getBasicHeader(username, password))
+		// remember so we don't re-handle non-interactively
+		c.handled = true
+		return responseHeaders, true, nil
+	}
+
+	klog.V(2).Info("no username or password available")
+	return nil, false, nil
+}
+func (c *BasicChallengeHandler) CompleteChallenge(requestURL string, headers http.Header) error {
+	return nil
+}
+
+func (c *BasicChallengeHandler) Release() error {
+	return nil
+}
+
+// if any of these match a WWW-Authenticate header, it is a basic challenge
+// capturing group 1 (if present) should contain the realm
+var basicRegexes = []*regexp.Regexp{
+	// quoted realm
+	regexp.MustCompile(`(?i)^\s*basic\s+realm\s*=\s*"(.*?)"\s*(,|$)`),
+	// token realm
+	regexp.MustCompile(`(?i)^\s*basic\s+realm\s*=\s*(.*?)\s*(,|$)`),
+	// no realm
+	regexp.MustCompile(`(?i)^\s*basic(?:\s+|$)`),
+}
+
+func basicRealm(headers http.Header) (bool, string) {
+	for _, challengeHeader := range headers[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		for _, r := range basicRegexes {
+			if matches := r.FindStringSubmatch(challengeHeader); matches != nil {
+				if len(matches) > 1 {
+					// We got a realm as well
+					return true, matches[1]
+				}
+				// No realm, but still basic
+				return true, ""
+			}
+		}
+	}
+	return false, ""
+}
+func getBasicHeader(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+}

--- a/test/extended/util/oauthserver/tokencmd/basicauth_test.go
+++ b/test/extended/util/oauthserver/tokencmd/basicauth_test.go
@@ -1,0 +1,363 @@
+package tokencmd
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var (
+	AUTHORIZATION    = http.CanonicalHeaderKey("Authorization")
+	WWW_AUTHENTICATE = http.CanonicalHeaderKey("WWW-Authenticate")
+)
+
+type Challenge struct {
+	Headers http.Header
+
+	ExpectedCanHandle bool
+	ExpectedHeaders   http.Header
+	ExpectedHandled   bool
+	ExpectedErr       error
+	ExpectedPrompt    string
+}
+
+func TestHandleChallenge(t *testing.T) {
+
+	basicChallenge := http.Header{WWW_AUTHENTICATE: []string{`Basic realm="myrealm"`}}
+
+	testCases := map[string]struct {
+		Handler    *BasicChallengeHandler
+		Challenges []Challenge
+	}{
+		"non-interactive with no defaults": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   nil,
+				Username: "",
+				Password: "",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+			},
+		},
+
+		"non-interactive challenge with defaults": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   nil,
+				Username: "myuser",
+				Password: "mypassword",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   http.Header{AUTHORIZATION: []string{getBasicHeader("myuser", "mypassword")}},
+					ExpectedHandled:   true,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+			},
+		},
+
+		"interactive challenge with default user": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   bytes.NewBufferString("mypassword\n"),
+				Username: "myuser",
+				Password: "",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   http.Header{AUTHORIZATION: []string{getBasicHeader("myuser", "mypassword")}},
+					ExpectedHandled:   true,
+					ExpectedErr:       nil,
+					ExpectedPrompt: `Authentication required for myhost (myrealm)
+Username: myuser
+Password: `,
+				},
+			},
+		},
+
+		"interactive challenge": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   bytes.NewBufferString("myuser\nmypassword\n"),
+				Username: "",
+				Password: "",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   http.Header{AUTHORIZATION: []string{getBasicHeader("myuser", "mypassword")}},
+					ExpectedHandled:   true,
+					ExpectedErr:       nil,
+					ExpectedPrompt: `Authentication required for myhost (myrealm)
+Username: Password: `,
+				},
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    ``,
+				},
+			},
+		},
+
+		"non-interactive challenge with reader defaults": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   bytes.NewBufferString(""),
+				Username: "myuser",
+				Password: "mypassword",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   http.Header{AUTHORIZATION: []string{getBasicHeader("myuser", "mypassword")}},
+					ExpectedHandled:   true,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       nil,
+					ExpectedPrompt:    "",
+				},
+			},
+		},
+
+		"invalid basic auth username": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   bytes.NewBufferString(""),
+				Username: "system:admin",
+				Password: "mypassword",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       errors.New("username system:admin is invalid for basic auth"),
+					ExpectedPrompt:    "",
+				},
+			},
+		},
+		"invalid basic auth username prompt": {
+			Handler: &BasicChallengeHandler{
+				Host:     "myhost",
+				Reader:   bytes.NewBufferString(``),
+				Username: "system:admin",
+				Password: "",
+			},
+			Challenges: []Challenge{
+				{
+					Headers:           basicChallenge,
+					ExpectedCanHandle: true,
+					ExpectedHeaders:   nil,
+					ExpectedHandled:   false,
+					ExpectedErr:       errors.New("username system:admin is invalid for basic auth"),
+					ExpectedPrompt: `Authentication required for myhost (myrealm)
+Username: system:admin
+Password: `,
+				},
+			},
+		},
+	}
+
+	for k, tc := range testCases {
+		for i, challenge := range tc.Challenges {
+			out := &bytes.Buffer{}
+			tc.Handler.Writer = out
+
+			canHandle := tc.Handler.CanHandle(challenge.Headers)
+			if canHandle != challenge.ExpectedCanHandle {
+				t.Errorf("%s: %d: Expected CanHandle=%v, got %v", k, i, challenge.ExpectedCanHandle, canHandle)
+			}
+
+			if canHandle {
+				headers, handled, err := tc.Handler.HandleChallenge("", challenge.Headers)
+				if !reflect.DeepEqual(headers, challenge.ExpectedHeaders) {
+					t.Errorf("%s: %d: Expected headers\n\t%#v\ngot\n\t%#v", k, i, challenge.ExpectedHeaders, headers)
+				}
+				if handled != challenge.ExpectedHandled {
+					t.Errorf("%s: %d: Expected handled=%v, got %v", k, i, challenge.ExpectedHandled, handled)
+				}
+				if ((err == nil) != (challenge.ExpectedErr == nil)) || (err != nil && err.Error() != challenge.ExpectedErr.Error()) {
+					t.Errorf("%s: %d: Expected err=%v, got %v", k, i, challenge.ExpectedErr, err)
+				}
+				if out.String() != challenge.ExpectedPrompt {
+					t.Errorf("%s: %d: Expected prompt %q, got %q", k, i, challenge.ExpectedPrompt, out.String())
+				}
+			}
+		}
+	}
+}
+
+func TestBasicRealm(t *testing.T) {
+
+	testCases := map[string]struct {
+		Headers       http.Header
+		ExpectedBasic bool
+		ExpectedRealm string
+	}{
+		"empty": {
+			Headers:       http.Header{},
+			ExpectedBasic: false,
+			ExpectedRealm: ``,
+		},
+
+		"non-challenge": {
+			Headers: http.Header{
+				"test": []string{`value`},
+			},
+			ExpectedBasic: false,
+			ExpectedRealm: ``,
+		},
+
+		"non-basic": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{
+					`basicrealm="myrealm"`,
+					`digest basic="realm"`,
+				},
+			},
+			ExpectedBasic: false,
+			ExpectedRealm: ``,
+		},
+
+		"basic multiple www-authenticate headers": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{
+					`digest realm="digestrealm"`,
+					`basic realm="Foo"`,
+					`foo bar="baz"`,
+				},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo`,
+		},
+
+		"basic no realm": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: ``,
+		},
+
+		"basic other param": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic otherparam="othervalue"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: ``,
+		},
+
+		"basic token realm": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic realm=Foo Bar `},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo Bar`,
+		},
+
+		"basic quoted realm": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic realm="Foo Bar"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo Bar`,
+		},
+
+		"basic case-insensitive scheme": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`BASIC realm="Foo"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo`,
+		},
+
+		"basic case-insensitive realm": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic REALM="Foo"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo`,
+		},
+
+		"basic whitespace": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{` 	basic 	realm 	= 	"Foo\" Bar" 	`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo\" Bar`,
+		},
+
+		"basic trailing comma": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic realm="Foo", otherparam="value"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo`,
+		},
+
+		"realm containing quotes": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic realm="F\"oo", otherparam="value"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `F\"oo`,
+		},
+
+		"realm containing comma": {
+			Headers: http.Header{
+				WWW_AUTHENTICATE: []string{`basic realm="Foo, bar", otherparam="value"`},
+			},
+			ExpectedBasic: true,
+			ExpectedRealm: `Foo, bar`,
+		},
+
+		// TODO: additional forms to support
+		//   Basic param="value", realm="myrealm"
+		//   Digest, Basic param="value", realm="myrealm"
+	}
+
+	for k, tc := range testCases {
+		isBasic, realm := basicRealm(tc.Headers)
+		if isBasic != tc.ExpectedBasic {
+			t.Errorf("%s: Expected isBasicChallenge=%v, got %v", k, tc.ExpectedBasic, isBasic)
+		}
+		if realm != tc.ExpectedRealm {
+			t.Errorf("%s: Expected realm=%q, got %q", k, tc.ExpectedRealm, realm)
+		}
+	}
+}

--- a/test/extended/util/oauthserver/tokencmd/multi.go
+++ b/test/extended/util/oauthserver/tokencmd/multi.go
@@ -1,0 +1,105 @@
+package tokencmd
+
+import (
+	"net/http"
+
+	"k8s.io/klog"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+var _ = ChallengeHandler(&MultiHandler{})
+
+// MultiHandler manages a series of authentication challenges
+// it is single-use only, and not thread-safe
+type MultiHandler struct {
+	// handler holds the selected handler.
+	// automatically populated with the first handler to successfully respond to HandleChallenge(),
+	// and used exclusively by CanHandle() and HandleChallenge() from that point forward.
+	handler ChallengeHandler
+
+	// possibleHandlers holds handlers that could handle subsequent challenges.
+	// filtered down during HandleChallenge() by calling CanHandle() on each item.
+	possibleHandlers []ChallengeHandler
+
+	// allHandlers holds all handlers, for purposes of delegating Release() calls
+	allHandlers []ChallengeHandler
+}
+
+func NewMultiHandler(handlers ...ChallengeHandler) ChallengeHandler {
+	return &MultiHandler{
+		possibleHandlers: handlers,
+		allHandlers:      handlers,
+	}
+}
+
+func (h *MultiHandler) CanHandle(headers http.Header) bool {
+	// If we've already selected a handler, it alone can decide whether we can handle the current request
+	if h.handler != nil {
+		return h.handler.CanHandle(headers)
+	}
+
+	// Otherwise, return true if any of our handlers can handle this request
+	for _, handler := range h.possibleHandlers {
+		if handler.CanHandle(headers) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *MultiHandler) HandleChallenge(requestURL string, headers http.Header) (http.Header, bool, error) {
+	// If we've already selected a handler, it alone can handle all subsequent challenges (don't change horses in mid-stream)
+	if h.handler != nil {
+		return h.handler.HandleChallenge(requestURL, headers)
+	}
+
+	// Otherwise, filter our list of handlers to the ones that can handle this request
+	applicable := []ChallengeHandler{}
+	for _, handler := range h.possibleHandlers {
+		if handler.CanHandle(headers) {
+			applicable = append(applicable, handler)
+		}
+	}
+	h.possibleHandlers = applicable
+
+	// Then select the first available handler that successfully handles the request
+	var (
+		retryHeaders http.Header
+		retry        bool
+		err          error
+	)
+	for i, handler := range h.possibleHandlers {
+		retryHeaders, retry, err = handler.HandleChallenge(requestURL, headers)
+
+		if err != nil {
+			klog.V(5).Infof("handler[%d] error: %v", i, err)
+		}
+		// If the handler successfully handled the challenge, or we have no other options, select it as our handler
+		if err == nil || i == len(h.possibleHandlers)-1 {
+			h.handler = handler
+			return retryHeaders, retry, err
+		}
+	}
+
+	return nil, false, apierrs.NewUnauthorized("unhandled challenge")
+}
+
+func (h *MultiHandler) CompleteChallenge(requestURL string, headers http.Header) error {
+	if h.handler != nil {
+		return h.handler.CompleteChallenge(requestURL, headers)
+	}
+	return nil
+}
+
+func (h *MultiHandler) Release() error {
+	var errs []error
+	for _, handler := range h.allHandlers {
+		if err := handler.Release(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/test/extended/util/oauthserver/tokencmd/negotiate.go
+++ b/test/extended/util/oauthserver/tokencmd/negotiate.go
@@ -1,0 +1,121 @@
+package tokencmd
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+// Negotiator defines the minimal interface needed to interact with GSSAPI to perform a negotiate challenge/response
+type Negotiator interface {
+	// Load gives the negotiator a chance to load any resources needed to handle a challenge/response sequence.
+	// It may be invoked multiple times. If an error is returned, InitSecContext and IsComplete are not called, but Release() is.
+	Load() error
+	// InitSecContext returns the response token for a Negotiate challenge token from a given URL,
+	// or an error if no response token could be obtained or the incoming token is invalid.
+	InitSecContext(requestURL string, challengeToken []byte) (tokenToSend []byte, err error)
+	// IsComplete returns true if the negotiator is satisfied with the negotiation.
+	// This typically means gssapi returned GSS_S_COMPLETE to an initSecContext call.
+	IsComplete() bool
+	// Release gives the negotiator a chance to release any resources held during a challenge/response sequence.
+	// It is always invoked, even in cases where no challenges were received or handled.
+	Release() error
+}
+
+// NegotiateChallengeHandler manages a challenge negotiation session
+// it is single-host, single-use only, and not thread-safe
+type NegotiateChallengeHandler struct {
+	negotiator Negotiator
+}
+
+func NewNegotiateChallengeHandler(negotiator Negotiator) ChallengeHandler {
+	return &NegotiateChallengeHandler{negotiator: negotiator}
+}
+
+func (c *NegotiateChallengeHandler) CanHandle(headers http.Header) bool {
+	// Make sure this is a negotiate request
+	if isNegotiate, _, err := getNegotiateToken(headers); err != nil || !isNegotiate {
+		return false
+	}
+	// Make sure our negotiator can initialize
+	if err := c.negotiator.Load(); err != nil {
+		return false
+	}
+	return true
+}
+
+func (c *NegotiateChallengeHandler) HandleChallenge(requestURL string, headers http.Header) (http.Header, bool, error) {
+	// Get incoming token
+	_, incomingToken, err := getNegotiateToken(headers)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Process the token
+	outgoingToken, err := c.negotiator.InitSecContext(requestURL, incomingToken)
+	if err != nil {
+		klog.V(5).Infof("InitSecContext returned error: %v", err)
+		return nil, false, err
+	}
+
+	// Build the response headers
+	responseHeaders := http.Header{}
+	responseHeaders.Set("Authorization", "Negotiate "+base64.StdEncoding.EncodeToString(outgoingToken))
+	return responseHeaders, true, nil
+}
+
+func (c *NegotiateChallengeHandler) CompleteChallenge(requestURL string, headers http.Header) error {
+	if c.negotiator.IsComplete() {
+		return nil
+	}
+	klog.V(5).Infof("continue needed")
+
+	// Get incoming token
+	isNegotiate, incomingToken, err := getNegotiateToken(headers)
+	if err != nil {
+		return err
+	}
+	if !isNegotiate {
+		return errors.New("client requires final negotiate token, none provided")
+	}
+
+	// Process the token
+	_, err = c.negotiator.InitSecContext(requestURL, incomingToken)
+	if err != nil {
+		klog.V(5).Infof("InitSecContext returned error during final negotiation: %v", err)
+		return err
+	}
+	if !c.negotiator.IsComplete() {
+		return errors.New("InitSecContext did not indicate final negotiation completed")
+	}
+	return nil
+}
+
+func (c *NegotiateChallengeHandler) Release() error {
+	return c.negotiator.Release()
+}
+
+const negotiateScheme = "negotiate"
+
+func getNegotiateToken(headers http.Header) (bool, []byte, error) {
+	for _, challengeHeader := range headers[http.CanonicalHeaderKey("WWW-Authenticate")] {
+		// TODO: handle WWW-Authenticate headers containing more than one scheme
+		caseInsensitiveHeader := strings.ToLower(challengeHeader)
+		if caseInsensitiveHeader == negotiateScheme {
+			return true, nil, nil
+		}
+		if strings.HasPrefix(caseInsensitiveHeader, negotiateScheme+" ") {
+			payload := challengeHeader[len(negotiateScheme):]
+			payload = strings.Replace(payload, " ", "", -1)
+			data, err := base64.StdEncoding.DecodeString(payload)
+			if err != nil {
+				return false, nil, err
+			}
+			return true, data, nil
+		}
+	}
+	return false, nil, nil
+}

--- a/test/extended/util/oauthserver/tokencmd/negotiate_helpers.go
+++ b/test/extended/util/oauthserver/tokencmd/negotiate_helpers.go
@@ -1,0 +1,39 @@
+package tokencmd
+
+import (
+	"errors"
+	"net/url"
+)
+
+func getServiceName(sep rune, requestURL string) (string, error) {
+	u, err := url.Parse(requestURL)
+	if err != nil {
+		return "", err
+	}
+
+	return "HTTP" + string(sep) + u.Hostname(), nil
+}
+
+type negotiateUnsupported struct {
+	error
+}
+
+func newUnsupportedNegotiator(name string) Negotiator {
+	return &negotiateUnsupported{error: errors.New(name + " support is not enabled")}
+}
+
+func (n *negotiateUnsupported) Load() error {
+	return n
+}
+
+func (n *negotiateUnsupported) InitSecContext(requestURL string, challengeToken []byte) ([]byte, error) {
+	return nil, n
+}
+
+func (*negotiateUnsupported) IsComplete() bool {
+	return false
+}
+
+func (n *negotiateUnsupported) Release() error {
+	return n
+}

--- a/test/extended/util/oauthserver/tokencmd/negotiator_gssapi_unsupported.go
+++ b/test/extended/util/oauthserver/tokencmd/negotiator_gssapi_unsupported.go
@@ -1,0 +1,9 @@
+package tokencmd
+
+func GSSAPIEnabled() bool {
+	return false
+}
+
+func NewGSSAPINegotiator(string) Negotiator {
+	return newUnsupportedNegotiator("GSSAPI")
+}

--- a/test/extended/util/oauthserver/tokencmd/negotiator_sspi_unsupported.go
+++ b/test/extended/util/oauthserver/tokencmd/negotiator_sspi_unsupported.go
@@ -1,0 +1,11 @@
+package tokencmd
+
+import "io"
+
+func SSPIEnabled() bool {
+	return false
+}
+
+func NewSSPINegotiator(string, string, string, io.Reader) Negotiator {
+	return newUnsupportedNegotiator("SSPI")
+}

--- a/test/extended/util/oauthserver/tokencmd/request_token.go
+++ b/test/extended/util/oauthserver/tokencmd/request_token.go
@@ -1,0 +1,451 @@
+package tokencmd
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/RangelReale/osincli"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/oauth/oauthdiscovery"
+)
+
+const (
+	// csrfTokenHeader is a marker header that indicates we are not a browser that got tricked into requesting basic auth
+	// Corresponds to the header expected by basic-auth challenging authenticators
+	// Copied from pkg/auth/authenticator/challenger/passwordchallenger/password_auth_handler.go
+	csrfTokenHeader = "X-CSRF-Token"
+
+	// Discovery endpoint for OAuth 2.0 Authorization Server Metadata
+	// See IETF Draft:
+	// https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+	// Copied from pkg/cmd/server/origin/nonapiserver.go
+	oauthMetadataEndpoint = "/.well-known/oauth-authorization-server"
+
+	// openShiftCLIClientID is the name of the CLI OAuth client, copied from pkg/oauth/apiserver/auth.go
+	openShiftCLIClientID = "openshift-challenging-client"
+
+	// pkce_s256 is sha256 hash per RFC7636, copied from github.com/RangelReale/osincli/pkce.go
+	pkce_s256 = "S256"
+
+	// token fakes the missing osin.TOKEN const
+	token osincli.AuthorizeRequestType = "token"
+)
+
+// ChallengeHandler handles responses to WWW-Authenticate challenges.
+type ChallengeHandler interface {
+	// CanHandle returns true if the handler recognizes a challenge it thinks it can handle.
+	CanHandle(headers http.Header) bool
+	// HandleChallenge lets the handler attempt to handle a challenge.
+	// It is only invoked if CanHandle() returned true for the given headers.
+	// Returns response headers and true if the challenge is successfully handled.
+	// Returns false if the challenge was not handled, and an optional error in error cases.
+	HandleChallenge(requestURL string, headers http.Header) (http.Header, bool, error)
+	// CompleteChallenge is invoked with the headers from a successful server response
+	// received after having handled one or more challenges.
+	// Returns an error if the handler does not consider the challenge/response interaction complete.
+	CompleteChallenge(requestURL string, headers http.Header) error
+	// Release gives the handler a chance to release any resources held during a challenge/response sequence.
+	// It is always invoked, even in cases where no challenges were received or handled.
+	Release() error
+}
+
+type RequestTokenOptions struct {
+	ClientConfig *restclient.Config
+	Handler      ChallengeHandler
+	OsinConfig   *osincli.ClientConfig
+	Issuer       string
+	TokenFlow    bool
+}
+
+// RequestToken uses the cmd arguments to locate an openshift oauth server and attempts to authenticate via an
+// OAuth code flow and challenge handling.  It returns the access token if it gets one or an error if it does not.
+func RequestToken(clientCfg *restclient.Config, reader io.Reader, defaultUsername string, defaultPassword string) (string, error) {
+	return NewRequestTokenOptions(clientCfg, reader, defaultUsername, defaultPassword, false).RequestToken()
+}
+
+func NewRequestTokenOptions(clientCfg *restclient.Config, reader io.Reader, defaultUsername string, defaultPassword string, tokenFlow bool) *RequestTokenOptions {
+	// priority ordered list of challenge handlers
+	// the SPNEGO ones must come before basic auth
+	var handlers []ChallengeHandler
+
+	if GSSAPIEnabled() {
+		klog.V(6).Info("GSSAPI Enabled")
+		handlers = append(handlers, NewNegotiateChallengeHandler(NewGSSAPINegotiator(defaultUsername)))
+	}
+
+	if SSPIEnabled() {
+		klog.V(6).Info("SSPI Enabled")
+		handlers = append(handlers, NewNegotiateChallengeHandler(NewSSPINegotiator(defaultUsername, defaultPassword, clientCfg.Host, reader)))
+	}
+
+	handlers = append(handlers, &BasicChallengeHandler{Host: clientCfg.Host, Reader: reader, Username: defaultUsername, Password: defaultPassword})
+
+	var handler ChallengeHandler
+	if len(handlers) == 1 {
+		handler = handlers[0]
+	} else {
+		handler = NewMultiHandler(handlers...)
+	}
+
+	return &RequestTokenOptions{
+		ClientConfig: clientCfg,
+		Handler:      handler,
+		TokenFlow:    tokenFlow,
+	}
+}
+
+// SetDefaultOsinConfig overwrites RequestTokenOptions.OsinConfig with the default CLI
+// OAuth client and PKCE support if the server supports S256 / a code flow is being used
+func (o *RequestTokenOptions) SetDefaultOsinConfig() error {
+	if o.OsinConfig != nil {
+		return fmt.Errorf("osin config is already set to: %#v", *o.OsinConfig)
+	}
+
+	// get the OAuth metadata directly from the api server
+	// we only want to use the ca data from our config
+	rt, err := restclient.TransportFor(o.ClientConfig)
+	if err != nil {
+		return err
+	}
+
+	requestURL := strings.TrimRight(o.ClientConfig.Host, "/") + oauthMetadataEndpoint
+	resp, err := request(rt, requestURL, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("couldn't get %v: unexpected response status %v", requestURL, resp.StatusCode)
+	}
+
+	metadata := &oauthdiscovery.OauthAuthorizationServerMetadata{}
+	if err := json.NewDecoder(resp.Body).Decode(metadata); err != nil {
+		return err
+	}
+
+	// use the metadata to build the osin config
+	config := &osincli.ClientConfig{
+		ClientId:     openShiftCLIClientID,
+		AuthorizeUrl: metadata.AuthorizationEndpoint,
+		TokenUrl:     metadata.TokenEndpoint,
+		RedirectUrl:  oauthdiscovery.OpenShiftOAuthTokenImplicitURL(metadata.Issuer),
+	}
+	if !o.TokenFlow && sets.NewString(metadata.CodeChallengeMethodsSupported...).Has(pkce_s256) {
+		if err := osincli.PopulatePKCE(config); err != nil {
+			return err
+		}
+	}
+
+	o.OsinConfig = config
+	o.Issuer = metadata.Issuer
+	return nil
+}
+
+// RequestToken locates an openshift oauth server and attempts to authenticate.
+// It returns the access token if it gets one, or an error if it does not.
+// It should only be invoked once on a given RequestTokenOptions instance.
+// The Handler held by the options is released as part of this call.
+// If RequestTokenOptions.OsinConfig is nil, it will be defaulted using SetDefaultOsinConfig.
+// The caller is responsible for setting up the entire OsinConfig if the value is not nil.
+func (o *RequestTokenOptions) RequestToken() (string, error) {
+	defer func() {
+		// Always release the handler
+		if err := o.Handler.Release(); err != nil {
+			// Release errors shouldn't fail the token request, just log
+			klog.V(4).Infof("error releasing handler: %v", err)
+		}
+	}()
+
+	if o.OsinConfig == nil {
+		if err := o.SetDefaultOsinConfig(); err != nil {
+			return "", err
+		}
+	}
+
+	// we are going to use this transport to talk
+	// with a server that may not be the api server
+	// thus we need to include the system roots
+	// in our ca data otherwise an external
+	// oauth server with a valid cert will fail with
+	// error: x509: certificate signed by unknown authority
+	rt, err := transportWithSystemRoots(o.Issuer, o.ClientConfig)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := osincli.NewClient(o.OsinConfig)
+	if err != nil {
+		return "", err
+	}
+	client.Transport = rt
+	authorizeRequest := client.NewAuthorizeRequest(osincli.CODE) // assume code flow to start with
+
+	var oauthTokenFunc func(redirectURL string) (accessToken string, oauthError error)
+	if o.TokenFlow {
+		// access_token in fragment or error parameter
+		authorizeRequest.Type = token // manually override to token flow if necessary
+		oauthTokenFunc = oauthTokenFlow
+	} else {
+		// code or error parameter
+		oauthTokenFunc = func(redirectURL string) (accessToken string, oauthError error) {
+			return oauthCodeFlow(client, authorizeRequest, redirectURL)
+		}
+	}
+
+	// requestURL holds the current URL to make requests to. This can change if the server responds with a redirect
+	requestURL := authorizeRequest.GetAuthorizeUrl().String()
+	// requestHeaders holds additional headers to add to the request. This can be changed by o.Handlers
+	requestHeaders := http.Header{}
+	// requestedURLSet/requestedURLList hold the URLs we have requested, to prevent redirect loops. Gets reset when a challenge is handled.
+	requestedURLSet := sets.NewString()
+	requestedURLList := []string{}
+	handledChallenge := false
+
+	for {
+		// Make the request
+		resp, err := request(rt, requestURL, requestHeaders)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusUnauthorized {
+			if resp.Header.Get("WWW-Authenticate") != "" {
+				if !o.Handler.CanHandle(resp.Header) {
+					return "", apierrs.NewUnauthorized("unhandled challenge")
+				}
+				// Handle the challenge
+				newRequestHeaders, shouldRetry, err := o.Handler.HandleChallenge(requestURL, resp.Header)
+				if err != nil {
+					return "", err
+				}
+				if !shouldRetry {
+					return "", apierrs.NewUnauthorized("challenger chose not to retry the request")
+				}
+				// Remember if we've ever handled a challenge
+				handledChallenge = true
+
+				// Reset request set/list. Since we're setting different headers, it is legitimate to request the same urls
+				requestedURLSet = sets.NewString()
+				requestedURLList = []string{}
+				// Use the response to the challenge as the new headers
+				requestHeaders = newRequestHeaders
+				continue
+			}
+
+			// Unauthorized with no challenge
+			unauthorizedError := apierrs.NewUnauthorized("")
+			// Attempt to read body content and include as an error detail
+			if details, err := ioutil.ReadAll(resp.Body); err == nil && len(details) > 0 {
+				unauthorizedError.ErrStatus.Details = &metav1.StatusDetails{
+					Causes: []metav1.StatusCause{
+						{Message: string(details)},
+					},
+				}
+			}
+
+			return "", unauthorizedError
+		}
+
+		// if we've ever handled a challenge, see if the handler also considers the interaction complete.
+		// this is required for negotiate flows with mutual authentication.
+		if handledChallenge {
+			if err := o.Handler.CompleteChallenge(requestURL, resp.Header); err != nil {
+				return "", err
+			}
+		}
+
+		if resp.StatusCode == http.StatusFound {
+			redirectURL := resp.Header.Get("Location")
+
+			// OAuth response case
+			accessToken, err := oauthTokenFunc(redirectURL)
+			if err != nil {
+				return "", err
+			}
+			if len(accessToken) > 0 {
+				return accessToken, nil
+			}
+
+			// Non-OAuth response, just follow the URL
+			// add to our list of redirects
+			requestedURLList = append(requestedURLList, redirectURL)
+			// detect loops
+			if !requestedURLSet.Has(redirectURL) {
+				requestedURLSet.Insert(redirectURL)
+				requestURL = redirectURL
+				continue
+			}
+			return "", apierrs.NewInternalError(fmt.Errorf("redirect loop: %s", strings.Join(requestedURLList, " -> ")))
+		}
+
+		// Unknown response
+		return "", apierrs.NewInternalError(fmt.Errorf("unexpected response: %d", resp.StatusCode))
+	}
+}
+
+// oauthTokenFlow attempts to extract an OAuth token from location's fragment's access_token value.
+// It only returns an error if something "impossible" happens (location is not a valid URL) or a definite
+// OAuth error is contained in the location URL.  No error is returned if location does not contain a token.
+// It is assumed that location was not part of the OAuth flow; it was a redirect that the client needs to follow
+// as part of the challenge flow (an authenticating proxy for example) and not a redirect step in the OAuth flow.
+func oauthTokenFlow(location string) (string, error) {
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", err
+	}
+
+	if oauthErr := oauthErrFromValues(u.Query()); oauthErr != nil {
+		return "", oauthErr
+	}
+
+	// Grab the raw fragment ourselves, since the stdlib URL parsing decodes parts of it
+	fragment := ""
+	if parts := strings.SplitN(location, "#", 2); len(parts) == 2 {
+		fragment = parts[1]
+	}
+	fragmentValues, err := url.ParseQuery(fragment)
+	if err != nil {
+		return "", err
+	}
+
+	return fragmentValues.Get("access_token"), nil
+}
+
+// oauthCodeFlow performs the OAuth code flow if location has a code parameter.
+// It only returns an error if something "impossible" happens (location is not a valid URL)
+// or a definite OAuth error is encountered during the code flow.  Other errors are assumed to be caused
+// by location not being part of the OAuth flow; it was a redirect that the client needs to follow as part
+// of the challenge flow (an authenticating proxy for example) and not a redirect step in the OAuth flow.
+func oauthCodeFlow(client *osincli.Client, authorizeRequest *osincli.AuthorizeRequest, location string) (string, error) {
+	// Make a request out of the URL since that is what AuthorizeRequest.HandleRequest expects to extract data from
+	req, err := http.NewRequest(http.MethodGet, location, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.ParseForm()
+	if oauthErr := oauthErrFromValues(req.Form); oauthErr != nil {
+		return "", oauthErr
+	}
+	if len(req.Form.Get("code")) == 0 {
+		return "", nil // no code parameter so this is not part of the OAuth flow
+	}
+
+	// any errors after this are fatal because we are committed to an OAuth flow now
+	authorizeData, err := authorizeRequest.HandleRequest(req)
+	if err != nil {
+		return "", osinToOAuthError(err)
+	}
+
+	accessRequest := client.NewAccessRequest(osincli.AUTHORIZATION_CODE, authorizeData)
+	accessData, err := accessRequest.GetToken()
+	if err != nil {
+		return "", osinToOAuthError(err)
+	}
+
+	return accessData.AccessToken, nil
+}
+
+// osinToOAuthError creates a better error message for osincli.Error
+func osinToOAuthError(err error) error {
+	if osinErr, ok := err.(*osincli.Error); ok {
+		return createOAuthError(osinErr.Id, osinErr.Description)
+	}
+	return err
+}
+
+func oauthErrFromValues(values url.Values) error {
+	if errorCode := values.Get("error"); len(errorCode) > 0 {
+		errorDescription := values.Get("error_description")
+		return createOAuthError(errorCode, errorDescription)
+	}
+	return nil
+}
+
+func createOAuthError(errorCode, errorDescription string) error {
+	return fmt.Errorf("%s %s", errorCode, errorDescription)
+}
+
+func request(rt http.RoundTripper, requestURL string, requestHeaders http.Header) (*http.Response, error) {
+	// Build the request
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range requestHeaders {
+		req.Header[k] = v
+	}
+	req.Header.Set(csrfTokenHeader, "1")
+
+	// Make the request
+	return rt.RoundTrip(req)
+}
+
+func transportWithSystemRoots(issuer string, clientConfig *restclient.Config) (http.RoundTripper, error) {
+	// copy the config so we can freely mutate it
+	configWithSystemRoots := restclient.CopyConfig(clientConfig)
+
+	// explicitly unset CA cert information
+	// this will make the transport use the system roots or OS specific verification
+	// this is required to have reasonable behavior on windows (cannot get system roots)
+	// in general there is no good with to say "I want system roots plus this CA bundle"
+	// so we just try system roots first before using the kubeconfig CA bundle
+	configWithSystemRoots.CAFile = ""
+	configWithSystemRoots.CAData = nil
+
+	systemRootsRT, err := restclient.TransportFor(configWithSystemRoots)
+	if err != nil {
+		return nil, err
+	}
+
+	// build a request to probe the OAuth server CA
+	req, err := http.NewRequest(http.MethodHead, issuer, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// see if get a certificate error when using the system roots
+	// we perform the check using this transport (instead of the kubeconfig based one)
+	// because it is most likely to work with a route (which is what the OAuth server uses in 4.0+)
+	// note that both transports are "safe" to use (in the sense that they have valid TLS configurations)
+	// thus the fallback case is not an "unsafe" operation
+	_, err = systemRootsRT.RoundTrip(req)
+	switch err.(type) {
+	case nil:
+		// no error meaning the system roots work with the OAuth server
+		klog.V(4).Info("using system roots as no error was encountered")
+		return systemRootsRT, nil
+	case x509.UnknownAuthorityError, x509.HostnameError, x509.CertificateInvalidError, x509.SystemRootsError,
+		tls.RecordHeaderError, *net.OpError:
+		// fallback to the CA in the kubeconfig since the system roots did not work
+		// we are very broad on the errors here to avoid failing when we should fallback
+		klog.V(4).Infof("falling back to kubeconfig CA due to possible x509 error: %v", err)
+		return restclient.TransportFor(clientConfig)
+	default:
+		switch err {
+		case io.EOF, io.ErrUnexpectedEOF, io.ErrNoProgress:
+			// also fallback on various io errors
+			klog.V(4).Infof("falling back to kubeconfig CA due to possible IO error: %v", err)
+			return restclient.TransportFor(clientConfig)
+		}
+		// unknown error, fail (ideally should never occur)
+		klog.V(4).Infof("unexpected error during system roots probe: %v", err)
+		return nil, err
+	}
+}

--- a/test/extended/util/oauthserver/tokencmd/request_token_test.go
+++ b/test/extended/util/oauthserver/tokencmd/request_token_test.go
@@ -1,0 +1,729 @@
+package tokencmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/RangelReale/osincli"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/openshift/library-go/pkg/oauth/oauthdiscovery"
+)
+
+type unloadableNegotiator struct {
+	releaseCalls int
+}
+
+func (n *unloadableNegotiator) Load() error {
+	return errors.New("Load failed")
+}
+func (n *unloadableNegotiator) InitSecContext(requestURL string, challengeToken []byte) (tokenToSend []byte, err error) {
+	return nil, errors.New("InitSecContext failed")
+}
+func (n *unloadableNegotiator) IsComplete() bool {
+	return false
+}
+func (n *unloadableNegotiator) Release() error {
+	n.releaseCalls++
+	return errors.New("Release failed")
+}
+
+type failingNegotiator struct {
+	releaseCalls int
+}
+
+func (n *failingNegotiator) Load() error {
+	return nil
+}
+func (n *failingNegotiator) InitSecContext(requestURL string, challengeToken []byte) (tokenToSend []byte, err error) {
+	return nil, errors.New("InitSecContext failed")
+}
+func (n *failingNegotiator) IsComplete() bool {
+	return false
+}
+func (n *failingNegotiator) Release() error {
+	n.releaseCalls++
+	return errors.New("Release failed")
+}
+
+type successfulNegotiator struct {
+	rounds              int
+	initSecContextCalls int
+	loadCalls           int
+	releaseCalls        int
+}
+
+func (n *successfulNegotiator) Load() error {
+	n.loadCalls++
+	return nil
+}
+func (n *successfulNegotiator) InitSecContext(requestURL string, challengeToken []byte) (tokenToSend []byte, err error) {
+	n.initSecContextCalls++
+
+	if n.initSecContextCalls > n.rounds {
+		return nil, fmt.Errorf("InitSecContext: expected %d calls, saw %d", n.rounds, n.initSecContextCalls)
+	}
+
+	if n.initSecContextCalls == 1 {
+		if len(challengeToken) > 0 {
+			return nil, errors.New("expected empty token for first challenge")
+		}
+	} else {
+		expectedChallengeToken := fmt.Sprintf("challenge%d", n.initSecContextCalls)
+		if string(challengeToken) != expectedChallengeToken {
+			return nil, fmt.Errorf("expected challenge token '%s', got '%s'", expectedChallengeToken, string(challengeToken))
+		}
+	}
+
+	return []byte(fmt.Sprintf("response%d", n.initSecContextCalls)), nil
+}
+func (n *successfulNegotiator) IsComplete() bool {
+	return n.initSecContextCalls == n.rounds
+}
+func (n *successfulNegotiator) Release() error {
+	n.releaseCalls++
+	return nil
+}
+
+func TestRequestToken(t *testing.T) {
+	type req struct {
+		authorization string
+		method        string
+		path          string
+	}
+	type resp struct {
+		status          int
+		location        string
+		wwwAuthenticate []string
+	}
+
+	type requestResponse struct {
+		expectedRequest req
+		serverResponse  resp
+	}
+
+	var verifyReleased func(test string, handler ChallengeHandler)
+	verifyReleased = func(test string, handler ChallengeHandler) {
+		switch handler := handler.(type) {
+		case *MultiHandler:
+			for _, subhandler := range handler.allHandlers {
+				verifyReleased(test, subhandler)
+			}
+		case *BasicChallengeHandler:
+			// we don't care
+		case *NegotiateChallengeHandler:
+			switch negotiator := handler.negotiator.(type) {
+			case *successfulNegotiator:
+				if negotiator.releaseCalls != 1 {
+					t.Errorf("%s: expected one call to Release(), saw %d", test, negotiator.releaseCalls)
+				}
+			case *failingNegotiator:
+				if negotiator.releaseCalls != 1 {
+					t.Errorf("%s: expected one call to Release(), saw %d", test, negotiator.releaseCalls)
+				}
+			case *unloadableNegotiator:
+				if negotiator.releaseCalls != 1 {
+					t.Errorf("%s: expected one call to Release(), saw %d", test, negotiator.releaseCalls)
+				}
+			default:
+				t.Errorf("%s: unrecognized negotiator: %#v", test, handler)
+			}
+		default:
+			t.Errorf("%s: unrecognized handler: %#v", test, handler)
+		}
+	}
+
+	initialHead := req{"", http.MethodHead, "/"}
+	initialHeadResp := resp{http.StatusInternalServerError, "", nil} // value of status is ignored
+
+	initialRequest := req{}
+
+	basicChallenge1 := resp{401, "", []string{"Basic realm=foo"}}
+	basicRequest1 := req{"Basic bXl1c2VyOm15cGFzc3dvcmQ=", "", ""} // base64("myuser:mypassword")
+	basicChallenge2 := resp{401, "", []string{"Basic realm=seriously...foo"}}
+
+	negotiateChallenge1 := resp{401, "", []string{"Negotiate"}}
+	negotiateRequest1 := req{"Negotiate cmVzcG9uc2Ux", "", ""}                   // base64("response1")
+	negotiateChallenge2 := resp{401, "", []string{"Negotiate Y2hhbGxlbmdlMg=="}} // base64("challenge2")
+	negotiateRequest2 := req{"Negotiate cmVzcG9uc2Uy", "", ""}                   // base64("response2")
+
+	doubleChallenge := resp{401, "", []string{"Negotiate", "Basic realm=foo"}}
+
+	successfulToken := "12345"
+	successfulLocation := fmt.Sprintf("/#access_token=%s", successfulToken)
+	success := resp{302, successfulLocation, nil}
+	successWithNegotiate := resp{302, successfulLocation, []string{"Negotiate Y2hhbGxlbmdlMg=="}}
+
+	testcases := map[string]struct {
+		Handler       ChallengeHandler
+		Requests      []requestResponse
+		ExpectedToken string
+		ExpectedError string
+	}{
+		// Defaulting basic handler
+		"defaulted basic handler, no challenge, success": {
+			Handler: &BasicChallengeHandler{Username: "myuser", Password: "mypassword"},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"defaulted basic handler, basic challenge, success": {
+			Handler: &BasicChallengeHandler{Username: "myuser", Password: "mypassword"},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+				{basicRequest1, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"defaulted basic handler, basic+negotiate challenge, success": {
+			Handler: &BasicChallengeHandler{Username: "myuser", Password: "mypassword"},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, doubleChallenge},
+				{basicRequest1, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"defaulted basic handler, basic challenge, failure": {
+			Handler: &BasicChallengeHandler{Username: "myuser", Password: "mypassword"},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+				{basicRequest1, basicChallenge2},
+			},
+			ExpectedError: "challenger chose not to retry the request",
+		},
+		"defaulted basic handler, negotiate challenge, failure": {
+			Handler: &BasicChallengeHandler{Username: "myuser", Password: "mypassword"},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+			},
+			ExpectedError: "unhandled challenge",
+		},
+		"failing basic handler, basic challenge, failure": {
+			Handler: &BasicChallengeHandler{},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+			},
+			ExpectedError: "challenger chose not to retry the request",
+		},
+
+		// Prompting basic handler
+		"prompting basic handler, no challenge, success": {
+			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"prompting basic handler, basic challenge, success": {
+			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+				{basicRequest1, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"prompting basic handler, basic+negotiate challenge, success": {
+			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, doubleChallenge},
+				{basicRequest1, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"prompting basic handler, basic challenge, failure": {
+			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+				{basicRequest1, basicChallenge2},
+			},
+			ExpectedError: "challenger chose not to retry the request",
+		},
+		"prompting basic handler, negotiate challenge, failure": {
+			Handler: &BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+			},
+			ExpectedError: "unhandled challenge",
+		},
+
+		// negotiate handler
+		"negotiate handler, no challenge, success": {
+			Handler: &NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 1}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate handler, negotiate challenge, success": {
+			Handler: &NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 1}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+				{negotiateRequest1, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate handler, negotiate challenge, 2 rounds, success": {
+			Handler: &NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 2}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+				{negotiateRequest1, negotiateChallenge2},
+				{negotiateRequest2, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate handler, negotiate challenge, 2 rounds, success with mutual auth": {
+			Handler: &NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 2}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+				{negotiateRequest1, successWithNegotiate},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate handler, negotiate challenge, 2 rounds expected, server success without client completion": {
+			Handler: &NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 2}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+				{negotiateRequest1, success},
+			},
+			ExpectedError: "client requires final negotiate token, none provided",
+		},
+
+		// Unloadable negotiate handler
+		"unloadable negotiate handler, no challenge, success": {
+			Handler: &NegotiateChallengeHandler{negotiator: &unloadableNegotiator{}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"unloadable negotiate handler, negotiate challenge, failure": {
+			Handler: &NegotiateChallengeHandler{negotiator: &unloadableNegotiator{}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+			},
+			ExpectedError: "unhandled challenge",
+		},
+		"unloadable negotiate handler, basic challenge, failure": {
+			Handler: &NegotiateChallengeHandler{negotiator: &unloadableNegotiator{}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+			},
+			ExpectedError: "unhandled challenge",
+		},
+
+		// Failing negotiate handler
+		"failing negotiate handler, no challenge, success": {
+			Handler: &NegotiateChallengeHandler{negotiator: &failingNegotiator{}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"failing negotiate handler, negotiate challenge, failure": {
+			Handler: &NegotiateChallengeHandler{negotiator: &failingNegotiator{}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, negotiateChallenge1},
+			},
+			ExpectedError: "InitSecContext failed",
+		},
+		"failing negotiate handler, basic challenge, failure": {
+			Handler: &NegotiateChallengeHandler{negotiator: &failingNegotiator{}},
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, basicChallenge1},
+			},
+			ExpectedError: "unhandled challenge",
+		},
+
+		// Negotiate+Basic fallback cases
+		"failing negotiate+prompting basic handler, no challenge, success": {
+			Handler: NewMultiHandler(
+				&NegotiateChallengeHandler{negotiator: &failingNegotiator{}},
+				&BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			),
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"failing negotiate+prompting basic handler, negotiate+basic challenge, success": {
+			Handler: NewMultiHandler(
+				&NegotiateChallengeHandler{negotiator: &failingNegotiator{}},
+				&BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			),
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, doubleChallenge},
+				{basicRequest1, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate+failing basic handler, negotiate+basic challenge, success": {
+			Handler: NewMultiHandler(
+				&NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 2}},
+				&BasicChallengeHandler{},
+			),
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, doubleChallenge},
+				{negotiateRequest1, negotiateChallenge2},
+				{negotiateRequest2, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate+basic handler, negotiate+basic challenge, prefers negotiation, success": {
+			Handler: NewMultiHandler(
+				&NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 2}},
+				&BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			),
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, doubleChallenge},
+				{negotiateRequest1, negotiateChallenge2},
+				{negotiateRequest2, success},
+			},
+			ExpectedToken: successfulToken,
+		},
+		"negotiate+basic handler, negotiate+basic challenge, prefers negotiation, sticks with selected handler on failure": {
+			Handler: NewMultiHandler(
+				&NegotiateChallengeHandler{negotiator: &successfulNegotiator{rounds: 2}},
+				&BasicChallengeHandler{Reader: bytes.NewBufferString("myuser\nmypassword\n")},
+			),
+			Requests: []requestResponse{
+				{initialHead, initialHeadResp},
+				{initialRequest, doubleChallenge},
+				{negotiateRequest1, negotiateChallenge2},
+				{negotiateRequest2, doubleChallenge},
+			},
+			ExpectedError: "InitSecContext: expected 2 calls, saw 3",
+		},
+	}
+
+	for k, tc := range testcases {
+		i := 0
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			defer func() {
+				if err := recover(); err != nil {
+					t.Errorf("test %s panicked: %v", k, err)
+				}
+			}()
+
+			if i >= len(tc.Requests) {
+				t.Errorf("%s: %d: more requests received than expected: %#v", k, i, req)
+				return
+			}
+			rr := tc.Requests[i]
+			i++
+
+			method := rr.expectedRequest.method
+			if len(method) == 0 {
+				method = http.MethodGet
+			}
+			if req.Method != method {
+				t.Errorf("%s: %d: Expected %s, got %s", k, i, method, req.Method)
+				return
+			}
+
+			path := rr.expectedRequest.path
+			if len(path) == 0 {
+				path = "/oauth/authorize"
+			}
+			if req.URL.Path != path {
+				t.Errorf("%s: %d: Expected %s, got %s", k, i, path, req.URL.Path)
+				return
+			}
+
+			if e, a := rr.expectedRequest.authorization, req.Header.Get("Authorization"); e != a {
+				t.Errorf("%s: %d: expected 'Authorization: %s', got 'Authorization: %s'", k, i, e, a)
+				return
+			}
+
+			if len(rr.serverResponse.location) > 0 {
+				w.Header().Add("Location", rr.serverResponse.location)
+			}
+			for _, v := range rr.serverResponse.wwwAuthenticate {
+				w.Header().Add("WWW-Authenticate", v)
+			}
+			w.WriteHeader(rr.serverResponse.status)
+		}))
+		defer s.Close()
+
+		opts := &RequestTokenOptions{
+			ClientConfig: &restclient.Config{Host: s.URL},
+			Handler:      tc.Handler,
+			OsinConfig: &osincli.ClientConfig{
+				ClientId:     openShiftCLIClientID,
+				AuthorizeUrl: oauthdiscovery.OpenShiftOAuthAuthorizeURL(s.URL),
+				TokenUrl:     oauthdiscovery.OpenShiftOAuthTokenURL(s.URL),
+				RedirectUrl:  oauthdiscovery.OpenShiftOAuthTokenImplicitURL(s.URL),
+			},
+			Issuer:    s.URL,
+			TokenFlow: true,
+		}
+		token, err := opts.RequestToken()
+		if token != tc.ExpectedToken {
+			t.Errorf("%s: expected token '%s', got '%s'", k, tc.ExpectedToken, token)
+		}
+		errStr := ""
+		if err != nil {
+			errStr = err.Error()
+		}
+		if errStr != tc.ExpectedError {
+			t.Errorf("%s: expected error '%s', got '%s'", k, tc.ExpectedError, errStr)
+		}
+		if i != len(tc.Requests) {
+			t.Errorf("%s: expected %d requests, saw %d", k, len(tc.Requests), i)
+		}
+		verifyReleased(k, tc.Handler)
+	}
+}
+
+func TestSetDefaultOsinConfig(t *testing.T) {
+	noHostChange := func(host string) string { return host }
+	for _, tc := range []struct {
+		name        string
+		metadata    *oauthdiscovery.OauthAuthorizationServerMetadata
+		hostWrapper func(host string) (newHost string)
+		tokenFlow   bool
+
+		expectPKCE     bool
+		expectedConfig *osincli.ClientConfig
+	}{
+		{
+			name: "code with PKCE support from server",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{pkce_s256},
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   false,
+
+			expectPKCE: true,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:            openShiftCLIClientID,
+				AuthorizeUrl:        "b",
+				TokenUrl:            "c",
+				RedirectUrl:         "a/oauth/token/implicit",
+				CodeChallengeMethod: pkce_s256,
+			},
+		},
+		{
+			name: "code without PKCE support from server",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{"someotherstuff"},
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   false,
+
+			expectPKCE: false,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:     openShiftCLIClientID,
+				AuthorizeUrl: "b",
+				TokenUrl:     "c",
+				RedirectUrl:  "a/oauth/token/implicit",
+			},
+		},
+		{
+			name: "token with PKCE support from server",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{pkce_s256},
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   true,
+
+			expectPKCE: false,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:     openShiftCLIClientID,
+				AuthorizeUrl: "b",
+				TokenUrl:     "c",
+				RedirectUrl:  "a/oauth/token/implicit",
+			},
+		},
+		{
+			name: "code with PKCE support from server, but wrong case",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{"s256"}, // we are case sensitive so this is not valid
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   false,
+
+			expectPKCE: false,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:     openShiftCLIClientID,
+				AuthorizeUrl: "b",
+				TokenUrl:     "c",
+				RedirectUrl:  "a/oauth/token/implicit",
+			},
+		},
+		{
+			name: "token without PKCE support from server",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{"random"},
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   true,
+
+			expectPKCE: false,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:     openShiftCLIClientID,
+				AuthorizeUrl: "b",
+				TokenUrl:     "c",
+				RedirectUrl:  "a/oauth/token/implicit",
+			},
+		},
+		{
+			name: "host with extra slashes",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{pkce_s256},
+			},
+			hostWrapper: func(host string) string { return host + "/////" },
+			tokenFlow:   false,
+
+			expectPKCE: true,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:            openShiftCLIClientID,
+				AuthorizeUrl:        "b",
+				TokenUrl:            "c",
+				RedirectUrl:         "a/oauth/token/implicit",
+				CodeChallengeMethod: pkce_s256,
+			},
+		},
+		{
+			name: "issuer with extra slashes",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "a/////",
+				AuthorizationEndpoint:         "b",
+				TokenEndpoint:                 "c",
+				CodeChallengeMethodsSupported: []string{pkce_s256},
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   false,
+
+			expectPKCE: true,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:            openShiftCLIClientID,
+				AuthorizeUrl:        "b",
+				TokenUrl:            "c",
+				RedirectUrl:         "a/oauth/token/implicit",
+				CodeChallengeMethod: pkce_s256,
+			},
+		},
+		{
+			name: "code with PKCE support from server, more complex JSON",
+			metadata: &oauthdiscovery.OauthAuthorizationServerMetadata{
+				Issuer:                        "arandomissuerthatisfun123!!!///",
+				AuthorizationEndpoint:         "44authzisanawesomeendpoint",
+				TokenEndpoint:                 "&&buttokenendpointisprettygoodtoo",
+				CodeChallengeMethodsSupported: []string{pkce_s256},
+			},
+			hostWrapper: noHostChange,
+			tokenFlow:   false,
+
+			expectPKCE: true,
+			expectedConfig: &osincli.ClientConfig{
+				ClientId:            openShiftCLIClientID,
+				AuthorizeUrl:        "44authzisanawesomeendpoint",
+				TokenUrl:            "&&buttokenendpointisprettygoodtoo",
+				RedirectUrl:         "arandomissuerthatisfun123!!!/oauth/token/implicit",
+				CodeChallengeMethod: pkce_s256,
+			},
+		},
+	} {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.Method != "GET" {
+				t.Errorf("%s: Expected GET, got %s", tc.name, req.Method)
+				return
+			}
+			if req.URL.Path != oauthMetadataEndpoint {
+				t.Errorf("%s: Expected metadata endpoint, got %s", tc.name, req.URL.Path)
+				return
+			}
+			data, err := json.Marshal(tc.metadata)
+			if err != nil {
+				t.Errorf("%s: unexpected json error: %v", tc.name, err)
+				return
+			}
+			w.Write(data)
+		}))
+		defer s.Close()
+
+		opts := &RequestTokenOptions{
+			ClientConfig: &restclient.Config{Host: tc.hostWrapper(s.URL)},
+			TokenFlow:    tc.tokenFlow,
+		}
+		if err := opts.SetDefaultOsinConfig(); err != nil {
+			t.Errorf("%s: unexpected SetDefaultOsinConfig error: %v", tc.name, err)
+			continue
+		}
+
+		// check PKCE data
+		if tc.expectPKCE {
+			if len(opts.OsinConfig.CodeChallenge) == 0 || len(opts.OsinConfig.CodeChallengeMethod) == 0 || len(opts.OsinConfig.CodeVerifier) == 0 {
+				t.Errorf("%s: did not set PKCE", tc.name)
+				continue
+			}
+		} else {
+			if len(opts.OsinConfig.CodeChallenge) != 0 || len(opts.OsinConfig.CodeChallengeMethod) != 0 || len(opts.OsinConfig.CodeVerifier) != 0 {
+				t.Errorf("%s: incorrectly set PKCE", tc.name)
+				continue
+			}
+		}
+
+		// blindly unset random PKCE data since we already checked for it
+		opts.OsinConfig.CodeChallenge = ""
+		opts.OsinConfig.CodeVerifier = ""
+
+		// compare the configs to see if they match
+		if !reflect.DeepEqual(*tc.expectedConfig, *opts.OsinConfig) {
+			t.Errorf("%s: expected osin config does not match, %s", tc.name, diff.ObjectDiff(*tc.expectedConfig, *opts.OsinConfig))
+		}
+	}
+}

--- a/test/extended/util/oc_copy.go
+++ b/test/extended/util/oc_copy.go
@@ -1,0 +1,131 @@
+package util
+
+import (
+	"net/url"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/third_party/forked/golang/netutil"
+	restclient "k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	userv1typedclient "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
+)
+
+// getClusterNicknameFromConfig returns host:port of the clientConfig.Host, with .'s replaced by -'s
+// TODO this is copied from pkg/client/config/smart_merge.go, looks like a good library-go candidate
+func getClusterNicknameFromConfig(clientCfg *restclient.Config) (string, error) {
+	u, err := url.Parse(clientCfg.Host)
+	if err != nil {
+		return "", err
+	}
+	hostPort := netutil.CanonicalAddr(u)
+
+	// we need a character other than "." to avoid conflicts with.  replace with '-'
+	return strings.Replace(hostPort, ".", "-", -1), nil
+}
+
+// getUserNicknameFromConfig returns "username(as known by the server)/getClusterNicknameFromConfig".  This allows tab completion for switching users to
+// work easily and obviously.
+func getUserNicknameFromConfig(clientCfg *restclient.Config) (string, error) {
+	userPartOfNick, err := getUserPartOfNickname(clientCfg)
+	if err != nil {
+		return "", err
+	}
+
+	clusterNick, err := getClusterNicknameFromConfig(clientCfg)
+	if err != nil {
+		return "", err
+	}
+
+	return userPartOfNick + "/" + clusterNick, nil
+}
+
+func getUserPartOfNickname(clientCfg *restclient.Config) (string, error) {
+	userClient, err := userv1typedclient.NewForConfig(clientCfg)
+	if err != nil {
+		return "", err
+	}
+	userInfo, err := userClient.Users().Get("~", metav1.GetOptions{})
+	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
+		// if we're talking to kube (or likely talking to kube), take a best guess consistent with login
+		switch {
+		case len(clientCfg.BearerToken) > 0:
+			userInfo.Name = clientCfg.BearerToken
+		case len(clientCfg.Username) > 0:
+			userInfo.Name = clientCfg.Username
+		}
+	} else if err != nil {
+		return "", err
+	}
+
+	return userInfo.Name, nil
+}
+
+// getContextNicknameFromConfig returns "namespace/getClusterNicknameFromConfig/username(as known by the server)".  This allows tab completion for switching projects/context
+// to work easily.  First tab is the most selective on project.  Second stanza in the next most selective on cluster name.  The chances of a user trying having
+// one projects on a single server that they want to operate against with two identities is low, so username is last.
+func getContextNicknameFromConfig(namespace string, clientCfg *restclient.Config) (string, error) {
+	userPartOfNick, err := getUserPartOfNickname(clientCfg)
+	if err != nil {
+		return "", err
+	}
+
+	clusterNick, err := getClusterNicknameFromConfig(clientCfg)
+	if err != nil {
+		return "", err
+	}
+
+	return namespace + "/" + clusterNick + "/" + userPartOfNick, nil
+}
+
+// CreateConfig takes a clientCfg and builds a config (kubeconfig style) from it.
+func createConfig(namespace string, clientCfg *restclient.Config) (*clientcmdapi.Config, error) {
+	clusterNick, err := getClusterNicknameFromConfig(clientCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	userNick, err := getUserNicknameFromConfig(clientCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	contextNick, err := getContextNicknameFromConfig(namespace, clientCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	config := clientcmdapi.NewConfig()
+
+	credentials := clientcmdapi.NewAuthInfo()
+	credentials.Token = clientCfg.BearerToken
+	credentials.ClientCertificate = clientCfg.TLSClientConfig.CertFile
+	if len(credentials.ClientCertificate) == 0 {
+		credentials.ClientCertificateData = clientCfg.TLSClientConfig.CertData
+	}
+	credentials.ClientKey = clientCfg.TLSClientConfig.KeyFile
+	if len(credentials.ClientKey) == 0 {
+		credentials.ClientKeyData = clientCfg.TLSClientConfig.KeyData
+	}
+	config.AuthInfos[userNick] = credentials
+
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = clientCfg.Host
+	cluster.CertificateAuthority = clientCfg.CAFile
+	if len(cluster.CertificateAuthority) == 0 {
+		cluster.CertificateAuthorityData = clientCfg.CAData
+	}
+	cluster.InsecureSkipTLSVerify = clientCfg.Insecure
+	config.Clusters[clusterNick] = cluster
+
+	context := clientcmdapi.NewContext()
+	context.Cluster = clusterNick
+	context.AuthInfo = userNick
+	context.Namespace = namespace
+	config.Contexts[contextNick] = context
+	config.CurrentContext = contextNick
+
+	return config, nil
+}


### PR DESCRIPTION
This removes our final `oc` links from e2e.  Some files were copied.  The deepest copy was for getting tokens. We may want to put that in library-go someday, but for now this copy holds us and we know that the API it uses can't change.