### PR TITLE
Fixed jenkins verifyservice e2e tests 

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -56140,81 +56140,28 @@ func testExtendedTestdataTestSecretJson() (*asset, error) {
 var _testExtendedTestdataVerifyservicePipelineTemplateYaml = []byte(`apiVersion: v1
 kind: Template
 labels:
-  template: nodejs-example
+  template: jenkins-verifyservice-pipeline
 metadata:
-  name: nodejs-example
+  name: redis-verifyservice-test
+  app: redis
 objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: nodejs-example
-  spec:
-    ports:
-    - name: web
-      port: 8080
-      targetPort: 8080
-    selector:
-      name: nodejs-example
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: nodejs-example-headless
+    name: redis-headless
+    app: redis
   spec:
     clusterIP: None
     ports:
-    - port: 8080
-      targetPort: 8080
+    - port: 6379
+      targetPort: 6379
     selector:
-      name: nodejs-example
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    name: nodejs-example
-  spec:
-    replicas: 2
-    selector:
-      name: nodejs-example
-    strategy:
-      type: Rolling
-    template:
-      metadata:
-        labels:
-          name: nodejs-example
-        name: nodejs-example
-      spec:
-        containers:
-        - env: []
-          image: ' '
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 30
-            timeoutSeconds: 3
-          name: nodejs-example
-          ports:
-          - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 3
-            timeoutSeconds: 3
-    triggers:
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - nodejs-example
-        from:
-          kind: ImageStreamTag
-          name: nodejs:latest
-          namespace: openshift
-      type: ImageChange
-    - type: ConfigChange
+      name: redis
 - apiVersion: v1
   kind: BuildConfig
   metadata:
     name: jenkins-verifyservice-pipeline
+    app: redis
   spec:
     strategy:
       jenkinsPipelineStrategy:
@@ -56226,9 +56173,9 @@ objects:
                       // Select the default project
                       openshift.withProject() {
                         // Verify Normal Services
-                        def connectedNormalService = openshift.verifyService('nodejs-example')
+                        def connectedNormalService = openshift.verifyService('redis')
                         // Verify Headless Services with Selectors
-                        def connectedHeadlessService = openshift.verifyService('nodejs-example-headless')
+                        def connectedHeadlessService = openshift.verifyService('redis-headless')
                       }
                   }
               }

--- a/test/extended/testdata/verifyservice-pipeline-template.yaml
+++ b/test/extended/testdata/verifyservice-pipeline-template.yaml
@@ -1,81 +1,28 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: nodejs-example
+  template: jenkins-verifyservice-pipeline
 metadata:
-  name: nodejs-example
+  name: redis-verifyservice-test
+  app: redis
 objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: nodejs-example
-  spec:
-    ports:
-    - name: web
-      port: 8080
-      targetPort: 8080
-    selector:
-      name: nodejs-example
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: nodejs-example-headless
+    name: redis-headless
+    app: redis
   spec:
     clusterIP: None
     ports:
-    - port: 8080
-      targetPort: 8080
+    - port: 6379
+      targetPort: 6379
     selector:
-      name: nodejs-example
-- apiVersion: v1
-  kind: DeploymentConfig
-  metadata:
-    name: nodejs-example
-  spec:
-    replicas: 2
-    selector:
-      name: nodejs-example
-    strategy:
-      type: Rolling
-    template:
-      metadata:
-        labels:
-          name: nodejs-example
-        name: nodejs-example
-      spec:
-        containers:
-        - env: []
-          image: ' '
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 30
-            timeoutSeconds: 3
-          name: nodejs-example
-          ports:
-          - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 3
-            timeoutSeconds: 3
-    triggers:
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - nodejs-example
-        from:
-          kind: ImageStreamTag
-          name: nodejs:latest
-          namespace: openshift
-      type: ImageChange
-    - type: ConfigChange
+      name: redis
 - apiVersion: v1
   kind: BuildConfig
   metadata:
     name: jenkins-verifyservice-pipeline
+    app: redis
   spec:
     strategy:
       jenkinsPipelineStrategy:
@@ -87,9 +34,9 @@ objects:
                       // Select the default project
                       openshift.withProject() {
                         // Verify Normal Services
-                        def connectedNormalService = openshift.verifyService('nodejs-example')
+                        def connectedNormalService = openshift.verifyService('redis')
                         // Verify Headless Services with Selectors
-                        def connectedHeadlessService = openshift.verifyService('nodejs-example-headless')
+                        def connectedHeadlessService = openshift.verifyService('redis-headless')
                       }
                   }
               }


### PR DESCRIPTION
Fixed as containers were going to crashloopbackoff.
The image loaded before was an s2i image without the source. 
In this iteration we are using the redis-epemeral template with reduced memory which also provides us with the basic service to test and in the template jenkins-verifyservice-pipeline we are creating the headless service and the buildconfig with the jenkins file to test the feature.

cc @akram @gabemontero 