### PR TITLE
Bug 1748073: UPSTREAM: 86009: kubelet: guarantee at most only one cinfo per containerID

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -329,16 +329,11 @@ func removeTerminatedContainerInfo(containerInfo map[string]cadvisorapiv2.Contai
 			continue
 		}
 		sort.Sort(ByCreationTime(refs))
-		i := 0
-		for ; i < len(refs); i++ {
+		for i := len(refs) - 1; i >= 0; i-- {
 			if hasMemoryAndCPUInstUsage(&refs[i].cinfo) {
-				// Stops removing when we first see an info with non-zero
-				// CPU/Memory usage.
+				result[refs[i].cgroup] = refs[i].cinfo
 				break
 			}
-		}
-		for ; i < len(refs); i++ {
-			result[refs[i].cgroup] = refs[i].cinfo
 		}
 	}
 	return result

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -62,16 +62,10 @@ func TestRemoveTerminatedContainerInfo(t *testing.T) {
 		// The latest containers, which should be in the results.
 		"/pod0-i":  getTestContainerInfo(seedPod0Infra, pName0, namespace, leaky.PodInfraContainerName),
 		"/pod0-c0": getTestContainerInfo(seedPod0Container0, pName0, namespace, cName00),
-
-		// Duplicated containers with non-zero CPU and memory usage. This case
-		// shouldn't happen unless something goes wrong, but we want to test
-		// that the metrics reporting logic works in this scenario.
-		"/pod0-i-duplicated":  getTestContainerInfo(seedPod0Infra, pName0, namespace, leaky.PodInfraContainerName),
-		"/pod0-c0-duplicated": getTestContainerInfo(seedPod0Container0, pName0, namespace, cName00),
 	}
 	output := removeTerminatedContainerInfo(infos)
-	assert.Len(t, output, 4)
-	for _, c := range []string{"/pod0-i", "/pod0-c0", "/pod0-i-duplicated", "/pod0-c0-duplicated"} {
+	assert.Len(t, output, 2)
+	for _, c := range []string{"/pod0-i", "/pod0-c0"} {
 		if _, found := output[c]; !found {
 			t.Errorf("%q is expected to be in the output\n", c)
 		}


### PR DESCRIPTION
Backports my fix from upstream with the kubelet injecting duplicate metrics causing 500 on the Kubelet's metric endpoint.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1748073

cc @mrunalp @sjenning 