### PR TITLE
Allow for customization of storageClass in the CSI test suite

### DIFF
--- a/cmd/openshift-tests/csi.go
+++ b/cmd/openshift-tests/csi.go
@@ -3,10 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/openshift/origin/test/extended/csi"
 
+	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/storage/external"
 )
 
@@ -46,6 +48,12 @@ func initCSITests(dryRun bool) error {
 			if err := external.AddDriverDefinition(manifest); err != nil {
 				return fmt.Errorf("failed to load manifest from %q: %s", manifest, err)
 			}
+			// Register the base dir of the manifest file as a file source.
+			// With this we can reference the CSI driver's storageClass
+			// in the manifest file (FromFile field).
+			testfiles.AddFileSource(testfiles.RootFileSource{
+				Root: filepath.Dir(manifest),
+			})
 		}
 	}
 

--- a/test/extended/csi/install.go
+++ b/test/extended/csi/install.go
@@ -28,9 +28,17 @@ func InstallCSIDriver(driverName string, dryRun bool) (string, error) {
 	if _, err := testdata.AssetInfo(templatePath); err != nil {
 		return "", fmt.Errorf("failed to install CSI driver %q: %s", driverName, err)
 	}
+
 	manifestPath := filepath.Join(csiBasePath, driverName, "manifest.yaml")
 	if _, err := testdata.AssetInfo(manifestPath); err != nil {
 		return "", fmt.Errorf("failed to install CSI driver %q: %s", driverName, err)
+	}
+
+	// storageclass.yaml is optional, so we don't return and error if it's absent
+	scPath := filepath.Join(csiBasePath, driverName, "storageclass.yaml")
+	if _, err := testdata.AssetInfo(scPath); err == nil {
+		scFixturePath := strings.Split(scPath, string(os.PathSeparator))[2:]
+		exutil.FixturePath(scFixturePath...)
 	}
 
 	// Convert to array and cut "test/extended" for FixturePath()

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -311,6 +311,7 @@
 // test/extended/testdata/config-map-jenkins-slave-pods.yaml
 // test/extended/testdata/csi/aws-ebs/install-template.yaml
 // test/extended/testdata/csi/aws-ebs/manifest.yaml
+// test/extended/testdata/csi/aws-ebs/storageclass.yaml
 // test/extended/testdata/custom-secret-builder/Dockerfile
 // test/extended/testdata/custom-secret-builder/build.sh
 // test/extended/testdata/deployments/custom-deployment.yaml
@@ -47330,7 +47331,7 @@ func testExtendedTestdataCsiAwsEbsInstallTemplateYaml() (*asset, error) {
 var _testExtendedTestdataCsiAwsEbsManifestYaml = []byte(`# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
 ShortName: ebs
 StorageClass:
-  FromName: true
+  FromFile: storageclass.yaml
 DriverInfo:
   Name: ebs.csi.aws.com
   SupportedSizeRange:
@@ -47363,6 +47364,29 @@ func testExtendedTestdataCsiAwsEbsManifestYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/csi/aws-ebs/manifest.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataCsiAwsEbsStorageclassYaml = []byte(`kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs.csi.aws.com
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+`)
+
+func testExtendedTestdataCsiAwsEbsStorageclassYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataCsiAwsEbsStorageclassYaml, nil
+}
+
+func testExtendedTestdataCsiAwsEbsStorageclassYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataCsiAwsEbsStorageclassYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/csi/aws-ebs/storageclass.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -58541,6 +58565,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/config-map-jenkins-slave-pods.yaml": testExtendedTestdataConfigMapJenkinsSlavePodsYaml,
 	"test/extended/testdata/csi/aws-ebs/install-template.yaml": testExtendedTestdataCsiAwsEbsInstallTemplateYaml,
 	"test/extended/testdata/csi/aws-ebs/manifest.yaml": testExtendedTestdataCsiAwsEbsManifestYaml,
+	"test/extended/testdata/csi/aws-ebs/storageclass.yaml": testExtendedTestdataCsiAwsEbsStorageclassYaml,
 	"test/extended/testdata/custom-secret-builder/Dockerfile": testExtendedTestdataCustomSecretBuilderDockerfile,
 	"test/extended/testdata/custom-secret-builder/build.sh": testExtendedTestdataCustomSecretBuilderBuildSh,
 	"test/extended/testdata/deployments/custom-deployment.yaml": testExtendedTestdataDeploymentsCustomDeploymentYaml,
@@ -59203,6 +59228,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"aws-ebs": &bintree{nil, map[string]*bintree{
 						"install-template.yaml": &bintree{testExtendedTestdataCsiAwsEbsInstallTemplateYaml, map[string]*bintree{}},
 						"manifest.yaml": &bintree{testExtendedTestdataCsiAwsEbsManifestYaml, map[string]*bintree{}},
+						"storageclass.yaml": &bintree{testExtendedTestdataCsiAwsEbsStorageclassYaml, map[string]*bintree{}},
 					}},
 				}},
 				"custom-secret-builder": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -47043,7 +47043,7 @@ metadata:
   name: ebs-csi-controller-sa
   namespace: kube-system
 
---- 
+---
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47122,11 +47122,14 @@ roleRef:
 ---
 
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: ebs-csi-controller
   serviceName: ebs-csi-controller
   replicas: 1
   template:
@@ -47200,7 +47203,7 @@ spec:
 ---
 # Node Service
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: ebs-csi-node
   namespace: kube-system
@@ -47328,10 +47331,11 @@ var _testExtendedTestdataCsiAwsEbsManifestYaml = []byte(`# Test manifest for htt
 ShortName: ebs
 StorageClass:
   FromName: true
-SupportedMountOption:
- dirsync: true
 DriverInfo:
   Name: ebs.csi.aws.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
   SnapshotClass:
     FromName: true
   SupportedFsType:
@@ -47339,12 +47343,13 @@ DriverInfo:
     ext4: {}
   SupportedMountOption:
     dirsync: {}
+  TopologyKeys: ["topology.ebs.csi.aws.com/zone"]
   Capabilities:
     persistence: true
     fsGroup: true
     block: true
     exec: true
-    volumeLimits: true
+    volumeLimits: false
 `)
 
 func testExtendedTestdataCsiAwsEbsManifestYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/csi/README.md
+++ b/test/extended/testdata/csi/README.md
@@ -1,11 +1,22 @@
 # CSI driver installer manifests
 
-Each CSI driver is represented as a directory with two files:
+Each CSI driver is represented as a directory with two required files:
 
 ```
 <driver name>/install-template.yaml
 <driver name>/manifest.yaml
 ```
+
+Optionally, there can also be a file for a storageClass:
+
+```
+<driver name>/storageclass.yaml
+```
+
+This file is typically used to set custom parameters in the storageClass. For instance,
+in order to use the [topology](https://kubernetes-csi.github.io/docs/topology.html)
+feature of a CSI driver, one might want to have a custom storageClass with `volumeBindingMode`
+set to `WaitForFirstConsumer`. Also, the custom storageClass needs to be refereced in the [manifest file](#manifest).
 
 ## Driver template
 `install-template.yaml` is a [golang template](https://golang.org/pkg/text/template/) of YAML file with all Kubernetes objects of a CSI driver.

--- a/test/extended/testdata/csi/aws-ebs/install-template.yaml
+++ b/test/extended/testdata/csi/aws-ebs/install-template.yaml
@@ -14,7 +14,7 @@ metadata:
   name: ebs-csi-controller-sa
   namespace: kube-system
 
---- 
+---
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -93,11 +93,14 @@ roleRef:
 ---
 
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: ebs-csi-controller
   serviceName: ebs-csi-controller
   replicas: 1
   template:
@@ -171,7 +174,7 @@ spec:
 ---
 # Node Service
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: ebs-csi-node
   namespace: kube-system

--- a/test/extended/testdata/csi/aws-ebs/manifest.yaml
+++ b/test/extended/testdata/csi/aws-ebs/manifest.yaml
@@ -1,7 +1,7 @@
 # Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
 ShortName: ebs
 StorageClass:
-  FromName: true
+  FromFile: storageclass.yaml
 DriverInfo:
   Name: ebs.csi.aws.com
   SupportedSizeRange:

--- a/test/extended/testdata/csi/aws-ebs/manifest.yaml
+++ b/test/extended/testdata/csi/aws-ebs/manifest.yaml
@@ -2,10 +2,11 @@
 ShortName: ebs
 StorageClass:
   FromName: true
-SupportedMountOption:
- dirsync: true
 DriverInfo:
   Name: ebs.csi.aws.com
+  SupportedSizeRange:
+    Min: 1Gi
+    Max: 16Ti
   SnapshotClass:
     FromName: true
   SupportedFsType:
@@ -13,9 +14,10 @@ DriverInfo:
     ext4: {}
   SupportedMountOption:
     dirsync: {}
+  TopologyKeys: ["topology.ebs.csi.aws.com/zone"]
   Capabilities:
     persistence: true
     fsGroup: true
     block: true
     exec: true
-    volumeLimits: true
+    volumeLimits: false

--- a/test/extended/testdata/csi/aws-ebs/storageclass.yaml
+++ b/test/extended/testdata/csi/aws-ebs/storageclass.yaml
@@ -1,0 +1,6 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs.csi.aws.com
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This patch is the result of running the CSI certification process outlined [here](https://github.com/openshift/enhancements/pull/162/files) against the EBS CSI driver. In other words, we need this change so partners can test and certify their CSI drivers with OpenShift.

We also want to use the EBS CSI driver in our CI, so getting it to work is the first step.

CC @openshift/storage 