### PR TITLE
Bug 1737389: UPSTREAM: 80191: Add passthrough for MountOptions for NodeStageVolume for CSI

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_attacher.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_attacher.go
@@ -366,6 +366,11 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 		accessMode = spec.PersistentVolume.Spec.AccessModes[0]
 	}
 
+	var mountOptions []string
+	if spec.PersistentVolume != nil && spec.PersistentVolume.Spec.MountOptions != nil {
+		mountOptions = spec.PersistentVolume.Spec.MountOptions
+	}
+
 	fsType := csiSource.FSType
 	err = csi.NodeStageVolume(ctx,
 		csiSource.VolumeHandle,
@@ -374,7 +379,8 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 		fsType,
 		accessMode,
 		nodeStageSecrets,
-		csiSource.VolumeAttributes)
+		csiSource.VolumeAttributes,
+		mountOptions)
 
 	if err != nil {
 		return err

--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_block.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_block.go
@@ -134,7 +134,8 @@ func (m *csiBlockMapper) stageVolumeForBlock(
 		fsTypeBlockName,
 		accessMode,
 		nodeStageSecrets,
-		csiSource.VolumeAttributes)
+		csiSource.VolumeAttributes,
+		nil /* MountOptions */)
 
 	if err != nil {
 		klog.Error(log("blockMapper.stageVolumeForBlock failed: %v", err))

--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_client_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_client_test.go
@@ -175,6 +175,7 @@ func (c *fakeCsiDriverClient) NodeStageVolume(ctx context.Context,
 	accessMode api.PersistentVolumeAccessMode,
 	secrets map[string]string,
 	volumeContext map[string]string,
+	mountOptions []string,
 ) error {
 	c.t.Log("calling fake.NodeStageVolume...")
 	req := &csipbv1.NodeStageVolumeRequest{
@@ -187,7 +188,8 @@ func (c *fakeCsiDriverClient) NodeStageVolume(ctx context.Context,
 			},
 			AccessType: &csipbv1.VolumeCapability_Mount{
 				Mount: &csipbv1.VolumeCapability_MountVolume{
-					FsType: fsType,
+					FsType:     fsType,
+					MountFlags: mountOptions,
 				},
 			},
 		},
@@ -448,10 +450,11 @@ func TestClientNodeStageVolume(t *testing.T) {
 		stagingTargetPath string
 		fsType            string
 		secrets           map[string]string
+		mountOptions      []string
 		mustFail          bool
 		err               error
 	}{
-		{name: "test ok", volID: "vol-test", stagingTargetPath: "/test/path", fsType: "ext4"},
+		{name: "test ok", volID: "vol-test", stagingTargetPath: "/test/path", fsType: "ext4", mountOptions: []string{"unvalidated"}},
 		{name: "missing volID", stagingTargetPath: "/test/path", mustFail: true},
 		{name: "missing target path", volID: "vol-test", mustFail: true},
 		{name: "bad fs", volID: "vol-test", stagingTargetPath: "/test/path", fsType: "badfs", mustFail: true},
@@ -479,6 +482,7 @@ func TestClientNodeStageVolume(t *testing.T) {
 			api.ReadWriteOnce,
 			tc.secrets,
 			map[string]string{"attr0": "val0"},
+			tc.mountOptions,
 		)
 		checkErr(t, tc.mustFail, err)
 

--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/fake/fake_client.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/fake/fake_client.go
@@ -189,20 +189,23 @@ func (f *NodeClient) NodeStageVolume(ctx context.Context, req *csipb.NodeStageVo
 		return nil, errors.New("missing staging target path")
 	}
 
+	csiVol := CSIVolume{
+		Path:          req.GetStagingTargetPath(),
+		VolumeContext: req.GetVolumeContext(),
+	}
+
 	fsType := ""
 	fsTypes := "block|ext4|xfs|zfs"
 	mounted := req.GetVolumeCapability().GetMount()
 	if mounted != nil {
 		fsType = mounted.GetFsType()
+		csiVol.MountFlags = mounted.GetMountFlags()
 	}
 	if !strings.Contains(fsTypes, fsType) {
 		return nil, errors.New("invalid fstype")
 	}
 
-	f.nodeStagedVolumes[req.GetVolumeId()] = CSIVolume{
-		Path:          req.GetStagingTargetPath(),
-		VolumeContext: req.GetVolumeContext(),
-	}
+	f.nodeStagedVolumes[req.GetVolumeId()] = csiVol
 	return &csipb.NodeStageVolumeResponse{}, nil
 }
 

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
@@ -348,6 +348,7 @@ func InitGcePDCSIDriver() testsuites.TestDriver {
 				"ext4",
 				"xfs",
 			),
+			SupportedMountOption: sets.NewString("debug", "nouid32"),
 			Capabilities: map[testsuites.Capability]bool{
 				testsuites.CapPersistence: true,
 				testsuites.CapFsGroup:     true,


### PR DESCRIPTION
NodeStageVolume needs the MountOptions passed through for drivers to mount the global directory with the correct options.

https://bugzilla.redhat.com/show_bug.cgi?id=1737389
https://github.com/kubernetes/kubernetes/pull/80191