### PR TITLE
Bug 1743881: Use dns go bindings instead of dig command for dns resolution in egress networkpolicies

### DIFF
--- a/pkg/network/common/egress_dns.go
+++ b/pkg/network/common/egress_dns.go
@@ -9,6 +9,7 @@ import (
 
 	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kexec "k8s.io/utils/exec"
 )
 
 type EgressDNSUpdate struct {
@@ -41,7 +42,7 @@ func NewEgressDNS() *EgressDNS {
 }
 
 func (e *EgressDNS) Add(policy networkapi.EgressNetworkPolicy) {
-	dnsInfo, err := NewDNS("/etc/resolv.conf")
+	dnsInfo, err := NewDNS(kexec.New(), "/etc/resolv.conf")
 	if err != nil {
 		utilruntime.HandleError(err)
 	}


### PR DESCRIPTION
Use dns go bindings instead of dig command for dns resolution in egress networkpolicies

- Query all nameservers in /etc/resolv.conf to populate ovs rules for domain names in egress policy
  When the given domain is using DNS load balancing algorithm, depending on which nameserver it queries,
  we may get different IP addr.

This is a backport to 3.11 of https://github.com/openshift/sdn/commit/4c01b7ba5023a49e541fccdeb687df538e0d6f44 , however there were a few conflicts and it's not exactly the same.