### PR TITLE
Bug 1741679: Bump cadvisor [3.11.z]

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 09d39ff0f4b05d9abeade5e9636d3a33eba4227e618e282deb39768a7dcdda80
-updated: 2019-08-16T13:39:21.306271868-05:00
+hash: 9409c48ec721d1a3a1a6336845d10efe49bbf0dfe5e363e5d95b8b657beaefc3
+updated: 2019-08-16T14:35:45.701339235-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -515,7 +515,7 @@ imports:
 - name: github.com/google/btree
   version: 20236160a414454a9c64b6c8829381c6f4bddcaa
 - name: github.com/google/cadvisor
-  version: e7bafcb870aceaff6ae15189520febdede52b50f
+  version: 087e94f7f4d628ac57e427d292607984dde59041
   repo: https://github.com/openshift/google-cadvisor.git
   subpackages:
   - accelerators

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fbd25b5deb27fc4a1a6983f6a4d763cdf5153fceffe72c16b9bc90e6e4e8dd
-updated: 2019-07-21T11:15:49.781134265+02:00
+hash: 09d39ff0f4b05d9abeade5e9636d3a33eba4227e618e282deb39768a7dcdda80
+updated: 2019-08-16T13:39:21.306271868-05:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -21,6 +21,7 @@ imports:
   - negotiate
 - name: github.com/apcera/gssapi
   version: 5fb4217df13b8e6878046fe1e5c10e560e1b86dc
+  repo: https://github.com/openshift/gssapi.git
 - name: github.com/armon/circbuf
   version: bbbad097214e2918d8543d5201d12bfd7bca254d
 - name: github.com/asaskevich/govalidator
@@ -67,7 +68,7 @@ imports:
 - name: github.com/Azure/azure-sdk-for-go
   version: 8c6dfb65cae4368cc3242549023a616e42fcb702
   subpackages:
-  - services/compute/mgmt/2017-12-01/compute
+  - services/compute/mgmt/2019-03-01/compute
   - services/containerregistry/mgmt/2017-10-01/containerregistry
   - services/network/mgmt/2017-09-01/network
   - services/storage/mgmt/2017-10-01/storage
@@ -512,7 +513,7 @@ imports:
   subpackages:
   - mat64
 - name: github.com/google/btree
-  version: bfb38958ad2298964492841280eea188b9c23e7b
+  version: 20236160a414454a9c64b6c8829381c6f4bddcaa
 - name: github.com/google/cadvisor
   version: e7bafcb870aceaff6ae15189520febdede52b50f
   repo: https://github.com/openshift/google-cadvisor.git
@@ -973,7 +974,7 @@ imports:
   - user/informers/externalversions/user/v1
   - user/listers/user/v1
 - name: github.com/openshift/imagebuilder
-  version: c0887bd82bb30c80ad4a0fd19a22b2520a8223c6
+  version: 88ea7f56be8b37593900daf982db5cde64f62221
   subpackages:
   - dockerclient
   - imageprogress
@@ -1438,7 +1439,7 @@ imports:
   - pkg/registry/customresourcedefinition
   - test/integration/testserver
 - name: k8s.io/apimachinery
-  version: 5f1ab6ad9104144e43c7e477938fd278ade27eb2
+  version: 5c0e7e0ce91a8083e170765a544def530b8ee4f0
   repo: https://github.com/openshift/kubernetes-apimachinery.git
   subpackages:
   - pkg/api/equality
@@ -1506,7 +1507,7 @@ imports:
   - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/apiserver
-  version: 996cefeb14170756dc1626dde64fcfb63c8edb24
+  version: 6eafd6a7ccfb33517f1d852155d8862d8b5d3e93
   repo: https://github.com/openshift/kubernetes-apiserver.git
   subpackages:
   - pkg/admission
@@ -1619,7 +1620,7 @@ imports:
   - plugin/pkg/authenticator/token/webhook
   - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
-  version: 7eaf7133bcfa11e19ebbbc76ff53e2cb32524683
+  version: 9feea9d4142fd23f46451ef4292787b85e2e0a52
   repo: https://github.com/openshift/kubernetes-client-go.git
   subpackages:
   - discovery
@@ -1861,7 +1862,7 @@ imports:
   - pkg/util/proto/testing
   - pkg/util/proto/validation
 - name: k8s.io/kubernetes
-  version: d8b46d72a413981e6ea99605dcef3b8ca3f2223f
+  version: 58be19a7e8bc2e29eef4936c8f6dedbcaa0d0388
   repo: https://github.com/openshift/kubernetes.git
   subpackages:
   - cmd/controller-manager/app

--- a/glide.yaml
+++ b/glide.yaml
@@ -75,7 +75,7 @@ import:
 # origin-3.11-cadvisor-v0.30.1
 - package: github.com/google/cadvisor
   repo:    https://github.com/openshift/google-cadvisor.git
-  version: e7bafcb870aceaff6ae15189520febdede52b50f
+  version: 087e94f7f4d628ac57e427d292607984dde59041
 # cli
 - package: github.com/docker/distribution
   repo:    https://github.com/openshift/docker-distribution.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -160,6 +160,7 @@ import:
   version: a3acf13e802c358d65f249324d14ed24aac11370
 # auth (for oc kerberos on linux + mac)
 - package: github.com/apcera/gssapi
+  repo:    https://github.com/openshift/gssapi.git
   version: release-2.6.3
 # auth (for oc kerberos on windows)
 - package: github.com/alexbrainman/sspi

--- a/vendor/github.com/evanphx/json-patch/patch_test.go
+++ b/vendor/github.com/evanphx/json-patch/patch_test.go
@@ -127,11 +127,6 @@ var Cases = []Case{
 		`{ "foo": [ "all", "cows", "grass", "eat" ] }`,
 	},
 	{
-		`{ "foo": [ "a", "b", "c", "d", "e" ] }`,
-		`[ { "op": "move", "from": "/foo/1", "path": "/foo/2" } ]`,
-		`{ "foo": [ "a", "c", "b", "d", "e" ] }`,
-	},
-	{
 		`{ "foo": "bar" }`,
 		`[ { "op": "add", "path": "/child", "value": { "grandchild": { } } } ]`,
 		`{ "foo": "bar", "child": { "grandchild": { } } }`,

--- a/vendor/github.com/google/btree/go.mod
+++ b/vendor/github.com/google/btree/go.mod
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 module github.com/google/btree
 
 go 1.12

--- a/vendor/github.com/google/cadvisor/container/crio/client.go
+++ b/vendor/github.com/google/cadvisor/container/crio/client.go
@@ -122,6 +122,13 @@ func (c *crioClientImpl) ContainerInfo(id string) (*ContainerInfo, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	// golang's http.Do doesn't return an error if non 200 response code is returned
+	// handle this case here, rather than failing to decode the body
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Error finding container %s: Status %d returned error %s", id, resp.StatusCode, resp.Body)
+	}
+
 	cInfo := ContainerInfo{}
 	if err := json.NewDecoder(resp.Body).Decode(&cInfo); err != nil {
 		return nil, err

--- a/vendor/github.com/google/cadvisor/container/crio/handler.go
+++ b/vendor/github.com/google/cadvisor/container/crio/handler.go
@@ -33,6 +33,9 @@ import (
 )
 
 type crioContainerHandler struct {
+	client crioClient
+	name   string
+
 	machineInfoFactory info.MachineInfoFactory
 
 	// Absolute path to the cgroup hierarchies of this container.
@@ -68,6 +71,9 @@ type crioContainerHandler struct {
 	reference info.ContainerReference
 
 	libcontainerHandler *containerlibcontainer.Handler
+	cgroupManager       *cgroupfs.Manager
+	rootFs              string
+	pidKnown            bool
 }
 
 var _ container.ContainerHandler = &crioContainerHandler{}
@@ -106,10 +112,19 @@ func newCrioContainerHandler(
 	}
 
 	id := ContainerNameToCrioId(name)
+	pidKnown := true
 
 	cInfo, err := client.ContainerInfo(id)
 	if err != nil {
 		return nil, err
+	}
+	if cInfo.Pid == 0 {
+		// If pid is not known yet, network related stats can not be retrieved by the
+		// libcontainer handler GetStats().  In this case, the crio handler GetStats()
+		// will reattempt to get the pid and, if now known, will construct the libcontainer
+		// handler.  This libcontainer handler is then cached and reused without additional
+		// calls to crio.
+		pidKnown = false
 	}
 
 	// passed to fs handler below ...
@@ -145,6 +160,8 @@ func newCrioContainerHandler(
 
 	// TODO: extract object mother method
 	handler := &crioContainerHandler{
+		client:              client,
+		name:                name,
 		machineInfoFactory:  machineInfoFactory,
 		cgroupPaths:         cgroupPaths,
 		storageDriver:       storageDriver,
@@ -155,6 +172,9 @@ func newCrioContainerHandler(
 		ignoreMetrics:       ignoreMetrics,
 		reference:           containerReference,
 		libcontainerHandler: libcontainerHandler,
+		cgroupManager:       cgroupManager,
+		rootFs:              rootFs,
+		pidKnown:            pidKnown,
 	}
 
 	handler.image = cInfo.Image
@@ -266,8 +286,27 @@ func (self *crioContainerHandler) getFsStats(stats *info.ContainerStats) error {
 	return nil
 }
 
+func (self *crioContainerHandler) getLibcontainerHandler() *containerlibcontainer.Handler {
+	if self.pidKnown {
+		return self.libcontainerHandler
+	}
+
+	id := ContainerNameToCrioId(self.name)
+
+	cInfo, err := self.client.ContainerInfo(id)
+	if err != nil || cInfo.Pid == 0 {
+		return self.libcontainerHandler
+	}
+
+	self.pidKnown = true
+	self.libcontainerHandler = containerlibcontainer.NewHandler(self.cgroupManager, self.rootFs, cInfo.Pid, self.ignoreMetrics)
+
+	return self.libcontainerHandler
+}
+
 func (self *crioContainerHandler) GetStats() (*info.ContainerStats, error) {
-	stats, err := self.libcontainerHandler.GetStats()
+	libcontainerHandler := self.getLibcontainerHandler()
+	stats, err := libcontainerHandler.GetStats()
 	if err != nil {
 		return stats, err
 	}

--- a/vendor/github.com/openshift/imagebuilder/OWNERS
+++ b/vendor/github.com/openshift/imagebuilder/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- TomSweeneyRedHat
+- mrunalp
+- nalind
+- rhatdan
+- smarterclayton

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive.go
@@ -357,6 +357,9 @@ func newArchiveMapper(src, dst string, excludes []string, resetOwners bool, chec
 			prefix = path.Base(archiveRoot)
 		}
 	}
+	if !strings.HasSuffix(archiveRoot, "/") {
+		archiveRoot += "/"
+	}
 
 	mapperFn := archivePathMapper(srcPattern, dst, isDestDir)
 

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/archive_test.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -449,8 +450,8 @@ func Test_archiveFromContainer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if path != testCase.path {
-				t.Errorf("unexpected path: %s", path)
+			if filepath.Clean(path) != testCase.path {
+				t.Errorf("unexpected path: %s != %s", filepath.Clean(path), testCase.path)
 			}
 			tr := tar.NewReader(r)
 			var found []string

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/conformance_test.go
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/conformance_test.go
@@ -111,6 +111,8 @@ func TestCopyFrom(t *testing.T) {
 		{name: "copy file to deeper directory with explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c/", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
 		{name: "copy file to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to deeper directory without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "/a /a/b/c", expect: "ls -al /a/b/c/1 && ! ls -al /a/b/1"},
+		{name: "copy item from directory that is a symbolic link", create: "mkdir -p /a && touch /a/1 && ln -s /a /b", copy: "b/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
+		{name: "copy item from directory that is a symbolic link", create: "mkdir -p /a && touch /a/1 && ln -s a /c", copy: "/c/1 /a/b/c", expect: "ls -al /a/b/c && ! ls -al /a/b/1"},
 		{name: "copy directory to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 		{name: "copy directory trailing to root without explicit slash", create: "mkdir -p /a && touch /a/1", copy: "a/. /a", expect: "ls -al /a/1 && ! ls -al /a/a"},
 	}

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_11
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_11
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+RUN ln -s /a /b
+FROM busybox
+COPY --from=base /b/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_12
+++ b/vendor/github.com/openshift/imagebuilder/dockerclient/testdata/Dockerfile.copyfrom_12
@@ -1,0 +1,6 @@
+FROM busybox as base
+RUN mkdir -p /a && touch /a/1
+RUN ln -s a /c
+FROM busybox
+COPY --from=base /c/1 /a/b/c
+RUN ls -al /a/b/c && ! ls -al /a/b/1

--- a/vendor/github.com/vmware/photon-controller-go-sdk/photon/client.go
+++ b/vendor/github.com/vmware/photon-controller-go-sdk/photon/client.go
@@ -142,8 +142,8 @@ func NewClient(endpoint string, options *ClientOptions, logger *log.Logger) (c *
 	}
 
 	restClient := &restClient{
-		httpClient: &http.Client{Transport: tr},
-		logger:     logger,
+		httpClient:                &http.Client{Transport: tr},
+		logger:                    logger,
 		UpdateAccessTokenCallback: tokenCallback,
 	}
 

--- a/vendor/github.com/vmware/photon-controller-go-sdk/photon/deployments_test.go
+++ b/vendor/github.com/vmware/photon-controller-go-sdk/photon/deployments_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Deployment", func() {
 		deploymentSpec = &DeploymentCreateSpec{
 			ImageDatastores:         []string{randomString(10, "go-sdk-deployment-")},
 			UseImageDatastoreForVms: true,
-			Auth: &AuthInfo{},
+			Auth:                    &AuthInfo{},
 		}
 	})
 
@@ -59,8 +59,8 @@ var _ = Describe("Deployment", func() {
 			mockDeployment := Deployment{
 				ImageDatastores:         deploymentSpec.ImageDatastores,
 				UseImageDatastoreForVms: deploymentSpec.UseImageDatastoreForVms,
-				Auth:                 &AuthInfo{},
-				NetworkConfiguration: &NetworkConfiguration{Enabled: false},
+				Auth:                    &AuthInfo{},
+				NetworkConfiguration:    &NetworkConfiguration{Enabled: false},
 			}
 			server.SetResponseJson(200, mockDeployment)
 			deployment, err := client.Deployments.Get(task.Entity.ID)

--- a/vendor/github.com/vmware/photon-controller-go-sdk/photon/lightwave/oidcclient_test.go
+++ b/vendor/github.com/vmware/photon-controller-go-sdk/photon/lightwave/oidcclient_test.go
@@ -66,7 +66,7 @@ var _ = Describe("OIDCClient", func() {
 			Context("when server responds with valid certificate", func() {
 				BeforeEach(func() {
 					template := &x509.Certificate{
-						IsCA: true,
+						IsCA:                  true,
 						BasicConstraintsValid: true,
 						SubjectKeyId:          []byte{1, 2, 3},
 						SerialNumber:          big.NewInt(1234),


### PR DESCRIPTION
master PR https://github.com/openshift/origin/pull/23585
4.1.z PR https://github.com/openshift/origin/pull/23619

pull in https://github.com/openshift/google-cadvisor/pull/7

The delta is larger because a `make update-deps` on a clean `origin/master` makes a lot of changes and the `github.com/apcera/gssapi` dep needed to be redirected to the openshift fork because that repo doesn't exist anymore.  I've split up the bump(*) on the clean master into a separate commit.

Fixes #23492

@derekwaynecarr @deads2k @mfojtik 