### PR TITLE
Bug 1703885: test/extended/router: Fix curl timeout, log dumping, template parameters, and router readiness probes

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -139,8 +139,9 @@ func waitForRouteToRespond(ns, execPodName, proto, host, abspath, ipaddr string,
 	uri := fmt.Sprintf("%s://%s:%d%s", proto, host, port, abspath)
 	cmd := fmt.Sprintf(`
 		set -e
-		for i in $(seq 1 %d); do
-			code=$( curl -k -s -o /dev/null -w '%%{http_code}\n' --resolve %s:%d:%s %q ) || rc=$?
+		STOP=$(($(date '+%%s') + %d))
+		while [ $(date '+%%s') -lt $STOP ]; do
+			code=$( curl -k -s -m 5 -o /dev/null -w '%%{http_code}\n' --resolve %s:%d:%s %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code
 				if [[ $code -eq 200 ]]; then

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -233,8 +233,9 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSeconds int) error {
 	cmd := fmt.Sprintf(`
 		set -e
-		for i in $(seq 1 %d); do
-			code=$( curl -k -s -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
+		STOP=$(($(date '+%%s') + %d))
+		while [ $(date '+%%s') -lt $STOP ]; do
+			code=$( curl -k -s -m 5 -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code
 				if [[ $code -eq 200 ]]; then
@@ -263,8 +264,9 @@ func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSecon
 func expectRouteStatusCodeRepeatedExec(ns, execPodName, url, host string, statusCode int, times int) error {
 	cmd := fmt.Sprintf(`
 		set -e
-		for i in $(seq 1 %d); do
-			code=$( curl -s -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
+		STOP=$(($(date '+%%s') + %d))
+		while [ $(date '+%%s') -lt $STOP ]; do
+			code=$( curl -s -m 5 -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code
 				if [[ $code -ne %d ]]; then

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -56,7 +56,8 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			g.By(fmt.Sprintf("creating a router from a config file %q", configPath))
 			err := oc.AsAdmin().Run("new-app").Args("-f", configPath,
 				`-p=IMAGE=`+routerImage,
-				`-p=SCOPE=["--name=test-unprivileged", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first", "--update-status=false"]`,
+				`-p=ROUTER_NAME=test-unprivileged`,
+				`-p=UPDATE_STATUS=false`,
 			).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			if routes, _ := client.List(metav1.ListOptions{}); routes != nil {
 				outputIngress(routes.Items...)
 			}
-			exutil.DumpPodLogsStartingWith("unprivileged-router", oc)
+			exutil.DumpPodLogsStartingWith("router-", oc)
 		}
 	})
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53668,6 +53668,8 @@ objects:
       - "--loglevel=4"
       - "--override-domains=null.ptr,void.str"
       - "--hostname-template=${name}-${namespace}.apps.veto.test"
+      - "--stats-port=1936"
+      - "--metrics-type=haproxy"
       hostNetwork: false
       ports:
       - containerPort: 80
@@ -53729,6 +53731,8 @@ objects:
       - "--loglevel=4"
       - "--override-hostname"
       - "--hostname-template=${name}-${namespace}.myapps.mycompany.com"
+      - "--stats-port=1936"
+      - "--metrics-type=haproxy"
       hostNetwork: false
       ports:
       - containerPort: 80
@@ -53793,6 +53797,8 @@ objects:
       - "--update-status=${UPDATE_STATUS}"
       - "--loglevel=4"
       - "--labels=select=first"
+      - "--stats-port=1936"
+      - "--metrics-type=haproxy"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53642,8 +53642,6 @@ kind: Template
 parameters:
 - name: IMAGE
   value: openshift/origin-haproxy-router:latest
-- name: SCOPE
-  value: '["--name=test-scoped", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first"]'
 objects:
 
 # a router that overrides domains
@@ -53664,7 +53662,12 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--name=test-override-domains", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--override-domains=null.ptr,void.str", "--hostname-template=${name}-${namespace}.apps.veto.test"]
+      args:
+      - "--name=test-override-domains"
+      - "--namespace=$(POD_NAMESPACE)"
+      - "--loglevel=4"
+      - "--override-domains=null.ptr,void.str"
+      - "--hostname-template=${name}-${namespace}.apps.veto.test"
       hostNetwork: false
       ports:
       - containerPort: 80
@@ -53700,8 +53703,6 @@ kind: Template
 parameters:
 - name: IMAGE
   value: openshift/origin-haproxy-router:latest
-- name: SCOPE
-  value: '["--name=test-scoped", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first"]'
 objects:
 
 # a router that overrides host
@@ -53722,7 +53723,12 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--name=test-override", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--override-hostname", "--hostname-template=${name}-${namespace}.myapps.mycompany.com"]
+      args:
+      - "--name=test-override"
+      - "--namespace=$(POD_NAMESPACE)"
+      - "--loglevel=4"
+      - "--override-hostname"
+      - "--hostname-template=${name}-${namespace}.myapps.mycompany.com"
       hostNetwork: false
       ports:
       - containerPort: 80
@@ -53758,8 +53764,10 @@ kind: Template
 parameters:
 - name: IMAGE
   value: openshift/origin-haproxy-router:latest
-- name: SCOPE
-  value: '["--name=test-scoped", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first"]'
+- name: ROUTER_NAME
+  value: "test-scoped"
+- name: UPDATE_STATUS
+  value: "true"
 objects:
 # a scoped router
 - apiVersion: v1
@@ -53779,7 +53787,12 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: "${{SCOPE}}"
+      args:
+      - "--name=${ROUTER_NAME}"
+      - "--namespace=$(POD_NAMESPACE)"
+      - "--update-status=${UPDATE_STATUS}"
+      - "--loglevel=4"
+      - "--labels=select=first"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-override-domains.yaml
+++ b/test/extended/testdata/router/router-override-domains.yaml
@@ -29,6 +29,8 @@ objects:
       - "--loglevel=4"
       - "--override-domains=null.ptr,void.str"
       - "--hostname-template=${name}-${namespace}.apps.veto.test"
+      - "--stats-port=1936"
+      - "--metrics-type=haproxy"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-override-domains.yaml
+++ b/test/extended/testdata/router/router-override-domains.yaml
@@ -3,8 +3,6 @@ kind: Template
 parameters:
 - name: IMAGE
   value: openshift/origin-haproxy-router:latest
-- name: SCOPE
-  value: '["--name=test-scoped", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first"]'
 objects:
 
 # a router that overrides domains
@@ -25,7 +23,12 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--name=test-override-domains", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--override-domains=null.ptr,void.str", "--hostname-template=${name}-${namespace}.apps.veto.test"]
+      args:
+      - "--name=test-override-domains"
+      - "--namespace=$(POD_NAMESPACE)"
+      - "--loglevel=4"
+      - "--override-domains=null.ptr,void.str"
+      - "--hostname-template=${name}-${namespace}.apps.veto.test"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-override.yaml
+++ b/test/extended/testdata/router/router-override.yaml
@@ -3,8 +3,6 @@ kind: Template
 parameters:
 - name: IMAGE
   value: openshift/origin-haproxy-router:latest
-- name: SCOPE
-  value: '["--name=test-scoped", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first"]'
 objects:
 
 # a router that overrides host
@@ -25,7 +23,12 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--name=test-override", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--override-hostname", "--hostname-template=${name}-${namespace}.myapps.mycompany.com"]
+      args:
+      - "--name=test-override"
+      - "--namespace=$(POD_NAMESPACE)"
+      - "--loglevel=4"
+      - "--override-hostname"
+      - "--hostname-template=${name}-${namespace}.myapps.mycompany.com"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-override.yaml
+++ b/test/extended/testdata/router/router-override.yaml
@@ -29,6 +29,8 @@ objects:
       - "--loglevel=4"
       - "--override-hostname"
       - "--hostname-template=${name}-${namespace}.myapps.mycompany.com"
+      - "--stats-port=1936"
+      - "--metrics-type=haproxy"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-scoped.yaml
+++ b/test/extended/testdata/router/router-scoped.yaml
@@ -32,6 +32,8 @@ objects:
       - "--update-status=${UPDATE_STATUS}"
       - "--loglevel=4"
       - "--labels=select=first"
+      - "--stats-port=1936"
+      - "--metrics-type=haproxy"
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-scoped.yaml
+++ b/test/extended/testdata/router/router-scoped.yaml
@@ -3,8 +3,10 @@ kind: Template
 parameters:
 - name: IMAGE
   value: openshift/origin-haproxy-router:latest
-- name: SCOPE
-  value: '["--name=test-scoped", "--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=first"]'
+- name: ROUTER_NAME
+  value: "test-scoped"
+- name: UPDATE_STATUS
+  value: "true"
 objects:
 # a scoped router
 - apiVersion: v1
@@ -24,7 +26,12 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: "${{SCOPE}}"
+      args:
+      - "--name=${ROUTER_NAME}"
+      - "--namespace=$(POD_NAMESPACE)"
+      - "--update-status=${UPDATE_STATUS}"
+      - "--loglevel=4"
+      - "--labels=select=first"
       hostNetwork: false
       ports:
       - containerPort: 80


### PR DESCRIPTION
#### `test/extended/router`: Fix curl timeout logic

Fix `waitForRouteToRespond`, `waitForRouterOKResponseExec`, and `expectRouteStatusCodeRepeatedExec` to honor their timeout parameter values and to specify a timeout for each curl invocation.

Before this change, each function used its timeout parameter value as the number of times to retry the curl command and did not specify a timeout value to that command.  As a result, each command invocation could keep trying indefinitely, and the function could keep retrying the command for far longer than the timeout period that the caller indicated.

Follow-up to https://github.com/openshift/origin/pull/12346 and https://github.com/openshift/origin/pull/19073.

* `test/extended/router/config_manager.go` (`waitForRouteToRespond`):
* `test/extended/router/scoped.go` (`waitForRouterOKResponseExec`)
(`expectRouteStatusCodeRepeatedExec`): Keep retrying until the amount of time that is indicated by the timeout value has elapsed.  Specify a timeout value of 5 seconds to curl using the `-m` option.


#### `test/extended/router/unprivileged`: Fix log dump

Fix the prefix for the pod name used in the unprivileged router test so that the pod's logs will be dumped on test failures.

Follow-up to https://github.com/openshift/origin/pull/21557.

* `test/extended/router/unprivileged.go`: Call `DumpPodLogsStartingWith` with the "router-" prefix instead of the "unprivileged-router" prefix.


#### `test/extended/router`: Delete `SCOPE` template param

Delete the `SCOPE` template parameter in the various router template fixtures, and add `ROUTER_NAME` (default value "test-scoped") and `UPDATE_STATUS` (default value "true") parameters to the `router-scoped.yaml` template fixture.

Most tests were not using the `SCOPE` parameter, and in the one test that did, its use evoked the following warning from `oc new-app`:

    warning: --param no longer accepts comma-separated lists of values.

* `test/extended/router/unprivileged.go`:
* `test/extended/testdata/router/router-scoped.yaml`: Replace the `SCOPE` template parameter with `ROUTER_NAME` and `UPDATE_STATUS` parameters.
* `test/extended/testdata/router/router-override-domains.yaml`:
* `test/extended/testdata/router/router-override.yaml`: Delete the `SCOPE` parameter.
* `test/extended/testdata/bindata.go`: Regenerate.


#### `test/extended/router`: Enable metrics, fix readiness

Fix the router template test fixtures that use the router's `/healthz/ready` endpoint for their readiness probes to enable HAProxy metrics, which are required for the endpoint to return OK.

Without HAProxy metrics enabled, the router pods that tests created using these fixtures never became ready.

Follow-up to https://github.com/openshift/origin/pull/21592.

* `test/extended/testdata/router/router-override-domains.yaml`:
* `test/extended/testdata/router/router-override.yaml`:
* `test/extended/testdata/router/router-scoped.yaml`: Enable HAProxy metrics.
* `test/extended/testdata/bindata.go`: Regenerate.


