### PR TITLE
Bug 1733600: kube-apiserver: wait for kube informers in openshift patch

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/openshiftkubeapiserver/patch.go
@@ -128,6 +128,10 @@ func NewOpenShiftKubeAPIServerConfigPatch(delegateAPIServer genericapiserver.Del
 		// END CONSTRUCT DELEGATE
 
 		patchContext.informerStartFuncs = append(patchContext.informerStartFuncs, kubeAPIServerInformers.Start)
+		patchContext.postStartHooks["openshift.io-kubernetes-informers-synched"] = func(context genericapiserver.PostStartHookContext) error {
+			kubeInformers.WaitForCacheSync(context.StopCh)
+			return nil
+		}
 		patchContext.initialized = true
 
 		return openshiftNonAPIServer.GenericAPIServer, nil


### PR DESCRIPTION
When SCCs are not synched, admission rejects pods with "no SecurityContextConstraints found in cluster".