### PR TITLE
Bug 1743104: DS - detect schedulable nodes on demand

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/apps/daemon_set.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/daemon_set.go
@@ -381,9 +381,8 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  rollback of updates to a DaemonSet.
 	*/
 	framework.ConformanceIt("should rollback without unnecessary restarts", func() {
-		if framework.TestContext.CloudConfig.NumNodes < 2 {
-			framework.Logf("Conformance test suite needs a cluster with at least 2 nodes.")
-		}
+		schedulableNodes := framework.GetReadySchedulableNodesOrDie(c)
+		Expect(len(schedulableNodes.Items)).To(BeNumerically(">", 1), "Conformance test suite needs a cluster with at least 2 nodes.")
 		framework.Logf("Create a RollingUpdate DaemonSet")
 		label := map[string]string{daemonsetNameLabel: dsName}
 		ds := newDaemonSet(dsName, image, label)
@@ -421,7 +420,8 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 				framework.Failf("unexpected pod found, image = %s", image)
 			}
 		}
-		if framework.TestContext.CloudConfig.NumNodes < 2 {
+		schedulableNodes = framework.GetReadySchedulableNodesOrDie(c)
+		if len(schedulableNodes.Items) < 2 {
 			Expect(len(existingPods)).To(Equal(0))
 		} else {
 			Expect(len(existingPods)).NotTo(Equal(0))


### PR DESCRIPTION
DS e2e detects schedulable nodes at startup which results in flakes if cluster has some nodes not schedulable yet when e2e start. This limits the occurence but doesn't fix the issue of us starting e2e on a cluster that is not ready for it.

backport of https://github.com/kubernetes/kubernetes/pull/75349 via https://github.com/kubernetes/kubernetes/pull/82415

/hold
(for https://github.com/kubernetes/kubernetes/pull/82415 to merge upstream first)

/cc @soltysh @smarterclayton @sjenning 