### PR TITLE
WIP: Disable Cinder tests that require access to remote OpenStack

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -439,6 +439,13 @@ var (
 
 			`\[HPA\] Horizontal pod autoscaling \(scale resource: Custom Metrics from Stackdriver\)`, // down custom metrics apiservices break other clients
 		},
+		"[Skipped:openstack]": {
+			// openshift-tests does not have /usr/bin/cinder configured to create in-line or
+			// pre-provisioned volumes to test OpenShift with.
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1748254
+			`\[Driver: cinder\].*Testpattern: Pre-provisioned PV`,
+			`\[Driver: cinder\].*Testpattern: Inline-volume PV`,
+		},
 		"[Skipped:azure]": {
 			"Networking should provide Internet connection for containers", // Azure does not allow ICMP traffic to internet.
 


### PR DESCRIPTION
openshift-tests binary requires configured /usr/bin/cinder to create / delete some volumes to test the OpenShift on OpenStack. We don't have cinder configured in the pod with the tests, let's disable the tests for now.

There are still tests that use dynamic provisioning and it should test the Cinder code in OpenShift enough.

cc @openshift/storage 

WIP:
  - check the test results