### PR TITLE
Bug: 1745776: UPSTREAM: 79529: change default timeout value in csi plugin

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
+++ b/vendor/k8s.io/kubernetes/pkg/volume/csi/csi_plugin.go
@@ -56,7 +56,7 @@ const (
 	// TODO (vladimirvivien) would be nice to name socket with a .sock extension
 	// for consistency.
 	csiAddrTemplate = "/var/lib/kubelet/plugins/%v/csi.sock"
-	csiTimeout      = 15 * time.Second
+	csiTimeout      = 2 * time.Minute
 	volNameSep      = "^"
 	volDataFileName = "vol_data.json"
 	fsTypeBlockName = "block"


### PR DESCRIPTION
In case of short timeout (15s), some CSI plugins like RBD can bahave
weird. That said, if timeout occurs RBD plugin try an unmap and do other cleanup/rollback operations. In most
of the cases, it is just that, its taking more than 15s when there are
parellel requests  to serve and map. If the timeout is high, most of the
mapping operations will succeed and it will not cause any rollback
operation/cleanup in the system which avoid other issues.

Fix#  https://bugzilla.redhat.com/show_bug.cgi?id=1745776
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>