### PR TITLE
Bug 1787457: Read cgroup settings from the right cgroup for build-quota tests

### DIFF
--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -53,11 +53,9 @@ var _ = g.Describe("[Feature:Builds][Conformance] s2i build with a quota", func(
 				o.Expect(br.Build.Status.Duration).To(o.Equal(duration), "Build duration should be computed correctly")
 
 				g.By("expecting the build logs to contain the correct cgroups values")
-				// buildLog, err := br.LogsNoTimestamp()
-				_, err = br.LogsNoTimestamp()
+				buildLog, err := br.LogsNoTimestamp()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				// TODO: re-enable this check when https://bugzilla.redhat.com/show_bug.cgi?id=1764323 is resolved
-				//o.Expect(buildLog).To(o.ContainSubstring("MEMORY=419430400"))
+				o.Expect(buildLog).To(o.ContainSubstring("MEMORY=419430400"))
 				// TODO: re-enable this check when https://github.com/containers/buildah/issues/1213 is resolved.
 				//o.Expect(buildLog).To(o.ContainSubstring("MEMORYSWAP=419430400"))
 


### PR DESCRIPTION
The assemble script was reading from the top of the controller's group hierarchy, even though the script itself is run inside of a different control group, which is where the settings are applied.  This is related to investigation in #24157.