### PR TITLE
Bug 1741499: [4.1] Pass egress IP packets to conntrack

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -768,7 +768,11 @@ func (oc *ovsController) SetNamespaceEgressViaEgressIP(vnid uint32, nodeIP, mark
 		}
 		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=set_field:%s->eth_dst,set_field:%s->pkt_mark,goto_table:101", vnid, oc.tunMAC, mark)
 	} else {
-		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", vnid, nodeIP)
+		commit := ""
+		if oc.useConnTrack {
+			commit = "ct(commit),"
+		}
+		otx.AddFlow("table=100, priority=100, reg0=%d, ip, actions=%smove:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", vnid, commit, nodeIP)
 	}
 	return otx.Commit()
 }


### PR DESCRIPTION
If a packet is being sent over the VXLAN to a remote egress IP, we have to tell conntrack to remember the packet first, so that when we get the response it will be recognized as such (and thus accepted regardless of NetworkPolicy).

Backport of https://github.com/openshift/sdn/pull/19 (on the way to backporting it to 3.11).

/assign @squeed 