### PR TITLE
tests: skip tests based on worker OS

### DIFF
--- a/test/extended/util/test_test.go
+++ b/test/extended/util/test_test.go
@@ -79,6 +79,7 @@ func TestStockRules(t *testing.T) {
 		testName string
 		provider string
 		netSkips []string
+		osSkips  []string
 
 		expectedText string
 	}{
@@ -101,11 +102,17 @@ func TestStockRules(t *testing.T) {
 			testName:     `[Feature:NetworkPolicy] should do something with NetworkPolicy`,
 			expectedText: `[Feature:NetworkPolicy] should do something with NetworkPolicy [Skipped:Network/OpenShiftSDN/Multitenant]`,
 		},
+		{
+			name:         "should skip NetworkPolicy tests on multitenant",
+			osSkips:      []string{"fedora"},
+			testName:     `[Feature:NetworkPolicy] should do something with NetworkPolicy`,
+			expectedText: `[Feature:NetworkPolicy] should do something with NetworkPolicy [Skipped:OS/fedora]`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testRenamer := newGinkgoTestRenamerFromGlobals(test.provider, test.netSkips)
+			testRenamer := newGinkgoTestRenamerFromGlobals(test.provider, test.netSkips, test.osSkips)
 			testNode := &testNode{
 				text: test.testName,
 			}


### PR DESCRIPTION
Some tests - e.g. one SDN test - doesn't pass on OKD-on-FCOS. This would 
ensure some tests can be skipped on working running Fedora.

/cc @smarterclayton