### PR TITLE
Bug 1737134: [Feature:Machines][Serial] Managed cluster should: get machineset role from template labels

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -43,8 +43,8 @@ func listWorkerMachineSets(dc dynamic.Interface) ([]objx.Map, error) {
 	}
 	machineSets := []objx.Map{}
 	for _, ms := range objects(objx.Map(obj.UnstructuredContent()).Get("items")) {
-		e2e.Logf("Labels %v", ms.Get("spec.selector.matchLabels"))
-		labels := (*ms.Get("spec.selector.matchLabels")).Data().(map[string]interface{})
+		e2e.Logf("Labels %v", ms.Get("spec.template.metadata.labels"))
+		labels := (*ms.Get("spec.template.metadata.labels")).Data().(map[string]interface{})
 		if val, ok := labels[machineLabelRole]; ok {
 			if val == "worker" {
 				machineSets = append(machineSets, ms)


### PR DESCRIPTION
Machineset matching labels do not guarantee they will contain any specific label.
Though, given we label templated machines with machine.openshift.io/cluster-api-machine-role,
it's sufficient replacement for now.