### PR TITLE
UPSTREAM: <carry>: Remove excessive logging during e2e upgrade test

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/framework/network/utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/network/utils.go
@@ -831,7 +831,8 @@ func PokeHTTP(host string, port int, path string, params *HTTPPokeParams) HTTPPo
 	}
 
 	ret.Status = HTTPSuccess
-	framework.Logf("Poke(%q): success", url)
+	// causes excessive logging that provides no value
+	// framework.Logf("Poke(%q): success", url)
 	return ret
 }
 


### PR DESCRIPTION
This line makes the upgrade log output unreadable and provides
no value during the set of tests it's used in:

```
Jan 12 20:49:25.628: INFO: cluster upgrade is Progressing: Working towards registry.svc.ci.openshift.org/ci-op-jbtg7jjb/release@sha256:144e73d125cce620bdf099be9a85225ade489a95622a70075d264ea3ff79219c: downloading update
Jan 12 20:49:26.692: INFO: Poke("http://a74e3476115ce4d2d817a1e5ea608dad-802917831.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
Jan 12 20:49:28.727: INFO: Poke("http://a74e3476115ce4d2d817a1e5ea608dad-802917831.us-east-1.elb.amazonaws.com:80/echo?msg=hello"): success
```