### PR TITLE
Log which tests are skipped, add tests

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -124,9 +124,10 @@ func newRunCommand() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return mirrorToFile(opt, func() error {
-				if err := initProvider(opt.Provider); err != nil {
+				if err := initProvider(opt.Provider, opt.DryRun); err != nil {
 					return err
 				}
+
 				e2e.AfterReadingAllFlags(exutil.TestContext)
 				e2e.TestContext.DumpLogsOnFailure = true
 				exutil.TestContext.DumpLogsOnFailure = true
@@ -187,7 +188,7 @@ func newRunUpgradeCommand() *cobra.Command {
 					}
 				}
 
-				if err := initProvider(opt.Provider); err != nil {
+				if err := initProvider(opt.Provider, opt.DryRun); err != nil {
 					return err
 				}
 				e2e.AfterReadingAllFlags(exutil.TestContext)
@@ -221,7 +222,7 @@ func newRunTestCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := initProvider(os.Getenv("TEST_PROVIDER")); err != nil {
+			if err := initProvider(os.Getenv("TEST_PROVIDER"), testOpt.DryRun); err != nil {
 				return err
 			}
 			if err := initUpgrade(os.Getenv("TEST_SUITE_OPTIONS")); err != nil {
@@ -273,7 +274,7 @@ func bindOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
 	flags.BoolVar(&opt.IncludeSuccessOutput, "include-success", opt.IncludeSuccessOutput, "Print output from successful tests.")
 }
 
-func initProvider(provider string) error {
+func initProvider(provider string, dryRun bool) error {
 	// record the exit error to the output file
 	if err := decodeProviderTo(provider, exutil.TestContext); err != nil {
 		return err
@@ -292,7 +293,7 @@ func initProvider(provider string) error {
 	//exutil.TestContext.LoggingSoak.MilliSecondsBetweenWaves = 5000
 
 	exutil.AnnotateTestSuite()
-	exutil.InitTest()
+	exutil.InitTest(dryRun)
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	// TODO: infer SSH keys from the cluster

--- a/test/extended/crdvalidation/apiserver.go
+++ b/test/extended/crdvalidation/apiserver.go
@@ -11,12 +11,13 @@ import (
 
 var _ = g.Describe("[Suite:openshift/crdvalidation/apiserver] APIServer CR fields validation", func() {
 	var (
-		oc              = exutil.NewCLI("cluster-basic-auth", exutil.KubeConfigPath())
-		apiServerClient = oc.AdminConfigClient().ConfigV1().APIServers()
+		oc = exutil.NewCLI("cluster-basic-auth", exutil.KubeConfigPath())
 	)
 	defer g.GinkgoRecover()
 
 	g.It("additionalCORSAllowedOrigins", func() {
+		apiServerClient := oc.AdminConfigClient().ConfigV1().APIServers()
+
 		apiServer, err := apiServerClient.Get("cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -41,9 +41,9 @@ var _ = g.Describe("[Suite:openshift/oauth] LDAP IDP", func() {
 		myEmail        = "person1smith@example.com"
 	)
 
-	adminConfig := oc.AdminConfig()
-
 	g.It("should authenticate against an ldap server", func() {
+		adminConfig := oc.AdminConfig()
+
 		// Clean up mapped identity and user.
 		defer userv1client.NewForConfigOrDie(oc.AdminConfig()).Identities().Delete(fmt.Sprintf("%s:%s", providerName, myUserDNBase64), nil)
 		defer userv1client.NewForConfigOrDie(oc.AdminConfig()).Users().Delete(userName, nil)

--- a/test/extended/util/test_test.go
+++ b/test/extended/util/test_test.go
@@ -1,0 +1,107 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/onsi/ginkgo/types"
+)
+
+type testNode struct {
+	text string
+}
+
+func (n *testNode) Type() types.SpecComponentType {
+	return 0
+}
+func (n *testNode) CodeLocation() types.CodeLocation {
+	return types.CodeLocation{}
+}
+func (n *testNode) Text() string {
+	return n.text
+}
+func (n *testNode) SetText(text string) {
+	n.text = text
+}
+func (n *testNode) Flag() types.FlagType {
+	return 0
+}
+func (n *testNode) SetFlag(flag types.FlagType) {
+}
+
+func TestMaybeRenameTest(t *testing.T) {
+	tests := []struct {
+		name string
+
+		testName             string
+		excludedTestPatterns []string
+
+		expectedText string
+	}{
+		{
+			name:                 "simple serial match",
+			testName:             "[Serial] test",
+			excludedTestPatterns: []string{`\[Skipped:local\]`},
+			expectedText:         "[Serial] test [Suite:openshift/conformance/serial]",
+		},
+		{
+			name:                 "don't tag skipped",
+			testName:             `[Serial] example test [Skipped:gce]`,
+			excludedTestPatterns: []string{`\[Skipped:gce\]`},
+			expectedText:         `[Serial] example test [Skipped:gce]`, // notice that this isn't categorized into any of our buckets
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testRenamer := &ginkgoTestRenamer{
+				excludedTestsFilter: regexp.MustCompile(strings.Join(test.excludedTestPatterns, `|`)),
+			}
+			testNode := &testNode{
+				text: test.testName,
+			}
+
+			testRenamer.maybeRenameTest(test.testName, testNode)
+
+			if e, a := test.expectedText, testNode.Text(); e != a {
+				t.Error(a)
+			}
+
+		})
+	}
+}
+
+func TestStockRules(t *testing.T) {
+	tests := []struct {
+		name string
+
+		testName string
+		provider string
+
+		expectedText string
+	}{
+		{
+			name:         "should skip localssd on gce",
+			provider:     "gce",
+			testName:     `[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: gce-localssd-scsi-fs] [Serial] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted`,
+			expectedText: `[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: gce-localssd-scsi-fs] [Serial] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted [Skipped:gce]`, // notice that this isn't categorized into any of our buckets
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testRenamer := newGinkgoTestRenamerFromGlobals(test.provider)
+			testNode := &testNode{
+				text: test.testName,
+			}
+
+			testRenamer.maybeRenameTest(test.testName, testNode)
+
+			if e, a := test.expectedText, testNode.Text(); e != a {
+				t.Error(a)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
The logic for adding labels to tests is twisty.  I refactored enough to add tests, so I can be convinced they work.  This let's me know that https://prow.k8s.io/view/gcs/origin-ci-test/logs/canary-openshift-ocp-installer-e2e-gcp-serial-4.2/142 still didn't have the latest skip logic from https://github.com/openshift/origin/pull/23768 applied.