### PR TITLE
test/extended/router: Fix namespace for DumpPodLogs

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -80,7 +80,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 
 	g.AfterEach(func() {
 		if g.CurrentGinkgoTestDescription().Failed {
-			exutil.DumpPodLogsStartingWithInNamespace("router", "default", oc.AsAdmin())
+			exutil.DumpPodLogsStartingWithInNamespace("router", "openshift-ingress", oc.AsAdmin())
 		}
 	})
 

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 			if routes, _ := client.List(metav1.ListOptions{}); routes != nil {
 				outputIngress(routes.Items...)
 			}
-			exutil.DumpPodLogsStartingWithInNamespace("router", "default", oc.AsAdmin())
+			exutil.DumpPodLogsStartingWithInNamespace("router", "openshift-ingress", oc.AsAdmin())
 		}
 	})
 


### PR DESCRIPTION
Specify the correct namespace to `DumpPodLogsStartingWithInNamespace`.

In OpenShift v3, the installer creates the default router in the `default` namespace, but in OpenShift v4, the ingress operator creates routers in the `openshift-ingress` namespace.

* `test/extended/router/metrics.go`:
* `test/extended/router/reencrypt.go`: Change the namespace argument for `DumpPodLogsStartingWithInNamespace` from `default` to `openshift-ingress`.