### PR TITLE
UPSTREAM: 82367: Enable block tests for Cinder

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/in_tree.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/in_tree.go
@@ -962,6 +962,7 @@ func InitCinderDriver() testsuites.TestDriver {
 				testsuites.CapPersistence: true,
 				testsuites.CapFsGroup:     true,
 				testsuites.CapExec:        true,
+				testsuites.CapBlock:       true,
 			},
 		},
 	}


### PR DESCRIPTION
Cinder tests are failing in a downstream test suite. With disabled block support, we test that a block volume cannot be dynamically provisioned and it fails, because Cinder provisions block volumes just fine.