### PR TITLE
openshift-test: azure don't set the UserAgent to include the current test name when loading cloud provider config

### DIFF
--- a/test/extended/util/azure/config_file.go
+++ b/test/extended/util/azure/config_file.go
@@ -17,7 +17,9 @@ import (
 // It then uses the `AZURE_AUTH_LOCATION` to load the credentials for Azure API and update the cloud provider config with the client secret. In-cluster cloud provider config
 // uses Azure Managed Identity attached to virtual machines to provide Azure API access, while the e2e tests are usually run from outside the cluster and therefore need explicit auth creds.
 func LoadConfigFile() ([]byte, error) {
-	client, err := e2e.LoadClientset()
+	// LoadClientset but don't set the UserAgent to include the current test name because
+	// we don't run any test yet and this call panics
+	client, err := e2e.LoadClientset(true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I hope that this PR will fix the following panic observed in [e2e-azure-upgrade](https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade/3/build-log.txt)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x127b1c6]

goroutine 1 [running]:
github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).CurrentSpecSummary(...)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:211
github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).CurrentRunningSpecSummary(0xc000283400, 0x121a, 0x121b)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:105 +0x26
github.com/openshift/origin/vendor/github.com/onsi/ginkgo.CurrentGinkgoTestDescription(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:159 +0x70
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.LoadConfig.func1(0xc0014e3198, 0xc0014e3190, 0x0, 0x0, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/util.go:573 +0x70
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.LoadConfig(0x0, 0x0, 0x0, 0xc002356600, 0x0, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/util.go:593 +0x34f
github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework.LoadClientset(0x0, 0x0, 0x0, 0x0, 0x0, 0x6000105)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/k8s.io/kubernetes/test/e2e/framework/util.go:598 +0x43
github.com/openshift/origin/test/extended/util/azure.LoadConfigFile(0xc0014e3340, 0xc004441b30, 0x3, 0x3, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/azure/config_file.go:20 +0x36
github.com/openshift/origin/test/extended/util/cloud.LoadConfig(0x5fb5ac0, 0xc003475590, 0x5fb5b00, 0xc0034755a0, 0x5fb5a40)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/test/extended/util/cloud/cloud.go:90 +0x625
main.decodeProviderTo(0x7ffd3e3a4933, 0x5, 0x9596520, 0x0, 0x1, 0x91e3c60)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:314 +0x76
main.initProvider(0x7ffd3e3a4933, 0x5, 0x0, 0x0, 0xc001c2a9c0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:280 +0x4e
main.newRunUpgradeCommand.func1.1(0xc0014e3b98, 0x2)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:189 +0x204
main.mirrorToFile(0xc00146c3c0, 0xc0014e3be8, 0x4, 0x5466732)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:255 +0x244
main.newRunUpgradeCommand.func1(0xc001c18a00, 0xc002535b00, 0x1, 0x9, 0x0, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:169 +0x82
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).execute(0xc001c18a00, 0xc002535a70, 0x9, 0x9, 0xc001c18a00, 0xc002535a70)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:826 +0x460
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc001c18500, 0x0, 0x5ecf860, 0x95b3308)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:914 +0x2fb
github.com/openshift/origin/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/vendor/github.com/spf13/cobra/command.go:864
main.main.func1(0xc001c18500, 0x0, 0x0)
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:68 +0x9c
main.main()
	/go/src/github.com/openshift/origin/_output/local/go/src/github.com/openshift/origin/cmd/openshift-tests/openshift-tests.go:69 +0x341
```