### PR TITLE
Bug 1763988: ldap: extended timeout for run once pod to 8 minutes

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1625,8 +1625,9 @@ func RunOneShotCommandPod(
 	// Wait for command completion.
 	err = wait.PollImmediate(1*time.Second, timeout, func() (done bool, err error) {
 		cmdPod, getErr := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(pod.Name, v1.GetOptions{})
-		if err != nil {
-			return false, getErr
+		if getErr != nil {
+			e2e.Logf("failed to get pod %q: %v", pod.Name, err)
+			return false, nil
 		}
 
 		if podHasErrored(cmdPod) {

--- a/test/extended/util/ldap.go
+++ b/test/extended/util/ldap.go
@@ -176,8 +176,7 @@ func checkLDAPConn(oc *CLI, host string) error {
 // Run an ldapsearch in a pod against host.
 func runLDAPSearchInPod(oc *CLI, host string) (string, error) {
 	mounts, volumes := LDAPClientMounts()
-	output, errs := RunOneShotCommandPod(oc, "runonce-ldapsearch-pod", OpenLDAPTestImage, fmt.Sprintf(ldapSearchCommandFormat, host), mounts,
-		volumes, nil, 5*time.Minute)
+	output, errs := RunOneShotCommandPod(oc, "runonce-ldapsearch-pod", OpenLDAPTestImage, fmt.Sprintf(ldapSearchCommandFormat, host), mounts, volumes, nil, 8*time.Minute)
 	if len(errs) != 0 {
 		return output, fmt.Errorf("errours encountered trying to run ldapsearch pod: %v", errs)
 	}


### PR DESCRIPTION
Flake: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.2/136

There is 5 minute timeout for running the pod:

20:12:49 - pod initialized
20:12:49 - pod scheduled
20:14:09 - pod completed

This is is not adding up, however, this was previously integration test and now it is e2e test, so it means it runs in HA environment... It is possible that the poller is hitting API server with outdated cache for pods?

Increasing the timeout here should increase the chance the client will eventually get the correct pod state.