### PR TITLE
test/extended/prometheus: revert #23605

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -207,7 +207,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			tests := map[string][]metricTest{
 				// should be checking there is no more than 1 alerts firing.
 				// Checking for specific alert is done in "should have a Watchdog alert in firing state".
-				`sum(ALERTS{alertstate="firing"})`: {metricTest{greaterThanEqual: false, value: 4}},
+				`sum(ALERTS{alertstate="firing"})`: {metricTest{greaterThanEqual: false, value: 2}},
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})


### PR DESCRIPTION
https://github.com/openshift/cluster-monitoring-operator/pull/390 is merged and we can revert #23605 as it is no longer needed.

/cc @s-urbaniak 