### PR TITLE
Disable oc new-app tests

### DIFF
--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -44,6 +44,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 		})
 
 		g.It("should succeed with a --name of 58 characters", func() {
+			g.Skip("Bug 1753731: builds do not always reference the correct location for pull-through imagestream tags")
 			g.By("calling oc new-app")
 			err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -61,6 +62,7 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 		})
 
 		g.It("should fail with a --name longer than 58 characters", func() {
+			g.Skip("Bug 1753731: builds do not always reference the correct location for pull-through imagestream tags")
 			g.By("calling oc new-app")
 			out, err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
 			o.Expect(err).To(o.HaveOccurred())


### PR DESCRIPTION
Disable flaking tests due to [bug 1753731](https://bugzilla.redhat.com/show_bug.cgi?id=1753731).