### PR TITLE
UPSTREAM: <carry>: Prevent deletion of openshift-config-managed

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -56,6 +56,8 @@ func Register(plugins *admission.Plugins) {
 		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic,
 			// user specified configuration that cannot be rebuilt
 			"openshift-config",
+			// cluster generated configuration that cannot be rebuilt (etcd encryption keys)
+			"openshift-config-managed",
 			// the CVO which is the root we use to rebuild all the rest
 			"openshift-cluster-version",
 			// contains a namespaced list of all nodes in the cluster (yeah, weird.  they do it for multi-tenant management I think?)


### PR DESCRIPTION
This namespace will soon be used to store etcd encryption keys.  Deleting it would cause the cluster to be unrecoverable.

Signed-off-by: Monis Khan <mkhan@redhat.com>