### PR TITLE
Bug 1759182: Add a RBAC checker for external IP ranger

### DIFF
--- a/pkg/network/admission/externalipranger/externalip_admission_test.go
+++ b/pkg/network/admission/externalipranger/externalip_admission_test.go
@@ -1,14 +1,42 @@
 package externalipranger
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/serviceaccount"
 )
+
+type fakeTestAuthorizer struct {
+	t *testing.T
+}
+
+func fakeAuthorizer(t *testing.T) authorizer.Authorizer {
+	return &fakeTestAuthorizer{
+		t: t,
+	}
+}
+
+func (a *fakeTestAuthorizer) Authorize(attributes authorizer.Attributes) (authorizer.Decision, string, error) {
+	ui := attributes.GetUser()
+	if ui == nil {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("No valid UserInfo for Context")
+	}
+	// system:serviceaccount:test:admin user aka admin user is allowed to set
+	// external IPs
+	if ui.GetName() == "system:serviceaccount:test:admin" {
+		return authorizer.DecisionAllow, "", nil
+	}
+	// Non test:admin user aka without admin privileges:
+	return authorizer.DecisionDeny, "", nil
+}
 
 // TestAdmission verifies various scenarios involving pod/project/global node label selectors
 func TestAdmission(t *testing.T) {
@@ -47,23 +75,34 @@ func TestAdmission(t *testing.T) {
 		errFn           func(err error) bool
 		loadBalancer    bool
 		ingressIP       string
+		userinfo        user.Info
 	}{
 		{
 			admit:    true,
 			op:       admission.Create,
-			testName: "No external IPs on create",
+			testName: "No external IPs on create for test:ordinary-user user",
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:    true,
 			op:       admission.Update,
-			testName: "No external IPs on update",
+			testName: "No external IPs on update for test:admin user",
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       false,
 			externalIPs: []string{"1.2.3.4"},
 			op:          admission.Create,
-			testName:    "No external IPs allowed on create",
+			testName:    "No external IPs allowed on create for test:ordinary-user user",
 			errFn:       func(err error) bool { return strings.Contains(err.Error(), "externalIPs have been disabled") },
+			userinfo:    serviceaccount.UserInfo("test", "ordinary-user", ""),
+		},
+		{
+			admit:       true,
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "External IPs allowed on create for test:admin user",
+			userinfo:    serviceaccount.UserInfo("test", "admin", ""),
 		},
 		{
 			admit:       false,
@@ -71,6 +110,14 @@ func TestAdmission(t *testing.T) {
 			op:          admission.Update,
 			testName:    "No external IPs allowed on update",
 			errFn:       func(err error) bool { return strings.Contains(err.Error(), "externalIPs have been disabled") },
+			userinfo:    serviceaccount.UserInfo("test", "ordinary-user", ""),
+		},
+		{
+			admit:       true,
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Update,
+			testName:    "External IPs allowed on update for test:admin user",
+			userinfo:    serviceaccount.UserInfo("test", "admin", ""),
 		},
 		{
 			admit:       false,
@@ -82,6 +129,7 @@ func TestAdmission(t *testing.T) {
 				return strings.Contains(err.Error(), "externalIP is not allowed") &&
 					strings.Contains(err.Error(), "spec.externalIPs[0]")
 			},
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       false,
@@ -93,6 +141,7 @@ func TestAdmission(t *testing.T) {
 				return strings.Contains(err.Error(), "externalIP is not allowed") &&
 					strings.Contains(err.Error(), "spec.externalIPs[0]")
 			},
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       false,
@@ -105,6 +154,7 @@ func TestAdmission(t *testing.T) {
 				return strings.Contains(err.Error(), "externalIP is not allowed") &&
 					strings.Contains(err.Error(), "spec.externalIPs[0]")
 			},
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       false,
@@ -117,20 +167,23 @@ func TestAdmission(t *testing.T) {
 				return strings.Contains(err.Error(), "externalIP is not allowed") &&
 					strings.Contains(err.Error(), "spec.externalIPs[0]")
 			},
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       true,
 			admits:      []*net.IPNet{ipv4},
 			externalIPs: []string{"172.0.0.1"},
 			op:          admission.Create,
-			testName:    "IP in range on create",
+			testName:    "IP in range on create for test:ordinary-user user",
+			userinfo:    serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       true,
 			admits:      []*net.IPNet{ipv4},
 			externalIPs: []string{"172.0.0.1"},
 			op:          admission.Update,
-			testName:    "IP in range on update",
+			testName:    "IP in range on update for test:admin user",
+			userinfo:    serviceaccount.UserInfo("test", "admin", ""),
 		},
 		// other checks
 		{
@@ -143,13 +196,24 @@ func TestAdmission(t *testing.T) {
 				return strings.Contains(err.Error(), "externalIPs must be a valid address") &&
 					strings.Contains(err.Error(), "spec.externalIPs[0]")
 			},
+			userinfo: serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:       false,
 			admits:      []*net.IPNet{none},
 			externalIPs: []string{"1.2.3.4"},
 			op:          admission.Create,
-			testName:    "IP range is empty",
+			testName:    "IP range is empty for test:ordinary-user user",
+			errFn:       func(err error) bool { return strings.Contains(err.Error(), "externalIP is not allowed") },
+			userinfo:    serviceaccount.UserInfo("test", "ordinary-user", ""),
+		},
+		{
+			admit:       true,
+			admits:      []*net.IPNet{none},
+			externalIPs: []string{"1.2.3.4"},
+			op:          admission.Create,
+			testName:    "IP range is empty, but test:admin user allowed",
+			userinfo:    serviceaccount.UserInfo("test", "admin", ""),
 		},
 		{
 			admit:       false,
@@ -158,6 +222,7 @@ func TestAdmission(t *testing.T) {
 			externalIPs: []string{"1.2.3.4"},
 			op:          admission.Create,
 			testName:    "rejections can cover the entire range",
+			userinfo:    serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		// Ingress IP checks
 		{
@@ -167,6 +232,7 @@ func TestAdmission(t *testing.T) {
 			testName:     "Ingress ip allowed when external ips are disabled",
 			loadBalancer: true,
 			ingressIP:    "1.2.3.4",
+			userinfo:     serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 		{
 			admit:        true,
@@ -176,6 +242,7 @@ func TestAdmission(t *testing.T) {
 			testName:     "Ingress ip allowed when external ips are enabled",
 			loadBalancer: true,
 			ingressIP:    "1.2.3.4",
+			userinfo:     serviceaccount.UserInfo("test", "admin", ""),
 		},
 		{
 			admit:        false,
@@ -185,13 +252,19 @@ func TestAdmission(t *testing.T) {
 			testName:     "Ingress ip not allowed for non-lb service",
 			loadBalancer: false,
 			ingressIP:    "1.2.3.4",
+			userinfo:     serviceaccount.UserInfo("test", "ordinary-user", ""),
 		},
 	}
 	for _, test := range tests {
 		svc.Spec.ExternalIPs = test.externalIPs
 		allowIngressIP := len(test.ingressIP) > 0 || test.loadBalancer
 		handler := NewExternalIPRanger(test.rejects, test.admits, allowIngressIP)
-
+		handler.SetAuthorizer(fakeAuthorizer(t))
+		err := handler.ValidateInitialization()
+		if err != nil {
+			t.Errorf("%s: Got an error %s", test.testName, err)
+			continue
+		}
 		if test.loadBalancer {
 			svc.Spec.Type = kapi.ServiceTypeLoadBalancer
 		} else {
@@ -217,7 +290,7 @@ func TestAdmission(t *testing.T) {
 			oldSvc = nil
 		}
 
-		err := handler.Validate(admission.NewAttributesRecord(svc, oldSvc, kapi.Kind("Service").WithVersion("version"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services").WithVersion("version"), "", test.op, false, nil))
+		err = handler.Validate(admission.NewAttributesRecord(svc, oldSvc, kapi.Kind("Service").WithVersion("version"), "namespace", svc.ObjectMeta.Name, kapi.Resource("services").WithVersion("version"), "", test.op, false, test.userinfo))
 		if test.admit && err != nil {
 			t.Errorf("%s: expected no error but got: %s", test.testName, err)
 		} else if !test.admit && err == nil {


### PR DESCRIPTION
In case the supplied external IPs in the service spec are valid,
allow the RBAC check to override the specified ranges in the
external IP range checker.