### PR TITLE
Automate [OLM] [OCP-21082] - [bz 1670311] Implement packages API server and list packagemanifest info with namespace not NULL

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -2,6 +2,7 @@ package operators
 
 import (
 	"fmt"
+	"strings"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -87,4 +88,21 @@ var _ = g.Describe("[Feature:Platform] OLM should", func() {
 			o.Expect(msg).To(o.Equal("IfNotPresent"))
 		}
 	})
+
+	// OCP-21082 - Implement packages API server and list packagemanifest info with namespace not NULL
+	// author: bandrade@redhat.com
+	g.It("Implement packages API server and list packagemanifest info with namespace not NULL", func() {
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "--all-namespaces", "--no-headers").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		packageserverLines := strings.Split(msg, "\n")
+		if len(packageserverLines) > 0 {
+			packageserverLine := strings.Fields(packageserverLines[0])
+			if strings.Index(packageserverLines[0], packageserverLine[0]) != 0 {
+				e2e.Failf("It should display a namespace for CSV: %s [ref:bz1670311]", packageserverLines[0])
+			}
+		} else {
+			e2e.Failf("No packages for evaluating if package namespace is not NULL")
+		}
+	})
+
 })


### PR DESCRIPTION
@ecordell @njhale As title, please have a review. Thanks! cc: @cuipinghuo @scolange @chengzhang1016 @zihantang-rh @emmajiafan @jianzhangbjz 

Success execution (when every package has namespace name defined)
```
./openshift-tests run all --dry-run | grep "Implement packages API server and list packagemanifest info with namespace not NULL" | ./openshift-tests run -f -
started: (0/1/1) "[Feature:Platform] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]"

E0912 16:33:36.334871   15161 request.go:853] Unexpected error when reading response body: &http.httpError{err:"context deadline exceeded (Client.Timeout exceeded while reading body)", timeout:true}
Sep 12 16:33:32.681: INFO: >>> kubeConfig: /home/vagrant/kubeconfig
Sep 12 16:33:32.689: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Sep 12 16:33:36.477: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Sep 12 16:33:37.614: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (1 seconds elapsed)
Sep 12 16:33:37.614: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Sep 12 16:33:37.614: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Sep 12 16:33:37.990: INFO: e2e test version: v0.0.0-master+$Format:%h$
Sep 12 16:33:38.356: INFO: kube-apiserver version: v1.14.6+13494ae
[BeforeEach] [Top Level]
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/util/test.go:73
[BeforeEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:149
STEP: Creating a kubernetes client
Sep 12 16:33:38.356: INFO: >>> kubeConfig: /home/vagrant/kubeconfig
[BeforeEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/util/client.go:109
Sep 12 16:33:41.797: INFO: configPath is now "/tmp/configfile995867157"
Sep 12 16:33:41.797: INFO: The user is now "e2e-test-olm-xrj6l-user"
Sep 12 16:33:41.797: INFO: Creating project "e2e-test-olm-xrj6l"
Sep 12 16:33:42.445: INFO: Waiting on permissions in project "e2e-test-olm-xrj6l" ...
Sep 12 16:33:42.842: INFO: Waiting for ServiceAccount "default" to be provisioned...
Sep 12 16:33:43.328: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Sep 12 16:33:43.811: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Sep 12 16:33:44.297: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Sep 12 16:33:45.077: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Sep 12 16:33:45.845: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Sep 12 16:33:46.610: INFO: Project "e2e-test-olm-xrj6l" has been fully provisioned.
[It] Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/operators/olm.go:78
Sep 12 16:33:46.611: INFO: Running 'oc --config=/home/vagrant/kubeconfig get packagemanifest --all-namespaces -o=jsonpath={range .items[*]}{.metadata.name};{.status.catalogSourceNamespace}{"\n"}'
[AfterEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/test/extended/util/client.go:101
Sep 12 16:33:55.787: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-xrj6l-user}, err: <nil>
Sep 12 16:33:56.163: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-xrj6l}, err: <nil>
Sep 12 16:33:56.543: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  G-piszmiQKmVdMkDzTLXOQAAAAAAAAAA}, err: <nil>
[AfterEach] [Feature:Platform] OLM should
  /home/vagrant/scripts/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:150
Sep 12 16:33:56.543: INFO: Waiting up to 3m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-xrj6l" for this suite.
Sep 12 16:34:04.806: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Sep 12 16:34:33.768: INFO: namespace e2e-test-olm-xrj6l deletion completed in 36.076239015s
Sep 12 16:34:33.801: INFO: Running AfterSuite actions on all nodes
Sep 12 16:34:33.811: INFO: Running AfterSuite actions on node 1

passed: (1m5s) 2019-09-12T16:34:33 "[Feature:Platform] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [Suite:openshift/conformance/parallel]"


Timeline:

Sep 12 16:33:33.334 E kube-apiserver Kube API started failing: Get https://api.bandrade1.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Sep 12 16:33:33.334 I openshift-apiserver OpenShift API started failing: Get https://api.bandrade1.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Sep 12 16:33:35.287 I kube-apiserver Kube API started responding to GET requests
Sep 12 16:33:37.857 I openshift-apiserver OpenShift API started responding to GET requests
Sep 12 16:34:23.889 I ns/openshift-machine-api machine/bandrade1-l85l4-worker-ap-southeast-1b-ltv9s Updated machine bandrade1-l85l4-worker-ap-southeast-1b-ltv9s (165 times)
Sep 12 16:34:24.037 I ns/openshift-machine-api machine/bandrade1-l85l4-worker-ap-southeast-1c-fmbr6 Updated machine bandrade1-l85l4-worker-ap-southeast-1c-fmbr6 (165 times)
Sep 12 16:34:25.123 I ns/openshift-machine-api machine/bandrade1-l85l4-master-1 Updated machine bandrade1-l85l4-master-1 (161 times)
Sep 12 16:34:26.051 I ns/openshift-machine-api machine/bandrade1-l85l4-master-2 Updated machine bandrade1-l85l4-master-2 (162 times)
Sep 12 16:34:27.099 I ns/openshift-machine-api machine/bandrade1-l85l4-master-0 Updated machine bandrade1-l85l4-master-0 (161 times)
Sep 12 16:34:27.307 I ns/openshift-machine-api machine/bandrade1-l85l4-worker-ap-southeast-1a-pd967 Updated machine bandrade1-l85l4-worker-ap-southeast-1a-pd967 (165 times)

1 pass, 0 skip (1m5s)
```
