### PR TITLE
test: Reduce wait interval, TestDockercfgTokenDeletedController times out

### DIFF
--- a/test/extended/controller_manager/pull_secret.go
+++ b/test/extended/controller_manager/pull_secret.go
@@ -169,7 +169,7 @@ var _ = g.Describe("[Feature:OpenShiftControllerManager]", func() {
 		}
 
 		// Expect the matching dockercfg secret to also be deleted
-		if err := wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
+		if err := wait.Poll(5*time.Second, 4*time.Minute, func() (bool, error) {
 			_, err := clusterAdminKubeClient.CoreV1().Secrets(sa.Namespace).Get(
 				dockercfgSecretName,
 				metav1.GetOptions{},


### PR DESCRIPTION
Timed out in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_openshift-apiserver/51/pull-ci-openshift-openshift-apiserver-master-e2e-aws/205, not sure why