### PR TITLE
Only check for tolerationSeconds on NoExecute tolerations

### DIFF
--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -49,7 +49,7 @@ var _ = Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 				continue
 			}
 			for _, toleration := range pod.Spec.Tolerations {
-				if toleration.Operator == v1.TolerationOpExists {
+				if toleration.Operator == v1.TolerationOpExists && toleration.Effect == v1.TaintEffectNoExecute {
 					if toleration.Key == "" {
 						invalidPodTolerations.Insert(fmt.Sprintf("%s/%s tolerates all taints", pod.Namespace, pod.Name))
 					}


### PR DESCRIPTION
The test `[Feature:Platform][Smoke] Managed cluster should ensure control plane operators do not make themselves unevictable` requires all `Exists` tolerations in non-whitelisted control plane pods to have a `tolerationSeconds` field. But it's mistakenly checking `NoSchedule` tolerations too, even though `NoSchedule` doesn't make you unevictable, and `tolerationSeconds` doesn't have any effect on `NoSchedule` tolerations anyway.

(This is currently breaking that test in e2e-aws-ovn-kubernetes:

    1 pods found with invalid tolerations:
    openshift-ovn-kubernetes/ovnkube-master-7b846b56b-76vs8 tolerates node.kubernetes.io/not-ready with no tolerationSeconds

but ovnkube-master has:

      tolerations:
      - key: "node-role.kubernetes.io/master"
        operator: "Exists"
        effect: "NoSchedule"
      - key: "node.kubernetes.io/not-ready"
        operator: "Exists"
        effect: "NoSchedule"

so it's not tolerating any `NoExecute` taints.)

/assign @sjenning 
