### PR TITLE
Bug 1744422: UPSTREAM: 82335: defer the close to after the error check

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/common/kubelet.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/common/kubelet.go
@@ -168,10 +168,10 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 
 			Eventually(func() error {
 				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream()
-				defer rc.Close()
 				if err != nil {
 					return err
 				}
+				defer rc.Close()
 				buf := new(bytes.Buffer)
 				buf.ReadFrom(rc)
 				hostsFileContent := buf.String()


### PR DESCRIPTION
Trivial fix for a crash in e2e tests.

ref: https://github.com/kubernetes/kubernetes/pull/82335