### PR TITLE
e2e: fix more flaky route wait functions

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -141,6 +141,7 @@ func waitForRouteToRespond(ns, execPodName, proto, host, abspath, ipaddr string,
 		set -e
 		STOP=$(($(date '+%%s') + %d))
 		while [ $(date '+%%s') -lt $STOP ]; do
+			rc=0
 			code=$( curl -k -s -m 5 -o /dev/null -w '%%{http_code}\n' --resolve %s:%d:%s %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -113,6 +113,7 @@ func dumpRouterHeadersLogs(oc *exutil.CLI, name string) {
 func getRoutePayloadExec(ns, execPodName, url, host string) (string, error) {
 	cmd := fmt.Sprintf(`
 		set -e
+		rc=0
 		payload=$( curl -s --header 'Host: %s' %q ) || rc=$?
 		if [[ "${rc:-0}" -eq 0 ]]; then
 			printf "${payload}"

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -267,6 +267,7 @@ func expectRouteStatusCodeRepeatedExec(ns, execPodName, url, host string, status
 		set -e
 		STOP=$(($(date '+%%s') + %d))
 		while [ $(date '+%%s') -lt $STOP ]; do
+			rc=0
 			code=$( curl -s -m 5 -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code


### PR DESCRIPTION
Follow-up to 34297f29e11c14918bbc098cf06598755419f89b with newly discovered
instances where a return code variable is uninitialized leading to flaky
wait behavior.