### PR TITLE
Bug 1753324: Allow skipping tests based on detected network plugin

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -44,16 +44,6 @@ var staticSuites = []*ginkgo.TestSuite{
 		},
 	},
 	{
-		Name: "openshift/conformance/multitenant",
-		Description: templates.LongDesc(`
-		Only the portion of the openshift/conformance test suite that applies to the openshift-sdn multitenant plugin.
-		`),
-		Matches: func(name string) bool {
-			return !strings.Contains(name, "[Feature:NetworkPolicy]") && strings.Contains(name, "[Suite:openshift/conformance/")
-		},
-		Parallelism: 30,
-	},
-	{
 		Name: "openshift/disruptive",
 		Description: templates.LongDesc(`
 		The disruptive test suite.

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -131,12 +131,21 @@ func ExecuteTest(t ginkgo.GinkgoTestingT, suite string) {
 }
 
 func AnnotateTestSuite() {
-	testRenamer := newGinkgoTestRenamerFromGlobals(e2e.TestContext.Provider)
+	testRenamer := newGinkgoTestRenamerFromGlobals(e2e.TestContext.Provider, getNetworkSkips())
 
 	ginkgo.WalkTests(testRenamer.maybeRenameTest)
 }
 
-func newGinkgoTestRenamerFromGlobals(provider string) *ginkgoTestRenamer {
+func getNetworkSkips() []string {
+	out, err := e2e.KubectlCmd("get", "network.operator.openshift.io", "cluster", "--template", "{{.spec.defaultNetwork.type}}{{if .spec.defaultNetwork.openshiftSDNConfig}} {{.spec.defaultNetwork.type}}/{{.spec.defaultNetwork.openshiftSDNConfig.mode}}{{end}}").CombinedOutput()
+	if err != nil {
+		e2e.Logf("Could not get network operator configuration: not adding any plugin-specific skips")
+		return nil
+	}
+	return strings.Split(string(out), " ")
+}
+
+func newGinkgoTestRenamerFromGlobals(provider string, networkSkips []string) *ginkgoTestRenamer {
 	var allLabels []string
 	matches := make(map[string]*regexp.Regexp)
 	stringMatches := make(map[string][]string)
@@ -166,6 +175,9 @@ func newGinkgoTestRenamerFromGlobals(provider string) *ginkgoTestRenamer {
 
 	if provider != "" {
 		excludedTests = append(excludedTests, fmt.Sprintf(`\[Skipped:%s\]`, provider))
+	}
+	for _, network := range networkSkips {
+		excludedTests = append(excludedTests, fmt.Sprintf(`\[Skipped:Network/%s\]`, network))
 	}
 	klog.Infof("openshift-tests excluded test regex is %q", strings.Join(excludedTests, `|`))
 	excludedTestsFilter := regexp.MustCompile(strings.Join(excludedTests, `|`))
@@ -363,8 +375,6 @@ var (
 			`\[Feature:RuntimeClass\]`,        // disable runtimeclass tests in 4.1 (sig-pod/sjenning@redhat.com)
 			`\[Feature:CustomResourceWebhookConversion\]`, // webhook conversion is off by default.  sig-master/@sttts
 
-			`NetworkPolicy between server and client should allow egress access on one named port`, // not yet implemented
-
 			`should proxy to cadvisor`, // we don't expose cAdvisor port directly for security reasons
 		},
 		// tests that rely on special configuration that we do not yet support
@@ -515,6 +525,23 @@ var (
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1750851
 			// should be serial if/when it's re-enabled
 			`\[HPA\] Horizontal pod autoscaling \(scale resource: Custom Metrics from Stackdriver\)`,
+		},
+		// tests that don't pass under openshift-sdn but that are expected to pass
+		// with other network plugins (particularly ovn-kubernetes)
+		"[Skipped:Network/OpenShiftSDN]": {
+			`NetworkPolicy between server and client should allow egress access on one named port`, // not yet implemented
+		},
+		// tests that don't pass under openshift-sdn multitenant mode
+		"[Skipped:Network/OpenShiftSDN/Multitenant]": {
+			`\[Feature:NetworkPolicy\]`, // not compatible with multitenant mode
+			`\[sig-network\] Services should preserve source pod IP for traffic thru service cluster IP`, // known bug, not planned to be fixed
+		},
+		// tests that don't pass under OVN Kubernetes
+		"[Skipped:Network/OVNKubernetes]": {
+			`\[sig-network\] Services should be able to switch session affinity for NodePort service`,            // https://jira.coreos.com/browse/SDN-510
+			`\[sig-network\] Services should be able to switch session affinity for service with type clusterIP`, // https://jira.coreos.com/browse/SDN-510
+			`\[sig-network\] Services should have session affinity work for NodePort service`,                    // https://jira.coreos.com/browse/SDN-510
+			`\[sig-network\] Services should have session affinity work for service with type clusterIP`,         // https://jira.coreos.com/browse/SDN-510
 		},
 		"[Suite:openshift/scalability]": {},
 		// tests that replace the old test-cmd script

--- a/test/extended/util/test_test.go
+++ b/test/extended/util/test_test.go
@@ -78,20 +78,34 @@ func TestStockRules(t *testing.T) {
 
 		testName string
 		provider string
+		netSkips []string
 
 		expectedText string
 	}{
+		{
+			name:         "not skipped",
+			provider:     "gce",
+			netSkips:     []string{"OpenShiftSDN"},
+			testName:     `[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [LinuxOnly] [NodeConformance] [Conformance]`,
+			expectedText: `[sig-network] Networking Granular Checks: Pods should function for intra-pod communication: http [LinuxOnly] [NodeConformance] [Conformance] [Suite:openshift/conformance/parallel/minimal]`,
+		},
 		{
 			name:         "should skip localssd on gce",
 			provider:     "gce",
 			testName:     `[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: gce-localssd-scsi-fs] [Serial] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted`,
 			expectedText: `[sig-storage] In-tree Volumes [Driver: local][LocalVolumeType: gce-localssd-scsi-fs] [Serial] [Testpattern: Dynamic PV (default fs)] subPath should be able to unmount after the subpath directory is deleted [Skipped:gce]`, // notice that this isn't categorized into any of our buckets
 		},
+		{
+			name:         "should skip NetworkPolicy tests on multitenant",
+			netSkips:     []string{"OpenShiftSDN", "OpenShiftSDN/Multitenant"},
+			testName:     `[Feature:NetworkPolicy] should do something with NetworkPolicy`,
+			expectedText: `[Feature:NetworkPolicy] should do something with NetworkPolicy [Skipped:Network/OpenShiftSDN/Multitenant]`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testRenamer := newGinkgoTestRenamerFromGlobals(test.provider)
+			testRenamer := newGinkgoTestRenamerFromGlobals(test.provider, test.netSkips)
 			testNode := &testNode{
 				text: test.testName,
 			}


### PR DESCRIPTION
This fixes two problems:
- We need to be able to skip some tests on ovn-kubernetes (eg, the Service SessionAffinity tests, since that feature isn't implemented yet in 4.2).
- We need to be able to *not* skip some tests on ovn-kubernetes that we are skipping on openshift-sdn (eg, NetworkPolicy egress tests)

This also lets us simplify the way the multitenant suite is done.

(WIP until the 1.16 rebase lands since this will need to be updated for that)