### PR TITLE
tests/extended: prevent QoS class regression on marketplace operators

### DIFF
--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -28,7 +28,7 @@ var _ = Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 		// a pod in a namespace that begins with kube-* or openshift-* must come from our release payload
 		// TODO components in openshift-operators may not come from our payload, may want to weaken restriction
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
-		excludeNamespaces := sets.NewString("openshift-marketplace", "openshift-operator-lifecycle-manager")
+		excludeNamespaces := sets.NewString("openshift-operator-lifecycle-manager")
 		excludePodPrefix := sets.NewString("revision-pruner-", "installer-")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces


### PR DESCRIPTION
Marketplace added resources requests
https://github.com/operator-framework/operator-lifecycle-manager/pull/955

Close the gate to prevent regression

@rphillips @derekwaynecarr @smarterclayton 