### PR TITLE
[release-3.11] openshift-node-config: Improve node IP lookup in the DNSIP selection

### DIFF
--- a/pkg/cmd/server/origin/node/node.go
+++ b/pkg/cmd/server/origin/node/node.go
@@ -62,7 +62,7 @@ func SetDNSIP(nodeConfig *configapi.NodeConfig) error {
 	}
 
 	var ipAddr net.IP
-	addrs, _ := net.LookupIP(nodeConfig.NodeName)
+	addrs, _ := net.LookupIP(hostname)
 	for _, addr := range addrs {
 		if err := cmdutil.ValidateNodeIP(addr); err == nil {
 			if addr.To4() != nil {


### PR DESCRIPTION
Modify the logic in `openshift-node-config` which tries to select an appropriate IP for the Kubelet's DNSIP configuration to use the result of `cmdutil.GetHostname(nodeConfig.NodeName)` for the call to `net.LookupIP()` instead of using `nodeConfig.NodeName` directly.

This addresses an issue we've had, where the DNSIP selection falls back onto the IP of the interface with the default route (as returned by `utilnet.ChooseHostInterface()`), instead of using the IP returned by DNS for the node's hostname.

This is a small improvment to the changes introduced in openshift/origin#22485.
