### PR TITLE
Bug 1761276: Write test monitor errors to monitor_*.xml

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -301,8 +301,11 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	if len(opt.JUnitDir) > 0 {
-		if err := writeJUnitReport("openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
-			fmt.Fprintf(opt.Out, "error: Unable to write JUnit results: %v", err)
+		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut); err != nil {
+			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit results: %v", err)
+		}
+		if err := writeJUnitReport("monitor", "openshift-tests", nil, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
+			fmt.Fprintf(opt.Out, "error: Unable to write monitor JUnit results: %v", err)
 		}
 	}
 

--- a/pkg/test/ginkgo/junit.go
+++ b/pkg/test/ginkgo/junit.go
@@ -115,7 +115,7 @@ const (
 	TestResultFail TestResult = "fail"
 )
 
-func writeJUnitReport(name string, tests []*testCase, dir string, duration time.Duration, errOut io.Writer, additionalResults ...*JUnitTestCase) error {
+func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, duration time.Duration, errOut io.Writer, additionalResults ...*JUnitTestCase) error {
 	s := &JUnitTestSuite{
 		Name:     name,
 		Duration: duration.Seconds(),
@@ -166,7 +166,7 @@ func writeJUnitReport(name string, tests []*testCase, dir string, duration time.
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(dir, fmt.Sprintf("junit_e2e_%s.xml", time.Now().UTC().Format("20060102-150405")))
+	path := filepath.Join(dir, fmt.Sprintf("%s_%s.xml", filePrefix, time.Now().UTC().Format("20060102-150405")))
 	fmt.Fprintf(errOut, "Writing JUnit report to %s\n\n", path)
 	return ioutil.WriteFile(path, out, 0640)
 }


### PR DESCRIPTION
By splitting monitor into a separate file we can exclude it from
testgrid, cleaning up the summary of jobs. We still however want
it to be visible to spyglass.