### PR TITLE
extended util oauthserver - increase pod ready wait time

### DIFF
--- a/test/extended/util/oauthserver/oauthserver.go
+++ b/test/extended/util/oauthserver/oauthserver.go
@@ -205,7 +205,7 @@ func waitForOAuthServerReady(oc *exutil.CLI) error {
 
 func waitForOAuthServerPodReady(oc *exutil.CLI) error {
 	e2e.Logf("Waiting for the OAuth server pod to be ready")
-	return wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+	return wait.PollImmediateInfinite(1*time.Second, func() (bool, error) {
 		pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get("test-oauth-server", metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
It seems that the images are being pulled for up to 55 seconds in
the CI test runs, which would leave the oauth-server to start for
only about 5 seconds.

Increase the timeout for pod readiness in order to stop jobs from
failing too often.