### PR TITLE
Skip 'recreate nodes' test until it is fixed upstream.

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -422,6 +422,7 @@ var (
 			`should be rejected when no endpoints exist`,                                 // https://bugzilla.redhat.com/show_bug.cgi?id=1711605
 			`PreemptionExecutionPath runs ReplicaSets to verify preemption running path`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711606
 			`TaintBasedEvictions`,                                                        // https://bugzilla.redhat.com/show_bug.cgi?id=1711608
+			`recreate nodes and ensure they function upon restart`,                       // https://bugzilla.redhat.com/show_bug.cgi?id=1756428
 			// TODO(workloads): reenable
 			`SchedulerPreemption`,
 


### PR DESCRIPTION
The test ` [Feature:Recreate] recreate nodes and ensure they function upon restart [Suite:openshift/conformance/parallel] [Suite:k8s]` should be labeled disruptive. It is causing all GCP CI tests to fail. We should disable until it is fixed upstream.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1756428