### PR TITLE
bug 1744908: [Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously: increase timeout for Azure

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -216,6 +216,8 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 			g.By(fmt.Sprintf("got %v nodes, expecting %v", len(nodeList.Items), initialNumberOfWorkers))
 			return len(nodeList.Items) == initialNumberOfWorkers
-		}, 2*time.Minute, 5*time.Second).Should(o.BeTrue())
+			// Azure actuator takes something over 3 minutes to delete a machine.
+			// Rounding to four minutes to accomodate for future new and slower cloud providers.
+		}, 4*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 })


### PR DESCRIPTION
```
I0823 05:57:02.704074       1 controller.go:205] Reconciling machine "ci-op-4inqf4cw-3a8ca-666zl-worker-centralus1-cz5td" triggers delete
I0823 06:00:14.863085       1 controller.go:239] Machine "ci-op-4inqf4cw-3a8ca-666zl-worker-centralus1-cz5td" deletion successful
```

The deletion on Azure just takes longer than on AWS. So even 2 minutes is not sufficient.