### PR TITLE
Add Ben as top-level OWNER

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ approvers:
   - deads2k
   - derekwaynecarr
   - eparis
+  - knobunc  # Network, Multi-cluster, Storage
   - mfojtik
   - pweil-
   - sjenning


### PR DESCRIPTION
He was in vendor/OWNERS that got accidentally removed in #24014. Since it's common to remove files in vendor/ during rebases, adding him to top-level OWNERS is more stable.

