### PR TITLE
test/extended: skip "Services should be rejected when no endpoints exist" for OVNKubernetes

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -534,6 +534,8 @@ var (
 			// SDN-587: OVN-Kubernetes doesn't support hairpin services
 			`\[sig-network\] Services should allow pods to hairpin back to themselves through services`,
 			`\[sig-network\] Networking Granular Checks: Services should function for endpoint-Service`,
+			// https://github.com/ovn-org/ovn-kubernetes/issues/928
+			`\[sig-network\] Services should be rejected when no endpoints exist`,
 		},
 		"[Suite:openshift/scalability]": {},
 		// tests that replace the old test-cmd script


### PR DESCRIPTION
Not expected to work yet. Only recently was re-enabled for SDN too, so clearly
it's not a huge issue that the test fails (at least for now).

@danwinship 