### PR TITLE
Bug 1767295: UPSTREAM: 84466: gce: skip ensureInstanceGroup for a zone that has no remaining nodes for k8s managed IG

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal.go
@@ -522,7 +522,9 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 				skip.Insert(groupInstances.UnsortedList()...)
 			}
 		}
-		gceZonedNodes[zone] = names.Difference(skip).UnsortedList()
+		if remaining := names.Difference(skip).UnsortedList(); len(remaining) > 0 {
+			gceZonedNodes[zone] = remaining
+		}
 	}
 	for zone, gceNodes := range gceZonedNodes {
 		igLink, err := g.ensureInternalInstanceGroup(name, zone, gceNodes)

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
@@ -682,25 +682,46 @@ func TestEnsureInternalInstanceGroupsReuseGroups(t *testing.T) {
 	require.NoError(t, err)
 	gce.externalInstanceGroupsPrefix = "pre-existing"
 
-	_, err = createAndInsertNodes(gce, []string{"test-node-1", "test-node-2"}, vals.ZoneName)
+	igName := makeInstanceGroupName(vals.ClusterID)
+	nodesA, err := createAndInsertNodes(gce, []string{"test-node-1", "test-node-2"}, vals.ZoneName)
+	require.NoError(t, err)
+	nodesB, err := createAndInsertNodes(gce, []string{"test-node-3"}, vals.SecondaryZoneName)
 	require.NoError(t, err)
 
 	preIGName := "pre-existing-ig"
-	igName := makeInstanceGroupName(vals.ClusterID)
 	err = gce.CreateInstanceGroup(&compute.InstanceGroup{Name: preIGName}, vals.ZoneName)
 	require.NoError(t, err)
-	gce.AddInstancesToInstanceGroup(preIGName, vals.ZoneName, gce.ToInstanceReferences(vals.ZoneName, []string{"test-node-1"}))
+	err = gce.CreateInstanceGroup(&compute.InstanceGroup{Name: preIGName}, vals.SecondaryZoneName)
+	require.NoError(t, err)
+	err = gce.AddInstancesToInstanceGroup(preIGName, vals.ZoneName, gce.ToInstanceReferences(vals.ZoneName, []string{"test-node-1"}))
+	require.NoError(t, err)
+	err = gce.AddInstancesToInstanceGroup(preIGName, vals.SecondaryZoneName, gce.ToInstanceReferences(vals.SecondaryZoneName, []string{"test-node-3"}))
+	require.NoError(t, err)
+
+	anotherPreIGName := "another-existing-ig"
+	err = gce.CreateInstanceGroup(&compute.InstanceGroup{Name: anotherPreIGName}, vals.ZoneName)
+	require.NoError(t, err)
+	err = gce.AddInstancesToInstanceGroup(anotherPreIGName, vals.ZoneName, gce.ToInstanceReferences(vals.ZoneName, []string{"test-node-2"}))
+	require.NoError(t, err)
 
 	svc := fakeLoadbalancerService(string(LBTypeInternal))
-	_, err = createInternalLoadBalancer(gce, svc, nil, []string{"test-node-1", "test-node-2"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	_, err = gce.ensureInternalLoadBalancer(
+		vals.ClusterName, vals.ClusterID,
+		svc,
+		nil,
+		append(nodesA, nodesB...),
+	)
 	assert.NoError(t, err)
 
 	backendServiceName := makeBackendServiceName(gce.GetLoadBalancerName(context.TODO(), "", svc), vals.ClusterID, shareBackendService(svc), cloud.SchemeInternal, "TCP", svc.Spec.SessionAffinity)
 	bs, err := gce.GetRegionBackendService(backendServiceName, gce.region)
 	require.NoError(t, err)
-	assert.Equal(t, 2, len(bs.Backends), "Want two backends referencing two instances groups")
+	assert.Equal(t, 3, len(bs.Backends), "Want three backends referencing three instances groups")
 
-	for _, name := range []string{preIGName, igName} {
+	igRef := func(zone, name string) string {
+		return fmt.Sprintf("zones/%s/instanceGroups/%s", zone, name)
+	}
+	for _, name := range []string{igRef(vals.ZoneName, preIGName), igRef(vals.SecondaryZoneName, preIGName), igRef(vals.ZoneName, igName)} {
 		var found bool
 		for _, be := range bs.Backends {
 			if strings.Contains(be.Group, name) {


### PR DESCRIPTION
Make sure we don't ensure cluster-managed instance group for a zone that has no more nodes left. Creating am IG for a zone that has no instances causes errors when attaching to backend service.

```
failed to ensure load balancer: googleapi: Error 400: Invalid value for field 'resource.backends[5].group': 'https://www.googleapis.com/compute/v1/projects/openshift-qe/zones/us-central1-c/instanceGroups/k8s-ig--8d8682bc12c7a717'. Instance group must have a network to be attached to a backend service. Add an instance to give the instance group a network., invalid
```