### PR TITLE
publish kube 1.14 from release-4.2

### DIFF
--- a/publishing-rules.yaml
+++ b/publishing-rules.yaml
@@ -5,7 +5,7 @@ rules:
   branches:
   - name: origin-4.2-kubernetes-1.14.6
     source:
-      branch: master
+      branch: release-4.2
       dir: vendor/k8s.io/kubernetes
   - name: origin-4.1-kubernetes-1.13.4
     source:


### PR DESCRIPTION
We are branching and need to update this

/cherrypick release-4.2