### PR TITLE
Bug 1726392: extended: clean up cluster role binding after scc test

### DIFF
--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -149,6 +149,7 @@ var _ = g.Describe("[Feature:SecurityContextConstraints] ", func() {
 		if _, err := clusterAdminKubeClientset.RbacV1().ClusterRoleBindings().Create(&crb); err != nil {
 			t.Fatal(err)
 		}
+		oc.AddExplicitResourceToDelete(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), "", crb.Name)
 
 		// wait for RBAC to catch up to user1 role binding for SCC
 		if err := oc.WaitForAccessAllowed(&kubeauthorizationv1.SelfSubjectAccessReview{


### PR DESCRIPTION
Fixing:

```
fail [github.com/openshift/origin/test/extended/authorization/authorization.go:361]: who can view deploymentconfigs in hammer by harold
: evaluation errors does not match (clusterrole.rbac.authorization.k8s.io "all-scc-e2e-test-scc-pmktf" not found!=)
```