### PR TITLE
Bug 1785326: Disable build OOM test

### DIFF
--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -125,6 +125,7 @@ var _ = g.Describe("[Feature:Builds][Slow] update failure status", func() {
 
 		g.Describe("Build status OutOfMemoryKilled", func() {
 			g.It("should contain OutOfMemoryKilled failure reason and message", func() {
+				g.Skip("Bug 1785326: Build pod reporting reason Error instead of OOMKilled")
 				err := oc.Run("create").Args("-f", oomkilled).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
RHCOS-related change broke the reason reported by the build container.
Disabling until it is fixed.