### PR TITLE
Bug 1711533: bootstrap-rbac-policy: prepare for non-anon discovery

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -78,6 +78,7 @@ var (
 
 		rbacv1helpers.NewRule("delete").Groups(oauthGroup, legacyOauthGroup).Resources("oauthaccesstokens", "oauthauthorizetokens").RuleOrDie(),
 
+		// this is openshift specific
 		rbacv1helpers.NewRule("get").URLs(
 			"/healthz/",
 			"/version/*",
@@ -86,19 +87,27 @@ var (
 			"/osapi", "/osapi/",
 			"/.well-known", "/.well-known/*",
 			"/",
+			"/version/openshift",
 			"/.well-known/oauth-authorization-server",
+			// TODO: remove when dropped from openshift-apiserver
+			"/openapi", "/openapi/*",
+			"/api", "/api/*",
+			"/apis", "/apis/*",
 		).RuleOrDie(),
 
+		// TODO: remove with after 1.15 rebase
 		rbacv1helpers.NewRule("get").URLs(
 			"/readyz",
 		).RuleOrDie(),
 
+		// this is from upstream kube
 		rbacv1helpers.NewRule("get").URLs(
 			"/healthz",
 			"/version",
 			"/openapi", "/openapi/*",
 			"/api", "/api/*",
 			"/apis", "/apis/*",
+			"/version/",
 		).RuleOrDie(),
 	}
 
@@ -118,6 +127,13 @@ var (
 			// These custom resources are used to extend console functionality
 			// The console team is working on eliminating this exception in the near future
 			rbacv1helpers.NewRule(read...).Groups(consoleGroup).Resources("consoleclidownloads", "consolelinks", "consoleexternalloglinks", "consolenotifications").RuleOrDie(),
+
+			// this is from upstream kube
+			rbacv1helpers.NewRule("get").URLs(
+				"/openapi", "/openapi/*",
+				"/api", "/api/*",
+				"/apis", "/apis/*",
+			).RuleOrDie(),
 		},
 		allUnauthenticatedRules...,
 	)

--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -86,6 +86,7 @@ var (
 			"/osapi", "/osapi/",
 			"/.well-known", "/.well-known/*",
 			"/",
+			"/.well-known/oauth-authorization-server",
 		).RuleOrDie(),
 
 		rbacv1helpers.NewRule("get").URLs(

--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -223,8 +223,12 @@ func testGroupRules(ruleResolver validation.AuthorizationRuleResolver, group, na
 	}
 
 	// force test data to be cleaned up every so often but allow extra rules to not deadlock new changes
-	if cover, missing := validation.Covers(actualRules, expectedRules); !cover && len(missing) > 12 {
-		e2e.Failf("test data for %s has too many unnecessary permissions:\n%s", group, rulesToString(missing))
+	if cover, missing := validation.Covers(actualRules, expectedRules); !cover {
+		log := e2e.Logf
+		if len(missing) > 100 {
+			log = e2e.Failf
+		}
+		log("test data for %s has too many unnecessary permissions:\n%s", group, rulesToString(missing))
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -207,10 +207,11 @@ func clusterRoles() []rbacv1.ClusterRole {
 		},
 		{
 			// a role which provides unauthenticated access to /readyz.
-			// TODO: integrate into system:public-info-viewer (new in 1.14) when upstreaming
 			ObjectMeta: metav1.ObjectMeta{Name: "system:openshift:public-info-viewer"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
+					"/.well-known", "/.well-known/*",
+					// TODO: drop with 1.15 rebase
 					"/readyz",
 				).RuleOrDie(),
 			},

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1123,6 +1123,8 @@ items:
     name: system:openshift:public-info-viewer
   rules:
   - nonResourceURLs:
+    - /.well-known
+    - /.well-known/*
     - /readyz
     verbs:
     - get


### PR DESCRIPTION
Preparation for https://bugzilla.redhat.com/show_bug.cgi?id=1711533.

This PR:
- moves the `.well-known` non-resource RBAC path to kube-apiserver. This is a preparation for pruning of the openshift-apiserver provided non-resource rules, in order to inherit upstream's discovery and status authentication behaviour (now openshift-apiserver adds additional RBAC rules to allow discovery and status for unauthenticated access).
- prepares the `groups_default_rules.go` test for remove anon discovery and status in openshift-apiserver.