### PR TITLE
Exclude openshift-ovirt-infra from tolerations tests

### DIFF
--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -28,7 +28,7 @@ var _ = Describe("[Feature:Platform] Managed cluster should", func() {
 		// a pod in a namespace that begins with kube-* or openshift-* must come from our release payload
 		// TODO components in openshift-operators may not come from our payload, may want to weaken restriction
 		namespacePrefixes := sets.NewString("kube-", "openshift-")
-		excludedNamespaces := sets.NewString("openshift-kube-apiserver", "openshift-kube-controller-manager", "openshift-kube-scheduler", "openshift-etcd", "openshift-openstack-infra")
+		excludedNamespaces := sets.NewString("openshift-kube-apiserver", "openshift-kube-controller-manager", "openshift-kube-scheduler", "openshift-etcd", "openshift-openstack-infra", "openshift-ovirt-infra")
 		// exclude these pods from checks
 		whitelistPods := sets.NewString("network-operator", "dns-operator", "olm-operators", "gcp-routes-controller", "ovnkube-master", "must-gather")
 		for _, pod := range pods.Items {


### PR DESCRIPTION
Exclude openshift-ovirt-infra namespaces when testing
"[Feature:Platform] Managed cluster should ensure control plane operators do not make themselves unevictable"