### PR TITLE
Bug 1757234: Cherry-pick: Kubelet should use watch-based configMapAndSecretChangeDetectionStrategy

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted.yaml
@@ -101,7 +101,7 @@ cgroupsPerQOS: true
 clusterDNS:
 - 10.192.0.10
 clusterDomain: cluster.global
-configMapAndSecretChangeDetectionStrategy: Cache
+configMapAndSecretChangeDetectionStrategy: Watch
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi
 contentType: application/vnd.kubernetes.protobuf

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/util/config/testdata/defaulting/controlplane/defaulted_non_linux.yaml
@@ -101,7 +101,7 @@ cgroupsPerQOS: true
 clusterDNS:
 - 10.192.0.10
 clusterDomain: cluster.global
-configMapAndSecretChangeDetectionStrategy: Cache
+configMapAndSecretChangeDetectionStrategy: Watch
 containerLogMaxFiles: 5
 containerLogMaxSize: 10Mi
 contentType: application/vnd.kubernetes.protobuf

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -215,7 +215,7 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 		obj.ContainerLogMaxFiles = utilpointer.Int32Ptr(5)
 	}
 	if obj.ConfigMapAndSecretChangeDetectionStrategy == "" {
-		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.TTLCacheChangeDetectionStrategy
+		obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.WatchChangeDetectionStrategy
 	}
 	if obj.EnforceNodeAllocatable == nil {
 		obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement


### PR DESCRIPTION
Pick of UPSTREAM: 74781: kubelet watch-manager test, restore watch-based manager default

We should be using the watch-based manager in 4.2 to reduce apiserver load.