### PR TITLE
Bug 1752578: UPSTREAM: <carry>: tolerate slow pod delete on GCP

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go
@@ -59,7 +59,7 @@ const (
 	maxKubectlExecRetries = 5
 	// TODO(mikedanese): reset this to 5 minutes once #47135 is resolved.
 	// ref https://github.com/kubernetes/kubernetes/issues/47135
-	DefaultNamespaceDeletionTimeout = 10 * time.Minute
+	DefaultNamespaceDeletionTimeout = 20 * time.Minute
 )
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.


### PR DESCRIPTION
Namespace clean up on GCP takes a long time because pods take a long time to reap:

```
namespace_controller.go:148] unexpected items still remain in namespace: e2e-svcaccounts-X for gvr: /v1, Resource=pods
```

Signed-off-by: Monis Khan <mkhan@redhat.com>

@deads2k 

Based on various test outputs, the namespaces are cleaned up some minutes later:

```
namespace_controller.go:171] Namespace has been deleted e2e-svcaccounts-X
```