### PR TITLE
Bug 1752351: UPSTREAM: 85293: Included FSType in CSI volumes

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -1267,9 +1267,10 @@ func printCSIVolumeSource(csi *corev1.CSIVolumeSource, w PrefixWriter) {
 func printCSIPersistentVolumeSource(csi *corev1.CSIPersistentVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tCSI (a Container Storage Interface (CSI) volume source)\n"+
 		"    Driver:\t%v\n"+
+		"    FSType:\t%v\n"+
 		"    VolumeHandle:\t%v\n"+
 		"    ReadOnly:\t%v\n",
-		csi.Driver, csi.VolumeHandle, csi.ReadOnly)
+		csi.Driver, csi.FSType, csi.VolumeHandle, csi.ReadOnly)
 	printCSIPersistentVolumeAttributesMultiline(w, "VolumeAttributes", csi.VolumeAttributes)
 }
 


### PR DESCRIPTION
Includes Kubernetes [PR85293](https://github.com/kubernetes/kubernetes/pull/85293), which includes the FSType when using `oc describe` on a CSI Driver.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Other volume types display the FSType when displayed using `kubectl describe`. This PR updates CSI PVs to display FSType as well.

**Which issue(s) this PR fixes**:
Bug 1752351

**Does this PR introduce a user-facing change?**:
```release-note
Includes FSType when describing CSI persistent volumes.
```
