### PR TITLE
Bug 1751640: Enable block bad-case tests

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -420,7 +420,6 @@ var (
 			`TaintBasedEvictions`,                                                        // https://bugzilla.redhat.com/show_bug.cgi?id=1711608
 			`recreate nodes and ensure they function upon restart`,                       // https://bugzilla.redhat.com/show_bug.cgi?id=1756428
 			`\[Driver: iscsi\]`,                                                          // https://bugzilla.redhat.com/show_bug.cgi?id=1711627
-			`volumeMode should not mount / map unused volumes in a pod`,                  // https://bugzilla.redhat.com/show_bug.cgi?id=1751640
 			// TODO(workloads): reenable
 			`SchedulerPreemption`,
 


### PR DESCRIPTION
The test was enabled in https://github.com/openshift/origin/pull/23921, but then accidentally disabled by https://github.com/openshift/origin/pull/23894 (github did not catch it as conflict).

@openshift/storage 