### PR TITLE
[release-4.1] Bug 1765181: e2e: fix flaky route wait function

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -140,6 +140,7 @@ func waitForRouteToRespond(ns, execPodName, proto, host, abspath, ipaddr string,
 	cmd := fmt.Sprintf(`
 		set -e
 		for i in $(seq 1 %d); do
+			rc=0
 			code=$( curl -k -s -o /dev/null -w '%%{http_code}\n' --resolve %s:%d:%s %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -123,6 +123,7 @@ func dumpRouterHeadersLogs(oc *exutil.CLI, name string) {
 func getRoutePayloadExec(ns, execPodName, url, host string) (string, error) {
 	cmd := fmt.Sprintf(`
 		set -e
+		rc=0
 		payload=$( curl -s --header 'Host: %s' %q ) || rc=$?
 		if [[ "${rc:-0}" -eq 0 ]]; then
 			printf "${payload}"

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -242,6 +242,7 @@ func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSecon
 	cmd := fmt.Sprintf(`
 		set -e
 		for i in $(seq 1 %d); do
+			rc=0
 			code=$( curl -k -s -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code
@@ -272,6 +273,7 @@ func expectRouteStatusCodeRepeatedExec(ns, execPodName, url, host string, status
 	cmd := fmt.Sprintf(`
 		set -e
 		for i in $(seq 1 %d); do
+			rc=0
 			code=$( curl -s -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
 				echo $code


### PR DESCRIPTION
Many router tests use waitForRouterOKResponseExec() to wait for test route
connectivity. However, due to a bug in the check script, if the underlying
curl command times out once during checks, the waitForRouterOKResponseExec()
function will always time out even if the target route becomes responsive.

If the curl command itself never times out, the function works properly.

Fix the check script so that curl timeouts are correctly handled.

This probably fixes many e2e flakes associated with router tests which use
waitForRouterOKResponseExec().