### PR TITLE
Bug 1788832: check ServiceCatalog basic usages in OCP 4.3

### DIFF
--- a/test/extended/operators/service_catalog.go
+++ b/test/extended/operators/service_catalog.go
@@ -1,0 +1,268 @@
+package operators
+
+import (
+	"fmt"
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var _ = g.Describe("[Feature:Platform][Serial] Service Catalog should", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLI("service-catalog", exutil.KubeConfigPath())
+		// serviceCatalogWait is how long to wait for Service Catalog operations to be ready
+		serviceCatalogWait  = 180 * time.Second
+		err                 error
+		buildPruningBaseDir = exutil.FixturePath("testdata", "service_catalog")
+		upsBroker           = filepath.Join(buildPruningBaseDir, "ups-broker.yaml")
+		upsDeployment       = filepath.Join(buildPruningBaseDir, "ups-deployment.yaml")
+		upsService          = filepath.Join(buildPruningBaseDir, "ups-service.yaml")
+		upsInstance         = filepath.Join(buildPruningBaseDir, "ups-instance.yaml")
+		upsBinding          = filepath.Join(buildPruningBaseDir, "ups-binding.yaml")
+	)
+
+	enableServiceCatalogResources := []struct {
+		object    string
+		namespace string
+		name      string
+	}{
+		{"servicecatalogapiserver", "openshift-service-catalog-apiserver", "apiserver"},
+		{"servicecatalogcontrollermanager", "openshift-service-catalog-controller-manager", "controller-manager"},
+	}
+	// Enable Service Catalog
+	g.BeforeEach(func() {
+		g.By("Enable Service Catalog")
+		for _, v := range enableServiceCatalogResources {
+			_, err := oc.AsAdmin().Run("patch").Args(v.object, "cluster", "-p", `{"spec":{"managementState":"Managed"}}`, "--type=merge").Output()
+			if err != nil {
+				e2e.Failf("Unable to create: %s, error:%v", v.object, err)
+			}
+
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				output, err := oc.AsAdmin().Run("get").Args("pods", "-n", v.namespace, "-o=jsonpath={.items[0].status.phase}").Output()
+				if err != nil && !strings.Contains(output, "out of bounds") {
+					e2e.Failf("output string: %s", output)
+					return false, err
+				}
+				if output == "Running" {
+					e2e.Logf("%s works well!", v.object)
+					return true, nil
+				}
+				return false, nil
+			})
+
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+	}, 120)
+
+	// The below steps will cover OCP-24049, author: jiazha@redhat.com
+	// Disable these servicecatalogoperator resource
+	g.AfterEach(func() {
+		g.By("delete this ups broker")
+		output, err := oc.AsAdmin().Run("get").Args("clusterservicebroker").Output()
+		if strings.Contains(output, "ups-broker") {
+			_, err = oc.AsAdmin().Run("delete").Args("clusterservicebroker", "ups-broker").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				output, err = oc.AsAdmin().Run("get").Args("clusterserviceclass").Output()
+				if err != nil {
+					e2e.Failf("Failed to delete ups-broker, error:%v", err)
+					return false, err
+				}
+				if !strings.Contains(output, "user-provided-service") {
+					return true, nil
+				}
+				return false, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+		for _, v := range enableServiceCatalogResources {
+			g.By("disable " + v.object)
+			_, err := oc.AsAdmin().Run("patch").Args(v.object, "cluster", "-p", `{"spec":{"managementState":"Removed"}}`, "--type=merge").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				output, err := oc.AsAdmin().Run("get").Args("ns", v.namespace).Output()
+				if err != nil {
+					if strings.Contains(output, "not found") {
+						e2e.Logf("Disable %s successfully.", v.object)
+						return true, nil
+					}
+				}
+				return false, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+	}, 120)
+
+	g.It("check basic usages: OCP-24062, OCP-24049, OCP-15600", func() {
+		g.By("Check Service Catalog apiservice")
+		err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+			output, err := oc.AsAdmin().Run("get").Args("apiservices", "v1beta1.servicecatalog.k8s.io", "-o=jsonpath={.status.conditions[0].reason}").Output()
+			if err != nil {
+				if strings.Contains(output, "not found") {
+					return false, nil
+				}
+				return false, err
+			}
+			if strings.Contains(output, "Passed") {
+				e2e.Logf("v1beta1.servicecatalog.k8s.io apiservice works well!")
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// The below steps will cover test case: OCP-15600, author: jiazha@redhat.com
+		g.By("Deploy a fake broker")
+
+		upsFiles := []string{upsDeployment, upsService, upsBroker}
+		e2e.Logf("current namespace:%s", oc.Namespace())
+		for _, v := range upsFiles {
+			configFile, err := oc.AsAdmin().Run("process").Args("-f", v, "-p", fmt.Sprintf("NAMESPACE=%s", oc.Namespace())).OutputToFile("config.json")
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				err = oc.AsAdmin().Run("create").Args("-f", configFile).Execute()
+				if err != nil {
+					e2e.Failf("Failed to install:%v, error:%v", v, err)
+					return false, err
+				}
+				e2e.Logf("Install:%v successfully", v)
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+		err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+			output, err := oc.AsAdmin().Run("get").Args("clusterservicebroker", "ups-broker", "-o=jsonpath={.status.conditions[0].status}").Output()
+			if err != nil {
+				e2e.Failf("Failed to install ups-broker, error:%v", err)
+				return false, err
+			}
+			if strings.Contains(output, "True") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		upsBrokers := []struct {
+			file         string
+			object       string
+			resourceName string
+			expect       string
+		}{
+			{upsInstance, "serviceinstance", "ups-instance", "ProvisionedSuccessfully"},
+			{upsBinding, "servicebinding", "ups-binding", "InjectedBindResult"},
+		}
+		for _, item := range upsBrokers {
+			g.By(fmt.Sprintf("create %s", item))
+			configFile, err := oc.AsAdmin().Run("process").Args("-f", item.file, "-p", fmt.Sprintf("NAMESPACE=%s", oc.Namespace())).OutputToFile("config.json")
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				err = oc.AsAdmin().Run("create").Args("-f", configFile).Execute()
+				if err != nil {
+					e2e.Failf("Failed to install:%v, error:%v", item.file, err)
+					return false, err
+				}
+				e2e.Logf("Install:%v successfully", item.file)
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				output, err := oc.AsAdmin().Run("get").Args(item.object, "-n", oc.Namespace(), item.resourceName, "-o=jsonpath={.status.conditions[0].reason}").Output()
+				if err != nil && !strings.Contains(output, "executing jsonpath") {
+					e2e.Failf("Failed to install %s, error:%v", item.resourceName, err)
+					return false, err
+				}
+				if strings.Contains(output, item.expect) {
+					return true, nil
+				}
+				return false, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
+		output, err := oc.AsAdmin().Run("get").Args("secret", "-n", oc.Namespace()).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring("my-secret"))
+
+		g.By("unbind from this instance")
+		output, err = oc.AsAdmin().Run("delete").Args("servicebinding", "-n", oc.Namespace(), "ups-binding").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+			output, err := oc.AsAdmin().Run("get").Args("servicebinding", "-n", oc.Namespace()).Output()
+			if err != nil {
+				e2e.Failf("Failed to delete servicebinding, error:%v", err)
+				return false, err
+			}
+			if !strings.Contains(output, "ups-binding") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		output, err = oc.AsAdmin().Run("get").Args("secret", "-n", oc.Namespace()).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.ContainSubstring("my-secret"))
+
+		g.By("delete this ups instance")
+		_, err = oc.AsAdmin().Run("delete").Args("serviceinstance", "-n", oc.Namespace(), "ups-instance").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+			output, err = oc.AsAdmin().Run("get").Args("serviceinstance", "-n", oc.Namespace()).Output()
+			if err != nil {
+				e2e.Failf("Failed to delete serviceinstance, error:%v", err)
+				return false, err
+			}
+			if !strings.Contains(output, "ups-instance") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// The below steps will cover OCP-24062, author: jiazha@redhat.com
+		// TODO: once https://bugzilla.redhat.com/show_bug.cgi?id=1712297 fix, we should cover the `Force` managementState
+		// Unmanage these servicecatalogoperator resource
+		g.By("set Service Catalog to Unmanaged")
+		for _, v := range enableServiceCatalogResources {
+			_, err := oc.AsAdmin().Run("patch").Args(v.object, "cluster", "-p", `{"spec":{"managementState":"Unmanaged"}}`, "--type=merge").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				output, err = oc.AsAdmin().Run("get").Args(v.object, "-n", v.namespace, "cluster", "-o=jsonpath={.spec.managementState}").Output()
+				if err != nil && !strings.Contains(output, "executing jsonpath") {
+					e2e.Failf("Failed to set the Unmanaged for Service Catalog, error:%v", err)
+					return false, err
+				}
+				if strings.Contains(output, "Unmanaged") {
+					return true, nil
+				}
+				return false, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			output, err := oc.AsAdmin().Run("patch").Args("daemonset", v.name, "-n", v.namespace, "-p", `{"spec":{"template":{"spec":{"priorityClassName":"test"}}}}`).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(output).To(o.ContainSubstring("patched"))
+
+			err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+				output, err = oc.AsAdmin().Run("get").Args("daemonset", v.name, "-n", v.namespace, "-o=jsonpath={.spec.template.spec.priorityClassName}").Output()
+				if err != nil && !strings.Contains(output, "executing jsonpath") {
+					e2e.Failf("Failed to check the priority of the daemonset, error:%v", err)
+					return false, err
+				}
+				if strings.Contains(output, "test") {
+					return true, nil
+				}
+				return false, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+	})
+
+})

--- a/test/extended/operators/service_catalog.go
+++ b/test/extended/operators/service_catalog.go
@@ -99,6 +99,19 @@ var _ = g.Describe("[Feature:Platform][Serial] Service Catalog should", func() {
 			})
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
+		g.By("Check if the apiservice is removed successfully after ServiceCatalog disabled")
+		err = wait.Poll(3*time.Second, serviceCatalogWait, func() (bool, error) {
+			output, err := oc.AsAdmin().Run("get").Args("apiservices", "v1beta1.servicecatalog.k8s.io", "-o=jsonpath={.status.conditions[0].reason}").Output()
+			if err != nil {
+				if strings.Contains(output, "not found") {
+					e2e.Logf("v1beta1.servicecatalog.k8s.io apiservice is removed successfully!")
+					return true, nil
+				}
+				return false, err
+			}
+			return false, err
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
 	}, 120)
 
 	g.It("check basic usages: OCP-24062, OCP-24049, OCP-15600", func() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -441,6 +441,11 @@
 // test/extended/testdata/sample-image-stream.json
 // test/extended/testdata/samplepipeline-withenvs.yaml
 // test/extended/testdata/service-serving-cert/nginx-serving-cert.conf
+// test/extended/testdata/service_catalog/ups-binding.yaml
+// test/extended/testdata/service_catalog/ups-broker.yaml
+// test/extended/testdata/service_catalog/ups-deployment.yaml
+// test/extended/testdata/service_catalog/ups-instance.yaml
+// test/extended/testdata/service_catalog/ups-service.yaml
 // test/extended/testdata/signer-buildconfig.yaml
 // test/extended/testdata/templates/crunchydata-pod.json
 // test/extended/testdata/templates/guestbook.json
@@ -55607,6 +55612,232 @@ func testExtendedTestdataServiceServingCertNginxServingCertConf() (*asset, error
 	return a, nil
 }
 
+var _testExtendedTestdataService_catalogUpsBindingYaml = []byte(`---
+apiVersion: v1
+kind: Template
+metadata:
+  name: upsBinding-template
+objects:
+- apiVersion: servicecatalog.k8s.io/v1beta1
+  kind: ServiceBinding
+  metadata:
+    name: ups-binding
+    namespace: "${NAMESPACE}"
+  spec:
+    instanceRef:
+      name: ups-instance
+    secretName: my-secret
+parameters:
+- name: NAMESPACE
+`)
+
+func testExtendedTestdataService_catalogUpsBindingYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataService_catalogUpsBindingYaml, nil
+}
+
+func testExtendedTestdataService_catalogUpsBindingYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataService_catalogUpsBindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/service_catalog/ups-binding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataService_catalogUpsBrokerYaml = []byte(`---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ups-broker-template
+objects:
+- apiVersion: servicecatalog.k8s.io/v1beta1
+  kind: ClusterServiceBroker
+  metadata:
+    name: ups-broker
+  spec:
+    url: http://ups-broker.${NAMESPACE}.svc.cluster.local
+parameters:
+- name: NAMESPACE
+`)
+
+func testExtendedTestdataService_catalogUpsBrokerYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataService_catalogUpsBrokerYaml, nil
+}
+
+func testExtendedTestdataService_catalogUpsBrokerYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataService_catalogUpsBrokerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/service_catalog/ups-broker.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataService_catalogUpsDeploymentYaml = []byte(`---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ups-deployment-template
+objects:
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ups-broker
+      chart: ups-broker-0.0.1
+      heritage: Tiller
+      release: ups-broker
+    name: ups-broker
+    namespace: "${NAMESPACE}"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ups-broker
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 1
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: ups-broker
+          chart: ups-broker-0.0.1
+          heritage: Tiller
+          release: ups-broker
+      spec:
+        containers:
+        - args:
+          - -alsologtostderr
+          - --port
+          - "8080"
+          image: quay.io/kubernetes-service-catalog/user-broker:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 2
+          name: ups-broker
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 2
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+parameters:
+- name: NAMESPACE
+`)
+
+func testExtendedTestdataService_catalogUpsDeploymentYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataService_catalogUpsDeploymentYaml, nil
+}
+
+func testExtendedTestdataService_catalogUpsDeploymentYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataService_catalogUpsDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/service_catalog/ups-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataService_catalogUpsInstanceYaml = []byte(`---
+apiVersion: v1
+kind: Template
+metadata:
+  name: upsInstance-template
+objects:
+- apiVersion: servicecatalog.k8s.io/v1beta1
+  kind: ServiceInstance
+  metadata:
+    name: ups-instance
+    namespace: "${NAMESPACE}"
+  spec:
+    clusterServiceClassExternalName: user-provided-service
+    clusterServicePlanExternalName: default
+parameters:
+- name: NAMESPACE
+`)
+
+func testExtendedTestdataService_catalogUpsInstanceYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataService_catalogUpsInstanceYaml, nil
+}
+
+func testExtendedTestdataService_catalogUpsInstanceYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataService_catalogUpsInstanceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/service_catalog/ups-instance.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataService_catalogUpsServiceYaml = []byte(`---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ups-service-template
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ups-broker
+      chart: ups-broker-0.0.1
+      heritage: Tiller
+      release: ups-broker
+    name: ups-broker
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: ups-broker
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- name: NAMESPACE
+`)
+
+func testExtendedTestdataService_catalogUpsServiceYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataService_catalogUpsServiceYaml, nil
+}
+
+func testExtendedTestdataService_catalogUpsServiceYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataService_catalogUpsServiceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/service_catalog/ups-service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataSignerBuildconfigYaml = []byte(`kind: List
 apiVersion: v1
 items:
@@ -58472,6 +58703,11 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/sample-image-stream.json": testExtendedTestdataSampleImageStreamJson,
 	"test/extended/testdata/samplepipeline-withenvs.yaml": testExtendedTestdataSamplepipelineWithenvsYaml,
 	"test/extended/testdata/service-serving-cert/nginx-serving-cert.conf": testExtendedTestdataServiceServingCertNginxServingCertConf,
+	"test/extended/testdata/service_catalog/ups-binding.yaml": testExtendedTestdataService_catalogUpsBindingYaml,
+	"test/extended/testdata/service_catalog/ups-broker.yaml": testExtendedTestdataService_catalogUpsBrokerYaml,
+	"test/extended/testdata/service_catalog/ups-deployment.yaml": testExtendedTestdataService_catalogUpsDeploymentYaml,
+	"test/extended/testdata/service_catalog/ups-instance.yaml": testExtendedTestdataService_catalogUpsInstanceYaml,
+	"test/extended/testdata/service_catalog/ups-service.yaml": testExtendedTestdataService_catalogUpsServiceYaml,
 	"test/extended/testdata/signer-buildconfig.yaml": testExtendedTestdataSignerBuildconfigYaml,
 	"test/extended/testdata/templates/crunchydata-pod.json": testExtendedTestdataTemplatesCrunchydataPodJson,
 	"test/extended/testdata/templates/guestbook.json": testExtendedTestdataTemplatesGuestbookJson,
@@ -59208,6 +59444,13 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"samplepipeline-withenvs.yaml": &bintree{testExtendedTestdataSamplepipelineWithenvsYaml, map[string]*bintree{}},
 				"service-serving-cert": &bintree{nil, map[string]*bintree{
 					"nginx-serving-cert.conf": &bintree{testExtendedTestdataServiceServingCertNginxServingCertConf, map[string]*bintree{}},
+				}},
+				"service_catalog": &bintree{nil, map[string]*bintree{
+					"ups-binding.yaml": &bintree{testExtendedTestdataService_catalogUpsBindingYaml, map[string]*bintree{}},
+					"ups-broker.yaml": &bintree{testExtendedTestdataService_catalogUpsBrokerYaml, map[string]*bintree{}},
+					"ups-deployment.yaml": &bintree{testExtendedTestdataService_catalogUpsDeploymentYaml, map[string]*bintree{}},
+					"ups-instance.yaml": &bintree{testExtendedTestdataService_catalogUpsInstanceYaml, map[string]*bintree{}},
+					"ups-service.yaml": &bintree{testExtendedTestdataService_catalogUpsServiceYaml, map[string]*bintree{}},
 				}},
 				"signer-buildconfig.yaml": &bintree{testExtendedTestdataSignerBuildconfigYaml, map[string]*bintree{}},
 				"templates": &bintree{nil, map[string]*bintree{

--- a/test/extended/testdata/service_catalog/ups-binding.yaml
+++ b/test/extended/testdata/service_catalog/ups-binding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: upsBinding-template
+objects:
+- apiVersion: servicecatalog.k8s.io/v1beta1
+  kind: ServiceBinding
+  metadata:
+    name: ups-binding
+    namespace: "${NAMESPACE}"
+  spec:
+    instanceRef:
+      name: ups-instance
+    secretName: my-secret
+parameters:
+- name: NAMESPACE

--- a/test/extended/testdata/service_catalog/ups-broker.yaml
+++ b/test/extended/testdata/service_catalog/ups-broker.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ups-broker-template
+objects:
+- apiVersion: servicecatalog.k8s.io/v1beta1
+  kind: ClusterServiceBroker
+  metadata:
+    name: ups-broker
+  spec:
+    url: http://ups-broker.${NAMESPACE}.svc.cluster.local
+parameters:
+- name: NAMESPACE

--- a/test/extended/testdata/service_catalog/ups-deployment.yaml
+++ b/test/extended/testdata/service_catalog/ups-deployment.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ups-deployment-template
+objects:
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ups-broker
+      chart: ups-broker-0.0.1
+      heritage: Tiller
+      release: ups-broker
+    name: ups-broker
+    namespace: "${NAMESPACE}"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ups-broker
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 1
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: ups-broker
+          chart: ups-broker-0.0.1
+          heritage: Tiller
+          release: ups-broker
+      spec:
+        containers:
+        - args:
+          - -alsologtostderr
+          - --port
+          - "8080"
+          image: quay.io/kubernetes-service-catalog/user-broker:latest
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 2
+          name: ups-broker
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 2
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+parameters:
+- name: NAMESPACE

--- a/test/extended/testdata/service_catalog/ups-instance.yaml
+++ b/test/extended/testdata/service_catalog/ups-instance.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: upsInstance-template
+objects:
+- apiVersion: servicecatalog.k8s.io/v1beta1
+  kind: ServiceInstance
+  metadata:
+    name: ups-instance
+    namespace: "${NAMESPACE}"
+  spec:
+    clusterServiceClassExternalName: user-provided-service
+    clusterServicePlanExternalName: default
+parameters:
+- name: NAMESPACE

--- a/test/extended/testdata/service_catalog/ups-service.yaml
+++ b/test/extended/testdata/service_catalog/ups-service.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ups-service-template
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ups-broker
+      chart: ups-broker-0.0.1
+      heritage: Tiller
+      release: ups-broker
+    name: ups-broker
+    namespace: "${NAMESPACE}"
+  spec:
+    ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: ups-broker
+    sessionAffinity: None
+    type: ClusterIP
+parameters:
+- name: NAMESPACE


### PR DESCRIPTION
As title, do some basic tests, such as, enable/disable ServiceCatalog, deploy a fake broker, etc.