### PR TITLE
Bug 1735502: ignore CNI plugin SIGTERM interrupt

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -11,14 +11,16 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/openshift/origin/pkg/network/node/cniserver"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
+	types020 "github.com/containernetworking/cni/pkg/types/020"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ip"
@@ -249,6 +251,7 @@ func (p *cniPlugin) CmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
+	signal.Ignore(syscall.SIGTERM)
 	rand.Seed(time.Now().UTC().UnixNano())
 	hostNS, err := ns.GetCurrentNS()
 	if err != nil {


### PR DESCRIPTION
This PR is required for a back-port to 3.11, where a [customer incident](https://bugzilla.redhat.com/show_bug.cgi?id=1735502) has highlighted strange issues with networking once the container runtime (docker in this case) crashes. It seems to be something from the kernel space that is sending a SIGTERM to the CNI plugin - after the container runtime crash. If this happens before the CNI plugin sets the default gateway for a given pod X, then the originating pod is not attributed such.

This PR just sets an ignore on SIGTERM, which will escape the interrupt from whatever calling process - we don't know which one yet, but are confident it's in the kernel space.