### PR TITLE
Fix e2e test: bump nodejs version after eol trimmed images

### DIFF
--- a/examples/jenkins/OWNERS
+++ b/examples/jenkins/OWNERS
@@ -6,8 +6,16 @@ reviewers:
   - smarterclayton
   - sspeiche
   - jupierce
+  - akram
+  - waveywaves
+  - adambkaplan
 approvers:
   - bparees
   - mfojtik
   - csrwng
   - smarterclayton
+  - gabemontero
+  - akram
+  - waveywaves
+  - adambkaplan
+

--- a/examples/jenkins/pipeline/bluegreen-pipeline.yaml
+++ b/examples/jenkins/pipeline/bluegreen-pipeline.yaml
@@ -150,7 +150,7 @@ objects:
           value: ${NPM_MIRROR}
         from:
           kind: ImageStreamTag
-          name: nodejs:4
+          name: nodejs:8
           namespace: ${NAMESPACE}
       type: Source
     triggers:

--- a/examples/jenkins/pipeline/samplepipeline.yaml
+++ b/examples/jenkins/pipeline/samplepipeline.yaml
@@ -198,7 +198,7 @@ objects:
           value: ${NPM_MIRROR}
         from:
           kind: ImageStreamTag
-          name: nodejs:4
+          name: nodejs:8
           namespace: ${NAMESPACE}
       type: Source
     triggers:

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -16484,7 +16484,7 @@ objects:
           value: ${NPM_MIRROR}
         from:
           kind: ImageStreamTag
-          name: nodejs:4
+          name: nodejs:8
           namespace: ${NAMESPACE}
       type: Source
     triggers:
@@ -17466,7 +17466,7 @@ objects:
           value: ${NPM_MIRROR}
         from:
           kind: ImageStreamTag
-          name: nodejs:4
+          name: nodejs:8
           namespace: ${NAMESPACE}
       type: Source
     triggers:


### PR DESCRIPTION
Hi team,

Jenkins e2e test are failing [1] because of nodejs:4 imagestreamtag was removed in openshift/cluster-samples-operator#158 

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_jenkins/895/pull-ci-openshift-jenkins-master-e2e-aws-jenkins/349

@mfojtik or @jupierce can you PTAL ?
