### PR TITLE
Don't always assume openshift-sdn in prometheus e2e tests

### DIFF
--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -457,3 +457,17 @@ func InPluginContext(plugins []string, body func()) {
 		},
 	)
 }
+
+func InOpenShiftSDNContext(body func()) {
+	Context("when using openshift-sdn",
+		func() {
+			BeforeEach(func() {
+				if networkPluginName() == "" {
+					e2e.Skipf("Not using openshift-sdn")
+				}
+			})
+
+			body()
+		},
+	)
+}


### PR DESCRIPTION
The tests

    [Feature:Prometheus][Conformance] Prometheus when installed on the cluster should be able to get the sdn ovs flows [Suite:openshift/conformance/parallel/minimal]
    [Feature:Prometheus][Conformance] Prometheus when installed on the cluster should start and expose a secured proxy and unsecured metrics [Suite:openshift/conformance/parallel/minimal]

are broken in e2e-aws-ovn-kubernetes because they assume the existence of openshift-sdn-specific metrics which won't exist when running other network plugins.

I've wrapped the "should be able to get the sdn ovs flows" test in a helper that will automatically skip it under other network plugins. (This is similar to what we have done in the past to skip multitenant-specific or NetworkPolicy-specific tests when using the other mode.)

For the sdn-specific part of the main "expose a secured proxy and unsecured metrics" test, I just removed the check for the sdn metrics. Presumably that was only included for completeness and it's not likely to fail if the rest of the test succeeds? If we do need to keep that it could be merged into the other sdn-specific test but I wasn't sure how much of the rest of that test would also need to be copied over?