### PR TITLE
Bug 1755039: Enable storage tests that require 1.16 kubelet

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -429,8 +429,6 @@ var (
 
 			`\[Driver: iscsi\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
 
-			`\[Driver: nfs\] \[Testpattern: Dynamic PV \(default fs\)\] provisioning should access volume from different nodes`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711688
-
 			// Test fails on platforms that use LoadBalancerService and HostNetwork endpoint publishing strategy
 			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should set Forwarded headers appropriately`, // https://bugzilla.redhat.com/show_bug.cgi?id=1752646
 

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -454,14 +454,6 @@ var (
 
 			// TODO(workload): reactivate when oc is rebased
 			`should support exec using resource/name`,
-
-			// Disable these tests for now because they require 1.16 kubelet
-			// https://bugzilla.redhat.com/show_bug.cgi?id=1755000
-			`VolumeSubpathEnvExpansion`,
-			`CSI mock volume CSI Volume expansion`,
-			`CSI mock volume CSI online volume expansion`,
-			`CSI mock volume CSI workload information using mock driver`,
-			`volume-expand should resize volume when PVC is edited while pod is using it`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -424,10 +424,10 @@ var (
 			`PreemptionExecutionPath runs ReplicaSets to verify preemption running path`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711606
 			`TaintBasedEvictions`,                                                        // https://bugzilla.redhat.com/show_bug.cgi?id=1711608
 			`recreate nodes and ensure they function upon restart`,                       // https://bugzilla.redhat.com/show_bug.cgi?id=1756428
+			`\[Driver: iscsi\]`,                                                          // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
+			`volumeMode should not mount / map unused volumes in a pod`,                  // https://bugzilla.redhat.com/show_bug.cgi?id=1751640
 			// TODO(workloads): reenable
 			`SchedulerPreemption`,
-
-			`\[Driver: iscsi\]`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
 
 			// Test fails on platforms that use LoadBalancerService and HostNetwork endpoint publishing strategy
 			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should set Forwarded headers appropriately`, // https://bugzilla.redhat.com/show_bug.cgi?id=1752646
@@ -446,9 +446,6 @@ var (
 
 			// TODO(sdn): test pod fails to connect in 1.16
 			`should allow ingress access from updated pod`,
-
-			// TODO(storage): fix the use of SSH into the node
-			`volumeMode should not mount / map unused volumes in a pod`,
 
 			// TODO(workload): reactivate when oc is rebased
 			`should support exec using resource/name`,


### PR DESCRIPTION
\+ remove one unused pattern
\+ reshuffle remaining disabled storage tests a bit and add BZ link to one
(see the individual commits)

@openshift/storage 
