### PR TITLE
Bug 1768002: Stabilize router stress test

### DIFF
--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -251,7 +251,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 					}
 				}
 				// we expect to see no more than 10 writes per router (we should hit the hard limit) (3 replicas and 1 master)
-				o.Expect(writes).To(o.BeNumerically("<=", 40))
+				o.Expect(writes).To(o.BeNumerically("<=", 50))
 			}()
 
 			// the os_http_be.map file will vary, so only check the haproxy config


### PR DESCRIPTION
The stress.go test makes some brittle assumptions about the number of writes to
Route resources in a namespace. The assumptions used to hold true on v3
clusters, but in v4 there are other routers which break the assumptions.

For now, relax the assumptions. In the future, this test should probably be
refactored to not rely on specific write counts.