### PR TITLE
OpenStack: ensure that cloud provider is initializing for Volumes

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -725,6 +725,12 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 		return nil, nil
 	}
 
+	// Initialize the provider if it hasn't been done yet
+	err := os.ensureCloudProviderWasInitialized()
+	if err != nil {
+		return nil, err
+	}
+
 	// Get Volume
 	volume, err := os.getVolume(pv.Spec.Cinder.VolumeID)
 	if err != nil {


### PR DESCRIPTION
For all top level functions in the cloud provider interface [1] we
make sure that CP was initialized. But there is another top-level
interface PVLabeler [2] and we also need to ensure that cloud provider
was initialized there.

[1] https://github.com/kubernetes/cloud-provider/blob/master/cloud.go#L43
[2] https://github.com/kubernetes/cloud-provider/blob/master/cloud.go#L249