### PR TITLE
switch to new registry for infra images

### DIFF
--- a/examples/atomic-registry/systemd/Dockerfile
+++ b/examples/atomic-registry/systemd/Dockerfile
@@ -1,4 +1,4 @@
-#FROM registry.access.redhat.com/openshift3/ose
+#FROM registry.redhat.io/openshift3/ose
 FROM openshift/origin-control-plane
 
 LABEL name="projectatomic/atomic-registry-install" \

--- a/test/extended/clusterup.sh
+++ b/test/extended/clusterup.sh
@@ -350,7 +350,7 @@ readonly extra_args=(
     # Test the previous OCP release
     # TODO - enable this once v3.9 ships, v3.7 didn't have a TSB image so it's
     # annoying to test.
-    #"--loglevel=4 --image=registry.access.redhat.com/openshift3/ose --tag=v3.7"
+    #"--loglevel=4 --image=registry.redhat.io/openshift3/ose --tag=v3.7"
 
     # Test the previous origin release
     # TODO - enable this once oc cluster up v3.9 supports modifiying cluster


### PR DESCRIPTION
This is a cherry-pick of d6396be664ae1e6da8402c9aeb0bb0f9c2b9cdf2 which is already in ose

https://bugzilla.redhat.com/show_bug.cgi?id=1622830
https://bugzilla.redhat.com/show_bug.cgi?id=1615743