### PR TITLE
Bug 1741039: Add ability to read pods to storage-admin users.

### DIFF
--- a/pkg/cmd/server/bootstrappolicy/policy.go
+++ b/pkg/cmd/server/bootstrappolicy/policy.go
@@ -265,6 +265,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule(readWrite...).Groups(kapiGroup).Resources("persistentvolumes").RuleOrDie(),
 				rbacv1helpers.NewRule(readWrite...).Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("persistentvolumeclaims", "events").RuleOrDie(),
+				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("pods").RuleOrDie(),
 			},
 		},
 		{

--- a/test/cmd/policy-storage-admin.sh
+++ b/test/cmd/policy-storage-admin.sh
@@ -21,14 +21,14 @@ os::cmd::expect_failure 'oc whoami --as=cluster-admin'
 # Test storage-admin can not do normal project scoped tasks
 os::cmd::expect_success_and_text 'oc policy can-i create pods --all-namespaces' 'no'
 os::cmd::expect_success_and_text 'oc policy can-i create projects' 'no'
-os::cmd::expect_success_and_text 'oc policy can-i get pods --all-namespaces' 'no'
 os::cmd::expect_success_and_text 'oc policy can-i create pvc' 'no'
 
-# Test storage-admin can read pvc and create pv and storageclass
+# Test storage-admin can read pvc and pods, and create pv and storageclass
 os::cmd::expect_success_and_text 'oc policy can-i get pvc --all-namespaces' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i get storageclass' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i create pv' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i create storageclass' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i get pods --all-namespaces' 'yes'
 
 # Test failure to change policy on users for storage-admin
 os::cmd::expect_failure_and_text 'oc policy add-role-to-user admin storage-adm' ' cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io"'

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -529,6 +529,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_policy_file.yaml
@@ -529,6 +529,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
Add ability to read pods to storage-admin users. This addresses [BZ-1741039](https://bugzilla.redhat.com/show_bug.cgi?id=1741039) for 4.1.

Note that this was addressed for 4.2 in the openshift-apiserver with https://github.com/openshift/openshift-apiserver/pull/10 .