### PR TITLE
fix router ingress fixture to use real apigroup

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -54044,7 +54044,7 @@ var _testExtendedTestdataRouterIngressYaml = []byte(`kind: List
 apiVersion: v1
 items:
 # an ingress that should be captured as individual routes
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1beta1
   kind: Ingress
   metadata:
     name: test

--- a/test/extended/testdata/router/ingress.yaml
+++ b/test/extended/testdata/router/ingress.yaml
@@ -2,7 +2,7 @@ kind: List
 apiVersion: v1
 items:
 # an ingress that should be captured as individual routes
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1beta1
   kind: Ingress
   metadata:
     name: test


### PR DESCRIPTION
found because it failed the kube-update job