### PR TITLE
Bug 1707506: Equivalence cache tests failing

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -400,7 +400,7 @@ var (
 			`ClusterDns \[Feature:Example\] should create pod that uses dns`,             // https://bugzilla.redhat.com/show_bug.cgi?id=1711601
 			`should be rejected when no endpoints exist`,                                 // https://bugzilla.redhat.com/show_bug.cgi?id=1711605
 			`PreemptionExecutionPath runs ReplicaSets to verify preemption running path`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711606
-			`TaintBasedEvictions`,                                                        // https://bugzilla.redhat.com/show_bug.cgi?id=1711608
+			`EquivalenceCache`,    // Equivalence tests are planned to be removed in 1.15, so we can safely disable them.
 
 			`\[Driver: iscsi\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
 			`\[Driver: ceph\]\[Feature:Volumes\] \[Testpattern: Pre-provisioned PV \(default fs\)\] subPath should verify container cannot write to subpath`,


### PR DESCRIPTION
Remove unnecessary equivalence cache tests. We plan to implement a newer version of equivalence cache in coming releases upstream. Till then upstream has decided to remove them

xref: https://github.com/kubernetes/kubernetes/pull/79828

 