### PR TITLE
Bug 1694935: Sanitize user input when erroring on an unknown redirect handler [3.11]

### DIFF
--- a/pkg/oauthserver/oauth/handlers/default_auth_handler.go
+++ b/pkg/oauthserver/oauth/handlers/default_auth_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"regexp"
 	"strings"
@@ -149,7 +150,7 @@ func (authHandler *unionAuthenticationHandler) AuthenticationNeeded(apiClient au
 	if len(redirectHandlerName) > 0 {
 		redirectHandler, ok := authHandler.redirectors.Get(redirectHandlerName)
 		if !ok {
-			return false, fmt.Errorf("Unable to locate redirect handler: %v", redirectHandlerName)
+			return false, fmt.Errorf("Unable to locate redirect handler: %v", html.EscapeString(redirectHandlerName))
 		}
 		err := redirectHandler.AuthenticationRedirect(w, req)
 		if err != nil {

--- a/pkg/oauthserver/oauth/handlers/default_auth_handler_test.go
+++ b/pkg/oauthserver/oauth/handlers/default_auth_handler_test.go
@@ -69,6 +69,26 @@ func TestNoHandlersRedirect(t *testing.T) {
 	}
 }
 
+func TestUnknownIDPRedirect(t *testing.T) {
+	expectedError := "Unable to locate redirect handler: something&lt;iframe&gt;awfull&lt;/iframe&gt;&lt;iframe&gt;encoded&lt;/iframe&gt;"
+
+	authHandler := NewUnionAuthenticationHandler(nil, nil, nil, nil)
+	client := &testClient{&oauthapi.OAuthClient{}}
+	req, _ := http.NewRequest("GET", "http://example.org/?idp=something<iframe>awfull</iframe>%3Ciframe%3Eencoded%3C%2Fiframe%3E", nil)
+	responseRecorder := httptest.NewRecorder()
+	handled, err := authHandler.AuthenticationNeeded(client, responseRecorder, req)
+
+	if err == nil {
+		t.Errorf("Expected error, got none")
+	} else if err.Error() != expectedError {
+		t.Errorf("expected error to be '%s', got '%v' instead", expectedError, err)
+	}
+
+	if handled {
+		t.Error("Unexpectedly handled.")
+	}
+}
+
 func TestNoHandlersChallenge(t *testing.T) {
 	authHandler := NewUnionAuthenticationHandler(nil, nil, nil, nil)
 	client := &testClient{&oauthapi.OAuthClient{RespondWithChallenges: true}}


### PR DESCRIPTION
Certain browsers might interpret the 500 error page as an HTML
page even though it's text/plain in some corner cases.

cc @enj 