### PR TITLE
test/extended/cli/explain.go: enable tests for service catalog crds

### DIFF
--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -117,8 +117,8 @@ var (
 		// {Group: "operator.openshift.io", Version: "v1", Resource: "networks"},
 		// {Group: "operator.openshift.io", Version: "v1", Resource: "openshiftcontrollermanagers"},
 		// {Group: "operator.openshift.io", Version: "v1", Resource: "servicecas"},
-		// {Group: "operator.openshift.io", Version: "v1", Resource: "servicecatalogapiservers"},
-		// {Group: "operator.openshift.io", Version: "v1", Resource: "servicecatalogcontrollermanagers"},
+		{Group: "operator.openshift.io", Version: "v1", Resource: "servicecatalogapiservers"},
+		{Group: "operator.openshift.io", Version: "v1", Resource: "servicecatalogcontrollermanagers"},
 
 		{Group: "quota.openshift.io", Version: "v1", Resource: "appliedclusterresourcequotas"},
 


### PR DESCRIPTION
This PR enables the `oc explain` tests for the service catalog CRDs. This is a follow-up to the recent fixes made in the respective svcat repos: 
* https://github.com/openshift/cluster-svcat-apiserver-operator/pull/68
* https://github.com/openshift/cluster-svcat-controller-manager-operator/pull/58

