### PR TITLE
mark bootstrap user test as disruptive

### DIFF
--- a/test/extended/bootstrap_user/bootstrap_user_login.go
+++ b/test/extended/bootstrap_user/bootstrap_user_login.go
@@ -28,7 +28,7 @@ var _ = g.Describe("The bootstrap user", func() {
 	// as that will give each one of our test runs a new config via SetupProject
 	oc := exutil.NewCLI("bootstrap-login", exutil.KubeConfigPath())
 
-	g.It("should successfully login with password decoded from kubeadmin secret", func() {
+	g.It("should successfully login with password decoded from kubeadmin secret [Disruptive]", func() {
 		var originalPasswordHash []byte
 		secretExists := true
 		recorder := events.NewInMemoryRecorder("")


### PR DESCRIPTION
The test removes the kubeadmin password, efectivelly disabling it
and causing oauth-server pods redeploy.