### PR TITLE
Disable flaky network tests on ovirt

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -520,6 +520,12 @@ var (
 			`\[sig-network\] Networking Granular Checks: Services should function for pod-Service`,
 			`\[sig-network\] Networking Granular Checks: Services should function for endpoint-Service`,
 		},
+		"[Skipped:ovirt]": {
+			// https://bugzilla.redhat.com/show_bug.cgi?id=1763936
+			`\[sig-network\] Networking Granular Checks: Services should function for node-Service`,
+			`\[sig-network\] Networking Granular Checks: Services should function for pod-Service`,
+			`\[sig-network\] Networking Granular Checks: Services should function for endpoint-Service`,
+		},
 		// tests that don't pass under openshift-sdn but that are expected to pass
 		// with other network plugins (particularly ovn-kubernetes)
 		"[Skipped:Network/OpenShiftSDN]": {


### PR DESCRIPTION
Those tests are constantly failing on our infrastructure
during conformance runs.

This commit is due to the removal of those test from the
Flaky on, https://github.com/openshift/origin/pull/24313.
And the PR from openstack who experience the same results
on there CI runs https://github.com/openshift/origin/pull/24330.

Signed-off-by: Gal Zaidman <gzaidman@redhat.com>