### PR TITLE
Bug 1753070: Allow an env var to disable certain tests for skew testing

### DIFF
--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -19,6 +19,9 @@ import (
 var _ = Describe("[Feature:Platform][Smoke] Managed cluster", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 	It("should ensure pods use downstream images from our release image with proper ImagePullPolicy", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2e.Skipf("Test is disabled to allow cluster components to have different versions")
+		}
 		imagePullSecret, err := oc.KubeFramework().ClientSet.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
 		if err != nil {
 			e2e.Failf("unable to get pull secret for cluster: %v", err)

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -3,6 +3,7 @@ package operators
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -174,6 +175,9 @@ var _ = g.Describe("[Feature:Platform] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have operators on the cluster version", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2e.Skipf("Test is disabled to allow cluster components to have different versions")
+		}
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c := configclient.NewForConfigOrDie(cfg)


### PR DESCRIPTION
When reproducing specific upgrade states (4.2 control plane and
4.1 nodes) we need to provide a partial payload. That causes certain
sanity tests to fail. Allow those tests to be bypassed in extremely
rare conditions.

A future change may make this more explicit but this is the easiest
short term option. Environment variables should not in general be used
to impact the contents of a suite, and the future "test options"
addition to openshift-tests will remove the env var.