### PR TITLE
Bug 1762162: e2e: fix incorrect router image references

### DIFF
--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -43,10 +43,10 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ := exutil.FindRouterImage(oc)
-		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
+		routerImage, err := exutil.FindRouterImage(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
+		err = oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -48,11 +48,12 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ = exutil.FindRouterImage(oc)
-		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
+		var err error
+		routerImage, err = exutil.FindRouterImage(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		configPath := exutil.FixturePath("testdata", "router", "router-common.yaml")
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath).Execute()
+		err = oc.AsAdmin().Run("new-app").Args("-f", configPath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -51,10 +51,11 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ = exutil.FindRouterImage(oc)
-		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
+		var err error
+		routerImage, err = exutil.FindRouterImage(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		_, err := oc.AdminKubeClient().RbacV1().RoleBindings(ns).Create(&rbacv1.RoleBinding{
+		_, err = oc.AdminKubeClient().RbacV1().RoleBindings(ns).Create(&rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "router",
 			},
@@ -79,7 +80,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 				scaledRouter(
 					routerImage,
 					[]string{
-						"--loglevel=4",
+						"-v=4",
 						fmt.Sprintf("--namespace=%s", ns),
 						"--resync-interval=2m",
 						"--name=namespaced",
@@ -161,7 +162,7 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 				scaledRouter(
 					routerImage,
 					[]string{
-						"--loglevel=4",
+						"-v=4",
 						fmt.Sprintf("--namespace=%s", ns),
 						// the contention tracker is resync / 10, so this will give us 2 minutes of contention tracking
 						"--resync-interval=20m",

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -3,7 +3,6 @@ package router
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo"
@@ -13,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
+
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -41,11 +41,12 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		routerImage, _ = exutil.FindRouterImage(oc)
-		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
+		var err error
+		routerImage, err = exutil.FindRouterImage(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		configPath := exutil.FixturePath("testdata", "router", "router-common.yaml")
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath).Execute()
+		err = oc.AsAdmin().Run("new-app").Args("-f", configPath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -28,9 +28,9 @@ var _ = g.Describe("[Conformance][Area:Networking][Feature:Router]", func() {
 	)
 
 	g.BeforeEach(func() {
-		routerImage, _ := exutil.FindRouterImage(oc)
-		routerImage = strings.Replace(routerImage, "${component}", "haproxy-router", -1)
-		err := oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
+		routerImage, err := exutil.FindRouterImage(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().Run("new-app").Args("-f", configPath, "-p", "IMAGE="+routerImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53928,7 +53928,7 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--haproxy-config-manager=true", "--blueprint-route-labels=select=hapcm-blueprint", "--labels=select=haproxy-cfgmgr", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
+      args: ["--namespace=$(POD_NAMESPACE)", "-v=4", "--haproxy-config-manager=true", "--blueprint-route-labels=select=hapcm-blueprint", "--labels=select=haproxy-cfgmgr", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
       hostNetwork: false
       ports:
       - containerPort: 80
@@ -54419,7 +54419,7 @@ objects:
       args:
       - "--name=test-override-domains"
       - "--namespace=$(POD_NAMESPACE)"
-      - "--loglevel=4"
+      - "-v=4"
       - "--override-domains=null.ptr,void.str"
       - "--hostname-template=${name}-${namespace}.apps.veto.test"
       - "--stats-port=1936"
@@ -54482,7 +54482,7 @@ objects:
       args:
       - "--name=test-override"
       - "--namespace=$(POD_NAMESPACE)"
-      - "--loglevel=4"
+      - "-v=4"
       - "--override-hostname"
       - "--hostname-template=${name}-${namespace}.myapps.mycompany.com"
       - "--stats-port=1936"
@@ -54549,7 +54549,7 @@ objects:
       - "--name=${ROUTER_NAME}"
       - "--namespace=$(POD_NAMESPACE)"
       - "--update-status=${UPDATE_STATUS}"
-      - "--loglevel=4"
+      - "-v=4"
       - "--labels=select=first"
       - "--stats-port=1936"
       - "--metrics-type=haproxy"
@@ -54607,7 +54607,7 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=weighted", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
+      args: ["--namespace=$(POD_NAMESPACE)", "-v=4", "--labels=select=weighted", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-config-manager.yaml
+++ b/test/extended/testdata/router/router-config-manager.yaml
@@ -21,7 +21,7 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--haproxy-config-manager=true", "--blueprint-route-labels=select=hapcm-blueprint", "--labels=select=haproxy-cfgmgr", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
+      args: ["--namespace=$(POD_NAMESPACE)", "-v=4", "--haproxy-config-manager=true", "--blueprint-route-labels=select=hapcm-blueprint", "--labels=select=haproxy-cfgmgr", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/testdata/router/router-override-domains.yaml
+++ b/test/extended/testdata/router/router-override-domains.yaml
@@ -26,7 +26,7 @@ objects:
       args:
       - "--name=test-override-domains"
       - "--namespace=$(POD_NAMESPACE)"
-      - "--loglevel=4"
+      - "-v=4"
       - "--override-domains=null.ptr,void.str"
       - "--hostname-template=${name}-${namespace}.apps.veto.test"
       - "--stats-port=1936"

--- a/test/extended/testdata/router/router-override.yaml
+++ b/test/extended/testdata/router/router-override.yaml
@@ -26,7 +26,7 @@ objects:
       args:
       - "--name=test-override"
       - "--namespace=$(POD_NAMESPACE)"
-      - "--loglevel=4"
+      - "-v=4"
       - "--override-hostname"
       - "--hostname-template=${name}-${namespace}.myapps.mycompany.com"
       - "--stats-port=1936"

--- a/test/extended/testdata/router/router-scoped.yaml
+++ b/test/extended/testdata/router/router-scoped.yaml
@@ -30,7 +30,7 @@ objects:
       - "--name=${ROUTER_NAME}"
       - "--namespace=$(POD_NAMESPACE)"
       - "--update-status=${UPDATE_STATUS}"
-      - "--loglevel=4"
+      - "-v=4"
       - "--labels=select=first"
       - "--stats-port=1936"
       - "--metrics-type=haproxy"

--- a/test/extended/testdata/router/weighted-router.yaml
+++ b/test/extended/testdata/router/weighted-router.yaml
@@ -22,7 +22,7 @@ objects:
         valueFrom:
           fieldRef:
             fieldPath: metadata.namespace
-      args: ["--namespace=$(POD_NAMESPACE)", "--loglevel=4", "--labels=select=weighted", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
+      args: ["--namespace=$(POD_NAMESPACE)", "-v=4", "--labels=select=weighted", "--stats-password=password", "--stats-port=1936", "--stats-user=admin"]
       hostNetwork: false
       ports:
       - containerPort: 80

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1850,9 +1850,18 @@ func FindCLIImage(oc *CLI) (string, bool) {
 	return strings.Replace(format, "${component}", "cli", -1), ok
 }
 
-func FindRouterImage(oc *CLI) (string, bool) {
-	format, ok := FindImageFormatString(oc)
-	return strings.Replace(format, "${component}", "haproxy-router", -1), ok
+func FindRouterImage(oc *CLI) (string, error) {
+	configclient := oc.AdminConfigClient().ConfigV1()
+	o, err := configclient.ClusterOperators().Get("ingress", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, v := range o.Status.Versions {
+		if v.Name == "ingress-controller" {
+			return v.Version, nil
+		}
+	}
+	return "", fmt.Errorf("expected to find ingress-controller version on clusteroperators/ingress")
 }
 
 func IsClusterOperated(oc *CLI) bool {


### PR DESCRIPTION
The router e2e tests are using a hard-coded router test image from dockerhub
that isn't part of the release payload. Fix the tests to discover the router
image from the clusteroperator/ingress resource, which references the image used
by the ingress operator.

Depends on https://github.com/openshift/router/pull/60