### PR TITLE
Make the metric more readable when fails

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -213,7 +213,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			tests := map[string][]metricTest{
 				// should be checking there is no more than 1 alerts firing.
 				// Checking for specific alert is done in "should have a Watchdog alert in firing state".
-				`sum(ALERTS{alertstate="firing"})`: {metricTest{greaterThanEqual: false, value: 2}},
+				`ALERTS{alertstate="firing"}`: {metricTest{greaterThanEqual: false, value: 2}},
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
We unnecessarily wrap the metric in `sum` function, because we are counting the results either way. Not wrapping that into the sum allows us to see the actual fired alrerts when they exceed the 2, example:

```
fail [github.com/openshift/origin/test/extended/prometheus/prometheus_builds.go:166]: Expected
    <map[string]error | len:1>: {
        "ALERTS{alertstate=\"firing\"}": {
            s: "query ALERTS{alertstate=\"firing\"} for tests []prometheus.metricTest{prometheus.metricTest{labels:map[string]string(nil), greaterThanEqual:false, value:-1, success:false}} had results {\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[{\"metric\":{\"__name__\":\"ALERTS\",\"alertname\":\"Watchdog\",\"alertstate\":\"firing\",\"severity\":\"none\"},\"value\":[1571674299.451,\"1\"]}]}}",
        },
    }
```
I tricked the test to fail always when there's a failure, but at least the above has a clear indication what alert is firing, which should provide much more information than previous numbers only.

/assign @jwforres @smarterclayton @mfojtik 