### PR TITLE
test: Move AZ spread e2e test to serial

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -475,6 +475,8 @@ var (
 			`should allow starting 95 pods per node`,
 			`DynamicProvisioner should test that deleting a claim before the volume is provisioned deletes the volume`, // test is very disruptive to other tests
 
+			`Multi-AZ Clusters should spread the pods`, // spreading is a priority, not a predicate, and if the node is temporarily full the priority will be ignored
+
 			`Should be able to support the 1\.7 Sample API Server using the current Aggregator`, // down apiservices break other clients today https://bugzilla.redhat.com/show_bug.cgi?id=1623195
 
 			`\[Feature:HPA\] Horizontal pod autoscaling \(scale resource: CPU\) \[sig-autoscaling\] ReplicationController light Should scale from 1 pod to 2 pods`,


### PR DESCRIPTION
The AZ spreading tests depend on scheduler priorities, not predicates,
and thus a mostly full cluster can result in spreading being ignored
(scheduler prefers to schedule pods that violate spreading priority
if one or more nodes is full). By moving to serial, we ensure that
nodes have the necessary capacity. These tests were flaking fairly
frequently.