### PR TITLE
Bug 1748501: UPSTREAM: <carry>: fix openshift admission plugin registration

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -133,6 +133,8 @@ cluster's shared state through which all other components interact.`,
 				}
 
 				enablement.ForceGlobalInitializationForOpenShift(s)
+				enablement.InstallOpenShiftAdmissionPlugins(s)
+
 			}
 
 			// set default options

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/configdefault/admission_config.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/configdefault/admission_config.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
-	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/namespaceconditions"
 	"k8s.io/kubernetes/openshift-kube-apiserver/kubeadmission"
 
@@ -15,13 +14,6 @@ import (
 )
 
 func SetAdmissionDefaults(o *options.ServerRunOptions, informers informers.SharedInformerFactory, kubeClient kubernetes.Interface) {
-	existingAdmissionOrder := o.Admission.GenericAdmission.RecommendedPluginOrder
-	o.Admission.GenericAdmission.RecommendedPluginOrder = kubeadmission.NewOrderedKubeAdmissionPlugins(existingAdmissionOrder)
-	kubeadmission.RegisterOpenshiftKubeAdmissionPlugins(o.Admission.GenericAdmission.Plugins)
-	customresourcevalidationregistration.RegisterCustomResourceValidation(o.Admission.GenericAdmission.Plugins)
-	existingDefaultOff := o.Admission.GenericAdmission.DefaultOffPlugins
-	o.Admission.GenericAdmission.DefaultOffPlugins = kubeadmission.NewDefaultOffPluginsFunc(existingDefaultOff)()
-
 	// set up the decorators we need.  This is done late and out of order because our decorators currently require informers which are not
 	// present until we start running
 	namespaceLabelDecorator := namespaceconditions.NamespaceLabelConditions{

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/enablement/admission.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/enablement/admission.go
@@ -1,0 +1,16 @@
+package enablement
+
+import (
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/openshift-kube-apiserver/admission/customresourcevalidation/customresourcevalidationregistration"
+	"k8s.io/kubernetes/openshift-kube-apiserver/kubeadmission"
+)
+
+func InstallOpenShiftAdmissionPlugins(o *options.ServerRunOptions) {
+	existingAdmissionOrder := o.Admission.GenericAdmission.RecommendedPluginOrder
+	o.Admission.GenericAdmission.RecommendedPluginOrder = kubeadmission.NewOrderedKubeAdmissionPlugins(existingAdmissionOrder)
+	kubeadmission.RegisterOpenshiftKubeAdmissionPlugins(o.Admission.GenericAdmission.Plugins)
+	customresourcevalidationregistration.RegisterCustomResourceValidation(o.Admission.GenericAdmission.Plugins)
+	existingDefaultOff := o.Admission.GenericAdmission.DefaultOffPlugins
+	o.Admission.GenericAdmission.DefaultOffPlugins = kubeadmission.NewDefaultOffPluginsFunc(existingDefaultOff)()
+}


### PR DESCRIPTION
Without this, no openshift admission plugin is registered and trying to enable them via unsupported config overrides error out with "unknown" plugin.

This is because of wrong order :-)

Credits to @sttts with debugging help.

/cc @sttts 
/cc @deads2k 