### PR TITLE
UPSTREAM:<carry>: Don't supress the node update error while logging

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -2935,7 +2935,7 @@ func AddOrUpdateAvoidPodOnNode(c clientset.Interface, nodeName string, avoidPods
 			if !apierrs.IsConflict(err) {
 				ExpectNoError(err)
 			} else {
-				Logf("Conflict when trying to add/update avoidPonds %v to %v", avoidPods, nodeName)
+				Logf("Conflict when trying to add/update avoidPonds %v to %v with error %v", avoidPods, nodeName, err)
 			}
 		}
 		return true, nil


### PR DESCRIPTION
We can see that this particular test is flaking at the following line `Conflict when trying to add/update avoidPonds` in the test suite 

Ref: https://search.svc.ci.openshift.org/?search=pod+should+avoid&maxAge=168h&context=2&type=all, 

I want to enable debugging so that we can see why the test is failing. Note that this test is passing continuously upstream

/cc @mfojtik @tnozicka 