### PR TITLE
Bug 1734673: UPSTREAM: 81306: Scheduler should terminate on loosing leader lock

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/BUILD
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//pkg/version:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/filters:go_default_library",

--- a/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-scheduler/app/server.go
@@ -26,7 +26,6 @@ import (
 	goruntime "runtime"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
@@ -245,7 +244,7 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 				sched.Run()
 			},
 			OnStoppedLeading: func() {
-				utilruntime.HandleError(fmt.Errorf("lost master"))
+				klog.Fatalf("leaderelection lost")
 			},
 		}
 		leaderElector, err := leaderelection.NewLeaderElector(*cc.LeaderElection)


### PR DESCRIPTION
This is a backport of kubernetes PR that Ravi pointed out in https://bugzilla.redhat.com/show_bug.cgi?id=1734673#c17

/assign @damemi 