### PR TITLE
Bug 1777189: test/extended/prometheus/prometheus_builds: Wait up to 40s

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -33,10 +33,6 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-const (
-	maxPrometheusQueryRetries = 5
-)
-
 var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 	defer g.GinkgoRecover()
 	var (


### PR DESCRIPTION
Since 10c6be0169 (#24117), we've been failing after only a few seconds of failures, which causes problems like:

```
fail [github.com/openshift/origin/test/extended/prometheus/prometheus_builds.go:156]: Expected
    <map[string]error | len:1>: {
        "openshift_build_total{phase=\"Complete\"} >= 0": {
            s: "promQL query: openshift_build_total{phase=\"Complete\"} >= 0 had reported incorrect results: model.Vector{}",
        },
    }
to be empty
...
failed: (1m4s) 2019-11-26T23:05:24 "[Feature:Prometheus][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [Suite:openshift/conformance/parallel]"
```

when we haven't waited long enough for the Prometheus scrape to notice the new builds.  Looking at the timing in that job:

```console
$ curl -s https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.4/73/build-log.txt | grep 'openshift_build_total.*Complete' | cut -b -50
STEP: perform prometheus metric query openshift_bu
Nov 26 23:05:08.772: INFO: Running '/usr/bin/kubec
Nov 26 23:05:09.480: INFO: stderr: "+ curl -s -k -
Nov 26 23:05:09.480: INFO: promQL query: openshift
STEP: perform prometheus metric query openshift_bu
Nov 26 23:05:10.481: INFO: Running '/usr/bin/kubec
Nov 26 23:05:11.121: INFO: stderr: "+ curl -s -k -
STEP: perform prometheus metric query openshift_bu
Nov 26 23:05:12.122: INFO: Running '/usr/bin/kubec
Nov 26 23:05:12.751: INFO: stderr: "+ curl -s -k -
STEP: perform prometheus metric query openshift_bu
Nov 26 23:05:13.751: INFO: Running '/usr/bin/kubec
Nov 26 23:05:14.356: INFO: stderr: "+ curl -s -k -
STEP: perform prometheus metric query openshift_bu
Nov 26 23:05:15.356: INFO: Running '/usr/bin/kubec
Nov 26 23:05:15.922: INFO: stderr: "+ curl -s -k -
        "openshift_build_total{phase=\"Complete\"}
            s: "promQL query: openshift_build_tota
```

so we had five queries over ~7s.  With this commit, we'll wait at least 10s between retries, for a minium duration of 40s between the first and fifth attempt, which should give us long enough to include at least one scrape ([scrapes every 30s][2]).

[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1777189#c3