### PR TITLE
Bug 1753731: add extended build new-app tests back

### DIFF
--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -44,7 +44,6 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 		})
 
 		g.It("should succeed with a --name of 58 characters", func() {
-			g.Skip("Bug 1753731: builds do not always reference the correct location for pull-through imagestream tags")
 			g.By("calling oc new-app")
 			err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -62,7 +61,6 @@ var _ = g.Describe("[Feature:Builds][Conformance] oc new-app", func() {
 		})
 
 		g.It("should fail with a --name longer than 58 characters", func() {
-			g.Skip("Bug 1753731: builds do not always reference the correct location for pull-through imagestream tags")
 			g.By("calling oc new-app")
 			out, err := oc.Run("new-app").Args("https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
 			o.Expect(err).To(o.HaveOccurred())


### PR DESCRIPTION
Undo https://github.com/openshift/origin/pull/23832 as part of https://github.com/openshift/openshift-controller-manager/pull/34 on path for merging

Getting a few runs in pre-merge to see if we can repro the original flake with any frequency, followed by absence of flakes after https://github.com/openshift/openshift-controller-manager/pull/34 merges

/assign @adambkaplan 