### PR TITLE
Add additional bit of information from pod status when it fails running

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1563,7 +1563,7 @@ func RunOneShotCommandPod(
 		}
 
 		if podHasErrored(cmdPod) {
-			return true, fmt.Errorf("the pod errored trying to run the command")
+			return true, fmt.Errorf("the pod errored trying to run the command: %#v", cmdPod.Status)
 		}
 		return podHasCompleted(cmdPod), nil
 	})


### PR DESCRIPTION
I've seen in the logs:
```
fail [github.com/openshift/origin/test/extended/cmd/cmd.go:117]: Expected
    <[]error | len:1, cap:1>: [
        {
            s: "error waiting for the pod 'test-cmd' to complete: the pod errored trying to run the command",
        },
    ]
to have length 0
```
several times, I'd like to know why it failed, so I'm adding pod status to that error. 
/assign @tnozicka 