### PR TITLE
Bug 1749649: Fix ignoring non-server records when server threshold is exceeded

### DIFF
--- a/pkg/router/metrics/haproxy/haproxy.go
+++ b/pkg/router/metrics/haproxy/haproxy.go
@@ -429,9 +429,9 @@ loop:
 		// displaying only backends and frontends.
 		if row[32] == serverType {
 			servers++
-		}
-		if servers > e.opts.ServerThreshold {
-			continue
+			if servers > e.opts.ServerThreshold {
+				continue
+			}
 		}
 
 		rows++


### PR DESCRIPTION
Description of problem:
When ServerThreshold is exceeded, it doesn't ignore the rest of the servers, it ignores the rest of the records including backend, frontend and server records.

Version-Release number of selected component (if applicable):
OCP 3.11

Actual results:
Currently, OCP 3.11 does not have the backport fix of https://github.com/openshift/router/pull/12 made in 4.2

Expected results:
OCP 3.11 to have this fix as well to not ignore the non-server records if the serverThreshold is reached.

Additional info:
Upstream 4.2 PR = https://github.com/openshift/router/pull/12
OCP 3.11 code reference = https://github.com/openshift/origin/blob/release-3.11/pkg/router/metrics/haproxy/haproxy.go#L428-L435