### PR TITLE
Fix config passing to test-cmd

### DIFF
--- a/test/extended/cmd/cmd.go
+++ b/test/extended/cmd/cmd.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[Suite:openshift/test-cmd][Serial][Disruptive] test-cmd:", f
 			hacklibVolume, hacklibVolumeMount := createConfigMapForDir(oc, hacklibDir, "/var/tests/hack")
 			testsVolume, testsVolumeMount := createConfigMapForDir(oc, testsDir, "/var/tests/test/cmd")
 
-			kubeconfigCont, err := oc.AsAdmin().Run("config").Args("view", "--flatten", "--minify").Output()
+			kubeconfigCont, _, err := oc.AsAdmin().Run("config").Args("view", "--flatten", "--minify").Outputs()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			_, err = oc.AdminKubeClient().CoreV1().ConfigMaps(oc.Namespace()).Create(&corev1.ConfigMap{


### PR DESCRIPTION
Since I'm deprecating `--config` flag from oc in https://github.com/openshift/oc/pull/256 the `Output` method being used in this call contains both the config file and the deprecation message which breaks the tests further. This PR make it explicit that we read only stdout when reading that config.

/assign @sallyom 