### PR TITLE
Bug 1767178: images/sdn: disable cgo when building CNI binaries

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -1,9 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
 WORKDIR /go/src/github.com/openshift/origin
 COPY . .
-RUN make build WHAT=" \
-    cmd/openshift-sdn \
-    cmd/sdn-cni-plugin \
+RUN make build WHAT=cmd/openshift-sdn
+RUN make build CGO_ENABLED=0 WHAT="cmd/sdn-cni-plugin \
     vendor/github.com/containernetworking/plugins/plugins/ipam/host-local \
     vendor/github.com/containernetworking/plugins/plugins/main/loopback \
     "


### PR DESCRIPTION
This is already done in 4.2 and 4.3 - these binaries are leaked on to the host; building them statically is much more reliable.