### PR TITLE
Adding myself to approve ISV-operators&OLM tests

### DIFF
--- a/test/extended/OWNERS
+++ b/test/extended/OWNERS
@@ -15,3 +15,4 @@ approvers:
   - ironcladlou
   - adambkaplan
   - shawn-hurley
+  - jianzhangbjz


### PR DESCRIPTION
Hi, All

I'm Jian, from the OpenShift QE team. I have been working on the Ginkgo automation test work for OLM, ServiceCatalog, and ISV operators. I need this permission to push the QE upstream automation work. Could you help give approval? Thanks! 