### PR TITLE
Bug 1739601: UPSTREAM: 80491: Changed IsCriticalPod to return true in case of static pods

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/eviction/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/eviction/BUILD
@@ -56,7 +56,6 @@ go_library(
         "//pkg/kubelet/eviction/api:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
         "//pkg/kubelet/metrics:go_default_library",
-        "//pkg/kubelet/pod:go_default_library",
         "//pkg/kubelet/server/stats:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/eviction/eviction_manager.go
@@ -37,7 +37,6 @@ import (
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
-	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
@@ -549,7 +548,7 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 	// If the pod is marked as critical and static, and support for critical pod annotations is enabled,
 	// do not evict such pods. Static pods are not re-admitted after evictions.
 	// https://github.com/kubernetes/kubernetes/issues/40573 has more details.
-	if kubepod.IsStaticPod(pod) {
+	if kubelettypes.IsStaticPod(pod) {
 		// need mirrorPod to check its "priority" value; static pod doesn't carry it
 		if mirrorPod, ok := m.mirrorPodFunc(pod); ok && mirrorPod != nil {
 			// skip only when it's a static and critical pod

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1621,7 +1621,7 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	}
 
 	// Create Mirror Pod for Static Pod if it doesn't already exist
-	if kubepod.IsStaticPod(pod) {
+	if kubetypes.IsStaticPod(pod) {
 		podFullName := kubecontainer.GetPodFullName(pod)
 		deleted := false
 		if mirrorPod != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/pod/pod_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/pod/pod_manager.go
@@ -307,7 +307,7 @@ func (pm *basicManager) GetUIDTranslations() (podToMirror map[kubetypes.Resolved
 	mirrorToPod = make(map[kubetypes.MirrorPodUID]kubetypes.ResolvedPodUID, len(pm.translationByUID))
 	// Insert empty translation mapping for all static pods.
 	for uid, pod := range pm.podByUID {
-		if !IsStaticPod(pod) {
+		if !kubetypes.IsStaticPod(pod) {
 			continue
 		}
 		podToMirror[uid] = ""

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/status/status_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/status/status_manager.go
@@ -577,7 +577,7 @@ func (m *manager) needsReconcile(uid types.UID, status v1.PodStatus) bool {
 		return false
 	}
 	// If the pod is a static pod, we should check its mirror pod, because only status in mirror pod is meaningful to us.
-	if kubepod.IsStaticPod(pod) {
+	if kubetypes.IsStaticPod(pod) {
 		mirrorPod, ok := m.podManager.GetMirrorPodByPod(pod)
 		if !ok {
 			klog.V(4).Infof("Static pod %q has no corresponding mirror pod, no need to reconcile", format.Pod(pod))

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/status/status_manager_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/status/status_manager_test.go
@@ -520,7 +520,7 @@ func TestStaticPod(t *testing.T) {
 
 	t.Logf("Create the static pod")
 	m.podManager.AddPod(staticPod)
-	assert.True(t, kubepod.IsStaticPod(staticPod), "SetUp error: staticPod")
+	assert.True(t, kubetypes.IsStaticPod(staticPod), "SetUp error: staticPod")
 
 	status := getRandomPodStatus()
 	now := metav1.Now()
@@ -836,7 +836,7 @@ func TestDoNotDeleteMirrorPods(t *testing.T) {
 	m.podManager.AddPod(staticPod)
 	m.podManager.AddPod(mirrorPod)
 	t.Logf("Verify setup.")
-	assert.True(t, kubepod.IsStaticPod(staticPod), "SetUp error: staticPod")
+	assert.True(t, kubetypes.IsStaticPod(staticPod), "SetUp error: staticPod")
 	assert.True(t, kubepod.IsMirrorPod(mirrorPod), "SetUp error: mirrorPod")
 	assert.Equal(t, m.podManager.TranslatePodUID(mirrorPod.UID), kubetypes.ResolvedPodUID(staticPod.UID))
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	kubeapi "k8s.io/kubernetes/pkg/apis/core"
@@ -147,6 +147,9 @@ func (sp SyncPodType) String() string {
 // or equal to SystemCriticalPriority. Both the default scheduler and the kubelet use this function
 // to make admission and scheduling decisions.
 func IsCriticalPod(pod *v1.Pod) bool {
+	if IsStaticPod(pod) {
+		return true
+	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodPriority) {
 		if pod.Spec.Priority != nil && IsCriticalPodBasedOnPriority(*pod.Spec.Priority) {
 			return true
@@ -201,4 +204,10 @@ func IsCriticalPodBasedOnPriority(priority int32) bool {
 		return true
 	}
 	return false
+}
+
+// IsStaticPod returns true if the pod is a static pod.
+func IsStaticPod(pod *v1.Pod) bool {
+	source, err := GetPodSource(pod)
+	return err == nil && source != ApiserverSource
 }

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/types/pod_update_test.go
@@ -184,6 +184,18 @@ func TestIsCriticalPod(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod5",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						ConfigSourceAnnotationKey: "abc",
+					},
+				},
+			},
+			expected: true,
+		},
 	}
 	for i, data := range cases {
 		actual := IsCriticalPod(&data.pod)


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/80491

Proactive pick for upstream fix.

Some fuzz around https://github.com/kubernetes/kubernetes/commit/ca6003bc75a3b9c81f38738c7363c9453247682e#diff-9fe046de3c6aaa377bb7fa24a34509c9 but otherwise it applies cleanly.

Extra +/-1 line changed is `goimports` adding `v1` alias
https://github.com/openshift/origin/pull/23576/files#diff-5cdd56e52dd392c4f849386f73dc723aR23

@derekwaynecarr @mrunalp