### PR TITLE
Bug 1768262: Bump nodes ready timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go
@@ -385,7 +385,7 @@ func (f *Framework) AfterEach() {
 	// Check whether all nodes are ready after the test.
 	// This is explicitly done at the very end of the test, to avoid
 	// e.g. not removing namespace in case of this failure.
-	if err := AllNodesReady(f.ClientSet, 3*time.Minute); err != nil {
+	if err := AllNodesReady(f.ClientSet, 7*time.Minute); err != nil {
 		Failf("All nodes should be ready after test, %v", err)
 	}
 }


### PR DESCRIPTION
I reviewed [BZ1768262](https://bugzilla.redhat.com/show_bug.cgi?id=1768262#c4) and various CI builds leading to the `Cluster upgrade should maintain a functioning cluster` error. The timeout for nodes to be ready is 3 minutes. 3 minutes is a relatively short period of time for a node to boot, get networking provisioned, and restart pods. A number of pods are transitioning to running after the timeout has triggered within CI, which has failed the test.

This PR bumps the timeout to 7 minutes.

/cc @sjenning