### PR TITLE
Skip another upstream test under multitenant

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -49,9 +49,10 @@ var staticSuites = []*ginkgo.TestSuite{
 		Only the portion of the openshift/conformance test suite that applies to the openshift-sdn multitenant plugin.
 		`),
 		Matches: func(name string) bool {
-			return !strings.Contains(name, "[Feature:NetworkPolicy]") && strings.Contains(name, "[Suite:openshift/conformance/")
+			return strings.Contains(name, "[Suite:openshift/conformance/parallel") && !strings.Contains(name, "[Skipped:multitenant]")
 		},
-		Parallelism: 30,
+		Parallelism:          30,
+		MaximumAllowedFlakes: 15,
 	},
 	{
 		Name: "openshift/disruptive",

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -486,6 +486,11 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1740959
 			`\[sig-api-machinery\] AdmissionWebhook Should be able to deny pod and configmap creation`,
 		},
+		// tests that aren't expected to pass under the old multitenant plugin
+		"[Skipped:multitenant]": {
+			`\[Feature:NetworkPolicy\]`,
+			`\[sig-network\] Services should preserve source pod IP for traffic thru service cluster IP`,
+		},
 		"[Suite:openshift/scalability]": {},
 		// tests that replace the old test-cmd script
 		"[Suite:openshift/test-cmd]": {


### PR DESCRIPTION
The multitenant test is still broken at the moment but once it's fixed, it shouldn't pass because we never implemented preservation of source pod IPs through service IPs in multitenant. So we need to skip that test too. Since it's possible there will be other tests we need to skip in the future too, this reorganizes a bit to put the multitenant skips in the same place as all the other skips.

/cc @rcarrillocruz @squeed 