### PR TITLE
Bug 1782467: update image eco perl imagestream refs from EOL 5.24 to 5.26

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50668,7 +50668,7 @@ var _testExtendedTestdataImage_ecosystemPerlHotdeployPerlJson = []byte(`{
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "openshift",
-              "name": "perl:5.24"
+              "name": "perl:5.26"
             }
           }
         },

--- a/test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json
+++ b/test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json
@@ -47,7 +47,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "openshift",
-              "name": "perl:5.24"
+              "name": "perl:5.26"
             }
           }
         },


### PR DESCRIPTION
/assign @bparees 
(for bindata)
@openshift/openshift-team-developer-experience FYI