### PR TITLE
Bug 1709178: Prevent egress DNS request flooding

### DIFF
--- a/pkg/network/common/dns_test.go
+++ b/pkg/network/common/dns_test.go
@@ -59,6 +59,14 @@ func TestAddDNS(t *testing.T) {
 			dnsResolverOutput: "",
 			expectFailure:     true,
 		},
+		{
+			testCase:          "Test min TTL",
+			domainName:        "example.com",
+			dnsResolverOutput: "example.com. 0 IN A 10.11.12.13",
+			ips:               []net.IP{ip},
+			ttl:               1800,
+			expectFailure:     false,
+		},
 	}
 
 	for _, test := range tests {
@@ -148,6 +156,17 @@ func TestUpdateDNS(t *testing.T) {
 			addResolverOutput:    "",
 			updateResolverOutput: "",
 			expectFailure:        true,
+		},
+		{
+			testCase:             "Test dns update min TTL",
+			domainName:           "example.com",
+			addResolverOutput:    "example.com. 5 IN A 10.11.12.13",
+			addIPs:               []net.IP{addIP},
+			addTTL:               5,
+			updateResolverOutput: "example.com. 0 IN A 10.11.12.14",
+			updateIPs:            []net.IP{updateIP},
+			updateTTL:            1800,
+			expectFailure:        false,
 		},
 	}
 


### PR DESCRIPTION
Before this change, zero-TTL records would cause the `EgressDNS` controller to
query for updates to those records in a tight loop with no rate limiting.

Prevent the flooding behavior by defaulting TTL to 30 minutes when the provided
TTL is zero.

An alternative considered was to store the true TTL internally but enforce a
minimum sync interval through `EgressDNS.GetMinQueryTime`, which may also be
useful in its own right as a hedge against future bugs. Using a rate limited
work queue would be another possibility.