### PR TITLE
Bug 1745720: Disable GCE CSI tests due to CRI-O bug

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -485,6 +485,9 @@ var (
 
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1740959
 			`\[sig-api-machinery\] AdmissionWebhook Should be able to deny pod and configmap creation`,
+
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1745720
+			`\[sig-storage\] CSI Volumes \[Driver: pd.csi.storage.gke.io\]\[Serial\]`,
 		},
 		"[Suite:openshift/scalability]": {},
 		// tests that replace the old test-cmd script


### PR DESCRIPTION
Disabled the GCE CSI tests temporarily, as they are currently failing due to a CRI-O bug that prevents accessing IPs [1], currently being targeted for 4.3.

This resolves [BZ 1745720](https://bugzilla.redhat.com/show_bug.cgi?id=1745720).

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1718389