### PR TITLE
DROP: Cause Sandboxes to be killed if they have no default route

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -162,12 +162,22 @@ func TestCNIPlugin(t *testing.T) {
 
 	podIP := "10.0.0.2"
 	podIPOutput := fmt.Sprintf("4: eth0    inet %s/24 scope global dynamic eth0\\       valid_lft forever preferred_lft forever", podIP)
+	podRouteOutput := fmt.Sprintf("broadcast 255.255.255.255 dev eth0 src %s uid 0 \\    cache <local,brd>", podIP)
 	fakeCmds := []fakeexec.FakeCommandAction{
 		func(cmd string, args ...string) exec.Cmd {
 			return fakeexec.InitFakeCmd(&fakeexec.FakeCmd{
 				CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 					func() ([]byte, error) {
 						return []byte(podIPOutput), nil
+					},
+				},
+			}, cmd, args...)
+		},
+		func(cmd string, args ...string) exec.Cmd {
+			return fakeexec.InitFakeCmd(&fakeexec.FakeCmd{
+				CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+					func() ([]byte, error) {
+						return []byte(podRouteOutput), nil
 					},
 				},
 			}, cmd, args...)


### PR DESCRIPTION
Taken from: https://github.com/openshift/origin/pull/24018
When restarting kubelet, we can kill in-flight CNI requests. If they're killed between setting the interface up and adding the default route, then kubelet upon restart thinks the container is up.

Add a check so we kill the sandbox in that case.

We do not need to bring this forward to 4.x, as we use CRIO.

Doing a separate PR so that I can get in the cluster and see what is actually failing