### PR TITLE
tests: Only the OpenShift upgrade e2e suite should run

### DIFF
--- a/cmd/openshift-tests/upgrade.go
+++ b/cmd/openshift-tests/upgrade.go
@@ -24,7 +24,9 @@ var upgradeSuites = []*ginkgo.TestSuite{
 		Description: templates.LongDesc(`
 		Run all tests.
 		`),
-		Matches: func(name string) bool { return strings.Contains(name, "[Feature:ClusterUpgrade]") },
+		Matches: func(name string) bool {
+			return strings.Contains(name, "[Feature:ClusterUpgrade]") && strings.Contains(name, "[Suite:openshift]")
+		},
 
 		Init: func(opt map[string]string) error {
 			for k, v := range opt {


### PR DESCRIPTION
On GCP the upstream upgrade test was being run (no skip rule) which fails because it doesn't actually know how to upgrade us. Disable that in the upgrade suite so only the openshift variant runs.

Caught in upgrade test https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.2/2

```
failed: (24m56s) 2019-09-16T21:39:43 "[sig-cluster-lifecycle] Upgrade [Feature:Upgrade] cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade] [Suite:k8s] [Disabled:SpecialConfig]"

started: (1/2/2) "[Disruptive] Cluster upgrade should maintain a functioning cluster [Feature:ClusterUpgrade] [Suite:openshift] [Serial]"
```

We only want to run the latter.