### PR TITLE
automate [OLM] [ocp-25148]:OLM aggregates CR roles to standard admin/view/edit

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/jobs"
 	_ "github.com/openshift/origin/test/extended/localquota"
 	_ "github.com/openshift/origin/test/extended/machines"
+	_ "github.com/openshift/origin/test/extended/marketplace"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/operators"

--- a/test/extended/marketplace/marketplace.go
+++ b/test/extended/marketplace/marketplace.go
@@ -1,0 +1,74 @@
+package marketplace
+
+import (
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Feature:Marketplace] Marketplace Default Sources", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLIWithoutNamespace("")
+
+	//[OCP-21921]:[Marketplace]Default resources of Marketplace operator
+	g.It("[ocp-21921]marketplace operators", func() {
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ns", "openshift-marketplace", "-o=jsonpath={.status.phase}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("Active"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "catalogsourceconfigs.operators.coreos.com", "-o=jsonpath={.status.acceptedNames.shortNames}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("csc"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("crd", "operatorsources.operators.coreos.com", "-o=jsonpath={.status.acceptedNames.shortNames}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("opsrc"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "sa").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterrole").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterrolebinding", "marketplace-operator", fmt.Sprintf("-o=jsonpath='{.subjects[?(@.kind==\"%s\")]}'", "ServiceAccount")).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("name:marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "deployment").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("marketplace-operator"))
+
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "catalogsource").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.ContainSubstring("certified-operators"))
+		o.Expect(msg).To(o.ContainSubstring("community-operators"))
+		o.Expect(msg).To(o.ContainSubstring("redhat-operators "))
+	})
+
+	//[OCP-21630]:[Marketplace] Default OperatorSources is installed and controled by CVO
+	//[OCP-24411]:[Marketplace] MarketplaceOperator manage the default OperatorSources
+	//author: chuo@redhat.com
+	g.It("[ocp-21630] OperatorSource installed and controled by CVO in 4.1 and [ocp-24411] by MarketplaceOperator in 4.2", func() {
+
+		var defaultOperatorSources = [3]string{"certified-operators", "community-operators", "redhat-operators"}
+		for _, opsrc := range defaultOperatorSources {
+			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "opsrc", opsrc, "-o=jsonpath={.status.currentPhase.phase.message}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(msg).To(o.Equal("The object has been successfully reconciled"))
+		}
+
+		err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("-n", "openshift-marketplace", "opsrc", "redhat-operators", "--type", "merge", "-p", `{"spec":{"registryNamespace":"wrong"}}`).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		time.Sleep(180 * time.Second)
+
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "opsrc", "redhat-operators", "-o=jsonpath={.spec.registryNamespace}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("redhat-operators"))
+	})
+})

--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -70,4 +70,36 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 			}
 		})
 	}
+
+	//OCP-21548 :OLM aggregates CR roles to standard admin/view/edit
+	//author: chuo@redhat.com
+	g.It("[ocp-21548]aggregates CR roles to standard admin/view/edit", func() {
+		oc.SetupProject()
+		user := oc.Username()
+		fmt.Printf("the user is %s", user)
+		msg, err := oc.Run("get").Args("rolebinding", "admin", "-o=jsonpath={.roleRef.kind}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("ClusterRole"))
+
+		msg, err = oc.Run("get").Args("clusterrole", "admin", "-o", "jsonpath={.rules[0].resources[*]},{.rules[0].verbs[*]}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("subscriptions,create update patch delete"))
+
+		msg, err = oc.Run("get").Args("clusterrole", "admin", "-o", "jsonpath={.rules[1].resources[*]},{.rules[1].verbs[*]}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("clusterserviceversions catalogsources installplans subscriptions,delete"))
+
+		msg, err = oc.Run("get").Args("clusterrole", "admin", "-o", "jsonpath={.rules[2].resources[*]},{.rules[2].verbs[*]}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("clusterserviceversions catalogsources installplans subscriptions operatorgroups,get list watch"))
+
+		msg, err = oc.Run("get").Args("clusterrole", "admin", "-o", "jsonpath={.rules[3].resources[0]},{.rules[3].verbs[*]}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("packagemanifests,get list watch"))
+
+		msg, err = oc.Run("get").Args("clusterrole", "admin", "-o", "jsonpath={.rules[4].resources[*]},{.rules[4].verbs[*]}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(msg).To(o.Equal("packagemanifests,create update patch delete"))
+
+	})
 })


### PR DESCRIPTION
./openshift-tests run all --dry-run | grep "\[Feature:Platform] OLM should \[ocp-21548" | ./openshift-tests run --junit-dir=./ -f -
started: (0/1/1) "[Feature:Platform] OLM should [ocp-21548]aggregates CR roles to standard admin/view/edit [Suite:openshift/conformance/parallel]"

Aug 28 17:48:40.295: INFO: >>> kubeConfig: /home/chuo/.kube/config
Aug 28 17:48:40.296: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Aug 28 17:48:42.106: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Aug 28 17:48:42.905: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Aug 28 17:48:42.905: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Aug 28 17:48:42.905: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Aug 28 17:48:43.170: INFO: e2e test version: v0.0.0-master+$Format:%h$
Aug 28 17:48:43.426: INFO: kube-apiserver version: v1.14.0+e12dd85
[BeforeEach] [Top Level]
  /home/chuo/go/src/github.com/openshift/origin/test/extended/util/test.go:73
[BeforeEach] [Feature:Platform] OLM should
  /home/chuo/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
Aug 28 17:48:43.429: INFO: >>> kubeConfig: /home/chuo/.kube/config
[BeforeEach] [Feature:Platform] OLM should
  /home/chuo/go/src/github.com/openshift/origin/test/extended/util/client.go:109
Aug 28 17:48:45.046: INFO: configPath is now "/tmp/configfile838346730"
Aug 28 17:48:45.046: INFO: The user is now "e2e-test-olm-5c2dg-user"
Aug 28 17:48:45.046: INFO: Creating project "e2e-test-olm-5c2dg"
Aug 28 17:48:45.570: INFO: Waiting on permissions in project "e2e-test-olm-5c2dg" ...
Aug 28 17:48:45.834: INFO: Waiting for ServiceAccount "default" to be provisioned...
Aug 28 17:48:46.198: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Aug 28 17:48:46.561: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Aug 28 17:48:46.924: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Aug 28 17:48:47.442: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Aug 28 17:48:47.962: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Aug 28 17:48:48.483: INFO: Project "e2e-test-olm-5c2dg" has been fully provisioned.
[It] [ocp-21548]aggregates CR roles to standard admin/view/edit [Suite:openshift/conformance/parallel]
  /home/chuo/go/src/github.com/openshift/origin/test/extended/operators/olm.go:75
Aug 28 17:48:50.084: INFO: configPath is now "/tmp/configfile553819713"
Aug 28 17:48:50.084: INFO: The user is now "e2e-test-olm-gxdkw-user"
Aug 28 17:48:50.084: INFO: Creating project "e2e-test-olm-gxdkw"
Aug 28 17:48:50.593: INFO: Waiting on permissions in project "e2e-test-olm-gxdkw" ...
Aug 28 17:48:50.854: INFO: Waiting for ServiceAccount "default" to be provisioned...
Aug 28 17:48:51.218: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Aug 28 17:48:51.583: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Aug 28 17:48:51.946: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Aug 28 17:48:52.470: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Aug 28 17:48:52.993: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Aug 28 17:48:53.517: INFO: Project "e2e-test-olm-gxdkw" has been fully provisioned.
the user is e2e-test-olm-gxdkw-userAug 28 17:48:53.517: INFO: Running 'oc --namespace=e2e-test-olm-gxdkw --config=/tmp/configfile553819713 get rolebinding admin -o=jsonpath={.roleRef.kind}'
Aug 28 17:48:56.045: INFO: Running 'oc --namespace=e2e-test-olm-gxdkw --config=/tmp/configfile553819713 get clusterrole admin -o jsonpath={.rules[0].resources[*]},{.rules[0].verbs[*]}'
Aug 28 17:48:57.444: INFO: Running 'oc --namespace=e2e-test-olm-gxdkw --config=/tmp/configfile553819713 get clusterrole admin -o jsonpath={.rules[1].resources[*]},{.rules[1].verbs[*]}'
Aug 28 17:48:58.964: INFO: Running 'oc --namespace=e2e-test-olm-gxdkw --config=/tmp/configfile553819713 get clusterrole admin -o jsonpath={.rules[2].resources[*]},{.rules[2].verbs[*]}'
Aug 28 17:49:00.352: INFO: Running 'oc --namespace=e2e-test-olm-gxdkw --config=/tmp/configfile553819713 get clusterrole admin -o jsonpath={.rules[3].resources[0]},{.rules[3].verbs[*]}'
Aug 28 17:49:02.873: INFO: Running 'oc --namespace=e2e-test-olm-gxdkw --config=/tmp/configfile553819713 get clusterrole admin -o jsonpath={.rules[4].resources[*]},{.rules[4].verbs[*]}'
[AfterEach] [Feature:Platform] OLM should
  /home/chuo/go/src/github.com/openshift/origin/test/extended/util/client.go:101
Aug 28 17:49:04.448: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-5c2dg-user}, err: <nil>
Aug 28 17:49:04.715: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-5c2dg}, err: <nil>
Aug 28 17:49:04.982: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  YG8d5wLcQVKdQG8MseRbqwAAAAAAAAAA}, err: <nil>
Aug 28 17:49:05.250: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-gxdkw-user}, err: <nil>
Aug 28 17:49:05.515: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-gxdkw}, err: <nil>
Aug 28 17:49:05.783: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  E1Hc-T5dTayPWPop9J65PAAAAAAAAAAA}, err: <nil>
[AfterEach] [Feature:Platform] OLM should
  /home/chuo/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:150
Aug 28 17:49:05.783: INFO: Waiting up to 3m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-5c2dg" for this suite.
Aug 28 17:49:13.075: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Aug 28 17:49:32.364: INFO: namespace e2e-test-olm-5c2dg deletion completed in 26.065619964s
STEP: Destroying namespace "e2e-test-olm-gxdkw" for this suite.
Aug 28 17:49:39.143: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Aug 28 17:49:58.541: INFO: namespace e2e-test-olm-gxdkw deletion completed in 26.176999786s
Aug 28 17:49:58.546: INFO: Running AfterSuite actions on all nodes
Aug 28 17:49:58.546: INFO: Running AfterSuite actions on node 1

passed: (1m19s) 2019-08-28T09:49:58 "[Feature:Platform] OLM should [ocp-21548]aggregates CR roles to standard admin/view/edit [Suite:openshift/conformance/parallel]"

Writing JUnit report to junit_e2e_20190828-094958.xml

1 pass, 0 skip (1m19s)
