### PR TITLE
Bug 1765756: UPSTREAM: 80004: Prefer to delete doubled-up pods of a ReplicaSet

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/controller/replicaset/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/controller/replicaset/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/informers/apps/v1:go_default_library",

--- a/vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/replicaset"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	testutil "k8s.io/kubernetes/test/utils"
+	"k8s.io/utils/integer"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -121,6 +122,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testProportionalScalingDeployment(f)
 	})
 	ginkgo.It("should not disrupt a cloud load-balancer's connectivity during rollout", func() {
+		framework.SkipUnlessNodeCountIsAtLeast(2)
 		framework.SkipUnlessProviderIs("aws", "azure", "gce", "gke")
 		testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f)
 	})
@@ -869,7 +871,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	name := "test-rolling-update-with-lb"
 	framework.Logf("Creating Deployment %q", name)
 	podLabels := map[string]string{"name": name}
-	replicas := int32(3)
+	replicas := int32(integer.IntMin(5, framework.TestContext.CloudConfig.NumNodes))
 	d := e2edeploy.NewDeployment(name, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	// NewDeployment assigned the same value to both d.Spec.Selector and
 	// d.Spec.Template.Labels, so mutating the one would mutate the other.

--- a/vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go
@@ -42,6 +42,7 @@ import (
 	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/framework/replicaset"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	testutil "k8s.io/kubernetes/test/utils"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -118,6 +119,10 @@ var _ = SIGDescribe("Deployment", func() {
 	*/
 	framework.ConformanceIt("deployment should support proportional scaling", func() {
 		testProportionalScalingDeployment(f)
+	})
+	ginkgo.It("should not disrupt a cloud load-balancer's connectivity during rollout", func() {
+		framework.SkipUnlessProviderIs("aws", "azure", "gce", "gke")
+		testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f)
 	})
 	// TODO: add tests that cover deployment.Spec.MinReadySeconds once we solved clock-skew issues
 	// See https://github.com/kubernetes/kubernetes/issues/29229
@@ -855,4 +860,152 @@ func orphanDeploymentReplicaSets(c clientset.Interface, d *appsv1.Deployment) er
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &trueVar}
 	deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(d.UID))
 	return c.AppsV1().Deployments(d.Namespace).Delete(d.Name, deleteOptions)
+}
+
+func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framework) {
+	ns := f.Namespace.Name
+	c := f.ClientSet
+
+	name := "test-rolling-update-with-lb"
+	framework.Logf("Creating Deployment %q", name)
+	podLabels := map[string]string{"name": name}
+	replicas := int32(3)
+	d := e2edeploy.NewDeployment(name, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
+	// NewDeployment assigned the same value to both d.Spec.Selector and
+	// d.Spec.Template.Labels, so mutating the one would mutate the other.
+	// Thus we need to set d.Spec.Template.Labels to a new value if we want
+	// to mutate it alone.
+	d.Spec.Template.Labels = map[string]string{
+		"iteration": "0",
+		"name":      name,
+	}
+	d.Spec.Template.Spec.Containers[0].Args = []string{"netexec", "--http-port=80", "--udp-port=80"}
+	// To ensure that a node that had a local endpoint prior to a rolling
+	// update continues to have a local endpoint throughout the rollout, we
+	// need an affinity policy that will cause pods to be scheduled on the
+	// same nodes as old pods, and we need the deployment to scale up a new
+	// pod before deleting an old pod.  This affinity policy will define
+	// inter-pod affinity for pods of different rollouts and anti-affinity
+	// for pods of the same rollout, so it will need to be updated when
+	// performing a rollout.
+	setAffinity(d)
+	d.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
+		MaxSurge:       intOrStrP(1),
+		MaxUnavailable: intOrStrP(0),
+	}
+	deployment, err := c.AppsV1().Deployments(ns).Create(d)
+	framework.ExpectNoError(err)
+	err = e2edeploy.WaitForDeploymentComplete(c, deployment)
+	framework.ExpectNoError(err)
+
+	framework.Logf("Creating a service %s with type=LoadBalancer and externalTrafficPolicy=Local in namespace %s", name, ns)
+	jig := e2eservice.NewTestJig(c, name)
+	jig.Labels = podLabels
+	service := jig.CreateLoadBalancerService(ns, name, e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
+		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	})
+
+	lbNameOrAddress := e2eservice.GetIngressPoint(&service.Status.LoadBalancer.Ingress[0])
+	svcPort := int(service.Spec.Ports[0].Port)
+
+	framework.Logf("Hitting the replica set's pods through the service's load balancer")
+	timeout := e2eservice.LoadBalancerLagTimeoutDefault
+	if framework.ProviderIs("aws") {
+		timeout = e2eservice.LoadBalancerLagTimeoutAWS
+	}
+	jig.TestReachableHTTP(lbNameOrAddress, svcPort, timeout)
+
+	framework.Logf("Starting a goroutine to watch the service's endpoints in the background")
+	done := make(chan struct{})
+	failed := make(chan struct{})
+	defer close(done)
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		expectedNodes := jig.GetEndpointNodeNames(service)
+		// The affinity policy should ensure that before an old pod is
+		// deleted, a new pod will have been created on the same node.
+		// Thus the set of nodes with local endpoints for the service
+		// should remain unchanged.
+		wait.Until(func() {
+			actualNodes := jig.GetEndpointNodeNames(service)
+			if !actualNodes.Equal(expectedNodes) {
+				framework.Logf("The set of nodes with local endpoints changed; started with %v, now have %v", expectedNodes.List(), actualNodes.List())
+				failed <- struct{}{}
+			}
+		}, framework.Poll, done)
+	}()
+
+	framework.Logf("Triggering a rolling deployment several times")
+	for i := 1; i <= 3; i++ {
+		framework.Logf("Updating label deployment %q pod spec (iteration #%d)", name, i)
+		deployment, err = e2edeploy.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1.Deployment) {
+			update.Spec.Template.Labels["iteration"] = fmt.Sprintf("%d", i)
+			setAffinity(update)
+		})
+		framework.ExpectNoError(err)
+
+		framework.Logf("Waiting for observed generation %d", deployment.Generation)
+		err = e2edeploy.WaitForObservedDeployment(c, ns, name, deployment.Generation)
+		framework.ExpectNoError(err)
+
+		framework.Logf("Make sure deployment %q is complete", name)
+		err = e2edeploy.WaitForDeploymentCompleteAndCheckRolling(c, deployment)
+		framework.ExpectNoError(err)
+	}
+
+	select {
+	case <-failed:
+		framework.Failf("Connectivity to the load balancer was interrupted")
+	case <-time.After(1 * time.Minute):
+	}
+}
+
+func setAffinity(d *appsv1.Deployment) {
+	d.Spec.Template.Spec.Affinity = &v1.Affinity{
+		PodAffinity: &v1.PodAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+				{
+					Weight: int32(100),
+					PodAffinityTerm: v1.PodAffinityTerm{
+						TopologyKey: "kubernetes.io/hostname",
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "name",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{d.Spec.Template.Labels["name"]},
+								},
+								{
+									Key:      "iteration",
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{d.Spec.Template.Labels["iteration"]},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		PodAntiAffinity: &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					TopologyKey: "kubernetes.io/hostname",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "name",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{d.Spec.Template.Labels["name"]},
+							},
+							{
+								Key:      "iteration",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{d.Spec.Template.Labels["iteration"]},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go
@@ -888,7 +888,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	// inter-pod affinity for pods of different rollouts and anti-affinity
 	// for pods of the same rollout, so it will need to be updated when
 	// performing a rollout.
-	setAffinity(d)
+	setAffinities(d, false)
 	d.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
 		MaxSurge:       intOrStrP(1),
 		MaxUnavailable: intOrStrP(0),
@@ -940,7 +940,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 		framework.Logf("Updating label deployment %q pod spec (iteration #%d)", name, i)
 		deployment, err = e2edeploy.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1.Deployment) {
 			update.Spec.Template.Labels["iteration"] = fmt.Sprintf("%d", i)
-			setAffinity(update)
+			setAffinities(update, true)
 		})
 		framework.ExpectNoError(err)
 
@@ -960,32 +960,14 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	}
 }
 
-func setAffinity(d *appsv1.Deployment) {
-	d.Spec.Template.Spec.Affinity = &v1.Affinity{
-		PodAffinity: &v1.PodAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
-				{
-					Weight: int32(100),
-					PodAffinityTerm: v1.PodAffinityTerm{
-						TopologyKey: "kubernetes.io/hostname",
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								{
-									Key:      "name",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{d.Spec.Template.Labels["name"]},
-								},
-								{
-									Key:      "iteration",
-									Operator: metav1.LabelSelectorOpNotIn,
-									Values:   []string{d.Spec.Template.Labels["iteration"]},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+// setAffinities set PodAntiAffinity across pods from the same generation
+// of Deployment and if, explicitly requested, also affinity with pods
+// from other generations.
+// It is required to make those "Required" so that in large clusters where
+// scheduler may not score all nodes if a lot of them are feasible, the
+// test will also have a chance to pass.
+func setAffinities(d *appsv1.Deployment, setAffinity bool) {
+	affinity := &v1.Affinity{
 		PodAntiAffinity: &v1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 				{
@@ -1008,4 +990,28 @@ func setAffinity(d *appsv1.Deployment) {
 			},
 		},
 	}
+	if setAffinity {
+		affinity.PodAffinity = &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					TopologyKey: "kubernetes.io/hostname",
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "name",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{d.Spec.Template.Labels["name"]},
+							},
+							{
+								Key:      "iteration",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{d.Spec.Template.Labels["iteration"]},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	d.Spec.Template.Spec.Affinity = affinity
 }

--- a/vendor/k8s.io/kubernetes/test/e2e/apps/types.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apps/types.go
@@ -25,6 +25,7 @@ import (
 const (
 	WebserverImageName = "httpd"
 	RedisImageName     = "redis"
+	AgnhostImageName   = "agnhost"
 )
 
 var (
@@ -48,4 +49,7 @@ var (
 
 	// RedisImage is the fully qualified URI to the Redis image
 	RedisImage = imageutils.GetE2EImage(imageutils.Redis)
+
+	// AgnhostImage is the fully qualified URI to the agnhost image.
+	AgnhostImage = imageutils.GetE2EImage(imageutils.Agnhost)
 )

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/service/jig.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/service/jig.go
@@ -271,6 +271,19 @@ func (j *TestJig) CreateLoadBalancerService(namespace, serviceName string, timeo
 // endpoints of the given Service are running.
 func (j *TestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
 	nodes := j.GetNodes(MaxNodesForEndpointsTests)
+	epNodes := j.GetEndpointNodeNames(svc)
+	nodeMap := map[string][]string{}
+	for _, n := range nodes.Items {
+		if epNodes.Has(n.Name) {
+			nodeMap[n.Name] = e2enode.GetAddresses(&n, v1.NodeExternalIP)
+		}
+	}
+	return nodeMap
+}
+
+// GetEndpointNodeNames returns a string set of node names on which the
+// endpoints of the given Service are running.
+func (j *TestJig) GetEndpointNodeNames(svc *v1.Service) sets.String {
 	endpoints, err := j.Client.CoreV1().Endpoints(svc.Namespace).Get(svc.Name, metav1.GetOptions{})
 	if err != nil {
 		framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
@@ -286,13 +299,7 @@ func (j *TestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
 			}
 		}
 	}
-	nodeMap := map[string][]string{}
-	for _, n := range nodes.Items {
-		if epNodes.Has(n.Name) {
-			nodeMap[n.Name] = e2enode.GetAddresses(&n, v1.NodeExternalIP)
-		}
-	}
-	return nodeMap
+	return epNodes
 }
 
 // GetNodes returns the first maxNodesForTest nodes. Useful in large clusters


### PR DESCRIPTION
This commit brings back https://github.com/openshift/origin/pull/23806, which was dropped during a rebase scuffle (see https://github.com/openshift/origin/pull/24014#commitcomment-35709732), and adds a fix for [BZ#1765756](https://bugzilla.redhat.com/show_bug.cgi?id=1765756).

---

#### UPSTREAM: 80004: Prefer to delete doubled-up pods of a ReplicaSet

When scaling down a ReplicaSet, delete doubled up replicas first, where a "doubled up replica" is defined as one that is on the same node as an active replica belonging to a related ReplicaSet.  ReplicaSets are considered "related" if they have a common controller (typically a Deployment).

The intention of this change is to make a rolling update of a Deployment scale down the old ReplicaSet as it scales up the new ReplicaSet by deleting pods from the old ReplicaSet that are colocated with ready pods of the new ReplicaSet.  This change in the behavior of rolling updates can be combined with pod affinity rules to preserve the locality of a Deployment's pods over rollout.

A specific scenario that benefits from this change is when a Deployment's pods are exposed by a Service that has type "LoadBalancer" and external traffic policy "Local".  In this scenario, the load balancer uses health checks to determine whether it should forward traffic for the Service to a particular node.  If the node has no local endpoints for the Service, the health check will fail for that node.  Eventually, the load balancer will stop forwarding traffic to that node.  In the meantime, the service proxy drops traffic for that Service.  Thus, in order to reduce risk of dropping traffic during a rolling update, it is desirable preserve node locality of endpoints.

* `vendor/k8s.io/kubernetes/pkg/controller/controller_utils.go` (`ActivePodsWithRanks`): New type to sort pods using a given ranking.
* `vendor/k8s.io/kubernetes/pkg/controller/controller_utils_test.go` (`TestSortingActivePodsWithRanks`): New test for `ActivePodsWithRanks`.
* `vendor/k8s.io/kubernetes/pkg/controller/replicaset/replica_set.go`
(`getReplicaSetsWithSameController`): New method.  Given a ReplicaSet, return all ReplicaSets that have the same owner.
(`manageReplicas`): Call `getIndirectlyRelatedPods`, and pass its result to `getPodsToDelete`.
(`getIndirectlyRelatedPods`): New method.  Given a ReplicaSet, return all pods that are owned by any ReplicaSet with the same owner.
(`getPodsToDelete`): Add an argument for related pods.  Use related pods and the new getPodsRankedByRelatedPodsOnSameNode function to take into account whether the pod is doubled up when sorting pods for deletion.
(`getPodsRankedByRelatedPodsOnSameNode`): New function.  Return an `ActivePodsWithRanks` value that wraps the given slice of pods and computes ranks where each pod's rank is equal to the number of active related pods that are colocated on the same node.
* `vendor/k8s.io/kubernetes/pkg/controller/replicaset/replica_set_test.go` (`newReplicaSet`): Set `OwnerReferences` on the ReplicaSet.
(`newPod`): Set a unique UID on the pod.
(`byName`): New type to sort pods by name.
(`TestRelatedPodsLookup`): New test for `getIndirectlyRelatedPods`.
(`TestGetPodsToDelete`): Augment the "various pod phases and conditions, diff = len(pods)" test case to ensure that scale-down still selects doubled-up pods if there are not enough other pods to scale down.  Add a "various pod phases and conditions, diff = len(pods), relatedPods empty" test case to verify that getPodsToDelete works even if related pods could not be determined.  Add a "ready and colocated with another ready pod vs not colocated, diff < len(pods)" test case to verify that a doubled-up pod gets preferred for deletion.  Augment the "various pod phases and conditions, diff < len(pods)" test case to ensure that not-ready pods are preferred over ready but doubled-up pods.
* `vendor/k8s.io/kubernetes/pkg/controller/replicaset/BUILD:` Regenerate.
* `vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go` (`testRollingUpdateDeploymentWithLocalTrafficLoadBalancer`): New end-to-end test.  Create a deployment with a rolling update strategy and affinity rules and a load balancer with "Local" external traffic policy, and verify that set of nodes with local endponts for the service remains unchanged during rollouts.
(`setAffinity`): New helper, used by `testRollingUpdateDeploymentWithLocalTrafficLoadBalancer`.
* `vendor/k8s.io/kubernetes/test/e2e/apps/types.go` (`AgnhostImageName`, `AgnhostImage`): New constants for the agnhost image.
* `vendor/k8s.io/kubernetes/test/e2e/framework/service/jig.go` (`GetEndpointNodes`): Factor building the set of node names out...
(`GetEndpointNodeNames`): ...into this new method.

#### UPSTREAM: 84339: Fix deployment e2e test at scale

#### UPSTREAM: 84568: test/e2e/apps: Skip or scale LB test per node count

Skip the "Deployment should not disrupt a cloud load-balancer's connectivity during rollout" test if the number of nodes is less than 2; otherwise, set the deployment's replicas equal to the lesser of 5 and the number of nodes.

The test would fail if there were fewer nodes than replicas, but the test needs at least 2 nodes, and the likelihood of failure absent the feature under test increases with the number of replicas, so it is desirable to set replicas to a higher value, within reason.

* `vendor/k8s.io/kubernetes/test/e2e/apps/deployment.go`: Skip the load-balancer connectivity test unless there are at least 2 nodes.
(`testRollingUpdateDeploymentWithLocalTrafficLoadBalancer`): Set `replicas` to the min of 5 and the number of nodes.

---

This PR supersedes #24047.