### PR TITLE
UPSTREAM: 76910: webhook interception for: connect, proxy, binding, eviction

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/storage/eviction.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/storage/eviction.go
@@ -86,6 +86,13 @@ func (r *EvictionREST) Create(ctx context.Context, obj runtime.Object, createVal
 		return nil, err
 	}
 	pod := obj.(*api.Pod)
+
+	if createValidation != nil {
+		if err := createValidation(eviction); err != nil {
+			return nil, err
+		}
+	}
+
 	// Evicting a terminal pod should result in direct deletion of pod as it already caused disruption by the time we are evicting.
 	// There is no need to check for pdb.
 	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {

--- a/vendor/k8s.io/kubernetes/pkg/registry/core/pod/storage/storage.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/core/pod/storage/storage.go
@@ -149,6 +149,12 @@ func (r *BindingREST) Create(ctx context.Context, obj runtime.Object, createVali
 		return nil, errs.ToAggregate()
 	}
 
+	if createValidation != nil {
+		if err := createValidation(binding); err != nil {
+			return nil, err
+		}
+	}
+
 	err = r.assignPod(ctx, binding.Name, binding.Target.Name, binding.Annotations, dryrun.IsDryRun(options.DryRun))
 	out = &metav1.Status{Status: metav1.StatusSuccess}
 	return


### PR DESCRIPTION
Allow intercepting pod subresources with webhooks. Needed for kubevirt to trigger migrations insead of shutdown when an eviction is intended.

This backports the following upstream PRs:

 * https://github.com/kubernetes/kubernetes/pull/76910