### PR TITLE
test: Upgrade rollback abort at 100 should work

### DIFF
--- a/test/e2e/upgrade/monitor.go
+++ b/test/e2e/upgrade/monitor.go
@@ -113,7 +113,7 @@ func (m *versionMonitor) ShouldUpgradeAbort(abortAt int) bool {
 		}
 	}
 	percent := float64(changed) / float64(len(coList.Items))
-	if percent <= float64(abortAt)/100 {
+	if percent < float64(abortAt)/100 {
 		return false
 	}
 


### PR DESCRIPTION
The use of `percent <=` meant that we never aborted at 100%. We should
use `percent <` so that we rollback after all operators are upgraded.