### PR TITLE
test/operators: whitelist gcp-routes-controller static pod as it is part of infra

### DIFF
--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -31,7 +31,7 @@ var _ = Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
 		excludedNamespaces := sets.NewString("openshift-kube-apiserver", "openshift-kube-controller-manager", "openshift-kube-scheduler", "openshift-etcd")
 		// exclude these pods from checks
-		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators")
+		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators", "gcp-routes-controller")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces
 			if !hasPrefixSet(pod.Namespace, namespacePrefixes) {


### PR DESCRIPTION
More info in https://github.com/openshift/machine-config-operator/pull/1031 as to why the gcp-routes-controller pod is required to keep running.

/cc @csrwng 