### PR TITLE
[WIP] Including hostNetwork: true for GCE CSI tests.

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/vendor/k8s.io/kubernetes/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -12,6 +12,7 @@ spec:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
       serviceAccountName: csi-node-sa
+      hostNetwork: true
       containers:
         - name: csi-driver-registrar
           image: gcr.io/gke-release/csi-driver-registrar:v1.0.1-gke.0


### PR DESCRIPTION
Includes `hostNetwork: true` for GCE CSI tests.

This resolves [BZ1745720](https://bugzilla.redhat.com/show_bug.cgi?id=1745720).