### PR TITLE
Bug 1752646: Move templateinsance impersonation to broken skip tag 

### DIFF
--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -250,14 +250,6 @@ var _ = g.Describe("[Conformance][templates] templateinstance impersonation test
 	})
 
 	g.It("should pass impersonation update tests", func() {
-		g.Skip("Bug 1731222: skip template tests until we determine what is broken")
-		// check who can update TemplateInstances.  Via Update(), spec updates
-		// should be rejected (with the exception of spec.metadata fields used
-		// by the garbage collector, not tested here).  Status updates should be
-		// silently ignored.  Via UpdateStatus(), spec updates should be
-		// silently ignored.  Status should only be updatable by a user with
-		// update access to that endpoint.  In practice this is intended only to
-		// be the templateinstance controller and system:admin.
 		for _, test := range tests {
 			var templateinstancecopy *templatev1.TemplateInstance
 			setUser(cli, test.user)

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -415,7 +415,7 @@ var (
 
 			// Test fails on platforms that use LoadBalancerService and HostNetwork endpoint publishing strategy
 			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should set Forwarded headers appropriately`, // https://bugzilla.redhat.com/show_bug.cgi?id=1752646
-
+			`\[Conformance\]\[templates\] templateinstance impersonation tests should pass impersonation creation tests`,         // https://bugzilla.redhat.com/show_bug.cgi?id=1752910
 			// requires a 1.14 kubelet, enable when rhcos is built for 4.2
 			"when the NodeLease feature is enabled",
 			"RuntimeClass should reject",


### PR DESCRIPTION
For some reason this test doesn't always get skipped on the openstack platform, so we are moving it with the other broken tests. This should be more consistent with other skipped tests, and will prevent the test from running on all platforms as originally intended.