### PR TITLE
Bug 1740315: Revert toleration priority function score computation

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/scheduling/priorities.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/scheduling/priorities.go
@@ -210,8 +210,31 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		// make the nodes have balanced cpu,mem usage ratio
 		err := createBalancedPodForNodes(f, cs, ns, nodeList.Items, podRequestedResource, 0.5)
 		framework.ExpectNoError(err)
-		// Apply 10 taints to first node
+		//we need apply more taints on a node, because one match toleration only count 1
+		By("Trying to apply 10 taint on the nodes except first one.")
 		nodeName := nodeList.Items[0].Name
+
+		for index, node := range nodeList.Items {
+			if index == 0 {
+				continue
+			}
+			for i := 0; i < 10; i++ {
+				testTaint := addRandomTaitToNode(cs, node.Name)
+				defer framework.RemoveTaintOffNode(cs, node.Name, *testTaint)
+			}
+		}
+		By("Create a pod without any tolerations")
+		tolerationPodName := "without-tolerations"
+		pod := createPausePod(f, pausePodConfig{
+			Name: tolerationPodName,
+		})
+		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
+
+		By("Pod should prefer scheduled to the node don't have the taint.")
+		tolePod, err := cs.CoreV1().Pods(ns).Get(tolerationPodName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tolePod.Spec.NodeName).To(Equal(nodeName))
+
 		By("Trying to apply 10 taint on the first node.")
 		var tolerations []v1.Toleration
 		for i := 0; i < 10; i++ {
@@ -219,16 +242,16 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 			tolerations = append(tolerations, v1.Toleration{Key: testTaint.Key, Value: testTaint.Value, Effect: testTaint.Effect})
 			defer framework.RemoveTaintOffNode(cs, nodeName, *testTaint)
 		}
-		tolerationPodName := "with-tolerations"
+		tolerationPodName = "with-tolerations"
 		By("Create a pod that tolerates all the taints of the first node.")
-		pod := createPausePod(f, pausePodConfig{
+		pod = createPausePod(f, pausePodConfig{
 			Name:        tolerationPodName,
 			Tolerations: tolerations,
 		})
 		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		By("Pod should prefer scheduled to the node that pod can tolerate.")
-		tolePod, err := cs.CoreV1().Pods(ns).Get(tolerationPodName, metav1.GetOptions{})
+		tolePod, err = cs.CoreV1().Pods(ns).Get(tolerationPodName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(tolePod.Spec.NodeName).To(Equal(nodeName))
 	})


### PR DESCRIPTION
Reverts openshift/origin#23544

This test is failing is continuously, I still need to debug why this is failing. In meanwhile, I'm reverting the PR.