### PR TITLE
test/extended/.../policy-storage-admin.sh: Fix pods test

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -33398,14 +33398,14 @@ os::cmd::expect_success_and_text 'oc policy who-can impersonate storage-admin' '
 # Test storage-admin can not do normal project scoped tasks
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create pods --all-namespaces' 'no'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create projects' 'no'
-os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get pods --all-namespaces' 'no'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create pvc' 'no'
 
-# Test storage-admin can read pvc and create pv and storageclass
+# Test storage-admin can read pvc and pods, and create pv and storageclass
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get pvc --all-namespaces' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get storageclass' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create pv' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create storageclass' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get pods --all-namespaces' 'yes'
 
 # Test failure to change policy on users for storage-admin
 os::cmd::expect_failure_and_text 'oc policy --as=storage-adm add-role-to-user admin storage-adm' ' cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io"'

--- a/test/extended/testdata/cmd/test/cmd/policy-storage-admin.sh
+++ b/test/extended/testdata/cmd/test/cmd/policy-storage-admin.sh
@@ -21,14 +21,14 @@ os::cmd::expect_success_and_text 'oc policy who-can impersonate storage-admin' '
 # Test storage-admin can not do normal project scoped tasks
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create pods --all-namespaces' 'no'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create projects' 'no'
-os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get pods --all-namespaces' 'no'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create pvc' 'no'
 
-# Test storage-admin can read pvc and create pv and storageclass
+# Test storage-admin can read pvc and pods, and create pv and storageclass
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get pvc --all-namespaces' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get storageclass' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create pv' 'yes'
 os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm create storageclass' 'yes'
+os::cmd::expect_success_and_text 'oc policy can-i --as=storage-adm get pods --all-namespaces' 'yes'
 
 # Test failure to change policy on users for storage-admin
 os::cmd::expect_failure_and_text 'oc policy --as=storage-adm add-role-to-user admin storage-adm' ' cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io"'


### PR DESCRIPTION
#### `test/extended/.../policy-storage-admin.sh`: Fix pods

Fix `cmd/policy-storage-admin` tests to verify that a user with the storage-admin role *can* get pods in all namespaces.

See https://github.com/openshift/openshift-apiserver/pull/10.

* `test/extended/testdata/cmd/test/cmd/policy-storage-admin.sh`: Replace an old test that verified that a user with the storage-admin role could *not* get pods in all namespaces with a test that verifies that the *can* get pods in all namespaces.
* `test/extended/testdata/bindata.go`: Regenerate.

