### PR TITLE
bug 1744908: [Feature:Machines][Serial] Managed cluster should: increase timeout waiting for nodes to disappear

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -217,7 +217,9 @@ var _ = g.Describe("[Feature:Machines][Serial] Managed cluster should", func() {
 			g.By(fmt.Sprintf("got %v nodes, expecting %v", len(nodeList.Items), initialNumberOfWorkers))
 			return len(nodeList.Items) == initialNumberOfWorkers
 			// Azure actuator takes something over 3 minutes to delete a machine.
-			// Rounding to four minutes to accomodate for future new and slower cloud providers.
-		}, 4*time.Minute, 5*time.Second).Should(o.BeTrue())
+			// The worst observable case to delete a machine was 5m15s however.
+			// Also, there are two instances to be deleted.
+			// Rounding to 7 minutes to accomodate for future new and slower cloud providers.
+		}, 7*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 })


### PR DESCRIPTION
From test suite logs

```
Aug 28 05:55:02.613: INFO: Running AfterSuite actions on all nodes
```

From machine controller logs:

```
I0828 05:51:37.299415       1 controller.go:205] Reconciling machine "ci-op-1zzgtx6m-3a8ca-trcpx-worker-centralus3-fvmdx" triggers delete
I0828 05:52:39.091238       1 controller.go:302] drain successful for machine "ci-op-1zzgtx6m-3a8ca-trcpx-worker-centralus3-fvmdx"
I0828 05:55:41.244092       1 virtualmachines.go:242] successfully deleted vm ci-op-1zzgtx6m-3a8ca-trcpx-worker-centralus3-fvmdx
I0828 05:56:41.832275       1 disks.go:65] successfully deleted disk ci-op-1zzgtx6m-3a8ca-trcpx-worker-centralus3-fvmdx_OSDisk
I0828 05:56:52.253019       1 networkinterfaces.go:197] successfully deleted nic ci-op-1zzgtx6m-3a8ca-trcpx-worker-centralus3-fvmdx-nic
I0828 05:56:52.328967       1 controller.go:239] Machine "ci-op-1zzgtx6m-3a8ca-trcpx-worker-centralus3-fvmdx" deletion successful
```

The last node was deleted almost 2 minutes after the timeout. It took smth over 3 minutes to delete the vm resource in Azure. In total, 5m15s to delete the last machine.

So even 6 minutes timeout does not have to enough if two machines are requested to be deleted.