### PR TITLE
Bug 1711600: UPSTREAM: 82424:Use pod + nsenter instead of SSH in mount propagation tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -417,7 +417,6 @@ var (
 			`should idle the service and DeploymentConfig properly`,                      // idling with a single service and DeploymentConfig [Conformance]
 			`\[Driver: csi-hostpath`,                                                     // https://bugzilla.redhat.com/show_bug.cgi?id=1711607
 			`should answer endpoint and wildcard queries for the cluster`,                // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
-			`should propagate mounts to the host`,                                        // requires SSH, https://bugzilla.redhat.com/show_bug.cgi?id=1711600
 			`should allow ingress access on one named port`,                              // https://bugzilla.redhat.com/show_bug.cgi?id=1711602
 			`ClusterDns \[Feature:Example\] should create pod that uses dns`,             // https://bugzilla.redhat.com/show_bug.cgi?id=1711601
 			`should be rejected when no endpoints exist`,                                 // https://bugzilla.redhat.com/show_bug.cgi?id=1711605

--- a/vendor/k8s.io/kubernetes/test/e2e/node/BUILD
+++ b/vendor/k8s.io/kubernetes/test/e2e/node/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//test/e2e/framework/volume:go_default_library",
         "//test/e2e/perftype:go_default_library",
         "//test/e2e/scheduling:go_default_library",
+        "//test/e2e/storage/utils:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/vendor/k8s.io/kubernetes/test/e2e/node/mount_propagation.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/node/mount_propagation.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
-	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
@@ -85,6 +85,9 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// tmpfs to a subdirectory there. We check that these mounts are
 		// propagated to the right places.
 
+		hostExec := utils.NewHostExec(f)
+		defer hostExec.Cleanup()
+
 		// Pick a node where all pods will run.
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		framework.ExpectNotEqual(len(nodes.Items), 0, "No available nodes for scheduling")
@@ -102,8 +105,8 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// running in parallel.
 		hostDir := "/var/lib/kubelet/" + f.Namespace.Name
 		defer func() {
-			cleanCmd := fmt.Sprintf("sudo rm -rf %q", hostDir)
-			e2essh.IssueSSHCommand(cleanCmd, framework.TestContext.Provider, node)
+			cleanCmd := fmt.Sprintf("rm -rf %q", hostDir)
+			hostExec.IssueCommand(cleanCmd, node)
 		}()
 
 		podClient := f.PodClient()
@@ -139,13 +142,13 @@ var _ = SIGDescribe("Mount propagation", func() {
 
 		// The host mounts one tmpfs to testdir/host and puts a file there so we
 		// can check mount propagation from the host to pods.
-		cmd := fmt.Sprintf("sudo mkdir %[1]q/host; sudo mount -t tmpfs e2e-mount-propagation-host %[1]q/host; echo host > %[1]q/host/file", hostDir)
-		err := e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		cmd := fmt.Sprintf("mkdir %[1]q/host; mount -t tmpfs e2e-mount-propagation-host %[1]q/host; echo host > %[1]q/host/file", hostDir)
+		err := hostExec.IssueCommand(cmd, node)
 		framework.ExpectNoError(err)
 
 		defer func() {
-			cmd := fmt.Sprintf("sudo umount %q/host", hostDir)
-			e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+			cmd := fmt.Sprintf("umount %q/host", hostDir)
+			hostExec.IssueCommand(cmd, node)
 		}()
 
 		// Now check that mounts are propagated to the right containers.
@@ -181,12 +184,12 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// Check that the mounts are/are not propagated to the host.
 		// Host can see mount from master
 		cmd = fmt.Sprintf("test `cat %q/master/file` = master", hostDir)
-		err = e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		err = hostExec.IssueCommand(cmd, node)
 		framework.ExpectNoError(err, "host should see mount from master")
 
 		// Host can't see mount from slave
 		cmd = fmt.Sprintf("test ! -e %q/slave/file", hostDir)
-		err = e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		err = hostExec.IssueCommand(cmd, node)
 		framework.ExpectNoError(err, "host shouldn't see mount from slave")
 	})
 })


### PR DESCRIPTION
\+ enable the test downstream

https://github.com/kubernetes/kubernetes/pull/82424
https://bugzilla.redhat.com/show_bug.cgi?id=1711600

@openshift/storage, PTAL