### PR TITLE
Revert "Reenable 'should be rejected when no endpoints exist' test"

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -415,6 +415,7 @@ var (
 			`should answer endpoint and wildcard queries for the cluster`,                // currently not supported by dns operator https://github.com/openshift/cluster-dns-operator/issues/43
 			`should allow ingress access on one named port`,                              // https://bugzilla.redhat.com/show_bug.cgi?id=1711602
 			`ClusterDns \[Feature:Example\] should create pod that uses dns`,             // https://bugzilla.redhat.com/show_bug.cgi?id=1711601
+			`should be rejected when no endpoints exist`,                                 // https://bugzilla.redhat.com/show_bug.cgi?id=1781575
 			`PreemptionExecutionPath runs ReplicaSets to verify preemption running path`, // https://bugzilla.redhat.com/show_bug.cgi?id=1711606
 			`TaintBasedEvictions`,                                                        // https://bugzilla.redhat.com/show_bug.cgi?id=1711608
 			`recreate nodes and ensure they function upon restart`,                       // https://bugzilla.redhat.com/show_bug.cgi?id=1756428


### PR DESCRIPTION
Reverts openshift/origin#23370

This test is broken on RHEL7 and OKD-on-FCOS, see https://bugzilla.redhat.com/show_bug.cgi?id=1781575