### PR TITLE
Bug 1739262: RequestHeaders IdP: fix TLS handshake [4.1]

### DIFF
--- a/pkg/oauthserver/oauthserver/auth.go
+++ b/pkg/oauthserver/oauthserver/auth.go
@@ -690,6 +690,10 @@ func (c *OAuthServerConfig) getAuthenticationRequestHandler() (authenticator.Req
 						return nil, fmt.Errorf("Error loading certs from %s: %v", provider.ClientCA, err)
 					}
 
+					// we need to add our CA data to secure serving as well to have the OAuth server
+					// advertise them for client auth during TLS handshake
+					c.GenericConfig.SecureServing.ClientCA.CABundles = append(c.GenericConfig.SecureServing.ClientCA.CABundles, provider.ClientCA)
+
 					authRequestHandler = x509request.NewVerifier(opts, authRequestHandler, sets.NewString(provider.ClientCommonNames...))
 				}
 				authRequestHandlers = append(authRequestHandlers, authRequestHandler)


### PR DESCRIPTION
OAuth server uses the APIServer wrapping for its endpoints. This
wrapping has its own RequestHeader IdP for the cluster admin login
with client cert. As a part of that, before the RequestHeader is
set, DelegatingAuthenticationOptions() adds its own ClientCA to
the serving info config.

The result of the above behavior is that during TLS handshake, when
the names for acceptable client certificate CAs are announced, the
CAs of the above mentioned apiserver RequestHeader IdP are announced.

When users configure their own RequestHeader IdP to be used in
OpenShift for the oauth-server to try to retrieve the users from,
oauth-server was not adding this RequestHeader's client CA name
among the acceptable client certificate CA names mentioned above.

This commit adds the client CA data from the user specified
RequestHeader IdP to 'GenericConfig.SecureServing.ClientCA',
which is later converted to tlsConfig object which defines the
data to be used in TLS handshakes.

/assign @deads2k 