### PR TITLE
bug 1752557: bump s2i quota test memory limit to avoid oomkills

### DIFF
--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -55,9 +55,9 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func(
 				g.By("expecting the build logs to contain the correct cgroups values")
 				buildLog, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(buildLog).To(o.ContainSubstring("MEMORY=209715200"))
+				o.Expect(buildLog).To(o.ContainSubstring("MEMORY=419430400"))
 				// TODO: re-enable this check when https://github.com/containers/buildah/issues/1213 is resolved.
-				//o.Expect(buildLog).To(o.ContainSubstring("MEMORYSWAP=209715200"))
+				//o.Expect(buildLog).To(o.ContainSubstring("MEMORYSWAP=419430400"))
 
 				testScheme := runtime.NewScheme()
 				utilruntime.Must(buildv1.Install(testScheme))

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -22819,7 +22819,7 @@ var _testExtendedTestdataBuildsTestS2iBuildQuotaJson = []byte(`{
     "resources": {
       "limits": {
         "cpu": "60m",
-        "memory": "200Mi"
+        "memory": "400Mi"
       }
     },
     "source": {

--- a/test/extended/testdata/builds/test-s2i-build-quota.json
+++ b/test/extended/testdata/builds/test-s2i-build-quota.json
@@ -12,7 +12,7 @@
     "resources": {
       "limits": {
         "cpu": "60m",
-        "memory": "200Mi"
+        "memory": "400Mi"
       }
     },
     "source": {


### PR DESCRIPTION
trying to get confirmation that OOMKills can appear when the container process hits the container memory limit: https://coreos.slack.com/archives/CK1AE4ZCK/p1568807371055900
