### PR TITLE
Bug 1734319: aws: sort addresses of multiple interfaces correctly

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -19,6 +19,8 @@ limitations under the License.
 package aws
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -335,7 +337,13 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 		return aws.StringValue(i.PublicIpAddress), nil
 	} else if strings.HasPrefix(key, networkInterfacesPrefix) {
 		if key == networkInterfacesPrefix {
-			return strings.Join(m.aws.networkInterfacesMacs, "/\n") + "/\n", nil
+			// Return the MACs sorted lexically rather than in device-number
+			// order; this matches AWS's observed behavior and lets us test
+			// that we fix up the ordering correctly in NodeAddresses().
+			macs := make([]string, len(m.aws.networkInterfacesMacs))
+			copy(macs, m.aws.networkInterfacesMacs)
+			sort.Strings(macs)
+			return strings.Join(macs, "/\n") + "/\n", nil
 		}
 
 		keySplit := strings.Split(key, "/")
@@ -344,6 +352,13 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 			for i, macElem := range m.aws.networkInterfacesMacs {
 				if macParam == macElem {
 					return m.aws.networkInterfacesVpcIDs[i], nil
+				}
+			}
+		}
+		if len(keySplit) == 5 && keySplit[4] == "device-number" {
+			for i, macElem := range m.aws.networkInterfacesMacs {
+				if macParam == macElem {
+					return fmt.Sprintf("%d\n", i), nil
 				}
 			}
 		}

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -580,7 +580,7 @@ func testHasNodeAddress(t *testing.T, addrs []v1.NodeAddress, addressType v1.Nod
 }
 
 func TestNodeAddresses(t *testing.T) {
-	// Note these instances have the same name
+	// Note instance0 and instance1 have the same name
 	// (we test that this produces an error)
 	var instance0 ec2.Instance
 	var instance1 ec2.Instance
@@ -696,7 +696,7 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
 	instances := []*ec2.Instance{&instance}
 	awsCloud, awsServices := mockInstancesResp(&instance, instances)
 
-	awsServices.networkInterfacesMacs = []string{"0a:26:89:f3:9c:f6", "0a:77:64:c4:6a:48"}
+	awsServices.networkInterfacesMacs = []string{"0a:77:89:f3:9c:f6", "0a:26:64:c4:6a:48"}
 	awsServices.networkInterfacesPrivateIPs = [][]string{{"192.168.0.1"}, {"192.168.0.2"}}
 	addrs, err := awsCloud.NodeAddresses(context.TODO(), "")
 	if err != nil {
@@ -705,6 +705,17 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.1")
 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.2")
 	testHasNodeAddress(t, addrs, v1.NodeExternalIP, "2.3.4.5")
+	var index1, index2 int
+	for i, addr := range addrs {
+		if addr.Type == v1.NodeInternalIP && addr.Address == "192.168.0.1" {
+			index1 = i
+		} else if addr.Type == v1.NodeInternalIP && addr.Address == "192.168.0.2" {
+			index2 = i
+		}
+	}
+	if index1 > index2 {
+		t.Errorf("Addresses in incorrect order: %v", addrs)
+	}
 }
 
 func TestParseMetadataLocalHostname(t *testing.T) {


### PR DESCRIPTION
Cherry-picked from https://github.com/kubernetes/kubernetes/pull/80747.

On AWS nodes with multiple network interfaces, the interfaces are iterated in an unpredictable order, so adding a new interface may cause the primary IP to change. This has apparently always been a problem but until recently people could work around it by using `--node-ip` to force the correct IP to be chosen. This is no longer really possible in 4.x so we need to fix the code to select the right IP itself.