### PR TITLE
test: Add a network stress test and --count to repeat tests

### DIFF
--- a/cmd/openshift-tests/e2e.go
+++ b/cmd/openshift-tests/e2e.go
@@ -144,6 +144,18 @@ var staticSuites = []*ginkgo.TestSuite{
 		},
 	},
 	{
+		Name: "openshift/network/stress",
+		Description: templates.LongDesc(`
+		This test suite repeatedly verifies the networking function of the cluster in parallel to find flakes.
+		`),
+		Matches: func(name string) bool {
+			return strings.Contains(name, "[Suite:openshift/conformance/") && strings.Contains(name, "[sig-network]")
+		},
+		Parallelism: 30,
+		Count:       15,
+		TestTimeout: 20 * time.Minute,
+	},
+	{
 		Name: "all",
 		Description: templates.LongDesc(`
 		Run all tests.

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -287,11 +287,6 @@ func initProvider(provider string, dryRun bool) error {
 		return err
 	}
 
-	// set defaults so these tests don't log
-	// these appear to be defaults now
-	//exutil.TestContext.LoggingSoak.Scale = 1
-	//exutil.TestContext.LoggingSoak.MilliSecondsBetweenWaves = 5000
-
 	exutil.AnnotateTestSuite()
 	err := exutil.InitTest(dryRun)
 	gomega.RegisterFailHandler(ginkgo.Fail)

--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -270,6 +270,7 @@ func bindOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
 	flags.StringVarP(&opt.TestFile, "file", "f", opt.TestFile, "Create a suite from the newline-delimited test names in this file.")
 	flags.StringVar(&opt.Regex, "run", opt.Regex, "Regular expression of tests to run.")
 	flags.StringVarP(&opt.OutFile, "output-file", "o", opt.OutFile, "Write all test output to this file.")
+	flags.IntVar(&opt.Count, "count", opt.Count, "Run each test a specified number of times. Defaults to 1 or the suite's preferred value.")
 	flags.DurationVar(&opt.Timeout, "timeout", opt.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
 	flags.BoolVar(&opt.IncludeSuccessOutput, "include-success", opt.IncludeSuccessOutput, "Print output from successful tests.")
 }

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -314,5 +314,5 @@ func (opt *Options) Run(args []string) error {
 	}
 
 	fmt.Fprintf(opt.Out, "%d pass, %d skip (%s)\n", pass, skip, duration)
-	return nil
+	return ctx.Err()
 }

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -23,6 +23,7 @@ import (
 // as a call to a child worker (the run-tests command).
 type Options struct {
 	Parallelism int
+	Count       int
 	Timeout     time.Duration
 	JUnitDir    string
 	TestFile    string
@@ -90,7 +91,7 @@ func (opt *Options) Run(args []string) error {
 
 	if len(opt.Regex) > 0 {
 		if err := filterWithRegex(suite, opt.Regex); err != nil {
-			return fmt.Errorf("regular expression passed to -run is invalid: %v", err)
+			return fmt.Errorf("regular expression for filtering tests is invalid: %v", err)
 		}
 	}
 
@@ -118,6 +119,18 @@ func (opt *Options) Run(args []string) error {
 	tests = suite.Filter(tests)
 	if len(tests) == 0 {
 		return fmt.Errorf("suite %q does not contain any tests", suite.Name)
+	}
+
+	count := opt.Count
+	if count == 0 {
+		count = suite.Count
+	}
+	if count > 1 {
+		var newTests []*testCase
+		for i := 0; i < count; i++ {
+			newTests = append(newTests, tests...)
+		}
+		tests = newTests
 	}
 
 	if opt.PrintCommands {

--- a/pkg/test/ginkgo/test.go
+++ b/pkg/test/ginkgo/test.go
@@ -66,6 +66,9 @@ type TestSuite struct {
 	// methods in this package.
 	Init func(map[string]string) error
 
+	// The number of times to execute each test in this suite.
+	Count int
+	// The maximum parallelism of this suite.
 	Parallelism int
 	// The number of flakes that may occur before this test is marked as a failure.
 	MaximumAllowedFlakes int

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/util.go
@@ -1096,7 +1096,7 @@ func KubectlVersion() (*utilversion.Version, error) {
 
 // RestclientConfig returns a config holds the information needed to build connection to kubernetes clusters.
 func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
-	e2elog.Logf(">>> kubeConfig: %s", TestContext.KubeConfig)
+	//e2elog.Logf(">>> kubeConfig: %s", TestContext.KubeConfig)
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
@@ -1105,7 +1105,7 @@ func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 		return nil, fmt.Errorf("error loading KubeConfig: %v", err.Error())
 	}
 	if kubeContext != "" {
-		e2elog.Logf(">>> kubeContext: %s", kubeContext)
+		//e2elog.Logf(">>> kubeContext: %s", kubeContext)
 		c.CurrentContext = kubeContext
 	}
 	return c, nil


### PR DESCRIPTION
Network stress runs the standard network tests 15 times at parallelism 30. 
This isn't perfectly representative of real stress testing - it does not 
verify that existing pods work, and doesn't take disruption or other 
transient behavior into account. But it at least can be used to surface 
problems that occur rarely.