### PR TITLE
Bug 1788621: Improve logging of kubelet-apiserver logging

### DIFF
--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/rest/request.go
@@ -535,7 +535,7 @@ func (r *Request) tryThrottle() error {
 	}
 
 	if latency := time.Since(now); latency > longThrottleLatency {
-		klog.V(4).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
+		klog.V(3).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
 	}
 
 	return err


### PR DESCRIPTION
UPSTREAM: 80649: Report api request throttling at v=3