### PR TITLE
Disable GPUDevicePluginAcrossRecreate test

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -358,8 +358,9 @@ var (
 			`\[Feature:Initializers\]`,     // admission controller disabled
 			`\[Feature:TTLAfterFinished\]`, // flag gate is off
 			`\[Feature:GPUDevicePlugin\]`,  // GPU node needs to be available
-			`\[Feature:ExpandCSIVolumes\]`, // off by default .  sig-storage
-			`\[Feature:DynamicAudit\]`,     // off by default.  sig-master
+			`\[sig-scheduling\] GPUDevicePluginAcrossRecreate \[Feature:Recreate\]`, // GPU node needs to be available
+			`\[Feature:ExpandCSIVolumes\]`,                                          // off by default .  sig-storage
+			`\[Feature:DynamicAudit\]`,                                              // off by default.  sig-master
 
 			`\[NodeAlphaFeature:VolumeSubpathEnvExpansion\]`, // flag gate is off
 			`\[Feature:IPv6DualStack.*\]`,


### PR DESCRIPTION
We missed a Nvidia GPU test when we rebased to 1.16. Disable from E2E for now.