### PR TITLE
[gcp] Add gcp-sdk to tests image

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -7,7 +7,9 @@ RUN make build WHAT=cmd/openshift-tests; \
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:cli
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
-RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
+COPY images/tests/gcp-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo    
+RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux google-cloud-sdk && \
+    yum clean all && rm -rf /var/cache/yum/* && \
     git config --system user.name test && \
     git config --system user.email test@test.com && \
     chmod g+w /etc/passwd

--- a/images/tests/gcp-sdk.repo
+++ b/images/tests/gcp-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
Adds google cloud sdk to tests images so we can use gcloud in e2e