### PR TITLE
Switch to docker.io/busybox

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51457,7 +51457,7 @@ spec:
     spec:
       containers:
       - name: simplev1
-        image: gcr.io/google_containers/busybox
+        image: docker.io/busybox
         command: ["/bin/sh", "-c", "exit 0"]
       restartPolicy: Never
 `)

--- a/test/extended/testdata/jobs/v1.yaml
+++ b/test/extended/testdata/jobs/v1.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: simplev1
-        image: gcr.io/google_containers/busybox
+        image: docker.io/busybox
         command: ["/bin/sh", "-c", "exit 0"]
       restartPolicy: Never


### PR DESCRIPTION
All the tests in k8s repos are now started using docker.io/busybox and it will be good to keep sync with that and will be helpful in terms of running tests on non-amd64 platforms as well.