### PR TITLE
Bug 1731892: add back in more ocm related test coverage after the openshift/origin…

### DIFF
--- a/test/extended/builds/controllers.go
+++ b/test/extended/builds/controllers.go
@@ -2,6 +2,7 @@ package builds
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,8 @@ const (
 	// BuildCancelledEventReason is the reason associated with the event registered when build is cancelled.
 	BuildCancelledEventReason = "BuildCancelled"
 	// BuildCancelledEventMessage is the message associated with the event registered when build is cancelled.
-	BuildCancelledEventMessage = "Build %s/%s has been cancelled"
+	BuildCancelledEventMessage        = "Build %s/%s has been cancelled"
+	additionalAllowedRegistriesEnvVar = "ADDITIONAL_ALLOWED_REGISTRIES"
 )
 
 var (
@@ -144,7 +146,7 @@ func RunImageChangeTriggerTest(t testingT, clusterAdminBuildClient buildv1client
 		registryHostname = "registry:8080"
 	)
 
-	//testutil.SetAdditionalAllowedRegistries(registryHostname)
+	os.Setenv(additionalAllowedRegistriesEnvVar, registryHostname)
 
 	imageStream := mockImageStream2(registryHostname, tag)
 	imageStreamMapping := mockImageStreamMapping(imageStream.Name, "someimage", tag, registryHostname+"/openshift/test-image-trigger:"+tag)

--- a/test/extended/image_ecosystem/mysql_replica.go
+++ b/test/extended/image_ecosystem/mysql_replica.go
@@ -1,0 +1,244 @@
+package image_ecosystem
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	"github.com/openshift/api/template"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/db"
+
+	//	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type testCase struct {
+	Version         string
+	TemplatePath    string
+	TemplateName    string
+	SkipReplication bool
+}
+
+var (
+	testCases = []testCase{
+		{
+			"5.7",
+			"https://raw.githubusercontent.com/sclorg/mysql-container/master/examples/replica/mysql_replica.json",
+			"mysql-replication-example",
+			false,
+		},
+	}
+	helperTemplate = exutil.FixturePath("..", "..", "examples", "db-templates", "mysql-ephemeral-template.json")
+	helperName     = "mysql-helper"
+)
+
+// CreateMySQLReplicationHelpers creates a set of MySQL helpers for master,
+// slave and an extra helper that is used for remote login test.
+func CreateMySQLReplicationHelpers(c kcoreclient.PodInterface, masterDeployment, slaveDeployment, helperDeployment string, slaveCount int) (exutil.Database, []exutil.Database, exutil.Database) {
+	podNames, err := exutil.WaitForPods(c, exutil.ParseLabelsOrDie(fmt.Sprintf("deployment=%s", masterDeployment)), exutil.CheckPodIsRunning, 1, 4*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	masterPod := podNames[0]
+
+	slavePods, err := exutil.WaitForPods(c, exutil.ParseLabelsOrDie(fmt.Sprintf("deployment=%s", slaveDeployment)), exutil.CheckPodIsRunning, slaveCount, 6*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Create MySQL helper for master
+	master := db.NewMysql(masterPod, "")
+
+	// Create MySQL helpers for slaves
+	slaves := make([]exutil.Database, len(slavePods))
+	for i := range slavePods {
+		slave := db.NewMysql(slavePods[i], masterPod)
+		slaves[i] = slave
+	}
+
+	helperNames, err := exutil.WaitForPods(c, exutil.ParseLabelsOrDie(fmt.Sprintf("deployment=%s", helperDeployment)), exutil.CheckPodIsRunning, 1, 4*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	helper := db.NewMysql(helperNames[0], masterPod)
+
+	return master, slaves, helper
+}
+
+func replicationTestFactory(oc *exutil.CLI, tc testCase, cleanup func()) func() {
+	return func() {
+		// per k8s e2e volume_util.go:VolumeTestCleanup, nuke any client pods
+		// before nfs server to assist with umount issues; as such, need to clean
+		// up prior to the AfterEach processing, to guaranteed deletion order
+		defer cleanup()
+
+		err := WaitForPolicyUpdate(oc.KubeClient().AuthorizationV1(), oc.Namespace(), "create", template.Resource("templates"), true)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		exutil.WaitForOpenShiftNamespaceImageStreams(oc)
+		err = oc.Run("create").Args("-f", tc.TemplatePath).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("new-app").Args("--template", tc.TemplateName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("new-app").Args("-f", helperTemplate, "-p", fmt.Sprintf("MYSQL_VERSION=%s", tc.Version), "-p", fmt.Sprintf("DATABASE_SERVICE_NAME=%s", helperName)).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
+		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
+		g.By("waiting for the deployment to complete")
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), helperName, 1, true, oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("waiting for an endpoint")
+		err = e2e.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), helperName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tableCounter := 0
+		assertReplicationIsWorking := func(masterDeployment, slaveDeployment string, slaveCount int) (exutil.Database, []exutil.Database, exutil.Database) {
+			tableCounter++
+			table := fmt.Sprintf("table_%0.2d", tableCounter)
+
+			g.By("creating replication helpers")
+			master, slaves, helper := CreateMySQLReplicationHelpers(oc.KubeClient().CoreV1().Pods(oc.Namespace()), masterDeployment, slaveDeployment, fmt.Sprintf("%s-1", helperName), slaveCount)
+			o.Expect(exutil.WaitUntilAllHelpersAreUp(oc, []exutil.Database{master})).NotTo(o.HaveOccurred())
+			o.Expect(exutil.WaitUntilAllHelpersAreUp(oc, slaves)).NotTo(o.HaveOccurred())
+
+			// Test if we can query as root
+			g.By("wait for mysql-master endpoint")
+			err = e2e.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), "mysql-master")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err := helper.TestRemoteLogin(oc, "mysql-master")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Create a new table with random name
+			g.By("create new table")
+			_, err = master.Query(oc, fmt.Sprintf("CREATE TABLE %s (col1 VARCHAR(20), col2 VARCHAR(20));", table))
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Write new data to the table through master
+			_, err = master.Query(oc, fmt.Sprintf("INSERT INTO %s (col1, col2) VALUES ('val1', 'val2');", table))
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Make sure data is present on master
+			err = exutil.WaitForQueryOutputContains(oc, master, 10*time.Second, false, fmt.Sprintf("SELECT * FROM %s\\G;", table), "col1: val1\ncol2: val2")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Make sure data was replicated to all slaves
+			for _, slave := range slaves {
+				err = exutil.WaitForQueryOutputContains(oc, slave, 90*time.Second, false, fmt.Sprintf("SELECT * FROM %s\\G;", table), "col1: val1\ncol2: val2")
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			return master, slaves, helper
+		}
+
+		g.By("after initial deployment")
+		master, _, _ := assertReplicationIsWorking("mysql-master-1", "mysql-slave-1", 1)
+
+		if tc.SkipReplication {
+			return
+		}
+
+		g.By("after master is restarted by changing the Deployment Config")
+		err = oc.Run("set", "env").Args("dc", "mysql-master", "MYSQL_ROOT_PASSWORD=newpass").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), master.PodName(), 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", master.PodName())
+			oc.Run("get").Args("pod", master.PodName(), "-o", "yaml").Execute()
+		}
+		master, _, _ = assertReplicationIsWorking("mysql-master-2", "mysql-slave-1", 1)
+
+		g.By("after master is restarted by deleting the pod")
+		err = oc.Run("delete").Args("pod", "-l", "deployment=mysql-master-2").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), master.PodName(), 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", master.PodName())
+			oc.Run("get").Args("pod", master.PodName(), "-o", "yaml").Execute()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		assertReplicationIsWorking("mysql-master-2", "mysql-slave-1", 1)
+		_, slaves, _ := assertReplicationIsWorking("mysql-master-2", "mysql-slave-1", 1)
+
+		// NOTE: slave restart with PVs does not work since https://github.com/sclorg/mysql-container/pull/215/
+		g.By("after slave is restarted by deleting the pod")
+		err = oc.Run("delete").Args("pod", "-l", "deployment=mysql-slave-1").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), slaves[0].PodName(), 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", slaves[0].PodName())
+			oc.Run("get").Args("pod", slaves[0].PodName(), "-o", "yaml").Execute()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		assertReplicationIsWorking("mysql-master-2", "mysql-slave-1", 1)
+
+		pods, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{LabelSelector: exutil.ParseLabelsOrDie("deployment=mysql-slave-1").String()})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(pods.Items)).To(o.Equal(1))
+
+		// NOTE: Commented out, current template does not support multiple replicas.
+		/*
+			g.By("after slave is scaled to 0 and then back to 4 replicas")
+			err = oc.Run("scale").Args("dc", "mysql-slave", "--replicas=0").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), pods.Items[0].Name, 2*time.Minute)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = oc.Run("scale").Args("dc", "mysql-slave", "--replicas=4").Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			assertReplicationIsWorking("mysql-master-2", "mysql-slave-1", 4)
+		*/
+	}
+}
+
+/*
+var _ = g.Describe("[image_ecosystem][mysql][Slow] openshift mysql replication", func() {
+	defer g.GinkgoRecover()
+	g.Skip("db replica tests are currently flaky and disabled")
+
+	var oc = exutil.NewCLI("mysql-replication", exutil.KubeConfigPath())
+	var pvs = []*kapiv1.PersistentVolume{}
+	var nfspod = &kapiv1.Pod{}
+	var cleanup = func() {
+		g.By("start cleanup")
+		if g.CurrentGinkgoTestDescription().Failed {
+			exutil.DumpPodStates(oc)
+			exutil.DumpPodLogsStartingWith("", oc)
+			exutil.DumpPersistentVolumeInfo(oc)
+		}
+
+		client := oc.AsAdmin().KubeFramework().ClientSet
+		g.By("removing mysql")
+		exutil.RemoveDeploymentConfigs(oc, "mysql-master", "mysql-slave")
+
+		g.By("deleting PVC")
+		exutil.DeletePVCsForDeployment(client, oc, "mysql")
+
+		g.By("removing nfs pvs")
+		for _, pv := range pvs {
+			e2e.DeletePersistentVolume(client, pv.Name)
+		}
+
+		g.By("removing nfs pod")
+		e2e.DeletePodWithWait(oc.AsAdmin().KubeFramework(), client, nfspod)
+	}
+
+	g.Context("", func() {
+		g.BeforeEach(func() {
+			exutil.PreTestDump()
+
+			g.By("waiting for default service account")
+			err := exutil.WaitForServiceAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()), "default")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			nfspod, pvs, err = exutil.SetupK8SNFSServerAndVolume(oc, 8)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		for _, tc := range testCases {
+			g.It(fmt.Sprintf("MySQL replication template for %s: %s", tc.Version, tc.TemplatePath), replicationTestFactory(oc, tc, cleanup))
+		}
+	})
+})
+*/

--- a/test/extended/image_ecosystem/policy.go
+++ b/test/extended/image_ecosystem/policy.go
@@ -1,0 +1,38 @@
+package image_ecosystem
+
+import (
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+const (
+	PolicyCachePollInterval = 100 * time.Millisecond
+	PolicyCachePollTimeout  = 10 * time.Second
+)
+
+// WaitForPolicyUpdate checks if the given client can perform the named verb and action.
+// If PolicyCachePollTimeout is reached without the expected condition matching, an error is returned
+func WaitForPolicyUpdate(c authorizationv1client.SelfSubjectAccessReviewsGetter, namespace, verb string, resource schema.GroupResource, allowed bool) error {
+	review := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      verb,
+				Group:     resource.Group,
+				Resource:  resource.Resource,
+			},
+		},
+	}
+	err := wait.Poll(PolicyCachePollInterval, PolicyCachePollTimeout, func() (bool, error) {
+		response, err := c.SelfSubjectAccessReviews().Create(review)
+		if err != nil {
+			return false, err
+		}
+		return response.Status.Allowed == allowed, nil
+	})
+	return err
+}

--- a/test/extended/image_ecosystem/postgresql_replica.go
+++ b/test/extended/image_ecosystem/postgresql_replica.go
@@ -1,0 +1,254 @@
+package image_ecosystem
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	"github.com/openshift/api/template"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/db"
+
+	//	kapiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var (
+	postgreSQLReplicationTemplate = "https://raw.githubusercontent.com/sclorg/postgresql-container/master/examples/replica/postgresql_replica.json"
+	postgreSQLEphemeralTemplate   = exutil.FixturePath("..", "..", "examples", "db-templates", "postgresql-ephemeral-template.json")
+	postgreSQLHelperName          = "postgresql-helper"
+	postgreSQLImages              = []string{
+		"postgresql:9.6",
+	}
+)
+
+/*
+var _ = g.Describe("[image_ecosystem][postgresql][Slow][local] openshift postgresql replication", func() {
+	defer g.GinkgoRecover()
+	g.Skip("db replica tests are currently flaky and disabled")
+
+	var oc = exutil.NewCLI("postgresql-replication", exutil.KubeConfigPath())
+	var pvs = []*kapiv1.PersistentVolume{}
+	var nfspod = &kapiv1.Pod{}
+	var cleanup = func() {
+		// per k8s e2e volume_util.go:VolumeTestCleanup, nuke any client pods
+		// before nfs server to assist with umount issues; as such, need to clean
+		// up prior to the AfterEach processing, to guaranteed deletion order
+		g.By("start cleanup")
+		if g.CurrentGinkgoTestDescription().Failed {
+			exutil.DumpPodStates(oc)
+			exutil.DumpPodLogsStartingWith("", oc)
+			exutil.DumpImageStreams(oc)
+			exutil.DumpPersistentVolumeInfo(oc)
+		}
+
+		client := oc.AsAdmin().KubeFramework().ClientSet
+		g.By("removing postgresql")
+		exutil.RemoveDeploymentConfigs(oc, "postgresql-master", "postgresql-slave")
+
+		g.By("deleting PVCs")
+		exutil.DeletePVCsForDeployment(client, oc, "postgre")
+
+		g.By("removing nfs pvs")
+		for _, pv := range pvs {
+			e2e.DeletePersistentVolume(client, pv.Name)
+		}
+
+		g.By("removing nfs pod")
+		e2e.DeletePodWithWait(oc.AsAdmin().KubeFramework(), client, nfspod)
+	}
+
+	g.Context("", func() {
+		g.BeforeEach(func() {
+			exutil.PreTestDump()
+
+			g.By("waiting for default service account")
+			err := exutil.WaitForServiceAccount(oc.KubeClient().Core().ServiceAccounts(oc.Namespace()), "default")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("PV/PVC dump before setup")
+			exutil.DumpPersistentVolumeInfo(oc)
+
+			nfspod, pvs, err = exutil.SetupK8SNFSServerAndVolume(oc, 8)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
+		for _, image := range postgreSQLImages {
+			g.It(fmt.Sprintf("postgresql replication works for %s", image), PostgreSQLReplicationTestFactory(oc, image, cleanup))
+		}
+	})
+})
+*/
+
+// CreatePostgreSQLReplicationHelpers creates a set of PostgreSQL helpers for master,
+// slave an en extra helper that is used for remote login test.
+func CreatePostgreSQLReplicationHelpers(c kcoreclient.PodInterface, masterDeployment, slaveDeployment, helperDeployment string, slaveCount int) (exutil.Database, []exutil.Database, exutil.Database) {
+	podNames, err := exutil.WaitForPods(c, exutil.ParseLabelsOrDie(fmt.Sprintf("deployment=%s", masterDeployment)), exutil.CheckPodIsRunning, 1, 4*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	masterPod := podNames[0]
+
+	slavePods, err := exutil.WaitForPods(c, exutil.ParseLabelsOrDie(fmt.Sprintf("deployment=%s", slaveDeployment)), exutil.CheckPodIsRunning, slaveCount, 6*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Create PostgreSQL helper for master
+	master := db.NewPostgreSQL(masterPod, "")
+
+	// Create PostgreSQL helpers for slaves
+	slaves := make([]exutil.Database, len(slavePods))
+	for i := range slavePods {
+		slave := db.NewPostgreSQL(slavePods[i], masterPod)
+		slaves[i] = slave
+	}
+
+	helperNames, err := exutil.WaitForPods(c, exutil.ParseLabelsOrDie(fmt.Sprintf("deployment=%s", helperDeployment)), exutil.CheckPodIsRunning, 1, 4*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	helper := db.NewPostgreSQL(helperNames[0], masterPod)
+
+	return master, slaves, helper
+}
+
+func PostgreSQLReplicationTestFactory(oc *exutil.CLI, image string, cleanup func()) func() {
+	return func() {
+		// per k8s e2e volume_util.go:VolumeTestCleanup, nuke any client pods
+		// before nfs server to assist with umount issues; as such, need to clean
+		// up prior to the AfterEach processing, to guaranteed deletion order
+		defer cleanup()
+
+		err := WaitForPolicyUpdate(oc.KubeClient().AuthorizationV1(), oc.Namespace(), "create", template.Resource("templates"), true)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		exutil.WaitForOpenShiftNamespaceImageStreams(oc)
+
+		err = oc.Run("create").Args("-f", postgreSQLReplicationTemplate).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("new-app").Args("--template", "pg-replica-example", "-p", fmt.Sprintf("IMAGESTREAMTAG=%s", image)).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.Run("new-app").Args("-f", postgreSQLEphemeralTemplate, "-p", fmt.Sprintf("DATABASE_SERVICE_NAME=%s", postgreSQLHelperName)).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("PV/PVC dump after setup")
+		exutil.DumpPersistentVolumeInfo(oc)
+
+		// oc.KubeFramework().WaitForAnEndpoint currently will wait forever;  for now, prefacing with our WaitForADeploymentToComplete,
+		// which does have a timeout, since in most cases a failure in the service coming up stems from a failed deployment
+		err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), postgreSQLHelperName, 1, true, oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = e2e.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), postgreSQLHelperName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		tableCounter := 0
+		assertReplicationIsWorking := func(masterDeployment, slaveDeployment string, slaveCount int) (exutil.Database, []exutil.Database, exutil.Database) {
+			check := func(err error) {
+				if err != nil {
+					exutil.DumpApplicationPodLogs("postgresql-master", oc)
+					exutil.DumpApplicationPodLogs("postgresql-slave", oc)
+				}
+				o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred())
+			}
+
+			tableCounter++
+			table := fmt.Sprintf("table_%0.2d", tableCounter)
+
+			master, slaves, helper := CreatePostgreSQLReplicationHelpers(oc.KubeClient().CoreV1().Pods(oc.Namespace()), masterDeployment, slaveDeployment, fmt.Sprintf("%s-1", postgreSQLHelperName), slaveCount)
+			err := exutil.WaitUntilAllHelpersAreUp(oc, []exutil.Database{master, helper})
+			if err != nil {
+				exutil.DumpApplicationPodLogs("postgresql-master", oc)
+				exutil.DumpApplicationPodLogs("postgresql-helper", oc)
+			}
+			o.ExpectWithOffset(1, err).NotTo(o.HaveOccurred())
+
+			err = exutil.WaitUntilAllHelpersAreUp(oc, slaves)
+			check(err)
+
+			// Test if we can query as admin
+			err = e2e.WaitForEndpoint(oc.KubeFramework().ClientSet, oc.Namespace(), "postgresql-master")
+			check(err)
+			err = helper.TestRemoteLogin(oc, "postgresql-master")
+			check(err)
+
+			// Create a new table with random name
+			_, err = master.Query(oc, fmt.Sprintf("CREATE TABLE %s (col1 VARCHAR(20), col2 VARCHAR(20));", table))
+			check(err)
+
+			// Write new data to the table through master
+			_, err = master.Query(oc, fmt.Sprintf("INSERT INTO %s (col1, col2) VALUES ('val1', 'val2');", table))
+			check(err)
+
+			// Make sure data is present on master
+			err = exutil.WaitForQueryOutputContains(oc, master, 10*time.Second, false,
+				fmt.Sprintf("SELECT * FROM %s;", table),
+				"col1 | val1\ncol2 | val2")
+			check(err)
+
+			// Make sure data was replicated to all slaves
+			for _, slave := range slaves {
+				err = exutil.WaitForQueryOutputContains(oc, slave, 90*time.Second, false,
+					fmt.Sprintf("SELECT * FROM %s;", table),
+					"col1 | val1\ncol2 | val2")
+				check(err)
+			}
+
+			return master, slaves, helper
+		}
+
+		g.By("after initial deployment")
+		master, _, _ := assertReplicationIsWorking("postgresql-master-1", "postgresql-slave-1", 1)
+
+		g.By("after master is restarted by changing the Deployment Config")
+		err = oc.Run("set", "env").Args("dc", "postgresql-master", "POSTGRESQL_ADMIN_PASSWORD=newpass").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), master.PodName(), 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", master.PodName())
+			oc.Run("get").Args("pod", master.PodName(), "-o", "yaml").Execute()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		master, _, _ = assertReplicationIsWorking("postgresql-master-2", "postgresql-slave-1", 1)
+
+		g.By("after master is restarted by deleting the pod")
+		err = oc.Run("delete").Args("pod", "-l", "deployment=postgresql-master-2").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), master.PodName(), 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", master.PodName())
+			oc.Run("get").Args("pod", master.PodName(), "-o", "yaml").Execute()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, slaves, _ := assertReplicationIsWorking("postgresql-master-2", "postgresql-slave-1", 1)
+
+		g.By("after slave is restarted by deleting the pod")
+		err = oc.Run("delete").Args("pod", "-l", "deployment=postgresql-slave-1").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), slaves[0].PodName(), 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", slaves[0].PodName())
+			oc.Run("get").Args("pod", slaves[0].PodName(), "-o", "yaml").Execute()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		assertReplicationIsWorking("postgresql-master-2", "postgresql-slave-1", 1)
+
+		pods, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).List(metav1.ListOptions{LabelSelector: exutil.ParseLabelsOrDie("deployment=postgresql-slave-1").String()})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(pods.Items)).To(o.Equal(1))
+
+		g.By("after slave is scaled to 0 and then back to 4 replicas")
+		err = oc.Run("scale").Args("dc", "postgresql-slave", "--replicas=0").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = exutil.WaitUntilPodIsGone(oc.KubeClient().CoreV1().Pods(oc.Namespace()), pods.Items[0].Name, 2*time.Minute)
+		if err != nil {
+			e2e.Logf("Checking if pod %s still exists", pods.Items[0].Name)
+			oc.Run("get").Args("pod", pods.Items[0].Name, "-o", "yaml").Execute()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.Run("scale").Args("dc", "postgresql-slave", "--replicas=4").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		assertReplicationIsWorking("postgresql-master-2", "postgresql-slave-1", 4)
+	}
+}

--- a/test/extended/templates/helpers.go
+++ b/test/extended/templates/helpers.go
@@ -4,22 +4,56 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
+	kappsv1 "k8s.io/api/apps/v1"
+	kappsv1beta1 "k8s.io/api/apps/v1beta1"
+	kappsv1beta2 "k8s.io/api/apps/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	kextensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
+	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 
+	appsv1 "github.com/openshift/api/apps/v1"
 	authorizationv1 "github.com/openshift/api/authorization/v1"
+	buildv1 "github.com/openshift/api/build/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	userv1 "github.com/openshift/api/user/v1"
+
+	"github.com/openshift/library-go/pkg/apps/appsutil"
+
+	buildv1client "github.com/openshift/client-go/build/clientset/versioned"
+
 	osbclient "github.com/openshift/origin/test/extended/templates/openservicebroker/client"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
+
+var readinessScheme = runtime.NewScheme()
+
+func init() {
+	kappsv1.AddToScheme(readinessScheme)
+	kappsv1beta1.AddToScheme(readinessScheme)
+	kappsv1beta2.AddToScheme(readinessScheme)
+	kextensionsv1beta1.AddToScheme(readinessScheme)
+	batchv1.AddToScheme(readinessScheme)
+	corev1.AddToScheme(readinessScheme)
+	appsv1.Install(readinessScheme)
+	buildv1.Install(readinessScheme)
+	routev1.Install(readinessScheme)
+}
 
 func createUser(cli *exutil.CLI, name, role string) *userv1.User {
 	name = cli.Namespace() + "-" + name
@@ -130,15 +164,293 @@ func TSBClient(oc *exutil.CLI) (osbclient.Client, error) {
 	}, "https://"+svc.Spec.ClusterIP+"/brokers/template.openshift.io"), nil
 }
 
+// readinessCheckers maps GroupKinds to the appropriate function.  Note that in
+// some cases more than one GK maps to the same function.
+var readinessCheckers = map[schema.GroupVersionKind]func(runtime.Object) (bool, bool, error){
+	// OpenShift kinds:
+	groupVersionKind(buildv1.GroupVersion, "Build"):           checkBuildReadiness,
+	groupVersionKind(appsv1.GroupVersion, "DeploymentConfig"): checkDeploymentConfigReadiness,
+	groupVersionKind(routev1.GroupVersion, "Route"):           checkRouteReadiness,
+
+	// Legacy (/oapi) kinds:
+	{Group: "", Version: "v1", Kind: "Build"}:            checkBuildReadiness,
+	{Group: "", Version: "v1", Kind: "DeploymentConfig"}: checkDeploymentConfigReadiness,
+	{Group: "", Version: "v1", Kind: "Route"}:            checkRouteReadiness,
+
+	// Kubernetes kinds:
+	groupVersionKind(kappsv1.SchemeGroupVersion, "Deployment"):            checkDeploymentReadiness,
+	groupVersionKind(kappsv1beta1.SchemeGroupVersion, "Deployment"):       checkDeploymentReadiness,
+	groupVersionKind(kappsv1beta2.SchemeGroupVersion, "Deployment"):       checkDeploymentReadiness,
+	groupVersionKind(kextensionsv1beta1.SchemeGroupVersion, "Deployment"): checkDeploymentReadiness,
+	groupVersionKind(kappsv1.SchemeGroupVersion, "StatefulSet"):           checkStatefulSetReadiness,
+	groupVersionKind(kappsv1beta1.SchemeGroupVersion, "StatefulSet"):      checkStatefulSetReadiness,
+	groupVersionKind(kappsv1beta2.SchemeGroupVersion, "StatefulSet"):      checkStatefulSetReadiness,
+	groupVersionKind(batchv1.SchemeGroupVersion, "Job"):                   checkJobReadiness,
+}
+
+//TODO candidate for openshift/library-go
+func isTerminalPhase(phase buildv1.BuildPhase) bool {
+	switch phase {
+	case buildv1.BuildPhaseNew,
+		buildv1.BuildPhasePending,
+		buildv1.BuildPhaseRunning:
+		return false
+	}
+	return true
+}
+
+//TODO candidate for openshift/library-go
+func checkBuildReadiness(obj runtime.Object) (bool, bool, error) {
+	b, ok := obj.(*buildv1.Build)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.Build", obj)
+	}
+
+	ready := isTerminalPhase(b.Status.Phase) &&
+		b.Status.Phase == buildv1.BuildPhaseComplete
+
+	failed := isTerminalPhase(b.Status.Phase) &&
+		b.Status.Phase != buildv1.BuildPhaseComplete
+
+	return ready, failed, nil
+}
+
+//TODO candidate for openshift/library-go
+func labelValue(name string) string {
+	if len(name) <= validation.DNS1123LabelMaxLength {
+		return name
+	}
+	return name[:validation.DNS1123LabelMaxLength]
+}
+
+//TODO candidate for openshift/library-go
+func buildConfigSelector(name string) labels.Selector {
+	return labels.Set{buildv1.BuildConfigLabel: labelValue(name)}.AsSelector()
+}
+
+func checkBuildConfigReadiness(oc buildv1client.Interface, obj runtime.Object) (bool, bool, error) {
+	bc, ok := obj.(*buildv1.BuildConfig)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.BuildConfig", obj)
+	}
+
+	builds, err := oc.BuildV1().Builds(bc.Namespace).List(metav1.ListOptions{LabelSelector: buildConfigSelector(bc.Name).String()})
+	if err != nil {
+		return false, false, err
+	}
+
+	for _, item := range builds.Items {
+		if item.Annotations[buildv1.BuildNumberAnnotation] == strconv.FormatInt(bc.Status.LastVersion, 10) {
+			return checkBuildReadiness(&item)
+		}
+	}
+
+	return false, false, nil
+}
+
+type deploymentCondition struct {
+	status corev1.ConditionStatus
+	reason string
+}
+
+func newDeploymentCondition(status corev1.ConditionStatus, reason string) *deploymentCondition {
+	return &deploymentCondition{
+		status: status,
+		reason: reason,
+	}
+}
+
+// checkDeploymentReadiness determins if a Deployment is ready, failed or
+// neither.
+func checkDeploymentReadiness(obj runtime.Object) (bool, bool, error) {
+	var (
+		isSynced               bool
+		progressing, available *deploymentCondition
+	)
+	switch d := obj.(type) {
+	case *kappsv1.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kappsv1.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kappsv1.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	case *kappsv1beta1.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kappsv1beta1.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kappsv1beta1.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	case *kappsv1beta2.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kappsv1beta2.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kappsv1beta2.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	case *kextensionsv1beta1.Deployment:
+		isSynced = d.Status.ObservedGeneration == d.Generation
+		for _, condition := range d.Status.Conditions {
+			switch condition.Type {
+			case kextensionsv1beta1.DeploymentProgressing:
+				progressing = newDeploymentCondition(condition.Status, condition.Reason)
+			case kextensionsv1beta1.DeploymentAvailable:
+				available = newDeploymentCondition(condition.Status, condition.Reason)
+			}
+		}
+	default:
+		return false, false, fmt.Errorf("unsupported deployment version: %T", d)
+	}
+
+	if !isSynced || progressing == nil {
+		return false, false, nil
+	}
+
+	ready := progressing.status == corev1.ConditionTrue &&
+		progressing.reason == deploymentutil.NewRSAvailableReason &&
+		available != nil &&
+		available.status == corev1.ConditionTrue
+
+	failed := progressing.status == corev1.ConditionFalse
+
+	return ready, failed, nil
+}
+
+//TODO candidate for openshift/library-go
+func checkDeploymentConfigReadiness(obj runtime.Object) (bool, bool, error) {
+	dc, ok := obj.(*appsv1.DeploymentConfig)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.DeploymentConfig", obj)
+	}
+
+	var progressing, available *appsv1.DeploymentCondition
+	for i, condition := range dc.Status.Conditions {
+		switch condition.Type {
+		case appsv1.DeploymentProgressing:
+			progressing = &dc.Status.Conditions[i]
+
+		case appsv1.DeploymentAvailable:
+			available = &dc.Status.Conditions[i]
+		}
+	}
+
+	ready := dc.Status.ObservedGeneration == dc.Generation &&
+		progressing != nil &&
+		progressing.Status == corev1.ConditionTrue &&
+		progressing.Reason == appsutil.NewRcAvailableReason &&
+		available != nil &&
+		available.Status == corev1.ConditionTrue
+
+	failed := dc.Status.ObservedGeneration == dc.Generation &&
+		progressing != nil &&
+		progressing.Status == corev1.ConditionFalse
+
+	return ready, failed, nil
+}
+
+func checkJobReadiness(obj runtime.Object) (bool, bool, error) {
+	var (
+		hasCompletionTime bool
+		isJobFailed       bool
+	)
+	switch j := obj.(type) {
+	case *batchv1.Job:
+		hasCompletionTime = j.Status.CompletionTime != nil
+		isJobFailed = j.Status.Failed > 0
+	default:
+		return false, false, fmt.Errorf("unsupported job version: %T", j)
+	}
+	return hasCompletionTime, isJobFailed, nil
+}
+
+func checkRouteReadiness(obj runtime.Object) (bool, bool, error) {
+	route, ok := obj.(*routev1.Route)
+	if !ok {
+		return false, false, fmt.Errorf("object %T is not v1.Route", obj)
+	}
+	return len(route.Spec.Host) > 0, false, nil
+}
+
+func checkStatefulSetReadiness(obj runtime.Object) (bool, bool, error) {
+	var (
+		isSynced         bool
+		hasReplicasReady bool
+	)
+
+	switch s := obj.(type) {
+	case *kappsv1.StatefulSet:
+		isSynced = s.Status.ObservedGeneration == s.Generation
+		hasReplicasReady = s.Spec.Replicas != nil && s.Status.ReadyReplicas == *s.Spec.Replicas
+	case *kappsv1beta1.StatefulSet:
+		isSynced = s.Status.ObservedGeneration != nil && *s.Status.ObservedGeneration == s.Generation
+		hasReplicasReady = s.Spec.Replicas != nil && s.Status.ReadyReplicas == *s.Spec.Replicas
+	case *kappsv1beta2.StatefulSet:
+		isSynced = s.Status.ObservedGeneration == s.Generation
+		hasReplicasReady = s.Spec.Replicas != nil && s.Status.ReadyReplicas == *s.Spec.Replicas
+	default:
+		return false, false, fmt.Errorf("unsupported statefulset version: %T", s)
+	}
+
+	return isSynced && hasReplicasReady, false, nil
+}
+
+func groupVersionKind(gv schema.GroupVersion, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   gv.Group,
+		Version: gv.Version,
+		Kind:    kind,
+	}
+}
+
+func canCheckReadiness(ref corev1.ObjectReference) bool {
+	switch ref.GroupVersionKind() {
+	case groupVersionKind(buildv1.GroupVersion, "BuildConfig"), schema.GroupVersionKind{Group: "", Version: "v1", Kind: "BuildConfig"}:
+		return true
+	}
+	_, found := readinessCheckers[ref.GroupVersionKind()]
+	return found
+}
+
+func checkReadiness(oc buildv1client.Interface, ref corev1.ObjectReference, obj *unstructured.Unstructured) (bool, bool, error) {
+	castObj, err := readinessScheme.New(ref.GroupVersionKind())
+	if err != nil {
+		return false, false, err
+	}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, castObj); err != nil {
+		return false, false, err
+	}
+
+	switch ref.GroupVersionKind() {
+	case groupVersionKind(buildv1.GroupVersion, "BuildConfig"), schema.GroupVersionKind{Group: "", Version: "v1", Kind: "BuildConfig"}:
+		return checkBuildConfigReadiness(oc, castObj)
+	}
+
+	readinessCheckFunc, ok := readinessCheckers[ref.GroupVersionKind()]
+	if !ok {
+		return false, false, fmt.Errorf("readiness check for %+v is not defined", ref.GroupVersionKind())
+	}
+	return readinessCheckFunc(castObj)
+}
+
 func dumpObjectReadiness(oc *exutil.CLI, templateInstance *templatev1.TemplateInstance) error {
 	restmapper := oc.RESTMapper()
 
 	fmt.Fprintf(g.GinkgoWriter, "dumping object readiness for %s/%s\n", templateInstance.Namespace, templateInstance.Name)
 
 	for _, object := range templateInstance.Status.Objects {
-		//if !controller.CanCheckReadiness(object.Ref) {
-		//	continue
-		//}
+		if !canCheckReadiness(object.Ref) {
+			continue
+		}
 
 		mapping, err := restmapper.RESTMapping(object.Ref.GroupVersionKind().GroupKind())
 		if err != nil {
@@ -158,15 +470,15 @@ func dumpObjectReadiness(oc *exutil.CLI, templateInstance *templatev1.TemplateIn
 			continue
 		}
 
-		//ready, failed, err := controller.CheckReadiness(oc.BuildClient(), object.Ref, obj)
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//fmt.Fprintf(g.GinkgoWriter, "%s %s/%s: ready %v, failed %v\n", object.Ref.Kind, object.Ref.Namespace, object.Ref.Name, ready, failed)
-		//if !ready || failed {
-		//	fmt.Fprintf(g.GinkgoWriter, "object: %#v\n", obj)
-		//}
+		ready, failed, err := checkReadiness(oc.BuildClient(), object.Ref, obj)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(g.GinkgoWriter, "%s %s/%s: ready %v, failed %v\n", object.Ref.Kind, object.Ref.Namespace, object.Ref.Name, ready, failed)
+		if !ready || failed {
+			fmt.Fprintf(g.GinkgoWriter, "object: %#v\n", obj)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
… purge

@openshift/openshift-team-developer-experience fyi / ptal

/assign @adambkaplan 

On the TODO's about library-go candidates, my thought is to get the test coverage back in asap, and then see what of the candidates are actually accepted by master team into library-go, and  then bump library-go in origin and access from there.

Generally speaking, based on my last conversation with them, anything schema related or generally atypical is not going to get into library-go.