### PR TITLE
Bug 1735404: ConfigMap printer ignores binaryData keys

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/printers/internalversion/printers.go
+++ b/vendor/k8s.io/kubernetes/pkg/printers/internalversion/printers.go
@@ -1725,7 +1725,7 @@ func printConfigMap(obj *api.ConfigMap, options printers.PrintOptions) ([]metav1
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, int64(len(obj.Data)), translateTimestampSince(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, int64(len(obj.Data)+len(obj.BinaryData)), translateTimestampSince(obj.CreationTimestamp))
 	return []metav1beta1.TableRow{row}, nil
 }
 


### PR DESCRIPTION
ConfigMaps may have both data and binaryData keys and the printer
was ignoring binaryData when counting the keys.