### PR TITLE
Re-fix to use mao metric which has backward compatible name

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -218,7 +218,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
 			tests := map[string][]metricTest{
-				`mapi_machine_set_status_available_replicas`: {metricTest{greaterThanEqual: true, value: 1}},
+				`mapi_machine_set_status_replicas`: {metricTest{greaterThanEqual: true, value: 1}},
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})


### PR DESCRIPTION
We are improving metric names in [this PR at MAO](https://github.com/openshift/machine-api-operator/pull/356/commits/93ba99c41a290b6b792b2fc536ad8c44369f2426#diff-7cbe8e056d62a2de30c7066e359bd9c9R20).
To get the CI passing on ^ PR, we need to use a metric in the e2e, name of which is not being changed.

We tried(**INCORRECTLY**) to do the same in[ previous PR](https://github.com/openshift/origin/pull/23518) and used a wrong metric by mistake. We actually wanted to use the metric which is being changed in this PR.
Apologies for the noise.