### PR TITLE
test/extended/prometheus: exclude AlertmanagerReceiversNotConfigured from checking

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -243,7 +243,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 				runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 			})
 		})
-		g.It("shouldn't report any alerts in firing state apart from Watchdog", func() {
+		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured", func() {
 			if len(os.Getenv("TEST_UNSUPPORTED_ALLOW_VERSION_SKEW")) > 0 {
 				e2e.Skipf("Test is disabled to allow cluster components to have different versions, and skewed versions trigger multiple other alerts")
 			}
@@ -255,7 +255,7 @@ var _ = g.Describe("[Feature:Prometheus][Conformance] Prometheus", func() {
 			tests := map[string]bool{
 				// Checking Watchdog alert state is done in "should have a Watchdog alert in firing state".
 				// FIXME(paulfantom): UsingDeprecatedAPIExtensionsV1Beta1 shouldn't be firing!
-				`ALERTS{alertname!~"Watchdog|UsingDeprecatedAPIExtensionsV1Beta1",alertstate="firing"} >= 1`: false,
+				`ALERTS{alertname!~"Watchdog|AlertmanagerReceiversNotConfigured|UsingDeprecatedAPIExtensionsV1Beta1",alertstate="firing"} >= 1`: false,
 			}
 			runQueries(tests, oc, ns, execPod.Name, url, bearerToken)
 		})


### PR DESCRIPTION
This is necessary to merge https://github.com/openshift/cluster-monitoring-operator/pull/585