### PR TITLE
bug 1713134: UPSTREAM: 84513: test/e2e: AddOrUpdateAvoidPodOnNode/RemoveAvoidPodsOffNode: retry when conflict hit during annotation update

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -1965,6 +1965,7 @@ func AddOrUpdateAvoidPodOnNode(c clientset.Interface, nodeName string, avoidPods
 				ExpectNoError(err)
 			} else {
 				e2elog.Logf("Conflict when trying to add/update avoidPods %v to %v with error %v", avoidPods, nodeName, err)
+				return false, nil
 			}
 		}
 		return true, nil
@@ -1993,6 +1994,7 @@ func RemoveAvoidPodsOffNode(c clientset.Interface, nodeName string) {
 				ExpectNoError(err)
 			} else {
 				e2elog.Logf("Conflict when trying to remove avoidPods to %v", nodeName)
+				return false, nil
 			}
 		}
 		return true, nil


### PR DESCRIPTION
Backport of https://github.com/kubernetes/kubernetes/pull/84513

In case node object update fails due to revision conflict, it does not make sense to return success.
It needs to be retried so the v1.PreferAvoidPodsAnnotationKey annotation can be properly set in the next round.