### PR TITLE
Bug 1792569: UPSTREAM: : admission/restrictusers ensure groups cache synced

### DIFF
--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/groupcache_test.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/groupcache_test.go
@@ -22,3 +22,7 @@ func (g fakeGroupCache) GroupsFor(user string) ([]*userv1.Group, error) {
 	}
 	return ret, nil
 }
+
+func (g fakeGroupCache) HasSynced() bool {
+	return true
+}

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/restrictusers.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/restrictusers.go
@@ -33,6 +33,7 @@ func Register(plugins *admission.Plugins) {
 
 type GroupCache interface {
 	GroupsFor(string) ([]*userv1.Group, error)
+	HasSynced() bool
 }
 
 // restrictUsersAdmission implements admission.ValidateInterface and enforces

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/subjectchecker.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/subjectchecker.go
@@ -2,10 +2,12 @@ package restrictusers
 
 import (
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 
@@ -102,6 +104,13 @@ func (ctx *RoleBindingRestrictionContext) labelSetForUser(subject rbac.Subject) 
 func (ctx *RoleBindingRestrictionContext) groupsForUser(subject rbac.Subject) ([]*userv1.Group, error) {
 	if subject.Kind != rbac.UserKind {
 		return []*userv1.Group{}, fmt.Errorf("not a user: %q", subject.Name)
+	}
+
+	err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+		return ctx.groupCache.HasSynced(), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("groups.user.openshift.io cache is not synchronized")
 	}
 
 	return ctx.groupCache.GroupsFor(subject.Name)

--- a/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache/groups.go
+++ b/vendor/k8s.io/kubernetes/openshift-kube-apiserver/admission/authorization/restrictusers/usercache/groups.go
@@ -12,7 +12,8 @@ import (
 // GroupCache is a skin on an indexer to provide the reverse index from user to groups.
 // Once we work out a cleaner way to extend a lister, this should live there.
 type GroupCache struct {
-	indexer cache.Indexer
+	indexer      cache.Indexer
+	groupsSynced cache.InformerSynced
 }
 
 const ByUserIndexName = "ByUser"
@@ -30,7 +31,8 @@ func ByUserIndexKeys(obj interface{}) ([]string, error) {
 
 func NewGroupCache(groupInformer userinformer.GroupInformer) *GroupCache {
 	return &GroupCache{
-		indexer: groupInformer.Informer().GetIndexer(),
+		indexer:      groupInformer.Informer().GetIndexer(),
+		groupsSynced: groupInformer.Informer().HasSynced,
 	}
 }
 
@@ -46,4 +48,8 @@ func (c *GroupCache) GroupsFor(username string) ([]*userapi.Group, error) {
 	}
 
 	return groups, nil
+}
+
+func (c *GroupCache) HasSynced() bool {
+	return c.groupsSynced()
 }


### PR DESCRIPTION
The restrictusers admission plugin uses a groups.user.openshift.io informer without waiting for its cache to sync. This results in misleading permission denials when cache is not synced. 