### PR TITLE
test: Catch panics in the disruption suite

### DIFF
--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -104,6 +104,7 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 		})
 	}
 	defer finalizeTest(start, cma.testReport)
+	defer g.GinkgoRecover()
 	defer ready()
 	if skippable, ok := cma.test.(upgrades.Skippable); ok && skippable.Skip(cma.UpgradeContext) {
 		g.By("skipping test " + cma.test.Name())


### PR DESCRIPTION
We need a relatively high level catch, caught during upgrade tests
where we observed this panic escape a goroutine.