### PR TITLE
Automate [OLM] [OCP-24061] - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -73,6 +73,7 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 	}
 
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
+	// author: bandrade@redhat.com
 	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {
 		var deploymentResource = [3]string{"catalog-operator", "olm-operator", "packageserver"}
 		for _, v := range deploymentResource {

--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -74,8 +74,8 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
 	// author: bandrade@redhat.com
-	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {
-		var deploymentResource = [3]string{"catalog-operator", "olm-operator", "packageserver"}
+	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {		
+		deploymentResources := []string{"catalog-operator", "olm-operator", "packageserver"}
 		for _, v := range deploymentResource {
 			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-operator-lifecycle-manager", "deployment", v, "-o=jsonpath={.spec.template.spec.containers[*].imagePullPolicy}").Output()
 			e2e.Logf("%s.imagePullPolicy:%s", v, msg)

--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -75,7 +75,7 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
 	// author: bandrade@redhat.com
 	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {		
-		deploymentResources := []string{"catalog-operator", "olm-operator", "packageserver"}
+		deploymentResource := []string{"catalog-operator", "olm-operator", "packageserver"}
 		for _, v := range deploymentResource {
 			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-operator-lifecycle-manager", "deployment", v, "-o=jsonpath={.spec.template.spec.containers[*].imagePullPolicy}").Output()
 			e2e.Logf("%s.imagePullPolicy:%s", v, msg)

--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -74,7 +74,7 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
 	// author: bandrade@redhat.com
-	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {		
+	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {
 		deploymentResource := []string{"catalog-operator", "olm-operator", "packageserver"}
 		for _, v := range deploymentResource {
 			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-operator-lifecycle-manager", "deployment", v, "-o=jsonpath={.spec.template.spec.containers[*].imagePullPolicy}").Output()


### PR DESCRIPTION
@bparees @ecordell @njhale As title, please have a review. Thanks! cc: @cuipinghuo @scolange @chengzhang1016 @zihantang-rh @emmajiafan @jianzhangbjz 

Log shows as below.

```
./openshift-tests run all --dry-run | grep "OLM should have imagePullPolicy:IfNotPresent" | ./openshift-tests run -f -
started: (0/1/1) "[Feature:Platform] OLM should have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]"

Sep  2 20:19:33.796: INFO: >>> kubeConfig: /home/vagrant/kubeconfig
Sep  2 20:19:33.801: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Sep  2 20:19:34.918: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Sep  2 20:19:35.454: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Sep  2 20:19:35.454: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Sep  2 20:19:35.454: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Sep  2 20:19:35.629: INFO: e2e test version: v0.0.0-master+$Format:%h$
Sep  2 20:19:35.779: INFO: kube-apiserver version: v1.14.0+a91f2ac
[BeforeEach] [Top Level]
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/util/test.go:73
[BeforeEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
Sep  2 20:19:35.780: INFO: >>> kubeConfig: /home/vagrant/kubeconfig
[BeforeEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/util/client.go:109
Sep  2 20:19:37.359: INFO: configPath is now "/tmp/configfile391617254"
Sep  2 20:19:37.359: INFO: The user is now "e2e-test-olm-n5dz6-user"
Sep  2 20:19:37.359: INFO: Creating project "e2e-test-olm-n5dz6"
Sep  2 20:19:37.786: INFO: Waiting on permissions in project "e2e-test-olm-n5dz6" ...
Sep  2 20:19:37.967: INFO: Waiting for ServiceAccount "default" to be provisioned...
Sep  2 20:19:38.232: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Sep  2 20:19:38.492: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Sep  2 20:19:38.756: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Sep  2 20:19:39.091: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Sep  2 20:19:39.416: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Sep  2 20:19:39.732: INFO: Project "e2e-test-olm-n5dz6" has been fully provisioned.
[It] have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/operators/olm.go:76
Sep  2 20:19:39.732: INFO: Running 'oc --config=/home/vagrant/kubeconfig get -n openshift-operator-lifecycle-manager deployment catalog-operator -o=jsonpath={.spec.template.spec.containers[*].imagePullPolicy}'
Sep  2 20:19:42.288: INFO: catalog-operator.imagePullPolicy:IfNotPresent
Sep  2 20:19:42.288: INFO: Running 'oc --config=/home/vagrant/kubeconfig get -n openshift-operator-lifecycle-manager deployment olm-operator -o=jsonpath={.spec.template.spec.containers[*].imagePullPolicy}'
Sep  2 20:19:43.109: INFO: olm-operator.imagePullPolicy:IfNotPresent
Sep  2 20:19:43.109: INFO: Running 'oc --config=/home/vagrant/kubeconfig get -n openshift-operator-lifecycle-manager deployment packageserver -o=jsonpath={.spec.template.spec.containers[*].imagePullPolicy}'
Sep  2 20:19:44.011: INFO: packageserver.imagePullPolicy:IfNotPresent
[AfterEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/util/client.go:101
Sep  2 20:19:44.182: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-n5dz6-user}, err: <nil>
Sep  2 20:19:44.349: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-n5dz6}, err: <nil>
Sep  2 20:19:44.516: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  QM0THmzYQRm0Up_drm_3jAAAAAAAAAAA}, err: <nil>
[AfterEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:150
Sep  2 20:19:44.517: INFO: Waiting up to 3m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-n5dz6" for this suite.
Sep  2 20:19:51.373: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Sep  2 20:20:04.270: INFO: namespace e2e-test-olm-n5dz6 deletion completed in 19.371790294s
Sep  2 20:20:04.282: INFO: Running AfterSuite actions on all nodes
Sep  2 20:20:04.289: INFO: Running AfterSuite actions on node 1

passed: (32.8s) 2019-09-02T20:20:04 "[Feature:Platform] OLM should have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]"

1 pass, 0 skip (32.9s)
```

