### PR TITLE
inject poststarthooks via config

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go
@@ -104,6 +104,8 @@ func createAggregatorConfig(
 			EnableAggregatedDiscoveryTimeout: utilfeature.DefaultFeatureGate.Enabled(kubefeatures.EnableAggregatedDiscoveryTimeout),
 		},
 	}
+	// we need to clear the poststarthooks so we don't add them multiple times to all the servers (that fails)
+	aggregatorConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
 
 	return aggregatorConfig, nil
 }

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/apiextensions.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/apiextensions.go
@@ -88,6 +88,9 @@ func createAPIExtensionsConfig(
 		},
 	}
 
+	// we need to clear the poststarthooks so we don't add them multiple times to all the servers (that fails)
+	apiextensionsConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+
 	return apiextensionsConfig, nil
 }
 

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/patch_openshift.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/patch_openshift.go
@@ -19,13 +19,3 @@ func PatchKubeAPIServerConfig(config *genericapiserver.Config, versionedInformer
 
 	return OpenShiftKubeAPIServerConfigPatch(config, versionedInformers, pluginInitializers)
 }
-
-var OpenShiftKubeAPIServerServerPatch KubeAPIServerServerFunc = nil
-
-func PatchKubeAPIServerServer(server *master.Master) error {
-	if OpenShiftKubeAPIServerServerPatch == nil {
-		return nil
-	}
-
-	return OpenShiftKubeAPIServerServerPatch(server)
-}

--- a/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/server.go
@@ -120,9 +120,8 @@ cluster's shared state through which all other components interact.`,
 
 				// this forces a patch to be called
 				// TODO we're going to try to remove bits of the patching.
-				configPatchFn, serverPatchContext := openshiftkubeapiserver.NewOpenShiftKubeAPIServerConfigPatch(openshiftConfig)
+				configPatchFn := openshiftkubeapiserver.NewOpenShiftKubeAPIServerConfigPatch(openshiftConfig)
 				OpenShiftKubeAPIServerConfigPatch = configPatchFn
-				OpenShiftKubeAPIServerServerPatch = serverPatchContext.PatchServer
 
 				args, err := openshiftkubeapiserver.ConfigToFlags(openshiftConfig)
 				if err != nil {
@@ -227,10 +226,6 @@ func CreateServerChain(completedOptions completedServerRunOptions, stopCh <-chan
 
 	kubeAPIServer, err := CreateKubeAPIServer(kubeAPIServerConfig, apiExtensionsServer.GenericAPIServer, admissionPostStartHook)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := PatchKubeAPIServerServer(kubeAPIServer); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This avoids a second coordinated callback that is prone to error on rebases.

If this works, I'll open the upstream.