### PR TITLE
auto OCP-21630: [Marketplace] Default OperatorSources is installed and controled by CVO

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"
 	_ "github.com/openshift/origin/test/extended/machines"
+	_ "github.com/openshift/origin/test/extended/marketplace"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/operators"

--- a/test/extended/marketplace/marketplace.go
+++ b/test/extended/marketplace/marketplace.go
@@ -1,0 +1,49 @@
+package marketplace
+
+import (
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[Feature:Marketplace] Marketplace Default Sources", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLIWithoutNamespace("")
+
+	//[OCP-21630]:[Marketplace] Default OperatorSources is installed and controled by CVO
+	//author: chuo@redhat.com
+	g.It("[ocp-21630][ocp-24411]OperatorSource installed and controled by CVO in 4.1 and MarketplaceOperator in 4.2", func() {
+
+		var defaultOperatorSources = [3]string{"certified-operators", "community-operators", "redhat-operators"}
+		for _, v := range defaultOperatorSources {
+			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "opsrc", v, "-o=jsonpath={.status.currentPhase.phase.message}").Output()
+			if err != nil {
+				e2e.Failf("Unable to get %s, error:%v", msg, err)
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(msg).To(o.Equal("The object has been successfully reconciled"))
+		}
+
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("-n", "openshift-marketplace", "opsrc", "redhat-operators", "--type", "merge", "-p", `{"spec":{"registryNamespace":"wrong"}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		time.Sleep(180 * time.Second)
+
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "opsrc", "redhat-operators", "-o=jsonpath={.spec.registryNamespace}").Output()
+		if err != nil {
+			e2e.Failf("Unable to get operatorsource redhat-operators.spec.registryNamespace :%v", err)
+		}
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("redhat-operators")
+	})
+	
+	//[OCP-21921]:[Marketplace]Default resources of Marketplace operator
+	g.It("[ocp-21921]marketplace operators", func(){
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("descirbe").Args("-n", "openshift-marketplace").Output()
+		e2e.Logf("the namespace is %s", msg)
+		
+	})
+})


### PR DESCRIPTION
@aravindhp @kevinrizza @awgreene As title, please have a review. Thanks! cc: @emmajiafan @bandrade @scolange @dongboyan77 @zihantang-rh @jianzhangbjz @chengzhang1016
Log shows as below.
./openshift-tests run all --dry-run | grep "\[Feature:Marketplace\] Marketplace Default" | ./openshift-tests run --junit-dir=./ -f -
started: (0/1/1) "[Feature:Marketplace] Marketplace Default OperatorSource [ocp-21630]installed and controled by CVO [Suite:openshift/conformance/parallel]"

Aug 15 15:19:37.786: INFO: >>> kubeConfig: /home/chuo/.kube/chuo.config
Aug 15 15:19:37.787: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Aug 15 15:19:40.195: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Aug 15 15:19:41.255: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (1 seconds elapsed)
Aug 15 15:19:41.255: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Aug 15 15:19:41.255: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Aug 15 15:19:41.605: INFO: e2e test version: v0.0.0-master+$Format:%h$
Aug 15 15:19:41.946: INFO: kube-apiserver version: v1.13.4+8560dd6
[BeforeEach] [Top Level]
  /home/chuo/go/src/github.com/openshift/origin/test/extended/util/test.go:73
[BeforeEach] [Feature:Marketplace] Marketplace Default OperatorSource
  /home/chuo/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
Aug 15 15:19:41.953: INFO: >>> kubeConfig: /home/chuo/.kube/chuo.config
[It] [ocp-21630]installed and controled by CVO [Suite:openshift/conformance/parallel]
  /home/chuo/go/src/github.com/openshift/origin/test/extended/marketplace/marketplace.go:19
Aug 15 15:19:41.954: INFO: Running 'oc --config=/home/chuo/.kube/chuo.config get -n openshift-marketplace opsrc certified-operators -o=jsonpath={.status.currentPhase.phase.message}'
Aug 15 15:19:43.157: INFO: Running 'oc --config=/home/chuo/.kube/chuo.config get -n openshift-marketplace opsrc community-operators -o=jsonpath={.status.currentPhase.phase.message}'
Aug 15 15:19:44.539: INFO: Running 'oc --config=/home/chuo/.kube/chuo.config get -n openshift-marketplace opsrc redhat-operators -o=jsonpath={.status.currentPhase.phase.message}'
Aug 15 15:19:45.734: INFO: Running 'oc --config=/home/chuo/.kube/chuo.config patch -n openshift-marketplace opsrc redhat-operators --type merge -p {"spec":{"registryNamespace":"wrong"}}'
operatorsource.operators.coreos.com/redhat-operators patched
Aug 15 15:22:47.575: INFO: Running 'oc --config=/home/chuo/.kube/chuo.config get -n openshift-marketplace opsrc redhat-operators -o=jsonpath={.spec.registryNamespace}'
[AfterEach] [Feature:Marketplace] Marketplace Default OperatorSource
  /home/chuo/go/src/github.com/openshift/origin/test/extended/util/client.go:120
[AfterEach] [Feature:Marketplace] Marketplace Default OperatorSource
  /home/chuo/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:150
Aug 15 15:22:51.098: INFO: Waiting up to 3m0s for all (but 100) nodes to be ready
Aug 15 15:22:51.788: INFO: Running AfterSuite actions on all nodes
Aug 15 15:22:51.788: INFO: Running AfterSuite actions on node 1

passed: (3m15s) 2019-08-15T07:22:51 "[Feature:Marketplace] Marketplace Default OperatorSource [ocp-21630]installed and controled by CVO [Suite:openshift/conformance/parallel]"


Timeline:

Aug 15 07:21:15.422 I ns/openshift-machine-api machine/qe-chuo-n2dcm-worker-eu-west-2b-l7l22 Updated machine qe-chuo-n2dcm-worker-eu-west-2b-l7l22 (9 times)
Aug 15 07:21:16.113 I ns/openshift-machine-api machine/qe-chuo-n2dcm-worker-eu-west-2c-f4j9m Updated machine qe-chuo-n2dcm-worker-eu-west-2c-f4j9m (9 times)
Aug 15 07:21:16.278 I ns/openshift-machine-api machine/qe-chuo-n2dcm-worker-eu-west-2a-4h5fz Updated machine qe-chuo-n2dcm-worker-eu-west-2a-4h5fz (9 times)
Aug 15 07:21:16.718 I ns/openshift-machine-api machine/qe-chuo-n2dcm-master-0 Updated machine qe-chuo-n2dcm-master-0 (6 times)
Aug 15 07:21:17.784 I ns/openshift-machine-api machine/qe-chuo-n2dcm-master-1 Updated machine qe-chuo-n2dcm-master-1 (6 times)
Aug 15 07:21:19.412 I ns/openshift-machine-api machine/qe-chuo-n2dcm-master-2 Updated machine qe-chuo-n2dcm-master-2 (6 times)
Aug 15 07:21:56.341 I ns/openshift-marketplace deployment/redhat-operators Scaled down replica set redhat-operators-66d487b5b7 to 0
Aug 15 07:21:56.349 I ns/openshift-marketplace replicaset/redhat-operators-66d487b5b7 Deleted pod: redhat-operators-66d487b5b7-jhr96
Aug 15 07:21:56.350 W ns/openshift-marketplace pod/redhat-operators-66d487b5b7-jhr96 node/ip-10-0-153-167.eu-west-2.compute.internal graceful deletion within 30s
Aug 15 07:21:56.351 I ns/openshift-marketplace pod/redhat-operators-66d487b5b7-jhr96 Stopping container redhat-operators
Aug 15 07:21:57.775 E ns/openshift-marketplace pod/redhat-operators-66d487b5b7-jhr96 node/ip-10-0-153-167.eu-west-2.compute.internal container=redhat-operators container exited with code 2 (Error): 
Aug 15 07:21:58.349 I ns/openshift-marketplace deployment/redhat-operators Scaled up replica set redhat-operators-588b5c7747 to 1
Aug 15 07:21:58.416 I ns/openshift-marketplace replicaset/redhat-operators-588b5c7747 Created pod: redhat-operators-588b5c7747-dbxj8
Aug 15 07:21:58.416 I ns/openshift-marketplace pod/redhat-operators-588b5c7747-dbxj8 Successfully assigned openshift-marketplace/redhat-operators-588b5c7747-dbxj8 to ip-10-0-153-167.eu-west-2.compute.internal
Aug 15 07:21:58.417 I ns/openshift-marketplace pod/redhat-operators-588b5c7747-dbxj8 node/ created
Aug 15 07:22:05.802 W ns/openshift-marketplace pod/redhat-operators-66d487b5b7-jhr96 node/ip-10-0-153-167.eu-west-2.compute.internal deleted
Aug 15 07:22:06.090 I ns/openshift-marketplace pod/redhat-operators-588b5c7747-dbxj8 Container image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6961bcb2dd0e0240638251a2a6a5b6e39da39eea9081935b738613282645da13" already present on machine
Aug 15 07:22:06.091 I ns/openshift-marketplace pod/redhat-operators-588b5c7747-dbxj8 Created container redhat-operators
Aug 15 07:22:06.091 I ns/openshift-marketplace pod/redhat-operators-588b5c7747-dbxj8 Started container redhat-operators

Writing JUnit report to junit_e2e_20190815-072251.xml

1 pass, 0 skip (3m15s)