### PR TITLE
Bug 1755000: Remove whitespace from online expansion test

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -459,7 +459,7 @@ var (
 			`CSI mock volume CSI Volume expansion`,
 			`CSI mock volume CSI online volume expansion`,
 			`CSI mock volume CSI workload information using mock driver`,
-			`volume-expand should resize volume when PVC is edited while pod is using it `,
+			`volume-expand should resize volume when PVC is edited while pod is using it`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
The additional whitespace was causing the test to still getting included. 

