### PR TITLE
Bug 1753071: Skip alert test when test environment is known to be skewed

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -196,6 +197,9 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})
 		g.It("should report less than two alerts in firing or pending state", func() {
+			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
+				e2e.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
+			}
 			oc.SetupProject()
 			ns := oc.Namespace()
 			execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })


### PR DESCRIPTION
Alerts are fired in skewed environments which prevent tests from
passing. This is required for the 4.2 and 4.1 skew tests to pass.