### PR TITLE
tests: import 'dr' package so that DR tests were registered in disruptive suite

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -57,4 +57,6 @@ import (
 	_ "github.com/openshift/origin/test/extended/security"
 	_ "github.com/openshift/origin/test/extended/templates"
 	_ "github.com/openshift/origin/test/extended/user"
+
+	_ "github.com/openshift/origin/test/e2e/dr"
 )


### PR DESCRIPTION
This is required for DR tests to appear in `openshift-tests run --dry-run`

/cc @smarterclayton 