### PR TITLE
Bug #1752646: Disable the router header test for all platforms

### DIFF
--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -33,17 +33,6 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 		metricsIP, err = exutil.WaitForRouterInternalIP(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		if routerIP != metricsIP {
-			// On 4.x clusters, there's couple of bugs to fix before
-			// we can enable this test:
-			//  1. Selector on router-internal-default service
-			//  2. There is a weird 10.131.0.1 IP in the mix which
-			//     shows up as the client ip and not the node IP.
-			// Dec 17 17:03:32.836: Unexpected header: '10.131.0.1' (expected 10.0.139.23); All headers: http.Header{"User-Agent":[]string{"curl/7.61.0"}, "Accept":[]string{"*/*"}, "X-Forwarded-Host":[]string{"router-headers.example.com"}, "X-Forwarded-Port":[]string{"80"}, "X-Forwarded-Proto":[]string{"http"}, "Forwarded":[]string{"for=10.131.0.1;host=router-headers.example.com;proto=http;proto-version="}, "X-Forwarded-For":[]string{"10.131.0.1"}}
-			g.Skip("skipped on 4.0 clusters")
-			return
-		}
 	})
 
 	g.Describe("The HAProxy router", func() {

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -413,6 +413,9 @@ var (
 
 			`\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\] provisioning should access volume from different nodes`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711688
 
+			// Test fails on platforms that use LoadBalancerService and HostNetwork endpoint publishing strategy
+			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should set Forwarded headers appropriately`, // https://bugzilla.redhat.com/show_bug.cgi?id=1752646
+
 			// requires a 1.14 kubelet, enable when rhcos is built for 4.2
 			"when the NodeLease feature is enabled",
 			"RuntimeClass should reject",


### PR DESCRIPTION
It seems that most platforms are either having trouble with, or have already disabled this test. This test occasionally passes but usually doesn't in our canaries, and we believe the best course of action is to disable it.

Test Grid:
https://testgrid.k8s.io/redhat-openshift-release-informing#redhat-canary-openshift-ocp-installer-e2e-openstack-4.2

Example Failure:
https://prow.k8s.io/view/gcs/origin-ci-test/logs/canary-openshift-ocp-installer-e2e-openstack-4.2/194