### PR TITLE
automate Marketplace case [OCP-21630]:[Marketplace] Default OperatorSources is installed and controled by CVO, [OCP-24411]:[Marketplace] MarketplaceOperator manage the default OperatorSources and [OCP-21921]:[Marketplace]Default resources of Marketplace operator

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"
 	_ "github.com/openshift/origin/test/extended/machines"
+	_ "github.com/openshift/origin/test/extended/marketplace"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/operators"

--- a/test/extended/marketplace/marketplace.go
+++ b/test/extended/marketplace/marketplace.go
@@ -1,0 +1,74 @@
+package marketplace
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Feature:Marketplace] Marketplace Default Sources", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLIWithoutNamespace("")
+
+	//[OCP-21921]:[Marketplace]Default resources of Marketplace operator
+	g.It("[ocp-21921]marketplace operators", func() {
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ns", "openshift-marketplace", "-o=jsonpath={.status.phase}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("Active"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "catalogsourceconfigs.operators.coreos.com", "-o=jsonpath={.status.acceptedNames.shortNames}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("csc"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "operatorsources.operators.coreos.com", "-o=jsonpath={.status.acceptedNames.shortNames}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("opsrc"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "sa").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterrole").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterrolebinding", "marketplace-operator", fmt.Sprintf("-o=jsonpath='{.subjects[?(@.kind==\"%s\")]}'", "ServiceAccount")).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("name:marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "deployment").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "catalogsource").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("certified-operators"))
+		o.Expect(msg).To(o.ContainSubstring("community-operators"))
+		o.Expect(msg).To(o.ContainSubstring("redhat-operators "))
+	})
+
+	//[OCP-21630]:[Marketplace] Default OperatorSources is installed and controled by CVO
+	//[OCP-24411]:[Marketplace] MarketplaceOperator manage the default OperatorSources
+	//author: chuo@redhat.com
+	g.It("[ocp-21630] OperatorSource installed and controled by CVO in 4.1 and [ocp-24411] by MarketplaceOperator in 4.2", func() {
+
+		var defaultOperatorSources = [3]string{"certified-operators", "community-operators", "redhat-operators"}
+		for _, opsrc := range defaultOperatorSources {
+			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "opsrc", opsrc, "-o=jsonpath={.status.currentPhase.phase.message}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(msg).To(o.Equal("The object has been successfully reconciled"))
+		}
+
+		err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("-n", "openshift-marketplace", "opsrc", "redhat-operators", "--type", "merge", "-p", `{"spec":{"registryNamespace":"wrong"}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		time.Sleep(180 * time.Second)
+
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "opsrc", "redhat-operators", "-o=jsonpath={.spec.registryNamespace}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("redhat-operators"))
+	})
+})


### PR DESCRIPTION
@aravindhp @kevinrizza @awgreene As title, please have a review. Thanks! cc: @emmajiafan @bandrade @scolange @dongboyan77 @zihantang-rh @jianzhangbjz @chengzhang1016
Log shows as below.
./openshift-tests run all --dry-run | grep "\[Feature:Marketplace\] Marketplace Default Sources" | ./openshift-tests run --junit-dir=./ -f -
started: (0/1/2) "[Feature:Marketplace] Marketplace Default Sources [ocp-21630] OperatorSource installed and controled by CVO in 4.1 and [ocp-24411] by MarketplaceOperator in 4.2 [Suite:openshift/conformance/parallel]"

started: (0/2/2) "[Feature:Marketplace] Marketplace Default Sources [ocp-21921]marketplace operators [Suite:openshift/conformance/parallel]"

passed: (15.7s) 2019-08-28T03:09:03 "[Feature:Marketplace] Marketplace Default Sources [ocp-21921]marketplace operators [Suite:openshift/conformance/parallel]"

passed: (3m12s) 2019-08-28T03:11:59 "[Feature:Marketplace] Marketplace Default Sources [ocp-21630] OperatorSource installed and controled by CVO in 4.1 and [ocp-24411] by MarketplaceOperator in 4.2 [Suite:openshift/conformance/parallel]"

Writing JUnit report to junit_e2e_20190828-031159.xml

2 pass, 0 skip (3m12s)
