### PR TITLE
Fix livenessprobe arguments and add CSI manifest OWNERS

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -47276,7 +47276,7 @@ spec:
           image: {{.LivenessProbeImage}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/test/extended/testdata/csi/OWNERS
+++ b/test/extended/testdata/csi/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- jsafrane
+- bertinatto
+- gnufied

--- a/test/extended/testdata/csi/aws-ebs/install-template.yaml
+++ b/test/extended/testdata/csi/aws-ebs/install-template.yaml
@@ -247,7 +247,7 @@ spec:
           image: {{.LivenessProbeImage}}
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
These manifests may need to be edited by storage team frequently, so adding OWNERS.