### PR TITLE
try to run all 4 jenkins e2e ginkgos in parallel before bumping timeout

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -105,7 +105,7 @@ var staticSuites = []*ginkgo.TestSuite{
 		Matches: func(name string) bool {
 			return strings.Contains(name, "[Feature:Jenkins]")
 		},
-		Parallelism: 3,
+		Parallelism: 4,
 		TestTimeout: 20 * time.Minute,
 	},
 	{


### PR DESCRIPTION
/assign @bparees 

@akram @waveywaves @openshift/openshift-team-developer-experience FYI

some of the individual ginkgo contexts are taking 12 to 15 minutes, and the test time is currently 20 minutes as you can see in the commit diff 