### PR TITLE
Bug 1751654: Revert "CHECK(workload): e2e: disable kubectl exec test with pod/name…

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -441,9 +441,6 @@ var (
 
 			// TODO(sdn): test pod fails to connect in 1.16
 			`should allow ingress access from updated pod`,
-
-			// TODO(workload): reactivate when oc is rebased
-			`should support exec using resource/name`,
 		},
 		// tests that may work, but we don't support them
 		"[Disabled:Unsupported]": {


### PR DESCRIPTION
/assign @sttts 

This reverts commit e6a760160cb1fbd267212cd6dd2edcfa3e5804cb.