### PR TITLE
check if ClusterMachineApproverDown UsingDeprecatedAPIExtensionsV1Beta1 alerts are not firing

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -254,8 +254,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 
 			tests := map[string]bool{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
-				// FIXME(paulfantom): UsingDeprecatedAPIExtensionsV1Beta1 shouldn't be firing!
-				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|UsingDeprecatedAPIExtensionsV1Beta1",alertstate="firing"} >= 1`: false,
+				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured",alertstate="firing"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
Follow-up to #24019.

/cc @LiliC @simonpasquier @s-urbaniak 