### PR TITLE
Harden test oauth server against flakiness

### DIFF
--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -4,16 +4,17 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	osinv1 "github.com/openshift/api/osin/v1"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 	utiloauth "github.com/openshift/origin/test/extended/util/oauthserver"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -53,18 +54,17 @@ var _ = g.Describe("[Suite:openshift/oauth/htpasswd] HTPasswd IDP", func() {
 			MappingMethod:   "claim",
 			Provider:        *htpasswdProvider,
 		}
-		tokenReqOpts, cleanup, err := utiloauth.DeployOAuthServer(oc, []osinv1.IdentityProvider{htpasswdConfig}, nil, secrets)
+		newTokenReqOpts, cleanup, err := utiloauth.DeployOAuthServer(oc, []osinv1.IdentityProvider{htpasswdConfig}, nil, secrets)
 		defer cleanup()
 		o.Expect(err).ToNot(o.HaveOccurred())
+		tokenReqOpts := newTokenReqOpts("testuser", "password")
 		e2e.Logf("got the OAuth server address: %s", tokenReqOpts.Issuer)
-
-		token, err := utiloauth.RequestTokenForUser(tokenReqOpts, "testuser", "password")
+		token, err := tokenReqOpts.RequestToken()
+		o.Expect(err).ToNot(o.HaveOccurred())
 		defer func() {
 			oc.AdminUserClient().UserV1().Users().Delete("testuser", &metav1.DeleteOptions{})
 			oc.AdminUserClient().UserV1().Identities().Delete("htpasswd:testuser", &metav1.DeleteOptions{})
 		}()
-		o.Expect(err).ToNot(o.HaveOccurred())
-
 		tokenUser, err := utiloauth.GetUserForToken(oc.AdminConfig(), token, "testuser")
 		o.Expect(err).ToNot(o.HaveOccurred())
 		o.Expect(tokenUser.Name).To(o.Equal("testuser"))

--- a/test/extended/util/oauthserver/helpers.go
+++ b/test/extended/util/oauthserver/helpers.go
@@ -12,7 +12,6 @@ import (
 	osinv1 "github.com/openshift/api/osin/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	userv1client "github.com/openshift/client-go/user/clientset/versioned/typed/user/v1"
-	"github.com/openshift/origin/test/extended/util/oauthserver/tokencmd"
 )
 
 var (
@@ -23,16 +22,6 @@ var (
 
 func init() {
 	utilruntime.Must(osinv1.Install(osinScheme))
-}
-
-func RequestTokenForUser(reqOpts *tokencmd.RequestTokenOptions, username, password string) (string, error) {
-	reqOpts.Handler = &tokencmd.BasicChallengeHandler{
-		Host:     reqOpts.ClientConfig.Host,
-		Username: username,
-		Password: password,
-	}
-
-	return reqOpts.RequestToken()
 }
 
 func GetRawExtensionForOsinProvider(obj runtime.Object) (*runtime.RawExtension, error) {


### PR DESCRIPTION
- When creating a test oauth-server, block until the oauth server rbac updates, pod, and route are ready.
- return a closure for creating TokenRequestOptions to discourage of a single instance.