### PR TITLE
[release-3.11] Bug 1730446: bump(github.com/openshift/imagebuilder)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fbd25b5deb27fc4a1a6983f6a4d763cdf5153fceffe72c16b9bc90e6e4e8dd
-updated: 2019-07-21T11:15:49.781134265+02:00
+hash: 5c459be4a51174fa532676eefe13d941ae19372cb838705e6177ebe0d35b6a98
+updated: 2019-08-08T10:07:51.388439632-04:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -973,7 +973,7 @@ imports:
   - user/informers/externalversions/user/v1
   - user/listers/user/v1
 - name: github.com/openshift/imagebuilder
-  version: c0887bd82bb30c80ad4a0fd19a22b2520a8223c6
+  version: 88ea7f56be8b37593900daf982db5cde64f62221
   subpackages:
   - dockerclient
   - imageprogress

--- a/glide.yaml
+++ b/glide.yaml
@@ -132,8 +132,6 @@ import:
 # pinned to the level that kubernetes uses.  Not sure why glide isn't matching this
 - package: github.com/sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
-# pinned to a level that kubernetes uses.
-#  version: 5858425f75500d40c52783dce87d085a483ce135
 
 # mine: specific to openshift
 # networking

--- a/vendor/github.com/openshift/imagebuilder/OWNERS
+++ b/vendor/github.com/openshift/imagebuilder/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- TomSweeneyRedHat
+- mrunalp
+- nalind
+- rhatdan
+- smarterclayton

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
@@ -357,6 +357,9 @@ func newArchiveMapper(src, dst string, excludes []string, resetOwners bool, chec
 			prefix = path.Base(archiveRoot)
 		}
 	}
+	if !strings.HasSuffix(archiveRoot, "/") {
+		archiveRoot += "/"
+	}
 
 	mapperFn := archivePathMapper(srcPattern, dst, isDestDir)
 

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive_test.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -449,8 +450,8 @@ func Test_archiveFromContainer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if path != testCase.path {
-				t.Errorf("unexpected path: %s", path)
+			if filepath.Clean(path) != testCase.path {
+				t.Errorf("unexpected path: %s != %s", filepath.Clean(path), testCase.path)
 			}
 			tr := tar.NewReader(r)
 			var found []string

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/conformance_test.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/conformance_test.go
@@ -111,6 +111,8 @@ func TestCopyFrom(t *testing.T) {
 		{name: "copy file to deeper directory with explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c/", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
 		{name: "copy file to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a /a/b/c", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
+		{name: "copy item from directory that is a symbolic link", create: "mkdir -p /a && touch /a/1 && ln -s /a /b", copy: "b/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
+		{name: "copy item from directory that is a symbolic link", create: "mkdir -p /a && touch /a/1 && ln -s a /c", copy: "/c/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 		{name: "copy directory trailing to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a/. /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 	}

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_11
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_11
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+RUN ln -s /a /b
+FROM busybox
+COPY --from=base /b/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_12
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_12
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+RUN ln -s a /c
+FROM busybox
+COPY --from=base /c/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1


### PR DESCRIPTION
Revendor the openshift-3.11 branch of openshift/imagebuilder to pick up its fix for #1730446.
Move the version override for github.com/evanphx/json-patch in glide.yaml to its stanza to get update-deps to pass.
Mark bitbucket.org/ww/goautoneg as a mercurial repository, as my copy of glide had trouble automatically detecting that.