### PR TITLE
Add consoleyamlsamples to list of console resource exceptions

### DIFF
--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -114,7 +114,7 @@ var (
 
 			// These custom resources are used to extend console functionality
 			// The console team is working on eliminating this exception in the near future
-			rbacv1helpers.NewRule(read...).Groups(consoleGroup).Resources("consoleclidownloads", "consolelinks", "consoleexternalloglinks", "consolenotifications").RuleOrDie(),
+			rbacv1helpers.NewRule(read...).Groups(consoleGroup).Resources("consoleclidownloads", "consolelinks", "consoleexternalloglinks", "consolenotifications", "consoleyamlsamples").RuleOrDie(),
 
 			// TODO: remove when openshift-apiserver has removed these
 			rbacv1helpers.NewRule("get").URLs(


### PR DESCRIPTION
Related to:
- https://github.com/openshift/origin/pull/23231
- https://github.com/openshift/origin/pull/23382

To unblock this PR in the console-operator:
- https://github.com/openshift/console-operator/pull/306

/cc @bparees @spadgett 
fyi @jhadvig 