### PR TITLE
Bug 1751820: test/extended/operators: ensure clusterversion current version is set

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -58,6 +58,11 @@ var _ = g.Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 			cv := objx.Map(obj.UnstructuredContent())
 			lastErr = nil
 			lastCV = cv
+			payload := cv.Get("status.desired.payload").String()
+			if len(payload) == 0 {
+				e2e.Logf("ClusterVersion has no current payload version")
+				return false, nil
+			}
 			if cond := condition(cv, "Progressing"); cond.Get("status").String() != "False" {
 				e2e.Logf("ClusterVersion is still progressing: %s", cond.Get("message").String())
 				return false, nil


### PR DESCRIPTION
The check was dropped in 040f521 [1] during the rebase. reinstating the check correctly.

[1]: https://github.com/openshift/origin/commit/040f521d78039a06be7c5393bc6968285ae4ba4e