### PR TITLE
changes openshift-tests to report and error when creating kube client fails

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -293,11 +293,11 @@ func initProvider(provider string, dryRun bool) error {
 	//exutil.TestContext.LoggingSoak.MilliSecondsBetweenWaves = 5000
 
 	exutil.AnnotateTestSuite()
-	exutil.InitTest(dryRun)
+	err := exutil.InitTest(dryRun)
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	// TODO: infer SSH keys from the cluster
-	return nil
+	return err
 }
 
 func decodeProviderTo(provider string, testContext *e2e.TestContextType) error {

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -54,7 +54,7 @@ func InitStandardFlags() {
 	//e2e.RegisterStorageFlags()
 }
 
-func InitTest(dryRun bool) {
+func InitTest(dryRun bool) error {
 	InitDefaultEnvironmentVariables()
 	// interpret synthetic input in `--ginkgo.focus` and/or `--ginkgo.skip`
 	ginkgo.BeforeEach(checkSyntheticInput)
@@ -78,7 +78,7 @@ func InitTest(dryRun bool) {
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: TestContext.KubeConfig}, &clientcmd.ConfigOverrides{})
 	cfg, err := clientConfig.ClientConfig()
 	if err != nil && !dryRun { // we don't need the host when doing a dryrun
-		FatalErr(err)
+		return err
 	}
 	if cfg != nil {
 		TestContext.Host = cfg.Host
@@ -95,6 +95,7 @@ func InitTest(dryRun bool) {
 	TestContext.CreateTestingNS = createTestingNS
 
 	klog.V(2).Infof("Extended test version %s", version.Get().String())
+	return nil
 }
 
 func ExecuteTest(t ginkgo.GinkgoTestingT, suite string) {


### PR DESCRIPTION
this pull changes `openshift-test` to print 
```
openshift-tests excluded test regex is "\\[Disabled:|\\[Disruptive\\]|\\[Skipped\\]|\\[Slow\\]|\\[Flaky\\]|\\[local\\]|\\[Suite:openshift/test-cmd\\]|\\[Skipped:skeleton\\]"
error: invalid configuration: no configuration has been provided
```

instead of
```
goroutine 1 [running]:
runtime/debug.Stack(0xc0039959a0, 0x1cbef8d, 0xc000bc4690)
	/usr/local/Cellar/go/1.12.9/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/openshift/origin/test/extended/util.FatalErr(0x5536180, 0xc00289c520)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/client.go:643 +0x26
github.com/openshift/origin/test/extended/util.InitTest(0x0, 0x0, 0x0)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/test.go:80 +0x5cb
main.initProvider(0x0, 0x0, 0x539fa00, 0x0, 0x5f44342)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:296 +0xe4
main.newRunCommand.func1.1(0x8010105, 0x0)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:127 +0x51
main.mirrorToFile(0xc002ee0c60, 0xc003995c90, 0x5e3a596, 0x4)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:247 +0x98
main.newRunCommand.func1(0xc000133b80, 0xc0003614f0, 0x1, 0x1, 0x0, 0x0)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:126 +0x7d
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc000133b80, 0xc0003612a0, 0x1, 0x1, 0xc000133b80, 0xc0003612a0)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:756 +0x465
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000133900, 0x68d7218, 0xa6060f0, 0xa6060f0)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:846 +0x2ec
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:794
main.main.func1(0xc000133900, 0x0, 0x0)
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:71 +0x93
main.main()
	/Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:72 +0x327

Sep 16 12:46:56.658: INFO: invalid configuration: no configuration has been provided
panic:
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.

But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call

        defer GinkgoRecover()

at the top of the goroutine that caused this panic.
 [recovered]
        panic:
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.

But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call

        defer GinkgoRecover()

at the top of the goroutine that caused this panic.
goroutine 1 [running]:
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/ginkgowrapper.Fail.func1(0xc0035379a0, 0x4e, 0xa1fdb80, 0x80, 0x284, 0xc002742000, 0x970)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/ginkgowrapper/wrapper.go:63 +0xa1
panic(0x517f8a0, 0x67f4fc0)
        /usr/local/Cellar/go/1.12.9/libexec/src/runtime/panic.go:522 +0x1b5
github.com/openshift/origin/vendor/github.com/onsi/ginkgo.Fail(0xc0035379a0, 0x4e, 0xc00386f878, 0x1, 0x1)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:259 +0xc8
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/ginkgowrapper.Fail(0xc0035379a0, 0x4e, 0xc00386f920, 0x1, 0x1)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/ginkgowrapper/wrapper.go:67 +0x19b
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.FailfWithOffset(0x1, 0x5e383c4, 0x2, 0xc00386f990, 0x1, 0x1)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/util.go:286 +0x143
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.Failf(...)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/util.go:278
github.com/openshift/origin/test/extended/util.FatalErr(0x5536180, 0xc0035571c0)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/client.go:644 +0x119
github.com/openshift/origin/test/extended/util.InitTest(0x0, 0x0, 0x0)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/test.go:80 +0x5cb
main.initProvider(0x0, 0x0, 0x539fa00, 0x0, 0x5f44342)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:296 +0xe4
main.newRunCommand.func1.1(0x8010107, 0x1)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:127 +0x51
main.mirrorToFile(0xc00243c840, 0xc00386fc90, 0x5e3a596, 0x4)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:247 +0x98
main.newRunCommand.func1(0xc0025d2c80, 0xc0037a8450, 0x1, 0x1, 0x0, 0x0)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:126 +0x7d
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc0025d2c80, 0xc0037a8420, 0x1, 0x1, 0xc0025d2c80, 0xc0037a8420)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:756 +0x465
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0025d2a00, 0x68d7218, 0xa6060f0, 0xa6060f0)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:846 +0x2ec
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(...)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:794
main.main.func1(0xc0025d2a00, 0x0, 0x0)
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:71 +0x93
main.main()
        /Users/lszaszki/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:72 +0x327
```
