### PR TITLE
[release-4.2] Bug 1765179: e2e: fix flaky route wait functions

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -141,6 +141,7 @@ func waitForRouteToRespond(ns, execPodName, proto, host, abspath, ipaddr string,
 		set -e
 		STOP=$(($(date '+%%s') + %d))
 		while [ $(date '+%%s') -lt $STOP ]; do
+			rc=0
 			code=$( curl -k -s -m 5 -o /dev/null -w '%%{http_code}\n' --resolve %s:%d:%s %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -112,6 +112,7 @@ func dumpRouterHeadersLogs(oc *exutil.CLI, name string) {
 func getRoutePayloadExec(ns, execPodName, url, host string) (string, error) {
 	cmd := fmt.Sprintf(`
 		set -e
+		rc=0
 		payload=$( curl -s --header 'Host: %s' %q ) || rc=$?
 		if [[ "${rc:-0}" -eq 0 ]]; then
 			printf "${payload}"

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -235,6 +235,7 @@ func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSecon
 		set -e
 		STOP=$(($(date '+%%s') + %d))
 		while [ $(date '+%%s') -lt $STOP ]; do
+			rc=0
 			code=$( curl -k -s -m 5 -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -266,6 +266,7 @@ func expectRouteStatusCodeRepeatedExec(ns, execPodName, url, host string, status
 		set -e
 		STOP=$(($(date '+%%s') + %d))
 		while [ $(date '+%%s') -lt $STOP ]; do
+			rc=0
 			code=$( curl -s -m 5 -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code


### PR DESCRIPTION
Many router tests use `waitForRouterOKResponseExec()` to wait for test route
connectivity. However, due to a bug in the check script, if the underlying
`curl` command times out once during checks, the `waitForRouterOKResponseExec()`
function will always time out even if the target route becomes responsive.

If the `curl` command itself never times out, the function works properly.

Fix the check script so that `curl` timeouts are correctly handled.

This probably fixes many e2e flakes associated with router tests which use
`waitForRouterOKResponseExec()`.