### PR TITLE
bug 1737134: [Feature:Machines][Serial] Managed cluster should: increase timeout waiting for nodes to disappear

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -216,6 +216,6 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			g.By(fmt.Sprintf("got %v nodes, expecting %v", len(nodeList.Items), initialNumberOfWorkers))
 			return len(nodeList.Items) == initialNumberOfWorkers
-		}, 1*time.Minute, 5*time.Second).Should(o.BeTrue())
+		}, 2*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 })

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -75,6 +75,7 @@ func getNodesFromMachineSet(c *kubernetes.Clientset, dc dynamic.Interface, machi
 		return nil, fmt.Errorf("failed to list worker nodes: %v", err)
 	}
 
+	e2e.Logf("Machines found %v, nodes found: %v", machines, allWorkerNodes.Items)
 	machineToNodes, match := mapMachineNameToNodeName(machines, allWorkerNodes.Items)
 	if !match {
 		return nil, fmt.Errorf("not all machines have a node reference: %v", machineToNodes)
@@ -147,14 +148,15 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 				return false
 			}
 			e2e.Logf("node count : %v, expectedCount %v", len(nodes), expectedScaleOut)
+			notReady := false
 			for i := range nodes {
 				e2e.Logf("node: %v", nodes[i].Name)
 				if !isNodeReady(*nodes[i]) {
 					e2e.Logf("Node %q is not ready", nodes[i].Name)
-					return false
+					notReady = true
 				}
 			}
-			return len(nodes) == expectedScaleOut
+			return !notReady && len(nodes) == expectedScaleOut
 		}
 
 		cfg, err := e2e.LoadConfig()
@@ -178,6 +180,7 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		initialNumberOfWorkers := len(nodeList.Items)
+		g.By(fmt.Sprintf("initial cluster workers size is %v", initialNumberOfWorkers))
 
 		initialReplicasMachineSets := map[string]int{}
 
@@ -189,6 +192,8 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 			err = scaleMachineSet(machineName(machineSet), expectedScaleOut)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
+
+		g.By("checking scaled up worker nodes are ready")
 		for _, machineSet := range machineSets {
 			expectedScaleOut := initialReplicasMachineSets[machineName(machineSet)] + 1
 			o.Eventually(func() bool {
@@ -209,6 +214,7 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 				LabelSelector: nodeLabelSelectorWorker,
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
+			g.By(fmt.Sprintf("got %v nodes, expecting %v", len(nodeList.Items), initialNumberOfWorkers))
 			return len(nodeList.Items) == initialNumberOfWorkers
 		}, 1*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})


### PR DESCRIPTION
Based on the logs in https://prow.k8s.io/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2/3322.

1) Both machineset were scaled up:

STEP: scaling "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1a" from 3 to 2 replicas
Aug 15 03:42:08.361: INFO: >>> kubeConfig: /tmp/admin.kubeconfig
STEP: scaling "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1b" from 2 to 1 replicas
Aug 15 03:42:08.485: INFO: >>> kubeConfig: /tmp/admin.kubeconfig

2) Machine controller deleted both machines and nodes successfully:

I0815 03:42:08.487601       1 controller.go:205] Reconciling machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1a-5djht" triggers delete
W0815 03:42:28.610350       1 controller.go:298] drain failed for machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1a-5djht": Drain did not complete within 20s
I0815 03:42:51.784629       1 controller.go:302] drain successful for machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1a-5djht"
I0815 03:42:52.010220       1 controller.go:225] Deleting node "ip-10-0-131-48.ec2.internal" for machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1a-5djht"
I0815 03:42:53.247097       1 controller.go:239] Machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1a-5djht" deletion successful

I0815 03:42:28.610464       1 controller.go:205] Reconciling machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1b-4khwk" triggers delete
W0815 03:42:48.708860       1 controller.go:298] drain failed for machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1b-4khwk": Drain did not complete within 20s
I0815 03:43:08.751529       1 controller.go:302] drain successful for machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1b-4khwk"
I0815 03:43:09.116137       1 controller.go:225] Deleting node "ip-10-0-149-176.ec2.internal" for machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1b-4khwk"
I0815 03:43:10.222152       1 controller.go:239] Machine "ci-op-4mlicwcq-ce7d8-mqsjq-worker-us-east-1b-4khwk" deletion successful

3) [Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Suite:openshift/conformance/serial] test waits for 60 seconds at most for nodes to be delete

Timestamp recap:

1) Request to delete machines were triggered at 03:42:08.485
2) Both nodes were deleted at 03:43:09.116137

As you can see the difference between nodes being deleted and request to delete them is a bit over 60 seconds (~1 second).

Conclusion:

I did not check logs of other flaking instances though bumping the timeout to 2 minutes will do fine.