### PR TITLE
e2e: RequestHeader IDP: fix common flake

### DIFF
--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -56,14 +56,6 @@ type certAuthTest struct {
 	expectedError string
 }
 
-// helper error to retrieve the token from a redirect chain stopped by custom
-// http client CheckRedirect
-type tokenFoundError struct{}
-
-func (e *tokenFoundError) Error() string {
-	return fmt.Sprintf("token found")
-}
-
 var _ = g.Describe("[Serial] [Feature:OAuthServer] [RequestHeaders] [IdP]", func() {
 	var oc = exutil.NewCLI("request-headers", exutil.KubeConfigPath())
 


### PR DESCRIPTION
This fixes a not-surprisingly often observed flake.

Partially replaces current changes in https://github.com/openshift/origin/pull/24042

/assign @mfojtik 