### PR TITLE
Enable iSCSI tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -425,8 +425,6 @@ var (
 			// TODO(workloads): reenable
 			`SchedulerPreemption`,
 
-			`\[Driver: iscsi\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
-
 			`\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\] provisioning should access volume from different nodes`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711688
 
 			// Test fails on platforms that use LoadBalancerService and HostNetwork endpoint publishing strategy


### PR DESCRIPTION
My tests show that https://bugzilla.redhat.com/show_bug.cgi?id=1721218 could be fixed
I ran 50 iscsi tests at the same time against 3 node cluster, none of them failed. And I tried all this few times in sequence.

/hold
to check if the test suite is not slow too much