### PR TITLE
e2e: use container network to access routes

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1459,7 +1459,7 @@ func GetEndpointAddress(oc *CLI, name string) (string, error) {
 // TODO: expose upstream
 func CreateExecPodOrFail(client corev1client.CoreV1Interface, ns, name string) string {
 	e2e.Logf("Creating new exec pod")
-	execPod := e2e.NewExecPodSpec(ns, name, true)
+	execPod := e2e.NewExecPodSpec(ns, name, false)
 	created, err := client.Pods(ns).Create(execPod)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	err = wait.PollImmediate(e2e.Poll, 5*time.Minute, func() (bool, error) {

--- a/test/extended/util/url/url.go
+++ b/test/extended/util/url/url.go
@@ -154,7 +154,7 @@ func createExecPod(clientset kclientset.Interface, ns, name string) (string, err
 					ImagePullPolicy: v1.PullIfNotPresent,
 				},
 			},
-			HostNetwork:                   true,
+			HostNetwork:                   false,
 			TerminationGracePeriodSeconds: &immediate,
 		},
 	}


### PR DESCRIPTION
The current level of Kubernetes does not support routing packets from
the host network interface to LoadBalancer Service external IPs. Although such
routing tends to work on AWS with our current topology, it only works by
coincidence. On other platforms like Azure and GCP, packets will not route to
the load balancer except when the node is part of the load balancer target pool.
At best, the level of support is undefined and all behavior in this context is
considered unintentional by upstream.

The practical implication is that connectivity to Routes on cloud platorms is
only supported from public and container network clients.

Refactor the e2e tests to exercise Route connectivity only through the container
network. This eliminates a class of test flake whereby tests pass when the test
pod (e.g. running curl against a Route) lands on a node hosting an
ingresscontroller but fails if the pod happens to land on a node that's not
hosting an ingresscontroller (which means the node is not part of the LB target
pool).

https://github.com/kubernetes/kubernetes/pull/77523
https://github.com/kubernetes/kubernetes/issues/65387

cc @openshift/sig-network-edge @smarterclayton @enj 