### PR TITLE
extended: RawExtension does not have fields

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -198,12 +198,12 @@ var (
 		{
 			gv:      schema.GroupVersion{Group: "template.openshift.io", Version: "v1"},
 			field:   "processedtemplates.objects",
-			pattern: `FIELDS\:.*`,
+			pattern: `DESCRIPTION\:.*`,
 		},
 		{
 			gv:      schema.GroupVersion{Group: "template.openshift.io", Version: "v1"},
 			field:   "templates.objects",
-			pattern: `FIELDS\:.*`,
+			pattern: `DESCRIPTION\:.*`,
 		},
 		{
 			gv:      schema.GroupVersion{Group: "user.openshift.io", Version: "v1"},


### PR DESCRIPTION
In 1.16 (maybe in 1.15) kube the RawExtension does not have any public fields to explain to show. This is failing the e2e test in 1.16 PR and should be changed here to only look for the description.

/cc @soltysh 
/cc @sttts 