### PR TITLE
Bug 1748073: UPSTREAM: 85852: kubelet: CAdvisor sometimes injects old Pod metrics from an old namespaces

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -317,6 +317,8 @@ func removeTerminatedContainerInfo(containerInfo map[string]cadvisorapiv2.Contai
 			podRef:        buildPodRef(cinfo.Spec.Labels),
 			containerName: kubetypes.GetContainerName(cinfo.Spec.Labels),
 		}
+		// Clear the UID since the container can be created in a new namespace.
+		cinfoID.podRef.UID = ""
 		cinfoMap[cinfoID] = append(cinfoMap[cinfoID], containerInfoWithCgroup{
 			cinfo:  cinfo,
 			cgroup: key,

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -143,19 +143,19 @@ func TestCRIListPodStats(t *testing.T) {
 	)
 
 	infos := map[string]cadvisorapiv2.ContainerInfo{
-		"/":                           getTestContainerInfo(seedRoot, "", "", ""),
-		"/kubelet":                    getTestContainerInfo(seedKubelet, "", "", ""),
-		"/system":                     getTestContainerInfo(seedMisc, "", "", ""),
-		sandbox0.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName),
-		sandbox0Cgroup:                getTestContainerInfo(seedSandbox0, "", "", ""),
-		container0.ContainerStatus.Id: getTestContainerInfo(seedContainer0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName0),
-		container1.ContainerStatus.Id: getTestContainerInfo(seedContainer1, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName1),
-		sandbox1.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox1, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName),
-		sandbox1Cgroup:                getTestContainerInfo(seedSandbox1, "", "", ""),
-		container2.ContainerStatus.Id: getTestContainerInfo(seedContainer2, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, cName2),
-		sandbox2.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox2, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName),
-		sandbox2Cgroup:                getTestContainerInfo(seedSandbox2, "", "", ""),
-		container4.ContainerStatus.Id: getTestContainerInfo(seedContainer3, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, cName3),
+		"/":                           getTestContainerInfo(seedRoot, "", "", "", ""),
+		"/kubelet":                    getTestContainerInfo(seedKubelet, "", "", "", ""),
+		"/system":                     getTestContainerInfo(seedMisc, "", "", "", ""),
+		sandbox0.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName, ""),
+		sandbox0Cgroup:                getTestContainerInfo(seedSandbox0, "", "", "", ""),
+		container0.ContainerStatus.Id: getTestContainerInfo(seedContainer0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName0, ""),
+		container1.ContainerStatus.Id: getTestContainerInfo(seedContainer1, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName1, ""),
+		sandbox1.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox1, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName, ""),
+		sandbox1Cgroup:                getTestContainerInfo(seedSandbox1, "", "", "", ""),
+		container2.ContainerStatus.Id: getTestContainerInfo(seedContainer2, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, cName2, ""),
+		sandbox2.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox2, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName, ""),
+		sandbox2Cgroup:                getTestContainerInfo(seedSandbox2, "", "", "", ""),
+		container4.ContainerStatus.Id: getTestContainerInfo(seedContainer3, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, cName3, ""),
 	}
 
 	options := cadvisorapiv2.RequestOptions{
@@ -360,19 +360,19 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 	)
 
 	infos := map[string]cadvisorapiv2.ContainerInfo{
-		"/":                           getTestContainerInfo(seedRoot, "", "", ""),
-		"/kubelet":                    getTestContainerInfo(seedKubelet, "", "", ""),
-		"/system":                     getTestContainerInfo(seedMisc, "", "", ""),
-		sandbox0.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName),
-		sandbox0Cgroup:                getTestContainerInfo(seedSandbox0, "", "", ""),
-		container0.ContainerStatus.Id: getTestContainerInfo(seedContainer0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName0),
-		container1.ContainerStatus.Id: getTestContainerInfo(seedContainer1, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName1),
-		sandbox1.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox1, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName),
-		sandbox1Cgroup:                getTestContainerInfo(seedSandbox1, "", "", ""),
-		container2.ContainerStatus.Id: getTestContainerInfo(seedContainer2, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, cName2),
-		sandbox2.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox2, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName),
-		sandbox2Cgroup:                getTestContainerInfo(seedSandbox2, "", "", ""),
-		container4.ContainerStatus.Id: getTestContainerInfo(seedContainer3, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, cName3),
+		"/":                           getTestContainerInfo(seedRoot, "", "", "", ""),
+		"/kubelet":                    getTestContainerInfo(seedKubelet, "", "", "", ""),
+		"/system":                     getTestContainerInfo(seedMisc, "", "", "", ""),
+		sandbox0.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName, ""),
+		sandbox0Cgroup:                getTestContainerInfo(seedSandbox0, "", "", "", ""),
+		container0.ContainerStatus.Id: getTestContainerInfo(seedContainer0, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName0, ""),
+		container1.ContainerStatus.Id: getTestContainerInfo(seedContainer1, pName0, sandbox0.PodSandboxStatus.Metadata.Namespace, cName1, ""),
+		sandbox1.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox1, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName, ""),
+		sandbox1Cgroup:                getTestContainerInfo(seedSandbox1, "", "", "", ""),
+		container2.ContainerStatus.Id: getTestContainerInfo(seedContainer2, pName1, sandbox1.PodSandboxStatus.Metadata.Namespace, cName2, ""),
+		sandbox2.PodSandboxStatus.Id:  getTestContainerInfo(seedSandbox2, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, leaky.PodInfraContainerName, ""),
+		sandbox2Cgroup:                getTestContainerInfo(seedSandbox2, "", "", "", ""),
+		container4.ContainerStatus.Id: getTestContainerInfo(seedContainer3, pName2, sandbox2.PodSandboxStatus.Metadata.Namespace, cName3, ""),
 	}
 
 	options := cadvisorapiv2.RequestOptions{

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/stats/stats_provider_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/stats/stats_provider_test.go
@@ -80,7 +80,7 @@ func TestGetCgroupStats(t *testing.T) {
 		assert  = assert.New(t)
 		options = cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false}
 
-		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container")
+		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container", "")
 		containerInfoMap = map[string]cadvisorapiv2.ContainerInfo{cgroupName: containerInfo}
 	)
 
@@ -114,7 +114,7 @@ func TestGetCgroupCPUAndMemoryStats(t *testing.T) {
 		assert  = assert.New(t)
 		options = cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false}
 
-		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container")
+		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container", "")
 		containerInfoMap = map[string]cadvisorapiv2.ContainerInfo{cgroupName: containerInfo}
 	)
 
@@ -147,7 +147,7 @@ func TestRootFsStats(t *testing.T) {
 		options = cadvisorapiv2.RequestOptions{IdType: cadvisorapiv2.TypeName, Count: 2, Recursive: false}
 
 		rootFsInfo       = getTestFsInfo(rootFsInfoSeed)
-		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container")
+		containerInfo    = getTestContainerInfo(containerInfoSeed, "test-pod", "test-ns", "test-container", "")
 		containerInfoMap = map[string]cadvisorapiv2.ContainerInfo{"/": containerInfo}
 	)
 
@@ -430,19 +430,22 @@ func TestHasDedicatedImageFs(t *testing.T) {
 	}
 }
 
-func getTerminatedContainerInfo(seed int, podName string, podNamespace string, containerName string) cadvisorapiv2.ContainerInfo {
-	cinfo := getTestContainerInfo(seed, podName, podNamespace, containerName)
+func getTerminatedContainerInfo(seed int, podName string, podNamespace string, containerName string, uid string) cadvisorapiv2.ContainerInfo {
+	cinfo := getTestContainerInfo(seed, podName, podNamespace, containerName, uid)
 	cinfo.Stats[0].Memory.RSS = 0
 	cinfo.Stats[0].CpuInst.Usage.Total = 0
 	return cinfo
 }
 
-func getTestContainerInfo(seed int, podName string, podNamespace string, containerName string) cadvisorapiv2.ContainerInfo {
+func getTestContainerInfo(seed int, podName string, podNamespace string, containerName string, uid string) cadvisorapiv2.ContainerInfo {
 	labels := map[string]string{}
+	if uid == "" {
+		uid = "UID" + podName
+	}
 	if podName != "" {
 		labels = map[string]string{
 			"io.kubernetes.pod.name":       podName,
-			"io.kubernetes.pod.uid":        "UID" + podName,
+			"io.kubernetes.pod.uid":        uid,
 			"io.kubernetes.pod.namespace":  podNamespace,
 			"io.kubernetes.container.name": containerName,
 		}


### PR DESCRIPTION
Picks my upstream patch to fix duplicate metrics causing 500's in the Kubelet /metrics endpoint.

ref: https://github.com/kubernetes/kubernetes/pull/85852
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1748073