### PR TITLE
Bug 1746499: Ensure images push without full tag spec

### DIFF
--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -197,6 +197,11 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 				br.AssertFailure()
 				br.DumpLogs()
 
+				// Bug 1746499: Image without tag should push with <imageid>:latest
+				logs, err := br.Logs()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(logs).NotTo(o.ContainSubstring("identifier is not an image"))
+
 				build, err := oc.BuildClient().BuildV1().Builds(oc.Namespace()).Get(br.Build.Name, metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Expect(build.Status.Reason).To(o.Equal(buildv1.StatusReasonPushImageToRegistryFailed))

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -20865,7 +20865,8 @@ spec:
   output:
     to:
       kind: DockerImage
-      name: bogus.registry/image:latest
+      # Bug 1746499: Image without tag should push with <imageid>:latest
+      name: bogus.registry/image
   strategy:
     sourceStrategy:
       from:

--- a/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
+++ b/test/extended/testdata/builds/statusfail-pushtoregistry.yaml
@@ -9,7 +9,8 @@ spec:
   output:
     to:
       kind: DockerImage
-      name: bogus.registry/image:latest
+      # Bug 1746499: Image without tag should push with <imageid>:latest
+      name: bogus.registry/image
   strategy:
     sourceStrategy:
       from:


### PR DESCRIPTION
If an image push doesn't have a tag, ensure that `:latest` is appended and doesn't fail due to an "identifier is not an image" error. 