### PR TITLE
OVN-Kubernetes: some more test tweaks

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -550,10 +550,16 @@ var (
 		},
 		// tests that don't pass under OVN Kubernetes
 		"[Skipped:Network/OVNKubernetes]": {
-			`\[sig-network\] Services should be able to switch session affinity for NodePort service`,            // https://jira.coreos.com/browse/SDN-510
-			`\[sig-network\] Services should be able to switch session affinity for service with type clusterIP`, // https://jira.coreos.com/browse/SDN-510
-			`\[sig-network\] Services should have session affinity work for NodePort service`,                    // https://jira.coreos.com/browse/SDN-510
-			`\[sig-network\] Services should have session affinity work for service with type clusterIP`,         // https://jira.coreos.com/browse/SDN-510
+			// https://jira.coreos.com/browse/SDN-510: OVN-K doesn't support session affinity
+			`\[sig-network\] Networking Granular Checks: Services should function for client IP based session affinity: http`,
+			`\[sig-network\] Networking Granular Checks: Services should function for client IP based session affinity: udp`,
+			`\[sig-network\] Services should be able to switch session affinity for NodePort service`,
+			`\[sig-network\] Services should be able to switch session affinity for service with type clusterIP`,
+			`\[sig-network\] Services should have session affinity work for NodePort service`,
+			`\[sig-network\] Services should have session affinity work for service with type clusterIP`,
+			// SDN-587: OVN-Kubernetes doesn't support hairpin services
+			`\[sig-network\] Services should allow pods to hairpin back to themselves through services`,
+			`\[sig-network\] Networking Granular Checks: Services should function for endpoint-Service`,
 		},
 		"[Suite:openshift/scalability]": {},
 		// tests that replace the old test-cmd script


### PR DESCRIPTION
- Let the ovn-master pod tolerate NotReady nodes
- Add some more variations of the session affinity test

/cc @danwinship 