### PR TITLE
[MON-832] test/extended/prometheus: check if any rule evaluation is failing

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -184,6 +184,17 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})
+		g.It("shouldn't have failing rules evaluation", func() {
+			oc.SetupProject()
+			ns := oc.Namespace()
+			execPod := exutil.CreateCentosExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", nil)
+			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPod.Name, metav1.NewDeleteOptions(1)) }()
+
+			tests := map[string]bool{
+				`prometheus_rule_evaluation_failures_total >= 1`: false,
+			}
+			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
+		})
 		networking.InOpenShiftSDNContext(func() {
 			g.It("should be able to get the sdn ovs flows", func() {
 				oc.SetupProject()


### PR DESCRIPTION
We shouldn't have any failing rule evaluation in a fresh cluster. If it is firing, it usually means there is a problem with promQL.

/cc @LiliC @simonpasquier @s-urbaniak