### PR TITLE
Bug 1776351: Restore UPSTREAM: <carry>: bump nodes ready timeout

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go
@@ -385,7 +385,7 @@ func (f *Framework) AfterEach() {
 	// Check whether all nodes are ready after the test.
 	// This is explicitly done at the very end of the test, to avoid
 	// e.g. not removing namespace in case of this failure.
-	if err := AllNodesReady(f.ClientSet, 3*time.Minute); err != nil {
+	if err := AllNodesReady(f.ClientSet, 7*time.Minute); err != nil {
 		Failf("All nodes should be ready after test, %v", err)
 	}
 }


### PR DESCRIPTION
Part of https://github.com/openshift/origin/pull/24195