### PR TITLE
[release-4.2] Bug 1771667: OpenStack: show original cloud provider init errors

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack.go
@@ -288,12 +288,12 @@ func (os *OpenStack) setConfigFromSecret() error {
 		err = gcfg.ReadStringInto(cfg, string(content))
 		if err != nil {
 			klog.Errorf("Cannot parse data from the secret.")
-			return fmt.Errorf("cannot parse data from the secret")
+			return fmt.Errorf("cannot parse data from the secret: %v", err)
 		}
 		provider, err := newProvider(*cfg)
 		if err != nil {
 			klog.Errorf("Cannot initialize cloud provider using data from the secret.")
-			return fmt.Errorf("cannot initialize cloud provider using data from the secret")
+			return fmt.Errorf("cannot initialize cloud provider using data from the secret: %v", err)
 		}
 		os.provider = provider
 		os.region = cfg.Global.Region


### PR DESCRIPTION
Now if an error happens during cloud provider initialization, users just see an abstract message:

"cannot initialize cloud provider using data from the secret"

without any details.

This commit wraps original errors to make them shown in the output.