### PR TITLE
UPSTREAM: 82803: dump namespace object in e2e when it doesn't get deleted

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/BUILD
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/BUILD
@@ -131,6 +131,7 @@ go_library(
         "//test/e2e/perftype:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
+        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/config:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -41,6 +41,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"golang.org/x/net/websocket"
 	"k8s.io/klog"
 
@@ -1189,8 +1190,11 @@ func deleteNS(c clientset.Interface, dynamicClient dynamic.Interface, namespace 
 	}
 
 	// wait for namespace to delete or timeout.
+	var lastNamespace *v1.Namespace
 	err := wait.PollImmediate(2*time.Second, timeout, func() (bool, error) {
-		if _, err := c.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{}); err != nil {
+		var err error
+		lastNamespace, err = c.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+		if err != nil {
 			if apierrs.IsNotFound(err) {
 				return true, nil
 			}
@@ -1220,6 +1224,9 @@ func deleteNS(c clientset.Interface, dynamicClient dynamic.Interface, namespace 
 
 	// a timeout waiting for namespace deletion happened!
 	if err != nil {
+		// namespaces now have conditions that are useful for debugging generic resources and finalizers
+		Logf("namespace did not cleanup: %s", spew.Sdump(lastNamespace))
+
 		// some content remains in the namespace
 		if remainingContent {
 			// pods remain


### PR DESCRIPTION
Adds debugging information when namespaces don't get cleaned up.

/assign @p0lyn0mial 