### PR TITLE
[release-4.3] Bug 1790481: Fix delegated auth CM perms

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
@@ -77,7 +77,7 @@ func init() {
 		ObjectMeta: metav1.ObjectMeta{Name: "extension-apiserver-authentication-reader"},
 		Rules: []rbacv1.PolicyRule{
 			// this particular config map is exposed and contains authentication configuration information
-			rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").Names("extension-apiserver-authentication").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("configmaps").Names("extension-apiserver-authentication").RuleOrDie(),
 		},
 	})
 	addNamespaceRole(metav1.NamespaceSystem, rbacv1.Role{

--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-roles.yaml
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-roles.yaml
@@ -55,6 +55,8 @@ items:
     - configmaps
     verbs:
     - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:


### PR DESCRIPTION
kube-scheduler was missing permissions for accessing CM kube-system/extension-apiserver-authentication

/cc @soltysh  @deads2k 