### PR TITLE
test: Verify API remains available during upgrade

### DIFF
--- a/pkg/monitor/api.go
+++ b/pkg/monitor/api.go
@@ -40,7 +40,7 @@ func Start(ctx context.Context) (*Monitor, error) {
 		return nil, err
 	}
 
-	if err := startAPIMonitoring(ctx, m, clusterConfig); err != nil {
+	if err := StartAPIMonitoring(ctx, m, clusterConfig); err != nil {
 		return nil, err
 	}
 	startPodMonitoring(ctx, m, client)
@@ -52,7 +52,7 @@ func Start(ctx context.Context) (*Monitor, error) {
 	return m, nil
 }
 
-func startAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
+func StartAPIMonitoring(ctx context.Context, m *Monitor, clusterConfig *rest.Config) error {
 	pollingConfig := *clusterConfig
 	pollingConfig.Timeout = 3 * time.Second
 	pollingClient, err := clientcorev1.NewForConfig(&pollingConfig)

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -27,10 +27,12 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/test/extended/util/disruption"
+	"github.com/openshift/origin/test/extended/util/disruption/controlplane"
 )
 
 func AllTests() []upgrades.Test {
 	return []upgrades.Test{
+		&controlplane.AvailableTest{},
 		&upgrades.ServiceUpgradeTest{},
 		&upgrades.SecretUpgradeTest{},
 		&apps.ReplicaSetUpgradeTest{},

--- a/test/extended/util/disruption/controlplane/controlplane.go
+++ b/test/extended/util/disruption/controlplane/controlplane.go
@@ -1,0 +1,53 @@
+package controlplane
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+
+	"github.com/openshift/origin/pkg/monitor"
+)
+
+// AvailableTest tests that the control plane remains is available
+// before and after a cluster upgrade.
+type AvailableTest struct {
+}
+
+// Name returns the tracking name of the test.
+func (AvailableTest) Name() string { return "control-plane-upgrade" }
+
+// Setup does nothing
+func (t *AvailableTest) Setup(f *framework.Framework) {
+}
+
+// Test runs a connectivity check to the core APIs.
+func (t *AvailableTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
+	config, err := framework.LoadConfig()
+	framework.ExpectNoError(err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m := monitor.NewMonitor()
+	err = monitor.StartAPIMonitoring(ctx, m, config)
+	framework.ExpectNoError(err, "unable to monitor API")
+	m.StartSampling(ctx)
+
+	// wait to ensure API is still up after the test ends
+	<-done
+	time.Sleep(15 * time.Second)
+	cancel()
+
+	conditions := m.Conditions(time.Time{}, time.Time{})
+	for _, interval := range conditions {
+		framework.Logf("Condition: %s", interval)
+	}
+	if len(conditions) > 0 {
+		framework.Failf("API was down during upgrade")
+	}
+
+}
+
+// Teardown cleans up any remaining resources.
+func (t *AvailableTest) Teardown(f *framework.Framework) {
+}


### PR DESCRIPTION
Check the API server during upgrade. There should be no errors.