### PR TITLE
Dump all pods logs to improve debuggability of e2e tests

### DIFF
--- a/test/extended/builds/pipeline_jenkins_e2e.go
+++ b/test/extended/builds/pipeline_jenkins_e2e.go
@@ -137,7 +137,7 @@ var _ = g.Describe("[Feature:Jenkins][Slow]jenkins repos e2e openshift using slo
 			g.By("waiting for jenkins deployment")
 			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "jenkins", 1, false, oc)
 			if err != nil {
-				exutil.DumpApplicationPodLogs("jenkins", oc)
+				exutil.DumpPodLogsStartingWith("jenkins", oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -147,7 +147,7 @@ var _ = g.Describe("[Feature:Jenkins][Slow]jenkins repos e2e openshift using slo
 			_, err = j.WaitForContent("", 200, 10*time.Minute, "")
 
 			if err != nil {
-				exutil.DumpApplicationPodLogs("jenkins", oc)
+				exutil.DumpPodLogsStartingWith("jenkins", oc)
 			}
 
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -158,7 +158,7 @@ var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Slow] openshift pipeline b
 			g.By("waiting for jenkins deployment")
 			err = exutil.WaitForDeploymentConfig(oc.KubeClient(), oc.AppsClient().AppsV1(), oc.Namespace(), "jenkins", 1, false, oc)
 			if err != nil {
-				exutil.DumpApplicationPodLogs("jenkins", oc)
+                               exutil.DumpPodLogsStartingWith("jenkins", oc)
 			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -168,7 +168,7 @@ var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Slow] openshift pipeline b
 			_, err = j.WaitForContent("", 200, 10*time.Minute, "")
 
 			if err != nil {
-				exutil.DumpApplicationPodLogs("jenkins", oc)
+				exutil.DumpPodLogsStartingWith("jenkins", oc)
 			}
 
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
For some pods failing to deploy, we cannot see the logs of the pods.
