### PR TITLE
test/extended/prometheus: better check for firing alerts

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -201,7 +201,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 			})
 		})
-		g.It("should report less than two alerts in firing or pending state", func() {
+		g.It("shouldn't report any alerts in firing state apart from Watchdog", func() {
 			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 				e2e.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
 			}
@@ -211,9 +211,8 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPod.Name, metav1.NewDeleteOptions(1)) }()
 
 			tests := map[string][]metricTest{
-				// should be checking there is no more than 1 alerts firing.
-				// Checking for specific alert is done in "should have a Watchdog alert in firing state".
-				`ALERTS{alertstate="firing"}`: {metricTest{greaterThanEqual: false, value: 2}},
+				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
+				`ALERTS{alertname!="Watchdog",alertstate="firing"}`: {metricTest{greaterThanEqual: true, value: 1}},
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -212,7 +212,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 			tests := map[string][]metricTest{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-				`ALERTS{alertname!="Watchdog",alertstate="firing"}`: {metricTest{greaterThanEqual: true, value: 1}},
+				`ALERTS{alertname!="Watchdog",alertstate="firing"}`: {metricTest{greaterThanEqual: true, value: 1, nodata: true}},
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -112,8 +112,9 @@ type metricTest struct {
 	// reliably filter; we do precise count validation in the unit tests, where "entire cluster" activity
 	// is more controlled :-)
 	greaterThanEqual bool
+	nodata           bool
 	value            float64
-	success          bool
+	status           bool
 }
 
 func runQueries(metricTests map[string][]metricTest, oc *exutil.CLI, ns, execPodName, baseURL, bearerToken string) {
@@ -135,7 +136,7 @@ func runQueries(metricTests map[string][]metricTest, oc *exutil.CLI, ns, execPod
 			for j, tc := range tcs {
 				for _, sample := range metrics {
 					if labelsWeWant(sample, tc.labels) && valueWeWant(sample, tc) {
-						tcs[j].success = true
+						tcs[j].status = !tcs[j].nodata
 						break
 					}
 				}
@@ -144,7 +145,7 @@ func runQueries(metricTests map[string][]metricTest, oc *exutil.CLI, ns, execPod
 			// now check the results, see if any bad
 			delete(errsMap, query) // clear out any prior faliures
 			for _, tc := range tcs {
-				if !tc.success {
+				if !tc.status {
 					dbg := fmt.Sprintf("query %s for tests %#v had results %s", query, tcs, contents)
 					fmt.Fprintf(g.GinkgoWriter, dbg)
 					errsMap[query] = fmt.Errorf(dbg)


### PR DESCRIPTION
Same as #24005 (Revert #23995 and improve reporting of which alerts are firing.)

Seems like CI is ok for other PRs in this repository, but not for #24005 so I recreated that one to see if it will also break. 
