### PR TITLE
[AUTO][OLM][OCP-21130] - [bug ALM-736]Fetching non-existent `PackageManifest` should return 404

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -226,4 +226,19 @@ var _ = g.Describe("[Feature:Platform] an end user use OLM", func() {
 		}
 
 	})
+
+	// OCP-21130 - [bug ALM-736] Fetching non-existent `PackageManifest` should return 404
+	// author: bandrade@redhat.com
+	g.It("Fetching non-existent `PackageManifest` should return 404", func() {
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "--all-namespaces", "--no-headers").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		packageserverLines := strings.Split(msg, "\n")
+		if len(packageserverLines) > 0 {
+			raw, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "a_package_that_not_exists", "-o yaml", "--loglevel=8").Output()
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(raw).To(o.ContainSubstring("\"code\": 404"))
+		} else {
+			e2e.Failf("No packages to evaluate if 404 works when a PackageManifest does not exists")
+		}
+	})
 })


### PR DESCRIPTION
PR Created to automate test case: @ecordell @njhale @kevinrizza. please have a review. Thanks! cc: @cuipinghuo @scolange @chengzhang1016 @emmajiafan @jianzhangbjz @tbuskey 

Success execution	

```
started: (0/1/1) "[Feature:Platform] OLM should Fetching non-existent `PackageManifest` does not return 404 [Suite:openshift/conformance/parallel]"

Dec 18 10:58:12.357: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Dec 18 10:58:12.819: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Dec 18 10:58:13.333: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Dec 18 10:58:13.333: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Dec 18 10:58:13.333: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Dec 18 10:58:13.497: INFO: e2e test version: v0.0.0-master+$Format:%h$
Dec 18 10:58:13.648: INFO: kube-apiserver version: v1.16.2
Dec 18 10:58:13.806: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /home/bandrade/go/src/github.com/openshift/origin/test/extended/util/test.go:60
[BeforeEach] [Feature:Platform] OLM should
  /home/bandrade/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:151
STEP: Creating a kubernetes client
[It] Fetching non-existent `PackageManifest` does not return 404 [Suite:openshift/conformance/parallel]
  /home/bandrade/go/src/github.com/openshift/origin/test/extended/operators/olm.go:110
Dec 18 10:58:13.853: INFO: Running 'oc --config=/home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig get packagemanifest --all-namespaces --no-headers'
Dec 18 10:58:15.208: INFO: Running 'oc --config=/home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig get packagemanifest a_package_that_not_exists -o yaml --loglevel=8'
Dec 18 10:58:16.062: INFO: Error running &{/usr/bin/oc [oc --config=/home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig get packagemanifest a_package_that_not_exists -o yaml --loglevel=8] []   I1218 10:58:15.413644   24813 loader.go:359] Config loaded from file /home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig
I1218 10:58:15.429269   24813 round_trippers.go:416] GET https://api.bandrade-888.qe.devcluster.openshift.com:6443/apis/packages.operators.coreos.com/v1/namespaces/default/packagemanifests/a_package_that_not_exists
I1218 10:58:15.429288   24813 round_trippers.go:423] Request Headers:
I1218 10:58:15.429294   24813 round_trippers.go:426]     Accept: application/json
I1218 10:58:15.429298   24813 round_trippers.go:426]     User-Agent: oc/v0.0.0 (linux/amd64) kubernetes/$Format
I1218 10:58:16.057924   24813 round_trippers.go:441] Response Status: 404 Not Found in 628 milliseconds
I1218 10:58:16.057949   24813 round_trippers.go:444] Response Headers:
I1218 10:58:16.057957   24813 round_trippers.go:447]     Audit-Id: a37296cf-6647-47aa-aa15-628a100fa206
I1218 10:58:16.057963   24813 round_trippers.go:447]     Cache-Control: no-cache, private
I1218 10:58:16.057969   24813 round_trippers.go:447]     Cache-Control: no-cache, private
I1218 10:58:16.057974   24813 round_trippers.go:447]     Content-Type: application/json
I1218 10:58:16.057979   24813 round_trippers.go:447]     Date: Wed, 18 Dec 2019 13:58:15 GMT
I1218 10:58:16.057984   24813 round_trippers.go:447]     Content-Length: 312
I1218 10:58:16.058015   24813 request.go:942] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"packagemanifests.packages.operators.coreos.com \"a_package_that_not_exists\" not found","reason":"NotFound","details":{"name":"a_package_that_not_exists","group":"packages.operators.coreos.com","kind":"packagemanifests"},"code":404}
I1218 10:58:16.058302   24813 helpers.go:196] server response object: [{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "packagemanifests.packages.operators.coreos.com \"a_package_that_not_exists\" not found",
  "reason": "NotFound",
  "details": {
    "name": "a_package_that_not_exists",
    "group": "packages.operators.coreos.com",
    "kind": "packagemanifests"
  },
  "code": 404
}]
F1218 10:58:16.058326   24813 helpers.go:114] Error from server (NotFound): packagemanifests.packages.operators.coreos.com "a_package_that_not_exists" not found
 I1218 10:58:15.413644   24813 loader.go:359] Config loaded from file /home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig
I1218 10:58:15.429269   24813 round_trippers.go:416] GET https://api.bandrade-888.qe.devcluster.openshift.com:6443/apis/packages.operators.coreos.com/v1/namespaces/default/packagemanifests/a_package_that_not_exists
I1218 10:58:15.429288   24813 round_trippers.go:423] Request Headers:
I1218 10:58:15.429294   24813 round_trippers.go:426]     Accept: application/json
I1218 10:58:15.429298   24813 round_trippers.go:426]     User-Agent: oc/v0.0.0 (linux/amd64) kubernetes/$Format
I1218 10:58:16.057924   24813 round_trippers.go:441] Response Status: 404 Not Found in 628 milliseconds
I1218 10:58:16.057949   24813 round_trippers.go:444] Response Headers:
I1218 10:58:16.057957   24813 round_trippers.go:447]     Audit-Id: a37296cf-6647-47aa-aa15-628a100fa206
I1218 10:58:16.057963   24813 round_trippers.go:447]     Cache-Control: no-cache, private
I1218 10:58:16.057969   24813 round_trippers.go:447]     Cache-Control: no-cache, private
I1218 10:58:16.057974   24813 round_trippers.go:447]     Content-Type: application/json
I1218 10:58:16.057979   24813 round_trippers.go:447]     Date: Wed, 18 Dec 2019 13:58:15 GMT
I1218 10:58:16.057984   24813 round_trippers.go:447]     Content-Length: 312
I1218 10:58:16.058015   24813 request.go:942] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"packagemanifests.packages.operators.coreos.com \"a_package_that_not_exists\" not found","reason":"NotFound","details":{"name":"a_package_that_not_exists","group":"packages.operators.coreos.com","kind":"packagemanifests"},"code":404}
I1218 10:58:16.058302   24813 helpers.go:196] server response object: [{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "packagemanifests.packages.operators.coreos.com \"a_package_that_not_exists\" not found",
  "reason": "NotFound",
  "details": {
    "name": "a_package_that_not_exists",
    "group": "packages.operators.coreos.com",
    "kind": "packagemanifests"
  },
  "code": 404
}]
F1218 10:58:16.058326   24813 helpers.go:114] Error from server (NotFound): packagemanifests.packages.operators.coreos.com "a_package_that_not_exists" not found
 [] <nil> 0xc004920030 exit status 255 <nil> <nil> true [0xc003e96310 0xc003e96338 0xc003e96338] [0xc003e96310 0xc003e96338] [0xc003e96318 0xc003e96330] [0x9d9180 0x9d92b0] 0xc001b396e0 <nil>}:
I1218 10:58:15.413644   24813 loader.go:359] Config loaded from file /home/bandrade/QE/ocp4-aws-ipi-vagrant-4.4/cluster/auth/kubeconfig
I1218 10:58:15.429269   24813 round_trippers.go:416] GET https://api.bandrade-888.qe.devcluster.openshift.com:6443/apis/packages.operators.coreos.com/v1/namespaces/default/packagemanifests/a_package_that_not_exists
I1218 10:58:15.429288   24813 round_trippers.go:423] Request Headers:
I1218 10:58:15.429294   24813 round_trippers.go:426]     Accept: application/json
I1218 10:58:15.429298   24813 round_trippers.go:426]     User-Agent: oc/v0.0.0 (linux/amd64) kubernetes/$Format
I1218 10:58:16.057924   24813 round_trippers.go:441] Response Status: 404 Not Found in 628 milliseconds
I1218 10:58:16.057949   24813 round_trippers.go:444] Response Headers:
I1218 10:58:16.057957   24813 round_trippers.go:447]     Audit-Id: a37296cf-6647-47aa-aa15-628a100fa206
I1218 10:58:16.057963   24813 round_trippers.go:447]     Cache-Control: no-cache, private
I1218 10:58:16.057969   24813 round_trippers.go:447]     Cache-Control: no-cache, private
I1218 10:58:16.057974   24813 round_trippers.go:447]     Content-Type: application/json
I1218 10:58:16.057979   24813 round_trippers.go:447]     Date: Wed, 18 Dec 2019 13:58:15 GMT
I1218 10:58:16.057984   24813 round_trippers.go:447]     Content-Length: 312
I1218 10:58:16.058015   24813 request.go:942] Response Body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"packagemanifests.packages.operators.coreos.com \"a_package_that_not_exists\" not found","reason":"NotFound","details":{"name":"a_package_that_not_exists","group":"packages.operators.coreos.com","kind":"packagemanifests"},"code":404}
I1218 10:58:16.058302   24813 helpers.go:196] server response object: [{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "packagemanifests.packages.operators.coreos.com \"a_package_that_not_exists\" not found",
  "reason": "NotFound",
  "details": {
    "name": "a_package_that_not_exists",
    "group": "packages.operators.coreos.com",
    "kind": "packagemanifests"
  },
  "code": 404
}]
F1218 10:58:16.058326   24813 helpers.go:114] Error from server (NotFound): packagemanifests.packages.operators.coreos.com "a_package_that_not_exists" not found
Dec 18 10:58:16.062: INFO: Response: true
[AfterEach] [Feature:Platform] OLM should
  /home/bandrade/go/src/github.com/openshift/origin/test/extended/util/client.go:120
[AfterEach] [Feature:Platform] OLM should
  /home/bandrade/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/framework.go:152
Dec 18 10:58:16.064: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
Dec 18 10:58:16.530: INFO: Running AfterSuite actions on all nodes
Dec 18 10:58:16.530: INFO: Running AfterSuite actions on node 1

passed: (21.7s) 2019-12-18T13:58:16 "[Feature:Platform] OLM should Fetching non-existent `PackageManifest` does not return 404 [Suite:openshift/conformance/parallel]"

1 pass, 0 skip (21.7s)
```