### PR TITLE
Bug 1761682: test oauth server: increase timeout, wait for pod ready first

### DIFF
--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -196,14 +196,14 @@ func waitForOAuthServerReady(oc *exutil.CLI) error {
 	if err := exutil.WaitForUserBeAuthorized(oc, "system:serviceaccount:"+oc.Namespace()+":e2e-oauth", "*", "*"); err != nil {
 		return err
 	}
-	if err := waitForOAuthServerRouteReady(oc); err != nil {
+	if err := waitForOAuthServerPodReady(oc); err != nil {
 		return err
 	}
-	return waitForOAuthServerPodReady(oc)
+	return waitForOAuthServerRouteReady(oc)
 }
 
 func waitForOAuthServerPodReady(oc *exutil.CLI) error {
-	return wait.PollImmediate(1*time.Second, 45*time.Second, func() (bool, error) {
+	return wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
 		e2e.Logf("Waiting for the OAuth server pod to be ready")
 		pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get("test-oauth-server", metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
Makes waiting for the pod to become ready prior to waiting for
the route readiness, increases timeout for the pod ready check.

-----

It seems that every now and then the oauth server container takes too long to become ready which causes flakes.

/assign @sanchezl 