### PR TITLE
[release-3.11] UPSTREAM: 58685: Fix that fails to resize pvc of cinder volume

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -235,6 +235,7 @@ func (volumes *VolumesV3) getVolume(volumeID string) (Volume, error) {
 		ID:               volumeV3.ID,
 		Name:             volumeV3.Name,
 		Status:           volumeV3.Status,
+		Size:             volumeV3.Size,
 	}
 
 	if len(volumeV3.Attachments) > 0 {


### PR DESCRIPTION
UPSTREAM: 58685: Fill size attribute for the OpenStack V3 API volumes

The getVolume method in OpenStack provider is not filling the Size for the V3 API type volumes. This
breaks the PV resizing of Cinder volumes which compares the existing volume size with the new request. This leads to redundant volume resize calls to the cloud provider that end with errors.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535314

---

Because of this commit: https://github.com/kubernetes/kubernetes/commit/9326e845e48e2cc61f57094bd7561e37fb831ce5#r29848898 , the following commit disappeared from the release-1.11 branch and your fork: 
https://github.com/openshift/origin/pull/18237 


I really need this working for Openshift 3.11