### PR TITLE
disable jenkins e2e in build suite until https://bugzilla.redhat.com/…

### DIFF
--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -214,6 +214,7 @@ var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Slow] openshift pipeline b
 	g.Context("jenkins-client-plugin tests", func() {
 
 		g.It("using the ephemeral template", func() {
+			g.Skip("disabling Jenkins until https://bugzilla.redhat.com/show_bug.cgi?id=1783530 sorted out")
 			defer cleanup(jenkinsEphemeralTemplatePath)
 			setupJenkins(jenkinsEphemeralTemplatePath)
 
@@ -380,6 +381,7 @@ var _ = g.Describe("[Feature:Builds][Feature:Jenkins][Slow] openshift pipeline b
 	g.Context("Sync plugin tests", func() {
 
 		g.It("using the ephemeral template", func() {
+			g.Skip("disabling Jenkins until https://bugzilla.redhat.com/show_bug.cgi?id=1783530 sorted out")
 			defer cleanup(jenkinsEphemeralTemplatePath)
 			setupJenkins(jenkinsEphemeralTemplatePath)
 


### PR DESCRIPTION
…show_bug.cgi?id=1783530 is resolved

/assign @bparees 
/assign @adambkaplan 

whoever can review / comment / tag first 

e2e-gcp-builds / e2e-aws-builds is broke until the jenkins / openshift oauth integration noted bug above is addressed