### PR TITLE
Bug 1776351: Restore UPSTREAM from #24159: Expose a simple journald shim on the kubelet logs endpoint

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_server_journal.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet_server_journal.go
@@ -241,7 +241,7 @@ var (
 )
 
 const (
-	dateFormat         = `"2006-01-02T15:04:05.999999Z`
+	dateFormat         = `2006-01-02T15:04:05.999999Z`
 	maxParameterLength = 100
 	maxTotalLength     = 1000
 )


### PR DESCRIPTION
Part of https://github.com/openshift/origin/pull/24195.