### PR TITLE
Fix extended tests imports

### DIFF
--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/openshift/origin/test/extended/testdata"
 	testutil "github.com/openshift/origin/test/extended/util"
-	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 

--- a/test/extended/util/ldap.go
+++ b/test/extended/util/ldap.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"


### PR DESCRIPTION
The tests should use the vendored repos directly, not from kube staging.

-----

This makes `openshift-tests` binary buildable with go-1.13