### PR TITLE
Don't test openshift-sdn-specific things in the CLI e2e tests

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -93,8 +93,6 @@ var (
 		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "machineconfigs"},
 		// {Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "mcoconfigs"},
 
-		{Group: "network.openshift.io", Version: "v1", Resource: "egressnetworkpolicies"},
-
 		{Group: "operator.openshift.io", Version: "v1", Resource: "authentications"},
 		{Group: "operator.openshift.io", Version: "v1", Resource: "consoles"},
 		{Group: "operator.openshift.io", Version: "v1", Resource: "dnses"},
@@ -226,21 +224,6 @@ var (
 			gv:      schema.GroupVersion{Group: "user.openshift.io", Version: "v1"},
 			field:   "users.fullName",
 			pattern: `FIELD\: +fullName`,
-		},
-		{
-			gv:      schema.GroupVersion{Group: "network.openshift.io", Version: "v1"},
-			field:   "clusternetworks.network",
-			pattern: `FIELD\: +network`,
-		},
-		{
-			gv:      schema.GroupVersion{Group: "network.openshift.io", Version: "v1"},
-			field:   "hostsubnets.subnet",
-			pattern: `FIELD\: +subnet`,
-		},
-		{
-			gv:      schema.GroupVersion{Group: "network.openshift.io", Version: "v1"},
-			field:   "netnamespaces.netname",
-			pattern: `FIELD\: +netname`,
 		},
 	}
 )


### PR DESCRIPTION
The tests

    [cli] oc explain should contain proper fields description for special types [Suite:openshift/conformance/parallel]
    [cli] oc explain should contain proper spec+status for CRDs [Suite:openshift/conformance/parallel]

are broken in e2e-aws-ovn-kubernetes because they assume the existence of the old `network.openshift.io` types that (in 4.x) only exist when using openshift-sdn.

The tests should be unnecessary anyway; the network types are CRDs now, so the other CRD-based tests would catch problems affecting CRDs in general. But if anyone thinks it's important to keep them, we could split these out into a separate ginkgo test case and use the `InPluginContext` function from `test/extended/networking/util.go` (or something like it) to automatically skip that test under non-openshift-sdn plugins.