### PR TITLE
add ci image to launch gce instance from openshift

### DIFF
--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,0 +1,17 @@
+# This Dockerfile is a used by CI to launch a gce instance with a mock user to enable ssh communication between pod,instance
+# It builds an image containing google-cloud-sdk, ns_wrapper and scripts to launch a gce instance.
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+WORKDIR /go/src/github.com/openshift/origin
+COPY . .
+
+FROM centos:7
+COPY --from=builder /go/src/github.com/openshift/origin/images/ci/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+COPY --from=builder /go/src/github.com/openshift/origin/images/ci/mock-nss.sh /bin/mock-nss.sh
+
+RUN yum install -y \
+    gettext \
+    google-cloud-sdk \
+    openssh-clients \
+    nss_wrapper && \
+    yum -y update && \
+    yum clean all

--- a/images/ci/README.md
+++ b/images/ci/README.md
@@ -1,0 +1,52 @@
+# Image to launch GCE from OpenShift for CI
+
+This image enables launching a GCE instance from OpenShift, for CI testing.
+
+This image contains [`nss_wrapper`](https://cwrap.org/nss_wrapper.html) to execute `ssh` commands as
+a mock user to interact with a GCE instance from an OpenShift container.
+
+OpenShift containers run with an arbitrary uid, but SSH requires a valid user.  `nss_wrapper`
+allows for the container's user ID to be mapped to a username inside of a container.
+
+### Example Usage
+
+You can override the container's current user ID and group ID by providing `NSS_WRAPPER_GROUP`
+and `NSS_WRAPPER_PASSWD` for the mock files, as well as `NSS_USERNAME`, `NSS_UID`, `NSS_GROUPNAME`,
+and/or `NSS_GID`. In OpenShift CI, `NSS_USERNAME` and `NSS_GROUPNAME` are set.
+The random UID assigned to the container is the UID that the mock username is mapped to.
+
+```console
+$ podman run --rm \
+>   -e NSS_WRAPPER_GROUP=/tmp/group \
+>   -e NSS_WRAPPER_PASSWD=/tmp/passwd \
+>   -e NSS_UID=1000 \
+>   -e NSS_GID=1000 \
+>   -e NSS_USERNAME=testuser \
+>   -e NSS_GROUPNAME=testuser \
+>   nss_wrapper_img mock-nss.sh id testuser
+uid=1000(testuser) gid=1000(testuser) groups=1000(testuser)
+```
+
+Or, in an OpenShift container:
+
+```yaml
+containers:
+- name: setup
+  image: nss-wrapper-image
+  env:
+  - name: NSS_WRAPPER_PASSWD
+    value: /tmp/passwd
+  - name: NSS_WRAPPER_GROUP
+    value: /tmp/group
+  - name: NSS_USERNAME
+    value: mockuser
+  - name: NSS_GROUPNAME
+    value: mockuser
+  command:
+  - /bin/sh
+  - -c
+  - |
+    #!/bin/sh
+    mock-nss.sh
+    LD_PRELOAD=/usr/lib64/libnss_wrapper.so gcloud compute scp [gcloud scp args]
+```

--- a/images/ci/google-cloud-sdk.repo
+++ b/images/ci/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/images/ci/mock-nss.sh
+++ b/images/ci/mock-nss.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# mock passwd and group files
+(
+  exec 2>/dev/null
+  username="${NSS_USERNAME:-$(id -un)}"
+  uid="${NSS_UID:-$(id -u)}"
+
+  groupname="${NSS_GROUPNAME:-$(id -gn)}"
+  gid="${NSS_GID:-$(id -g)}"
+
+  echo "${username}:x:${uid}:${uid}:gecos:${HOME}:/bin/bash" > "${NSS_WRAPPER_PASSWD}"
+  echo "${groupname}:x:${gid}:" > "${NSS_WRAPPER_GROUP}"
+)
+
+# wrap command
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+exec "$@"


### PR DESCRIPTION
This image plus scripts allow a gcp instance to launch from OpenShift CI pod, with a 'real' user, to be able to ssh to the gcp instance to run commands. 

We use a similar setup to launch a libvirt cluster nested in a gcp instance in CI. 

This PR is necessary for https://github.com/openshift/release/pull/5741
/cc @mrunalp 