### PR TITLE
Bug 1752983: Ensure the OLM e2e test loops correctly

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -1,12 +1,10 @@
 package operators
 
 import (
-	"reflect"
+	"fmt"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
-	yaml "gopkg.in/yaml.v2"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -14,39 +12,63 @@ import (
 var _ = g.Describe("[Feature:Platform] OLM should", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLI("olm", exutil.KubeConfigPath())
+	var oc = exutil.NewCLIWithoutNamespace("default")
 
-	// The list of all available OLM resources
-	olmResources := []string{
-		"packagemanifests", "catalogsources", "clusterserviceversions",
-		"installplans", "operatorgroups", "subscriptions",
+	operators := "operators.coreos.com"
+	providedAPIs := []struct {
+		fromAPIService bool
+		group          string
+		version        string
+		plural         string
+	}{
+		{
+			fromAPIService: true,
+			group:          "packages." + operators,
+			version:        "v1",
+			plural:         "packagemanifests",
+		},
+		{
+			group:   operators,
+			version: "v1",
+			plural:  "operatorgroups",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "clusterserviceversions",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "catalogsources",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "installplans",
+		},
+		{
+			group:   operators,
+			version: "v1alpha1",
+			plural:  "subscriptions",
+		},
 	}
 
-	for i := range olmResources {
-		g.It("list "+olmResources[i], func() {
-			var resourceList map[string]interface{}
-			// Get resource yaml and parse
-			output, err := oc.AsAdmin().Run("get").Args(olmResources[i], "--all-namespaces", "-o", "yaml").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			err = yaml.Unmarshal([]byte(output), &resourceList)
-			if err != nil {
-				e2e.Logf("Unable to parse %s yaml list", olmResources[i])
+	for i := range providedAPIs {
+		api := providedAPIs[i]
+		g.It(fmt.Sprintf("be installed with %s at version %s", api.plural, api.version), func() {
+			if api.fromAPIService {
+				// Ensure spec.version matches expected
+				raw, err := oc.AsAdmin().Run("get").Args("apiservices", fmt.Sprintf("%s.%s", api.version, api.group), "-o=jsonpath={.spec.version}").Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(raw).To(o.Equal(api.version))
+			} else {
+				// Ensure expected version exists in spec.versions and is both served and stored
+				raw, err := oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==\"%s\")]}", api.version)).Output()
+				o.Expect(err).NotTo(o.HaveOccurred())
+				o.Expect(raw).To(o.ContainSubstring("served:true"))
+				o.Expect(raw).To(o.ContainSubstring("storage:true"))
 			}
-			// Verify resource items list has at least one item
-			o.Expect(isResourceItemsEmpty(resourceList)).To(o.BeFalse(), olmResources[i]+" list should have at least one item")
-			e2e.Logf("Successfully list %s", olmResources[i])
 		})
 	}
 })
-
-func isResourceItemsEmpty(resourceList map[string]interface{}) bool {
-	// Get resource items and check if it is empty
-	items, err := resourceList["items"].([]interface{})
-	o.Expect(err).To(o.BeTrue(), "Unable to verify items is a slice")
-
-	if reflect.ValueOf(items).Len() > 0 {
-		return false
-	} else {
-		return true
-	}
-}


### PR DESCRIPTION
The closure was capturing the last i value instead of testing each individual item. Change the test to loop correctly.

```
fail [github.com/openshift/origin/test/extended/operators/olm.go:36]: subscriptions list should have at least one item
Expected
    <bool>: true
to be false
```

All of the tests in the suite return that when a 4.1 cluster is run against 4.2.  Blocks us starting the skew test (there's almost certainly an actual bug here, this is just a blocker for knowing what the other bugs are).

No 4.2 change necessary because the test was already refactored as part of an epic.