### PR TITLE
allow openshift-tests --dry-run without kubeconfig

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -124,9 +124,10 @@ func newRunCommand() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return mirrorToFile(opt, func() error {
-				if err := initProvider(opt.Provider); err != nil {
+				if err := initProvider(opt.Provider, opt.DryRun); err != nil {
 					return err
 				}
+
 				e2e.AfterReadingAllFlags(exutil.TestContext)
 				e2e.TestContext.DumpLogsOnFailure = true
 				exutil.TestContext.DumpLogsOnFailure = true
@@ -187,7 +188,7 @@ func newRunUpgradeCommand() *cobra.Command {
 					}
 				}
 
-				if err := initProvider(opt.Provider); err != nil {
+				if err := initProvider(opt.Provider, opt.DryRun); err != nil {
 					return err
 				}
 				e2e.AfterReadingAllFlags(exutil.TestContext)
@@ -221,7 +222,7 @@ func newRunTestCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := initProvider(os.Getenv("TEST_PROVIDER")); err != nil {
+			if err := initProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun); err != nil {
 				return err
 			}
 			if err := initUpgrade(os.Getenv("TEST_SUITE_OPTIONS")); err != nil {
@@ -273,7 +274,7 @@ func bindOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
 	flags.BoolVar(&opt.IncludeSuccessOutput, "include-success", opt.IncludeSuccessOutput, "Print output from successful tests.")
 }
 
-func initProvider(provider string) error {
+func initProvider(provider string, dryRun bool) error {
 	// record the exit error to the output file
 	if err := decodeProviderTo(provider, exutil.TestContext); err != nil {
 		return err
@@ -292,7 +293,7 @@ func initProvider(provider string) error {
 	//exutil.TestContext.LoggingSoak.MilliSecondsBetweenWaves = 5000
 
 	exutil.AnnotateTestSuite()
-	exutil.InitTest()
+	exutil.InitTest(dryRun)
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	// TODO: infer SSH keys from the cluster

--- a/test/extended/crdvalidation/apiserver.go
+++ b/test/extended/crdvalidation/apiserver.go
@@ -11,12 +11,13 @@ import (
 
 var _ = g.Describe("[Suite:openshift/crdvalidation/apiserver] APIServer CR fields validation", func() {
 	var (
-		oc              = exutil.NewCLI("cluster-basic-auth", exutil.KubeConfigPath())
-		apiServerClient = oc.AdminConfigClient().ConfigV1().APIServers()
+		oc = exutil.NewCLI("cluster-basic-auth", exutil.KubeConfigPath())
 	)
 	defer g.GinkgoRecover()
 
 	g.It("additionalCORSAllowedOrigins", func() {
+		apiServerClient := oc.AdminConfigClient().ConfigV1().APIServers()
+
 		apiServer, err := apiServerClient.Get("cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -41,9 +41,9 @@ var _ = g.Describe("[Suite:openshift/oauth] LDAP IDP", func() {
 		myEmail        = "person1smith@example.com"
 	)
 
-	adminConfig := oc.AdminConfig()
-
 	g.It("should authenticate against an ldap server", func() {
+		adminConfig := oc.AdminConfig()
+
 		// Clean up mapped identity and user.
 		defer userv1client.NewForConfigOrDie(oc.AdminConfig()).Identities().Delete(fmt.Sprintf("%s:%s", providerName, myUserDNBase64), nil)
 		defer userv1client.NewForConfigOrDie(oc.AdminConfig()).Users().Delete(userName, nil)


### PR DESCRIPTION
Found a few places that required valid kubeconfigs before allowing a dry-run.  --dry-run shouldn't logically have that dep.

/assign @derekwaynecarr 