### PR TITLE
Revert "test/extended/operators: ensure clusterversion current version is set"

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -58,11 +58,6 @@ var _ = g.Describe("[Feature:Platform][Smoke] Managed cluster should", func() {
 			cv := objx.Map(obj.UnstructuredContent())
 			lastErr = nil
 			lastCV = cv
-			payload := cv.Get("status.desired.payload").String()
-			if len(payload) == 0 {
-				e2e.Logf("ClusterVersion has no current payload version")
-				return false, nil
-			}
 			if cond := condition(cv, "Progressing"); cond.Get("status").String() != "False" {
 				e2e.Logf("ClusterVersion is still progressing: %s", cond.Get("message").String())
 				return false, nil


### PR DESCRIPTION
The ClusterVersions config/v1 type has no status.desired.payload: https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go#L197

Pruning will remove this value. It blocks 1.16.2 rebase.

This reverts commit 2f21b747a119d1427111987255a508e4e26b086f.