### PR TITLE
Bug 1748073: disable kubelet_container_log_filesystem_used_bytes due to duplicate log metrics

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/kubelet.go
@@ -1321,7 +1321,7 @@ func (kl *Kubelet) initializeModules() error {
 	metrics.Register(
 		kl.runtimeCache,
 		collectors.NewVolumeStatsCollector(kl),
-		collectors.NewLogMetricsCollector(kl.StatsProvider.ListPodStats),
+		//BZ1748073 collectors.NewLogMetricsCollector(kl.StatsProvider.ListPodStats),
 	)
 	metrics.SetNodeName(kl.nodeName)
 	servermetrics.Register()


### PR DESCRIPTION
This log metric is being injected into the metrics stream more than once. A duplicate metric in the log stream will cause the /metrics endpoint to 500, causing metrics to stop being emitted by the kubuelet.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1748073