### PR TITLE
UPSTREAM: <carry>: kill kube-controller-manager on CSR file content change

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/certificates/certificate_controller.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/certificates/certificate_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/certificates/csrsuicider"
 )
 
 type CertificateController struct {
@@ -112,6 +113,8 @@ func (cc *CertificateController) Run(workers int, stopCh <-chan struct{}) {
 
 	klog.Infof("Starting certificate controller")
 	defer klog.Infof("Shutting down certificate controller")
+
+	csrsuicider.DieOnCertChange(stopCh)
 
 	if !controller.WaitForCacheSync("certificate", stopCh, cc.csrsSynced) {
 		return

--- a/vendor/k8s.io/kubernetes/pkg/controller/certificates/csrsuicider/patch_die_on_cert_change.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/certificates/csrsuicider/patch_die_on_cert_change.go
@@ -1,0 +1,62 @@
+package csrsuicider
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/klog"
+
+	"github.com/openshift/library-go/pkg/controller/fileobserver"
+)
+
+// this is a global side-effect because we have the file content in package A and the stopChannel/run signal in
+// package B, so package A creates this and package B starts it
+var csrObserver fileobserver.Observer
+
+type FileAndContent struct {
+	filename string
+	content  []byte
+}
+
+func NewFile(filename string, content []byte) FileAndContent {
+	return FileAndContent{filename: filename, content: content}
+}
+
+// StartingCertValues sets the global observer
+func StartingCertValues(cert, key FileAndContent) {
+	fileCheckFrequence := 1 * time.Minute
+	observer, err := fileobserver.NewObserver(fileCheckFrequence)
+	if err != nil {
+		panic(err)
+	}
+
+	var once sync.Once
+	restartFn := func(filename string, action fileobserver.ActionType) error {
+		once.Do(func() {
+			klog.Warning(fmt.Sprintf("Restart triggered because of %s", action.String(filename)))
+			// no graceful shutdown for a KCM
+			klog.Fatalf("Restart triggered because of %s", action.String(filename))
+		})
+		return nil
+	}
+
+	fileContent := map[string][]byte{
+		cert.filename: cert.content,
+		key.filename:  key.content,
+	}
+
+	observer.AddReactor(restartFn, fileContent, sets.StringKeySet(fileContent).List()...)
+
+	csrObserver = observer
+}
+
+func DieOnCertChange(stopCh <-chan struct{}) {
+	if csrObserver == nil {
+		return
+	}
+
+	go csrObserver.Run(stopCh)
+}

--- a/vendor/k8s.io/kubernetes/pkg/controller/certificates/signer/cfssl_signer.go
+++ b/vendor/k8s.io/kubernetes/pkg/controller/certificates/signer/cfssl_signer.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/kubernetes/pkg/controller/certificates/csrsuicider"
+
 	capi "k8s.io/api/certificates/v1beta1"
 	certificatesinformers "k8s.io/client-go/informers/certificates/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -78,6 +80,8 @@ func newCFSSLSigner(caFile, caKeyFile string, client clientset.Interface, certif
 	if err != nil {
 		return nil, fmt.Errorf("error parsing CA cert file %q: %v", caFile, err)
 	}
+
+	csrsuicider.StartingCertValues(csrsuicider.NewFile(caFile, ca), csrsuicider.NewFile(caKeyFile, cakey))
 
 	strPassword := os.Getenv("CFSSL_CA_PK_PASSWORD")
 	password := []byte(strPassword)


### PR DESCRIPTION
Once we have this, we can wire a cert-syncer to it in the operator and we'll be able to avoid relying on rollouts to get a new CSR signer.  This appears to have caused an unstable cluster where a rollout failed and all kubelets are lost.  Can't get logs from a dead kubelet though.

@soltysh 

