### PR TITLE
test: Fewer smoke tests

### DIFF
--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -25,7 +25,7 @@ const (
 	operatorWait = 1 * time.Minute
 )
 
-var _ = g.Describe("[Feature:Machines][Smoke] Managed cluster should", func() {
+var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
 	g.It("have machine resources", func() {

--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -16,7 +16,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = Describe("[Feature:Platform][Smoke] Managed cluster", func() {
+var _ = Describe("[Feature:Platform] Managed cluster", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 	It("should ensure pods use downstream images from our release image with proper ImagePullPolicy", func() {
 		if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {

--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -13,7 +13,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
+var _ = Describe("[Feature:Platform] Managed cluster should", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 
 	It("ensure control plane pods do not run in best-effort QoS", func() {

--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -14,7 +14,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
+var _ = Describe("[Feature:Platform] Managed cluster should", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 
 	It("ensure control plane operators do not make themselves unevictable", func() {


### PR DESCRIPTION
These tests are not necessary for preventing a bad CI run, just for
ensuring tests are valid.