### PR TITLE
Bug 1733429: pkg/network: skip OPENSHIFT-MASQ for traffic already marked for masquerade

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -104,6 +104,7 @@ type OsdnNode struct {
 	useConnTrack       bool
 	iptablesSyncPeriod time.Duration
 	mtu                uint32
+	masqueradeBit      uint32
 	cniDirPath         string
 
 	// Synchronizes operations on egressPolicies
@@ -164,6 +165,11 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 	}
 	oc := NewOVSController(ovsif, pluginId, useConnTrack, c.SelfIP)
 
+	masqBit := uint32(0)
+	if c.MasqueradeBit != nil {
+		masqBit = uint32(*c.MasqueradeBit)
+	}
+
 	plugin := &OsdnNode{
 		policy:             policy,
 		kClient:            c.KClient,
@@ -176,6 +182,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		useConnTrack:       useConnTrack,
 		iptablesSyncPeriod: c.IPTablesSyncPeriod,
 		mtu:                c.MTU,
+		masqueradeBit:      masqBit,
 		egressPolicies:     make(map[uint32][]networkapi.EgressNetworkPolicy),
 		egressDNS:          common.NewEgressDNS(),
 		kubeInformers:      c.KubeInformers,
@@ -316,7 +323,7 @@ func (node *OsdnNode) Start() error {
 	for _, cn := range node.networkInfo.ClusterNetworks {
 		cidrList = append(cidrList, cn.ClusterCIDR.String())
 	}
-	nodeIPTables := newNodeIPTables(cidrList, node.iptablesSyncPeriod, !node.useConnTrack, node.networkInfo.VXLANPort)
+	nodeIPTables := newNodeIPTables(cidrList, node.iptablesSyncPeriod, !node.useConnTrack, node.networkInfo.VXLANPort, node.masqueradeBit)
 
 	if err = nodeIPTables.Setup(); err != nil {
 		return fmt.Errorf("failed to set up iptables: %v", err)


### PR DESCRIPTION
Fixes: [1733429](https://bugzilla.redhat.com/show_bug.cgi?id=1733429)

This backports the following openshift/sdn commits:
- c171df175a6be9ae9c97f84b0f8601f0443fb1f5 (sdn #13)
- b6e0ec16c9c35829a2b6b55fc6ebb3a3438420cb (sdn #17)