### PR TITLE
[3.11] Bug 1768612: mirror: Support v2_1 docker registries as mirror source

### DIFF
--- a/pkg/oc/cli/image/mirror/mirror.go
+++ b/pkg/oc/cli/image/mirror/mirror.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client"
@@ -413,6 +414,7 @@ func (o *MirrorImageOptions) plan() (*plan, error) {
 								for _, srcManifest := range srcManifests {
 									switch srcManifest.(type) {
 									case *schema2.DeserializedManifest:
+									case *schema1.SignedManifest:
 									case *manifestlist.DeserializedManifestList:
 										// we do not need to upload layers in a manifestlist
 										continue


### PR DESCRIPTION
Simple fix

(cherry picked from commit 72270c620de703fd9d4d07d9818ca2276c4e9086)