### PR TITLE
Bug 1765294: Adding debug to test.

### DIFF
--- a/test/extended/controller_manager/pull_secret.go
+++ b/test/extended/controller_manager/pull_secret.go
@@ -174,6 +174,9 @@ var _ = g.Describe("[Feature:OpenShiftControllerManager]", func() {
 				dockercfgSecretName,
 				metav1.GetOptions{},
 			)
+			if err != nil {
+				t.Logf("getting docker secret returned: %v", err)
+			}
 			return errors.IsNotFound(err), nil
 		}); err != nil {
 			t.Fatalf("waiting for secret deletion: %v", err)


### PR DESCRIPTION
Added debug to a test. This test is constantly flaking and we need to
discover why, this debug will report all attempts to get the secret.