### PR TITLE
Bug 1752646: e2e: Re-enable HAProxy router header test

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -423,9 +423,6 @@ var (
 			// TODO(workloads): reenable
 			`SchedulerPreemption`,
 
-			// Test fails on platforms that use LoadBalancerService and HostNetwork endpoint publishing strategy
-			`\[Conformance\]\[Area:Networking\]\[Feature:Router\] The HAProxy router should set Forwarded headers appropriately`, // https://bugzilla.redhat.com/show_bug.cgi?id=1752646
-
 			// requires a 1.14 kubelet, enable when rhcos is built for 4.2
 			"when the NodeLease feature is enabled",
 			"RuntimeClass should reject",


### PR DESCRIPTION
This change loosens the test expectations for AWS only.

On AWS the packet (GET request) leaves the cluster and will be NAT'd;
source addresses will now reflect the elastic IP address of the node.
Matching on the PODs IP address is therefore not possible on AWS; we
now assert that we have an 'X-Forwarded-For' header only.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1752646