### PR TITLE
Bug 1749246: Change pod antiaffinity weight in e2e

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/scheduling/priorities.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/scheduling/priorities.go
@@ -224,7 +224,7 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 								TopologyKey: k,
 								Namespaces:  []string{ns},
 							},
-							Weight: 10,
+							Weight: 100,
 						},
 					},
 				},


### PR DESCRIPTION
This pulls in upstream changes to fix improperly labeling in a pod anti-affinity e2e test

This issue is part of https://bugzilla.redhat.com/show_bug.cgi?id=1749246