### PR TITLE
Bug 1739445: Remove oc rpms

### DIFF
--- a/images/os/Dockerfile
+++ b/images/os/Dockerfile
@@ -4,7 +4,9 @@ COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-conte
 RUN set -x && yum install -y ostree yum-utils selinux-policy-targeted && \
     commit=$( find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1 ) && \
     mkdir /tmp/working && cd /tmp/working && \
-    yumdownloader --enablerepo=built --destdir=/tmp/rpms openshift-hyperkube openshift-clients && \
+    PACKAGES=(openshift-hyperkube openshift-clients) && \
+    yumdownloader --enablerepo=built --destdir=/tmp/rpms "${PACKAGES[@]}"  && \
+    ls /tmp/rpms/ && (cd /tmp/rpms/ && ls ${PACKAGES[@]/%/*}) && \
     for i in $(find /tmp/rpms/ -name openshift-* -iname *.rpm); do echo "Extracting $i ..."; rpm2cpio $i | cpio -div; done && \
     mv etc usr/ && \
     mkdir -p /tmp/tmprootfs/etc && \

--- a/images/os/Dockerfile
+++ b/images/os/Dockerfile
@@ -4,11 +4,11 @@ COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-conte
 RUN set -x && yum install -y ostree yum-utils selinux-policy-targeted && \
     commit=$( find /srv -name *.commit | sed -Ee 's|.*objects/(.+)/(.+)\.commit|\1\2|' | head -1 ) && \
     mkdir /tmp/working && cd /tmp/working && \
-    PACKAGES=(openshift-hyperkube openshift-clients) && \
+    PACKAGES=(openshift-hyperkube) && \
     yumdownloader --enablerepo=built --destdir=/tmp/rpms "${PACKAGES[@]}"  && \
     ls /tmp/rpms/ && (cd /tmp/rpms/ && ls ${PACKAGES[@]/%/*}) && \
     for i in $(find /tmp/rpms/ -name openshift-* -iname *.rpm); do echo "Extracting $i ..."; rpm2cpio $i | cpio -div; done && \
-    mv etc usr/ && \
+    if [[ -d etc ]]; then mv etc usr/; fi && \
     mkdir -p /tmp/tmprootfs/etc && \
     ostree --repo=/srv/repo checkout -U $commit --subpath /usr/etc/selinux /tmp/tmprootfs/etc/selinux && \
     ostree --repo=/srv/repo commit --parent=$commit --tree=ref=$commit --tree=dir=. \

--- a/origin.spec
+++ b/origin.spec
@@ -110,26 +110,6 @@ Provides:       atomic-openshift-node
 %description hyperkube
 %{summary}
 
-%package clients
-Summary:        %{product_name} Client binaries for Linux
-Provides:       atomic-openshift-clients
-Obsoletes:      atomic-openshift-clients
-Requires:       bash-completion
-
-%description clients
-%{summary}
-
-%if 0%{?make_redistributable}
-%package clients-redistributable
-Summary:        %{product_name} Client binaries for Linux, Mac OSX, and Windows
-Provides:       atomic-openshift-clients-redistributable
-Obsoletes:      atomic-openshift-clients-redistributable
-BuildRequires:  goversioninfo
-
-%description clients-redistributable
-%{summary}
-%endif
-
 %prep
 %if 0%{do_prep}
 %setup -q
@@ -168,62 +148,15 @@ PLATFORM="$(go env GOHOSTOS)/$(go env GOHOSTARCH)"
 install -d %{buildroot}%{_bindir}
 
 # Install linux components
-for bin in oc hyperkube
+for bin in hyperkube
 do
   echo "+++ INSTALLING ${bin}"
   install -p -m 755 _output/local/bin/${PLATFORM}/${bin} %{buildroot}%{_bindir}/${bin}
-done
-
-%if 0%{?make_redistributable}
-# Install client executable for windows and mac
-install -d %{buildroot}%{_datadir}/%{name}/{linux,macosx,windows}
-install -p -m 755 _output/local/bin/linux/amd64/oc %{buildroot}%{_datadir}/%{name}/linux/oc
-install -p -m 755 _output/local/bin/linux/amd64/kubectl %{buildroot}%{_datadir}/%{name}/linux/kubectl
-install -p -m 755 _output/local/bin/darwin/amd64/oc %{buildroot}/%{_datadir}/%{name}/macosx/oc
-install -p -m 755 _output/local/bin/darwin/amd64/kubectl %{buildroot}/%{_datadir}/%{name}/macosx/kubectl
-install -p -m 755 _output/local/bin/windows/amd64/oc.exe %{buildroot}/%{_datadir}/%{name}/windows/oc.exe
-install -p -m 755 _output/local/bin/windows/amd64/kubectl.exe %{buildroot}/%{_datadir}/%{name}/windows/kubectl.exe
-%endif
-
-for cmd in \
-    kubectl
-do
-    ln -s oc %{buildroot}%{_bindir}/$cmd
-done
-
-# Install bash completions
-install -d -m 755 %{buildroot}%{_sysconfdir}/bash_completion.d/
-for bin in oc kubectl
-do
-  echo "+++ INSTALLING BASH COMPLETIONS FOR ${bin} "
-  %{buildroot}%{_bindir}/${bin} completion bash > %{buildroot}%{_sysconfdir}/bash_completion.d/${bin}
-  chmod 644 %{buildroot}%{_sysconfdir}/bash_completion.d/${bin}
 done
 
 %files hyperkube
 %license LICENSE
 %{_bindir}/hyperkube
 %defattr(-,root,root,0700)
-
-%files clients
-%license LICENSE
-%{_bindir}/oc
-%{_bindir}/kubectl
-%{_sysconfdir}/bash_completion.d/oc
-%{_sysconfdir}/bash_completion.d/kubectl
-
-%if 0%{?make_redistributable}
-%files clients-redistributable
-%license LICENSE
-%dir %{_datadir}/%{name}/linux/
-%dir %{_datadir}/%{name}/macosx/
-%dir %{_datadir}/%{name}/windows/
-%{_datadir}/%{name}/linux/oc
-%{_datadir}/%{name}/linux/kubectl
-%{_datadir}/%{name}/macosx/oc
-%{_datadir}/%{name}/macosx/kubectl
-%{_datadir}/%{name}/windows/oc.exe
-%{_datadir}/%{name}/windows/kubectl.exe
-%endif
 
 %changelog


### PR DESCRIPTION
Those RPMs have moved into oc repo. We are now trying to switch ART team to use them but we shouldn't build from 2 places at once. 

hyperkube needs to stay for providing kubelet to the base image. (https://github.com/openshift/origin/blob/7aedc3cb19c39e22b382eff96380bef245f92352/images/os/Dockerfile#L7)

/cc @smarterclayton @eparis @deads2k @soltysh 