### PR TITLE
Switch oc used in e2e tests to use --kubeconfig flag

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -473,7 +473,7 @@ func (c *CLI) Run(commands ...string) *CLI {
 		configPath:      c.configPath,
 		username:        c.username,
 		globalArgs: append([]string{
-			fmt.Sprintf("--config=%s", c.configPath),
+			fmt.Sprintf("--kubeconfig=%s", c.configPath),
 		}, commands...),
 	}
 	if !c.withoutNamespace {


### PR DESCRIPTION
Since I'm deprecating `--config` flag from oc in openshift/oc#256 and majority of commands rely on `Output` method combining `stdout` and `stderr` they are getting the deprecation which in turns fails the rest of the test. 

/assign @mfojtik