### PR TITLE
update build-local-images, use 3.11 tag (more stable)

### DIFF
--- a/hack/build-local-images.py
+++ b/hack/build-local-images.py
@@ -58,7 +58,7 @@ image_namespace, _, image_prefix = os_image_prefix.rpartition("/")
 # with no arguments
 image_config = {
     "cli": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "cli",
         "binaries": {
             "oc": "/usr/bin/oc",
@@ -66,7 +66,7 @@ image_config = {
         "files": {}
     },
     "control-plane": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "origin",
         "binaries": {
             "openshift": "/usr/bin/openshift",
@@ -75,7 +75,7 @@ image_config = {
         "files": {}
     },
     "hyperkube": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "hyperkube",
         "binaries": {
             "hyperkube": "/usr/bin/hyperkube",
@@ -83,7 +83,7 @@ image_config = {
         "files": {}
     },
     "hypershift": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "hypershift",
         "binaries": {
             "hypershift": "/usr/bin/hypershift",
@@ -91,7 +91,7 @@ image_config = {
         "files": {}
     },
     "deployer": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "deployer",
         "binaries": {
             "openshift-deploy": "/usr/bin/openshift-deploy",
@@ -100,7 +100,7 @@ image_config = {
         "files": {}
     },
     "recycler": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "recycler",
         "binaries": {
             "oc": "/usr/bin/oc"
@@ -108,7 +108,7 @@ image_config = {
         "files": {}
     },
     "docker-builder": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "builder/docker/docker-builder",
         "binaries": {
             "oc": "/usr/bin/oc"
@@ -116,7 +116,7 @@ image_config = {
         "files": {}
     },
     "f5-router": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "router/f5",
         "binaries": {
             "oc": "/usr/bin/oc"
@@ -124,7 +124,7 @@ image_config = {
         "files": {}
     },
     "haproxy-router": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "router/haproxy",
         "binaries": {
             "openshift": "/usr/bin/openshift"
@@ -134,7 +134,7 @@ image_config = {
         }
     },
     "keepalived-ipfailover": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "ipfailover/keepalived",
         "binaries": {
             "openshift": "/usr/bin/openshift"
@@ -144,7 +144,7 @@ image_config = {
         }
     },
     "node": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "node",
         "binaries": {
             "openshift": "/usr/bin/openshift",
@@ -154,7 +154,7 @@ image_config = {
         "files": {}
     },
     "template-service-broker": {
-        "tag": "latest",
+        "tag": "v3.11",
         "directory": "template-service-broker",
         "binaries": {
             "template-service-broker": "/usr/bin/template-service-broker"


### PR DESCRIPTION
/assign @bparees 

@openshift/openshift-team-developer-experience fyi

I found in my attempts to inject development versions of things like the openshift/origin-hypershift image, it was better to inject my locally built binaries into the image with the v3.11 tag that `oc cluster up` wants to pull down by default.

the latest and v3.11 tags at docker.io are not the same image ... just pulled them down a second ago:

```
gmontero ~/go/src/github.com/openshift/origin  (upd-build-local-images-311)$ docker images 
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
openshift/origin-hypershift   v3.11               9b50ed8c6a93        2 days ago          550MB
openshift/origin-hypershift   latest              020d15eb71bb        4 months ago        458MB
gmontero ~/go/src/github.com/openshift/origin  (upd-build-local-images-311)$ 
```