### PR TITLE
Bug 1743927: Add sleep before starting a watch in project e2e test

### DIFF
--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -132,6 +132,9 @@ var _ = g.Describe("[Feature:ProjectAPI] ", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			waitForAdd(ns01Name, beginningWatch)
 
+			// Background: in HA we have no guarantee that watch caches are synchronized and this test already broke on Azure.
+			// Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1744105
+			time.Sleep(5 * time.Second)
 			fromNowWatch, err := bobProjectClient.Projects().Watch(metav1.ListOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			select {


### PR DESCRIPTION
This test breaks in HA clusters because there is no guarantee the watches will be synchronized.
The bug in title links to a flake found in Azure e2e tests already.

https://bugzilla.redhat.com/show_bug.cgi?id=1744105 is tracking conversion of this (and other) tests to openshift-apiserver unit tests (4.3).

/cc @deads2k 
/cc @sttts 