### PR TITLE
Disable flaky tests on OpenStack

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -516,6 +516,12 @@ var (
 			// should be serial if/when it's re-enabled
 			`\[HPA\] Horizontal pod autoscaling \(scale resource: Custom Metrics from Stackdriver\)`,
 		},
+		"[Skipped:openstack]": {
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1763936
+			`\[sig-network\] Networking Granular Checks: Services should function for node-Service`,
+			`\[sig-network\] Networking Granular Checks: Services should function for pod-Service`,
+			`\[sig-network\] Networking Granular Checks: Services should function for endpoint-Service`,
+		},
 		// tests that don't pass under openshift-sdn but that are expected to pass
 		// with other network plugins (particularly ovn-kubernetes)
 		"[Skipped:Network/OpenShiftSDN]": {


### PR DESCRIPTION
In order to increase chances to get a voting CI for OpenStack soon, I
propose to skip Network Granular Check tests that are intermittently
failing on our infrastructure.

This commit must be reverted and the issue properly investigated once
the minimum result of a voting CI is achieved.

ref.: https://bugzilla.redhat.com/show_bug.cgi?id=1763936
ref.: https://github.com/openshift/origin/pull/24313

The bug reference is not in the PR title nor leading the commit message, because this proposed change does not fix it.

/assign @smarterclayton 
/cc @knobunc 

@danwinship Do you think this work for OpenStack? Sorry I am not familiar with the skip logic, and I could not find specific documentation on the matter.