### PR TITLE
Bug 1755000: Disable tests that need latest kubelet

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -452,6 +452,14 @@ var (
 
 			// TODO(workload): reactivate when oc is rebased
 			`should support exec using resource/name`,
+
+			// Disable these tests for now because they require 1.16 kubelet
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1755000
+			`VolumeSubpathEnvExpansion`,
+			`CSI mock volume CSI Volume expansion`,
+			`CSI mock volume CSI online volume expansion`,
+			`CSI mock volume CSI workload information using mock driver`,
+			`volume-expand should resize volume when PVC is edited while pod is using it `,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1755000 until kubelet version is updated.

/sig storage
