### PR TITLE
Bug 1767182: test/extended/prometheus: run full promQL queries and improve reporting firing alerts

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -63,11 +63,11 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
-			tests := map[string][]metricTest{
+			tests := map[string]bool{
 				// should have successfully sent at least once to remote
-				`metricsclient_request_send{client="federate_to",job="telemeter-client",status_code="200"}`: {metricTest{greaterThanEqual: true, value: 1}},
+				`metricsclient_request_send{client="federate_to",job="telemeter-client",status_code="200"} >= 1`: true,
 				// should have scraped some metrics from prometheus
-				`federate_samples{job="telemeter-client"}`: {metricTest{greaterThanEqual: true, value: 10}},
+				`federate_samples{job="telemeter-client"} >= 10`: true,
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 
@@ -166,11 +166,9 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
-			tests := map[string][]metricTest{
-				// should have a constantly firing watchdog alert
-				`ALERTS{alertstate="firing",alertname="Watchdog"}`: {metricTest{greaterThanEqual: true, value: 1}},
-				// should be only one watchdog alert (this is a workaround as metricTest doesn't offer equality operator)
-				`ALERTS{alertstate="firing",alertname="Watchdog",severity="none"}`: {metricTest{greaterThanEqual: false, value: 2}},
+			tests := map[string]bool{
+				// should have constantly firing a watchdog alert
+				`ALERTS{alertstate="firing",alertname="Watchdog",severity="none"} == 1`: true,
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 
@@ -182,9 +180,8 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
-			tests := map[string][]metricTest{
-				// should have constantly firing a watchdog alert
-				`container_cpu_usage_seconds_total{id!~"/kubepods.slice/.*"}`: {metricTest{greaterThanEqual: true, value: 1}},
+			tests := map[string]bool{
+				`container_cpu_usage_seconds_total{id!~"/kubepods.slice/.*"} >= 1`: true,
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})
@@ -195,9 +192,9 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })
 				defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
-				tests := map[string][]metricTest{
+				tests := map[string]bool{
 					//something
-					`openshift_sdn_ovs_flows`: {metricTest{greaterThanEqual: true, value: 1}},
+					`openshift_sdn_ovs_flows >= 1`: true,
 				}
 				runQueries(tests, oc, ns, execPodName, url, bearerToken)
 			})
@@ -211,10 +208,9 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			execPodName := e2e.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod", func(pod *v1.Pod) { pod.Spec.Containers[0].Image = "centos:7" })
 			defer func() { oc.AdminKubeClient().CoreV1().Pods(ns).Delete(execPodName, metav1.NewDeleteOptions(1)) }()
 
-			tests := map[string][]metricTest{
-				// should be checking there is no more than 1 alerts firing.
-				// Checking for specific alert is done in "should have a Watchdog alert in firing state".
-				`sum(ALERTS{alertstate="firing"})`: {metricTest{greaterThanEqual: false, value: 2}},
+			tests := map[string]bool{
+				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
+				`ALERTS{alertname!="Watchdog",alertstate="firing"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPodName, url, bearerToken)
 		})
@@ -247,9 +243,9 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			})).NotTo(o.HaveOccurred(), "ingress router cannot report metrics to monitoring system")
 
 			g.By("verifying standard metrics keys")
-			queries := map[string][]metricTest{
-				`template_router_reload_seconds_count{job="router-internal-default"}`: {metricTest{greaterThanEqual: true, value: 1}},
-				`haproxy_server_up{job="router-internal-default"}`:                    {metricTest{greaterThanEqual: true, value: 1}},
+			queries := map[string]bool{
+				`template_router_reload_seconds_count{job="router-internal-default"} >= 1`: true,
+				`haproxy_server_up{job="router-internal-default"} >= 1`:                    true,
 			}
 			runQueries(queries, oc, ns, execPodName, url, bearerToken)
 		})

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -42,9 +42,6 @@ var _ = g.Describe("[Feature:Prometheus][Feature:Builds] Prometheus", func() {
 
 	g.Describe("when installed on the cluster", func() {
 		g.It("should start and expose a secured proxy and verify build metrics", func() {
-			const (
-				buildCountQuery = "openshift_build_total"
-			)
 			oc.SetupProject()
 			ns := oc.Namespace()
 			appTemplate := exutil.FixturePath("testdata", "builds", "build-pruning", "successful-build-config.yaml")
@@ -78,13 +75,9 @@ var _ = g.Describe("[Feature:Prometheus][Feature:Builds] Prometheus", func() {
 
 			g.By("verifying a service account token is able to query terminal build metrics from the Prometheus API")
 			// note, no longer register a metric if it is zero, so a successful build won't have failed or cancelled metrics
-			terminalTests := map[string][]metricTest{
-				buildCountQuery: {
-					metricTest{
-						labels:           map[string]string{"phase": string(buildv1.BuildPhaseComplete)},
-						greaterThanEqual: true,
-					},
-				},
+			buildCountMetricName := fmt.Sprintf(`openshift_build_total{phase="%s"} >= 0`, string(buildv1.BuildPhaseComplete))
+			terminalTests := map[string]bool{
+				buildCountMetricName: true,
 			}
 			runQueries(terminalTests, oc, ns, execPodName, url, bearerToken)
 
@@ -106,22 +99,11 @@ type prometheusResponseData struct {
 	Result     model.Vector `json:"result"`
 }
 
-type metricTest struct {
-	labels map[string]string
-	// we are not more precise (greater than only, or equal only) becauses the extended build tests
-	// run in parallel on the CI system, and some of the metrics are cross namespace, so we cannot
-	// reliably filter; we do precise count validation in the unit tests, where "entire cluster" activity
-	// is more controlled :-)
-	greaterThanEqual bool
-	value            float64
-	success          bool
-}
-
-func runQueries(metricTests map[string][]metricTest, oc *exutil.CLI, ns, execPodName, baseURL, bearerToken string) {
+func runQueries(promQueries map[string]bool, oc *exutil.CLI, ns, execPodName, baseURL, bearerToken string) {
 	// expect all correct metrics within a reasonable time period
 	errsMap := map[string]error{}
 	for i := 0; i < waitForPrometheusStartSeconds; i++ {
-		for query, tcs := range metricTests {
+		for query, expected := range promQueries {
 			//TODO when the http/query apis discussed at https://github.com/prometheus/client_golang#client-for-the-prometheus-http-api
 			// and introduced at https://github.com/prometheus/client_golang/blob/master/api/prometheus/v1/api.go are vendored into
 			// openshift/origin, look to replace this homegrown http request / query param with that API
@@ -132,32 +114,18 @@ func runQueries(metricTests map[string][]metricTest, oc *exutil.CLI, ns, execPod
 			json.Unmarshal([]byte(contents), &result)
 			metrics := result.Data.Result
 
-			// for each test case, register that one of the returned metrics has the desired labels and value
-			for j, tc := range tcs {
-				for _, sample := range metrics {
-					if labelsWeWant(sample, tc.labels) && valueWeWant(sample, tc) {
-						tcs[j].success = true
-						break
-					}
-				}
+			delete(errsMap, query) // clear out any prior failures
+			if (len(metrics) > 0 && !expected) || (len(metrics) == 0 && expected) {
+				dbg := fmt.Sprintf("promQL query: %s had reported incorrect results: %v", query, metrics)
+				fmt.Fprintf(g.GinkgoWriter, dbg)
+				errsMap[query] = fmt.Errorf(dbg)
 			}
 
-			// now check the results, see if any bad
-			delete(errsMap, query) // clear out any prior faliures
-			for _, tc := range tcs {
-				if !tc.success {
-					dbg := fmt.Sprintf("query %s for tests %#v had results %s", query, tcs, contents)
-					fmt.Fprintf(g.GinkgoWriter, dbg)
-					errsMap[query] = fmt.Errorf(dbg)
-					break
-				}
-			}
 		}
 
 		if len(errsMap) == 0 {
 			break
 		}
-
 		time.Sleep(time.Second)
 	}
 
@@ -175,29 +143,4 @@ func startOpenShiftBuild(oc *exutil.CLI, appTemplate string) *exutil.BuildResult
 	br, err := exutil.StartBuildResult(oc, "myphp")
 	o.Expect(err).NotTo(o.HaveOccurred())
 	return br
-}
-
-func labelsWeWant(sample *model.Sample, labels map[string]string) bool {
-	//NOTE - prometheus LabelSet.Equals is of little use to us, since the "instance" label
-	// is specific to the host things are running on, so we can't craft an accurate Metric
-	// to compare against
-	for labelName, labelValue := range labels {
-		if v, ok := sample.Metric[model.LabelName(labelName)]; ok {
-			if string(v) != labelValue {
-				return false
-			}
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
-func valueWeWant(sample *model.Sample, tc metricTest) bool {
-	//NOTE - we could use SampleValue has an Equals func, but since SampleValue has no GreaterThanEqual,
-	// we have to go down the float64 compare anyway
-	if tc.greaterThanEqual {
-		return float64(sample.Value) >= tc.value
-	}
-	return float64(sample.Value) < tc.value
 }


### PR DESCRIPTION
This extends test framework by adding a way to expect no metrics being
returned. Additionally it should improve testing if no alerts are
firing, apart from Watchdog.

Backporting MON-813 from #24019