### PR TITLE
Add adm node-logs with --since=date parameter test

### DIFF
--- a/test/extended/cli/adm.go
+++ b/test/extended/cli/adm.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"fmt"
 	"math/rand"
+	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -46,6 +48,13 @@ var _ = g.Describe("[cli] oc adm", func() {
 
 	g.It("oc adm node-logs --since=-2m --until=-1m", func() {
 		o.Expect(oc.Run("adm", "node-logs").Args(randomNode(oc), "--since=-2m", "--until=-1m").Execute()).To(o.Succeed())
+	})
+
+	g.It("oc adm node-logs --since=<explicit-date> --until=-1m", func() {
+		since := time.Now().Add(-2 * time.Minute).Format("2006-01-02 15:04:05")
+		out, err := oc.Run("adm", "node-logs").Args(randomNode(oc), fmt.Sprintf("--since=%s", since)).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).NotTo(o.ContainSubstring("Failed to parse timestamp: "))
 	})
 
 	g.It("oc adm node-logs --unit=kubelet --since=-1m", func() {


### PR DESCRIPTION
This builds on top of https://github.com/openshift/origin/pull/24258 but should not be merged until the former is merged and a new image with new kubelet is delivered otherwise this will block the queue. 
I'll drop the hold once I'm certain the prereq is deployed. 
/hold

/assign @smarterclayton 