### PR TITLE
Bug 1740731: Initializing runningPods on SDN bootup for 4.x

### DIFF
--- a/pkg/network/node/multitenant.go
+++ b/pkg/network/node/multitenant.go
@@ -63,7 +63,7 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 	// VNID before the service and firewall rules are updated to match. We need
 	// to do the updates as a single transaction (ovs-ofctl --bundle).
 
-	pods, err := mp.node.GetLocalPods(namespace)
+	pods, err := mp.node.GetRunningPods(namespace)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Could not get list of local pods in namespace %q: %v", namespace, err))
 	}

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -287,7 +287,7 @@ func (node *OsdnNode) Start() error {
 		return fmt.Errorf("failed to set up iptables: %v", err)
 	}
 
-	networkChanged, existingPods, err := node.SetupSDN()
+	networkChanged, existingOFPodNetworks, err := node.SetupSDN()
 	if err != nil {
 		return fmt.Errorf("node SDN setup failed: %v", err)
 	}
@@ -310,6 +310,20 @@ func (node *OsdnNode) Start() error {
 		node.watchServices()
 	}
 
+	existingSandboxPods, err := node.getPodSandboxes()
+	if err != nil {
+		return err
+	}
+
+	runningPods, err := node.GetRunningPods(metav1.NamespaceAll)
+	if err != nil {
+		return err
+	}
+
+	if err = node.podManager.InitRunningPods(existingSandboxPods, existingOFPodNetworks, runningPods); err != nil {
+		return err
+	}
+
 	klog.V(2).Infof("Starting openshift-sdn pod manager")
 	if err := node.podManager.Start(cniserver.CNIServerRunDir, node.localSubnetCIDR,
 		node.networkInfo.ClusterNetworks, node.networkInfo.ServiceNetwork.String(),
@@ -317,8 +331,8 @@ func (node *OsdnNode) Start() error {
 		return err
 	}
 
-	if networkChanged && len(existingPods) > 0 {
-		err := node.reattachPods(existingPods)
+	if networkChanged && len(existingOFPodNetworks) > 0 {
+		err := node.reattachPods(existingSandboxPods, existingOFPodNetworks)
 		if err != nil {
 			return err
 		}
@@ -335,15 +349,11 @@ func (node *OsdnNode) Start() error {
 // reattachPods takes an array containing the information about pods that had been
 // attached to the OVS bridge before restart, and either reattaches or kills each of the
 // corresponding pods.
-func (node *OsdnNode) reattachPods(existingPods map[string]podNetworkInfo) error {
-	sandboxes, err := node.getPodSandboxes()
-	if err != nil {
-		return err
-	}
+func (node *OsdnNode) reattachPods(existingPodSandboxes map[string]*kruntimeapi.PodSandbox, existingOFPodNetworks map[string]podNetworkInfo) error {
 
 	failed := []*kruntimeapi.PodSandbox{}
-	for sandboxID, podInfo := range existingPods {
-		sandbox, ok := sandboxes[sandboxID]
+	for sandboxID, podInfo := range existingOFPodNetworks {
+		sandbox, ok := existingPodSandboxes[sandboxID]
 		if !ok {
 			klog.V(5).Infof("Sandbox for pod with IP %s no longer exists", podInfo.ip)
 			continue
@@ -416,7 +426,7 @@ func (node *OsdnNode) UpdatePod(pod corev1.Pod) error {
 	return err
 }
 
-func (node *OsdnNode) GetLocalPods(namespace string) ([]corev1.Pod, error) {
+func (node *OsdnNode) GetRunningPods(namespace string) ([]corev1.Pod, error) {
 	fieldSelector := fields.Set{"spec.nodeName": node.hostName}.AsSelector()
 	opts := metav1.ListOptions{
 		LabelSelector: labels.Everything().String(),

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -234,18 +234,19 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 type podNetworkInfo struct {
 	vethName string
 	ip       string
+	ofport   int
 }
 
 // GetPodNetworkInfo returns network interface information about all currently-attached pods.
 func (oc *ovsController) GetPodNetworkInfo() (map[string]podNetworkInfo, error) {
-	rows, err := oc.ovs.Find("interface", []string{"name", "external_ids"}, "external_ids:sandbox!=\"\"")
+	rows, err := oc.ovs.Find("interface", []string{"name", "external_ids", "ofport"}, "external_ids:sandbox!=\"\"")
 	if err != nil {
 		return nil, err
 	}
 
 	results := make(map[string]podNetworkInfo)
 	for _, row := range rows {
-		if row["name"] == "" || row["external_ids"] == "" {
+		if row["name"] == "" || row["external_ids"] == "" || row["ofport"] == "" {
 			utilruntime.HandleError(fmt.Errorf("ovs-vsctl output missing one or more fields: %v", row))
 			continue
 		}
@@ -264,9 +265,16 @@ func (oc *ovsController) GetPodNetworkInfo() (map[string]podNetworkInfo, error) 
 			continue
 		}
 
+		ofport, err := strconv.Atoi(row["ofport"])
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("Could not parse ofport %q: %v", row["ofport"], err))
+			continue
+		}
+
 		results[ids["sandbox"]] = podNetworkInfo{
 			vethName: row["name"],
 			ip:       ids["ip"],
+			ofport:   ofport,
 		}
 	}
 

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -133,15 +133,15 @@ func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 	}
 
 	var changed bool
-	var existingPods map[string]podNetworkInfo
+	existingPods, err := plugin.oc.GetPodNetworkInfo()
+	if err != nil {
+		klog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
+	}
+
 	if err := plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs); err == nil {
 		klog.V(5).Infof("[SDN setup] no SDN setup required")
 	} else {
 		klog.Infof("[SDN setup] full SDN setup required (%v)", err)
-		existingPods, err = plugin.oc.GetPodNetworkInfo()
-		if err != nil {
-			klog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
-		}
 		if err := plugin.setup(clusterNetworkCIDRs, localSubnetCIDR, localSubnetGateway, gwCIDR); err != nil {
 			return false, nil, err
 		}


### PR DESCRIPTION
This is a fix for [BUG 1723924](https://bugzilla.redhat.com/show_bug.cgi?id=1723924)

FIX for 4.X on origin, see linked PR's in 

SDN:

https://github.com/openshift/sdn/pull/20

3.11:

https://github.com/openshift/origin/pull/23522

The problem:

As mentioned in the link above, when the openshift networking process dies, the "podManager" object and its attribute "runningPods" is wiped for memory, which can lead to stateful inconsistencies 
with openflow ports concerning pods from a multicast-enabled namespaces 

The fix:

We now initialize the "podManager" with the initial state of all running pods when the process is booted, as such we will have a synchronized state. 