### PR TITLE
revert: Disable probe restart test because it is flaky under kubelet skew

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -408,8 +408,6 @@ var (
 
 			`\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\] provisioning should access volume from different nodes`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711688
 
-			`Probing container should \*not\* be restarted with a non-local redirect http liveness probe`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711687
-
 			// requires a 1.14 kubelet, enable when rhcos is built for 4.2
 			"when the NodeLease feature is enabled",
 			"RuntimeClass should reject",


### PR DESCRIPTION
revert https://github.com/openshift/origin/pull/22865 now that 4.2 kubelet is in place

xref https://bugzilla.redhat.com/show_bug.cgi?id=1711687#c3

@smarterclayton 