### PR TITLE
UPSTREAM: 83751: Fixed bug in TopologyManager with SingleNUMANode Policy

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -192,7 +192,7 @@ func (m *manager) calculateAffinity(pod v1.Pod, container v1.Container) Topology
 		// If hints is nil, insert a single, preferred any-numa hint into allProviderHints.
 		if len(hints) == 0 {
 			klog.Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with any resource")
-			allProviderHints = append(allProviderHints, []TopologyHint{{defaultAffinity, true}})
+			allProviderHints = append(allProviderHints, []TopologyHint{{nil, true}})
 			continue
 		}
 
@@ -200,13 +200,13 @@ func (m *manager) calculateAffinity(pod v1.Pod, container v1.Container) Topology
 		for resource := range hints {
 			if hints[resource] == nil {
 				klog.Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with resource '%s'", resource)
-				allProviderHints = append(allProviderHints, []TopologyHint{{defaultAffinity, true}})
+				allProviderHints = append(allProviderHints, []TopologyHint{{nil, true}})
 				continue
 			}
 
 			if len(hints[resource]) == 0 {
 				klog.Infof("[topologymanager] Hint Provider has no possible NUMA affinities for resource '%s'", resource)
-				allProviderHints = append(allProviderHints, []TopologyHint{{defaultAffinity, false}})
+				allProviderHints = append(allProviderHints, []TopologyHint{{nil, false}})
 				continue
 			}
 
@@ -226,17 +226,20 @@ func (m *manager) calculateAffinity(pod v1.Pod, container v1.Container) Topology
 		preferred := true
 		var numaAffinities []socketmask.SocketMask
 		for _, hint := range permutation {
-			// Only consider hints that have an actual NUMANodeAffinity set.
-			if hint.NUMANodeAffinity != nil {
-				if !hint.Preferred {
-					preferred = false
-				}
-				// Special case PolicySingleNumaNode to only prefer hints where
-				// all providers have a single NUMA affinity set.
-				if m.policy != nil && m.policy.Name() == PolicySingleNumaNode && hint.NUMANodeAffinity.Count() > 1 {
-					preferred = false
-				}
+			if hint.NUMANodeAffinity == nil {
+				numaAffinities = append(numaAffinities, defaultAffinity)
+			} else {
 				numaAffinities = append(numaAffinities, hint.NUMANodeAffinity)
+			}
+
+			if !hint.Preferred {
+				preferred = false
+			}
+
+			// Special case PolicySingleNumaNode to only prefer hints where
+			// all providers have a single NUMA affinity set.
+			if m.policy != nil && m.policy.Name() == PolicySingleNumaNode && hint.NUMANodeAffinity != nil && hint.NUMANodeAffinity.Count() > 1 {
+				preferred = false
 			}
 		}
 

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -196,7 +196,7 @@ func TestCalculateAffinity(t *testing.T) {
 			},
 			expected: TopologyHint{
 				NUMANodeAffinity: NewTestSocketMask(numaNodes...),
-				Preferred:        true,
+				Preferred:        false,
 			},
 		},
 		{
@@ -688,6 +688,37 @@ func TestCalculateAffinity(t *testing.T) {
 			expected: TopologyHint{
 				NUMANodeAffinity: NewTestSocketMask(0),
 				Preferred:        false,
+			},
+		},
+		{
+			name:   "Special cased PolicySingleNumaNode with one no-preference provider",
+			policy: NewSingleNumaNodePolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {
+							{
+								NUMANodeAffinity: NewTestSocketMask(0),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestSocketMask(1),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestSocketMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+				&mockHintProvider{
+					nil,
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestSocketMask(0),
+				Preferred:        true,
 			},
 		},
 	}


### PR DESCRIPTION
Picks an upstream patch to fix a bug in TopologyManager with SingleNUMANode Policy.

ref: https://github.com/kubernetes/kubernetes/pull/83697