### PR TITLE
tests/extented/prometheus: Disable telemetry e2e for remote-write move

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -51,6 +51,15 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 	g.Describe("when installed on the cluster", func() {
 		g.It("should report telemetry if a cloud.openshift.com token is present", func() {
+			// https://github.com/openshift/cluster-monitoring-operator/pull/434
+			// changes the behavior from using the extra telemeter-client to
+			// the Prometheus native remote-write protocol. This causes the
+			// telemeter-client metrics to not be available anymore, causing
+			// this test to fail on that PR, but we can't merge modifying this
+			// test yet because the new metrics are not there yet. Skipping
+			// this test intermediately to merge the PR.
+			e2e.Skipf("skipping in order to merge https://github.com/openshift/cluster-monitoring-operator/pull/434")
+
 			if !hasPullSecret(oc.AdminKubeClient(), "cloud.openshift.com") {
 				e2e.Skipf("Telemetry is disabled")
 			}
@@ -61,6 +70,11 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPod.Name, metav1.NewDeleteOptions(1)) }()
 
 			tests := map[string]bool{
+				// Should have successfully sent at least some metrics to remote write endpoint
+				// uncomment this once https://github.com/openshift/cluster-monitoring-operator/pull/434
+				// is merged, and remove the other two checks.
+				// `prometheus_remote_storage_succeeded_samples_total{job="prometheus-k8s"} >= 1`: true,
+
 				// should have successfully sent at least once to remote
 				`metricsclient_request_send{client="federate_to",job="telemeter-client",status_code="200"} >= 1`: true,
 				// should have scraped some metrics from prometheus
@@ -148,7 +162,6 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 					targets.Expect(labels{"job": "prometheus-operator"}, "up", "^http://.*/metrics$"),
 					targets.Expect(labels{"job": "alertmanager-main"}, "up", "^https://.*/metrics$"),
 					targets.Expect(labels{"job": "crio"}, "up", "^http://.*/metrics$"),
-					targets.Expect(labels{"job": "telemeter-client"}, "up", "^https://.*/metrics$"),
 				)
 				if len(lastErrs) > 0 {
 					e2e.Logf("missing some targets: %v", lastErrs)


### PR DESCRIPTION
This will be temporarily required in order to switch sending telemetry to Prometheus native remote-write capabilities (https://github.com/openshift/cluster-monitoring-operator/pull/434). We will want to merge this PR and https://github.com/openshift/cluster-monitoring-operator/pull/434 quickly after each other and then enable the here commented out check that verifies, that remote-write successfully sent data instead of the bespoke telemeter client.

Telemetry via remote-write can only be accepted by the v2 receiving infrastructure, so we need to hold off on merging this and https://github.com/openshift/cluster-monitoring-operator/pull/434 until the infrastructure is completely migrated.

@s-urbaniak @paulfantom @LiliC @squat @smarterclayton 

/hold