### PR TITLE
UPSTREAM: <carry>: run ResourceQuota before ClusterResourceQuota

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ notifications:
   irc: "chat.freenode.net#openshift-dev"
 
 sudo: false
+
+git:
+  depth: false

--- a/pkg/quota/admission/clusterresourcequota/admission.go
+++ b/pkg/quota/admission/clusterresourcequota/admission.go
@@ -56,6 +56,7 @@ type clusterQuotaAdmission struct {
 var _ oadmission.WantsInternalKubernetesInformers = &clusterQuotaAdmission{}
 var _ oadmission.WantsOpenshiftInternalQuotaClient = &clusterQuotaAdmission{}
 var _ oadmission.WantsClusterQuota = &clusterQuotaAdmission{}
+var _ admission.ValidationInterface = &clusterQuotaAdmission{}
 
 const (
 	timeToWaitForCacheSync = 10 * time.Second
@@ -72,8 +73,8 @@ func NewClusterResourceQuota() (admission.Interface, error) {
 	}, nil
 }
 
-// Admit makes admission decisions while enforcing clusterQuota
-func (q *clusterQuotaAdmission) Admit(a admission.Attributes) (err error) {
+// Validate makes admission decisions while enforcing clusterQuota
+func (q *clusterQuotaAdmission) Validate(a admission.Attributes) (err error) {
 	// ignore all operations that correspond to sub-resource actions
 	if len(a.GetSubresource()) != 0 {
 		return nil


### PR DESCRIPTION
changes ClusterResourceQuota to be a validating admission plugin so that the correct order of admission is preserved, that is RQ is before CRQ.
this prevents a scenario where a resource cannot be created due to RQ limits but CRQ would allow for it because it doesn't know about RQ constraints.