### PR TITLE
Bug 1734003:  Unidling: minimize iptables lock contention

### DIFF
--- a/pkg/cmd/openshift-sdn/proxy.go
+++ b/pkg/cmd/openshift-sdn/proxy.go
@@ -241,10 +241,16 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		if err != nil {
 			klog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root (and if containerized, in the host network namespace as privileged) to use the service proxy: %v", err)
 		}
+		hp, ok := proxier.(hybrid.RunnableProxy)
+		if !ok {
+			// unreachable
+			klog.Fatalf("unidling proxy must be used in iptables mode")
+		}
 		proxier, err = hybrid.NewHybridProxier(
-			proxier,
+			hp,
 			unidlingUserspaceProxy,
 			sdn.ProxyConfig.IPTables.SyncPeriod.Duration,
+			sdn.ProxyConfig.IPTables.MinSyncPeriod.Duration,
 			sdn.informers.KubeInformers.Core().V1().Services().Lister(),
 		)
 		if err != nil {

--- a/pkg/cmd/openshift-sdn/proxy.go
+++ b/pkg/cmd/openshift-sdn/proxy.go
@@ -153,8 +153,6 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 	iptInterface := utiliptables.New(execer, dbus, protocol)
 
 	var proxier proxy.ProxyProvider
-	var servicesHandler pconfig.ServiceHandler
-	var endpointsHandler pconfig.EndpointsHandler
 	var healthzServer *healthcheck.HealthzServer
 	if len(sdn.ProxyConfig.HealthzBindAddress) > 0 {
 		nodeRef := &v1.ObjectReference{
@@ -180,7 +178,7 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 			// IPTablesMasqueradeBit must be specified or defaulted.
 			klog.Fatalf("Unable to read IPTablesMasqueradeBit from config")
 		}
-		proxierIptables, err := iptables.NewProxier(
+		proxier, err = iptables.NewProxier(
 			iptInterface,
 			utilsysctl.New(),
 			execer,
@@ -200,23 +198,15 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		if err != nil {
 			klog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root (and if containerized, in the host network namespace as privileged) to use the service proxy: %v", err)
 		}
-		proxier = proxierIptables
-		endpointsHandler = proxierIptables
-		servicesHandler = proxierIptables
 		// No turning back. Remove artifacts that might still exist from the userspace Proxier.
 		klog.V(0).Info("Tearing down userspace rules.")
 		userspace.CleanupLeftovers(iptInterface)
 	case kubeproxyconfig.ProxyModeUserspace:
 		klog.V(0).Info("Using userspace Proxier.")
-		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
-		// our config.EndpointsHandler.
-		loadBalancer := userspace.NewLoadBalancerRR()
-		// set EndpointsHandler to our loadBalancer
-		endpointsHandler = loadBalancer
 
 		execer := utilexec.New()
-		proxierUserspace, err := userspace.NewProxier(
-			loadBalancer,
+		proxier, err = userspace.NewProxier(
+			userspace.NewLoadBalancerRR(),
 			bindAddr,
 			iptInterface,
 			execer,
@@ -229,8 +219,6 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		if err != nil {
 			klog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root (and if containerized, in the host network namespace as privileged) to use the service proxy: %v", err)
 		}
-		proxier = proxierUserspace
-		servicesHandler = proxierUserspace
 		// Remove artifacts from the pure-iptables Proxier.
 		klog.V(0).Info("Tearing down pure-iptables proxy rules.")
 		iptables.CleanupLeftovers(iptInterface)
@@ -248,17 +236,12 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 	)
 
 	if sdn.NodeConfig.EnableUnidling {
-		unidlingLoadBalancer := userspace.NewLoadBalancerRR()
 		signaler := unidler.NewEventSignaler(recorder)
-		unidlingUserspaceProxy, err := unidler.NewUnidlerProxier(unidlingLoadBalancer, bindAddr, iptInterface, execer, *portRange, sdn.ProxyConfig.IPTables.SyncPeriod.Duration, sdn.ProxyConfig.IPTables.MinSyncPeriod.Duration, sdn.ProxyConfig.UDPIdleTimeout.Duration, sdn.ProxyConfig.NodePortAddresses, signaler)
+		unidlingUserspaceProxy, err := unidler.NewUnidlerProxier(userspace.NewLoadBalancerRR(), bindAddr, iptInterface, execer, *portRange, sdn.ProxyConfig.IPTables.SyncPeriod.Duration, sdn.ProxyConfig.IPTables.MinSyncPeriod.Duration, sdn.ProxyConfig.UDPIdleTimeout.Duration, sdn.ProxyConfig.NodePortAddresses, signaler)
 		if err != nil {
 			klog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root (and if containerized, in the host network namespace as privileged) to use the service proxy: %v", err)
 		}
-		hybridProxier, err := hybrid.NewHybridProxier(
-			unidlingLoadBalancer,
-			unidlingUserspaceProxy,
-			endpointsHandler,
-			servicesHandler,
+		proxier, err = hybrid.NewHybridProxier(
 			proxier,
 			unidlingUserspaceProxy,
 			sdn.ProxyConfig.IPTables.SyncPeriod.Duration,
@@ -267,9 +250,6 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		if err != nil {
 			klog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root (and if containerized, in the host network namespace as privileged) to use the service proxy: %v", err)
 		}
-		endpointsHandler = hybridProxier
-		servicesHandler = hybridProxier
-		proxier = hybridProxier
 	}
 
 	endpointsConfig := pconfig.NewEndpointsConfig(
@@ -277,13 +257,13 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		sdn.ProxyConfig.ConfigSyncPeriod.Duration,
 	)
 	// customized handling registration that inserts a filter if needed
-	if err := sdn.OsdnProxy.Start(endpointsHandler); err != nil {
+	if err := sdn.OsdnProxy.Start(proxier); err != nil {
 		klog.Fatalf("error: node proxy plugin startup failed: %v", err)
 	}
-	endpointsHandler = sdn.OsdnProxy
+	proxier = sdn.OsdnProxy
 
 	// Wrap the proxy to know when it finally initializes
-	waitingProxy := newWaitingProxyHandler(servicesHandler, endpointsHandler, waitChan)
+	waitingProxy := newWaitingProxyHandler(proxier, waitChan)
 
 	iptInterface.AddReloadFunc(proxier.Sync)
 	serviceConfig.RegisterEventHandler(waitingProxy)
@@ -361,17 +341,15 @@ type waitingProxyHandler struct {
 	waitChan    chan<- bool
 	initialized bool
 
-	serviceChild    pconfig.ServiceHandler
+	proxier         proxy.ProxyProvider
 	serviceSynced   bool
-	endpointsChild  pconfig.EndpointsHandler
 	endpointsSynced bool
 }
 
-func newWaitingProxyHandler(serviceChild pconfig.ServiceHandler, endpointsChild pconfig.EndpointsHandler, waitChan chan<- bool) *waitingProxyHandler {
+func newWaitingProxyHandler(proxier proxy.ProxyProvider, waitChan chan<- bool) *waitingProxyHandler {
 	return &waitingProxyHandler{
-		serviceChild:   serviceChild,
-		endpointsChild: endpointsChild,
-		waitChan:       waitChan,
+		proxier:  proxier,
+		waitChan: waitChan,
 	}
 }
 
@@ -384,19 +362,19 @@ func (wph *waitingProxyHandler) checkInitialized() {
 }
 
 func (wph *waitingProxyHandler) OnServiceAdd(service *v1.Service) {
-	wph.serviceChild.OnServiceAdd(service)
+	wph.proxier.OnServiceAdd(service)
 }
 
 func (wph *waitingProxyHandler) OnServiceUpdate(oldService, service *v1.Service) {
-	wph.serviceChild.OnServiceUpdate(oldService, service)
+	wph.proxier.OnServiceUpdate(oldService, service)
 }
 
 func (wph *waitingProxyHandler) OnServiceDelete(service *v1.Service) {
-	wph.serviceChild.OnServiceDelete(service)
+	wph.proxier.OnServiceDelete(service)
 }
 
 func (wph *waitingProxyHandler) OnServiceSynced() {
-	wph.serviceChild.OnServiceSynced()
+	wph.proxier.OnServiceSynced()
 	wph.Lock()
 	defer wph.Unlock()
 	wph.serviceSynced = true
@@ -404,19 +382,19 @@ func (wph *waitingProxyHandler) OnServiceSynced() {
 }
 
 func (wph *waitingProxyHandler) OnEndpointsAdd(endpoints *v1.Endpoints) {
-	wph.endpointsChild.OnEndpointsAdd(endpoints)
+	wph.proxier.OnEndpointsAdd(endpoints)
 }
 
 func (wph *waitingProxyHandler) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {
-	wph.endpointsChild.OnEndpointsUpdate(oldEndpoints, endpoints)
+	wph.proxier.OnEndpointsUpdate(oldEndpoints, endpoints)
 }
 
 func (wph *waitingProxyHandler) OnEndpointsDelete(endpoints *v1.Endpoints) {
-	wph.endpointsChild.OnEndpointsDelete(endpoints)
+	wph.proxier.OnEndpointsDelete(endpoints)
 }
 
 func (wph *waitingProxyHandler) OnEndpointsSynced() {
-	wph.endpointsChild.OnEndpointsSynced()
+	wph.proxier.OnEndpointsSynced()
 	wph.Lock()
 	defer wph.Unlock()
 	wph.endpointsSynced = true

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -16,7 +16,7 @@ import (
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	pconfig "k8s.io/kubernetes/pkg/proxy/config"
+	kubeproxy "k8s.io/kubernetes/pkg/proxy"
 
 	networkv1 "github.com/openshift/api/network/v1"
 	networkclient "github.com/openshift/client-go/network/clientset/versioned"
@@ -49,12 +49,12 @@ type proxyEndpoints struct {
 }
 
 type OsdnProxy struct {
-	kClient              kubernetes.Interface
-	networkClient        networkclient.Interface
-	networkInformers     networkinformers.SharedInformerFactory
-	networkInfo          *common.NetworkInfo
-	egressDNS            *common.EgressDNS
-	baseEndpointsHandler pconfig.EndpointsHandler
+	kClient          kubernetes.Interface
+	networkClient    networkclient.Interface
+	networkInformers networkinformers.SharedInformerFactory
+	networkInfo      *common.NetworkInfo
+	egressDNS        *common.EgressDNS
+	baseProxy        kubeproxy.ProxyProvider
 
 	lock         sync.Mutex
 	firewall     map[string]*proxyFirewallItem
@@ -78,7 +78,7 @@ func New(pluginName string, networkClient networkclient.Interface, kClient kuber
 	}, nil
 }
 
-func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsHandler) error {
+func (proxy *OsdnProxy) Start(proxier kubeproxy.ProxyProvider) error {
 	klog.Infof("Starting multitenant SDN proxy endpoint filter")
 
 	var err error
@@ -86,7 +86,7 @@ func (proxy *OsdnProxy) Start(baseHandler pconfig.EndpointsHandler) error {
 	if err != nil {
 		return fmt.Errorf("could not get network info: %s", err)
 	}
-	proxy.baseEndpointsHandler = baseHandler
+	proxy.baseProxy = proxier
 
 	policies, err := proxy.networkClient.NetworkV1().EgressNetworkPolicies(metav1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
@@ -247,9 +247,9 @@ func (proxy *OsdnProxy) updateEgressNetworkPolicy(policy networkv1.EgressNetwork
 		pep.blocked = proxy.endpointsBlocked(pep.endpoints)
 		switch {
 		case wasBlocked && !pep.blocked:
-			proxy.baseEndpointsHandler.OnEndpointsAdd(pep.endpoints)
+			proxy.baseProxy.OnEndpointsAdd(pep.endpoints)
 		case !wasBlocked && pep.blocked:
-			proxy.baseEndpointsHandler.OnEndpointsDelete(pep.endpoints)
+			proxy.baseProxy.OnEndpointsDelete(pep.endpoints)
 		}
 	}
 }
@@ -293,7 +293,7 @@ func (proxy *OsdnProxy) OnEndpointsAdd(ep *corev1.Endpoints) {
 	pep := &proxyEndpoints{ep, proxy.endpointsBlocked(ep)}
 	proxy.allEndpoints[ep.UID] = pep
 	if !pep.blocked {
-		proxy.baseEndpointsHandler.OnEndpointsAdd(ep)
+		proxy.baseProxy.OnEndpointsAdd(ep)
 	}
 }
 
@@ -313,11 +313,11 @@ func (proxy *OsdnProxy) OnEndpointsUpdate(old, ep *corev1.Endpoints) {
 
 	switch {
 	case wasBlocked && !pep.blocked:
-		proxy.baseEndpointsHandler.OnEndpointsAdd(ep)
+		proxy.baseProxy.OnEndpointsAdd(ep)
 	case !wasBlocked && !pep.blocked:
-		proxy.baseEndpointsHandler.OnEndpointsUpdate(old, ep)
+		proxy.baseProxy.OnEndpointsUpdate(old, ep)
 	case !wasBlocked && pep.blocked:
-		proxy.baseEndpointsHandler.OnEndpointsDelete(ep)
+		proxy.baseProxy.OnEndpointsDelete(ep)
 	}
 }
 
@@ -332,12 +332,37 @@ func (proxy *OsdnProxy) OnEndpointsDelete(ep *corev1.Endpoints) {
 	}
 	delete(proxy.allEndpoints, ep.UID)
 	if !pep.blocked {
-		proxy.baseEndpointsHandler.OnEndpointsDelete(ep)
+		proxy.baseProxy.OnEndpointsDelete(ep)
 	}
 }
 
 func (proxy *OsdnProxy) OnEndpointsSynced() {
-	proxy.baseEndpointsHandler.OnEndpointsSynced()
+	proxy.baseProxy.OnEndpointsSynced()
+}
+
+func (proxy *OsdnProxy) OnServiceAdd(service *corev1.Service) {
+	klog.V(2).Infof("sdn proxy: add svc %s/%s: %v", service.Namespace, service.Name, service)
+	proxy.baseProxy.OnServiceAdd(service)
+}
+
+func (proxy *OsdnProxy) OnServiceUpdate(oldService, service *corev1.Service) {
+	proxy.baseProxy.OnServiceUpdate(oldService, service)
+}
+
+func (proxy *OsdnProxy) OnServiceDelete(service *corev1.Service) {
+	proxy.baseProxy.OnServiceDelete(service)
+}
+
+func (proxy *OsdnProxy) OnServiceSynced() {
+	proxy.baseProxy.OnServiceSynced()
+}
+
+func (proxy *OsdnProxy) Sync() {
+	proxy.baseProxy.Sync()
+}
+
+func (proxy *OsdnProxy) SyncLoop() {
+	proxy.baseProxy.SyncLoop()
 }
 
 func (proxy *OsdnProxy) syncEgressDNSProxyFirewall() {

--- a/pkg/proxy/hybrid/proxy.go
+++ b/pkg/proxy/hybrid/proxy.go
@@ -12,7 +12,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 
 	unidlingapi "github.com/openshift/origin/pkg/unidling/api"
 )
@@ -21,14 +20,10 @@ import (
 // delegating idled services to the unidling proxy and other services to the
 // primary proxy.
 type HybridProxier struct {
-	unidlingServiceHandler   proxyconfig.ServiceHandler
-	unidlingEndpointsHandler proxyconfig.EndpointsHandler
-	mainEndpointsHandler     proxyconfig.EndpointsHandler
-	mainServicesHandler      proxyconfig.ServiceHandler
-	mainProxy                proxy.ProxyProvider
-	unidlingProxy            proxy.ProxyProvider
-	syncPeriod               time.Duration
-	serviceLister            corev1listers.ServiceLister
+	mainProxy     proxy.ProxyProvider
+	unidlingProxy proxy.ProxyProvider
+	syncPeriod    time.Duration
+	serviceLister corev1listers.ServiceLister
 
 	// TODO(directxman12): figure out a good way to avoid duplicating this information
 	// (it's saved in the individual proxies as well)
@@ -47,24 +42,16 @@ type HybridProxier struct {
 }
 
 func NewHybridProxier(
-	unidlingEndpointsHandler proxyconfig.EndpointsHandler,
-	unidlingServiceHandler proxyconfig.ServiceHandler,
-	mainEndpointsHandler proxyconfig.EndpointsHandler,
-	mainServicesHandler proxyconfig.ServiceHandler,
 	mainProxy proxy.ProxyProvider,
 	unidlingProxy proxy.ProxyProvider,
 	syncPeriod time.Duration,
 	serviceLister corev1listers.ServiceLister,
 ) (*HybridProxier, error) {
 	return &HybridProxier{
-		unidlingEndpointsHandler: unidlingEndpointsHandler,
-		unidlingServiceHandler:   unidlingServiceHandler,
-		mainEndpointsHandler:     mainEndpointsHandler,
-		mainServicesHandler:      mainServicesHandler,
-		mainProxy:                mainProxy,
-		unidlingProxy:            unidlingProxy,
-		syncPeriod:               syncPeriod,
-		serviceLister:            serviceLister,
+		mainProxy:     mainProxy,
+		unidlingProxy: unidlingProxy,
+		syncPeriod:    syncPeriod,
+		serviceLister: serviceLister,
 
 		usingUserspace:      make(map[types.NamespacedName]bool),
 		switchedToUserspace: make(map[types.NamespacedName]bool),
@@ -84,10 +71,10 @@ func (p *HybridProxier) OnServiceAdd(service *corev1.Service) {
 	// proxy, so don't bother trying to remove like on an update
 	if isUsingUserspace, ok := p.usingUserspace[svcName]; ok && isUsingUserspace {
 		klog.V(6).Infof("hybrid proxy: add svc %s/%s in unidling proxy", service.Namespace, service.Name)
-		p.unidlingServiceHandler.OnServiceAdd(service)
+		p.unidlingProxy.OnServiceAdd(service)
 	} else {
 		klog.V(6).Infof("hybrid proxy: add svc %s/%s in main proxy", service.Namespace, service.Name)
-		p.mainServicesHandler.OnServiceAdd(service)
+		p.mainProxy.OnServiceAdd(service)
 	}
 }
 
@@ -104,10 +91,10 @@ func (p *HybridProxier) OnServiceUpdate(oldService, service *corev1.Service) {
 	// so that should deal with calling OnServiceDelete on switches
 	if isUsingUserspace, ok := p.usingUserspace[svcName]; ok && isUsingUserspace {
 		klog.V(6).Infof("hybrid proxy: update svc %s/%s in unidling proxy", service.Namespace, service.Name)
-		p.unidlingServiceHandler.OnServiceUpdate(oldService, service)
+		p.unidlingProxy.OnServiceUpdate(oldService, service)
 	} else {
 		klog.V(6).Infof("hybrid proxy: update svc %s/%s in main proxy", service.Namespace, service.Name)
-		p.mainServicesHandler.OnServiceUpdate(oldService, service)
+		p.mainProxy.OnServiceUpdate(oldService, service)
 	}
 }
 
@@ -126,18 +113,18 @@ func (p *HybridProxier) OnServiceDelete(service *corev1.Service) {
 
 	if isUsingUserspace, ok := p.usingUserspace[svcName]; ok && isUsingUserspace {
 		klog.V(6).Infof("hybrid proxy: del svc %s/%s in unidling proxy", service.Namespace, service.Name)
-		p.unidlingServiceHandler.OnServiceDelete(service)
+		p.unidlingProxy.OnServiceDelete(service)
 	} else {
 		klog.V(6).Infof("hybrid proxy: del svc %s/%s in main proxy", service.Namespace, service.Name)
-		p.mainServicesHandler.OnServiceDelete(service)
+		p.mainProxy.OnServiceDelete(service)
 	}
 
 	delete(p.switchedToUserspace, svcName)
 }
 
 func (p *HybridProxier) OnServiceSynced() {
-	p.unidlingServiceHandler.OnServiceSynced()
-	p.mainServicesHandler.OnServiceSynced()
+	p.unidlingProxy.OnServiceSynced()
+	p.mainProxy.OnServiceSynced()
 	klog.V(6).Infof("hybrid proxy: services synced")
 }
 
@@ -184,12 +171,12 @@ func (p *HybridProxier) switchService(name types.NamespacedName) {
 
 	if p.usingUserspace[name] {
 		klog.V(6).Infof("hybrid proxy: switching svc %s/%s to unidling proxy", svc.Namespace, svc.Name)
-		p.unidlingServiceHandler.OnServiceAdd(svc)
-		p.mainServicesHandler.OnServiceDelete(svc)
+		p.unidlingProxy.OnServiceAdd(svc)
+		p.mainProxy.OnServiceDelete(svc)
 	} else {
 		klog.V(6).Infof("hybrid proxy: switching svc %s/%s to main proxy", svc.Namespace, svc.Name)
-		p.mainServicesHandler.OnServiceAdd(svc)
-		p.unidlingServiceHandler.OnServiceDelete(svc)
+		p.mainProxy.OnServiceAdd(svc)
+		p.unidlingProxy.OnServiceDelete(svc)
 	}
 
 	p.switchedToUserspace[name] = p.usingUserspace[name]
@@ -199,7 +186,7 @@ func (p *HybridProxier) OnEndpointsAdd(endpoints *corev1.Endpoints) {
 	// we track all endpoints in the unidling endpoints handler so that we can succesfully
 	// detect when a service become unidling
 	klog.V(6).Infof("hybrid proxy: (always) add ep %s/%s in unidling proxy", endpoints.Namespace, endpoints.Name)
-	p.unidlingEndpointsHandler.OnEndpointsAdd(endpoints)
+	p.unidlingProxy.OnEndpointsAdd(endpoints)
 
 	p.usingUserspaceLock.Lock()
 	defer p.usingUserspaceLock.Unlock()
@@ -214,7 +201,7 @@ func (p *HybridProxier) OnEndpointsAdd(endpoints *corev1.Endpoints) {
 
 	if !p.usingUserspace[svcName] {
 		klog.V(6).Infof("hybrid proxy: add ep %s/%s in main proxy", endpoints.Namespace, endpoints.Name)
-		p.mainEndpointsHandler.OnEndpointsAdd(endpoints)
+		p.mainProxy.OnEndpointsAdd(endpoints)
 	}
 
 	// a service could appear before endpoints, so we have to treat this as a potential
@@ -228,7 +215,7 @@ func (p *HybridProxier) OnEndpointsUpdate(oldEndpoints, endpoints *corev1.Endpoi
 	// we track all endpoints in the unidling endpoints handler so that we can succesfully
 	// detect when a service become unidling
 	klog.V(6).Infof("hybrid proxy: (always) update ep %s/%s in unidling proxy", endpoints.Namespace, endpoints.Name)
-	p.unidlingEndpointsHandler.OnEndpointsUpdate(oldEndpoints, endpoints)
+	p.unidlingProxy.OnEndpointsUpdate(oldEndpoints, endpoints)
 
 	p.usingUserspaceLock.Lock()
 	defer p.usingUserspaceLock.Unlock()
@@ -250,16 +237,16 @@ func (p *HybridProxier) OnEndpointsUpdate(oldEndpoints, endpoints *corev1.Endpoi
 
 	if !isSwitch && !p.usingUserspace[svcName] {
 		klog.V(6).Infof("hybrid proxy: update ep %s/%s in main proxy", endpoints.Namespace, endpoints.Name)
-		p.mainEndpointsHandler.OnEndpointsUpdate(oldEndpoints, endpoints)
+		p.mainProxy.OnEndpointsUpdate(oldEndpoints, endpoints)
 		return
 	}
 
 	if p.usingUserspace[svcName] {
 		klog.V(6).Infof("hybrid proxy: del ep %s/%s in main proxy", endpoints.Namespace, endpoints.Name)
-		p.mainEndpointsHandler.OnEndpointsDelete(oldEndpoints)
+		p.mainProxy.OnEndpointsDelete(oldEndpoints)
 	} else {
 		klog.V(6).Infof("hybrid proxy: add ep %s/%s in main proxy", endpoints.Namespace, endpoints.Name)
-		p.mainEndpointsHandler.OnEndpointsAdd(endpoints)
+		p.mainProxy.OnEndpointsAdd(endpoints)
 	}
 
 	p.switchService(svcName)
@@ -269,7 +256,7 @@ func (p *HybridProxier) OnEndpointsDelete(endpoints *corev1.Endpoints) {
 	// we track all endpoints in the unidling endpoints handler so that we can succesfully
 	// detect when a service become unidling
 	klog.V(6).Infof("hybrid proxy: (always) del ep %s/%s in unidling proxy", endpoints.Namespace, endpoints.Name)
-	p.unidlingEndpointsHandler.OnEndpointsDelete(endpoints)
+	p.unidlingProxy.OnEndpointsDelete(endpoints)
 
 	// Careful - there is the potential for deadlocks here,
 	// except that we always get usingUserspaceLock first, then
@@ -291,15 +278,15 @@ func (p *HybridProxier) OnEndpointsDelete(endpoints *corev1.Endpoints) {
 
 	if !usingUserspace {
 		klog.V(6).Infof("hybrid proxy: del ep %s/%s in main proxy", endpoints.Namespace, endpoints.Name)
-		p.mainEndpointsHandler.OnEndpointsDelete(endpoints)
+		p.mainProxy.OnEndpointsDelete(endpoints)
 	}
 
 	delete(p.usingUserspace, svcName)
 }
 
 func (p *HybridProxier) OnEndpointsSynced() {
-	p.unidlingEndpointsHandler.OnEndpointsSynced()
-	p.mainEndpointsHandler.OnEndpointsSynced()
+	p.unidlingProxy.OnEndpointsSynced()
+	p.mainProxy.OnEndpointsSynced()
 	klog.V(6).Infof("hybrid proxy: endpoints synced")
 }
 

--- a/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/server.go
@@ -433,8 +433,6 @@ type ProxyServer struct {
 	OOMScoreAdj            *int32
 	ResourceContainer      string
 	ConfigSyncPeriod       time.Duration
-	ServiceEventHandler    config.ServiceHandler
-	EndpointsEventHandler  config.EndpointsHandler
 	HealthzServer          *healthcheck.HealthzServer
 }
 
@@ -586,11 +584,11 @@ func (s *ProxyServer) Run() error {
 	// only notify on changes, and the initial update (on process start) may be lost if no handlers
 	// are registered yet.
 	serviceConfig := config.NewServiceConfig(informerFactory.Core().V1().Services(), s.ConfigSyncPeriod)
-	serviceConfig.RegisterEventHandler(s.ServiceEventHandler)
+	serviceConfig.RegisterEventHandler(s.Proxier)
 	go serviceConfig.Run(wait.NeverStop)
 
 	endpointsConfig := config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), s.ConfigSyncPeriod)
-	endpointsConfig.RegisterEventHandler(s.EndpointsEventHandler)
+	endpointsConfig.RegisterEventHandler(s.Proxier)
 	go endpointsConfig.Run(wait.NeverStop)
 
 	// This has to start after the calls to NewServiceConfig and NewEndpointsConfig because those

--- a/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/server_others.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/server_others.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
@@ -136,8 +135,6 @@ func newProxyServer(
 	}
 
 	var proxier proxy.ProxyProvider
-	var serviceEventHandler proxyconfig.ServiceHandler
-	var endpointsEventHandler proxyconfig.EndpointsHandler
 
 	proxyMode := getProxyMode(string(config.Mode), iptInterface, kernelHandler, ipsetInterface, iptables.LinuxKernelCompatTester{})
 	nodeIP := net.ParseIP(config.BindAddress)
@@ -152,7 +149,7 @@ func newProxyServer(
 		}
 
 		// TODO this has side effects that should only happen when Run() is invoked.
-		proxierIPTables, err := iptables.NewProxier(
+		proxier, err = iptables.NewProxier(
 			iptInterface,
 			utilsysctl.New(),
 			execer,
@@ -171,9 +168,6 @@ func newProxyServer(
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
 		metrics.RegisterMetrics()
-		proxier = proxierIPTables
-		serviceEventHandler = proxierIPTables
-		endpointsEventHandler = proxierIPTables
 		// No turning back. Remove artifacts that might still exist from the userspace Proxier.
 		klog.V(0).Info("Tearing down inactive rules.")
 		// TODO this has side effects that should only happen when Run() is invoked.
@@ -187,7 +181,7 @@ func newProxyServer(
 		}
 	} else if proxyMode == proxyModeIPVS {
 		klog.V(0).Info("Using ipvs Proxier.")
-		proxierIPVS, err := ipvs.NewProxier(
+		proxier, err = ipvs.NewProxier(
 			iptInterface,
 			ipvsInterface,
 			ipsetInterface,
@@ -210,24 +204,16 @@ func newProxyServer(
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
 		metrics.RegisterMetrics()
-		proxier = proxierIPVS
-		serviceEventHandler = proxierIPVS
-		endpointsEventHandler = proxierIPVS
 		klog.V(0).Info("Tearing down inactive rules.")
 		// TODO this has side effects that should only happen when Run() is invoked.
 		userspace.CleanupLeftovers(iptInterface)
 		iptables.CleanupLeftovers(iptInterface)
 	} else {
 		klog.V(0).Info("Using userspace Proxier.")
-		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
-		// our config.EndpointsConfigHandler.
-		loadBalancer := userspace.NewLoadBalancerRR()
-		// set EndpointsConfigHandler to our loadBalancer
-		endpointsEventHandler = loadBalancer
 
 		// TODO this has side effects that should only happen when Run() is invoked.
-		proxierUserspace, err := userspace.NewProxier(
-			loadBalancer,
+		proxier, err = userspace.NewProxier(
+			userspace.NewLoadBalancerRR(),
 			net.ParseIP(config.BindAddress),
 			iptInterface,
 			execer,
@@ -240,8 +226,6 @@ func newProxyServer(
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-		serviceEventHandler = proxierUserspace
-		proxier = proxierUserspace
 
 		// Remove artifacts from the iptables and ipvs Proxier, if not on Windows.
 		klog.V(0).Info("Tearing down inactive rules.")
@@ -277,8 +261,6 @@ func newProxyServer(
 		OOMScoreAdj:            config.OOMScoreAdj,
 		ResourceContainer:      config.ResourceContainer,
 		ConfigSyncPeriod:       config.ConfigSyncPeriod.Duration,
-		ServiceEventHandler:    serviceEventHandler,
-		EndpointsEventHandler:  endpointsEventHandler,
 		HealthzServer:          healthzServer,
 	}, nil
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/server_windows.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/server_windows.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 	"k8s.io/kubernetes/pkg/proxy/winuserspace"
@@ -94,13 +93,11 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 	}
 
 	var proxier proxy.ProxyProvider
-	var serviceEventHandler proxyconfig.ServiceHandler
-	var endpointsEventHandler proxyconfig.EndpointsHandler
 
 	proxyMode := getProxyMode(string(config.Mode), winkernel.WindowsKernelCompatTester{})
 	if proxyMode == proxyModeKernelspace {
 		klog.V(0).Info("Using Kernelspace Proxier.")
-		proxierKernelspace, err := winkernel.NewProxier(
+		proxier, err = winkernel.NewProxier(
 			config.IPTables.SyncPeriod.Duration,
 			config.IPTables.MinSyncPeriod.Duration,
 			config.IPTables.MasqueradeAll,
@@ -114,23 +111,14 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-		proxier = proxierKernelspace
-		endpointsEventHandler = proxierKernelspace
-		serviceEventHandler = proxierKernelspace
 	} else {
 		klog.V(0).Info("Using userspace Proxier.")
 		execer := exec.New()
 		var netshInterface utilnetsh.Interface
 		netshInterface = utilnetsh.New(execer)
 
-		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
-		// our config.EndpointsConfigHandler.
-		loadBalancer := winuserspace.NewLoadBalancerRR()
-
-		// set EndpointsConfigHandler to our loadBalancer
-		endpointsEventHandler = loadBalancer
-		proxierUserspace, err := winuserspace.NewProxier(
-			loadBalancer,
+		proxier, err = winuserspace.NewProxier(
+			winuserspace.NewLoadBalancerRR(),
 			net.ParseIP(config.BindAddress),
 			netshInterface,
 			*utilnet.ParsePortRangeOrDie(config.PortRange),
@@ -141,28 +129,24 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-		proxier = proxierUserspace
-		serviceEventHandler = proxierUserspace
 		klog.V(0).Info("Tearing down pure-winkernel proxy rules.")
 		winkernel.CleanupLeftovers()
 	}
 
 	return &ProxyServer{
-		Client:                client,
-		EventClient:           eventClient,
-		Proxier:               proxier,
-		Broadcaster:           eventBroadcaster,
-		Recorder:              recorder,
-		ProxyMode:             proxyMode,
-		NodeRef:               nodeRef,
-		MetricsBindAddress:    config.MetricsBindAddress,
-		EnableProfiling:       config.EnableProfiling,
-		OOMScoreAdj:           config.OOMScoreAdj,
-		ResourceContainer:     config.ResourceContainer,
-		ConfigSyncPeriod:      config.ConfigSyncPeriod.Duration,
-		ServiceEventHandler:   serviceEventHandler,
-		EndpointsEventHandler: endpointsEventHandler,
-		HealthzServer:         healthzServer,
+		Client:             client,
+		EventClient:        eventClient,
+		Proxier:            proxier,
+		Broadcaster:        eventBroadcaster,
+		Recorder:           recorder,
+		ProxyMode:          proxyMode,
+		NodeRef:            nodeRef,
+		MetricsBindAddress: config.MetricsBindAddress,
+		EnableProfiling:    config.EnableProfiling,
+		OOMScoreAdj:        config.OOMScoreAdj,
+		ResourceContainer:  config.ResourceContainer,
+		ConfigSyncPeriod:   config.ConfigSyncPeriod.Duration,
+		HealthzServer:      healthzServer,
 	}, nil
 }
 

--- a/vendor/k8s.io/kubernetes/pkg/kubemark/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubemark/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//pkg/kubelet/dockershim:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/proxy:go_default_library",
-        "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/iptables:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/mount:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/proxy/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/BUILD
@@ -17,6 +17,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/proxy",
     deps = [
         "//pkg/api/v1/service:go_default_library",
+        "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/util:go_default_library",
         "//pkg/util/net:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier_openshift.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier_openshift.go
@@ -1,0 +1,13 @@
+package iptables
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/vendor/k8s.io/kubernetes/pkg/proxy/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/types.go
@@ -21,10 +21,14 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/proxy/config"
 )
 
 // ProxyProvider is the interface provided by proxier implementations.
 type ProxyProvider interface {
+	config.EndpointsHandler
+	config.ServiceHandler
+
 	// Sync immediately synchronizes the ProxyProvider's current state to proxy rules.
 	Sync()
 	// SyncLoop runs periodic work.

--- a/vendor/k8s.io/kubernetes/pkg/proxy/userspace/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/userspace/BUILD
@@ -21,7 +21,9 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/proxy:go_default_library",
+        "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/util:go_default_library",
+        "//pkg/util/async:go_default_library",
         "//pkg/util/conntrack:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/slice:go_default_library",
@@ -85,6 +87,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/exec/testing:go_default_library",
     ],

--- a/vendor/k8s.io/kubernetes/pkg/proxy/userspace/loadbalancer.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/userspace/loadbalancer.go
@@ -19,6 +19,7 @@ package userspace
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"net"
 )
 
@@ -31,4 +32,6 @@ type LoadBalancer interface {
 	DeleteService(service proxy.ServicePortName)
 	CleanupStaleStickySessions(service proxy.ServicePortName)
 	ServiceHasEndpoints(service proxy.ServicePortName) bool
+
+	proxyconfig.EndpointsHandler
 }

--- a/vendor/k8s.io/kubernetes/pkg/proxy/userspace/proxier_openshift.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/userspace/proxier_openshift.go
@@ -1,0 +1,13 @@
+package userspace
+
+// Some extra hacking for openshift-specific stuff
+
+import "k8s.io/kubernetes/pkg/util/async"
+
+func (p *Proxier) SyncProxyRules() {
+	p.syncProxyRules()
+}
+
+func (p *Proxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+	p.syncRunner = b
+}

--- a/vendor/k8s.io/kubernetes/pkg/proxy/userspace/proxier_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/userspace/proxier_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/proxy"
 	ipttest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/utils/exec"
@@ -84,6 +86,16 @@ func waitForClosedPortUDP(p *Proxier, proxyPort int) error {
 		time.Sleep(1 * time.Millisecond)
 	}
 	return fmt.Errorf("port %d still open", proxyPort)
+}
+
+func waitForServiceInfo(p *Proxier, service proxy.ServicePortName) (*ServiceInfo, bool) {
+	var svcInfo *ServiceInfo
+	var exists bool
+	wait.PollImmediate(50*time.Millisecond, 3*time.Second, func() (bool, error) {
+		svcInfo, exists = p.getServiceInfo(service)
+		return exists, nil
+	})
+	return svcInfo, exists
 }
 
 // udpEchoServer is a simple echo server in UDP, intended for testing the proxy.
@@ -225,6 +237,15 @@ func waitForNumProxyClients(t *testing.T, s *ServiceInfo, want int, timeout time
 	t.Errorf("expected %d ProxyClients live, got %d", want, got)
 }
 
+func startProxier(p *Proxier, t *testing.T) {
+	go func() {
+		p.SyncLoop()
+	}()
+	waitForNumProxyLoops(t, p, 0)
+	p.OnServiceSynced()
+	p.OnEndpointsSynced()
+}
+
 func TestTCPProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
 	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
@@ -242,7 +263,8 @@ func TestTCPProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -269,7 +291,8 @@ func TestUDPProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -296,7 +319,8 @@ func TestUDPProxyTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -335,7 +359,8 @@ func TestMultiPortProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfoP, err := p.addServiceOnPort(serviceP, "TCP", 0, time.Second)
 	if err != nil {
@@ -364,7 +389,8 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	p.OnServiceAdd(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceP.Name, Namespace: serviceP.Namespace},
@@ -379,7 +405,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 		}}},
 	})
 	waitForNumProxyLoops(t, p, 2)
-	svcInfo, exists := p.getServiceInfo(serviceP)
+	svcInfo, exists := waitForServiceInfo(p, serviceP)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", serviceP)
 	}
@@ -387,7 +413,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 		t.Errorf("unexpected serviceInfo for %s: %#v", serviceP, svcInfo)
 	}
 
-	svcInfo, exists = p.getServiceInfo(serviceQ)
+	svcInfo, exists = waitForServiceInfo(p, serviceQ)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", serviceQ)
 	}
@@ -403,7 +429,9 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 
 // Helper: Stops the proxy for the named service.
 func stopProxyByName(proxier *Proxier, service proxy.ServicePortName) error {
-	info, found := proxier.getServiceInfo(service)
+	proxier.mu.Lock()
+	defer proxier.mu.Unlock()
+	info, found := proxier.serviceMap[service]
 	if !found {
 		return fmt.Errorf("unknown service: %s", service)
 	}
@@ -427,7 +455,8 @@ func TestTCPProxyStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -471,7 +500,8 @@ func TestUDPProxyStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -494,9 +524,9 @@ func TestUDPProxyStop(t *testing.T) {
 
 func TestTCPProxyUpdateDelete(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	servicePortName := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: servicePortName.Namespace, Name: servicePortName.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
@@ -509,28 +539,22 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
-	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
-	if err != nil {
-		t.Fatalf("error adding new service: %#v", err)
-	}
-	conn, err := net.Dial("tcp", joinHostPort("", svcInfo.proxyPort))
-	if err != nil {
-		t.Fatalf("error connecting to proxy: %v", err)
-	}
-	conn.Close()
-	waitForNumProxyLoops(t, p, 1)
-
-	p.OnServiceDelete(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: servicePortName.Name, Namespace: servicePortName.Namespace},
 		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []v1.ServicePort{{
 			Name:     "p",
-			Port:     int32(svcInfo.proxyPort),
+			Port:     9997,
 			Protocol: "TCP",
 		}}},
-	})
-	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
+	}
+
+	p.OnServiceAdd(service)
+	waitForNumProxyLoops(t, p, 1)
+	p.OnServiceDelete(service)
+	if err := waitForClosedPortTCP(p, int(service.Spec.Ports[0].Port)); err != nil {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
@@ -553,7 +577,8 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -598,7 +623,8 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -634,7 +660,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	})
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", service)
 	}
@@ -660,7 +686,8 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -696,7 +723,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Protocol: "UDP",
 		}}},
 	})
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -721,7 +748,8 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -742,7 +770,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -769,7 +797,8 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "UDP", 0, time.Second)
 	if err != nil {
@@ -789,7 +818,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	if err := waitForClosedPortUDP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -814,7 +843,8 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -839,7 +869,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
-	svcInfo, exists := p.getServiceInfo(service)
+	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
 	}
@@ -867,7 +897,8 @@ func TestProxyUpdatePortal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitForNumProxyLoops(t, p, 0)
+	startProxier(p, t)
+	defer p.shutdown()
 
 	svcInfo, err := p.addServiceOnPort(service, "TCP", 0, time.Second)
 	if err != nil {
@@ -894,7 +925,16 @@ func TestProxyUpdatePortal(t *testing.T) {
 		}}},
 	}
 	p.OnServiceUpdate(svcv0, svcv1)
-	_, exists := p.getServiceInfo(service)
+
+	// Wait for the service to be removed because it had an empty ClusterIP
+	var exists bool
+	for i := 0; i < 50; i++ {
+		_, exists = p.getServiceInfo(service)
+		if !exists {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	if exists {
 		t.Fatalf("service with empty ClusterIP should not be included in the proxy")
 	}
@@ -923,12 +963,178 @@ func TestProxyUpdatePortal(t *testing.T) {
 	}
 	p.OnServiceUpdate(svcv2, svcv3)
 	lb.OnEndpointsAdd(endpoint)
-	svcInfo, exists = p.getServiceInfo(service)
+	svcInfo, exists = waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("service with ClusterIP set not found in the proxy")
 	}
 	testEchoTCP(t, "127.0.0.1", svcInfo.proxyPort)
 	waitForNumProxyLoops(t, p, 1)
+}
+
+type fakeRunner struct{}
+
+// assert fakeAsyncRunner is a ProxyProvider
+var _ asyncRunnerInterface = &fakeRunner{}
+
+func (f fakeRunner) Run() {
+}
+
+func (f fakeRunner) Loop(stop <-chan struct{}) {
+}
+
+func TestOnServiceAddChangeMap(t *testing.T) {
+	fexec := makeFakeExec()
+
+	// Use long minSyncPeriod so we can test that immediate syncs work
+	p, err := createProxier(NewLoadBalancerRR(), net.ParseIP("0.0.0.0"), ipttest.NewFake(), fexec, net.ParseIP("127.0.0.1"), nil, time.Minute, time.Minute, udpIdleTimeoutForTest, newProxySocket)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake out sync runner
+	p.syncRunner = fakeRunner{}
+
+	serviceMeta := metav1.ObjectMeta{Namespace: "testnamespace", Name: "testname"}
+	service := &v1.Service{
+		ObjectMeta: serviceMeta,
+		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []v1.ServicePort{{
+			Name:     "p",
+			Port:     99,
+			Protocol: "TCP",
+		}}},
+	}
+
+	serviceUpdate := &v1.Service{
+		ObjectMeta: serviceMeta,
+		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.5", Ports: []v1.ServicePort{{
+			Name:     "p",
+			Port:     100,
+			Protocol: "TCP",
+		}}},
+	}
+
+	serviceUpdate2 := &v1.Service{
+		ObjectMeta: serviceMeta,
+		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.6", Ports: []v1.ServicePort{{
+			Name:     "p",
+			Port:     101,
+			Protocol: "TCP",
+		}}},
+	}
+
+	type onServiceTest struct {
+		detail         string
+		changes        []serviceChange
+		expectedChange *serviceChange
+	}
+
+	tests := []onServiceTest{
+		{
+			detail: "add",
+			changes: []serviceChange{
+				{current: service},
+			},
+			expectedChange: &serviceChange{
+				current: service,
+			},
+		},
+		{
+			detail: "add+update=add",
+			changes: []serviceChange{
+				{current: service},
+				{
+					previous: service,
+					current:  serviceUpdate,
+				},
+			},
+			expectedChange: &serviceChange{
+				current: serviceUpdate,
+			},
+		},
+		{
+			detail: "add+del=none",
+			changes: []serviceChange{
+				{current: service},
+				{previous: service},
+			},
+		},
+		{
+			detail: "update+update=update",
+			changes: []serviceChange{
+				{
+					previous: service,
+					current:  serviceUpdate,
+				},
+				{
+					previous: serviceUpdate,
+					current:  serviceUpdate2,
+				},
+			},
+			expectedChange: &serviceChange{
+				previous: service,
+				current:  serviceUpdate2,
+			},
+		},
+		{
+			detail: "update+del=del",
+			changes: []serviceChange{
+				{
+					previous: service,
+					current:  serviceUpdate,
+				},
+				{previous: serviceUpdate},
+			},
+			// change collapsing always keeps the oldest service
+			// info since correct unmerging depends on the least
+			// recent update, not the most current.
+			expectedChange: &serviceChange{
+				previous: service,
+			},
+		},
+		{
+			detail: "del+add=update",
+			changes: []serviceChange{
+				{previous: service},
+				{current: serviceUpdate},
+			},
+			expectedChange: &serviceChange{
+				previous: service,
+				current:  serviceUpdate,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		for _, change := range test.changes {
+			p.serviceChange(change.previous, change.current, test.detail)
+		}
+
+		if test.expectedChange != nil {
+			if len(p.serviceChanges) != 1 {
+				t.Fatalf("[%s] expected 1 service change but found %d", test.detail, len(p.serviceChanges))
+			}
+			expectedService := test.expectedChange.current
+			if expectedService == nil {
+				expectedService = test.expectedChange.previous
+			}
+			svcName := types.NamespacedName{Namespace: expectedService.Namespace, Name: expectedService.Name}
+
+			change, ok := p.serviceChanges[svcName]
+			if !ok {
+				t.Fatalf("[%s] did not find service change for %v", test.detail, svcName)
+			}
+			if !reflect.DeepEqual(change.previous, test.expectedChange.previous) {
+				t.Fatalf("[%s] change previous service and expected previous service don't match\nchange: %+v\nexp:    %+v", test.detail, change.previous, test.expectedChange.previous)
+			}
+			if !reflect.DeepEqual(change.current, test.expectedChange.current) {
+				t.Fatalf("[%s] change current service and expected current service don't match\nchange: %+v\nexp:    %+v", test.detail, change.current, test.expectedChange.current)
+			}
+		} else {
+			if len(p.serviceChanges) != 0 {
+				t.Fatalf("[%s] expected no service changes but found %d", test.detail, len(p.serviceChanges))
+			}
+		}
+	}
 }
 
 func makeFakeExec() *fakeexec.FakeExec {

--- a/vendor/k8s.io/kubernetes/pkg/proxy/winuserspace/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/winuserspace/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/proxy:go_default_library",
+        "//pkg/proxy/config:go_default_library",
         "//pkg/util/ipconfig:go_default_library",
         "//pkg/util/netsh:go_default_library",
         "//pkg/util/slice:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/proxy/winuserspace/loadbalancer.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/winuserspace/loadbalancer.go
@@ -19,6 +19,7 @@ package winuserspace
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
 	"net"
 )
 
@@ -30,4 +31,6 @@ type LoadBalancer interface {
 	NewService(service proxy.ServicePortName, sessionAffinityType v1.ServiceAffinity, stickyMaxAgeMinutes int) error
 	DeleteService(service proxy.ServicePortName)
 	CleanupStaleStickySessions(service proxy.ServicePortName)
+
+	proxyconfig.EndpointsHandler
 }

--- a/vendor/k8s.io/kubernetes/pkg/proxy/winuserspace/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/winuserspace/proxier.go
@@ -444,6 +444,22 @@ func (proxier *Proxier) OnServiceDelete(service *v1.Service) {
 func (proxier *Proxier) OnServiceSynced() {
 }
 
+func (proxier *Proxier) OnEndpointsAdd(endpoints *v1.Endpoints) {
+	proxier.loadBalancer.OnEndpointsAdd(endpoints)
+}
+
+func (proxier *Proxier) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {
+	proxier.loadBalancer.OnEndpointsUpdate(oldEndpoints, endpoints)
+}
+
+func (proxier *Proxier) OnEndpointsDelete(endpoints *v1.Endpoints) {
+	proxier.loadBalancer.OnEndpointsDelete(endpoints)
+}
+
+func (proxier *Proxier) OnEndpointsSynced() {
+	proxier.loadBalancer.OnEndpointsSynced()
+}
+
 func sameConfig(info *serviceInfo, service *v1.Service, protocol v1.Protocol, listenPort int) bool {
 	return info.protocol == protocol && info.portal.port == listenPort && info.sessionAffinityType == service.Spec.SessionAffinity
 }


### PR DESCRIPTION
This is the 4.1 backport of https://github.com/openshift/sdn/pull/8. It includes:

- backport of upstream PR 71735, which moves the userspace proxy over to an asynchronous model
- Changes needed to use that backport
- A small carry patch that lets us tweak the proxy internals slightly
- A patch that combines both proxy's sync loops, preventing lock contention