### PR TITLE
Bug 1752582: e2e: wait longer for authz checks

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -756,16 +756,13 @@ func (c *CLI) WaitForAccessDenied(review *kubeauthorizationv1.SelfSubjectAccessR
 }
 
 func waitForAccess(c kubernetes.Interface, allowed bool, review *kubeauthorizationv1.SelfSubjectAccessReview) error {
-	policyCachePollInterval := 100 * time.Millisecond
-	policyCachePollTimeout := 10 * time.Second
-	err := wait.Poll(policyCachePollInterval, policyCachePollTimeout, func() (bool, error) {
+	return wait.Poll(time.Second, time.Minute, func() (bool, error) {
 		response, err := c.AuthorizationV1().SelfSubjectAccessReviews().Create(review)
 		if err != nil {
 			return false, err
 		}
 		return response.Status.Allowed == allowed, nil
 	})
-	return err
 }
 
 func getClientConfig(kubeConfigFile string) (*rest.Config, error) {


### PR DESCRIPTION
Group based permissions can take a long time to be effective due to the extra layer of indirection via the group reverse index.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@deads2k 