### PR TITLE
Bug 1753071: Allow certain tests to be skipped when performing skew testing

### DIFF
--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -21,6 +21,9 @@ var _ = Describe("[Feature:Platform][Smoke] Managed cluster", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 
 	It("should ensure pods use images from our release image with proper ImagePullPolicy", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2e.Skipf("Test is disabled to allow cluster components to have different versions")
+		}
 		imagePullSecret, err := oc.KubeFramework().ClientSet.CoreV1().Secrets("openshift-config").Get("pull-secret", metav1.GetOptions{})
 		if err != nil {
 			e2e.Failf("unable to get pull secret for cluster: %v", err)

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -3,6 +3,7 @@ package operators
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -174,6 +175,9 @@ var _ = g.Describe("[Feature:Platform] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have operators on the cluster version", func() {
+		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+			e2e.Skipf("Test is disabled to allow cluster components to have different versions")
+		}
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c := configclient.NewForConfigOrDie(cfg)


### PR DESCRIPTION
Skew tests create payloads that don't completely upgrade a cluster in order to get reproducible partial upgrade states. Some tests need to be disabled in order to allow the suite to succeed. Uses an env var for now, although future changes will switch to an argument flag.

Backport of #23820 to enable skewed node testing.