### PR TITLE
Bug 1723924: Initializing runningPods on SDN bootup for 3.11

### DIFF
--- a/pkg/network/node/cniserver/cniserver.go
+++ b/pkg/network/node/cniserver/cniserver.go
@@ -94,6 +94,8 @@ type PodRequest struct {
 	Netns string
 	// for an ADD request, the host side of the created veth
 	HostVeth string
+	// for an ADD request, the (optional) already-assigned IP
+	AssignedIP string
 	// Channel for returning the operation result to the CNIServer
 	Result chan *PodResult
 }

--- a/pkg/network/node/multitenant.go
+++ b/pkg/network/node/multitenant.go
@@ -62,7 +62,7 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 	// VNID before the service and firewall rules are updated to match. We need
 	// to do the updates as a single transaction (ovs-ofctl --bundle).
 
-	pods, err := mp.node.GetLocalPods(namespace)
+	pods, err := mp.node.GetRunningPods(namespace)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Could not get list of local pods in namespace %q: %v", namespace, err))
 	}

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	kubeutilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -262,29 +263,6 @@ func GetLinkDetails(ip string) (netlink.Link, *net.IPNet, error) {
 	return nil, nil, ErrorNetworkInterfaceNotFound
 }
 
-func (node *OsdnNode) killUpdateFailedPods(pods []kapi.Pod) error {
-	for _, pod := range pods {
-		// Get the sandbox ID for this pod from the runtime
-		filter := &kruntimeapi.PodSandboxFilter{
-			LabelSelector: map[string]string{ktypes.KubernetesPodUIDLabel: string(pod.UID)},
-		}
-		sandboxID, err := node.getPodSandboxID(filter)
-		if err != nil {
-			return err
-		}
-
-		// Make an event that the pod is going to be killed
-		podRef := &v1.ObjectReference{Kind: "Pod", Name: pod.Name, Namespace: pod.Namespace, UID: pod.UID}
-		node.recorder.Eventf(podRef, v1.EventTypeWarning, "NetworkFailed", "The pod's network interface has been lost and the pod will be stopped.")
-
-		glog.V(5).Infof("Killing pod '%s/%s' sandbox due to failed restart", pod.Namespace, pod.Name)
-		if err := node.runtimeService.StopPodSandbox(sandboxID); err != nil {
-			glog.Warningf("Failed to kill pod '%s/%s' sandbox: %v", pod.Namespace, pod.Name, err)
-		}
-	}
-	return nil
-}
-
 func (node *OsdnNode) Start() error {
 	glog.V(2).Infof("Starting openshift-sdn network plugin")
 
@@ -322,7 +300,7 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("failed to set up iptables: %v", err)
 	}
 
-	networkChanged, err := node.SetupSDN()
+	networkChanged, existingPods, err := node.SetupSDN()
 	if err != nil {
 		return fmt.Errorf("node SDN setup failed: %v", err)
 	}
@@ -347,36 +325,16 @@ func (node *OsdnNode) Start() error {
 
 	glog.V(2).Infof("Starting openshift-sdn pod manager")
 	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR,
-		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String()); err != nil {
+		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String(),
+		networkChanged); err != nil {
 		return err
 	}
 
-	if networkChanged {
-		var pods, podsToKill []kapi.Pod
-
-		pods, err = node.GetLocalPods(metav1.NamespaceAll)
+	if networkChanged && len(existingPods) > 0 {
+		glog.Infof("OVS bridge has been recreated. Will reattach %d existing pods...", len(existingPods))
+		err := node.reattachPods(existingPods)
 		if err != nil {
 			return err
-		}
-		for _, p := range pods {
-			// Ignore HostNetwork pods since they don't go through OVS
-			if p.Spec.SecurityContext != nil && p.Spec.SecurityContext.HostNetwork {
-				continue
-			}
-			if err := node.UpdatePod(p); err != nil {
-				glog.Warningf("will restart pod '%s/%s' due to update failure on restart: %s", p.Namespace, p.Name, err)
-				podsToKill = append(podsToKill, p)
-			} else if vnid, err := node.policy.GetVNID(p.Namespace); err == nil {
-				node.policy.EnsureVNIDRules(vnid)
-			}
-		}
-
-		// Kill pods we couldn't recover; they will get restarted and then
-		// we'll be able to set them up correctly
-		if len(podsToKill) > 0 {
-			if err := node.killUpdateFailedPods(podsToKill); err != nil {
-				glog.Warningf("failed to restart pods that failed to update at startup: %v", err)
-			}
 		}
 	}
 
@@ -408,6 +366,53 @@ func (node *OsdnNode) Start() error {
 	}
 
 	glog.V(2).Infof("openshift-sdn network plugin ready")
+	return nil
+}
+
+// reattachPods takes an array containing the information about pods that had been
+// attached to the OVS bridge before restart, and either reattaches or kills each of the
+// corresponding pods.
+func (node *OsdnNode) reattachPods(existingPods map[string]podNetworkInfo) error {
+	sandboxes, err := node.getPodSandboxes()
+	if err != nil {
+		return err
+	}
+
+	failed := []*kruntimeapi.PodSandbox{}
+	for sandboxID, podInfo := range existingPods {
+		sandbox, ok := sandboxes[sandboxID]
+		if !ok {
+			glog.Warningf("Could not find sandbox for existing pod with IP %s; it may be in an inconsistent state", podInfo.ip)
+			continue
+		}
+
+		req := &cniserver.PodRequest{
+			Command:      cniserver.CNI_ADD,
+			PodNamespace: sandbox.Metadata.Namespace,
+			PodName:      sandbox.Metadata.Name,
+			SandboxID:    sandboxID,
+			HostVeth:     podInfo.vethName,
+			AssignedIP:   podInfo.ip,
+			Result:       make(chan *cniserver.PodResult),
+		}
+		if _, err := node.podManager.handleCNIRequest(req); err != nil {
+			glog.Warningf("Could not reattach pod '%s/%s' to SDN: %v", req.PodNamespace, req.PodName, err)
+			failed = append(failed, sandbox)
+		}
+	}
+
+	// Kill pods we couldn't recover; they will get restarted and then
+	// we'll be able to set them up correctly
+	for _, sandbox := range failed {
+		podRef := &v1.ObjectReference{Kind: "Pod", Name: sandbox.Metadata.Name, Namespace: sandbox.Metadata.Namespace, UID: types.UID(sandbox.Metadata.Uid)}
+		node.recorder.Eventf(podRef, v1.EventTypeWarning, "NetworkFailed", "The pod's network interface has been lost and the pod will be stopped.")
+
+		glog.V(5).Infof("Killing pod '%s/%s' sandbox due to failed restart", podRef.Namespace, podRef.Name)
+		if err := node.runtimeService.StopPodSandbox(sandbox.Id); err != nil {
+			glog.Warningf("Failed to kill pod '%s/%s' sandbox: %v", podRef.Namespace, podRef.Name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -405,11 +405,11 @@ func (oc *ovsController) getPodDetailsBySandboxID(sandboxID string) (int, net.IP
 		return 0, nil, fmt.Errorf("could not parse ofport %q: %v", rows[0]["ofport"], err)
 	}
 
-	ids, err := ovs.ParseExternalIDs(rows[0]["external-ids"])
+	ids, err := ovs.ParseExternalIDs(rows[0]["external_ids"])
 	if err != nil {
-		return 0, nil, fmt.Errorf("could not parse external-ids %q: %v", rows[0]["external-ids"], err)
+		return 0, nil, fmt.Errorf("could not parse external_ids %q: %v", rows[0]["external_ids"], err)
 	} else if ids["ip"] == "" {
-		return 0, nil, fmt.Errorf("external-ids %#v does not contain IP", ids)
+		return 0, nil, fmt.Errorf("external_ids %#v does not contain IP", ids)
 	}
 	podIP := net.ParseIP(ids["ip"])
 	if podIP == nil {

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -75,7 +75,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	if err != nil {
 		return err
 	}
-	err = oc.ovs.AddBridge("fail-mode=secure", "protocols=OpenFlow13")
+	err = oc.ovs.AddBridge("fail_mode=secure", "protocols=OpenFlow13")
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ type podNetworkInfo struct {
 
 // GetPodNetworkInfo returns network interface information about all currently-attached pods.
 func (oc *ovsController) GetPodNetworkInfo() (map[string]podNetworkInfo, error) {
-	rows, err := oc.ovs.Find("interface", []string{"name", "external_ids"}, "external-ids:sandbox!=\"\"")
+	rows, err := oc.ovs.Find("interface", []string{"name", "external_ids"}, "external_ids:sandbox!=\"\"")
 	if err != nil {
 		return nil, err
 	}
@@ -249,11 +249,11 @@ func (oc *ovsController) GetPodNetworkInfo() (map[string]podNetworkInfo, error) 
 
 		ids, err := ovs.ParseExternalIDs(row["external_ids"])
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Could not parse external-ids %q: %v", row["external_ids"], err))
+			utilruntime.HandleError(fmt.Errorf("Could not parse external_ids %q: %v", row["external_ids"], err))
 			continue
 		}
 		if ids["ip"] == "" || ids["sandbox"] == "" {
-			utilruntime.HandleError(fmt.Errorf("ovs-vsctl output missing one or more external-ids: %v", ids))
+			utilruntime.HandleError(fmt.Errorf("ovs-vsctl output missing one or more external_ids: %v", ids))
 			continue
 		}
 		if net.ParseIP(ids["ip"]) == nil {
@@ -276,7 +276,7 @@ func (oc *ovsController) NewTransaction() ovs.Transaction {
 
 func (oc *ovsController) ensureOvsPort(hostVeth, sandboxID, podIP string) (int, error) {
 	ofport, err := oc.ovs.AddPort(hostVeth, -1,
-		fmt.Sprintf(`external-ids=sandbox="%s",ip="%s"`, sandboxID, podIP),
+		fmt.Sprintf(`external_ids=sandbox="%s",ip="%s"`, sandboxID, podIP),
 	)
 	if err != nil {
 		// If hostVeth doesn't exist, ovs-vsctl will return an error, but will
@@ -330,7 +330,7 @@ func (oc *ovsController) SetUpPod(sandboxID, hostVeth string, podIP net.IP, vnid
 
 // Returned list can also be used for port names
 func (oc *ovsController) getInterfacesForSandbox(sandboxID string) ([]string, error) {
-	return oc.ovs.FindOne("interface", "name", "external-ids:sandbox="+sandboxID)
+	return oc.ovs.FindOne("interface", "name", "external_ids:sandbox="+sandboxID)
 }
 
 func (oc *ovsController) ClearPodBandwidth(portList []string, sandboxID string) error {
@@ -342,7 +342,7 @@ func (oc *ovsController) ClearPodBandwidth(portList []string, sandboxID string) 
 	}
 
 	// Now that the QoS is unused remove it
-	qosList, err := oc.ovs.FindOne("qos", "_uuid", "external-ids:sandbox="+sandboxID)
+	qosList, err := oc.ovs.FindOne("qos", "_uuid", "external_ids:sandbox="+sandboxID)
 	if err != nil {
 		return err
 	}
@@ -368,7 +368,7 @@ func (oc *ovsController) SetPodBandwidth(hostVeth, sandboxID string, ingressBPS,
 	}
 
 	if ingressBPS > 0 {
-		qos, err := oc.ovs.Create("qos", "type=linux-htb", fmt.Sprintf("other-config:max-rate=%d", ingressBPS), "external-ids=sandbox="+sandboxID)
+		qos, err := oc.ovs.Create("qos", "type=linux-htb", fmt.Sprintf("other_config:max-rate=%d", ingressBPS), "external_ids=sandbox="+sandboxID)
 		if err != nil {
 			return err
 		}
@@ -389,7 +389,7 @@ func (oc *ovsController) SetPodBandwidth(hostVeth, sandboxID string, ingressBPS,
 }
 
 func (oc *ovsController) getPodDetailsBySandboxID(sandboxID string) (int, net.IP, error) {
-	rows, err := oc.ovs.Find("interface", []string{"ofport", "external-ids"}, "external-ids:sandbox="+sandboxID)
+	rows, err := oc.ovs.Find("interface", []string{"ofport", "external_ids"}, "external_ids:sandbox="+sandboxID)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -798,7 +798,7 @@ func TestAlreadySetUp(t *testing.T) {
 
 	for i, tc := range testcases {
 		ovsif := ovs.NewFake(Br0)
-		if err := ovsif.AddBridge("fail-mode=secure", "protocols=OpenFlow13"); err != nil {
+		if err := ovsif.AddBridge("fail_mode=secure", "protocols=OpenFlow13"); err != nil {
 			t.Fatalf("(%d) unexpected error from AddBridge: %v", i, err)
 		}
 		oc := NewOVSController(ovsif, 0, true, "172.17.0.4")

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -171,10 +171,13 @@ func getIPAMConfig(clusterNetworks []common.ClusterNetwork, localSubnet string) 
 }
 
 // Start the CNI server and start processing requests from it
-func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string) error {
+func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetworks []common.ClusterNetwork, serviceNetworkCIDR string, clearHostPorts bool) error {
 	if m.enableHostports {
 		iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
 		m.hostportSyncer = kubehostport.NewHostportSyncer(iptInterface)
+		if clearHostPorts {
+			_ = m.hostportSyncer.SyncHostports(Tun0, nil)
+		}
 	}
 
 	var err error
@@ -500,16 +503,6 @@ func podIsExited(p *kcontainer.Pod) bool {
 func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *runningPod, error) {
 	defer PodOperationsLatency.WithLabelValues(PodOperationSetup).Observe(sinceInMicroseconds(time.Now()))
 
-	pod, err := m.kClient.Core().Pods(req.PodNamespace).Get(req.PodName, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ipamResult, podIP, err := m.ipamAdd(req.Netns, req.SandboxID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to run IPAM for %v: %v", req.SandboxID, err)
-	}
-
 	// Release any IPAM allocations and hostports if the setup failed
 	var success bool
 	defer func() {
@@ -522,6 +515,23 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 			}
 		}
 	}()
+
+	pod, err := m.kClient.Core().Pods(req.PodNamespace).Get(req.PodName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ipamResult cnitypes.Result
+	podIP := net.ParseIP(req.AssignedIP)
+	if podIP == nil {
+		ipamResult, podIP, err = m.ipamAdd(req.Netns, req.SandboxID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to run IPAM for %v: %v", req.SandboxID, err)
+		}
+		if err := maybeAddMacvlan(pod, req.Netns); err != nil {
+			return nil, nil, err
+		}
+	}
 
 	// Open any hostports the pod wants
 	var v1Pod v1.Pod
@@ -537,10 +547,6 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 
 	vnid, err := m.policy.GetVNID(req.PodNamespace)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := maybeAddMacvlan(pod, req.Netns); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/network/node/pod_test.go
+++ b/pkg/network/node/pod_test.go
@@ -318,7 +318,7 @@ func TestPodManager(t *testing.T) {
 		podManager := newDefaultPodManager()
 		podManager.podHandler = podTester
 		_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
+		err := podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
 		if err != nil {
 			t.Fatalf("could not start PodManager: %v", err)
 		}
@@ -417,7 +417,7 @@ func TestDirectPodUpdate(t *testing.T) {
 	podManager := newDefaultPodManager()
 	podManager.podHandler = podTester
 	_, cidr, _ := net.ParseCIDR("1.2.0.0/16")
-	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16")
+	err = podManager.Start(tmpDir, "1.2.3.0/24", []common.ClusterNetwork{{ClusterCIDR: cidr, HostSubnetLength: 8}}, "172.30.0.0/16", false)
 	if err != nil {
 		t.Fatalf("could not start PodManager: %v", err)
 	}

--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -70,7 +70,9 @@ func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, err
 		return nil, err
 	}
 
-	podSandboxList, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{})
+	podSandboxList, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{
+		State: &kruntimeapi.PodSandboxStateValue{State: kruntimeapi.PodSandboxState_SANDBOX_READY},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pod sandboxes: %v", err)
 	}

--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -63,3 +63,21 @@ func (node *OsdnNode) getPodSandboxID(filter *kruntimeapi.PodSandboxFilter) (str
 	}
 	return podSandboxList[0].Id, nil
 }
+
+func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, error) {
+	runtimeService, err := node.getRuntimeService()
+	if err != nil {
+		return nil, err
+	}
+
+	podSandboxList, err := runtimeService.ListPodSandbox(&kruntimeapi.PodSandboxFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pod sandboxes: %v", err)
+	}
+
+	podSandboxMap := make(map[string]*kruntimeapi.PodSandbox)
+	for _, sandbox := range podSandboxList {
+		podSandboxMap[sandbox.Id] = sandbox
+	}
+	return podSandboxMap, nil
+}

--- a/pkg/network/node/runtime.go
+++ b/pkg/network/node/runtime.go
@@ -77,7 +77,7 @@ func (node *OsdnNode) getPodSandboxes() (map[string]*kruntimeapi.PodSandbox, err
 
 	podSandboxMap := make(map[string]*kruntimeapi.PodSandbox)
 	for _, sandbox := range podSandboxList {
-		podSandboxMap[sandbox.Id] = sandbox
+		podSandboxMap[getPodKey(sandbox.Metadata.Namespace, sandbox.Metadata.Name)] = sandbox
 	}
 	return podSandboxMap, nil
 }

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -133,15 +133,14 @@ func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 	}
 
 	var changed bool
-	var existingPods map[string]podNetworkInfo
+	existingPods, err := plugin.oc.GetPodNetworkInfo()
+	if err != nil {
+		glog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
+	}
 	if err := plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs); err == nil {
 		glog.V(5).Infof("[SDN setup] no SDN setup required")
 	} else {
 		glog.Infof("[SDN setup] full SDN setup required (%v)", err)
-		existingPods, err = plugin.oc.GetPodNetworkInfo()
-		if err != nil {
-			glog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
-		}
 		if err := plugin.setup(clusterNetworkCIDRs, localSubnetCIDR, localSubnetGateway, gwCIDR); err != nil {
 			return false, nil, err
 		}

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -100,15 +100,15 @@ func deleteLocalSubnetRoute(device, localSubnetCIDR string) {
 	}
 }
 
-func (plugin *OsdnNode) SetupSDN() (bool, error) {
+func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 	// Make sure IPv4 forwarding state is 1
 	sysctl := sysctl.New()
 	val, err := sysctl.GetSysctl("net/ipv4/ip_forward")
 	if err != nil {
-		return false, fmt.Errorf("could not get IPv4 forwarding state: %s", err)
+		return false, nil, fmt.Errorf("could not get IPv4 forwarding state: %s", err)
 	}
 	if val != 1 {
-		return false, fmt.Errorf("net/ipv4/ip_forward=0, it must be set to 1")
+		return false, nil, fmt.Errorf("net/ipv4/ip_forward=0, it must be set to 1")
 	}
 
 	var clusterNetworkCIDRs []string
@@ -119,7 +119,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	localSubnetCIDR := plugin.localSubnetCIDR
 	_, ipnet, err := net.ParseCIDR(localSubnetCIDR)
 	if err != nil {
-		return false, fmt.Errorf("invalid local subnet CIDR: %v", err)
+		return false, nil, fmt.Errorf("invalid local subnet CIDR: %v", err)
 	}
 	localSubnetMaskLength, _ := ipnet.Mask.Size()
 	localSubnetGateway := netutils.GenerateDefaultGateway(ipnet).String()
@@ -129,16 +129,21 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	gwCIDR := fmt.Sprintf("%s/%d", localSubnetGateway, localSubnetMaskLength)
 
 	if err := waitForOVS(ovsDialDefaultNetwork, ovsDialDefaultAddress); err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	var changed bool
+	var existingPods map[string]podNetworkInfo
 	if err := plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs); err == nil {
 		glog.V(5).Infof("[SDN setup] no SDN setup required")
 	} else {
 		glog.Infof("[SDN setup] full SDN setup required (%v)", err)
+		existingPods, err = plugin.oc.GetPodNetworkInfo()
+		if err != nil {
+			glog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
+		}
 		if err := plugin.setup(clusterNetworkCIDRs, localSubnetCIDR, localSubnetGateway, gwCIDR); err != nil {
-			return false, err
+			return false, nil, err
 		}
 		changed = true
 	}
@@ -148,7 +153,7 @@ func (plugin *OsdnNode) SetupSDN() (bool, error) {
 	healthFn := func() error { return plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs) }
 	runOVSHealthCheck(ovsDialDefaultNetwork, ovsDialDefaultAddress, healthFn)
 
-	return changed, nil
+	return changed, existingPods, nil
 }
 
 func (plugin *OsdnNode) setup(clusterNetworkCIDRs []string, localSubnetCIDR, localSubnetGateway, gwCIDR string) error {

--- a/pkg/util/ovs/fake_ovs_test.go
+++ b/pkg/util/ovs/fake_ovs_test.go
@@ -123,7 +123,7 @@ func TestTransaction(t *testing.T) {
 	}
 }
 
-func TestFind(t *testing.T) {
+func TestFakeFind(t *testing.T) {
 	ovsif := NewFake("br0")
 	if err := ovsif.AddBridge(); err != nil {
 		t.Fatalf("unexpected error adding bridge: %v", err)
@@ -145,7 +145,7 @@ func TestFind(t *testing.T) {
 		t.Fatalf("port numbers are reused: %d, %d, %d", vethA, vethB, vethC)
 	}
 
-	ports, err := ovsif.Find("interface", "name", "external-ids:sandboxID=ALPHA")
+	ports, err := ovsif.FindOne("interface", "name", "external-ids:sandboxID=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestFind(t *testing.T) {
 		t.Fatalf("unexpected result finding port ALPHA's name: %#v", ports)
 	}
 
-	ports, err = ovsif.Find("interface", "ofport", "external-ids:sandboxID=BETA")
+	ports, err = ovsif.FindOne("interface", "ofport", "external-ids:sandboxID=BETA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestFind(t *testing.T) {
 		t.Fatalf("unexpected result finding port BETA's ofport: %#v", ports)
 	}
 
-	ports, err = ovsif.Find("interface", "name", "external-ids:notSandbox=ALPHA")
+	ports, err = ovsif.FindOne("interface", "name", "external-ids:notSandbox=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestFind(t *testing.T) {
 		t.Fatalf("unexpected result finding notSandbox=ALPHA ports: %#v", ports)
 	}
 
-	ports, err = ovsif.Find("interface", "name", "external-ids:sandboxID=DELTA")
+	ports, err = ovsif.FindOne("interface", "name", "external-ids:sandboxID=DELTA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}

--- a/pkg/util/ovs/fake_ovs_test.go
+++ b/pkg/util/ovs/fake_ovs_test.go
@@ -129,15 +129,15 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("unexpected error adding bridge: %v", err)
 	}
 
-	vethA, err := ovsif.AddPort("vethA", -1, "external-ids=sandboxID=ALPHA")
+	vethA, err := ovsif.AddPort("vethA", -1, "external_ids=sandboxID=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error adding port: %v", err)
 	}
-	vethB, err := ovsif.AddPort("vethB", -1, "external-ids=sandboxID=BETA,notSandbox=ALPHA")
+	vethB, err := ovsif.AddPort("vethB", -1, "external_ids=sandboxID=BETA,notSandbox=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error adding port: %v", err)
 	}
-	vethC, err := ovsif.AddPort("vethC", -1, "external-ids=sandboxID=GAMMA,notSandbox=ALPHA")
+	vethC, err := ovsif.AddPort("vethC", -1, "external_ids=sandboxID=GAMMA,notSandbox=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error adding port: %v", err)
 	}
@@ -145,15 +145,23 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("port numbers are reused: %d, %d, %d", vethA, vethB, vethC)
 	}
 
-	ports, err := ovsif.FindOne("interface", "name", "external-ids:sandboxID=ALPHA")
+	ports, err := ovsif.FindOne("interface", "name", "external_ids:sandboxID=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
 	if len(ports) != 1 || ports[0] != "vethA" {
 		t.Fatalf("unexpected result finding port ALPHA's name: %#v", ports)
 	}
+	_, err = ovsif.FindOne("interface", "name", "external-ids:sandboxID=ALPHA")
+	if err == nil {
+		t.Fatalf("failed to get error when looking up 'external-ids' with hyphen")
+	}
+	_, err = ovsif.FindOne("interface", "external-ids", "external_ids:sandboxID=ALPHA")
+	if err == nil {
+		t.Fatalf("failed to get error when looking up 'external-ids' with hyphen")
+	}
 
-	ports, err = ovsif.FindOne("interface", "ofport", "external-ids:sandboxID=BETA")
+	ports, err = ovsif.FindOne("interface", "ofport", "external_ids:sandboxID=BETA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -161,7 +169,7 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("unexpected result finding port BETA's ofport: %#v", ports)
 	}
 
-	ports, err = ovsif.FindOne("interface", "name", "external-ids:notSandbox=ALPHA")
+	ports, err = ovsif.FindOne("interface", "name", "external_ids:notSandbox=ALPHA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}
@@ -169,7 +177,7 @@ func TestFakeFind(t *testing.T) {
 		t.Fatalf("unexpected result finding notSandbox=ALPHA ports: %#v", ports)
 	}
 
-	ports, err = ovsif.FindOne("interface", "name", "external-ids:sandboxID=DELTA")
+	ports, err = ovsif.FindOne("interface", "name", "external_ids:sandboxID=DELTA")
 	if err != nil {
 		t.Fatalf("unexpected error finding port: %v", err)
 	}

--- a/pkg/util/ovs/ovs_test.go
+++ b/pkg/util/ovs/ovs_test.go
@@ -325,4 +325,14 @@ ofport              : 3
 		t.Fatalf("Unexpected response: %#v", valuesMap)
 	}
 	ensureTestResults(t, fexec)
+
+	// No addTestResult() since this should fail without calling exec
+	_, err = ovsif.Find("interface", []string{"external-ids"}, "external_ids:sandbox!=\"\"")
+	if err == nil {
+		t.Fatalf("failed to get error when referring to 'external-ids'")
+	}
+	_, err = ovsif.Find("interface", []string{"external_ids"}, "external-ids:sandbox!=\"\"")
+	if err == nil {
+		t.Fatalf("failed to get error when referring to 'external-ids'")
+	}
 }

--- a/pkg/util/ovs/parse.go
+++ b/pkg/util/ovs/parse.go
@@ -372,7 +372,7 @@ func fieldMatches(val, match string, ptype ParseType) bool {
 func ParseExternalIDs(externalIDs string) (map[string]string, error) {
 	ids := make(map[string]string, 1)
 	// Output from "find" and "list" will have braces, but input to "set" won't
-	if externalIDs[0] == '{' && externalIDs[len(externalIDs)-1] == '}' {
+	if strings.HasPrefix(externalIDs, "{") && strings.HasSuffix(externalIDs, "}") {
 		externalIDs = externalIDs[1 : len(externalIDs)-1]
 	}
 	for _, id := range strings.Split(externalIDs, ",") {


### PR DESCRIPTION
This is a fix for [BUG 1723924](https://bugzilla.redhat.com/show_bug.cgi?id=1723924)

The problem:

As mentioned in the link above, when the openshift networking process dies, the "podManager" object and its attribute "runningPods" is wiped for memory, which can lead to stateful inconsistencies with iptable rules defined for the pods running on that node. 

The fix:

We now initialize the "podManager" with the initial state of all running pods when the process is booted, as such we will have a synchronized state. 