### PR TITLE
Bug 1748814: Remove 'option tcplog' from passthrough backend in template router

### DIFF
--- a/images/router/haproxy/conf/haproxy-config.template
+++ b/images/router/haproxy/conf/haproxy-config.template
@@ -508,9 +508,6 @@ backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
 
 # Secure backend, pass through
 backend {{genBackendNamePrefix $cfg.TLSTermination}}:{{$cfgIdx}}
-{{- if ne (env "ROUTER_SYSLOG_ADDRESS") ""}}
-  option tcplog
-{{- end }}
     {{- with $balanceAlgo := firstMatch "roundrobin|leastconn|source" (index $cfg.Annotations "haproxy.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME" (env "ROUTER_LOAD_BALANCE_ALGORITHM")) }}
   balance {{ $balanceAlgo }}
     {{- else }}


### PR DESCRIPTION
Fix for BZ1748814 (OCP 3.11)  backport-of-BZ1579729

The option tcplog is not supported in backends, hence removing it.