### PR TITLE
e2e: test ingress controller prometheus integration

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -12,20 +12,26 @@ import (
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
+
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 
 	v1 "k8s.io/api/core/v1"
+
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	clientset "k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
+
 	kapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
 )
 
 const waitForPrometheusStartSeconds = 240
@@ -221,6 +227,66 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				`mapi_machine_set_status_replicas`: {metricTest{greaterThanEqual: true, value: 1}},
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
+		})
+		g.It("should provide ingress metrics", func() {
+			oc.SetupProject()
+			ns := oc.Namespace()
+
+			execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })
+			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
+
+			g.By("creating a non-default ingresscontroller")
+			replicas := int32(1)
+			ingress := &operatorv1.IngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "openshift-ingress-operator",
+					Name:      "prometheus",
+				},
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   "prometheus.e2e.openshift.example.com",
+					Replicas: &replicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.PrivateStrategyType,
+					},
+					RouteSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"e2e-test": ns,
+						},
+					},
+				},
+			}
+			_, err := oc.AdminOperatorClient().OperatorV1().IngressControllers(ingress.Namespace).Create(ingress)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			defer func() {
+				if err := oc.AdminOperatorClient().OperatorV1().IngressControllers(ingress.Namespace).Delete(ingress.Name, metav1.NewDeleteOptions(1)); err != nil {
+					e2e.Logf("WARNING: failed to delete ingresscontroller '%s/%s' created during test cleanup: %v", ingress.Namespace, ingress.Name, err)
+				} else {
+					e2e.Logf("deleted test ingresscontroller '%s/%s'", ingress.Namespace, ingress.Name)
+				}
+			}()
+
+			var lastErrs []error
+			o.Expect(wait.PollImmediate(10*time.Second, 4*time.Minute, func() (bool, error) {
+				contents, err := getBearerTokenURLViaPod(ns, execPodName, fmt.Sprintf("%s/api/v1/targets", url), bearerToken)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				targets := &prometheusTargets{}
+				err = json.Unmarshal([]byte(contents), targets)
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				g.By("verifying all expected jobs have a working target")
+				lastErrs = all(
+					// Is there a good way to discover the name and thereby avoid leaking the naming algorithm?
+					targets.Expect(labels{"job": "router-internal-default"}, "up", "^https://.*/metrics$"),
+					targets.Expect(labels{"job": "router-internal-prometheus"}, "up", "^https://.*/metrics$"),
+				)
+				if len(lastErrs) > 0 {
+					e2e.Logf("missing some targets: %v", lastErrs)
+					return false, nil
+				}
+				return true, nil
+			})).NotTo(o.HaveOccurred())
 		})
 	})
 })

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -287,6 +287,15 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				}
 				return true, nil
 			})).NotTo(o.HaveOccurred())
+
+			g.By("verifying standard metrics keys")
+			queries := map[string][]metricTest{
+				`template_router_reload_seconds_count{job="router-internal-default"}`:    {metricTest{greaterThanEqual: true, value: 1}},
+				`haproxy_server_up{job="router-internal-default"}`:                       {metricTest{greaterThanEqual: true, value: 1}},
+				`template_router_reload_seconds_count{job="router-internal-prometheus"}`: {metricTest{greaterThanEqual: true, value: 1}},
+				`haproxy_server_up{job="router-internal-prometheus"}`:                    {metricTest{greaterThanEqual: true, value: 1}},
+			}
+			runQueries(queries, oc, ns, execPodName, url, bearerToken)
 		})
 	})
 })


### PR DESCRIPTION
Add an e2e test which ensures that ingress controllers are successfully scraped
by Prometheus. Cover the default ingresscontroller and a non-default instance.

cc @smarterclayton @openshift/sig-network-edge 