### PR TITLE
Bug 1737653: UPSTREAM: 75037: UPSTREAM: 76788: UPSTREAM: 80436

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/cp.go
@@ -32,6 +32,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 
+	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
 )
@@ -161,13 +162,13 @@ func checkDestinationIsDir(dest fileSpec, f cmdutil.Factory, cmd *cobra.Command)
 }
 
 func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, src, dest fileSpec) error {
-	if len(src.File) == 0 {
+	if len(src.File) == 0 || len(dest.File) == 0 {
 		return errFileCannotBeEmpty
 	}
 	reader, writer := io.Pipe()
 
 	// strip trailing slash (if any)
-	if strings.HasSuffix(string(dest.File[len(dest.File)-1]), "/") {
+	if dest.File != "/" && strings.HasSuffix(string(dest.File[len(dest.File)-1]), "/") {
 		dest.File = dest.File[:len(dest.File)-1]
 	}
 
@@ -208,7 +209,7 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 }
 
 func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, dest fileSpec) error {
-	if len(src.File) == 0 {
+	if len(src.File) == 0 || len(dest.File) == 0 {
 		return errFileCannotBeEmpty
 	}
 
@@ -234,7 +235,32 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 	}()
 	prefix := getPrefix(src.File)
 	prefix = path.Clean(prefix)
+	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
+	// and attempted to navigate beyond "/" in a remote filesystem
+	prefix = stripPathShortcuts(prefix)
 	return untarAll(reader, dest.File, prefix)
+}
+
+// stripPathShortcuts removes any leading or trailing "../" from a given path
+func stripPathShortcuts(p string) string {
+	newPath := path.Clean(p)
+	trimmed := strings.TrimPrefix(newPath, "../")
+
+	for trimmed != newPath {
+		newPath = trimmed
+		trimmed = strings.TrimPrefix(newPath, "../")
+	}
+
+	// trim leftover ".."
+	if newPath == ".." {
+		newPath = ""
+	}
+
+	if len(newPath) > 0 && string(newPath[0]) == "/" {
+		return newPath[1:]
+	}
+
+	return newPath
 }
 
 func makeTar(srcPath, destPath string, writer io.Writer) error {
@@ -311,9 +337,13 @@ func recursiveTar(srcBase, srcFile, destBase, destFile string, tw *tar.Writer) e
 	return nil
 }
 
-func untarAll(reader io.Reader, destFile, prefix string) error {
-	entrySeq := -1
+// clean prevents path traversals by stripping them out.
+// This is adapted from https://golang.org/src/net/http/fs.go#L74
+func clean(fileName string) string {
+	return path.Clean(string(os.PathSeparator) + fileName)
+}
 
+func untarAll(reader io.Reader, destDir, prefix string) error {
 	// TODO: use compression here?
 	tarReader := tar.NewReader(reader)
 	for {
@@ -324,38 +354,68 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 			}
 			break
 		}
-		entrySeq++
+
+		// All the files will start with the prefix, which is the directory where
+		// they were located on the pod, we need to strip down that prefix, but
+		// if the prefix is missing it means the tar was tempered with.
+		// For the case where prefix is empty we need to ensure that the path
+		// is not absolute, which also indicates the tar file was tempered with.
+		if !strings.HasPrefix(header.Name, prefix) {
+			return fmt.Errorf("tar contents corrupted")
+		}
+
+		// basic file information
 		mode := header.FileInfo().Mode()
-		outFileName := path.Join(destFile, header.Name[len(prefix):])
-		baseName := path.Dir(outFileName)
+		destFileName := filepath.Join(destDir, header.Name[len(prefix):])
+		if !isDestRelative(destDir, destFileName) {
+			glog.Warningf("warning: file %q is outside target destination, skipping\n", destFileName)
+			continue
+		}
+
+		baseName := filepath.Dir(destFileName)
 		if err := os.MkdirAll(baseName, 0755); err != nil {
 			return err
 		}
 		if header.FileInfo().IsDir() {
-			if err := os.MkdirAll(outFileName, 0755); err != nil {
+			if err := os.MkdirAll(destFileName, 0755); err != nil {
 				return err
 			}
 			continue
 		}
 
-		// handle coping remote file into local directory
-		if entrySeq == 0 && !header.FileInfo().IsDir() {
-			exists, err := dirExists(outFileName)
-			if err != nil {
-				return err
-			}
-			if exists {
-				outFileName = filepath.Join(outFileName, path.Base(header.Name))
-			}
+		// We need to ensure that the destination file is always within boundries
+		// of the destination directory. This prevents any kind of path traversal
+		// from within tar archive.
+		evaledPath, err := filepath.EvalSymlinks(baseName)
+		if err != nil {
+			return err
+		}
+		// For scrutiny we verify both the actual destination as well as we follow
+		// all the links that might lead outside of the destination directory.
+		if !isDestRelative(destDir, filepath.Join(evaledPath, filepath.Base(destFileName))) {
+			glog.Warningf("warning: file %q is outside target destination, skipping\n", destFileName)
+			continue
 		}
 
 		if mode&os.ModeSymlink != 0 {
-			err := os.Symlink(header.Linkname, outFileName)
+			linkname := header.Linkname
+			// We need to ensure that the link destination is always within boundries
+			// of the destination directory. This prevents any kind of path traversal
+			// from within tar archive.
+			linktarget := linkname
+			if !filepath.IsAbs(linkname) {
+				linktarget = filepath.Join(evaledPath, linkname)
+			}
+			if !isDestRelative(destDir, linktarget) {
+				glog.Warningf("warning: link %q is pointing to %q which is outside target destination, skipping\n", destFileName, header.Linkname)
+				continue
+			}
+			err := os.Symlink(linkname, destFileName)
 			if err != nil {
 				return err
 			}
 		} else {
-			outFile, err := os.Create(outFileName)
+			outFile, err := os.Create(destFileName)
 			if err != nil {
 				return err
 			}
@@ -369,20 +429,22 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 		}
 	}
 
-	if entrySeq == -1 {
-		//if no file was copied
-		errInfo := fmt.Sprintf("error: %s no such file or directory", prefix)
-		return errors.New(errInfo)
-	}
 	return nil
 }
 
-func getPrefix(file string) string {
-	if file[0] == '/' {
-		// tar strips the leading '/' if it's there, so we will too
-		return file[1:]
+// isDestRelative returns true if dest is pointing outside the base directory,
+// false otherwise.
+func isDestRelative(base, dest string) bool {
+	relative, err := filepath.Rel(base, dest)
+	if err != nil {
+		return false
 	}
-	return file
+	return relative == "." || relative == stripPathShortcuts(relative)
+}
+
+func getPrefix(file string) string {
+	// tar strips the leading '/' if it's there, so we will too
+	return strings.TrimLeft(file, "/")
 }
 
 func execute(f cmdutil.Factory, cmd *cobra.Command, options *ExecOptions) error {
@@ -419,16 +481,4 @@ func execute(f cmdutil.Factory, cmd *cobra.Command, options *ExecOptions) error 
 		return err
 	}
 	return nil
-}
-
-// dirExists checks if a path exists and is a directory.
-func dirExists(path string) (bool, error) {
-	fi, err := os.Stat(path)
-	if err == nil && fi.IsDir() {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, err
 }


### PR DESCRIPTION
This was a manual process of bringing in changes from mentioned UPSTREAM commits.   
This is a pick-ish of:
* [UPSTREAM: 80871](https://github.com/kubernetes/kubernetes/pull/80871) (that is an automatic cherry-pick of 80436 on kube release-1.13)  kube only carried as far as 1.13
* [UPSTREAM: 82834](https://github.com/kubernetes/kubernetes/pull/82384) 