### PR TITLE
test: must-gather pods may tolerate all taints

### DIFF
--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -29,7 +29,7 @@ var _ = Describe("[Feature:Platform] Managed cluster should", func() {
 		// TODO components in openshift-operators may not come from our payload, may want to weaken restriction
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
 		excludeNamespaces := sets.NewString("openshift-operator-lifecycle-manager")
-		excludePodPrefix := sets.NewString("revision-pruner-", "installer-")
+		excludePodPrefix := sets.NewString("revision-pruner-", "installer-", "must-gather-")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces
 			if !hasPrefixSet(pod.Namespace, namespacePrefixes) {

--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -31,7 +31,7 @@ var _ = Describe("[Feature:Platform] Managed cluster should", func() {
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
 		excludedNamespaces := sets.NewString("openshift-kube-apiserver", "openshift-kube-controller-manager", "openshift-kube-scheduler", "openshift-etcd", "openshift-openstack-infra")
 		// exclude these pods from checks
-		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators", "gcp-routes-controller", "ovnkube-master")
+		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators", "gcp-routes-controller", "ovnkube-master", "must-gather")
 		for _, pod := range pods.Items {
 			// exclude non-control plane namespaces
 			if !hasPrefixSet(pod.Namespace, namespacePrefixes) {


### PR DESCRIPTION
Because the test runs when other tests run, it can sometimes fail
if must gather happens to be running. It's ok for must-gather pods
to tolerate all taints.