### PR TITLE
Bug 1752045: UPSTREAM: <carry>:Add a RBAC checker for external IP ranger

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/network/externalipranger/externalip_admission.go
@@ -7,15 +7,15 @@ import (
 	"net"
 	"strings"
 
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/openshift/library-go/pkg/config/helpers"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/klog"
-	kapi "k8s.io/kubernetes/pkg/apis/core"
-
-	"github.com/openshift/library-go/pkg/config/helpers"
 	"k8s.io/kubernetes/openshift-kube-apiserver/admission/network/apis/externalipranger"
 	v1 "k8s.io/kubernetes/openshift-kube-apiserver/admission/network/apis/externalipranger/v1"
+	kapi "k8s.io/kubernetes/pkg/apis/core"
 )
 
 const ExternalIPPluginName = "network.openshift.io/ExternalIPRanger"
@@ -63,11 +63,13 @@ type externalIPRanger struct {
 	*admission.Handler
 	reject         []*net.IPNet
 	admit          []*net.IPNet
+	authorizer     authorizer.Authorizer
 	allowIngressIP bool
 }
 
 var _ admission.Interface = &externalIPRanger{}
 var _ admission.ValidationInterface = &externalIPRanger{}
+var _ = initializer.WantsAuthorizer(&externalIPRanger{})
 
 // ParseRejectAdmitCIDRRules calculates a blacklist and whitelist from a list of string CIDR rules (treating
 // a leading ! as a negation). Returns an error if any rule is invalid.
@@ -99,6 +101,17 @@ func NewExternalIPRanger(reject, admit []*net.IPNet, allowIngressIP bool) *exter
 		admit:          admit,
 		allowIngressIP: allowIngressIP,
 	}
+}
+
+func (r *externalIPRanger) SetAuthorizer(a authorizer.Authorizer) {
+	r.authorizer = a
+}
+
+func (r *externalIPRanger) ValidateInitialization() error {
+	if r.authorizer == nil {
+		return fmt.Errorf("missing authorizer")
+	}
+	return nil
 }
 
 // NetworkSlice is a helper for checking whether an IP is contained in a range
@@ -165,8 +178,31 @@ func (r *externalIPRanger) Validate(ctx context.Context, a admission.Attributes,
 			}
 		}
 	}
+
 	if len(errs) > 0 {
-		return apierrs.NewInvalid(a.GetKind().GroupKind(), a.GetName(), errs)
+		//if there are errors reported, resort to RBAC check to see
+		//if this is an admin user who can over-ride the check
+		allow, err := r.checkAccess(a)
+		if err != nil {
+			return err
+		}
+		if !allow {
+			return admission.NewForbidden(a, errs.ToAggregate())
+		}
 	}
+
 	return nil
+}
+
+func (r *externalIPRanger) checkAccess(attr admission.Attributes) (bool, error) {
+	authzAttr := authorizer.AttributesRecord{
+		User:            attr.GetUserInfo(),
+		Verb:            "create",
+		Resource:        "service",
+		Subresource:     "externalips",
+		APIGroup:        "network.openshift.io",
+		ResourceRequest: true,
+	}
+	authorized, _, err := r.authorizer.Authorize(authzAttr)
+	return authorized == authorizer.DecisionAllow, err
 }


### PR DESCRIPTION
This PR adds a RBAC checker for adding an External IP range for a service. 