### PR TITLE
test: Don't load client on dryRun or perform cloud autodetect

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -276,7 +276,7 @@ func bindOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
 
 func initProvider(provider string, dryRun bool) error {
 	// record the exit error to the output file
-	if err := decodeProviderTo(provider, exutil.TestContext); err != nil {
+	if err := decodeProviderTo(provider, exutil.TestContext, dryRun); err != nil {
 		return err
 	}
 	exutil.TestContext.AllowedNotReadyNodes = 100
@@ -300,15 +300,21 @@ func initProvider(provider string, dryRun bool) error {
 	return err
 }
 
-func decodeProviderTo(provider string, testContext *e2e.TestContextType) error {
+func decodeProviderTo(provider string, testContext *e2e.TestContextType, dryRun bool) error {
 	switch provider {
-	case "", "azure", "aws", "gce":
+	case "":
 		if _, ok := os.LookupEnv("KUBE_SSH_USER"); ok {
 			if _, ok := os.LookupEnv("LOCAL_SSH_KEY"); ok {
 				testContext.Provider = "local"
+				break
 			}
 		}
+		if dryRun {
+			break
+		}
+		fallthrough
 
+	case "azure", "aws", "gce", "vsphere":
 		provider, cfg, err := exutilcloud.LoadConfig()
 		if err != nil {
 			return err

--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -75,12 +75,12 @@ func InitTest(dryRun bool) error {
 	TestContext.MasterOSDistro = "custom"
 
 	// load and set the host variable for kubectl
-	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: TestContext.KubeConfig}, &clientcmd.ConfigOverrides{})
-	cfg, err := clientConfig.ClientConfig()
-	if err != nil && !dryRun { // we don't need the host when doing a dryrun
-		return err
-	}
-	if cfg != nil {
+	if !dryRun {
+		clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: TestContext.KubeConfig}, &clientcmd.ConfigOverrides{})
+		cfg, err := clientConfig.ClientConfig()
+		if err != nil {
+			return err
+		}
 		TestContext.Host = cfg.Host
 	}
 


### PR DESCRIPTION
Ensure that if a user does `--dry-run` and `--provider=aws` we do
the right thing. Also add `vsphere` to ensure we can test this way.