### PR TITLE
OpenStack: Disable cinder tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -498,6 +498,10 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1751367
 			`gce-localssd-scsi-fs`,
 		},
+		"[Skipped:openstack]": {
+			// The cinder tests require the cinder binary in the test image
+			`\[Driver: cinder\]`,
+		},
 		"[Suite:openshift/scalability]": {},
 		// tests that replace the old test-cmd script
 		"[Suite:openshift/test-cmd]": {


### PR DESCRIPTION
The upstream cinder tests require the cinder binary in the test image,
and swapping the test image to use openstack-installer is not a good
solution either as has unwanted side-effects as seen in
https://github.com/openshift/release/pull/5001.

If we merge this patch, we can revert
https://github.com/openshift/release/pull/4954 to restore the test
image.