### PR TITLE
Bug 1749653: (attempt to) fix ECDSA formatted private key usage in route

### DIFF
--- a/pkg/route/controller/routeapihelpers/validation.go
+++ b/pkg/route/controller/routeapihelpers/validation.go
@@ -62,7 +62,7 @@ func privateKeyBlockVerifier(block *pem.Block) (*pem.Block, error) {
 		}
 	case *ecdsa.PrivateKey:
 		block = &pem.Block{
-			Type: "ECDSA PRIVATE KEY",
+			Type: "EC PRIVATE KEY",
 		}
 		if block.Bytes, err = x509.MarshalECPrivateKey(t); err != nil {
 			return nil, err
@@ -78,15 +78,15 @@ func ignoreBlockVerifier(block *pem.Block) (*pem.Block, error) {
 }
 
 var knownBlockDecoders = map[string]blockVerifierFunc{
-	"RSA PRIVATE KEY":   privateKeyBlockVerifier,
-	"ECDSA PRIVATE KEY": privateKeyBlockVerifier,
-	"PRIVATE KEY":       privateKeyBlockVerifier,
-	"PUBLIC KEY":        publicKeyBlockVerifier,
+	"RSA PRIVATE KEY": privateKeyBlockVerifier,
+	"EC PRIVATE KEY":  privateKeyBlockVerifier,
+	"PRIVATE KEY":     privateKeyBlockVerifier,
+	"PUBLIC KEY":      publicKeyBlockVerifier,
 	// Potential "in the wild" PEM encoded blocks that can be normalized
-	"RSA PUBLIC KEY":   publicKeyBlockVerifier,
-	"DSA PUBLIC KEY":   publicKeyBlockVerifier,
-	"ECDSA PUBLIC KEY": publicKeyBlockVerifier,
-	"CERTIFICATE":      certificateBlockVerifier,
+	"RSA PUBLIC KEY": publicKeyBlockVerifier,
+	"DSA PUBLIC KEY": publicKeyBlockVerifier,
+	"EC PUBLIC KEY":  publicKeyBlockVerifier,
+	"CERTIFICATE":    certificateBlockVerifier,
 	// Blocks that should be dropped
 	"EC PARAMETERS": ignoreBlockVerifier,
 }


### PR DESCRIPTION
An ECDSA private key only specifies "EC PRIVATE KEY", not "ECDSA PRIVATE KEY": https://tools.ietf.org/html/rfc5915

Wouldn't it be better to use `MarshalPKCS8PrivateKey` in the `*KeyBlockVerifier` functions? The [go documentation](https://golang.org/pkg/crypto/x509/#MarshalECPrivateKey) specifies

>For a more flexible key format which is not EC specific, use MarshalPKCS8PrivateKey.

This is probably incomplete, I tried to set up a test environment to build everything but was having quite some issues there. I'd need to spend quite some more time to set that up. Any/all comments/additions/criticism etc. welcome.

Also, `gofmt` changed some of the spacing :)