### PR TITLE
Bug 1763988: LDAP e2e: add dnf install retries, extend run timeout

### DIFF
--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -39,7 +39,13 @@ var _ = g.Describe("[Suite:openshift/oauth][Serial] ldap group sync", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// Install stuff needed for the exec pod to run groupsync.sh and hack/lib
-		_, err = pod.Exec("dnf install findutils golang docker which bc openldap-clients -y")
+		for i := 0; i < 5; i++ {
+			if _, err = pod.Exec("dnf install -y findutils golang docker which bc openldap-clients"); err == nil {
+				break
+			}
+			// it apparently hit error syncing caches, clean all to try again
+			pod.Exec("dnf clean all")
+		}
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// Copy oc

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1625,8 +1625,9 @@ func RunOneShotCommandPod(
 	// Wait for command completion.
 	err = wait.PollImmediate(1*time.Second, timeout, func() (done bool, err error) {
 		cmdPod, getErr := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(pod.Name, v1.GetOptions{})
-		if err != nil {
-			return false, getErr
+		if getErr != nil {
+			e2e.Logf("failed to get pod %q: %v", pod.Name, err)
+			return false, nil
 		}
 
 		if podHasErrored(cmdPod) {

--- a/test/extended/util/ldap.go
+++ b/test/extended/util/ldap.go
@@ -176,8 +176,7 @@ func checkLDAPConn(oc *CLI, host string) error {
 // Run an ldapsearch in a pod against host.
 func runLDAPSearchInPod(oc *CLI, host string) (string, error) {
 	mounts, volumes := LDAPClientMounts()
-	output, errs := RunOneShotCommandPod(oc, "runonce-ldapsearch-pod", OpenLDAPTestImage, fmt.Sprintf(ldapSearchCommandFormat, host), mounts,
-		volumes, nil, 5*time.Minute)
+	output, errs := RunOneShotCommandPod(oc, "runonce-ldapsearch-pod", OpenLDAPTestImage, fmt.Sprintf(ldapSearchCommandFormat, host), mounts, volumes, nil, 8*time.Minute)
 	if len(errs) != 0 {
 		return output, fmt.Errorf("errours encountered trying to run ldapsearch pod: %v", errs)
 	}

--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/RangelReale/osincli"
+	"github.com/davecgh/go-spew/spew"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -203,13 +204,14 @@ func waitForOAuthServerReady(oc *exutil.CLI) error {
 }
 
 func waitForOAuthServerPodReady(oc *exutil.CLI) error {
+	e2e.Logf("Waiting for the OAuth server pod to be ready")
 	return wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
-		e2e.Logf("Waiting for the OAuth server pod to be ready")
 		pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get("test-oauth-server", metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 		if !exutil.CheckPodIsReady(*pod) {
+			e2e.Logf("OAuth server pod is not ready: %s\nContainer statuses: %s", pod.Status.Message, spew.Sdump(pod.Status.ContainerStatuses))
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
Fixes a couple of issues with the LDAP e2e tests

Also tries to fix https://bugzilla.redhat.com/show_bug.cgi?id=1759248

/assign @mfojtik 