### PR TITLE
test/extended/util: SetupProject: Fix cancel logic

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -229,7 +229,7 @@ func (c *CLI) SetupProject() {
 
 	var ctx context.Context
 	cancel := func() {}
-	defer cancel()
+	defer func() { cancel() }()
 	// Wait for default role bindings for those SAs
 	for _, name := range []string{"system:image-pullers", "system:image-builders", "system:deployers"} {
 		e2e.Logf("Waiting for RoleBinding %q to be provisioned...", name)


### PR DESCRIPTION
Fix the deferred call to the `cancel` function in `SetupProject`.

`SetupProject` has a deferred call to the function in the variable named `cancel`, which is initialized to a no-op function with the expectation that subsequent statements may assign another function to the variable.  However, because `defer` statements evaluate their expressions immediately, what is actually deferred is a call to the initial value of the `cancel` variable (i.e., the no-op function).  To defer a call to whatever is in the `cancel` variable when the deferred statement is executed, an anonymous function that calls the `cancel` function must be used, so that the variable is closed over at the point of the `defer` statement and only evaluated when the deferred statement is executed.

* `test/extended/util/client.go` (`SetupProject`): Replace deferred call to `cancel` with a deferred call to an anonymous function that calls `cancel`.