### PR TITLE
test: Update junit naming to ensure disruption tests are recorded

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -301,11 +301,8 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	if len(opt.JUnitDir) > 0 {
-		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut); err != nil {
+		if err := writeJUnitReport("junit_e2e", "openshift-tests", tests, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
 			fmt.Fprintf(opt.Out, "error: Unable to write e2e JUnit results: %v", err)
-		}
-		if err := writeJUnitReport("monitor", "openshift-tests", nil, opt.JUnitDir, duration, opt.ErrOut, syntheticTestResults...); err != nil {
-			fmt.Fprintf(opt.Out, "error: Unable to write monitor JUnit results: %v", err)
 		}
 	}
 

--- a/pkg/test/ginkgo/junit.go
+++ b/pkg/test/ginkgo/junit.go
@@ -124,6 +124,7 @@ func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, du
 		switch {
 		case test.skipped:
 			s.NumTests++
+			s.NumSkipped++
 			s.TestCases = append(s.TestCases, &JUnitTestCase{
 				Name:      test.name,
 				SystemOut: string(test.out),
@@ -134,7 +135,7 @@ func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, du
 			})
 		case test.failed:
 			s.NumTests++
-			s.NumSkipped++
+			s.NumFailed++
 			s.TestCases = append(s.TestCases, &JUnitTestCase{
 				Name:      test.name,
 				SystemOut: string(test.out),
@@ -144,7 +145,6 @@ func writeJUnitReport(filePrefix, name string, tests []*testCase, dir string, du
 				},
 			})
 		case test.success:
-			s.NumTests++
 			s.NumFailed++
 			s.TestCases = append(s.TestCases, &JUnitTestCase{
 				Name:     test.name,

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -120,7 +120,7 @@ var _ = g.Describe("[Disruptive]", func() {
 
 			disruption.Run(
 				"Cluster upgrade",
-				"upgrade_tests",
+				"upgrade",
 				disruption.TestData{
 					UpgradeType:    upgrades.ClusterUpgrade,
 					UpgradeContext: *upgCtx,

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -32,7 +32,7 @@ type TestData struct {
 // test is being executed. Description is used to populate the JUnit suite name, and testname is
 // used to define the overall test that will be run.
 func Run(description, testname string, adapter TestData, invariants []upgrades.Test, fn func()) {
-	testSuite := &junit.TestSuite{Name: description}
+	testSuite := &junit.TestSuite{Name: description, Package: testname}
 	test := &junit.TestCase{Name: testname, Classname: testname}
 	testSuite.TestCases = append(testSuite.TestCases, test)
 	cm := chaosmonkey.New(func() {
@@ -53,7 +53,7 @@ func runChaosmonkey(
 	for _, t := range tests {
 		testCase := &junit.TestCase{
 			Name:      t.Name(),
-			Classname: "upgrade_tests",
+			Classname: "disruption_tests",
 		}
 		testSuite.TestCases = append(testSuite.TestCases, testCase)
 
@@ -75,7 +75,7 @@ func runChaosmonkey(
 		testSuite.Update()
 		testSuite.Time = time.Since(start).Seconds()
 		if framework.TestContext.ReportDir != "" {
-			fname := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%s%s.xml", framework.TestContext.ReportPrefix, testSuite.TestCases[0].Classname))
+			fname := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%s_%d.xml", testSuite.Package, time.Now().Unix()))
 			f, err := os.Create(fname)
 			if err != nil {
 				return


### PR DESCRIPTION
Testgrid would omit disruption tests.