### PR TITLE
Check ocm rollout between build tests

### DIFF
--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -4,6 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
@@ -11,11 +18,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // e2e tests of the build controller configuration.
@@ -94,6 +96,12 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 					ds.Status.UpdatedNumberScheduled == ds.Status.DesiredNumberScheduled {
 					return true, nil
 				}
+				e2e.Logf("ocm Desired: %d, Current: %d, Ready: %d, Available: %d, Updated: %d",
+					ds.Status.DesiredNumberScheduled,
+					ds.Status.CurrentNumberScheduled,
+					ds.Status.NumberReady,
+					ds.Status.NumberAvailable,
+					ds.Status.UpdatedNumberScheduled)
 				return false, nil
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -238,6 +238,10 @@ var _ = g.Describe("[Feature:Builds][Serial][Slow][Disruptive] alter builds via 
 				buildConfig.Spec.BuildOverrides = configv1.BuildOverrides{}
 				_, err = oc.AdminConfigClient().ConfigV1().Builds().Update(buildConfig)
 				o.Expect(err).NotTo(o.HaveOccurred())
+				checkOCMProgressing(operatorv1.ConditionTrue)
+				checkOCMProgressing(operatorv1.ConditionFalse)
+				checkDSRolloutState(true)
+				checkDSRolloutState(false)
 			})
 
 			g.It("Apply default proxy configuration to source build pod through env vars", func() {


### PR DESCRIPTION
* Make sure the OCM rollout completes between disruptive test runs.

/assign @gabemontero 

fyi @openshift/openshift-team-developer-experience 