### PR TITLE
skip psp test consistently

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/master/master.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/master.go
@@ -622,6 +622,13 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 		storageapiv1alpha1.SchemeGroupVersion,
 		flowcontrolv1alpha1.SchemeGroupVersion,
 	)
+	// disable PodSecurityPolicies
+	// note that we decided to disable PSP explicitly in the code instead of using `runtime-config` flag.
+	// at the moment the flag allows only for disabling the entire group, not individual resources.
+	// we don't want to disable the group as it contains critical resources like `PodDisruptionBudgets`.
+	ret.DisableResources(
+		policyapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"),
+	)
 
 	return ret
 }

--- a/vendor/k8s.io/kubernetes/pkg/master/storageversionhashdata/data.go
+++ b/vendor/k8s.io/kubernetes/pkg/master/storageversionhashdata/data.go
@@ -71,7 +71,6 @@ var GVRToStorageVersionHash = map[string]string{
 	"networking.k8s.io/v1beta1/ingresses":                                  "ZOAfGflaKd0=",
 	"node.k8s.io/v1beta1/runtimeclasses":                                   "8nMHWqj34s0=",
 	"policy/v1beta1/poddisruptionbudgets":                                  "6BGBu0kpHtk=",
-	"policy/v1beta1/podsecuritypolicies":                                   "khBLobUXkqA=",
 	"rbac.authorization.k8s.io/v1/clusterrolebindings":                     "48tpQ8gZHFc=",
 	"rbac.authorization.k8s.io/v1/clusterroles":                            "bYE5ZWDrJ44=",
 	"rbac.authorization.k8s.io/v1/rolebindings":                            "eGsCzGH6b1g=",

--- a/vendor/k8s.io/kubernetes/pkg/registry/policy/rest/storage_policy.go
+++ b/vendor/k8s.io/kubernetes/pkg/registry/policy/rest/storage_policy.go
@@ -55,11 +55,13 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource serverstorag
 	storage["poddisruptionbudgets"] = poddisruptionbudgetStorage
 	storage["poddisruptionbudgets/status"] = poddisruptionbudgetStatusStorage
 
-	rest, err := pspstore.NewREST(restOptionsGetter)
-	if err != nil {
-		return storage, err
+	if apiResourceConfigSource.ResourceEnabled(policyapiv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies")) {
+		rest, err := pspstore.NewREST(restOptionsGetter)
+		if err != nil {
+			return storage, err
+		}
+		storage["podsecuritypolicies"] = rest
 	}
-	storage["podsecuritypolicies"] = rest
 
 	return storage, err
 }

--- a/vendor/k8s.io/kubernetes/test/e2e/auth/pod_security_policy.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/auth/pod_security_policy.go
@@ -52,7 +52,6 @@ var _ = SIGDescribe("PodSecurityPolicy", func() {
 	var c clientset.Interface
 	var ns string // Test namespace, for convenience
 	ginkgo.BeforeEach(func() {
-		framework.Skipf("This test should always be skipped for us, but occasionally PSP is on!")
 		if !framework.IsPodSecurityPolicyEnabled(f.ClientSet) {
 			framework.Skipf("PodSecurityPolicy not enabled")
 		}


### PR DESCRIPTION
This PR:
 - brings back disabled e2e test
 - changes Kube API server in a way that it stops serving `PodSecurityPolicies` resources.


Note:
We decided to disable PSP explicitly in the code instead of using `runtime-config` flag. At the moment the flag allows only for disabling the entire group, not individual resources. We don't want to disable the group as it contains critical resources like `PodDisruptionBudgets`. 